### PR TITLE
fix: label DetectRaptor detections by their specific rule pack

### DIFF
--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -592,6 +592,21 @@ function mapSigma(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEve
 }
 
 
+// DetectRaptor ships many distinct "*.Detection.*" rule packs (MFT, Amcache, LolDrivers,
+// PSReadline, ...) that all flow through rowVerdict()/mapDetection() — folding them all under the
+// generic "Velociraptor detection" bucket hides WHICH rule pack actually fired. When the artifact
+// names a DetectRaptor pack, lead with its specific technique name instead (e.g. "DetectRaptor MFT
+// detection"); any other Velociraptor-hosted rule pack (Custom.*, Chainsaw, etc.) keeps the
+// generic "Velociraptor detection" label.
+function detectionLabel(artifact: string): string {
+  const a = artifact.trim();
+  if (/^DetectRaptor\./i.test(a)) {
+    const last = a.split(".").pop();
+    if (last) return `DetectRaptor ${last} detection`;
+  }
+  return "Velociraptor detection";
+}
+
 // A DetectRaptor-style detection: the `Detection`/`RuleName` verdict leads. If a parsed Windows
 // event sits underneath (Evtx), overlay the verdict onto the per-EID mapping (like Sigma);
 // otherwise build the event from the row's file/process/pipe/path + hashes.
@@ -599,13 +614,14 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
   const v = rowVerdict(row)!; // guaranteed by classify()
   let severity = detectionSeverity(v);
   scrapeEvidence(row, sink); // pull URLs/IPs/hashes out of the matched command line / file content
+  const label = detectionLabel(artifact);
 
   const flat = winRowToFlat(row);
   const win = flat ? mapWindows(flat.rec, flat.host || host, sink) : null;
   if (win) {
     win.severity = worst(win.severity, severity);
     for (const m of v.mitre) if (!win.mitre.includes(m)) win.mitre.push(m);
-    win.description = `Velociraptor detection: ${v.title} - ${win.description}`.slice(0, 600);
+    win.description = `${label}: ${v.title} - ${win.description}`.slice(0, 600);
     win.aggKey = `vr-det|${v.title.toLowerCase()}|${win.aggKey}`.slice(0, 400);
     win.sources = ["Velociraptor"];
     if (!win.timestamp) win.timestamp = pickTime(row);
@@ -682,7 +698,7 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
     subject = parts.join(" - ");
   }
 
-  let description = `Velociraptor detection: ${v.title}`;
+  let description = `${label}: ${v.title}`;
   if (subject) description += ` - ${subject}`;
   if (fileDeleted) description += ` [deleted]`;
   if (host) description += ` @ ${host}`;
@@ -1087,8 +1103,10 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
       // Place it consistently right after "Velociraptor" (the same spot mapGeneric already uses), so
       // detection/sigma/yara read "Velociraptor [artifact] detection: …" not "… [artifact]" at the
       // end. Only a REAL artifact name (from _Source) is shown — never the filename fallback.
+      // Skip when mapDetection already led with a DetectRaptor-specific label (detectionLabel()) —
+      // that already names the rule pack, so bracketing the full dotted artifact too is redundant.
       const realArtifact = artifactName(row);
