### PR TITLE
fix: sort the False Positives panel by most-recently-marked first

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -11446,7 +11446,10 @@
       // The global filter toolbar (search + exclude terms) scopes this panel too, same as the
       // Timeline/Findings/IOCs — matched against kind/ref/label/reason/note (see _fpMatchesSearch).
       const q = searchTerm;
-      const visible = fpMarkers.filter(m =>
+      // Most-recently-marked first, so a fresh mark-as-FP surfaces at the top instead of getting
+      // buried at the bottom of a long list (markedAt is an ISO timestamp; unparsable sorts last).
+      const sorted = [...fpMarkers].sort((a, b) => (Date.parse(b.markedAt) || 0) - (Date.parse(a.markedAt) || 0));
+      const visible = sorted.filter(m =>
         (!q || _fpMatchesSearch(m, q)) &&
         !(excludeTerms.length && _fpMatchesExclude(m, excludeTerms)));
       // For event markers, prefer the human-readable label (the event description)


### PR DESCRIPTION
## Summary
- The False Positives panel rendered markers in raw storage order, so a fresh mark-as-FP could land buried at the bottom of a long list instead of being visible near the top.
- `renderFalsePositives()` now sorts a copy of the markers by `markedAt` descending (most recent first) before applying the existing search/exclude filter.

## Test plan
- [x] `npx vitest run tests/reports/dashboardHtml.test.ts tests/analysis/falsePositive.test.ts` — 39/39 pass
- [x] Manually verified against the real `demo` case's 4 existing FP markers via a live dev server (browse skill): panel now renders newest-marked → oldest (Spear-Phishing 12:18 → routine update 10:17 → WSUS 10:16 → DNS 10:15), matching each marker's `markedAt` timestamp.