### PR TITLE
refactor: add RouteContext seam + route-inventory parity script (router split, Task 0)

### DIFF
--- a/companion/scripts/route-inventory.sh
+++ b/companion/scripts/route-inventory.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Prints a sorted "METHOD /path" list of every route registered across server.ts and the
+# extracted route modules (src/routes/). Run before and after an extraction; the two outputs
+# must be byte-identical — routes only move between files, they never appear or disappear.
+set -euo pipefail
+src="$(dirname "$0")/../src"
+grep -rhaoE '\.(get|post|put|delete|patch)\("[^"]+"' "$src/server.ts" "$src/routes" \
+  | sed -E 's/^\.//; s/\("/ /; s/"$//' \
+  | sort || true

--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -1,0 +1,19 @@
+import type { Request } from "express";
+import type { CaseStore } from "../storage/caseStore.js";
+import type { Logger } from "../logging/logger.js";
+import type { AppOptions } from "../server.js";
+
+/**
+ * Dependencies shared across more than one route domain, built once in createApp and passed to
+ * every registerXRoutes(app, ctx). Domain-local state (per-domain timers/caches) does NOT go here —
+ * it stays as closure state inside the owning domain module. Fields are added here only when a
+ * second domain needs them ("graduate on demand").
+ */
+export interface RouteContext {
+  readonly store: CaseStore;
+  readonly options: AppOptions;
+  readonly serverLogger: Logger;
+  recordImportFailure(caseId: string, kind: string, filename: string, err: unknown): void;
+  recordAiError(caseId: string, phase: string, err: unknown): void;
+  readUnlockState(req: Request, id: string, salt: string): { unlocked: boolean; remembered: boolean };
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -8,6 +8,7 @@ import { ZodError } from "zod";
 import { CaseStore, isValidCaseId } from "./storage/caseStore.js";
 import { BackupManager, resolveBackupConfig } from "./storage/backupManager.js";
 import { atomicWrite } from "./storage/atomicWrite.js";
+import type { RouteContext } from "./routes/context.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
 import { AiControlStore, type AiControl } from "./analysis/aiControl.js";
 import { JobManager } from "./analysis/jobManager.js";
@@ -781,6 +782,16 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     const unlocked = verifyUnlockToken(token, id, salt, instanceSecret);
     return { unlocked, remembered: unlocked && isRememberedUnlockToken(token, id, salt, instanceSecret) };
   }
+
+  const ctx: RouteContext = {
+    store,
+    options,
+    serverLogger,
+    recordImportFailure,
+    recordAiError,
+    readUnlockState,
+  };
+  void ctx; // consumed by registerXRoutes calls added in later tasks
 
   app.get("/cases/:id/lock-status", async (req: Request, res: Response) => {
     try {


### PR DESCRIPTION
## What & why

First step of splitting the ~10.4k-line `companion/src/server.ts` (`createApp` is an ~8,800-line closure registering ~316 routes) into per-domain route modules. **This PR moves no routes** — it only lays the shared infrastructure that the domain-extraction PRs build on.

## Changes

- **`src/routes/context.ts`** — new `RouteContext` interface: the shared dependencies (`store`, `options`, `serverLogger`, and the cross-cutting `recordImportFailure` / `recordAiError` / `readUnlockState` helpers) that each future `registerXRoutes(app, ctx)` will receive. Domain-local state stays in its own module; fields graduate onto `RouteContext` only when a second domain needs them.
- **`src/server.ts`** — builds `ctx` once inside `createApp` (after the three helpers are in scope) and imports the type. `void ctx;` marks it as consumed by the register calls added in later PRs. No routes moved, no handler logic changed.
- **`scripts/route-inventory.sh`** — prints a sorted `METHOD /path` list across `server.ts` **and** `src/routes/`. Every subsequent extraction runs this before/after and asserts a byte-identical result, guaranteeing routes only move between files and none appear/disappear.

## Verification

- `tsc --noEmit` clean
- Full server suite green (398 tests)
- Route inventory: 316 before = 316 after (nothing moved)

Part of the router-split refactor (design + full 18-task plan tracked locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)