### PR TITLE
fix: save unsaved Integrations-tab edits before reconnecting

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2168,7 +2168,7 @@
           <div class="sfield"><label>Skip TLS verify<span class="sfield-hint">DFIR_IRIS_INSECURE — true to accept self-signed certs (lab only)</span></label><input id="env-DFIR_IRIS_INSECURE" placeholder="false" /></div>
         </div>
         <div style="display:flex; gap:8px; align-items:center; margin-top:4px;">
-          <button id="irisReconnectBtn" type="button" data-tip="Re-read the IRIS settings from .env, rebuild the client, and test the connection — applies a saved URL/key (or IRIS coming back online) WITHOUT restarting the server. Save settings first.">Test / reconnect</button>
+          <button id="irisReconnectBtn" type="button" data-tip="Saves any edits above, re-reads the IRIS settings, rebuilds the client, and tests the connection — applies WITHOUT restarting the server.">Test / reconnect</button>
           <span id="irisReconnectMsg" style="font-size:12px; color:var(--c-9aa4b2);"></span>
         </div>
         <div class="settings-group-head">Timesketch</div>
@@ -6991,12 +6991,20 @@
         .catch(e => { if (msg) msg.textContent = "error: " + e.message; })
         .finally(() => { if (btn) btn.disabled = false; });
     }
-    // Re-read .env, rebuild the Velociraptor client, and refresh the inventory (the reachability probe).
-    // Works even when the API wasn't configured at boot or the server was down — no companion restart.
-    function doVeloReconnect() {
+    // Save any unsaved field edits, then re-read .env, rebuild the Velociraptor client, and refresh
+    // the inventory (the reachability probe). Works even when the API wasn't configured at boot or
+    // the server was down — no companion restart.
+    async function doVeloReconnect() {
       const btn = document.getElementById("veloReconnectBtn");
       const msg = document.getElementById("veloClientsMsg");
       if (btn) btn.disabled = true;
+      if (msg) msg.textContent = "saving…";
+      const saved = await saveSettings();
+      if (!saved) {
+        if (msg) msg.textContent = "save failed — fix the error above and retry";
+        if (btn) btn.disabled = false;
+        return;
+      }
       if (msg) msg.textContent = "reconnecting to the Velociraptor server…";
       fetch("/velociraptor/reconnect", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
         .then(r => r.json().then(j => ({ ok: r.ok, j })))
@@ -7005,7 +7013,7 @@
           // Reflect the (possibly newly) configured client across the velo UI without a page reload.
           veloEnabled = !!j.configured;
           applyVeloEnabled();
-          if (!j.configured) { if (msg) msg.textContent = "Velociraptor API not configured — set the API config path on the Integrations tab, Save, then Reconnect"; return; }
+          if (!j.configured) { if (msg) msg.textContent = "Velociraptor API not configured — set the API config path on the Integrations tab and reconnect"; return; }
           if (!j.ok) { if (msg) msg.textContent = "⚠ configured but unreachable: " + (j.error || "the Velociraptor server is not responding"); return; }
           if (msg) msg.textContent = `✓ connected — ${j.clients || 0} enrolled client(s)`;
           loadVeloClients();
@@ -14100,13 +14108,22 @@
         .finally(() => { btn.disabled = false; });
     };
 
-    // Settings → DFIR-IRIS "Test / reconnect": re-read .env, rebuild the client, ping. Applies a
-    // saved URL/key (or IRIS coming back online) without the #1-gotcha restart.
+    // Settings → DFIR-IRIS "Test / reconnect": save any unsaved field edits first, then re-read
+    // .env, rebuild the client, and ping. Applies a saved URL/key (or IRIS coming back online)
+    // without the #1-gotcha restart.
     const irisReconnectBtn = document.getElementById("irisReconnectBtn");
-    if (irisReconnectBtn) irisReconnectBtn.onclick = () => {
+    if (irisReconnectBtn) irisReconnectBtn.onclick = async () => {
       const msg = document.getElementById("irisReconnectMsg");
       irisReconnectBtn.disabled = true;
       msg.style.color = "var(--c-9aa4b2)";
+      msg.textContent = "saving…";
+      const saved = await saveSettings();
+      if (!saved) {
+        msg.style.color = "var(--c-f87171, #f87171)";
+        msg.textContent = "save failed — fix the error above and retry";
+        irisReconnectBtn.disabled = false;
+        return;
+      }
       msg.textContent = "reconnecting…";
       fetch("/iris/reconnect", { method: "POST" })
         .then(async (r) => { const j = await r.json().catch(() => ({})); if (!r.ok) throw new Error(j.error || ("HTTP " + r.status)); return j; })
@@ -14120,7 +14137,7 @@
             msg.textContent = "✗ configured but unreachable: " + (res.error || "ping failed");
           } else {
             msg.style.color = "var(--c-9aa4b2)";
-            msg.textContent = "not configured — set IRIS URL + key above, Save, then reconnect";
+            msg.textContent = "not configured — set IRIS URL + key above and reconnect";
           }
         })
         .catch((err) => { msg.style.color = "var(--c-f87171, #f87171)"; msg.textContent = "reconnect failed: " + err.message; })
@@ -14632,6 +14649,7 @@
       });
       const msg = document.getElementById("settingsSaveMsg");
       msg.textContent = "";
