### PR TITLE
feat: authoritative IOC-to-event provenance linking for 5 priority importers

### DIFF
--- a/companion/src/analysis/combinedLogImport.ts
+++ b/companion/src/analysis/combinedLogImport.ts
@@ -48,7 +48,7 @@
 // here (that cap is shared code, not specific to this format).
 
 import type { Severity } from "./stateTypes.js";
-import { aggregateEvents, addIoc, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult } from "./siemImport.js";
+import { aggregateEvents, addIoc, mergeRowIocs, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult } from "./siemImport.js";
 
 export interface CombinedLogImportOptions {
   aggregate?: boolean;
@@ -178,8 +178,9 @@ export function parseCombinedLog(text: string, opts: CombinedLogImportOptions = 
   for (const raw of text.split(/\r?\n/)) {
     const line = raw.trim();
     if (!line) continue;
-    const m = mapCombinedLogLine(line, sink);
-    if (m) { total++; mapped.push(m); }
+    const rowSink = new Map<string, SiemIoc>();
+    const m = mapCombinedLogLine(line, rowSink);
+    if (m) { total++; mergeRowIocs(sink, rowSink, m.aggKey); mapped.push(m); }
   }
 
   const { events, groups } = aggregateEvents(mapped, {

--- a/companion/src/analysis/iocProvenanceChain.ts
+++ b/companion/src/analysis/iocProvenanceChain.ts
@@ -4,9 +4,13 @@
 // distinct TOOL names) — this assembles the actual timestamped steps. Pure, derived on read, like
 // those siblings — never mutates state.
 //
-// IMPORTANT CAVEAT: no importer records which specific event produced an IOC (addIoc() takes only a
-// type+value, across ~20 importers), so the "extraction" leg is APPROXIMATE — the same indexed
-// exact-token match iocCorroboration/iocProvenance already use, not an authoritative link. Enrichment
+// IMPORTANT CAVEAT: not every importer records which specific event produced an IOC (addIoc() takes
+// only a type+value in most of the ~20 importers), so the "extraction" leg falls back to APPROXIMATE
+// — the same indexed exact-token match iocCorroboration/iocProvenance already use — whenever an IOC
+// has no (or no resolvable) IOC.extractedFrom link. 5 priority importers (SIEM/EVTX, Security Onion,
+// Network, Combined-log, Velociraptor) DO populate extractedFrom, so buildIocProvenanceChains prefers
+// that authoritative link when present. Check `extractionAuthoritative` on the returned chain to see
+// which path applied for a given IOC. Enrichment
 // lookups ARE authoritative (IOC.enrichments already carries a real fetchedAt per hit). Findings ARE
 // authoritative (Finding.relatedIocs is a real reference). There is no data model for "which playbook
 // task referenced this IOC" (playbook tasks don't carry IOC ids) — that leg is intentionally omitted

--- a/companion/src/analysis/iocProvenanceChain.ts
+++ b/companion/src/analysis/iocProvenanceChain.ts
@@ -10,8 +10,8 @@
 // has no (or no resolvable) IOC.extractedFrom link. 5 priority importers (SIEM/EVTX, Security Onion,
 // Network, Combined-log, Velociraptor) DO populate extractedFrom, so buildIocProvenanceChains prefers
 // that authoritative link when present. Check `extractionAuthoritative` on the returned chain to see
-// which path applied for a given IOC. Enrichment
-// lookups ARE authoritative (IOC.enrichments already carries a real fetchedAt per hit). Findings ARE
+// which path applied for a given IOC. Enrichment lookups ARE authoritative (IOC.enrichments already
+// carries a real fetchedAt per hit). Findings ARE
 // authoritative (Finding.relatedIocs is a real reference). There is no data model for "which playbook
 // task referenced this IOC" (playbook tasks don't carry IOC ids) — that leg is intentionally omitted
 // rather than faked as an always-empty field; playbook linkage would need new state, tracked in #247.

--- a/companion/src/analysis/iocProvenanceChain.ts
+++ b/companion/src/analysis/iocProvenanceChain.ts
@@ -49,6 +49,8 @@ export interface IocProvenanceChain {
   type: IOC["type"];
   extraction: ProvenanceExtractionEvent[];
   extractionTruncated: number;   // count of matching events dropped past MAX_EXTRACTION_EVENTS, 0 if none
+  extractionAuthoritative: boolean; // true when extraction came from IOC.extractedFrom (a real link),
+                                     // false when it's the value-match guess below
   enrichment: ProvenanceEnrichmentLookup[];
   findings: ProvenanceFindingRef[];
 }
@@ -79,6 +81,9 @@ export function buildIocProvenanceChains(
     if (tokens) for (const t of tokens) addEvent(t, e);
   }
 
+  const eventById = new Map<string, ForensicEvent>();
+  for (const e of events) eventById.set(e.id, e);
+
   const findingIndex = new Map<string, Finding[]>();
   for (const f of findings) {
     for (const iocId of f.relatedIocs || []) {
@@ -89,11 +94,22 @@ export function buildIocProvenanceChains(
   }
 
   for (const ioc of iocs) {
-    const key = ioc.value.trim().toLowerCase();
-    const matched = key.length >= 3 ? (eventIndex.get(key) ?? []) : [];
-    const seenIds = new Set<string>();
-    const dedup: ForensicEvent[] = [];
-    for (const e of matched) { if (!seenIds.has(e.id)) { seenIds.add(e.id); dedup.push(e); } }
+    const authoritativeIds = (ioc.extractedFrom ?? []).filter((id) => eventById.has(id));
+    const extractionAuthoritative = authoritativeIds.length > 0;
+    let dedup: ForensicEvent[];
+    if (extractionAuthoritative) {
+      const seen = new Set<string>();
+      dedup = [];
+      for (const id of authoritativeIds) {
+        if (!seen.has(id)) { seen.add(id); dedup.push(eventById.get(id)!); }
+      }
+    } else {
+      const key = ioc.value.trim().toLowerCase();
+      const matched = key.length >= 3 ? (eventIndex.get(key) ?? []) : [];
+      const seenIds = new Set<string>();
+      dedup = [];
+      for (const e of matched) { if (!seenIds.has(e.id)) { seenIds.add(e.id); dedup.push(e); } }
+    }
     dedup.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
     const extractionTruncated = Math.max(0, dedup.length - MAX_EXTRACTION_EVENTS);
     const extraction: ProvenanceExtractionEvent[] = dedup.slice(0, MAX_EXTRACTION_EVENTS).map((e) => ({
@@ -112,7 +128,10 @@ export function buildIocProvenanceChains(
       .sort((a, b) => a.firstSeen.localeCompare(b.firstSeen))
       .map((f) => ({ findingId: f.id, title: f.title, severity: f.severity, status: f.status, firstSeen: f.firstSeen }));
 
-    out[ioc.id] = { iocId: ioc.id, value: ioc.value, type: ioc.type, extraction, extractionTruncated, enrichment, findings: citing };
+    out[ioc.id] = {
+      iocId: ioc.id, value: ioc.value, type: ioc.type, extraction, extractionTruncated,
+      extractionAuthoritative, enrichment, findings: citing,
+    };
   }
   return out;
 }

--- a/companion/src/analysis/networkImport.ts
+++ b/companion/src/analysis/networkImport.ts
@@ -20,6 +20,7 @@ import {
   aggregateEvents,
   cleanIp,
   addIoc,
+  mergeRowIocs,
   firstStr,
   str,
   isObject,
@@ -272,17 +273,32 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
 
     const etype = str(getCI(row, "event_type")).toLowerCase();
     const zpath = str(getCI(row, "_path")).toLowerCase();
+    const rowSink = new Map<string, SiemIoc>();
 
     if (etype) {
       sawSuricata = true;
-      suricataIocs(row, etype, iocSink);
-      if (etype === "alert") { mapped.push(mapSuricataAlert(row, host, iocSink)); alerts++; }
+      suricataIocs(row, etype, rowSink);
+      if (etype === "alert") {
+        const m = mapSuricataAlert(row, host, rowSink);
+        mergeRowIocs(iocSink, rowSink, m.aggKey);
+        mapped.push(m);
+        alerts++;
+      } else {
+        mergeRowIocs(iocSink, rowSink);
+      }
     } else {
       // Zeek: either `_path`-tagged (combined JSON) or per-stream (filename / field-inferred).
       const zstream = zpath || fileStream || inferZeekStream(row);
       sawZeek = true;
-      zeekIocs(row, zstream, iocSink);
-      if (zstream === "notice") { mapped.push(mapZeekNotice(row, host, iocSink)); alerts++; }
+      zeekIocs(row, zstream, rowSink);
+      if (zstream === "notice") {
+        const m = mapZeekNotice(row, host, rowSink);
+        mergeRowIocs(iocSink, rowSink, m.aggKey);
+        mapped.push(m);
+        alerts++;
+      } else {
+        mergeRowIocs(iocSink, rowSink);
+      }
     }
   }
 

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -13,7 +13,7 @@ import type { DiscoveredEntitiesStore } from "./anonDiscovered.js";
 import type { CaptureMetadata } from "../types.js";
 import type { StateStore } from "./stateStore.js";
 import type { InvestigationState, InvestigationQuestion, ForensicEvent, Severity, TimelineEntry } from "./stateTypes.js";
-import { deltaSchema, askSchema, execSummarySchema, explainEventSchema, remediationPlanSchema, fpSimilaritySchema, type AskAnswer, type ExecSummary, type ExplainEventResult, type RemediationPlan } from "./responseSchema.js";
+import { deltaSchema, askSchema, execSummarySchema, explainEventSchema, remediationPlanSchema, fpSimilaritySchema, stripAiExtractedFrom, type AskAnswer, type ExecSummary, type ExplainEventResult, type RemediationPlan } from "./responseSchema.js";
 import { buildMitigationsResult } from "./attackMitigations.js";
 import { loadMitigationsDataset } from "./attackMitigationsData.js";
 import { buildD3fendResult } from "./d3fendMap.js";
@@ -1474,7 +1474,7 @@ export class AnalysisPipeline {
 
       const delta = await withRetry(async () => {
         const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getSystemPrompt(), userPrompt, images }, "extract");
-        return deltaSchema.parse(parsed);
+        return stripAiExtractedFrom(deltaSchema.parse(parsed));
       }, retries, backoffMs);
 
       const windowSequence = analyzable[analyzable.length - 1].sequenceNumber;
@@ -1539,7 +1539,7 @@ export class AnalysisPipeline {
 
         const delta = await withRetry(async () => {
           const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getCsvPrompt(), userPrompt, images: [], ...(opts.signal ? { signal: opts.signal } : {}) }, "csv");
-          return deltaSchema.parse(parsed);
+          return stripAiExtractedFrom(deltaSchema.parse(parsed));
         }, retries, backoffMs);
 
         // Renumber event ids so chunked imports don't overwrite each other (merge
@@ -1622,7 +1622,7 @@ export class AnalysisPipeline {
 
         const delta = await withRetry(async () => {
           const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getLogPrompt(), userPrompt, images: [], ...(opts.signal ? { signal: opts.signal } : {}) }, "log");
-          return deltaSchema.parse(parsed);
+          return stripAiExtractedFrom(deltaSchema.parse(parsed));
         }, retries, backoffMs);
 
         const renumbered = {
@@ -4248,7 +4248,7 @@ export class AnalysisPipeline {
         { systemPrompt: getSynthesisPrompt(), userPrompt, images: [], ...(synthThinkingTokens > 0 ? { thinkingTokens: synthThinkingTokens } : {}), ...(opts.signal ? { signal: opts.signal } : {}) },
         "synthesis",
       );
-      return deltaSchema.parse(parsed);
+      return stripAiExtractedFrom(deltaSchema.parse(parsed));
     }, retries, backoffMs);
 
     // Anchor finding timestamps to the last real event time (fallback: existing state time).

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -69,7 +69,7 @@ import { parseCsv, chunkToCsvText } from "./csvImport.js";
 import { parseLogLines } from "./logImport.js";
 import { aggregateLogLines } from "./logAggregate.js";
 import { parseThorReport, type ThorImportOptions } from "./thorImport.js";
-import { parseSiemExport, type SiemImportOptions } from "./siemImport.js";
+import { parseSiemExport, resolveExtractedFrom, type SiemImportOptions } from "./siemImport.js";
 import { parseEvtxXml } from "./evtxXmlImport.js";
 import { parseShellHistoryFile, userFromHistoryFilename } from "./bashHistoryImport.js";
 import { parseChainsawReport, type ChainsawImportOptions } from "./chainsawImport.js";
@@ -1715,13 +1715,21 @@ export class AnalysisPipeline {
     if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
 
     const source = detectTool(opts.label) ?? detectTool(parsed.format) ?? "SIEM import";
+    const eventIdByAggKey = new Map<string, string>();
+    const forensicEvents = parsed.events.map((e, i) => {
+      const { aggKey, ...rest } = e;
+      const id = `${opts.idPrefix}e${i + 1}`;
+      if (aggKey) eventIdByAggKey.set(aggKey, id);
+      return { ...rest, id, sources: rest.sources?.length ? rest.sources : [source] };
+    });
     const raw = {
       findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [source],
+      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
+        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
       })),
+      mitreTechniques: [],
+      forensicEvents,
       threadsOpened: [],
       threadsClosed: [],
       timelineNote: `SIEM import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
@@ -2044,14 +2052,24 @@ export class AnalysisPipeline {
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
 
+    const eventIdByAggKey = new Map<string, string>();
+    const forensicEvents = parsed.events.map((e, i) => {
+      const { aggKey, ...rest } = e;
+      const id = `${opts.idPrefix}e${i + 1}`;
+      if (aggKey) eventIdByAggKey.set(aggKey, id);
+      return {
+        ...rest, id, sources: rest.sources?.length ? rest.sources : ["Velociraptor"],
+        ...(opts.veloUrl ? { veloUrl: opts.veloUrl } : {}),
+      };
+    });
     const raw = {
       findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Velociraptor"],
-        ...(opts.veloUrl ? { veloUrl: opts.veloUrl } : {}),
+      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
+        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
       })),
+      mitreTechniques: [],
+      forensicEvents,
       threadsOpened: [],
       threadsClosed: [],
       timelineNote: `Velociraptor import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
@@ -2146,13 +2164,21 @@ export class AnalysisPipeline {
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
 
+    const eventIdByAggKey = new Map<string, string>();
+    const forensicEvents = parsed.events.map((e, i) => {
+      const { aggKey, ...rest } = e;
+      const id = `${opts.idPrefix}e${i + 1}`;
+      if (aggKey) eventIdByAggKey.set(aggKey, id);
+      return { ...rest, id, sources: rest.sources?.length ? rest.sources : [COMBINED_LOG_SOURCE] };
+    });
     const raw = {
       findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [COMBINED_LOG_SOURCE],
+      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
+        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
       })),
+      mitreTechniques: [],
+      forensicEvents,
       threadsOpened: [],
       threadsClosed: [],
       timelineNote: `Web/proxy access-log import (${parsed.format}): ${parsed.kept} request(s) from ${parsed.total} line(s)` +
@@ -2392,13 +2418,21 @@ export class AnalysisPipeline {
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
 
+    const eventIdByAggKey = new Map<string, string>();
+    const forensicEvents = parsed.events.map((e, i) => {
+      const { aggKey, ...rest } = e;
+      const id = `${opts.idPrefix}e${i + 1}`;
+      if (aggKey) eventIdByAggKey.set(aggKey, id);
+      return { ...rest, id, sources: rest.sources?.length ? rest.sources : ["Suricata"] };
+    });
     const raw = {
       findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Suricata"],
+      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
+        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
       })),
+      mitreTechniques: [],
+      forensicEvents,
       threadsOpened: [],
       threadsClosed: [],
       timelineNote: `Network import (${parsed.format}): ${parsed.kept} detection event(s) from ${parsed.total} record(s)` +
@@ -2492,13 +2526,21 @@ export class AnalysisPipeline {
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
 
+    const eventIdByAggKey = new Map<string, string>();
+    const forensicEvents = parsed.events.map((e, i) => {
+      const { aggKey, ...rest } = e;
+      const id = `${opts.idPrefix}e${i + 1}`;
+      if (aggKey) eventIdByAggKey.set(aggKey, id);
+      return { ...rest, id, sources: rest.sources?.length ? rest.sources : ["Security Onion"] };
+    });
     const raw = {
       findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Security Onion"],
+      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
+        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
       })),
+      mitreTechniques: [],
+      forensicEvents,
       threadsOpened: [],
       threadsClosed: [],
       timelineNote: `Security Onion import: ${parsed.kept} event(s) from ${parsed.total} record(s)` +

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -24,6 +24,9 @@ export const deltaSchema = z.object({
     id: z.string().min(1),
     type: iocType.catch("other"),
     value: z.string().min(1),
+    // Authoritative source-event links (set by the deterministic importers via pipeline.ts, never
+    // by AI synthesis). Optional — absent for every existing caller.
+    extractedFrom: z.array(z.string()).optional(),
   })),
   mitreTechniques: z.array(z.object({
     id: z.string().min(1),

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -103,6 +103,17 @@ export const deltaSchema = z.object({
 
 export type AnalysisDelta = z.infer<typeof deltaSchema>;
 
+// AI synthesis/extraction responses must never carry extractedFrom — that field asserts an
+// authoritative, stored source-event link, which only the deterministic importers (pipeline.ts)
+// are allowed to set. Without this, a model response (or prompt-injected content it read from
+// evidence) could fabricate the field and have it rendered as "linked" in the IOC provenance
+// panel — a false trust claim. Strip it defensively after schema validation, at every AI
+// extraction/synthesis call site (never at the deterministic-importer call sites, which build
+// their delta objects field-by-field and set extractedFrom themselves via resolveExtractedFrom).
+export function stripAiExtractedFrom(delta: AnalysisDelta): AnalysisDelta {
+  return { ...delta, iocs: delta.iocs.map(({ extractedFrom, ...rest }) => rest) };
+}
+
 // Answer to an analyst's free-form question about the case ("was data exfiltrated?").
 // Lenient (.catch) like the delta so a slightly-off model response still parses.
 export const askSchema = z.object({

--- a/companion/src/analysis/securityOnionImport.ts
+++ b/companion/src/analysis/securityOnionImport.ts
@@ -21,6 +21,7 @@ import {
   aggregateEvents,
   cleanIp,
   addIoc,
+  mergeRowIocs,
   str,
   isObject,
   getCI,
@@ -213,7 +214,10 @@ export function parseSecurityOnion(text: string, opts: SecurityOnionImportOption
     if (!isObject(row)) continue;
     const host = pickHost(row);
     if (host) hostTally.set(host, (hostTally.get(host) ?? 0) + 1);
-    mapped.push(mapSecurityOnionRow(row, iocSink));
+    const rowSink = new Map<string, SiemIoc>();
+    const m = mapSecurityOnionRow(row, rowSink);
+    mergeRowIocs(iocSink, rowSink, m.aggKey);
+    mapped.push(m);
   }
 
   const { events, groups } = aggregateEvents(mapped, {

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -62,11 +62,22 @@ export interface SiemEvent {
   artifactName?: string;
   // Full, untruncated event message/detail (beyond the truncated `description`) when the mapper had it.
   message?: string;
+  // The row's own aggKey, carried through unconditionally (independent of the `aggregate` option)
+  // so IOC provenance linkage (mergeRowIocs/resolveExtractedFrom) always has a stable key to
+  // resolve against — not persisted on ForensicEvent, stripped before it reaches case state.
+  aggKey?: string;
 }
 
 export interface SiemIoc {
   type: "ip" | "domain" | "hash" | "file" | "process" | "url" | "sid" | "other";
   value: string;
+  // Import-scoped only: the aggKey(s) of the row(s) that produced this IOC within one parse call.
+  // Resolved to real case-scoped event ids by pipeline.ts and converted into `extractedFrom`;
+  // never itself persisted into case state.
+  sourceAggKeys?: string[];
+  // Case-scoped event id(s) this IOC was authoritatively extracted from. Set by pipeline.ts after
+  // resolving sourceAggKeys; empty/absent falls back to iocProvenanceChain.ts's approximate matcher.
+  extractedFrom?: string[];
 }
 
 export interface SiemParseResult {
@@ -926,6 +937,30 @@ export function addIoc(sink: Map<string, SiemIoc>, type: SiemIoc["type"], value:
   if (!sink.has(key)) sink.set(key, { type, value: v });
 }
 
+// Merge a per-row IOC sink into the file-level sink once that row's aggKey (from its MappedEvent)
+// is known, unioning sourceAggKeys so a value seen across multiple rows keeps every row's link.
+// Call with no aggKey for a row that produced IOCs but no event (e.g. non-alert network telemetry)
+// — the value still merges in, just without a link, matching today's approximate-only behavior.
+export function mergeRowIocs(fileSink: Map<string, SiemIoc>, rowSink: Map<string, SiemIoc>, aggKey?: string): void {
+  for (const [key, ioc] of rowSink) {
+    const existing = fileSink.get(key);
+    const keys = existing?.sourceAggKeys ?? [];
+    const nextKeys = aggKey && !keys.includes(aggKey) ? [...keys, aggKey] : keys;
+    fileSink.set(key, { ...(existing ?? ioc), ...(nextKeys.length ? { sourceAggKeys: nextKeys } : {}) });
+  }
+}
+
+// Resolve each IOC's sourceAggKeys against a final aggKey->event-id lookup (built once events have
+// their case-scoped ids), stamping extractedFrom. An aggKey with no match (e.g. the event was
+// capped by maxEvents) is silently dropped — that IOC just falls back to approximate matching.
+export function resolveExtractedFrom(iocs: readonly SiemIoc[], eventIdByAggKey: ReadonlyMap<string, string>): SiemIoc[] {
+  return iocs.map((c) => {
+    if (!c.sourceAggKeys?.length) return c;
+    const ids = [...new Set(c.sourceAggKeys.map((k) => eventIdByAggKey.get(k)).filter((x): x is string => !!x))];
+    return ids.length ? { ...c, extractedFrom: ids } : c;
+  });
+}
+
 // ───────────────────────────── aggregation (shared) ─────────────────────────────
 
 // Incremental accumulator behind aggregateEvents — collapse mapped events by aggKey into counted
@@ -973,6 +1008,7 @@ export function createEventAggregator(
           severity: m.severity,
           mitreTechniques: [...m.mitre],
           count: 1,
+          aggKey: m.aggKey,
           ...(m.sha256 ? { sha256: m.sha256 } : {}),
           ...(m.md5 ? { md5: m.md5 } : {}),
           ...(m.path ? { path: m.path } : {}),
@@ -1037,7 +1073,10 @@ export function buildSiemResult(records: Row[], format: string, opts: SiemImport
   for (const rec of records) {
     const host = pickHost(rec);
     if (host) hostTally.set(host, (hostTally.get(host) ?? 0) + 1);
-    mapped.push(mapWindows(rec, host, iocSink) ?? mapGeneric(rec, host, iocSink));
+    const rowSink = new Map<string, SiemIoc>();
+    const m = mapWindows(rec, host, rowSink) ?? mapGeneric(rec, host, rowSink);
+    mergeRowIocs(iocSink, rowSink, m.aggKey);
+    mapped.push(m);
   }
 
   const { events, groups } = aggregateEvents(mapped, {

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -58,8 +58,18 @@ export function mergeDelta(
     const incomingLower = incoming.value.toLowerCase();
     const dup = iocs.find((i) => i.value.toLowerCase() === incomingLower);
     const canonical = dup ? dup.id : padIocId(nextSeq++);
-    if (!dup) {
-      iocs.push({ id: canonical, type: incoming.type, value: incoming.value, firstSeen: ctx.timestamp });
+    if (dup) {
+      // Union (not overwrite): the same value can legitimately be extracted from
+      // different source events across separate import runs — preserve every link.
+      if (incoming.extractedFrom?.length) {
+        const existingRefs = dup.extractedFrom ?? [];
+        dup.extractedFrom = uniq([...existingRefs, ...incoming.extractedFrom]);
+      }
+    } else {
+      iocs.push({
+        id: canonical, type: incoming.type, value: incoming.value, firstSeen: ctx.timestamp,
+        ...(incoming.extractedFrom?.length ? { extractedFrom: [...incoming.extractedFrom] } : {}),
+      });
     }
     // First occurrence wins: when the model reuses an id (e.g. "i2") across
     // multiple distinct IOCs, a finding's `relatedIocs: ["i2"]` should refer to

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -30,6 +30,10 @@ export interface IOC {
   firstSeen: string;
   enrichments?: IocEnrichment[];                               // threat-intel HITS (added by the enrich pass)
   enrichedBy?: string[];                                       // provider names that have CHECKED this IOC (hit or not) — so a newly-enabled provider re-checks every IOC, and checked ones aren't re-queried
+  // Case-scoped forensic-event id(s) this IOC was authoritatively extracted from (set by the 5
+  // priority importers via pipeline.ts). Absent/empty ⇒ iocProvenanceChain.ts falls back to
+  // matching by value, same as before this field existed.
+  extractedFrom?: string[];
 }
 
 export interface Finding {

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -32,6 +32,7 @@ import {
   parseHashes,
   cleanIp,
   addIoc,
+  mergeRowIocs,
   firstStr,
   baseName,
   oneLine,
@@ -1071,19 +1072,20 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
     const host = pickHost(row) || fallbackHost; // a row's own host always wins; fallback only fills the gap
     if (host) hostTally.set(host, (hostTally.get(host) ?? 0) + 1);
 
+    const rowSink = new Map<string, SiemIoc>();
     const kind = classify(row, artifact);
     let m: MappedEvent | null;
-    if (kind === "yara") { m = mapYara(row, artifact, host, iocSink); detections++; }
-    else if (kind === "sigma") { m = mapSigma(row, host, iocSink); detections++; }
-    else if (kind === "chainsaw") { m = mapFlatChainsawRow(row, host, iocSink); detections++; }
-    else if (kind === "detection") { m = mapDetection(row, artifact, host, iocSink); detections++; }
-    else if (kind === "eventlog") { m = mapEventlog(row, host, iocSink) ?? mapGeneric(row, artifact, host, iocSink); }
-    else if (kind === "pslist") { m = mapPslist(row, host, iocSink); }
-    else if (kind === "netstat") { m = mapNetstat(row, host, iocSink); }
-    else if (kind === "download") { m = mapDownload(row, host, iocSink); }
-    else if (kind === "startup") { m = mapStartup(row, host, iocSink); }
-    else if (kind === "taskscheduler") { m = mapTaskScheduler(row, host, iocSink); }
-    else { m = mapGeneric(row, artifact, host, iocSink); }
+    if (kind === "yara") { m = mapYara(row, artifact, host, rowSink); detections++; }
+    else if (kind === "sigma") { m = mapSigma(row, host, rowSink); detections++; }
+    else if (kind === "chainsaw") { m = mapFlatChainsawRow(row, host, rowSink); detections++; }
+    else if (kind === "detection") { m = mapDetection(row, artifact, host, rowSink); detections++; }
+    else if (kind === "eventlog") { m = mapEventlog(row, host, rowSink) ?? mapGeneric(row, artifact, host, rowSink); }
+    else if (kind === "pslist") { m = mapPslist(row, host, rowSink); }
+    else if (kind === "netstat") { m = mapNetstat(row, host, rowSink); }
+    else if (kind === "download") { m = mapDownload(row, host, rowSink); }
+    else if (kind === "startup") { m = mapStartup(row, host, rowSink); }
+    else if (kind === "taskscheduler") { m = mapTaskScheduler(row, host, rowSink); }
+    else { m = mapGeneric(row, artifact, host, rowSink); }
     if (m) {
       // Stamp the produced event with the VQL artifact that emitted it. Done once here (rather than in
       // each map* function) because `artifact` is already resolved in this dispatch loop and every
@@ -1117,6 +1119,7 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
       // repeats (differing only in volatile ids) still merge. See msgFingerprint.
       const fp = msgFingerprint(rowMessage(row));
       if (fp) m.aggKey = `${m.aggKey}|m:${fp}`.slice(0, 440);
+      mergeRowIocs(iocSink, rowSink, m.aggKey);
       mapped.push(m);
     }
   }

--- a/companion/tests/analysis/combinedLogImport.test.ts
+++ b/companion/tests/analysis/combinedLogImport.test.ts
@@ -179,3 +179,27 @@ describe("parseCombinedLog", () => {
     expect(r.iocs.some((i) => i.type === "other" && i.value.includes("EFORGE_TEST-CANARY-B4fnIM1Ay4mk"))).toBe(true);
   });
 });
+
+describe("parseCombinedLog — IOC provenance", () => {
+  it("tags the request-host domain IOC's sourceAggKeys with its line's aggKey", () => {
+    const line = '10.0.0.5 - - [10/Jan/2026:00:00:00 +0000] "GET http://evil.example.com/x HTTP/1.1" 200 512 "-" "curl/8.0"';
+    const parsed = parseCombinedLog(line);
+    expect(parsed.events).toHaveLength(1);
+    const domainIoc = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil.example.com");
+    expect(domainIoc?.sourceAggKeys).toEqual([parsed.events[0].aggKey]);
+  });
+
+  it("tags two different lines' domain IOCs with their own distinct aggKeys", () => {
+    const lineA = '10.0.0.5 - - [10/Jan/2026:00:00:00 +0000] "GET http://evil-a.example.com/x HTTP/1.1" 200 512 "-" "curl/8.0"';
+    const lineB = '10.0.0.6 - - [10/Jan/2026:00:05:00 +0000] "GET http://evil-b.example.com/y HTTP/1.1" 200 512 "-" "curl/8.0"';
+    const parsed = parseCombinedLog(`${lineA}\n${lineB}`);
+    expect(parsed.events).toHaveLength(2);
+    const iocA = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil-a.example.com");
+    const iocB = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil-b.example.com");
+    const eventA = parsed.events.find((e) => e.description.includes("evil-a.example.com"));
+    const eventB = parsed.events.find((e) => e.description.includes("evil-b.example.com"));
+    expect(iocA?.sourceAggKeys).toEqual([eventA?.aggKey]);
+    expect(iocB?.sourceAggKeys).toEqual([eventB?.aggKey]);
+    expect(iocA?.sourceAggKeys).not.toEqual(iocB?.sourceAggKeys);
+  });
+});

--- a/companion/tests/analysis/iocProvenanceChain.test.ts
+++ b/companion/tests/analysis/iocProvenanceChain.test.ts
@@ -92,7 +92,34 @@ describe("buildIocProvenanceChains", () => {
   it("returns empty arrays for an IOC with no matches", () => {
     const chains = buildIocProvenanceChains([ioc({ id: "i1", type: "ip", value: "1.2.3.4" })], [], []);
     expect(chains.i1).toEqual({
-      iocId: "i1", value: "1.2.3.4", type: "ip", extraction: [], extractionTruncated: 0, enrichment: [], findings: [],
+      iocId: "i1", value: "1.2.3.4", type: "ip", extraction: [], extractionTruncated: 0,
+      extractionAuthoritative: false, enrichment: [], findings: [],
     });
+  });
+
+  it("uses extractedFrom directly when present, ignoring the value-match index", () => {
+    const events = [
+      ev({ id: "e1", severity: "High", timestamp: "2026-01-01T00:00:00Z", description: "unrelated text" }),
+      ev({ id: "e2", severity: "Low", timestamp: "2026-01-02T00:00:00Z", description: "also unrelated" }),
+    ];
+    const i = ioc({ id: "i1", type: "domain", value: "evil.example.com", extractedFrom: ["e2", "e1"] });
+    const chains = buildIocProvenanceChains([i], events, []);
+    expect(chains.i1.extraction.map((x) => x.eventId)).toEqual(["e1", "e2"]); // sorted chronologically
+    expect(chains.i1.extractionAuthoritative).toBe(true);
+  });
+
+  it("falls back to approximate matching when extractedFrom points at no existing event", () => {
+    const events = [ev({ id: "e1", severity: "High", description: "connection to evil.example.com observed" })];
+    const i = ioc({ id: "i1", type: "domain", value: "evil.example.com", extractedFrom: ["e999"] });
+    const chains = buildIocProvenanceChains([i], events, []);
+    expect(chains.i1.extraction.map((x) => x.eventId)).toEqual(["e1"]);
+    expect(chains.i1.extractionAuthoritative).toBe(false);
+  });
+
+  it("falls back to approximate matching when extractedFrom is empty", () => {
+    const events = [ev({ id: "e1", severity: "High", dstIp: "8.8.8.8" })];
+    const i = ioc({ id: "i1", type: "ip", value: "8.8.8.8" });
+    const chains = buildIocProvenanceChains([i], events, []);
+    expect(chains.i1.extractionAuthoritative).toBe(false);
   });
 });

--- a/companion/tests/analysis/networkImport.test.ts
+++ b/companion/tests/analysis/networkImport.test.ts
@@ -185,3 +185,53 @@ describe("parseNetworkLogs — Zeek per-stream JSON (no _path)", () => {
     expect(inferZeekStream(conn)).toBe("conn");
   });
 });
+
+describe("parseNetworkLogs — IOC provenance", () => {
+  it("tags a Suricata alert's domain IOC with the alert event's aggKey", () => {
+    const row = {
+      event_type: "alert", timestamp: "2017-12-01T08:00:00.123456+0000",
+      src_ip: "10.0.0.5", src_port: 51000, dest_ip: "203.0.113.9", dest_port: 443, proto: "TCP",
+      alert: { signature: "ET MALWARE C2 beacon", category: "A Network Trojan was detected", signature_id: 2027000, severity: 1 },
+      dns: { type: "query", rrname: "evil.example.com", rrtype: "A" },
+    };
+    const parsed = parseNetworkLogs(JSON.stringify(row));
+    expect(parsed.events).toHaveLength(1);
+    const domainIoc = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil.example.com");
+    expect(domainIoc?.sourceAggKeys).toEqual([parsed.events[0].aggKey]);
+  });
+
+  it("leaves sourceAggKeys unset for an IOC from a non-alert row (no event produced)", () => {
+    const row = {
+      event_type: "dns", timestamp: "2017-12-01T08:00:01+0000",
+      src_ip: "10.0.0.5", dest_ip: "10.0.0.1",
+      dns: { type: "query", rrname: "benign.example.com", rrtype: "A" },
+    };
+    const parsed = parseNetworkLogs(JSON.stringify(row));
+    expect(parsed.events).toHaveLength(0);
+    const domainIoc = parsed.iocs.find((i) => i.type === "domain" && i.value === "benign.example.com");
+    expect(domainIoc).toBeDefined();
+    expect(domainIoc?.sourceAggKeys).toBeUndefined();
+  });
+
+  it("tags two alert rows' domain IOCs with their own distinct aggKeys", () => {
+    const rowA = {
+      event_type: "alert", timestamp: "2017-12-01T08:00:00.123456+0000",
+      src_ip: "10.0.0.5", src_port: 51000, dest_ip: "203.0.113.9", dest_port: 443, proto: "TCP",
+      alert: { signature: "ET MALWARE C2 beacon A", category: "A Network Trojan was detected", signature_id: 1001, severity: 1 },
+      dns: { rrname: "evil-a.example.com" },
+    };
+    const rowB = {
+      event_type: "alert", timestamp: "2017-12-01T08:05:00.123456+0000",
+      src_ip: "10.0.0.6", src_port: 51001, dest_ip: "203.0.113.10", dest_port: 443, proto: "TCP",
+      alert: { signature: "ET MALWARE C2 beacon B", category: "A Network Trojan was detected", signature_id: 1002, severity: 1 },
+      dns: { rrname: "evil-b.example.com" },
+    };
+    const parsed = parseNetworkLogs(`${JSON.stringify(rowA)}\n${JSON.stringify(rowB)}`);
+    expect(parsed.events).toHaveLength(2);
+    const iocA = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil-a.example.com");
+    const iocB = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil-b.example.com");
+    expect(iocA?.sourceAggKeys?.[0]).not.toEqual(iocB?.sourceAggKeys?.[0]);
+    expect(iocA?.sourceAggKeys?.length).toBe(1);
+    expect(iocB?.sourceAggKeys?.length).toBe(1);
+  });
+});

--- a/companion/tests/analysis/pipeline.test.ts
+++ b/companion/tests/analysis/pipeline.test.ts
@@ -749,3 +749,57 @@ describe("AnalysisPipeline", () => {
     expect(state.forensicTimeline).toHaveLength(0);
   });
 });
+
+// Authoritative IOC->event linkage (issue: IOC/artifact traceability). importSiem /
+// importSecurityOnion / importCombinedLog / importNetwork / importVelociraptor each tag every
+// IOC they extract with the aggKey(s) of the row(s) it came from; the pipeline resolves those
+// aggKeys against the final case-scoped event ids (assigned only once severity filtering has
+// happened) and stamps IOC.extractedFrom, giving each IOC an authoritative link back to its
+// source forensic event instead of relying on iocProvenanceChain's approximate matcher.
+describe("pipeline import — IOC extractedFrom", () => {
+  it("importSiem stamps extractedFrom with the final case-scoped event id", async () => {
+    const pipeline = new AnalysisPipeline({
+      stateStore,
+      imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+    });
+    // A Sysmon Event ID 1 (process creation) record — deterministically maps to one forensic
+    // event carrying a SHA256 hash IOC.
+    const sysmonProc = {
+      "@timestamp": "2026-07-06T09:46:58.001Z",
+      log_name: "Microsoft-Windows-Sysmon/Operational", computer_name: "WKSTN-1.corp.local",
+      event_id: 1, level: "Information",
+      event_data: {
+        UtcTime: "2026-07-06 09:46:58.000", Image: "C:\\Windows\\System32\\taskeng.exe",
+        CommandLine: "taskeng.exe {GUID}", ParentImage: "C:\\Windows\\System32\\svchost.exe",
+        ParentCommandLine: "svchost.exe -k netsvcs", User: "NT AUTHORITY\\SYSTEM",
+        Hashes: "SHA256=425A1A21A4DBC212C3C3DB5F8FECDD6235E7E7FE2FCFCE3AFFE3F9F80AA24A92",
+      },
+    };
+    const state = await pipeline.importSiem("c1", JSON.stringify([sysmonProc]), {
+      label: "evtx.json", idPrefix: "s1", importedAt: "2026-07-06T00:00:00Z",
+    });
+
+    const hashIoc = state.iocs.find((i) => i.type === "hash");
+    expect(hashIoc?.extractedFrom).toEqual(["s1e1"]);
+    expect(state.forensicTimeline.map((e) => e.id)).toContain("s1e1");
+  });
+
+  it("importSecurityOnion stamps extractedFrom for a domain IOC", async () => {
+    const pipeline = new AnalysisPipeline({
+      stateStore,
+      imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+    });
+    const row = {
+      "@timestamp": "2026-07-06T00:00:00Z", "rule.name": "DNS to known-bad domain",
+      "event.severity_label": "high",
+      "dns.query": "evil.example.com", "source.ip": "10.0.0.5", "destination.ip": "10.0.0.1",
+      "host.name": "WKSTN-1",
+    };
+    const state = await pipeline.importSecurityOnion("c1", JSON.stringify([row]), {
+      label: "so.json", idPrefix: "so1", importedAt: "2026-07-06T00:00:00Z",
+    });
+
+    const domainIoc = state.iocs.find((i) => i.value === "evil.example.com");
+    expect(domainIoc?.extractedFrom).toEqual(["so1e1"]);
+  });
+});

--- a/companion/tests/analysis/responseSchema.test.ts
+++ b/companion/tests/analysis/responseSchema.test.ts
@@ -61,3 +61,23 @@ describe("deltaSchema", () => {
     expect(delta.findings[0].confidenceReason).toBeUndefined();
   });
 });
+
+describe("deltaSchema — iocs.extractedFrom", () => {
+  const base = {
+    findings: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [],
+    timelineNote: "", summary: "", forensicEvents: [],
+  };
+
+  it("accepts an ioc with extractedFrom", () => {
+    const parsed = deltaSchema.parse({
+      ...base,
+      iocs: [{ id: "i1", type: "domain", value: "evil.example.com", extractedFrom: ["e001", "e002"] }],
+    });
+    expect(parsed.iocs[0].extractedFrom).toEqual(["e001", "e002"]);
+  });
+
+  it("accepts an ioc without extractedFrom (existing AI-synthesis shape)", () => {
+    const parsed = deltaSchema.parse({ ...base, iocs: [{ id: "i1", type: "ip", value: "1.2.3.4" }] });
+    expect(parsed.iocs[0].extractedFrom).toBeUndefined();
+  });
+});

--- a/companion/tests/analysis/responseSchema.test.ts
+++ b/companion/tests/analysis/responseSchema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { deltaSchema } from "../../src/analysis/responseSchema.js";
+import { deltaSchema, stripAiExtractedFrom } from "../../src/analysis/responseSchema.js";
 
 describe("deltaSchema", () => {
   it("parses a valid delta", () => {
@@ -79,5 +79,46 @@ describe("deltaSchema — iocs.extractedFrom", () => {
   it("accepts an ioc without extractedFrom (existing AI-synthesis shape)", () => {
     const parsed = deltaSchema.parse({ ...base, iocs: [{ id: "i1", type: "ip", value: "1.2.3.4" }] });
     expect(parsed.iocs[0].extractedFrom).toBeUndefined();
+  });
+});
+
+describe("stripAiExtractedFrom", () => {
+  const base = {
+    findings: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [],
+    timelineNote: "", summary: "", forensicEvents: [],
+  };
+
+  it("removes a forged extractedFrom from every ioc", () => {
+    // Simulates a model (possibly influenced by prompt-injected evidence content) fabricating
+    // extractedFrom pointing at a real event id it read from the prompt context, to be rendered
+    // as an authoritative "linked" provenance claim it never actually earned.
+    const parsed = deltaSchema.parse({
+      ...base,
+      iocs: [
+        { id: "i1", type: "domain", value: "evil.example.com", extractedFrom: ["e042"] },
+        { id: "i2", type: "ip", value: "1.2.3.4" },
+      ],
+    });
+    const result = stripAiExtractedFrom(parsed);
+    expect(result.iocs[0].extractedFrom).toBeUndefined();
+    expect("extractedFrom" in result.iocs[0]).toBe(false); // key actually removed, not just set to undefined
+    expect(result.iocs[1].extractedFrom).toBeUndefined();
+    // Everything else on the ioc is preserved untouched.
+    expect(result.iocs[0]).toEqual({ id: "i1", type: "domain", value: "evil.example.com" });
+  });
+
+  it("is a no-op when no ioc carries extractedFrom", () => {
+    const parsed = deltaSchema.parse({ ...base, iocs: [{ id: "i1", type: "ip", value: "1.2.3.4" }] });
+    const result = stripAiExtractedFrom(parsed);
+    expect(result.iocs).toEqual(parsed.iocs);
+  });
+
+  it("does not mutate the input delta (immutable)", () => {
+    const parsed = deltaSchema.parse({
+      ...base,
+      iocs: [{ id: "i1", type: "domain", value: "evil.example.com", extractedFrom: ["e042"] }],
+    });
+    stripAiExtractedFrom(parsed);
+    expect(parsed.iocs[0].extractedFrom).toEqual(["e042"]); // original untouched
   });
 });

--- a/companion/tests/analysis/securityOnionImport.test.ts
+++ b/companion/tests/analysis/securityOnionImport.test.ts
@@ -109,3 +109,20 @@ describe("parseSecurityOnion", () => {
     expect(parseSecurityOnion("[]").events).toHaveLength(0);
   });
 });
+
+describe("parseSecurityOnion — IOC provenance", () => {
+  it("tags a domain IOC's sourceAggKeys with its row's aggKey", () => {
+    const row = {
+      "@timestamp": "2026-01-01T00:00:00Z",
+      "rule.name": "DNS query to known-bad domain",
+      "dns.query": "evil.example.com",
+      "source.ip": "10.0.0.5", "destination.ip": "10.0.0.1",
+      "host.name": "WKSTN-1",
+    };
+    const parsed = parseSecurityOnion(JSON.stringify([row]));
+    expect(parsed.events).toHaveLength(1);
+    const domainIoc = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil.example.com");
+    expect(domainIoc?.sourceAggKeys).toEqual([parsed.events[0].aggKey ? parsed.events[0].aggKey : undefined].filter(Boolean));
+    expect(domainIoc?.sourceAggKeys?.length).toBe(1);
+  });
+});

--- a/companion/tests/analysis/securityOnionImport.test.ts
+++ b/companion/tests/analysis/securityOnionImport.test.ts
@@ -122,7 +122,38 @@ describe("parseSecurityOnion — IOC provenance", () => {
     const parsed = parseSecurityOnion(JSON.stringify([row]));
     expect(parsed.events).toHaveLength(1);
     const domainIoc = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil.example.com");
-    expect(domainIoc?.sourceAggKeys).toEqual([parsed.events[0].aggKey ? parsed.events[0].aggKey : undefined].filter(Boolean));
+    expect(domainIoc?.sourceAggKeys).toEqual([parsed.events[0].aggKey]);
     expect(domainIoc?.sourceAggKeys?.length).toBe(1);
+  });
+
+  it("tags two different rows' domain IOCs with their own distinct aggKeys", () => {
+    const rows = [
+      {
+        "@timestamp": "2026-01-01T00:00:00Z",
+        "rule.name": "DNS query to known-bad domain A",
+        "dns.query": "evil-a.example.com",
+        "source.ip": "10.0.0.5", "destination.ip": "10.0.0.1",
+        "host.name": "WKSTN-1",
+      },
+      {
+        "@timestamp": "2026-01-01T00:05:00Z",
+        "rule.name": "DNS query to known-bad domain B",
+        "dns.query": "evil-b.example.com",
+        "source.ip": "10.0.0.6", "destination.ip": "10.0.0.2",
+        "host.name": "WKSTN-2",
+      },
+    ];
+    const parsed = parseSecurityOnion(JSON.stringify(rows));
+    expect(parsed.events).toHaveLength(2);
+    const iocA = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil-a.example.com");
+    const iocB = parsed.iocs.find((i) => i.type === "domain" && i.value === "evil-b.example.com");
+    const eventA = parsed.events.find((e) => e.description.includes("domain A"));
+    const eventB = parsed.events.find((e) => e.description.includes("domain B"));
+    expect(eventA).toBeDefined();
+    expect(eventB).toBeDefined();
+    expect(eventA?.aggKey).not.toBe(eventB?.aggKey);
+    expect(iocA?.sourceAggKeys).toEqual([eventA?.aggKey]);
+    expect(iocB?.sourceAggKeys).toEqual([eventB?.aggKey]);
+    expect(iocA?.sourceAggKeys).not.toEqual(iocB?.sourceAggKeys);
   });
 });

--- a/companion/tests/analysis/siemImport.test.ts
+++ b/companion/tests/analysis/siemImport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseSiemExport, extractRecords, isSuspiciousCmd, cleanIp, textIocs, type SiemIoc } from "../../src/analysis/siemImport.js";
+import { parseSiemExport, extractRecords, isSuspiciousCmd, cleanIp, textIocs, mergeRowIocs, resolveExtractedFrom, type SiemIoc } from "../../src/analysis/siemImport.js";
 
 // ── Representative Windows Event Log records (Elastic _source shape) ─────────────
 const LOGON_4624 = {
@@ -532,5 +532,47 @@ describe("textIocs — Windows account SID extraction (#221)", () => {
   it("does NOT flood on well-known service/builtin SIDs (S-1-5-18, S-1-5-32-544)", () => {
     const iocs = scrape("SYSTEM S-1-5-18 and Administrators S-1-5-32-544 ran the task");
     expect(iocs.filter((i) => i.type === "sid")).toHaveLength(0);
+  });
+});
+
+describe("row-scoped IOC provenance (aggKey plumbing)", () => {
+  it("stamps the surviving event's aggKey and tags its IOCs with sourceAggKeys", () => {
+    const parsed = parseSiemExport(elastic(SYSMON_PROC));
+    expect(parsed.events).toHaveLength(1);
+    const hashIoc = parsed.iocs.find((i) => i.type === "hash" && i.value.includes("425a1a21"));
+    expect(hashIoc?.sourceAggKeys).toHaveLength(1);
+  });
+
+  it("mergeRowIocs unions sourceAggKeys when the same value recurs across rows", () => {
+    const fileSink = new Map<string, SiemIoc>();
+    const rowSink1 = new Map<string, SiemIoc>([["domain:evil.example.com", { type: "domain", value: "evil.example.com" }]]);
+    mergeRowIocs(fileSink, rowSink1, "agg-1");
+    const rowSink2 = new Map<string, SiemIoc>([["domain:evil.example.com", { type: "domain", value: "evil.example.com" }]]);
+    mergeRowIocs(fileSink, rowSink2, "agg-2");
+    expect(fileSink.get("domain:evil.example.com")?.sourceAggKeys).toEqual(["agg-1", "agg-2"]);
+  });
+
+  it("mergeRowIocs with no aggKey merges the value without tagging it", () => {
+    const fileSink = new Map<string, SiemIoc>();
+    const rowSink = new Map<string, SiemIoc>([["ip:1.2.3.4", { type: "ip", value: "1.2.3.4" }]]);
+    mergeRowIocs(fileSink, rowSink);
+    expect(fileSink.get("ip:1.2.3.4")?.sourceAggKeys).toBeUndefined();
+  });
+
+  it("resolveExtractedFrom maps sourceAggKeys through an aggKey->id lookup", () => {
+    const iocs: SiemIoc[] = [
+      { type: "domain", value: "evil.example.com", sourceAggKeys: ["agg-1", "agg-2"] },
+      { type: "ip", value: "9.9.9.9" },
+    ];
+    const eventIdByAggKey = new Map([["agg-1", "e001"], ["agg-2", "e002"]]);
+    const resolved = resolveExtractedFrom(iocs, eventIdByAggKey);
+    expect(resolved[0].extractedFrom).toEqual(["e001", "e002"]);
+    expect(resolved[1].extractedFrom).toBeUndefined();
+  });
+
+  it("resolveExtractedFrom drops an aggKey that never resolved (event capped away)", () => {
+    const iocs: SiemIoc[] = [{ type: "domain", value: "x.com", sourceAggKeys: ["agg-1", "agg-missing"] }];
+    const eventIdByAggKey = new Map([["agg-1", "e001"]]);
+    expect(resolveExtractedFrom(iocs, eventIdByAggKey)[0].extractedFrom).toEqual(["e001"]);
   });
 });

--- a/companion/tests/analysis/stateMerge.test.ts
+++ b/companion/tests/analysis/stateMerge.test.ts
@@ -377,3 +377,40 @@ describe("mergeDelta", () => {
     expect(state.narrativeTimeline).toBe("Updated narrative after more evidence.");
   });
 });
+
+describe("mergeDelta — ioc extractedFrom", () => {
+  it("carries extractedFrom onto a newly created IOC", () => {
+    const state = emptyState("c1");
+    const next = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [{ id: "si1", type: "domain", value: "evil.example.com", extractedFrom: ["e001"] }],
+    }, { windowSequence: -1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] });
+    expect(next.iocs).toHaveLength(1);
+    expect(next.iocs[0].extractedFrom).toEqual(["e001"]);
+  });
+
+  it("unions extractedFrom when the same IOC value recurs across separate imports", () => {
+    let state = emptyState("c1");
+    state = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [{ id: "si1", type: "domain", value: "evil.example.com", extractedFrom: ["e001"] }],
+    }, { windowSequence: -1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] });
+
+    state = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [{ id: "si1", type: "domain", value: "EVIL.example.com", extractedFrom: ["e050"] }],
+    }, { windowSequence: -1, timestamp: "2026-05-28T11:00:00.000Z", sourceScreenshots: [] });
+
+    expect(state.iocs).toHaveLength(1);
+    expect(state.iocs[0].extractedFrom).toEqual(["e001", "e050"]);
+  });
+
+  it("leaves extractedFrom undefined for an IOC whose delta never sets it", () => {
+    const state = emptyState("c1");
+    const next = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [{ id: "si1", type: "ip", value: "9.9.9.9" }],
+    }, { windowSequence: 1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] });
+    expect(next.iocs[0].extractedFrom).toBeUndefined();
+  });
+});

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -933,3 +933,43 @@ describe("parseVelociraptorJson — timestamp coverage for raw artifacts", () =>
     expect(r.events[0].message).toBeUndefined();
   });
 });
