### PR TITLE
fix: widen the OCR-burst test's poll budget to absorb CI scheduling noise

### DIFF
--- a/companion/tests/server/ocrSearchRoute.test.ts
+++ b/companion/tests/server/ocrSearchRoute.test.ts
@@ -119,9 +119,11 @@ describe("POST /captures background OCR indexing", () => {
       files.push(res.body.screenshotFile as string);
     }
     // All seven must eventually be indexed — the queue drains them, none is dropped.
-    for (const f of files) expect(await waitForIndex(f, 80)).toBe(true);
+    // A generous per-file budget (160 tries × 25ms = 4s) absorbs CI-runner scheduling noise;
+    // a real drop/deadlock still fails well before the 20s test timeout below.
+    for (const f of files) expect(await waitForIndex(f, 160)).toBe(true);
     expect(Object.keys(await cases.loadOcrIndex("c1"))).toHaveLength(7);
-  });
+  }, 20_000);
 
   it("does not index when DFIR_OCR_SEARCH is off", async () => {
     process.env.DFIR_OCR_SEARCH = "off";


### PR DESCRIPTION
## Summary
- `tests/server/ocrSearchRoute.test.ts`'s "indexes EVERY screenshot in a burst" test polled each of 7 files for only 80×25ms (2s) before asserting it was indexed — tight enough that CI-runner scheduling noise (not an actual drop) occasionally failed it, most recently on the v0.31.0 release commit's CI run.
- Raises the per-file poll budget to 160×25ms (4s) and gives the test its own 20s timeout, so a genuine stuck/dropped item still fails fast without vitest's default 5s test timeout cutting the poll short.

## Test plan
- [x] `npx vitest run tests/server/ocrSearchRoute.test.ts` passes locally (553ms, 7/7 tests)
- [ ] CI green on this PR