### PR TITLE
fix: catch async route errors via express-async-errors + terminal handler

### DIFF
--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -12,6 +12,7 @@
         "docx": "^9.7.1",
         "dotenv": "^17.4.2",
         "express": "^4.19.2",
+        "express-async-errors": "^3.1.1",
         "marked": "^18.0.4",
         "sharp": "^0.33.4",
         "tesseract.js": "^5.1.1",
@@ -2142,6 +2143,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2181,6 +2183,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "license": "ISC",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/fast-safe-stringify": {

--- a/companion/package.json
+++ b/companion/package.json
@@ -43,6 +43,7 @@
     "docx": "^9.7.1",
     "dotenv": "^17.4.2",
     "express": "^4.19.2",
+    "express-async-errors": "^3.1.1",
     "marked": "^18.0.4",
     "sharp": "^0.33.4",
     "tesseract.js": "^5.1.1",

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -1,4 +1,9 @@
 import express, { type Express, type Request, type Response, type NextFunction, type CookieOptions } from "express";
+// Patch Express 4's router so async route handlers that throw or reject are forwarded to the
+// terminal error middleware (see the end of createApp) instead of hanging the client connection
+// or surfacing an UnhandledPromiseRejection. Side-effect-only import; must load before any route
+// is registered, so it stays at the top with express itself.
+import "express-async-errors";
 import { config as loadDotenv } from "dotenv";
 import { join, basename, isAbsolute, resolve, dirname, relative, extname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9088,6 +9093,24 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       }
     });
   }
+
+  // Terminal error handler (4-arg, last-registered so it runs after every route). express-async-errors
+  // forwards any error thrown or rejected inside an async route here; explicit next(err) calls land here
+  // too. Without it, Express 4 would fall through to its default handler and leak an HTML stack-trace page
+  // — or, for async routes it never catches, hang the connection. The failure is always logged (never
+  // silently swallowed); ZodError/CaseNotFoundError keep their conventional 400/404 for routes that forgot
+  // their own try/catch, and everything else becomes a generic JSON 500 so the client always gets a clean,
+  // closed response. Per-route try/catch blocks still handle their own errors and never reach this.
+  app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
+    if (res.headersSent) return next(err);
+    if (err instanceof ZodError) return res.status(400).json({ error: "invalid payload", details: err.issues });
+    if (err instanceof CaseNotFoundError) {
+      return res.status(404).json({ error: `case ${err.caseId} does not exist — create it in the dashboard first` });
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    serverLogger.error(`unhandled error on ${req.method} ${req.path}: ${message}`);
+    return res.status(500).json({ error: "internal server error" });
+  });
 
   return app;
 }

--- a/companion/tests/server/asyncErrorHandling.test.ts
+++ b/companion/tests/server/asyncErrorHandling.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import express, { type Request, type Response, type NextFunction } from "express";
+// Same side-effect patch server.ts applies. Importing it here (and there) monkeypatches the
+// Express 4 router so a rejected async handler is forwarded to the error middleware instead of
+// hanging the connection. This test pins that behaviour so nobody drops the dependency without
+// a failing test.
+import "express-async-errors";
+import { ZodError, z } from "zod";
+import request from "supertest";
+
+/**
+ * Builds a throwaway app whose only route rejects, wired with the SAME terminal error handler
+ * shape as createApp() in src/server.ts. If express-async-errors is ever removed, the rejected
+ * promise escapes and supertest times out / gets no clean response — turning this test red.
+ */
+function appThatThrows(makeError: () => never) {
+  const app = express();
+  app.get("/boom", async (_req: Request, _res: Response) => {
+    makeError();
+  });
+  // Mirror of the terminal handler in createApp (kept in sync intentionally).
+  app.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
+    if (res.headersSent) return next(err);
+    if (err instanceof ZodError) return res.status(400).json({ error: "invalid payload", details: err.issues });
+    return res.status(500).json({ error: "internal server error" });
+  });
+  return app;
+}
+
+describe("async route error forwarding (express-async-errors)", () => {
+  it("a rejected async route resolves to a clean 500 JSON instead of hanging", async () => {
+    const app = appThatThrows(() => {
+      throw new Error("kaboom");
+    });
+    const res = await request(app).get("/boom");
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "internal server error" });
+    expect(res.type).toMatch(/json/);
+  });
+
+  it("a ZodError thrown from an async route keeps its conventional 400", async () => {
+    const app = appThatThrows(() => {
+      // A parse failure raises ZodError synchronously inside the async handler.
+      z.object({ n: z.number() }).parse({ n: "not-a-number" });
+      throw new Error("unreachable");
+    });
+    const res = await request(app).get("/boom");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid payload");
+    expect(Array.isArray(res.body.details)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Express 4 does not forward errors thrown or rejected inside `async` route handlers to error-handling middleware. Any of the ~250 async routes in `server.ts` that is missing (or one day loses) its `try/catch` would leave the client connection hanging and emit an `UnhandledPromiseRejection` — which can terminate the Node process depending on version/flags. This was flagged in a code review of the codebase.

## Fix

- Import `express-async-errors` **before any route is registered** (side-effect patch of the Express 4 router so rejected async handlers forward to error middleware).
- Add a **terminal 4-arg error handler** at the end of `createApp` that logs the failure and returns clean JSON: `ZodError → 400`, `CaseNotFoundError → 404`, everything else → `500`. Without it, forwarded errors would hit Express's default HTML stack-trace page.
- Existing per-route `try/catch` blocks are untouched and never reach the terminal handler — this is a pure safety net, additive only.
- Add `tests/server/asyncErrorHandling.test.ts` pinning the behaviour (rejected async route → clean 500 JSON; thrown `ZodError` → 400) so the dependency can't be dropped without a failing test.

## Verification

- `tsc --noEmit` clean
- Full server suite green (397 tests at branch point)
- Independently confirmed the failure mode: the same setup **without** the patch lets the rejection escape to Node as an unhandled error — proving the fix is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)