### PR TITLE
fix: track auto/backfill synthesis as a background job

### DIFF
--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -921,9 +921,20 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       if (synthInFlight.has(caseId)) { scheduleSynthesis(caseId); return; } // busy — retry after debounce
       synthInFlight.add(caseId);
       options.onAiStatus?.(caseId, { status: "analyzing", phase: "synthesizing", at: new Date().toISOString(), detail: "synthesizing conclusions" });
-      options.pipeline!.synthesize(caseId)
-        .then(() => { options.onAiStatus?.(caseId, { status: "idle", at: new Date().toISOString() }); autoEnrichIfEnabled(caseId); })
-        .catch((err) => { recordAiError(caseId, "synthesizing", err); options.onAiStatus?.(caseId, { status: "error", at: new Date().toISOString(), detail: (err as Error).message }); })
+      // #225: this debounced/auto path (live re-synth after captures, and the AI off→on backfill
+      // catch-up) previously ran outside the job registry, so it never showed up in the Jobs panel
+      // or offered a Cancel button — only the manual "re-synthesize" button did. Track it the same way.
+      const job = options.jobManager?.register({ caseId, kind: "synthesis", label: "live synthesis", cancellable: true });
+      options.pipeline!.synthesize(caseId, job?.signal ? { signal: job.signal } : {})
+        .then(() => { if (job) options.jobManager?.finish(job.jobId); options.onAiStatus?.(caseId, { status: "idle", at: new Date().toISOString() }); autoEnrichIfEnabled(caseId); })
+        .catch((err) => {
+          const aborted = job?.signal?.aborted === true;
+          if (job) options.jobManager?.fail(job.jobId, err); // no-op if already cancelled
+          recordAiError(caseId, "synthesizing", err);
+          options.onAiStatus?.(caseId, aborted
+            ? { status: "idle", at: new Date().toISOString(), detail: "synthesis cancelled" }
+            : { status: "error", at: new Date().toISOString(), detail: (err as Error).message });
+        })
         .finally(() => synthInFlight.delete(caseId));
     }, synthDebounceMs));
   }

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -18,6 +18,7 @@ import { PlaybookControlStore } from "../src/analysis/playbookControl.js";
 import { IocWhitelistStore } from "../src/analysis/iocWhitelistStore.js";
 import { emptyState, type InvestigationState } from "../src/analysis/stateTypes.js";
 import type { CustomerExposureProvider } from "../src/analysis/customerExposure.js";
+import { JobManager } from "../src/analysis/jobManager.js";
 
 let app: ReturnType<typeof createApp>;
 
@@ -1783,6 +1784,29 @@ describe("AI on/off control", () => {
     await request(app).post("/cases/c1/ai-control").send({ enabled: true });
     for (let i = 0; i < 80 && !phases.includes("synthesizing"); i++) await new Promise((r) => setTimeout(r, 25));
     expect(phases).toContain("synthesizing");
+  });
+
+  it("tracks AI off→on backfill synthesis as a job, not just an onAiStatus ping", async () => {
+    // Bug: turning AI on ran synthesis via the debounced auto path (scheduleSynthesis), which never
+    // registered with the jobManager — so it showed the "AI: synthesizing…" banner but never appeared
+    // in the Jobs panel, unlike the manual "re-synthesize" button. Both must be trackable/cancellable.
+    const root = await mkdtemp(join(tmpdir(), "dfir-aibackfill-job-"));
+    const store = new CaseStore(root);
+    const stateStore = new StateStore(store);
+    const jobManager = new JobManager();
+    const app = createApp(store, {
+      pipeline: findingPipeline(stateStore), stateStore, jobManager,
+      autoSynthesize: true, autoSynthesizeDebounceMs: 10,
+    });
+    await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+    await request(app).post("/cases/c1/ai-control").send({ enabled: true });
+    let jobs: { kind: string; status: string }[] = [];
+    for (let i = 0; i < 80; i++) {
+      jobs = jobManager.list("c1");
+      if (jobs.some((j) => j.kind === "synthesis")) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(jobs.some((j) => j.kind === "synthesis")).toBe(true);
   });
 
   it("POST /import fires onImport(caseId) so dashboards can warn cross-case (parity with captures)", async () => {


### PR DESCRIPTION
## Summary
- Turning AI on from off (or any other debounced auto-synthesis trigger, e.g. after a capture window) ran synthesis via `scheduleSynthesis`, which only pinged the AI status banner ("AI: synthesizing...") and never registered with the job registry.
- As a result it never showed up in the Jobs panel or offered a Cancel button, unlike the manual "re-synthesize" button which already used `jobManager.register(...)`.
- `scheduleSynthesis` now registers a cancellable `synthesis` job before running, and finishes/fails it on completion, with its abort signal wired into `pipeline.synthesize()` just like the manual path.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/server.test.ts` — 83/83 passed, including a new regression test asserting the AI off→on backfill path registers a `synthesis` job
- [x] `npx vitest run tests/server/ tests/analysis/pipeline.test.ts` — passed