+
+describe("parseVelociraptorJson — IOC provenance", () => {
+  // Modeled on the "download rows (Zone.Identifier / BrowserDownloads)" fixture above (mapDownload
+  // reads DownloadedFilePath/Mtime/HostUrl/ReferrerUrl, not URL/Referrer/Path).
+  function downloadRow(overrides: object = {}): object {
+    return {
+      DownloadedFilePath: "C:\\Users\\a\\Downloads\\payload.exe",
+      Mtime: "2026-01-01T00:00:00Z",
+      HostUrl: "http://evil.example.com/payload.exe",
+      ReferrerUrl: "",
+      ...overrides,
+    };
+  }
+
+  it("tags a download URL IOC's sourceAggKeys with its event's (post-fingerprint) aggKey", () => {
+    const parsed = parseVelociraptorJson(JSON.stringify([downloadRow()]));
+    expect(parsed.events).toHaveLength(1);
+    const urlIoc = parsed.iocs.find((i) => i.type === "url" && i.value.includes("evil.example.com"));
+    expect(urlIoc?.sourceAggKeys).toEqual([parsed.events[0].aggKey]);
+  });
+
+  it("tags two different rows' IOCs with their own distinct (post-fingerprint) aggKeys", () => {
+    const rowA = downloadRow({
+      HostUrl: "http://evil-a.example.com/payload.exe",
+      DownloadedFilePath: "C:\\Users\\a\\Downloads\\payload-a.exe",
+      Mtime: "2026-01-01T00:00:00Z",
+    });
+    const rowB = downloadRow({
+      HostUrl: "http://evil-b.example.com/payload.exe",
+      DownloadedFilePath: "C:\\Users\\a\\Downloads\\payload-b.exe",
+      Mtime: "2026-01-01T00:05:00Z",
+    });
+    const parsed = parseVelociraptorJson(JSON.stringify([rowA, rowB]));
+    const iocA = parsed.iocs.find((i) => i.type === "url" && i.value.includes("evil-a.example.com"));
+    const iocB = parsed.iocs.find((i) => i.type === "url" && i.value.includes("evil-b.example.com"));
+    expect(iocA?.sourceAggKeys?.length).toBe(1);
+    expect(iocB?.sourceAggKeys?.length).toBe(1);
+    expect(iocA?.sourceAggKeys?.[0]).not.toEqual(iocB?.sourceAggKeys?.[0]);
+  });
+});

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -937,12 +937,16 @@ describe("parseVelociraptorJson — timestamp coverage for raw artifacts", () =>
 describe("parseVelociraptorJson — IOC provenance", () => {
   // Modeled on the "download rows (Zone.Identifier / BrowserDownloads)" fixture above (mapDownload
   // reads DownloadedFilePath/Mtime/HostUrl/ReferrerUrl, not URL/Referrer/Path).
+  // `Message` is populated so rowMessage()/msgFingerprint() actually produce a non-empty fingerprint
+  // (see rowMessage() in velociraptorImport.ts, which reads Message/Details/message) — otherwise the
+  // `if (fp) m.aggKey = ...` fold line never runs and these tests can't detect it being skipped/reordered.
   function downloadRow(overrides: object = {}): object {
     return {
       DownloadedFilePath: "C:\\Users\\a\\Downloads\\payload.exe",
       Mtime: "2026-01-01T00:00:00Z",
       HostUrl: "http://evil.example.com/payload.exe",
       ReferrerUrl: "",
+      Message: "User downloaded payload.exe from evil.example.com via browser",
       ...overrides,
     };
   }
@@ -950,8 +954,12 @@ describe("parseVelociraptorJson — IOC provenance", () => {
   it("tags a download URL IOC's sourceAggKeys with its event's (post-fingerprint) aggKey", () => {
     const parsed = parseVelociraptorJson(JSON.stringify([downloadRow()]));
     expect(parsed.events).toHaveLength(1);
+    // Prove the fold actually ran (not just that both sides read the same already-computed field,
+    // which would also pass if mergeRowIocs ran BEFORE the fingerprint fold).
+    expect(parsed.events[0].aggKey).toMatch(/\|m:/);
     const urlIoc = parsed.iocs.find((i) => i.type === "url" && i.value.includes("evil.example.com"));
     expect(urlIoc?.sourceAggKeys).toEqual([parsed.events[0].aggKey]);
+    expect(urlIoc?.sourceAggKeys?.[0]).toMatch(/\|m:/);
   });
 
   it("tags two different rows' IOCs with their own distinct (post-fingerprint) aggKeys", () => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -9384,8 +9384,11 @@
             `<a class="finding-jump iocchain-desc" data-fid="${escAttr(f.findingId)}" title="Jump to this finding">${esc(f.title)}</a>` +
             `<span class="iocchain-tag">${esc(f.severity)}, ${esc(f.status)}</span></div>`).join("")
         : "<div style='color:var(--c-9aa4b2);font-size:12px'>no findings cite this IOC yet</div>";
+      const extractionCaveat = chain.extractionAuthoritative
+        ? `<small style="color:var(--c-6aa9ff)">(linked — a real source-event reference, not a guess)</small>`
+        : `<small style="color:var(--c-9aa4b2)">(approximate — matched by value, not a stored link)</small>`;
       bodyEl.innerHTML =
-        `<div class="explain-section"><strong>Extraction — event(s) this IOC was seen in <small style="color:var(--c-9aa4b2)">(approximate — matched by value, not a stored link)</small></strong>${extractionRows}${truncNote}</div>` +
+        `<div class="explain-section"><strong>Extraction — event(s) this IOC was seen in ${extractionCaveat}</strong>${extractionRows}${truncNote}</div>` +
         `<div class="explain-section"><strong>Enrichment — threat-intel lookups</strong>${enrichRows}</div>` +
         `<div class="explain-section"><strong>Findings citing this IOC</strong>${findingRows}</div>` +
         `<div style="color:var(--c-9aa4b2);font-size:11px;margin-top:6px">Playbook references aren't tracked yet — playbook tasks don't carry IOC links.</div>`;


### PR DESCRIPTION
## Summary
- Adds a real, stored link (`IOC.extractedFrom`) from an IOC to the exact forensic event(s) it was extracted from, for the 5 highest-volume importers: SIEM/EVTX, Security Onion, Network, Combined-log, and Velociraptor.
- The IOC 🔗 provenance chain panel now shows "linked" (authoritative) vs "approximate" (the pre-existing value-match guess, still used as a fallback for every other importer and for old IOCs).
- Closes a real gap found while investigating: several importers (e.g. Security Onion's `dns.query`/`url.domain`) extracted a domain IOC but never wrote it anywhere the old approximate matcher could find, so those IOCs showed "no provenance data" even though the source event existed.
- Hardening: the shared delta schema used by both these deterministic importers and the AI synthesis pipeline was widened to carry `extractedFrom`, so a defensive strip was added at every AI-parse call site to make sure model output (or prompt-injected content) can never forge an authoritative link.

## Test plan
- [x] Full `vitest` suite green (287 files / 3309+ tests); a handful of unrelated full-suite-parallel timeouts reproduced as the known Windows resource-contention flake and were confirmed passing in isolation, including the two tests that exercise the new AI-strip code path.
- [x] `tsc --noEmit` clean throughout.
- [x] Manually verified end-to-end via the dashboard: a combined-log-imported domain IOC shows "linked"; an auditd-imported IOC (non-priority importer) still shows "approximate", proving the fallback is unchanged.
- [x] Each of the 12 implementation tasks independently spec-reviewed and code-reviewed, plus a final holistic cross-task review that caught and fixed the AI-synthesis trust-boundary gap above.