### PR TITLE
fix: show "stopped or deleted" instead of "collect again later" for a removed Velociraptor hunt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Structured hostname/fqdn/domain columns** (e.g. a JSON/CSV field literally named `Hostname`) now skip internal zones (`.lan`/`.local`/`.corp`/etc.) the same way free-text scraping already did, instead of creating a domain IOC for every client hostname.
 - **Cited-event badges (`[1]`, `[2]`…) couldn't be right-clicked to open in a new tab/window** — they now carry a real deep link (`?caseId=...#event=...`), so right-click/middle-click/Ctrl-click all work; opening the link reloads the case and jumps straight to the cited event.
 - **Timesketch push failures logged an unhelpful bare `fetch failed`** — Node's `fetch()` hides the real network reason (e.g. `ECONNREFUSED`, `ENOTFOUND`, a TLS error) behind a generic message; the Timesketch client now walks the error's `.cause` chain so the actual reason is surfaced in the log and API response.
+- **A hunt deleted in Velociraptor kept showing "no new results collected yet — collect again later"** instead of saying so — deleting a hunt in the Velociraptor GUI doesn't remove it from `hunts()`, it just reports `STOPPED`, identical to a hunt that finished naturally. The collector now compares that state against the hunt's own scheduled `expires`: a terminal state reported well before expiry is flagged `stoppedEarly` and the dashboard shows "this hunt was stopped before its scheduled expiry in Velociraptor — likely stopped or deleted" instead of implying a retry will help.
 
 ## [0.30.0] - 2026-07-07
 

