### PR TITLE
fix: vertically center timestamp against multi-line timeline rows

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -826,7 +826,7 @@
     .ev-geo { background: none; border: none; cursor: pointer; padding: 0 4px; color: var(--c-6b7280); display: inline-flex; align-items: center; }
     .ev-geo:hover { color: var(--c-6aa9ff); }
     .ev-geo svg { width: 12px; height: 12px; }
-    .ev-col-time { flex-shrink: 0; width: 192px; font-size: 11px; padding-top: 2px; font-family: ui-monospace, Menlo, Consolas, monospace; }
+    .ev-col-time { flex-shrink: 0; width: 192px; font-size: 11px; font-family: ui-monospace, Menlo, Consolas, monospace; align-self: center; }
     .ev-col-content { flex: 1; min-width: 0; padding-top: 1px; }
     .ev-origin { color: var(--c-7e8aa0); white-space: nowrap; font-size: 11px; }
     .ev-more-btn { background: none; border: none; color: var(--c-6aa9ff); cursor: pointer; font-size: 0.78em; padding: 0 3px; margin-left: 2px; vertical-align: middle; }


### PR DESCRIPTION
## Summary
- Timeline event timestamps stuck to the top of the row instead of centering when the description wraps onto multiple lines (e.g. long PowerShell command-line entries).
- Changed `.ev-col-time` to use `align-self: center` instead of a fixed `padding-top`, so it centers within whatever height the row grows to.

## Test plan
- [x] Verified layout numerically in a live preview: injected a short single-line row and a long 2-line-wrapping row, measured the timestamp's offset from the row's top/bottom — both are now symmetric (centered).