-      if (realArtifact && !m.description.includes(realArtifact)) {
+      if (realArtifact && !m.description.includes(realArtifact) && !m.description.startsWith("DetectRaptor ")) {
         m.description = (m.description.startsWith("Velociraptor")
           ? m.description.replace(/^Velociraptor/, `Velociraptor [${realArtifact}]`)
           : `[${realArtifact}] ${m.description}`).slice(0, 1200);

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -101,7 +101,7 @@ describe("parseVelociraptorJson — artifactName provenance", () => {
 // arrive reshaped (dotted keys, `.keyword` multi-fields, the artifact in the `artifact_<name>` index,
 // ES doc metadata). normalizeElasticRow should reverse that so the native mappers fire.
 describe("parseVelociraptorJson — Elastic-indexed Velociraptor (Kibana push)", () => {
-  it("MFT keyword hit → keyword-escalated High detection, dated, [artifact]-tagged, Velociraptor source", () => {
+  it("MFT keyword hit → keyword-escalated High detection, dated, DetectRaptor-labeled, Velociraptor source", () => {
     const row = {
       _id: "x1", _index: "artifact_detectraptor_windows_detection_mft", _version: 1,
       "@timestamp": "2026-05-07T16:03:56.000Z",
@@ -116,7 +116,7 @@ describe("parseVelociraptorJson — Elastic-indexed Velociraptor (Kibana push)",
     const e = r.events[0];
     expect(e.severity).toBe("High"); // "psexec" keyword
     expect(e.description).toContain("PsExec.exe");
-    expect(e.description).toContain("[DetectRaptor.Windows.Detection.MFT]");
+    expect(e.description).toContain("DetectRaptor MFT detection:");
     expect(e.description).not.toContain("_index");
     expect(e.timestamp).toContain("2026-01-28"); // the artifact's own MFT time, not @timestamp
     expect(e.sources).toEqual(["Velociraptor"]);
@@ -149,7 +149,7 @@ describe("parseVelociraptorJson — Elastic-indexed Velociraptor (Kibana push)",
     const e = r.events[0];
     expect(e.severity).toBe("Medium"); // honors Detection.Criticality over the psexec keyword
     expect(e.description).toContain("Execution - PsExec");
-    expect(e.description).toContain("[DetectRaptor.Windows.Detection.Amcache]");
+    expect(e.description).toContain("DetectRaptor Amcache detection:");
     expect(e.description).not.toContain("-1"); // "-" cells dropped, not rendered
     expect(e.timestamp).toContain("2026-05-07T16:31:04"); // Kibana "@" date → ISO
     expect(e.sources).toEqual(["Velociraptor"]);
@@ -449,8 +449,9 @@ describe("parseVelociraptorJson — IOC hygiene & extra time keys (#102)", () =>
     const generic = { _Source: "Windows.Analysis.EvidenceOfDownload", DownloadedFilePath: "C:\\Users\\v\\a.exe", Mtime: "2026-06-03T08:00:00Z" };
     const det = parseVelociraptorJson(JSON.stringify([detection])).events[0];
     const gen = parseVelociraptorJson(JSON.stringify([generic])).events[0];
-    // Consistent placement: artifact right after "Velociraptor" for BOTH detection and generic.
-    expect(det.description).toContain("Velociraptor [DetectRaptor.Windows.Detection.LolDrivers] detection:");
+    // DetectRaptor detections lead with the specific rule-pack name (not the generic "Velociraptor"
+    // bucket); other Velociraptor-hosted artifacts still get the bracketed full artifact name.
+    expect(det.description).toContain("DetectRaptor LolDrivers detection:");
     expect(gen.description).toContain("Velociraptor [Windows.Analysis.EvidenceOfDownload]:");
     // The filename fallback (no _Source) is NOT shown as a bracketed artifact tag.
     const noSource = parseVelociraptorJson(JSON.stringify([{ Detection: { Name: "X" }, EntryPath: "c:\\y.sys" }]), { artifact: "0036_velociraptor-2026.json" }).events[0];


### PR DESCRIPTION
## Summary
- DetectRaptor findings were labeled with the generic "Velociraptor detection: ..." prefix, hiding which specific DetectRaptor rule pack (MFT, Amcache, LolDrivers, etc.) actually fired.
- Now leads with "DetectRaptor <Pack> detection: <title>" (e.g. "DetectRaptor MFT detection: RMM") when the source artifact is a DetectRaptor.* rule pack; other Velociraptor-hosted detections keep the generic label.

## Test plan
- [x] `vitest run tests/analysis/velociraptorImport.test.ts` — 76/76 passed
- [x] `vitest run tests/analysis tests/integrations/velociraptor.test.ts` — 2189/2189 passed