--- a/companion/src/analysis/veloHuntStore.ts
+++ b/companion/src/analysis/veloHuntStore.ts
@@ -35,6 +35,12 @@ export interface VeloHuntJob {
   expirySeconds?: number;     // relative hunt expiry used at launch (seconds); default one hour
   filters?: Record<string, string>;   // per-artifact VQL WHERE filters snapshotted from the bundle (applied at collect)
   error?: string;
+  // Set at collect time when Velociraptor reported this hunt terminal (STOPPED/ARCHIVED) well before
+  // its own scheduled expiry — a strong signal an analyst stopped or deleted it in Velociraptor rather
+  // than it running to natural completion (see isHuntStoppedEarly). Lets the UI say so instead of the
+  // generic "no new results collected yet — collect again later", which is misleading for a hunt that
+  // will never produce anything again.
+  stoppedEarly?: boolean;
   importedAt?: string;    // ISO — when results were collected + imported
   importFile?: string;    // stored evidence filename
   addedEvents?: number;

--- a/companion/src/integrations/velociraptor/huntStatusPoller.ts
+++ b/companion/src/integrations/velociraptor/huntStatusPoller.ts
@@ -10,8 +10,8 @@ import type { VeloHuntJob, VeloHuntStatus } from "../../analysis/veloHuntStore.j
 // hunt at all (deleted) rather than an empty-state object. A present-but-unrecognized state string
 // (state-vocabulary drift — a future Velociraptor version, a typo) is NOT rejected: it's treated as
 // "still running" (logged, not silently absorbed) so an operator can spot it without the poller itself
-// getting stuck.
-export type HuntStateReader = (huntId: string) => Promise<{ state: string } | null>;
+// getting stuck. `expires` (ISO) is the hunt's own scheduled end — see isHuntStoppedEarly().
+export type HuntStateReader = (huntId: string) => Promise<{ state: string; expires?: string } | null>;
 
 export interface HuntPollDeps {
   getState: HuntStateReader;
@@ -29,6 +29,25 @@ const TERMINAL_STATUSES: readonly VeloHuntStatus[] = ["collecting", "imported", 
 
 // Velociraptor hunt states that mean "done collecting, ready to import" (case-insensitive).
 const DONE_STATES = new Set(["STOPPED", "ARCHIVED"]);
+
+// Absorbs Velociraptor's own housekeeping lag around a hunt's expiry boundary (its background sweep
+// that flips RUNNING → STOPPED at expiry isn't instant) so a hunt that finished naturally a few
+// seconds ago isn't misread as "stopped early".
+const EARLY_STOP_GRACE_MS = 60_000;
+
+// Deleting a hunt from the Velociraptor GUI does NOT remove it from hunts() (confirmed against a live
+// server) — it just leaves it STOPPED, identical to a hunt that ran to natural completion. The one
+// signal Velociraptor still exposes is the hunt's own `expires`: natural completion lands AT (or just
+// after) that time; a hunt an analyst stopped or deleted partway through reports terminal well BEFORE
+// it. Used at collect time (not inside pollHuntStatusOnce) so every entry point — the status poller,
+// the fixed-delay auto-collect timer, and a manual "Collect now" — gets the same signal.
+export function isHuntStoppedEarly(result: { state: string; expires?: string } | null, nowMs: number, graceMs: number = EARLY_STOP_GRACE_MS): boolean {
+  if (!result || !result.expires) return false;
+  if (!DONE_STATES.has(result.state.toUpperCase())) return false;
+  const expiresMs = new Date(result.expires).getTime();
+  if (!Number.isFinite(expiresMs)) return false;
+  return nowMs < expiresMs - graceMs;
+}
 
 // One poll cycle. NEVER throws: a getState failure is captured into the returned job's status
 // ("unreachable") + logged, and polling continues (transient — a network blip or a Velociraptor

--- a/companion/src/integrations/velociraptor/velociraptorApi.ts
+++ b/companion/src/integrations/velociraptor/velociraptorApi.ts
@@ -691,14 +691,19 @@ export class VelociraptorClient {
   // The hunt's own state (issue: 30s status polling) — is it still RUNNING, PAUSED, STOPPED, or
   // ARCHIVED, or has it been deleted entirely in Velociraptor? Mirrors flowStatus() but queries the
   // hunts() plugin by hunt_id instead of flows() by session_id. Returns null when Velociraptor has no
-  // record of the hunt at all (deleted) rather than an empty-state object, so callers can tell
-  // "gone" apart from "state field came back blank".
-  async huntStatus(huntId: string): Promise<{ state: string } | null> {
+  // record of the hunt at all rather than an empty-state object, so callers can tell "gone" apart from
+  // "state field came back blank" — though in practice a hunt DELETED from the Velociraptor GUI still
+  // shows up here as ordinary STOPPED (confirmed against a live server); it does not disappear from
+  // hunts(). `expires` (the hunt's own scheduled end, converted from Velociraptor's microsecond epoch
+  // to ISO) lets a caller tell that apart from natural completion — see isHuntStoppedEarly().
+  async huntStatus(huntId: string): Promise<{ state: string; expires?: string } | null> {
     if (!HUNT_RE.test(huntId)) throw new Error("invalid hunt id");
-    const rows = await this.runRaw(`SELECT state FROM hunts() WHERE hunt_id='${huntId}' LIMIT 1`);
+    const rows = await this.runRaw(`SELECT state, expires FROM hunts() WHERE hunt_id='${huntId}' LIMIT 1`);
     if (!rows.length) return null;
-    const r = (rows[0] ?? {}) as { state?: unknown };
-    return { state: String(r.state ?? "").trim() };
+    const r = (rows[0] ?? {}) as { state?: unknown; expires?: unknown };
+    const expiresMicros = Number(r.expires);
+    const expires = Number.isFinite(expiresMicros) && expiresMicros > 0 ? new Date(expiresMicros / 1000).toISOString() : undefined;
+    return { state: String(r.state ?? "").trim(), ...(expires ? { expires } : {}) };
   }
 
   // The artifacts an EXTERNAL hunt collected — so the Companion can read the results of a hunt it did

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -190,7 +190,7 @@ import { VelociraptorClientStore } from "./analysis/velociraptorClientStore.js";
 import { VeloHuntStore, type VeloHuntJob } from "./analysis/veloHuntStore.js";
 import { VeloMonitorStore, monitorId, type VeloMonitor } from "./analysis/veloMonitorStore.js";
 import { pollMonitorOnce, monitorArtifactMap, type PollDeps } from "./integrations/velociraptor/monitorPoller.js";
-import { pollHuntStatusOnce, type HuntPollDeps } from "./integrations/velociraptor/huntStatusPoller.js";
+import { pollHuntStatusOnce, isHuntStoppedEarly, type HuntPollDeps } from "./integrations/velociraptor/huntStatusPoller.js";
 import { PushTokenStore, generatePushToken } from "./analysis/pushTokenStore.js";
 import { resolvePushAuth } from "./analysis/pushAuth.js";
 import { extractPushPayload } from "./analysis/pushPayload.js";
@@ -3425,7 +3425,15 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     if (!job) return;
     if (job.status === "collecting") return;   // a collection of this hunt is already in flight
     try {
-      job = { ...job, status: "collecting" };
+      // A last live check right before collecting: was this hunt stopped/deleted in Velociraptor well
+      // before its own scheduled expiry? Checked HERE (not just in the status poller) so every entry
+      // point — the poller, the fixed-delay auto-collect timer, and a manual "Collect now" — gets the
+      // same signal. Best-effort: a failed check must not block the collect itself.
+      let stoppedEarly = job.stoppedEarly === true;
+      if (!stoppedEarly) {
+        try { stoppedEarly = isHuntStoppedEarly(await client.huntStatus(job.huntId), Date.now()); } catch { /* best-effort */ }
+      }
+      job = { ...job, status: "collecting", ...(stoppedEarly ? { stoppedEarly: true } : {}) };
       await huntStore.upsert(caseId, job);
       options.onVeloHunt?.(caseId);
       const minSeverity = job.minSeverity;

--- a/companion/tests/integrations/huntStatusPoller.test.ts
+++ b/companion/tests/integrations/huntStatusPoller.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pollHuntStatusOnce, type HuntPollDeps } from "../../src/integrations/velociraptor/huntStatusPoller.js";
+import { pollHuntStatusOnce, isHuntStoppedEarly, type HuntPollDeps } from "../../src/integrations/velociraptor/huntStatusPoller.js";
 import type { VeloHuntJob } from "../../src/analysis/veloHuntStore.js";
 
 function job(over: Partial<VeloHuntJob> = {}): VeloHuntJob {
@@ -89,5 +89,43 @@ describe("pollHuntStatusOnce", () => {
       expect(out.action).toBe("stop");
       expect(out.job).toBe(j);   // untouched, same reference
     }
+  });
+});
+
+// A hunt DELETED from the Velociraptor GUI does not disappear from hunts() (confirmed against a live
+// server) — it just reports STOPPED, identical to natural completion. The only signal Velociraptor
+// still exposes is the hunt's own `expires`: natural completion happens AT (or just after) expires;
+// a hunt an analyst stopped/deleted partway through reports terminal well BEFORE it. isHuntStoppedEarly
+// is the collect-time check that tells these apart so the UI can stop saying "collect again later"
+// for a hunt that will never produce anything again.
+describe("isHuntStoppedEarly", () => {
+  const NOW = new Date("2026-07-09T08:00:00.000Z").getTime();
+
+  it("is false when the hunt is still running, regardless of expires", () => {
+    expect(isHuntStoppedEarly({ state: "RUNNING", expires: "2026-07-09T09:00:00.000Z" }, NOW)).toBe(false);
+  });
+
+  it("is false when there's no result (hunt truly not found)", () => {
+    expect(isHuntStoppedEarly(null, NOW)).toBe(false);
+  });
+
+  it("is false when a terminal state is reported at/after its own expiry (natural completion)", () => {
+    expect(isHuntStoppedEarly({ state: "STOPPED", expires: "2026-07-09T07:59:00.000Z" }, NOW)).toBe(false);
+  });
+
+  it("is true when a terminal state is reported well before its own expiry (stopped/deleted early)", () => {
+    expect(isHuntStoppedEarly({ state: "STOPPED", expires: "2026-07-09T09:00:00.000Z" }, NOW)).toBe(true);
+  });
+
+  it("is case-insensitive on state and also recognizes ARCHIVED", () => {
+    expect(isHuntStoppedEarly({ state: "archived", expires: "2026-07-09T09:00:00.000Z" }, NOW)).toBe(true);
+  });
+
+  it("is false when expires is missing (nothing to compare against)", () => {
+    expect(isHuntStoppedEarly({ state: "STOPPED" }, NOW)).toBe(false);
+  });
+
+  it("stays false within the grace window just before expiry (housekeeping lag, not an early stop)", () => {
+    expect(isHuntStoppedEarly({ state: "STOPPED", expires: "2026-07-09T08:00:30.000Z" }, NOW)).toBe(false);
   });
 });

--- a/companion/tests/integrations/velociraptor.test.ts
+++ b/companion/tests/integrations/velociraptor.test.ts
@@ -348,6 +348,7 @@ describe("VelociraptorClient.huntStatus", () => {
     const st = await new VelociraptorClient(cfg, runner).huntStatus("H.ABC123");
     expect(st).toEqual({ state: "RUNNING" });
     expect(program).toContain("FROM hunts() WHERE hunt_id='H.ABC123'");
+    expect(program).toContain("SELECT state, expires");
   });
 
   it("returns null when the hunt is not found (deleted)", async () => {
@@ -363,6 +364,20 @@ describe("VelociraptorClient.huntStatus", () => {
   it("throws on an invalid hunt id", async () => {
     const runner: VqlRunner = async () => ({ rows: [], raw: "" });
     await expect(new VelociraptorClient(cfg, runner).huntStatus("not-a-hunt-id")).rejects.toThrow(/invalid hunt id/);
+  });
+
+  // Velociraptor's `hunts()` plugin reports `expires` as MICROSECONDS since the epoch (matching
+  // create_time/start_time) — confirmed against a live server. Converted to an ISO string so callers
+  // never have to know the unit.
+  it("converts the hunt's microsecond expires field to an ISO string", async () => {
+    const runner: VqlRunner = async () => ({ rows: [{ state: "STOPPED", expires: 1_783_586_781_000_000 }], raw: "" });
+    const st = await new VelociraptorClient(cfg, runner).huntStatus("H.ABC123");
+    expect(st).toEqual({ state: "STOPPED", expires: new Date(1_783_586_781_000).toISOString() });
+  });
+
+  it("omits expires when the field is missing or zero", async () => {
+    const runner: VqlRunner = async () => ({ rows: [{ state: "RUNNING", expires: 0 }], raw: "" });
+    expect(await new VelociraptorClient(cfg, runner).huntStatus("H.ABC123")).toEqual({ state: "RUNNING" });
   });
 });
 

--- a/companion/tests/server/veloBundle.test.ts
+++ b/companion/tests/server/veloBundle.test.ts
@@ -283,6 +283,35 @@ describe("Velociraptor hunt status polling — routes", () => {
     expect(job?.status).toBe("imported");
   });
 
+  // Deleting a hunt from the Velociraptor GUI does not make it disappear from hunts() (confirmed
+  // against a live server) — it just reports STOPPED, same as a hunt that finished naturally. The only
+  // usable signal is the hunt's own `expires`: STOPPED well before it means an analyst intervened.
+  // Exercised via the plain /collect route (not poll-status) since that's also the path a manual
+  // "Collect now" click and the fixed-delay auto-collect timer take — the check must fire there too.
+  it("collect flags a hunt reported STOPPED well before its own expiry as stoppedEarly", async () => {
+    const farFutureExpiresMicros = (Date.now() + 60 * 60 * 1000) * 1000;   // 1h from now, in microseconds
+    const runner: VqlRunner = async (statements) => {
+      const p = statements[0];
+      if (p.includes("hunt(") && p.includes("artifacts=[")) return { rows: [{ Hunt: { HuntId: "H.EARLY1", state: "RUNNING" } }], raw: "" };
+      if (p.includes("FROM hunts()")) return { rows: [{ state: "STOPPED", expires: farFutureExpiresMicros }], raw: "" };
+      if (p.includes("hunt_results(")) return { rows: [], raw: "" };
+      return { rows: [], raw: "" };
+    };
+    const made = await makeApp(runner);
+    await request(made.app).post("/cases/c1/velociraptor/run-bundle").send({ bundleId: "best-practice", waitMinutes: 30 });
+    expect((await request(made.app).post("/cases/c1/velociraptor/collect")).status).toBe(202);
+
+    let job: { status: string; stoppedEarly?: boolean; addedEvents?: number } | null = null;
+    for (let i = 0; i < 100; i++) {
+      job = (await request(made.app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
+      if (job && (job.status === "imported" || job.status === "error")) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(job?.status).toBe("imported");
+    expect(job?.stoppedEarly).toBe(true);
+    expect(job?.addedEvents ?? 0).toBe(0);
+  });
+
   it("poll-status marks the job deleted when Velociraptor has no record of the hunt", async () => {
     const runner: VqlRunner = async (statements) => {
       const p = statements[0];

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7242,7 +7242,9 @@
         let detail = "";
         if (job.status === "imported") {
           const ev = job.addedEvents || 0, io = job.addedIocs || 0;
-          detail = (ev || io) ? `+${ev} event(s), +${io} IOC(s) imported` : "no new results collected yet — clients may not have checked in; collect again later";
+          detail = (ev || io) ? `+${ev} event(s), +${io} IOC(s) imported`
+            : (job.stoppedEarly ? "this hunt was stopped before its scheduled expiry in Velociraptor — likely stopped or deleted; no results were collected"
+              : "no new results collected yet — clients may not have checked in; collect again later");
         } else if (job.status === "error") {
           detail = "error: " + (job.error || "");
         } else if (job.status === "deleted") {


### PR DESCRIPTION
## Summary
- A hunt stopped/deleted in the Velociraptor GUI doesn't disappear from `hunts()` — it just reports `STOPPED`, identical to a hunt that finished naturally, so the dashboard kept saying "no new results collected yet — collect again later" even though nothing would ever arrive.
- The collector now compares the hunt's terminal state against its own scheduled `expires`; a terminal state reported well before expiry is flagged `stoppedEarly` and the dashboard shows a message that doesn't imply retrying will help.
- Confirmed against a live Velociraptor server (queried `hunts()` directly) before implementing.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/integrations/huntStatusPoller.test.ts tests/integrations/velociraptor.test.ts tests/server/veloBundle.test.ts` — 154/154 passed
- [x] Full suite: 3281/3282 passed (1 unrelated pre-existing flake in `iocBulkRoutes.test.ts`, confirmed passes in isolation)
- [x] Verified the new dashboard message renders correctly in a live browser preview