### PR TITLE
feat: add persistent drop-folder log (drop-log.txt)

### DIFF
--- a/companion/src/analysis/dropLog.ts
+++ b/companion/src/analysis/dropLog.ts
@@ -44,3 +44,33 @@ export async function appendDropLog(dropDir: string, lines: readonly string[]): 
   if (lines.length === 0) return;
   await appendFile(join(dropDir, DROP_LOG_FILE), lines.join("\n") + "\n", "utf8");
 }
+
+/** Given one sweep's outcomes and the relpaths already logged as PENDING for this case, returns the
+ *  DropLogEntry[] to append this sweep and the updated "already logged pending" set (a pending file
+ *  logs once; it drops out once resolved by the caller, so if it becomes pending again later it will
+ *  log again). Pure — the caller replaces its stored set with `nextLoggedPending`, no mutation here. */
+export function buildSweepLogEntries(
+  sweep: {
+    imported: readonly string[];
+    failed: readonly { relpath: string; reason: string }[];
+    pendingRawInputs: readonly { relpath: string; ext: string; configured: boolean }[];
+  },
+  loggedPending: ReadonlySet<string>,
+): { entries: DropLogEntry[]; nextLoggedPending: Set<string> } {
+  const entries: DropLogEntry[] = [
+    ...sweep.imported.map((relpath): DropLogEntry => ({ status: "IMPORTED", relpath })),
+    ...sweep.failed.map((f): DropLogEntry => ({ status: "FAILED", relpath: f.relpath, reason: f.reason })),
+    ...sweep.pendingRawInputs
+      .filter((p) => !loggedPending.has(p.relpath))
+      .map((p): DropLogEntry => ({
+        status: "PENDING",
+        relpath: p.relpath,
+        reason: p.configured
+          ? `awaiting tool run for ${p.ext} (drop banner: Run)`
+          : `no tool configured for ${p.ext} (drop banner: Configure)`,
+      })),
+  ];
+  const nextLoggedPending = new Set(loggedPending);
+  for (const p of sweep.pendingRawInputs) nextLoggedPending.add(p.relpath);
+  return { entries, nextLoggedPending };
+}

