### PR TITLE
fix: back-link gap-coverage findings so case scope changes hide them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Timesketch export (Super Timeline)** — push or download the full super-timeline (forensic timeline + raw host-triage artifacts) to/from Timesketch, alongside the existing Timesketch export (Forensic Timeline); both existing options were relabeled for clarity and both push into the same sketch under separate timelines so neither clobbers the other.
 
 ### Fixed
+- **Timeline coverage-gap findings survived a case scope change** — they were never back-linked to the two events bounding the silence, so the dashboard's client-side scope filter (which drops a finding only when it's provably backed by out-of-scope events) could never tell a gap finding was out of scope and kept showing it, however far outside the analyst's chosen window, until the next full AI re-synthesis. Gap findings are now linked to their bounding events like every other backfilled finding.
 - **Structured hostname/fqdn/domain columns** (e.g. a JSON/CSV field literally named `Hostname`) now skip internal zones (`.lan`/`.local`/`.corp`/etc.) the same way free-text scraping already did, instead of creating a domain IOC for every client hostname.
 - **Cited-event badges (`[1]`, `[2]`…) couldn't be right-clicked to open in a new tab/window** — they now carry a real deep link (`?caseId=...#event=...`), so right-click/middle-click/Ctrl-click all work; opening the link reloads the case and jumps straight to the cited event.
 

--- a/companion/src/analysis/gapDetect.ts
+++ b/companion/src/analysis/gapDetect.ts
@@ -376,6 +376,12 @@ export function backfillSilenceGapFindings(
   const cap = Math.max(0, Math.floor(maxFindings));
   const existingIds = new Set(state.findings.map((f) => f.id));
   const newFindings: Finding[] = [];
+  // Back-link each gap finding to the two events that bound it, mirroring backfillHighSeverityFindings.
+  // Without this, the dashboard's client-side scope projection (which drops a finding only when it's
+  // backed EXCLUSIVELY by out-of-scope events, keeping anything unlinked under "can't prove out of
+  // scope") can never identify a gap finding as out of scope — it would survive every scope change
+  // until the next AI re-synthesis, however far outside the analyst's chosen window it falls.
+  const linkByEvent = new Map<string, string[]>();
   // `gaps` is sorted worst-first, so the complete gaps stream out longest-first — keep the worst `cap`.
   for (const gap of gaps) {
     if (!gap.complete) continue;
@@ -406,7 +412,20 @@ export function backfillSilenceGapFindings(
       lastUpdated: timestamp,
       status: "open",
     });
+    for (const eid of [gap.beforeEventId, gap.afterEventId]) {
+      const arr = linkByEvent.get(eid) ?? [];
+      arr.push(id);
+      linkByEvent.set(eid, arr);
+    }
   }
   if (newFindings.length === 0) return state;
-  return { ...state, findings: [...state.findings, ...newFindings] };
+  return {
+    ...state,
+    findings: [...state.findings, ...newFindings],
+    forensicTimeline: state.forensicTimeline.map((e) =>
+      linkByEvent.has(e.id)
+        ? { ...e, relatedFindingIds: [...e.relatedFindingIds, ...linkByEvent.get(e.id)!] }
+        : e,
+    ),
+  };
 }

--- a/companion/tests/analysis/gapDetect.test.ts
+++ b/companion/tests/analysis/gapDetect.test.ts
@@ -235,6 +235,24 @@ describe("backfillSilenceGapFindings", () => {
     expect(f.id).toBe("f-gap-a9-b0");
   });
 
+  it("back-links the finding onto its bounding events, so scope filtering can identify it as out of scope", () => {
+    // Same as the previous test, but this time the state carries the actual timeline (the way the
+    // pipeline calls it), so relatedFindingIds on the bounding events can be asserted.
+    const before = series("a", "EventLog", "2026-05-20T08:00:00Z", 60, 10);
+    const after = series("b", "EventLog", "2026-05-20T10:09:00Z", 60, 5);
+    const timeline = [...before, ...after];
+    const gaps = detectTimelineGaps(timeline);
+    const state: InvestigationState = { ...emptyState("c1"), forensicTimeline: timeline };
+    const next = backfillSilenceGapFindings(state, gaps, "2026-05-20T12:00:00Z");
+    const findingId = next.findings[0].id;
+    const beforeEvent = next.forensicTimeline.find((e) => e.id === "a9")!;
+    const afterEvent = next.forensicTimeline.find((e) => e.id === "b0")!;
+    expect(beforeEvent.relatedFindingIds).toContain(findingId);
+    expect(afterEvent.relatedFindingIds).toContain(findingId);
+    // Unrelated events elsewhere on the timeline are untouched.
+    expect(next.forensicTimeline.find((e) => e.id === "a0")!.relatedFindingIds).toEqual([]);
+  });
+
   it("is idempotent — re-running over the same gaps does not duplicate findings", () => {
     const before = series("a", "EventLog", "2026-05-20T08:00:00Z", 60, 10);
     const after = series("b", "EventLog", "2026-05-20T10:09:00Z", 60, 5);


### PR DESCRIPTION
## Summary
- Timeline coverage-gap findings (`Timeline coverage gap: ... complete silence`) were appended to case state without ever linking back to the two events bounding the gap.
- The dashboard's client-side scope filter only drops a finding when it can prove it's backed exclusively by out-of-scope events; with no backlink, gap findings always fell into the safe "can't prove out of scope, keep" default — so they kept showing after a case scope change (e.g. scoping a case to "since May 2026" still showed 2000s-era coverage-gap findings) until the next full AI re-synthesis rebuilt the timeline links from scratch.
- `backfillSilenceGapFindings` now links each gap finding onto its `beforeEventId`/`afterEventId`, mirroring the existing pattern in `backfillHighSeverityFindings`.

## Test plan
- [x] `gapDetect.test.ts` — added a test asserting the bounding events carry `relatedFindingIds` back to the gap finding; all 23 tests pass
- [x] `pipeline.test.ts` (27 tests), `scope.test.ts`, `knownUnknowns.test.ts` — all pass
- [x] `tsc --noEmit` clean