### PR TITLE
fix: remove Linux.Detection.Yara.Glob from Linux Triage bundle

### DIFF
--- a/companion/src/analysis/artifactBundleStore.ts
+++ b/companion/src/analysis/artifactBundleStore.ts
@@ -208,7 +208,6 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
       "Linux.Detection.BruteForce",
       "Linux.Detection.IncorrectPermissions",
       "Linux.Detection.SSHKeyFileCmd",
-      "Linux.Detection.Yara.Glob",
       "Linux.Detection.Yara.Process",
       "Linux.Forensics.EnvironmentVariables",
       "Linux.Forensics.ImmutableFiles",


### PR DESCRIPTION
## Summary
- Remove `Linux.Detection.Yara.Glob` from the built-in **Linux Triage** bundle (`linux-triage` in `artifactBundleStore.ts`).

## Test plan
- [x] Manual diff review — single-line removal, no logic touched