### PR TITLE
fix: make the global filter toolbar scope the False Positives panel

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3619,7 +3619,7 @@
       #sec-nlquery .nlq-deploy:disabled{opacity:.6;cursor:default}
       #sec-nlquery .nlq-res{margin-top:6px}
     </style>
-    <section id="sec-false-positive" style="grid-column: 1 / -1"><h2>False Positives (excluded from analysis)</h2><div id="false-positive">—</div></section>
+    <section id="sec-false-positive" style="grid-column: 1 / -1"><h2>False Positives (excluded from analysis)<span id="fpCount" title="Total false-positive markers in scope; updates in real time"></span></h2><div id="false-positive">—</div></section>
     <style>
       #sec-playbook .pb-badge{font-size:12px;color:var(--c-9aa4b2);font-weight:normal;margin-left:8px}
       .pb-toolbar{display:flex;align-items:center;gap:14px;flex-wrap:wrap;margin-bottom:4px}
@@ -3925,6 +3925,7 @@
       renderExcludeChips();
       if (lastState) render(lastState);
       if (lastSuperData) loadSuperTimeline();   // the main filter's exclude terms scope the super-timeline too
+      renderFalsePositives(fpMarkers);   // exclude terms scope the False Positives panel too
     }
     function renderExcludeChips() {
       const box = document.getElementById("excludeChips");
@@ -3987,6 +3988,19 @@
     function _evMatchesExclude(e, terms) { return terms.some(t => t && _evMatchesSearch(e, t.toLowerCase())); }
     function _iocMatchesExclude(i, terms) { return terms.some(t => t && _iocMatchesSearch(i, t.toLowerCase())); }
     function _findingMatchesExclude(f, terms) { return terms.some(t => t && _findingMatchesSearch(f, t.toLowerCase())); }
+    // False-positive marker search/exclude (filter-fp-panel): the global filter toolbar already scopes
+    // the Timeline/Findings/IOCs; mirror that for the False Positives panel so "search an IP" or an
+    // exclude term narrows it too. Matches against the marker's kind, ref (id/value/title), display
+    // label, reason and free-text note — there's no per-marker event timestamp, so the time-range
+    // inputs don't apply here.
+    function _fpMatchesSearch(m, q) {
+      return (m.kind || "").toLowerCase().includes(q) ||
+        (m.ref || "").toLowerCase().includes(q) ||
+        (m.label || "").toLowerCase().includes(q) ||
+        (m.reason || "").toLowerCase().includes(q) ||
+        (m.note || "").toLowerCase().includes(q);
+    }
+    function _fpMatchesExclude(m, terms) { return terms.some(t => t && _fpMatchesSearch(m, t.toLowerCase())); }
     function _evMatchesTimeRange(e, from, to) {
       const ts = e.timestamp; if (!ts) return true;
       const t = Date.parse(ts); if (isNaN(t)) return true;
@@ -11429,10 +11443,16 @@
     function renderFalsePositives(markers) {
       fpMarkers = markers || [];
       const el = document.getElementById("false-positive");
+      // The global filter toolbar (search + exclude terms) scopes this panel too, same as the
+      // Timeline/Findings/IOCs — matched against kind/ref/label/reason/note (see _fpMatchesSearch).
+      const q = searchTerm;
+      const visible = fpMarkers.filter(m =>
+        (!q || _fpMatchesSearch(m, q)) &&
+        !(excludeTerms.length && _fpMatchesExclude(m, excludeTerms)));
       // For event markers, prefer the human-readable label (the event description)
       // over the opaque event id stored as ref.
-      el.innerHTML = (fpMarkers.length)
-        ? fpMarkers.map(m => {
+      el.innerHTML = (visible.length)
+        ? visible.map(m => {
             const shown = (m.kind === "event" && m.label) ? m.label : m.ref;
             return `<div style="margin-bottom:4px"><span style="color:var(--c-9aa4b2)">${esc(m.kind)}:</span> ` +
               `<span style="text-decoration:line-through">${esc(shown)}</span>` +
@@ -11440,7 +11460,15 @@
               `${m.note ? ` — <small>${esc(m.note)}</small>` : ""} ` +
               `<button class="unfp-btn" data-id="${escAttr(m.id)}">un-mark</button></div>`;
           }).join("")
-        : "<div style='color:var(--c-9aa4b2)'>Nothing marked false positive.</div>";
+        : (fpMarkers.length
+            ? "<div style='color:var(--c-9aa4b2)'>No false positives match the current filter.</div>"
+            : "<div style='color:var(--c-9aa4b2)'>Nothing marked false positive.</div>");
+      const fpCountEl = document.getElementById("fpCount");
+      if (fpCountEl) {
+        fpCountEl.textContent = (q || excludeTerms.length)
+          ? `(${visible.length} of ${fpMarkers.length})`
+          : (fpMarkers.length ? `(${fpMarkers.length})` : "");
+      }
       // FP events are hidden from the timeline — re-render it with the new set.
       if (lastState) render(lastState);
     }
@@ -13525,6 +13553,7 @@
         cs.hidden = !searchTerm;
         if (lastState) render(lastState);
         if (lastSuperData) loadSuperTimeline();   // the main filter's search term scopes the super-timeline too
+        renderFalsePositives(fpMarkers);   // search term scopes the False Positives panel too
       }
       function applyTimeRange() {
         filterFrom = utcInputToIso(ff.value);


### PR DESCRIPTION
## Summary
- Search text and exclude terms already scoped the Timeline/Findings/IOCs sections but left every marker in the False Positives panel showing regardless of the active filter.
- `renderFalsePositives()` now applies the same searchTerm/excludeTerms matching (against kind/ref/label/reason/note) and shows a `(N of M)` count in the section header.
- `applySearch()` and `setExcludeTerms()` re-render the panel so it stays in sync live as the filter changes, matching existing behavior elsewhere.
- Time-range inputs intentionally don't apply here since FP markers carry no per-event timestamp.

## Test plan
- [x] `npx vitest run tests/reports/dashboardHtml.test.ts tests/analysis/falsePositive.test.ts` — 39/39 pass
- [x] Manually verified against the real `demo` case's 4 existing FP markers via a live dev server: searching "wsus" narrowed the panel to 1/4, excluding "internal dns" narrowed it to 3/4, clearing both restored all 4 with the correct count.