+      let ok = true;
       if (Object.keys(updates).length > 0) {
         try {
           const r = await fetch("/settings/env", {
@@ -14646,16 +14664,19 @@
             const j = await r.json().catch(() => ({}));
             msg.textContent = "Error: " + (j.error || r.status);
             msg.style.color = "#ff7a7a";
+            ok = false;
           }
         } catch {
           msg.textContent = "Could not reach server";
           msg.style.color = "#ff7a7a";
+          ok = false;
         }
       } else {
         msg.textContent = "✓ Saved";
         msg.style.color = "#5fd470";
       }
       setTimeout(() => { if (msg) msg.textContent = ""; }, 5000);
+      return ok;
     }
 
     function openSettingsModal() {
@@ -15904,8 +15925,14 @@
         if (msg) msg.textContent = ok ? `${toolId}: ${(j.output || "updated").slice(0, 200)}` : (j.error || "update failed") + " — restart the companion server if this 404s";
       }).catch(e => { if (btn) { btn.disabled = false; btn.textContent = "↻ Update rules"; } if (msg) msg.textContent = "update failed: " + e.message; });
     }
-    document.getElementById("toolsReconnectBtn").onclick = () => {
+    document.getElementById("toolsReconnectBtn").onclick = async () => {
       const msg = document.getElementById("toolsMsg");
+      if (msg) msg.textContent = "saving…";
+      const saved = await saveSettings();
+      if (!saved) {
+        if (msg) msg.textContent = "save failed — fix the error above and retry";
+        return;
+      }
       if (msg) msg.textContent = "applying…";
       fetch("/tools/reconnect", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
         .then(r => r.json()).then(j => { if (msg) msg.textContent = j.ok ? `applied — ${(j.configured || []).length} tool(s) configured` : (j.error || "reconnect failed"); loadTools(); })


### PR DESCRIPTION
## Summary
- The IRIS, Velociraptor, and Tools "Test / reconnect" buttons in Settings → Integrations tested the connection using whatever was already saved to `.env`, ignoring any edits typed into the form but not yet saved — you had to manually click Save, watch it fail, then click Save, then Reconnect.
- `saveSettings()` now returns a success/failure boolean, and all three reconnect handlers `await saveSettings()` before pinging the service. Stale "Save, then Reconnect" UI copy was updated to match.

## Test plan
- [x] Verified live via the dashboard preview: filled in a new `DFIR_IRIS_KEY`, clicked "Test / reconnect", and confirmed network order `POST /settings/env` (200) → `POST /iris/reconnect` (200), with the new key persisted to `.env` automatically before the reconnect fired.
- [ ] Manually re-verify Velociraptor and Tools reconnect buttons in a live environment with real credentials.