--- a/companion/src/analysis/dropLog.ts
+++ b/companion/src/analysis/dropLog.ts
@@ -1,0 +1,38 @@
+// Pure formatting of drop-folder event lines, plus a thin append helper for the folder-visible
+// history file `drop/drop-log.txt`. Mirrors the pure-logic/IO split used by dropScan.ts and
+// dropStatus.ts: the walk + import + move stay in the server.ts closure, this module only formats
+// and appends. Written directly into the drop folder (unlike drop-status.json, which lives in
+// case state) so an analyst can see what happened to dropped files without opening the dashboard.
+
+import { appendFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/** The log file's basename inside `drop/`. Also added to dropScan.ts's IGNORED_BASENAMES. */
+export const DROP_LOG_FILE = "drop-log.txt";
+
+export type DropLogStatus = "IMPORTED" | "FAILED" | "PENDING";
+
+export interface DropLogEntry {
+  status: DropLogStatus;
+  relpath: string;
+  /** Present for FAILED and PENDING; optional for IMPORTED (e.g. "via <tool>" when resolved from pending). */
+  reason?: string;
+}
+
+// "IMPORTED" is the longest status (8 chars); pad the others to match for column alignment.
+const STATUS_WIDTH = 8;
+
+/** One formatted line per entry: "<iso-timestamp>  <STATUS>  <relpath>[  — <reason>]". Pure, no I/O. */
+export function formatDropLogLines(entries: readonly DropLogEntry[], at: string): string[] {
+  return entries.map((e) => {
+    const status = e.status.padEnd(STATUS_WIDTH);
+    const reason = e.reason ? `  — ${e.reason}` : "";
+    return `${at}  ${status}  ${e.relpath}${reason}`;
+  });
+}
+
+/** Append pre-formatted lines to drop/drop-log.txt, creating the file if it doesn't exist yet. */
+export async function appendDropLog(dropDir: string, lines: readonly string[]): Promise<void> {
+  if (lines.length === 0) return;
+  await appendFile(join(dropDir, DROP_LOG_FILE), lines.join("\n") + "\n", "utf8");
+}

--- a/companion/src/analysis/dropLog.ts
+++ b/companion/src/analysis/dropLog.ts
@@ -22,12 +22,20 @@ export interface DropLogEntry {
 // "IMPORTED" is the longest status (8 chars); pad the others to match for column alignment.
 const STATUS_WIDTH = 8;
 
+// Collapse embedded newlines (and surrounding whitespace) to a single space so one logical event
+// never splits across multiple physical lines in drop-log.txt. Real Error messages (Node/Zod/parser)
+// are frequently multi-line, so this is applied at the one chokepoint all callers funnel through.
+function sanitize(s: string): string {
+  return s.replace(/\s*[\r\n]+\s*/g, " ").trim();
+}
+
 /** One formatted line per entry: "<iso-timestamp>  <STATUS>  <relpath>[  — <reason>]". Pure, no I/O. */
 export function formatDropLogLines(entries: readonly DropLogEntry[], at: string): string[] {
   return entries.map((e) => {
     const status = e.status.padEnd(STATUS_WIDTH);
-    const reason = e.reason ? `  — ${e.reason}` : "";
-    return `${at}  ${status}  ${e.relpath}${reason}`;
+    const relpath = sanitize(e.relpath);
+    const reason = e.reason ? `  — ${sanitize(e.reason)}` : "";
+    return `${at}  ${status}  ${relpath}${reason}`;
   });
 }
 

--- a/companion/src/analysis/dropScan.ts
+++ b/companion/src/analysis/dropScan.ts
@@ -10,6 +10,7 @@
 // unit-tested in isolation. Pairs with `dropStatus.ts` (the persisted last-sweep summary).
 
 import { extname, basename } from "node:path";
+import { DROP_LOG_FILE } from "./dropLog.js";
 
 /** A drop-folder file as seen by one poll: its path relative to `drop/`, plus size + mtime. */
 export interface DropFileStat {
@@ -46,6 +47,7 @@ export const DROP_README = "README.txt";
 // OS / sync junk files that must never be treated as evidence.
 const IGNORED_BASENAMES = new Set([
   DROP_README.toLowerCase(),
+  DROP_LOG_FILE.toLowerCase(),
   ".ds_store",
   "thumbs.db",
   "desktop.ini",

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2596,46 +2596,56 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
     if (!options.dropStatusStore) return res.status(501).json({ error: "drop folder not enabled" });
     if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
-    const pending = (await options.dropStatusStore.load(caseId)).pendingRawInputs ?? [];
-    const configured = liveToolConfigs();
-    const dropDir = dropDirOf(caseId);
-    // ONE undo checkpoint for the whole "Run all" batch (the user clicked once): snapshot before, then
-    // push a single checkpoint after if anything imported — so undo reverts the batch in one step.
-    let before: InvestigationState | null = null;
-    if (options.stateStore) { try { before = await options.stateStore.load(caseId); } catch { /* keep null */ } }
-    let ran = 0, failed = 0, skipped = 0;
-    const stillPending: PendingRawInput[] = [];
-    const resolvedEntries: DropLogEntry[] = [];
-    for (const p of pending) {
-      const toolId = resolveToolForExt(p.ext, configured);
-      if (!toolId) { skipped++; stillPending.push({ ...p, configured: false, suggestedTool: suggestedToolForExtension(p.ext) }); continue; }
-      try {
-        await runToolAndIngest(caseId, toolId, join(dropDir, p.relpath));
-        await moveDropFile(dropDir, p.relpath, true).catch(() => { /* best-effort */ });
-        resolvedEntries.push({ status: "IMPORTED", relpath: p.relpath, reason: `via ${toolId} (tool run)` });
-        ran++;
-      } catch (err) {
-        failed++;
-        recordImportFailure(caseId, "drop-tool", p.relpath, err);
-        resolvedEntries.push({ status: "FAILED", relpath: p.relpath, reason: (err as Error)?.message ?? String(err) });
-        await moveDropFile(dropDir, p.relpath, false).catch(() => { /* best-effort */ });
+    // Serialize against the poller's scanCaseDrops sweep for this case: both are writers of
+    // dropPendingLogged, and this route awaits per-file tool runs, so an overlapping sweep could
+    // read a stale dropPendingLogged snapshot and clobber this route's deletes / emit a stray
+    // PENDING line for a file this route just resolved.
+    if (dropScanning.has(caseId)) return res.status(409).json({ error: "a drop sweep is in progress for this case, try again shortly" });
+    dropScanning.add(caseId);
+    try {
+      const pending = (await options.dropStatusStore.load(caseId)).pendingRawInputs ?? [];
+      const configured = liveToolConfigs();
+      const dropDir = dropDirOf(caseId);
+      // ONE undo checkpoint for the whole "Run all" batch (the user clicked once): snapshot before, then
+      // push a single checkpoint after if anything imported — so undo reverts the batch in one step.
+      let before: InvestigationState | null = null;
+      if (options.stateStore) { try { before = await options.stateStore.load(caseId); } catch { /* keep null */ } }
+      let ran = 0, failed = 0, skipped = 0;
+      const stillPending: PendingRawInput[] = [];
+      const resolvedEntries: DropLogEntry[] = [];
+      for (const p of pending) {
+        const toolId = resolveToolForExt(p.ext, configured);
+        if (!toolId) { skipped++; stillPending.push({ ...p, configured: false, suggestedTool: suggestedToolForExtension(p.ext) }); continue; }
+        try {
+          await runToolAndIngest(caseId, toolId, join(dropDir, p.relpath));
+          await moveDropFile(dropDir, p.relpath, true).catch(() => { /* best-effort */ });
+          resolvedEntries.push({ status: "IMPORTED", relpath: p.relpath, reason: `via ${toolId} (tool run)` });
+          ran++;
+        } catch (err) {
+          failed++;
+          recordImportFailure(caseId, "drop-tool", p.relpath, err);
+          resolvedEntries.push({ status: "FAILED", relpath: p.relpath, reason: (err as Error)?.message ?? String(err) });
+          await moveDropFile(dropDir, p.relpath, false).catch(() => { /* best-effort */ });
+        }
+        dropSeen.get(caseId)?.delete(p.relpath);   // moved out of the watched area — forget it
+        dropPendingLogged.get(caseId)?.delete(p.relpath); // resolved — no longer pending
       }
-      dropSeen.get(caseId)?.delete(p.relpath);   // moved out of the watched area — forget it
-      dropPendingLogged.get(caseId)?.delete(p.relpath); // resolved — no longer pending
-    }
-    if (before && ran > 0) {
-      const s = await options.stateStore?.load(caseId).catch(() => null);
-      if (!s || s.forensicTimeline.length !== before.forensicTimeline.length || s.iocs.length !== before.iocs.length) {
-        await pushImportCheckpoint(caseId, before, `Tools: drop batch (${ran} file${ran !== 1 ? "s" : ""})`);
+      if (before && ran > 0) {
+        const s = await options.stateStore?.load(caseId).catch(() => null);
+        if (!s || s.forensicTimeline.length !== before.forensicTimeline.length || s.iocs.length !== before.iocs.length) {
+          await pushImportCheckpoint(caseId, before, `Tools: drop batch (${ran} file${ran !== 1 ? "s" : ""})`);
+        }
       }
+      if (resolvedEntries.length > 0) {
+        await appendDropLog(dropDir, formatDropLogLines(resolvedEntries, new Date().toISOString()))
+          .catch((e) => logLine(`[drop] log append failed: ${(e as Error).message}`));
+      }
+      await options.dropStatusStore.record(caseId, { dropPath: dropDir, imported: [], failed: [], pendingRawInputs: stillPending });
+      options.onDropStatus?.(caseId);
+      return res.status(200).json({ ok: true, ran, failed, skipped });
+    } finally {
+      dropScanning.delete(caseId);
     }
-    if (resolvedEntries.length > 0) {
-      await appendDropLog(dropDir, formatDropLogLines(resolvedEntries, new Date().toISOString()))
-        .catch((e) => logLine(`[drop] log append failed: ${(e as Error).message}`));
-    }
-    await options.dropStatusStore.record(caseId, { dropPath: dropDir, imported: [], failed: [], pendingRawInputs: stillPending });
-    options.onDropStatus?.(caseId);
-    return res.status(200).json({ ok: true, ran, failed, skipped });
   });
 
   // Run a tool's "update rules" command (Settings → Tools). Does NOT touch case data — a rule update is

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -146,6 +146,7 @@ import {
   selectReadyFiles, classifyDropFile, rawToolInputExt, RAW_TOOL_EXTS, shouldIgnoreDropFile, isOversize,
   DROP_PROCESSED, DROP_FAILED, DROP_README, type DropFileStat,
 } from "./analysis/dropScan.js";
+import { formatDropLogLines, appendDropLog, type DropLogEntry } from "./analysis/dropLog.js";
 import {
   loadAllToolConfigs, toolForExtension, suggestedToolForExtension, TOOL_DEFS, type ToolId, type ToolConfig,
 } from "./integrations/tools/toolConfig.js";
@@ -3050,6 +3051,9 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   const DROP_CONCURRENCY = 4;
   const dropSeen = new Map<string, Map<string, { size: number; mtimeMs: number }>>();
   const dropScanning = new Set<string>();
+  // Files logged as PENDING (relpath per case) so a still-waiting raw-tool file doesn't get a new
+  // PENDING line every poll — only once when first seen pending, cleared once it resolves.
+  const dropPendingLogged = new Map<string, Set<string>>();
   const DROP_README_TEXT = [
     "DFIR Companion — evidence drop folder",
     "",
@@ -3274,6 +3278,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
           else failed.push({ relpath: file.relpath, reason: res.reason ?? "import failed" });
           await moveDropFile(dropDir, file.relpath, res.ok).catch((e) => logLine(`[drop] move failed for ${file.relpath}: ${(e as Error).message}`));
           nextSeen.delete(file.relpath); // moved out of the watched area — forget it
+          dropPendingLogged.get(caseId)?.delete(file.relpath); // resolved — no longer pending
         }));
       }
       if (imported.length === 0 && failed.length === 0 && pendingRawInputs.length === 0) return;
@@ -3284,6 +3289,31 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
           options.onDropStatus?.(caseId);
         } catch (e) { logLine(`[drop] status record failed: ${(e as Error).message}`); }
       }
+
+      // Folder-visible history (drop/drop-log.txt): every imported/failed file gets a line; a pending
+      // raw-tool file gets ONE PENDING line the first time it's seen (dropPendingLogged dedups it across
+      // the ~10s poll interval until it resolves).
+      const loggedPending = dropPendingLogged.get(caseId) ?? new Set<string>();
+      const logEntries: DropLogEntry[] = [
+        ...imported.map((relpath): DropLogEntry => ({ status: "IMPORTED", relpath })),
+        ...failed.map((f): DropLogEntry => ({ status: "FAILED", relpath: f.relpath, reason: f.reason })),
+        ...pendingRawInputs
+          .filter((p) => !loggedPending.has(p.relpath))
+          .map((p): DropLogEntry => ({
+            status: "PENDING",
+            relpath: p.relpath,
+            reason: p.configured
+              ? `awaiting tool run for ${p.ext} (drop banner: Run)`
+              : `no tool configured for ${p.ext} (drop banner: Configure)`,
+          })),
+      ];
+      for (const p of pendingRawInputs) loggedPending.add(p.relpath);
+      dropPendingLogged.set(caseId, loggedPending);
+      if (logEntries.length > 0) {
+        await appendDropLog(dropDir, formatDropLogLines(logEntries, new Date().toISOString()))
+          .catch((e) => logLine(`[drop] log append failed: ${(e as Error).message}`));
+      }
+
       logLine(`[drop] ${caseId}: ${imported.length} imported, ${failed.length} failed`);
       if (failed.length > 0) {
         const lines = failed.slice(0, 20).map((x) => `• ${x.relpath} — ${x.reason}`);

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -3081,8 +3081,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     "",
     "After processing, files move to _processed/ (success) or _failed/ (error).",
     "Failures are reported in the dashboard (📥 Drop banner) and any configured notification channel.",
+    "A running history of every file processed (imported/failed/pending, with reasons) is kept in",
+    "drop-log.txt in this same folder.",
     "",
-    "This README and the _processed/ and _failed/ subfolders are ignored by the scanner.",
+    "This README, drop-log.txt, and the _processed/ and _failed/ subfolders are ignored by the scanner.",
     "",
   ].join("\n");
 

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -146,7 +146,7 @@ import {
   selectReadyFiles, classifyDropFile, rawToolInputExt, RAW_TOOL_EXTS, shouldIgnoreDropFile, isOversize,
   DROP_PROCESSED, DROP_FAILED, DROP_README, type DropFileStat,
 } from "./analysis/dropScan.js";
-import { formatDropLogLines, appendDropLog, type DropLogEntry } from "./analysis/dropLog.js";
+import { formatDropLogLines, appendDropLog, buildSweepLogEntries } from "./analysis/dropLog.js";
 import {
   loadAllToolConfigs, toolForExtension, suggestedToolForExtension, TOOL_DEFS, type ToolId, type ToolConfig,
 } from "./integrations/tools/toolConfig.js";
@@ -3293,22 +3293,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       // Folder-visible history (drop/drop-log.txt): every imported/failed file gets a line; a pending
       // raw-tool file gets ONE PENDING line the first time it's seen (dropPendingLogged dedups it across
       // the ~10s poll interval until it resolves).
-      const loggedPending = dropPendingLogged.get(caseId) ?? new Set<string>();
-      const logEntries: DropLogEntry[] = [
-        ...imported.map((relpath): DropLogEntry => ({ status: "IMPORTED", relpath })),
-        ...failed.map((f): DropLogEntry => ({ status: "FAILED", relpath: f.relpath, reason: f.reason })),
-        ...pendingRawInputs
-          .filter((p) => !loggedPending.has(p.relpath))
-          .map((p): DropLogEntry => ({
-            status: "PENDING",
-            relpath: p.relpath,
-            reason: p.configured
-              ? `awaiting tool run for ${p.ext} (drop banner: Run)`
-              : `no tool configured for ${p.ext} (drop banner: Configure)`,
-          })),
-      ];
-      for (const p of pendingRawInputs) loggedPending.add(p.relpath);
-      dropPendingLogged.set(caseId, loggedPending);
+      const { entries: logEntries, nextLoggedPending } = buildSweepLogEntries(
+        { imported, failed, pendingRawInputs },
+        dropPendingLogged.get(caseId) ?? new Set<string>(),
+      );
+      dropPendingLogged.set(caseId, nextLoggedPending);
       if (logEntries.length > 0) {
         await appendDropLog(dropDir, formatDropLogLines(logEntries, new Date().toISOString()))
           .catch((e) => logLine(`[drop] log append failed: ${(e as Error).message}`));

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -146,7 +146,7 @@ import {
   selectReadyFiles, classifyDropFile, rawToolInputExt, RAW_TOOL_EXTS, shouldIgnoreDropFile, isOversize,
   DROP_PROCESSED, DROP_FAILED, DROP_README, type DropFileStat,
 } from "./analysis/dropScan.js";
-import { formatDropLogLines, appendDropLog, buildSweepLogEntries } from "./analysis/dropLog.js";
+import { formatDropLogLines, appendDropLog, buildSweepLogEntries, type DropLogEntry } from "./analysis/dropLog.js";
 import {
   loadAllToolConfigs, toolForExtension, suggestedToolForExtension, TOOL_DEFS, type ToolId, type ToolConfig,
 } from "./integrations/tools/toolConfig.js";
@@ -2605,25 +2605,33 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     if (options.stateStore) { try { before = await options.stateStore.load(caseId); } catch { /* keep null */ } }
     let ran = 0, failed = 0, skipped = 0;
     const stillPending: PendingRawInput[] = [];
+    const resolvedEntries: DropLogEntry[] = [];
     for (const p of pending) {
       const toolId = resolveToolForExt(p.ext, configured);
       if (!toolId) { skipped++; stillPending.push({ ...p, configured: false, suggestedTool: suggestedToolForExtension(p.ext) }); continue; }
       try {
         await runToolAndIngest(caseId, toolId, join(dropDir, p.relpath));
         await moveDropFile(dropDir, p.relpath, true).catch(() => { /* best-effort */ });
+        resolvedEntries.push({ status: "IMPORTED", relpath: p.relpath, reason: `via ${toolId} (tool run)` });
         ran++;
       } catch (err) {
         failed++;
         recordImportFailure(caseId, "drop-tool", p.relpath, err);
+        resolvedEntries.push({ status: "FAILED", relpath: p.relpath, reason: (err as Error)?.message ?? String(err) });
         await moveDropFile(dropDir, p.relpath, false).catch(() => { /* best-effort */ });
       }
       dropSeen.get(caseId)?.delete(p.relpath);   // moved out of the watched area — forget it
+      dropPendingLogged.get(caseId)?.delete(p.relpath); // resolved — no longer pending
     }
     if (before && ran > 0) {
       const s = await options.stateStore?.load(caseId).catch(() => null);
       if (!s || s.forensicTimeline.length !== before.forensicTimeline.length || s.iocs.length !== before.iocs.length) {
         await pushImportCheckpoint(caseId, before, `Tools: drop batch (${ran} file${ran !== 1 ? "s" : ""})`);
       }
+    }
+    if (resolvedEntries.length > 0) {
+      await appendDropLog(dropDir, formatDropLogLines(resolvedEntries, new Date().toISOString()))
+        .catch((e) => logLine(`[drop] log append failed: ${(e as Error).message}`));
     }
     await options.dropStatusStore.record(caseId, { dropPath: dropDir, imported: [], failed: [], pendingRawInputs: stillPending });
     options.onDropStatus?.(caseId);

--- a/companion/tests/analysis/dropLog.test.ts
+++ b/companion/tests/analysis/dropLog.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { formatDropLogLines, appendDropLog, DROP_LOG_FILE, type DropLogEntry } from "../../src/analysis/dropLog.js";
+import {
+  formatDropLogLines, appendDropLog, buildSweepLogEntries, DROP_LOG_FILE, type DropLogEntry,
+} from "../../src/analysis/dropLog.js";
 
 describe("formatDropLogLines", () => {
   const at = "2026-07-09T14:02:11.482Z";
@@ -81,5 +83,124 @@ describe("appendDropLog", () => {
   it("does nothing for an empty entries list (no file created)", async () => {
     await appendDropLog(dropDir, []);
     await expect(readFile(join(dropDir, DROP_LOG_FILE), "utf8")).rejects.toThrow();
+  });
+});
+
+describe("buildSweepLogEntries", () => {
+  it("always produces entries for imported and failed files regardless of loggedPending", () => {
+    const { entries, nextLoggedPending } = buildSweepLogEntries(
+      {
+        imported: ["a.csv"],
+        failed: [{ relpath: "b.csv", reason: "bad header" }],
+        pendingRawInputs: [],
+      },
+      new Set(["a.csv", "b.csv"]), // even if these happen to already be "logged pending", imported/failed always log
+    );
+    expect(entries).toEqual([
+      { status: "IMPORTED", relpath: "a.csv" },
+      { status: "FAILED", relpath: "b.csv", reason: "bad header" },
+    ]);
+    // loggedPending tracking is only about pendingRawInputs; imported/failed relpaths pass through untouched
+    expect(nextLoggedPending).toEqual(new Set(["a.csv", "b.csv"]));
+  });
+
+  it("logs a pending file not yet in loggedPending, and adds it to nextLoggedPending", () => {
+    const { entries, nextLoggedPending } = buildSweepLogEntries(
+      {
+        imported: [],
+        failed: [],
+        pendingRawInputs: [{ relpath: "capture.evtx", ext: ".evtx", configured: true }],
+      },
+      new Set(),
+    );
+    expect(entries).toEqual([
+      {
+        status: "PENDING",
+        relpath: "capture.evtx",
+        reason: "awaiting tool run for .evtx (drop banner: Run)",
+      },
+    ]);
+    expect(nextLoggedPending.has("capture.evtx")).toBe(true);
+  });
+
+  it("does not re-log a pending file already in loggedPending, but keeps it in nextLoggedPending", () => {
+    const { entries, nextLoggedPending } = buildSweepLogEntries(
+      {
+        imported: [],
+        failed: [],
+        pendingRawInputs: [{ relpath: "capture.evtx", ext: ".evtx", configured: true }],
+      },
+      new Set(["capture.evtx"]),
+    );
+    expect(entries).toEqual([]);
+    expect(nextLoggedPending.has("capture.evtx")).toBe(true);
+  });
+
+  it("does not carry a resolved relpath into nextLoggedPending", () => {
+    // In production, server.ts deletes a resolved relpath from its stored dropPendingLogged set (via
+    // dropPendingLogged.get(caseId)?.delete(file.relpath)) as soon as a file moves from pending to
+    // imported/failed — BEFORE calling buildSweepLogEntries for the sweep. So loggedPending passed in
+    // here already excludes "capture.evtx". buildSweepLogEntries only ever ADDS relpaths present in
+    // this sweep's pendingRawInputs — it never resurrects a relpath the caller already removed.
+    const { entries, nextLoggedPending } = buildSweepLogEntries(
+      {
+        imported: ["capture.evtx"], // resolved: now imported, no longer pending
+        failed: [],
+        pendingRawInputs: [], // absent from this sweep's pendingRawInputs — it resolved
+      },
+      new Set(), // caller already deleted "capture.evtx" from loggedPending when it resolved
+    );
+    expect(entries).toEqual([{ status: "IMPORTED", relpath: "capture.evtx" }]);
+    expect(nextLoggedPending.has("capture.evtx")).toBe(false);
+  });
+
+  it("if a resolved file becomes pending again later, it logs again (fresh loggedPending without it)", () => {
+    const { entries, nextLoggedPending } = buildSweepLogEntries(
+      {
+        imported: [],
+        failed: [],
+        pendingRawInputs: [{ relpath: "capture.evtx", ext: ".evtx", configured: true }],
+      },
+      new Set(), // caller already deleted "capture.evtx" from loggedPending when it resolved earlier
+    );
+    expect(entries).toEqual([
+      {
+        status: "PENDING",
+        relpath: "capture.evtx",
+        reason: "awaiting tool run for .evtx (drop banner: Run)",
+      },
+    ]);
+    expect(nextLoggedPending.has("capture.evtx")).toBe(true);
+  });
+
+  it("uses the 'no tool configured' reason text when configured is false", () => {
+    const { entries } = buildSweepLogEntries(
+      {
+        imported: [],
+        failed: [],
+        pendingRawInputs: [{ relpath: "traffic.pcap", ext: ".pcap", configured: false }],
+      },
+      new Set(),
+    );
+    expect(entries).toEqual([
+      {
+        status: "PENDING",
+        relpath: "traffic.pcap",
+        reason: "no tool configured for .pcap (drop banner: Configure)",
+      },
+    ]);
+  });
+
+  it("does not mutate the input loggedPending set", () => {
+    const original = new Set(["existing.evtx"]);
+    buildSweepLogEntries(
+      {
+        imported: [],
+        failed: [],
+        pendingRawInputs: [{ relpath: "new.evtx", ext: ".evtx", configured: true }],
+      },
+      original,
+    );
+    expect(original).toEqual(new Set(["existing.evtx"])); // unchanged — caller must use the returned set
   });
 });

--- a/companion/tests/analysis/dropLog.test.ts
+++ b/companion/tests/analysis/dropLog.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { formatDropLogLines, appendDropLog, DROP_LOG_FILE, type DropLogEntry } from "../../src/analysis/dropLog.js";
+
+describe("formatDropLogLines", () => {
+  const at = "2026-07-09T14:02:11.482Z";
+
+  it("formats an IMPORTED line with no reason", () => {
+    const lines = formatDropLogLines([{ status: "IMPORTED", relpath: "alerts.csv" }], at);
+    expect(lines).toEqual([`${at}  IMPORTED  alerts.csv`]);
+  });
+
+  it("formats a FAILED line with a reason", () => {
+    const lines = formatDropLogLines(
+      [{ status: "FAILED", relpath: "weird.csv", reason: "unrecognized file type (not a supported import format)" }],
+      at,
+    );
+    expect(lines).toEqual([`${at}  FAILED    weird.csv  — unrecognized file type (not a supported import format)`]);
+  });
+
+  it("formats a PENDING line with a reason", () => {
+    const lines = formatDropLogLines(
+      [{ status: "PENDING", relpath: "capture.evtx", reason: "no tool configured for .evtx" }],
+      at,
+    );
+    expect(lines).toEqual([`${at}  PENDING   capture.evtx  — no tool configured for .evtx`]);
+  });
+
+  it("preserves entry order across multiple entries in one call", () => {
+    const entries: DropLogEntry[] = [
+      { status: "IMPORTED", relpath: "a.csv" },
+      { status: "FAILED", relpath: "b.csv", reason: "empty file" },
+      { status: "PENDING", relpath: "c.evtx", reason: "no tool configured" },
+    ];
+    const lines = formatDropLogLines(entries, at);
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("a.csv");
+    expect(lines[1]).toContain("b.csv");
+    expect(lines[2]).toContain("c.evtx");
+  });
+
+  it("round-trips a reason containing an em-dash and pipe as plain text", () => {
+    const lines = formatDropLogLines(
+      [{ status: "FAILED", relpath: "x.csv", reason: "bad row — col1|col2 mismatch" }],
+      at,
+    );
+    expect(lines[0]).toContain("bad row — col1|col2 mismatch");
+  });
+});
+
+describe("appendDropLog", () => {
+  let dropDir: string;
+  beforeEach(async () => {
+    dropDir = await mkdtemp(join(tmpdir(), "dfir-droplog-"));
+  });
+
+  it("creates the file on first append", async () => {
+    await appendDropLog(dropDir, ["line one"]);
+    const text = await readFile(join(dropDir, DROP_LOG_FILE), "utf8");
+    expect(text).toBe("line one\n");
+  });
+
+  it("appends rather than overwrites on a second call", async () => {
+    await appendDropLog(dropDir, ["line one"]);
+    await appendDropLog(dropDir, ["line two", "line three"]);
+    const text = await readFile(join(dropDir, DROP_LOG_FILE), "utf8");
+    expect(text).toBe("line one\nline two\nline three\n");
+  });
+
+  it("does nothing for an empty entries list (no file created)", async () => {
+    await appendDropLog(dropDir, []);
+    await expect(readFile(join(dropDir, DROP_LOG_FILE), "utf8")).rejects.toThrow();
+  });
+});

--- a/companion/tests/analysis/dropLog.test.ts
+++ b/companion/tests/analysis/dropLog.test.ts
@@ -48,6 +48,15 @@ describe("formatDropLogLines", () => {
     );
     expect(lines[0]).toContain("bad row — col1|col2 mismatch");
   });
+
+  it("collapses embedded newlines in a multi-line reason to a single line", () => {
+    const lines = formatDropLogLines(
+      [{ status: "FAILED", relpath: "y.csv", reason: "SyntaxError: Unexpected token\n    at parse (parser.js:12)\n    at import (importer.js:5)" }],
+      at,
+    );
+    expect(lines[0]).not.toContain("\n");
+    expect(lines[0]).toContain("SyntaxError: Unexpected token at parse (parser.js:12) at import (importer.js:5)");
+  });
 });
 
 describe("appendDropLog", () => {

--- a/companion/tests/analysis/dropScan.test.ts
+++ b/companion/tests/analysis/dropScan.test.ts
@@ -47,6 +47,7 @@ describe("dropScan — ignore rules", () => {
     expect(shouldIgnoreDropFile("sub/.DS_Store")).toBe(true);
     expect(shouldIgnoreDropFile("Thumbs.db")).toBe(true);
     expect(shouldIgnoreDropFile("desktop.ini")).toBe(true);
+    expect(shouldIgnoreDropFile("drop-log.txt")).toBe(true);
   });
   it("does not ignore a real evidence file", () => {
     expect(shouldIgnoreDropFile("triage/prefetch.csv")).toBe(false);


### PR DESCRIPTION
## Summary
- Adds a plain-text, append-only `drop-log.txt` inside each case's evidence drop folder (`cases/<id>/drop/`), recording every IMPORTED/FAILED/PENDING outcome with reasons — previously the only record was an internal JSON status file that only reflected the last sweep, invisible from the folder itself.
- Wires the log into both places files get resolved: the automatic poller (`scanCaseDrops`, with PENDING lines deduped so a file awaiting a tool doesn't spam a line every poll) and the manual "Run tools on these N files" button (`/cases/:id/drop/run-pending`), which is now also guarded against racing the poller.
- Updates the drop-folder README hint to mention the new log file.

## Test plan
- [x] `npx vitest run tests/analysis/dropLog.test.ts tests/analysis/dropScan.test.ts` — 29/29 pass
- [x] Full suite (`npm test`) — 3302/3308 pass; the 6 timeout failures are pre-existing Windows parallel-test flakiness (all 146 tests in those 6 files pass individually, none touch drop-log code)
- [x] Manual end-to-end: ran the built server, created a case, dropped a valid CSV and a garbage file, confirmed `_processed`/`_failed` moves and correct `IMPORTED`/`FAILED` lines in `drop-log.txt`

Design spec and implementation plan (not committed — gitignored under `docs/superpowers/`) covered: format, retention (append-only, no cap), and scope boundaries (the generic single-tool-run endpoint is intentionally not wired in).