### PR TITLE
feat: add case introspection stats to Diagnostics tab

### DIFF
--- a/companion/src/analysis/caseStats.ts
+++ b/companion/src/analysis/caseStats.ts
@@ -1,0 +1,63 @@
+// Case-scoped introspection stats (#241): totals, event-by-source breakdown, and daily import
+// velocity for the current case's Diagnostics tab. Pure, derived-on-read — no AI, no caching,
+// same pattern as hostRanking.ts.
+
+import type { InvestigationState } from "./stateTypes.js";
+import { buildAssetGraph } from "./assetGraph.js";
+import type { ImportMetadata } from "../types.js";
+
+export interface CaseStatsTotals {
+  events: number;
+  findings: number;
+  iocs: number;
+  assets: number;
+}
+
+export interface SourceCount {
+  source: string;
+  count: number;
+}
+
+export interface ImportVelocityDay {
+  date: string;    // YYYY-MM-DD (UTC)
+  imports: number;
+  rows: number;
+}
+
+export interface CaseStats {
+  totals: CaseStatsTotals;
+  bySource: SourceCount[];
+  importVelocity: ImportVelocityDay[];
+}
+
+export function computeCaseStats(state: InvestigationState, importLog: ImportMetadata[]): CaseStats {
+  const totals: CaseStatsTotals = {
+    events: state.forensicTimeline.length,
+    findings: state.findings.length,
+    iocs: state.iocs.length,
+    assets: buildAssetGraph(state).assets.length,
+  };
+
+  const sourceCounts = new Map<string, number>();
+  for (const e of state.forensicTimeline) {
+    for (const s of e.sources ?? []) sourceCounts.set(s, (sourceCounts.get(s) ?? 0) + 1);
+  }
+  const bySource = [...sourceCounts.entries()]
+    .map(([source, count]) => ({ source, count }))
+    .sort((a, b) => b.count - a.count || a.source.localeCompare(b.source));
+
+  const byDay = new Map<string, { imports: number; rows: number }>();
+  for (const rec of importLog) {
+    const date = (rec.importedAt ?? "").slice(0, 10);
+    if (!date) continue;
+    const day = byDay.get(date) ?? { imports: 0, rows: 0 };
+    day.imports++;
+    day.rows += rec.rows ?? 0;
+    byDay.set(date, day);
+  }
+  const importVelocity = [...byDay.entries()]
+    .map(([date, v]) => ({ date, imports: v.imports, rows: v.rows }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return { totals, bySource, importVelocity };
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -116,7 +116,7 @@ import { buildTlsFetch } from "./enrichment/tlsFetch.js";
 import { validateProcessChains, hasChainWork, type ChainSummary } from "./enrichment/chainValidate.js";
 import type { AnalysisPipeline } from "./analysis/pipeline.js";
 import type { InvestigationState, InvestigationQuestion, QuestionStatus, Severity, ForensicEvent, IOC, Finding } from "./analysis/stateTypes.js";
-import type { CaptureMetadata } from "./types.js";
+import type { CaptureMetadata, ImportMetadata } from "./types.js";
 import type { StateStore } from "./analysis/stateStore.js";
 import type { ReportWriter } from "./reports/reportWriter.js";
 import type { IocBlocklistFormat, IocBlocklistOptions, BlocklistIocType } from "./reports/iocBlocklist.js";
@@ -138,6 +138,7 @@ import { DwellWindowStore } from "./analysis/dwellWindowStore.js";
 import { SuperTimelineStore } from "./analysis/superTimelineStore.js";
 import { deriveIocProvenance } from "./analysis/iocProvenance.js";
 import { buildIocProvenanceChains } from "./analysis/iocProvenanceChain.js";
+import { computeCaseStats } from "./analysis/caseStats.js";
 import { ForensicGateControlStore } from "./analysis/forensicGateControl.js";
 import { demoteBelowSeverity, resolveForensicMinSeverity } from "./analysis/forensicGate.js";
 import { ConfidenceControlStore } from "./analysis/confidenceControl.js";
@@ -2067,6 +2068,32 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
     try {
       return res.status(200).json(await options.reportWriter.adversaryHints(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Case introspection stats (#241): totals, event-count-by-source, and daily import velocity for
+  // the CURRENT case only — powers the Diagnostics tab "Case Statistics" panel. Derived on read,
+  // no caching (same as host-ranking below). Disk usage is intentionally NOT included here — it's
+  // global, not per-case, and already served by GET /disk-stats.
+  app.get("/cases/:id/stats", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    try {
+      if (!(await store.caseExists(req.params.id))) {
+        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
+      }
+      const state = await options.stateStore.load(req.params.id);
+      const importLog: ImportMetadata[] = [];
+      try {
+        const log = await readFile(store.importsLogPath(req.params.id), "utf8");
+        for (const line of log.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try { importLog.push(JSON.parse(trimmed) as ImportMetadata); } catch { /* skip a malformed audit line */ }
+        }
+      } catch { /* no imports for this case yet */ }
+      return res.status(200).json(computeCaseStats(state, importLog));
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/tests/analysis/caseStats.test.ts
+++ b/companion/tests/analysis/caseStats.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+import { computeCaseStats } from "../../src/analysis/caseStats.js";
+import type { ImportMetadata } from "../../src/types.js";
+
+function ev(id: string, asset: string, sources: string[]): any {
+  return {
+    id,
+    timestamp: "2024-03-18T15:24:38Z",
+    description: "d",
+    severity: "Info",
+    mitreTechniques: [],
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+    asset,
+    sources,
+  };
+}
+
+function imp(caseId: string, seq: number, importedAt: string, rows: number): ImportMetadata {
+  return { caseId, sequenceNumber: seq, importedAt, filename: `f${seq}.csv`, originalName: `f${seq}.csv`, rows, bytes: rows * 100 };
+}
+
+describe("computeCaseStats (#241)", () => {
+  it("totals events, findings, IOCs, and distinct assets", () => {
+    const s = emptyState("c1");
+    s.forensicTimeline.push(ev("a1", "WS-01", ["Sysmon"]), ev("a2", "WS-02", ["Zeek"]));
+    s.findings.push({
+      id: "f1", severity: "High", title: "t", description: "d", relatedIocs: [], sourceScreenshots: [],
+      mitreTechniques: [], firstSeen: "2024-03-18T15:24:38Z", lastUpdated: "2024-03-18T15:24:38Z", status: "open",
+    });
+    s.iocs.push({ id: "i1", type: "ip", value: "1.2.3.4", firstSeen: "2024-03-18T15:24:38Z" });
+
+    const stats = computeCaseStats(s, []);
+    expect(stats.totals.events).toBe(2);
+    expect(stats.totals.findings).toBe(1);
+    expect(stats.totals.iocs).toBe(1);
+    expect(stats.totals.assets).toBe(2);
+  });
+
+  it("groups events by source, counting an event once per source it carries", () => {
+    const s = emptyState("c1");
+    s.forensicTimeline.push(ev("a1", "WS-01", ["Sysmon"]), ev("a2", "WS-01", ["Sysmon", "Zeek"]), ev("a3", "WS-01", ["Zeek"]));
+
+    const stats = computeCaseStats(s, []);
+    expect(stats.bySource).toEqual([
+      { source: "Sysmon", count: 2 },
+      { source: "Zeek", count: 2 },
+    ]);
+  });
+
+  it("buckets import history into daily import/row counts, sorted ascending", () => {
+    const s = emptyState("c1");
+    const log = [
+      imp("c1", 1, "2024-03-18T09:00:00Z", 100),
+      imp("c1", 2, "2024-03-18T14:00:00Z", 50),
+      imp("c1", 3, "2024-03-19T09:00:00Z", 20),
+    ];
+
+    const stats = computeCaseStats(s, log);
+    expect(stats.importVelocity).toEqual([
+      { date: "2024-03-18", imports: 2, rows: 150 },
+      { date: "2024-03-19", imports: 1, rows: 20 },
+    ]);
+  });
+
+  it("returns empty structures for a case with no data", () => {
+    const stats = computeCaseStats(emptyState("empty"), []);
+    expect(stats.totals).toEqual({ events: 0, findings: 0, iocs: 0, assets: 0 });
+    expect(stats.bySource).toEqual([]);
+    expect(stats.importVelocity).toEqual([]);
+  });
+});

--- a/companion/tests/server/caseStats.test.ts
+++ b/companion/tests/server/caseStats.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, buildRuntimePipeline } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+const EVENT_A: ForensicEvent = {
+  id: "e1", timestamp: "2026-06-01T00:00:00Z", description: "d", severity: "Info",
+  mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], asset: "WS-01", sources: ["Sysmon"],
+};
+
+async function makeApp() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-case-stats-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const pipeline = buildRuntimePipeline({
+    provider: undefined, synthesisProvider: undefined, stateStore, store,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+  const app = createApp(store, { pipeline, stateStore });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, stateStore, store };
+}
+
+describe("GET /cases/:id/stats", () => {
+  it("returns totals, source breakdown, and import velocity for the case", async () => {
+    const { app, stateStore, store } = await makeApp();
+    const state = emptyState("c1");
+    state.forensicTimeline = [EVENT_A];
+    await stateStore.save(state);
+    await store.appendImport("c1", {
+      caseId: "c1", sequenceNumber: 1, importedAt: "2026-06-01T09:00:00Z",
+      filename: "f1.csv", originalName: "f1.csv", rows: 10, bytes: 1000,
+    });
+
+    const res = await request(app).get("/cases/c1/stats");
+    expect(res.status).toBe(200);
+    expect(res.body.totals.events).toBe(1);
+    expect(res.body.bySource).toEqual([{ source: "Sysmon", count: 1 }]);
+    expect(res.body.importVelocity).toEqual([{ date: "2026-06-01", imports: 1, rows: 10 }]);
+  });
+
+  it("returns empty stats for a case with no imports yet", async () => {
+    const { app } = await makeApp();
+    const res = await request(app).get("/cases/c1/stats");
+    expect(res.status).toBe(200);
+    expect(res.body.totals).toEqual({ events: 0, findings: 0, iocs: 0, assets: 0 });
+    expect(res.body.importVelocity).toEqual([]);
+  });
+
+  it("404s for an unknown case", async () => {
+    const { app } = await makeApp();
+    const res = await request(app).get("/cases/does-not-exist/stats");
+    expect(res.status).toBe(404);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3244,6 +3244,12 @@
           </div>
         </div>
 
+        <!-- Case Statistics (#241) — totals/source-breakdown/import-velocity for the CURRENT case. -->
+        <div style="margin-bottom:12px;padding:10px;background:var(--c-161a22);border:1px solid var(--c-2a2f3a);border-radius:6px">
+          <div style="font-weight:600;color:var(--c-9aa4b2);font-size:12.5px;margin-bottom:6px">Case Statistics</div>
+          <div id="caseStatsPanel" style="font-size:12.5px;color:var(--c-cbd3df)">Loading…</div>
+        </div>
+
         <div class="sfield-row" style="margin-bottom:10px">
           <div class="sfield"><label>Size scan file limit<span class="sfield-hint">DFIR_DIAG_MAX_FILES — max files visited by "Compute case sizes" before stopping (default 100000)</span></label><input id="env-DFIR_DIAG_MAX_FILES" placeholder="100000" /></div>
           <div class="sfield"><label>Job registry retention<span class="sfield-hint">DFIR_JOBS_MAX — max finished jobs kept in the jobs badge/popover before the oldest are evicted (default 100); running jobs are never evicted</span></label><input id="env-DFIR_JOBS_MAX" placeholder="100" /></div>
@@ -16290,7 +16296,7 @@
         if (tab === "notifications") { ntfTypeChanged(); loadNotifications(); }
         if (tab === "updates") loadUpdateCheck();
         if (tab === "tools") loadTools();
-        if (tab === "diagnostics") { loadPreflightStatus(); loadDiagnostics(); }
+        if (tab === "diagnostics") { loadPreflightStatus(); loadDiagnostics(); loadCaseStats(); }
       });
     });
 
@@ -17176,6 +17182,48 @@
         diagCopyText = j.text || "";
         body.innerHTML = renderDiagnostics(j.report, cost);
       }).catch(e => { body.textContent = "Could not load diagnostics: " + e.message + " — restart the companion server if this 404s."; });
+    }
+    // Case Statistics panel (#241) — totals/source-breakdown/import-velocity for the current case.
+    function caseStatsBarChart(days) {
+      if (!days.length) return `<div style="color:#7e8aa0">no imports yet</div>`;
+      const barW = 16, gap = 3, h = 46;
+      const maxRows = Math.max(1, ...days.map(d => d.rows));
+      const bars = days.map((d, i) => {
+        const barH = Math.max(2, Math.round((d.rows / maxRows) * (h - 12)));
+        const x = i * (barW + gap);
+        return `<rect x="${x}" y="${h - barH}" width="${barW}" height="${barH}" rx="2" fill="#7ec8e3">
+          <title>${esc(d.date)}: ${d.imports} import${d.imports !== 1 ? "s" : ""}, ${d.rows.toLocaleString()} rows</title>
+        </rect>`;
+      }).join("");
+      const w = days.length * (barW + gap) - gap;
+      return `<svg viewBox="0 0 ${w} ${h}" width="${w}" height="${h}" style="max-width:100%">${bars}</svg>
+        <div style="display:flex;justify-content:space-between;color:#7e8aa0;font-size:10px;margin-top:2px">
+          <span>${esc(days[0].date)}</span><span>${esc(days[days.length - 1].date)}</span>
+        </div>`;
+    }
+    function loadCaseStats() {
+      const el = document.getElementById("caseStatsPanel");
+      if (!el) return;
+      const caseId = document.getElementById("caseId").value.trim();
+      if (!caseId) { el.innerHTML = '<span style="color:#7e8aa0">Select a case first.</span>'; return; }
+      el.textContent = "Loading…";
+      fetch(`/cases/${encodeURIComponent(caseId)}/stats`)
+        .then(async r => { if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "HTTP " + r.status); return r.json(); })
+        .then(j => {
+          const t = j.totals || {};
+          const tiles = ["events", "findings", "iocs", "assets"].map(k =>
+            `<div style="text-align:center;padding:4px 8px"><div style="font-size:18px;font-weight:600;color:#cbd3df">${(t[k] || 0).toLocaleString()}</div>
+              <div style="font-size:10.5px;color:#7e8aa0;text-transform:uppercase">${k}</div></div>`).join("");
+          const bySource = (j.bySource || []).map(s => diagRow(esc(s.source), s.count.toLocaleString())).join("")
+            || `<div style="color:#7e8aa0">no events yet</div>`;
+          el.innerHTML = `
+            <div style="display:flex;justify-content:space-around;flex-wrap:wrap;border-bottom:1px solid var(--c-2a2f3a);padding-bottom:8px;margin-bottom:8px">${tiles}</div>
+            <div style="font-weight:600;color:#9aa4b2;margin-bottom:3px">Events by source</div>
+            ${bySource}
+            <div style="font-weight:600;color:#9aa4b2;margin:8px 0 3px">Import velocity (daily)</div>
+            ${caseStatsBarChart(j.importVelocity || [])}`;
+        })
+        .catch(e => { el.innerHTML = `<span style="color:#ff9f9f">Could not load case stats: ${esc(e.message)}</span>`; });
     }
     function diagAiTest() {
       const btn = document.getElementById("diagAiTestBtn");


### PR DESCRIPTION
## Summary
- New `GET /cases/:id/stats` endpoint (`companion/src/analysis/caseStats.ts`) computing per-case totals (events/findings/IOCs/assets), event count by source, and daily import velocity — derived on read, no caching, same pattern as `hostRanking.ts`.
- New "Case Statistics" panel in Settings → Diagnostics (`public/dashboard.html`): stat tiles, events-by-source breakdown, and an inline-SVG import-velocity bar chart.
- Disk usage warning is not duplicated — the Diagnostics tab already has a "Disk" card.
- "Top hosts/users by activity" from the issue is intentionally not duplicated as a new ranking — the existing severity-weighted Host & Account Ranking section already covers it; a raw-volume ranking would be redundant.

Part of #241.

## Test plan
- [x] `npx vitest run tests/analysis/caseStats.test.ts tests/server/caseStats.test.ts` — 7/7 pass
- [x] `npx tsc --noEmit` — clean
- [x] Verified live against a real case (`veridia-breach`) via the browse skill — totals/source-breakdown/chart render correctly, no console errors from new code