### PR TITLE
fix: surface real network cause behind Timesketch fetch failed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Timeline coverage-gap findings survived a case scope change** — they were never back-linked to the two events bounding the silence, so the dashboard's client-side scope filter (which drops a finding only when it's provably backed by out-of-scope events) could never tell a gap finding was out of scope and kept showing it, however far outside the analyst's chosen window, until the next full AI re-synthesis. Gap findings are now linked to their bounding events like every other backfilled finding.
 - **Structured hostname/fqdn/domain columns** (e.g. a JSON/CSV field literally named `Hostname`) now skip internal zones (`.lan`/`.local`/`.corp`/etc.) the same way free-text scraping already did, instead of creating a domain IOC for every client hostname.
 - **Cited-event badges (`[1]`, `[2]`…) couldn't be right-clicked to open in a new tab/window** — they now carry a real deep link (`?caseId=...#event=...`), so right-click/middle-click/Ctrl-click all work; opening the link reloads the case and jumps straight to the cited event.
+- **Timesketch push failures logged an unhelpful bare `fetch failed`** — Node's `fetch()` hides the real network reason (e.g. `ECONNREFUSED`, `ENOTFOUND`, a TLS error) behind a generic message; the Timesketch client now walks the error's `.cause` chain so the actual reason is surfaced in the log and API response.
 
 ## [0.30.0] - 2026-07-07
 

--- a/companion/src/integrations/timesketch/timesketchClient.ts
+++ b/companion/src/integrations/timesketch/timesketchClient.ts
@@ -57,6 +57,23 @@ function firstObject(json: unknown): Record<string, unknown> | undefined {
   return objectList(json)[0];
 }
 
+// Node's fetch() throws a generic `TypeError: fetch failed` for every low-level network
+// failure (connection refused, DNS lookup failure, TLS error, timeout) — the actual reason
+// lives in `.cause` (an errno-style error with a `.code` like ECONNREFUSED/ENOTFOUND/
+// CERT_HAS_EXPIRED), which is easy to lose if only `.message` is read. Walk the cause chain
+// so the real reason reaches the user instead of a bare "fetch failed".
+export function describeFetchError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const parts: string[] = [err.message];
+  let cause: unknown = (err as { cause?: unknown }).cause;
+  while (cause instanceof Error) {
+    const code = (cause as NodeJS.ErrnoException).code;
+    parts.push(code ? `${cause.message} (${code})` : cause.message);
+    cause = (cause as { cause?: unknown }).cause;
+  }
+  return parts.join(" -> ");
+}
+
 interface SendOptions {
   body?: BodyInit;
   json?: unknown;
@@ -115,7 +132,7 @@ export class TimesketchClient {
         signal: AbortSignal.timeout(this.timeoutMs),
       } as RequestInit);
     } catch (err) {
-      throw new TimesketchApiError(`Timesketch request failed: ${(err as Error).message}`, 0, "network");
+      throw new TimesketchApiError(`Timesketch request failed: ${describeFetchError(err)}`, 0, "network");
     }
     this.ingestCookies(res);
     return res;

--- a/companion/tests/integrations/timesketch.test.ts
+++ b/companion/tests/integrations/timesketch.test.ts
@@ -3,7 +3,7 @@ import {
   timesketchDate, mapForensicEvent, toTimesketchEvents, toTimesketchJsonl,
   toTimesketchEventsFromList, toTimesketchJsonlFromList,
 } from "../../src/integrations/timesketch/timesketchMap.js";
-import { scrapeCsrfToken } from "../../src/integrations/timesketch/timesketchClient.js";
+import { scrapeCsrfToken, describeFetchError, TimesketchClient } from "../../src/integrations/timesketch/timesketchClient.js";
 import {
   pushCaseToTimesketch, pushSuperTimelineToTimesketch, type TimesketchClientLike,
 } from "../../src/integrations/timesketch/timesketchPush.js";
@@ -92,6 +92,37 @@ describe("scrapeCsrfToken", () => {
     expect(scrapeCsrfToken('<input id="csrf_token" name="csrf_token" type="hidden" value="abc123">')).toBe("abc123");
     expect(scrapeCsrfToken('<meta name="csrf-token" content="meta-tok">')).toBe("meta-tok");
     expect(scrapeCsrfToken("<html>no token here</html>")).toBeUndefined();
+  });
+});
+
+describe("describeFetchError", () => {
+  it("walks the cause chain so an errno code isn't lost behind Node's generic 'fetch failed'", () => {
+    const errno = Object.assign(new Error("connect ECONNREFUSED 10.0.0.2:5000"), { code: "ECONNREFUSED" });
+    const fetchFailed = new TypeError("fetch failed", { cause: errno });
+    expect(describeFetchError(fetchFailed)).toBe("fetch failed -> connect ECONNREFUSED 10.0.0.2:5000 (ECONNREFUSED)");
+  });
+
+  it("passes through a plain error message when there is no cause", () => {
+    expect(describeFetchError(new Error("boom"))).toBe("boom");
+  });
+
+  it("stringifies non-Error throws", () => {
+    expect(describeFetchError("not an error")).toBe("not an error");
+  });
+});
+
+describe("TimesketchClient network failure", () => {
+  it("surfaces the underlying cause instead of a bare 'fetch failed'", async () => {
+    const errno = Object.assign(new Error("connect ECONNREFUSED 10.0.0.2:5000"), { code: "ECONNREFUSED" });
+    const client = new TimesketchClient({
+      baseUrl: "https://10.0.0.2:5000",
+      username: "u",
+      password: "p",
+      fetchFn: async () => { throw new TypeError("fetch failed", { cause: errno }); },
+    });
+    await expect(client.login()).rejects.toThrow(
+      "Timesketch request failed: fetch failed -> connect ECONNREFUSED 10.0.0.2:5000 (ECONNREFUSED)",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Node's `fetch()` throws a generic `TypeError: fetch failed` for any low-level network failure (connection refused, DNS failure, TLS error, timeout), hiding the real reason in `err.cause`.
- `TimesketchClient` only read `err.message`, so both the push-to-Timesketch flow and the Settings "Test connection" / reconnect button logged/displayed an undiagnosable bare `fetch failed`.
- Added `describeFetchError()` to walk the cause chain (including errno `.code` like `ECONNREFUSED`/`ENOTFOUND`) and wired it into the client's request error path, so `login()`, pushes, and the Settings reconnect test all now surface the actual reason.

## Test plan
- [x] `npx vitest run tests/integrations/timesketch.test.ts tests/integrations/timesketchClient.integration.test.ts` — 20/20 passing (4 new tests covering the cause-chain walk and the client's network-failure path)
- [x] `tsc --noEmit` clean