### PR TITLE
Per-case IOC exclude list (domain/hostname), plus internal-zone extraction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-case IOC exclude list** — permanently remove domain/hostname (or any IOC type) matches from a case via exact/suffix/regex rules in the IOCs panel title bar; excluded values are purged immediately and never re-imported or enriched.
+
+### Fixed
+- **Structured hostname/fqdn/domain columns** (e.g. a JSON/CSV field literally named `Hostname`) now skip internal zones (`.lan`/`.local`/`.corp`/etc.) the same way free-text scraping already did, instead of creating a domain IOC for every client hostname.
+
 ## [0.30.0] - 2026-07-07
 
 ### Added

--- a/companion/src/analysis/iocExclude.ts
+++ b/companion/src/analysis/iocExclude.ts
@@ -1,0 +1,91 @@
+// IOC exclude list — per-case, PERMANENT removal of indicators the analyst never wants tracked
+// (e.g. internal client hostnames like "*.lan"). Deliberately separate from the IOC whitelist
+// (iocWhitelist.ts), which is global and reversible (auto-marks a match as a false positive but
+// keeps the record — the whitelist is intentionally opt-in and non-destructive, see its header).
+// An exclude rule instead deletes matching IOCs outright and prevents them from ever being
+// re-created, so they can never reach enrichment (enrichIocs only ever sees state.iocs).
+//
+// Pure logic only (match + sanitize) so it unit-tests without I/O. Persistence lives directly on
+// InvestigationState.iocExcludeRules (per-case, not a separate store — see stateTypes.ts); the
+// purge-on-add wiring lives in the /cases/:id/ioc-exclude route, and the going-forward filter
+// lives in stateMerge.ts's mergeDelta.
+
+import type { IOC } from "./stateTypes.js";
+
+export const EXCLUDE_MATCH_MODES = ["exact", "suffix", "regex"] as const;
+export type ExcludeMatchMode = (typeof EXCLUDE_MATCH_MODES)[number];
+
+const IOC_TYPES = ["ip", "domain", "hash", "file", "process", "url", "sid", "other"] as const;
+
+export interface IocExcludeRule {
+  id: string;
+  match: ExcludeMatchMode;     // how `pattern` is compared to the IOC value
+  pattern: string;             // "client01.lan" (exact) | "lan" (suffix — normalized to ".lan") | a regex
+  iocType?: IOC["type"];       // optional: only apply to this IOC type; unset = any type
+  note?: string;               // why it's excluded (e.g. "client's internal AD domain")
+  addedAt: string;             // ISO time the rule was added
+}
+
+// The validated core of a rule, before the caller assigns an id + addedAt.
+export type ExcludeRuleInput = Omit<IocExcludeRule, "id" | "addedAt">;
+
+// Normalize a suffix pattern to always carry a leading "." so "lan" and ".lan" behave identically —
+// matching is on whole DNS labels, not an arbitrary substring.
+export function normalizeSuffixPattern(pattern: string): string {
+  const p = pattern.trim();
+  return p.startsWith(".") ? p : `.${p}`;
+}
+
+// ── matching ───────────────────────────────────────────────────────────────────────────────────
+export function ruleMatchesIoc(rule: IocExcludeRule | ExcludeRuleInput, ioc: { type: IOC["type"]; value: string }): boolean {
+  if (rule.iocType && rule.iocType !== ioc.type) return false;
+  const raw = String(ioc.value ?? "").trim();
+  if (!raw) return false;
+  const val = raw.toLowerCase();
+  switch (rule.match) {
+    case "exact":
+      return val === rule.pattern.trim().toLowerCase();
+    case "suffix": {
+      const suffix = normalizeSuffixPattern(rule.pattern).toLowerCase();
+      return val === suffix.slice(1) || val.endsWith(suffix);
+    }
+    case "regex":
+      try { return new RegExp(rule.pattern, "i").test(raw); } catch { return false; }
+    default:
+      return false;
+  }
+}
+
+// First rule that matches this IOC, or null.
+export function matchIocToExclude(
+  ioc: { type: IOC["type"]; value: string },
+  rules: readonly IocExcludeRule[],
+): IocExcludeRule | null {
+  for (const r of rules) if (ruleMatchesIoc(r, ioc)) return r;
+  return null;
+}
+
+// Every IOC (out of a case's current list) that matches at least one rule — used to purge on add.
+export function excludeMatches(iocs: readonly IOC[], rules: readonly IocExcludeRule[]): IOC[] {
+  if (rules.length === 0) return [];
+  return iocs.filter((ioc) => matchIocToExclude(ioc, rules) !== null);
+}
+
+// ── validation ───────────────────────────────────────────────────────────────────────────────
+// Coerce an untrusted object into a valid rule core, or null when it can't be (bad mode, empty
+// pattern, invalid regex). Keeps the route from persisting garbage.
+export function sanitizeExcludeRuleInput(raw: unknown): ExcludeRuleInput | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const mode = String(r.match ?? "").trim().toLowerCase();
+  if (!EXCLUDE_MATCH_MODES.includes(mode as ExcludeMatchMode)) return null;
+  const match = mode as ExcludeMatchMode;
+  let pattern = String(r.pattern ?? "").trim();
+  if (!pattern || pattern.length > 500) return null;
+  if (match === "suffix") pattern = normalizeSuffixPattern(pattern);
+  if (match === "regex") { try { new RegExp(pattern); } catch { return null; } }
+  const rawType = String(r.iocType ?? "").trim().toLowerCase();
+  const iocType = (IOC_TYPES as readonly string[]).includes(rawType) ? (rawType as IOC["type"]) : undefined;
+  const note = r.note != null ? String(r.note).trim().slice(0, 500) : undefined;
+  return { match, pattern, ...(iocType ? { iocType } : {}), ...(note ? { note } : {}) };
+}

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -794,7 +794,7 @@ export function genericIocs(pairs: [string, string][], iocSink: Map<string, Siem
     }
     if (/sha256|sha1|\bmd5\b|imphash|(?:^|[._])hash$/.test(k) && HEX_HASH.test(v)) { addIoc(iocSink, "hash", v.toLowerCase()); continue; }
     if (/(?:url|uri)$/.test(k) && /^https?:\/\//i.test(v)) { addIoc(iocSink, "url", v.slice(0, 300)); continue; }
-    if (/(?:domain|fqdn|dns|query|host_name|hostname)$/.test(k) && /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(v) && !IPV4.test(v)) { addIoc(iocSink, "domain", v.toLowerCase()); continue; }
+    if (/(?:domain|fqdn|dns|query|host_name|hostname)$/.test(k) && /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(v) && !IPV4.test(v) && !TEXT_DOMAIN_SKIP_RE.test(v) && !TEXT_FILE_EXT_RE.test(v)) { addIoc(iocSink, "domain", v.toLowerCase()); continue; }
     if (/(?:image|process|exe|process_name|processname|command_line|commandline|cmdline)$/.test(k)) {
       const bn = baseName(v); if (/\.\w{2,4}$/.test(bn)) addIoc(iocSink, "process", bn); continue;
     }

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -7,6 +7,7 @@ import { clampOutlierYears } from "./timeYearClamp.js";
 import { linkEmailDelivery } from "./initialAccess.js";
 import { linkArchiveToExfil } from "./exfilCorrelate.js";
 import { toUtcIso } from "./timeUtc.js";
+import { matchIocToExclude } from "./iocExclude.js";
 
 export interface WindowContext {
   windowSequence: number;
@@ -45,6 +46,11 @@ export function mergeDelta(
   const iocIdRemap = new Map<string, string>();
   let nextSeq = nextIocSeq(iocs);
   for (const incoming of delta.iocs) {
+    // Permanently excluded (per-case IOC Exclude List — e.g. ".lan"-style client hostname noise):
+    // never create it, so it can never be enriched either (enrichIocs only ever sees state.iocs).
+    // The id is deliberately never added to iocIdRemap; a finding's relatedIocs reference falls
+    // back to the raw id via remapIocRefs's `?? id`, a harmless dangling reference.
+    if (matchIocToExclude({ type: incoming.type, value: incoming.value }, state.iocExcludeRules)) continue;
     // Case-insensitive: the same indicator (a hostname/domain especially) routinely arrives with
     // different casing across importers/rows (e.g. "DESKTOP-X" vs "desktop-x"), and an exact-match
     // comparison let those through as separate rows instead of collapsing into one (matches
@@ -249,6 +255,7 @@ export function mergeDelta(
     lastSummary: delta.summary.trim().length > 0 ? delta.summary : state.lastSummary,
     attackerPath: (delta.attackerPath ?? "").trim().length > 0 ? (delta.attackerPath as string) : state.attackerPath,
     narrativeTimeline: (delta.narrativeTimeline ?? "").trim().length > 0 ? (delta.narrativeTimeline as string) : state.narrativeTimeline,
+    iocExcludeRules: state.iocExcludeRules,
     updatedAt: ctx.timestamp,
   };
 }

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -1,3 +1,5 @@
+import type { IocExcludeRule } from "./iocExclude.js";
+
 export type Severity = "Critical" | "High" | "Medium" | "Low" | "Info";
 export type FindingStatus = "open" | "confirmed" | "dismissed";
 export type ThreadStatus = "open" | "closed";
@@ -178,6 +180,10 @@ export interface InvestigationState {
   lastSummary: string;
   attackerPath: string;                // narrative reconstruction of the attacker's path
   narrativeTimeline: string;           // prose story of the incident for stakeholders (re-generated on synthesis)
+  // Per-case domain/hostname (or any IOC type) exclude rules — a match is deleted from `iocs`
+  // outright and never re-created by a future import/AI-synthesis delta (see mergeDelta). Distinct
+  // from the global IOC Whitelist, which is reversible and merely marks a match false-positive.
+  iocExcludeRules: IocExcludeRule[];
   updatedAt: string;
 }
 
@@ -195,6 +201,7 @@ export function emptyState(caseId: string): InvestigationState {
     lastSummary: "",
     attackerPath: "",
     narrativeTimeline: "",
+    iocExcludeRules: [],
     updatedAt: new Date(0).toISOString(),
   };
 }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2,6 +2,7 @@ import express, { type Express, type Request, type Response, type NextFunction }
 import { config as loadDotenv } from "dotenv";
 import { join, basename, isAbsolute, resolve, dirname, relative, extname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
 import { writeFile, readFile, rm, readdir, stat, open, copyFile, mkdir, mkdtemp, rename } from "node:fs/promises";
 import { ZodError } from "zod";
 import { CaseStore, isValidCaseId } from "./storage/caseStore.js";
@@ -151,6 +152,7 @@ import { ImportUndoStore, pushCheckpoint, applyUndo, applyRedo, summarizeUndoSta
 import { mergeEnrichedSubset } from "./analysis/iocBulkOps.js";
 import { IocWhitelistStore } from "./analysis/iocWhitelistStore.js";
 import { whitelistMatches, parseWhitelistText, toWhitelistCsv, sanitizeRuleInput } from "./analysis/iocWhitelist.js";
+import { sanitizeExcludeRuleInput, matchIocToExclude, type IocExcludeRule } from "./analysis/iocExclude.js";
 import { NsrlStore, ingestNsrlFiles, splitNsrlPaths } from "./analysis/nsrlStore.js";
 import { parseNsrlText, nsrlMatchIocs, nsrlMatchEvents } from "./analysis/nsrl.js";
 import { KevStore } from "./analysis/kevStore.js";
@@ -5467,6 +5469,73 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       res.setHeader("Content-Type", "application/json");
       res.setHeader("Content-Disposition", 'attachment; filename="ioc-whitelist.json"');
       return res.status(200).send(JSON.stringify(rules, null, 2));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── IOC exclude list (per-case, PERMANENT) ─────────────────────────────────────────────────
+  // Distinct from the IOC whitelist above: a match here is deleted from the case outright (not
+  // just marked false-positive) and is filtered at the source for every future import/AI-synthesis
+  // delta (see mergeDelta in stateMerge.ts), so it can never reach enrichment either. Scoped to
+  // this case only (not global) — the rules live on InvestigationState.iocExcludeRules.
+
+  app.get("/cases/:id/ioc-exclude", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(200).json([]);
+    try {
+      const state = await options.stateStore.load(req.params.id);
+      return res.status(200).json(state.iocExcludeRules);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Add one rule and immediately purge any matching IOCs already in this case. Body:
+  // { match: "exact"|"suffix"|"regex", pattern, iocType?, note? }. Returns { rule, purged }.
+  app.post("/cases/:id/ioc-exclude", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    const input = sanitizeExcludeRuleInput(req.body ?? {});
+    if (!input) return res.status(400).json({ error: "invalid rule — need match (exact|suffix|regex) and a non-empty pattern (valid regex for regex)" });
+    const caseId = req.params.id;
+    const stateStore = options.stateStore;
+    let rule: IocExcludeRule | undefined;
+    let purged = 0;
+    try {
+      await runStateExclusive(caseId, async () => {
+        const state = await stateStore.load(caseId);
+        rule = { id: randomUUID(), addedAt: new Date().toISOString(), ...input };
+        const nextRules = [...state.iocExcludeRules, rule];
+        const keptIocs = state.iocs.filter((ioc) => !matchIocToExclude(ioc, nextRules));
+        purged = state.iocs.length - keptIocs.length;
+        const next = { ...state, iocs: keptIocs, iocExcludeRules: nextRules, updatedAt: new Date().toISOString() };
+        await stateStore.save(next);
+        options.onState?.(next);
+      });
+      logLine(`[ioc-exclude] ${caseId} added rule ${rule!.match}:${rule!.pattern} — purged ${purged} IOC(s)`);
+      return res.status(201).json({ rule, purged });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Remove a rule. Does NOT restore any IOCs it already purged — exclusion is a one-way operation.
+  app.delete("/cases/:id/ioc-exclude/:ruleId", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    const caseId = req.params.id;
+    const stateStore = options.stateStore;
+    let removed = false;
+    try {
+      await runStateExclusive(caseId, async () => {
+        const state = await stateStore.load(caseId);
+        const nextRules = state.iocExcludeRules.filter((r) => r.id !== req.params.ruleId);
+        removed = nextRules.length !== state.iocExcludeRules.length;
+        if (!removed) return;
+        const next = { ...state, iocExcludeRules: nextRules, updatedAt: new Date().toISOString() };
+        await stateStore.save(next);
+        options.onState?.(next);
+      });
+      if (!removed) return res.status(404).json({ error: "rule not found" });
+      return res.status(200).json({ removed: true });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/tests/analysis/iocExclude.test.ts
+++ b/companion/tests/analysis/iocExclude.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  ruleMatchesIoc,
+  matchIocToExclude,
+  excludeMatches,
+  sanitizeExcludeRuleInput,
+  normalizeSuffixPattern,
+  type IocExcludeRule,
+} from "../../src/analysis/iocExclude.js";
+import type { IOC } from "../../src/analysis/stateTypes.js";
+
+const rule = (over: Partial<IocExcludeRule> & Pick<IocExcludeRule, "match" | "pattern">): IocExcludeRule => ({
+  id: "r1", addedAt: "2026-01-01T00:00:00Z", ...over,
+});
+const ioc = (type: IOC["type"], value: string): IOC => ({ id: "i", type, value, firstSeen: "2026-01-01T00:00:00Z" });
+
+describe("normalizeSuffixPattern", () => {
+  it("adds a leading dot when missing, leaves it alone otherwise", () => {
+    expect(normalizeSuffixPattern("lan")).toBe(".lan");
+    expect(normalizeSuffixPattern(".lan")).toBe(".lan");
+    expect(normalizeSuffixPattern("  corp.local  ")).toBe(".corp.local");
+  });
+});
+
+describe("ruleMatchesIoc", () => {
+  it("exact rule is case-insensitive", () => {
+    const r = rule({ match: "exact", pattern: "CLIENT01.LAN" });
+    expect(ruleMatchesIoc(r, ioc("domain", "client01.lan"))).toBe(true);
+    expect(ruleMatchesIoc(r, ioc("domain", "other.lan"))).toBe(false);
+  });
+  it("suffix rule matches the bare label and any subdomain, not an arbitrary substring", () => {
+    const r = rule({ match: "suffix", pattern: "lan" });
+    expect(ruleMatchesIoc(r, ioc("domain", "lan"))).toBe(true);
+    expect(ruleMatchesIoc(r, ioc("domain", "CLIENT01.lan"))).toBe(true);
+    expect(ruleMatchesIoc(r, ioc("domain", "sub.client01.lan"))).toBe(true);
+    expect(ruleMatchesIoc(r, ioc("domain", "evilan.com"))).toBe(false); // not a ".lan" suffix
+  });
+  it("regex rule matches by pattern, case-insensitively", () => {
+    const r = rule({ match: "regex", pattern: "\\.example\\.com$" });
+    expect(ruleMatchesIoc(r, ioc("domain", "PROD.EXAMPLE.COM"))).toBe(true);
+    expect(ruleMatchesIoc(r, ioc("domain", "evil.com"))).toBe(false);
+  });
+  it("honors the optional iocType restriction", () => {
+    const r = rule({ match: "exact", pattern: "client01.lan", iocType: "domain" });
+    expect(ruleMatchesIoc(r, ioc("domain", "client01.lan"))).toBe(true);
+    expect(ruleMatchesIoc(r, ioc("other", "client01.lan"))).toBe(false);
+  });
+});
+
+describe("matchIocToExclude / excludeMatches", () => {
+  const rules = [
+    rule({ id: "lan", match: "suffix", pattern: "lan" }),
+    rule({ id: "exact", match: "exact", pattern: "badsite.com", iocType: "domain" }),
+  ];
+  it("returns the first matching rule (or null)", () => {
+    expect(matchIocToExclude(ioc("domain", "client01.lan"), rules)?.id).toBe("lan");
+    expect(matchIocToExclude(ioc("domain", "badsite.com"), rules)?.id).toBe("exact");
+    expect(matchIocToExclude(ioc("domain", "fine.com"), rules)).toBeNull();
+  });
+  it("collects every matching IOC", () => {
+    const iocs = [ioc("domain", "client01.lan"), ioc("domain", "fine.com"), ioc("domain", "badsite.com")];
+    const matched = excludeMatches(iocs, rules).map((i) => i.value).sort();
+    expect(matched).toEqual(["badsite.com", "client01.lan"]);
+  });
+  it("returns nothing when there are no rules", () => {
+    expect(excludeMatches([ioc("domain", "client01.lan")], [])).toEqual([]);
+  });
+});
+
+describe("sanitizeExcludeRuleInput", () => {
+  it("accepts a valid rule and normalizes the mode/type/suffix pattern", () => {
+    expect(sanitizeExcludeRuleInput({ match: "SUFFIX", pattern: "lan", iocType: "DOMAIN", note: " internal " }))
+      .toEqual({ match: "suffix", pattern: ".lan", iocType: "domain", note: "internal" });
+  });
+  it("rejects an unknown match mode, empty pattern, bad regex", () => {
+    expect(sanitizeExcludeRuleInput({ match: "nope", pattern: "x" })).toBeNull();
+    expect(sanitizeExcludeRuleInput({ match: "exact", pattern: "  " })).toBeNull();
+    expect(sanitizeExcludeRuleInput({ match: "regex", pattern: "(" })).toBeNull();
+  });
+  it("drops an unknown iocType rather than rejecting the rule", () => {
+    expect(sanitizeExcludeRuleInput({ match: "exact", pattern: "x", iocType: "banana" }))
+      .toEqual({ match: "exact", pattern: "x" });
+  });
+});

--- a/companion/tests/analysis/siemImport.test.ts
+++ b/companion/tests/analysis/siemImport.test.ts
@@ -427,6 +427,24 @@ describe("parseSiemExport — generic (non-Windows) SIEM/EDR fallback", () => {
     expect(vals.some((v) => v.includes(".local"))).toBe(false);   // AD hostname not flooded into IOCs
   });
 
+  it("does not create a domain IOC from a STRUCTURED hostname/fqdn column when it's an internal zone (.lan/.local/etc.) — same skip the free-text scraper already applies", () => {
+    const rec = {
+      "@timestamp": "2024-05-14T14:20:09.941Z", message: "host telemetry",
+      hostname: "CLIENT01.lan", fqdn: "WIN10.corp.local",
+    };
+    const vals = parseSiemExport(JSON.stringify([rec])).iocs.map((i) => `${i.type}:${i.value}`);
+    expect(vals.some((v) => v.startsWith("domain:"))).toBe(false);
+  });
+
+  it("still creates a domain IOC from a structured hostname column for a real external domain", () => {
+    const rec = {
+      "@timestamp": "2024-05-14T14:20:09.941Z", message: "host telemetry",
+      hostname: "evil-c2.example.com",
+    };
+    const vals = parseSiemExport(JSON.stringify([rec])).iocs.map((i) => `${i.type}:${i.value}`);
+    expect(vals).toContain("domain:evil-c2.example.com");
+  });
+
   it("parses Kibana display-format timestamps (\"May 7, 2026 @ 16:31:04.000\") to UTC ISO", () => {
     const rec = { "@timestamp": "May 7, 2026 @ 16:31:04.000", host: "h", message: "x" };
     const e = parseSiemExport(JSON.stringify([rec])).events[0];

--- a/companion/tests/analysis/stateMerge.test.ts
+++ b/companion/tests/analysis/stateMerge.test.ts
@@ -131,6 +131,38 @@ describe("mergeDelta", () => {
     expect(state.iocs[0].value).toBe("DESKTOP-MNNUHHU.localdomain"); // first-seen casing wins
   });
 
+  it("drops an incoming IOC that matches a per-case exclude rule — never created, so it can't be enriched", () => {
+    const state = {
+      ...emptyState("c1"),
+      iocExcludeRules: [{ id: "r1", match: "suffix" as const, pattern: ".lan", addedAt: "2026-01-01T00:00:00Z" }],
+    };
+    const next = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [
+        { id: "i1", type: "domain", value: "CLIENT01.lan" },
+        { id: "i2", type: "ip", value: "10.0.0.5" },
+      ],
+    }, { windowSequence: 1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] });
+
+    expect(next.iocs).toHaveLength(1);
+    expect(next.iocs[0].value).toBe("10.0.0.5");
+  });
+
+  it("a finding referencing an excluded IOC's id doesn't throw — the reference just dangles harmlessly", () => {
+    const state = {
+      ...emptyState("c1"),
+      iocExcludeRules: [{ id: "r1", match: "exact" as const, pattern: "client01.lan", addedAt: "2026-01-01T00:00:00Z" }],
+    };
+    const next = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [{ id: "i1", type: "domain", value: "client01.lan" }],
+      findings: [{ id: "f1", severity: "Low", title: "t", description: "d", relatedIocs: ["i1"], mitreTechniques: [], status: "open" }],
+    }, { windowSequence: 1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] });
+
+    expect(next.iocs).toHaveLength(0);
+    expect(next.findings[0].relatedIocs).toEqual(["i1"]); // dangling id, but no crash
+  });
+
   it("assigns canonical 3-digit ids and remaps finding.relatedIocs even when the model reuses ids", () => {
     // The vision model often groups its output per-finding and emits i1/i2/i3
     // multiple times with different values. We must give each unique-value IOC

--- a/companion/tests/server/iocExcludeRoutes.test.ts
+++ b/companion/tests/server/iocExcludeRoutes.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+
+async function tmp(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "dfir-ioc-exclude-"));
+}
+
+async function harness() {
+  const root = await tmp();
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const app = createApp(store, { stateStore });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, stateStore };
+}
+
+describe("IOC exclude list routes (per-case)", () => {
+  it("starts empty, adds a rule (purging matches now), lists it, and deletes it (without restoring)", async () => {
+    const { app, stateStore } = await harness();
+    await stateStore.save({
+      ...emptyState("c1"),
+      iocs: [
+        { id: "i1", type: "domain", value: "CLIENT01.lan", firstSeen: "2026-01-01T00:00:00Z" },
+        { id: "i2", type: "domain", value: "keep.example.com", firstSeen: "2026-01-01T00:00:00Z" },
+      ],
+    });
+    expect((await request(app).get("/cases/c1/ioc-exclude")).body).toEqual([]);
+
+    const add = await request(app).post("/cases/c1/ioc-exclude").send({ match: "suffix", pattern: "lan" });
+    expect(add.status).toBe(201);
+    expect(add.body.purged).toBe(1);
+    expect(add.body.rule).toMatchObject({ match: "suffix", pattern: ".lan" });
+
+    const state = await stateStore.load("c1");
+    expect(state.iocs.map((i) => i.value)).toEqual(["keep.example.com"]);
+
+    const list = await request(app).get("/cases/c1/ioc-exclude");
+    expect(list.body).toHaveLength(1);
+
+    const del = await request(app).delete(`/cases/c1/ioc-exclude/${add.body.rule.id}`);
+    expect(del.status).toBe(200);
+    expect((await request(app).get("/cases/c1/ioc-exclude")).body).toEqual([]);
+
+    // deleting the rule does not resurrect the already-purged IOC
+    const after = await stateStore.load("c1");
+    expect(after.iocs.map((i) => i.value)).toEqual(["keep.example.com"]);
+  });
+
+  it("rejects an invalid rule (400) and a missing rule on delete (404)", async () => {
+    const { app } = await harness();
+    expect((await request(app).post("/cases/c1/ioc-exclude").send({ match: "regex", pattern: "(" })).status).toBe(400);
+    expect((await request(app).post("/cases/c1/ioc-exclude").send({ match: "bogus", pattern: "x" })).status).toBe(400);
+    expect((await request(app).delete("/cases/c1/ioc-exclude/ghost")).status).toBe(404);
+  });
+
+  it("scopes rules to the case they were added on", async () => {
+    const { app } = await harness();
+    await request(app).post("/cases").send({ caseId: "c2", name: "n", investigator: "i", aiProvider: null });
+    await request(app).post("/cases/c1/ioc-exclude").send({ match: "suffix", pattern: "lan" });
+    expect((await request(app).get("/cases/c1/ioc-exclude")).body).toHaveLength(1);
+    expect((await request(app).get("/cases/c2/ioc-exclude")).body).toEqual([]);
+  });
+
+  it("returns 501 when no state store is configured", async () => {
+    const store = new CaseStore(await tmp());
+    const app = createApp(store);
+    expect((await request(app).post("/cases/c1/ioc-exclude").send({ match: "exact", pattern: "x" })).status).toBe(501);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -6496,17 +6496,21 @@
       const statusEl = document.getElementById("status");
       statusEl.textContent = `excluding ${values.length} IOC(s)…`;
       let purged = 0;
+      let succeeded = 0;
       for (const value of values) {
         try {
           const r = await fetch(`/cases/${encodeURIComponent(caseId)}/ioc-exclude`, {
             method: "POST", headers: { "content-type": "application/json" },
             body: JSON.stringify({ match: "exact", pattern: value }),
           });
-          if (r.ok) { const j = await r.json(); purged += j.purged || 0; }
+          if (r.ok) { const j = await r.json(); purged += j.purged || 0; succeeded++; }
         } catch {}
       }
-      statusEl.textContent = `excluded ${values.length} value(s), purged ${purged} IOC(s) total`;
+      statusEl.textContent = succeeded === values.length
+        ? `excluded ${succeeded} value(s), purged ${purged} IOC(s) total`
+        : `excluded ${succeeded} of ${values.length} value(s) (${values.length - succeeded} failed), purged ${purged} IOC(s) total`;
       selectedIocs.clear();
+      if (lastState) renderIocs(lastState.iocs || []);
     }
     function bulkCopyIocs() {
       const iocById = new Map((lastState?.iocs || []).map(i => [i.id, i.value]));

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3378,7 +3378,7 @@
       </div>
     </section>
 
-    <section id="sec-iocs" style="grid-column: 1 / -1"><h2>IOCs<span id="iocFlaggedCount" style="color:var(--c-9aa4b2);font-size:12px;font-weight:normal"></span><button id="iocSignalBtn" type="button" class="active" title="Show only IOCs that are flagged (malicious/suspicious), corroborated by 2+ tools, or have enrichment data — click to show every IOC">🎯 Signal only</button><button id="iocFlaggedBtn" type="button" title="Show only IOCs with a malicious or suspicious verdict from any enrichment engine">⚠ Flagged only</button><span class="ioc-prov-filter" title="Provenance lens — how each IOC entered the case: detection-linked (appears in a graded Low+ event) vs telemetry-only (only in Info telemetry). Distinct from the threat-intel verdict."><button type="button" class="ioc-prov-btn active" data-prov="all">All IOCs</button><button type="button" class="ioc-prov-btn" data-prov="detection">Detection-linked</button><button type="button" class="ioc-prov-btn" data-prov="telemetry">Telemetry-only</button></span><label class="ioc-noise-chk" title="Hide IOCs marked as a false positive or checked against threat intel with no result"><input type="checkbox" id="iocHideNoiseChk" checked /> Hide FP/no-intel</label><label class="ioc-noise-chk" title="Hide file IOCs under well-known OS system paths (e.g. C:\Windows\System32\*.exe, C:\Windows\SysWOW64\*.exe) — display only, nothing is deleted"><input type="checkbox" id="iocHideSysPathsChk" checked /> Hide OS system paths</label><span class="src-legend" id="iocTypeLegendWrap" style="display:none" title="Show or hide IOCs by indicator type" onclick="event.stopPropagation()"><button type="button" id="iocTypeFilterBtn" class="src-filter-btn">▾ Types</button><div id="iocTypeFilterMenu" class="src-filter-menu" hidden></div></span><select class="corrob-sel" id="corrobIocs" title="Corroboration lens — show only IOCs observed by ≥N distinct tools (a lens; nothing is deleted)" onclick="event.stopPropagation()"><option value="0">⊕ any</option><option value="2">⊕ 2+ src</option><option value="3">⊕ 3+ src</option></select><button class="add-toggle" type="button" title="Add an IOC manually" aria-label="Add an IOC manually">+</button></h2>
+    <section id="sec-iocs" style="grid-column: 1 / -1"><h2>IOCs<span id="iocFlaggedCount" style="color:var(--c-9aa4b2);font-size:12px;font-weight:normal"></span><button id="iocSignalBtn" type="button" class="active" title="Show only IOCs that are flagged (malicious/suspicious), corroborated by 2+ tools, or have enrichment data — click to show every IOC">🎯 Signal only</button><button id="iocFlaggedBtn" type="button" title="Show only IOCs with a malicious or suspicious verdict from any enrichment engine">⚠ Flagged only</button><span class="ioc-prov-filter" title="Provenance lens — how each IOC entered the case: detection-linked (appears in a graded Low+ event) vs telemetry-only (only in Info telemetry). Distinct from the threat-intel verdict."><button type="button" class="ioc-prov-btn active" data-prov="all">All IOCs</button><button type="button" class="ioc-prov-btn" data-prov="detection">Detection-linked</button><button type="button" class="ioc-prov-btn" data-prov="telemetry">Telemetry-only</button></span><label class="ioc-noise-chk" title="Hide IOCs marked as a false positive or checked against threat intel with no result"><input type="checkbox" id="iocHideNoiseChk" checked /> Hide FP/no-intel</label><label class="ioc-noise-chk" title="Hide file IOCs under well-known OS system paths (e.g. C:\Windows\System32\*.exe, C:\Windows\SysWOW64\*.exe) — display only, nothing is deleted"><input type="checkbox" id="iocHideSysPathsChk" checked /> Hide OS system paths</label><span class="src-legend" id="iocTypeLegendWrap" style="display:none" title="Show or hide IOCs by indicator type" onclick="event.stopPropagation()"><button type="button" id="iocTypeFilterBtn" class="src-filter-btn">▾ Types</button><div id="iocTypeFilterMenu" class="src-filter-menu" hidden></div></span><select class="corrob-sel" id="corrobIocs" title="Corroboration lens — show only IOCs observed by ≥N distinct tools (a lens; nothing is deleted)" onclick="event.stopPropagation()"><option value="0">⊕ any</option><option value="2">⊕ 2+ src</option><option value="3">⊕ 3+ src</option></select><span class="src-legend" id="iocExcludeWrap" title="Domains/hostnames matching a rule are removed entirely from this case and never enriched (per-case, permanent — separate from the global IOC Whitelist)" onclick="event.stopPropagation()"><button type="button" id="iocExcludeBtn" class="src-filter-btn">🚫 Exclude</button><div id="iocExcludeMenu" class="src-filter-menu" hidden><div id="iocExcludeList" style="max-height:220px;overflow:auto;margin-bottom:6px"></div><form id="iocExcludeForm" onsubmit="return false" style="display:flex;gap:4px;flex-wrap:wrap;align-items:center"><select id="iocExcludeMode" title="Match mode"><option value="suffix">suffix</option><option value="exact">exact</option><option value="regex">regex</option></select><input id="iocExcludePattern" placeholder="e.g. lan" style="flex:1;min-width:110px" /><input id="iocExcludeNote" placeholder="note (optional)" style="flex:1;min-width:110px" /><button id="iocExcludeAddBtn" type="button">Add</button></form><span id="iocExcludeMsg" class="manual-msg"></span></div></span><button class="add-toggle" type="button" title="Add an IOC manually" aria-label="Add an IOC manually">+</button></h2>
       <div class="manual-add" hidden>
         <form class="manual-form" onsubmit="return false">
           <select id="miType" title="IOC type"><option value="ip">ip</option><option value="domain">domain</option><option value="hash">hash</option><option value="url">url</option><option value="file">file</option><option value="process">process</option><option value="other">other</option></select>
@@ -11393,6 +11393,7 @@
       if (!el) return;
       const iocs = sortIocsForDisplay(dedupeIocsById(iocsRaw));
       renderIocTypeFilter(iocs);
+      renderIocExcludeRules((lastState && lastState.iocExcludeRules) || []);
       const flaggedTotal = iocs.filter(iocFlagged).length;
       let visible = showFlaggedIocsOnly ? iocs.filter(iocFlagged) : iocs;
       if (searchTerm) visible = visible.filter(i => _iocMatchesSearch(i, searchTerm));
@@ -11486,6 +11487,31 @@
       const out = [...known, ...extra];
       if (present.has("other")) out.push("other");
       return out;
+    }
+
+    // Per-case IOC exclude rules — list/add/remove UI, IOCs section title bar (🚫 Exclude). Rules
+    // ride along on every pushed state (InvestigationState.iocExcludeRules), so this just re-renders
+    // off `lastState` — no separate fetch needed.
+    function renderIocExcludeRules(rules) {
+      const btn = document.getElementById("iocExcludeBtn");
+      const list = document.getElementById("iocExcludeList");
+      if (!btn || !list) return;
+      btn.classList.toggle("active", rules.length > 0);
+      btn.textContent = rules.length ? `🚫 Exclude (${rules.length})` : "🚫 Exclude";
+      if (!rules.length) {
+        list.innerHTML = "<div style='color:var(--c-9aa4b2);font-size:12px;padding:4px'>No exclude rules yet for this case.</div>";
+        return;
+      }
+      list.innerHTML = rules.map(r => {
+        const type = r.iocType ? `<span style="color:var(--c-9aa4b2)">${esc(r.iocType)}</span> ` : "";
+        const note = r.note ? ` <span style="color:var(--c-7e8aa0)">— ${esc(r.note)}</span>` : "";
+        return `<div style="display:flex;align-items:center;gap:6px;padding:2px 0;border-bottom:1px solid var(--c-1a1f28);font-size:12px">`
+          + `<span style="color:var(--c-6aa9ff);flex:0 0 46px">${esc(r.match)}</span>`
+          + `<span style="flex:1;font-family:monospace;word-break:break-all">${esc(r.pattern)}</span>`
+          + `<span style="flex:0 0 auto">${type}${note}</span>`
+          + `<button class="iex-del" data-id="${escAttr(r.id)}" title="Delete rule (does not restore already-purged IOCs)" style="background:transparent;border:1px solid var(--c-5a2a2a);color:var(--c-ff9f9f);border-radius:5px;padding:0 7px;cursor:pointer">✕</button>`
+          + `</div>`;
+      }).join("");
     }
 
     // Build/refresh the IOC-type-filter dropdown from the current (full, pre-filter) IOC list. Hidden
@@ -12018,6 +12044,48 @@
       menu.addEventListener("click", (e) => {
         if (e.target.dataset.ioctypeAll) { hiddenIocTypes.clear(); rerender(); }
         else if (e.target.dataset.ioctypeNone) { iocTypeFacets(scopedIocs()).forEach(t => hiddenIocTypes.add(t)); rerender(); }
+      });
+      document.addEventListener("click", (e) => {
+        if (!menu.hidden && !wrap.contains(e.target)) menu.hidden = true;
+      });
+    })();
+
+    // IOC exclude-rule popover — list/add/remove. Add/delete just POST/DELETE; the server pushes
+    // the updated state over the websocket (options.onState), which re-renders via render()/renderIocs()
+    // → renderIocExcludeRules(), same reactive pattern as every other case mutation in this dashboard.
+    (function () {
+      const wrap = document.getElementById("iocExcludeWrap");
+      const btn = document.getElementById("iocExcludeBtn");
+      const menu = document.getElementById("iocExcludeMenu");
+      if (!wrap || !btn || !menu) return;
+      btn.addEventListener("click", () => { menu.hidden = !menu.hidden; });
+      document.getElementById("iocExcludeAddBtn").addEventListener("click", () => {
+        const caseId = document.getElementById("caseId").value.trim();
+        const msg = document.getElementById("iocExcludeMsg");
+        const pattern = document.getElementById("iocExcludePattern").value.trim();
+        if (!caseId || !pattern) { msg.textContent = "pattern is required"; return; }
+        const body = {
+          match: document.getElementById("iocExcludeMode").value,
+          pattern,
+          note: document.getElementById("iocExcludeNote").value.trim(),
+        };
+        msg.textContent = "adding…";
+        fetch(`/cases/${encodeURIComponent(caseId)}/ioc-exclude`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) })
+          .then(async r => { const j = await r.json().catch(() => ({})); if (!r.ok) throw new Error(j.error || "HTTP " + r.status); return j; })
+          .then(j => {
+            msg.textContent = `added — purged ${j.purged} IOC${j.purged === 1 ? "" : "s"}`;
+            document.getElementById("iocExcludePattern").value = "";
+            document.getElementById("iocExcludeNote").value = "";
+            setTimeout(() => { msg.textContent = ""; }, 3000);
+          })
+          .catch(e => { msg.textContent = "failed: " + e.message; });
+      });
+      menu.addEventListener("click", (e) => {
+        const del = e.target.closest(".iex-del");
+        if (!del) return;
+        const caseId = document.getElementById("caseId").value.trim();
+        if (!caseId) return;
+        fetch(`/cases/${encodeURIComponent(caseId)}/ioc-exclude/${del.dataset.id}`, { method: "DELETE" }).catch(() => {});
       });
       document.addEventListener("click", (e) => {
         if (!menu.hidden && !wrap.contains(e.target)) menu.hidden = true;

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -12093,6 +12093,7 @@
         const msg = document.getElementById("iocExcludeMsg");
         const pattern = document.getElementById("iocExcludePattern").value.trim();
         if (!caseId || !pattern) { msg.textContent = "pattern is required"; return; }
+        if (!confirm(`Add this exclude rule?\n\nAny IOC in this case currently matching "${pattern}" (${document.getElementById("iocExcludeMode").value}) will be permanently removed and never re-imported or enriched. This cannot be undone.`)) return;
         const body = {
           match: document.getElementById("iocExcludeMode").value,
           pattern,

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3388,7 +3388,7 @@
         </form>
       </div>
       <div id="iocImportMeta" class="synth-meta" style="display:none"></div>
-      <div class="ioc-bulk-bar" id="iocBulkBar"><span id="iocBulkCount" style="font-weight:600;color:var(--c-6aa9ff)"></span> <span>Actions:</span> <button class="ioc-bulk-btn" id="iocBulkEnrichBtn" title="Enrich selected IOCs against enabled threat-intel providers">🔬 Enrich</button> <button class="ioc-bulk-btn" id="iocBulkTagBtn" title="Add a tag to all selected IOCs">🏷 Tag</button> <button class="ioc-bulk-btn" id="iocBulkFpBtn" title="Mark selected IOCs as a false positive (exclude from analysis)">🚫 Mark False Positive</button> <button class="ioc-bulk-btn" id="iocBulkCopyBtn" title="Copy selected IOC values to clipboard (one per line)">📋 Copy</button> <button class="ioc-bulk-btn" id="iocBulkClearBtn" style="color:var(--c-9aa4b2)">✕ Clear</button></div>
+      <div class="ioc-bulk-bar" id="iocBulkBar"><span id="iocBulkCount" style="font-weight:600;color:var(--c-6aa9ff)"></span> <span>Actions:</span> <button class="ioc-bulk-btn" id="iocBulkEnrichBtn" title="Enrich selected IOCs against enabled threat-intel providers">🔬 Enrich</button> <button class="ioc-bulk-btn" id="iocBulkTagBtn" title="Add a tag to all selected IOCs">🏷 Tag</button> <button class="ioc-bulk-btn" id="iocBulkFpBtn" title="Mark selected IOCs as a false positive (exclude from analysis)">🚫 Mark False Positive</button> <button class="ioc-bulk-btn" id="iocBulkExcludeBtn" title="Permanently exclude the selected IOC value(s) from this case — removed now, never re-imported or re-enriched (per-case, not reversible)">🗑 Exclude</button> <button class="ioc-bulk-btn" id="iocBulkCopyBtn" title="Copy selected IOC values to clipboard (one per line)">📋 Copy</button> <button class="ioc-bulk-btn" id="iocBulkClearBtn" style="color:var(--c-9aa4b2)">✕ Clear</button></div>
       <div id="iocs">—</div></section>
     <section id="sec-exposure" style="grid-column: 1 / -1"><h2>Customer Exposure</h2>
       <div class="ce-body">
@@ -6482,6 +6482,31 @@
         selectedFindings.clear();
         if (lastState) render(lastState);
       });
+    }
+    // One-click exclude for the offending IOC rows the analyst already has selected: adds an
+    // exact-match exclude rule per selected value (one POST per value — mirrors how bulk mark-FP
+    // has no dedicated batch route either). The server purges + pushes updated state per call.
+    async function bulkExcludeIocs() {
+      const caseId = document.getElementById("caseId").value.trim();
+      if (!caseId || !selectedIocs.size) return;
+      const iocById = new Map((lastState?.iocs || []).map(i => [i.id, i.value]));
+      const values = [...selectedIocs].map(id => iocById.get(id)).filter(Boolean);
+      if (!values.length) return;
+      if (!confirm(`Permanently exclude ${values.length} IOC value(s) from this case?\n\nThey are removed now and will never be re-imported or enriched. This cannot be undone (deleting the exclude rule later will not bring them back).`)) return;
+      const statusEl = document.getElementById("status");
+      statusEl.textContent = `excluding ${values.length} IOC(s)…`;
+      let purged = 0;
+      for (const value of values) {
+        try {
+          const r = await fetch(`/cases/${encodeURIComponent(caseId)}/ioc-exclude`, {
+            method: "POST", headers: { "content-type": "application/json" },
+            body: JSON.stringify({ match: "exact", pattern: value }),
+          });
+          if (r.ok) { const j = await r.json(); purged += j.purged || 0; }
+        } catch {}
+      }
+      statusEl.textContent = `excluded ${values.length} value(s), purged ${purged} IOC(s) total`;
+      selectedIocs.clear();
     }
     function bulkCopyIocs() {
       const iocById = new Map((lastState?.iocs || []).map(i => [i.id, i.value]));
@@ -12855,6 +12880,7 @@
       if (e.target.id === "iocBulkEnrichBtn") { bulkEnrichIocs(); return; }
       if (e.target.id === "iocBulkTagBtn") { bulkTagIocs(); return; }
       if (e.target.id === "iocBulkFpBtn") { bulkMarkIocsFalsePositive(); return; }
+      if (e.target.id === "iocBulkExcludeBtn") { bulkExcludeIocs(); return; }
       if (e.target.id === "iocBulkCopyBtn") { bulkCopyIocs(); return; }
       if (e.target.id === "iocBulkClearBtn") { clearIocSelection(); return; }
       // Bulk action bar buttons (Findings)


### PR DESCRIPTION
## Summary
- New per-case IOC exclude list: exact/suffix/regex rules that permanently remove matching IOCs (e.g. client hostnames like `*.lan`) from a case — purged immediately on add, and never re-created by future imports or AI synthesis, so excluded values can never reach threat-intel enrichment.
- Root-cause fix: structured `hostname`/`fqdn`/`domain` columns (e.g. a JSON/CSV field literally named `Hostname`) now skip internal zones (`.lan`/`.local`/`.corp`/etc.) the same way free-text scraping already did — closes most of the reported noise even with zero configuration.
- New `GET/POST/DELETE /cases/:id/ioc-exclude` routes; new "🚫 Exclude" popover in the IOCs panel title bar (list/add/remove rules, each add shows a confirm dialog and reports how many IOCs it purged); a one-click bulk "🗑 Exclude" button for selected IOC rows.
- Deliberately separate from the existing global, reversible IOC Whitelist — this new mechanism is per-case and permanent by design.

## Test plan
- [x] `cd companion && npx tsc --noEmit` — clean
- [x] `cd companion && npx vitest run` — 282 files / 3194 tests passing (one pre-existing unrelated OCR-indexing test flaked under full-parallel load, confirmed passing 7/7 in isolation)
- [x] Manual end-to-end verification in a real browser against a running dev server: added a `.lan` domain IOC, added a `suffix` rule, confirmed immediate purge; imported a SIEM record with an internal-zone hostname and confirmed no IOC was created; added a custom rule for a non-hardcoded domain and confirmed both existing-IOC purge and future-import filtering; deleted a rule and confirmed the purged IOC did not return; used the bulk-exclude button and confirmed correct behavior with no stale UI state; checked browser console and server logs for errors — none found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)