### PR TITLE
refactor: extract push/notification routes into routes/pushNotify.ts (router split, Task 3)

### DIFF
--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -9,6 +9,7 @@ import type { IrisClient } from "../integrations/iris/irisClient.js";
 import type { EnrichmentProvider } from "../enrichment/provider.js";
 import type { ProviderHealthCache } from "../enrichment/providerHealth.js";
 import type { ImporterFailure, AiError } from "../analysis/diagnostics.js";
+import type { Severity } from "../analysis/stateTypes.js";
 
 /**
  * Dependencies shared across more than one route domain, built once in createApp and passed to
@@ -46,6 +47,12 @@ export interface RouteContext {
   getControl(caseId: string): Promise<AiControl>;
   flush(caseId: string): Promise<void>;
   indexCaptureText(metadata: CaptureMetadata): void;
+  // Run a raw text/log blob through the full import → diff → re-synthesize pipeline (the same chain
+  // as the Import button). A hoisted async function in createApp shared by the /import, /tools and
+  // Velociraptor ingest paths (still there); graduated for routes/pushNotify.ts's POST /cases/:id/push.
+  ingestStreamed(
+    caseId: string, kind: string, text: string, originalName: string, minSeverity?: Severity,
+  ): Promise<{ storedName: string; addedEvents: number; addedIocs: number; analyzed: boolean }>;
 
   // ── LIVE accessors ───────────────────────────────────────────────────────────────────
   // Call these INSIDE the request handler (or inside per-request logic like a preflight run),
@@ -59,4 +66,8 @@ export interface RouteContext {
   dropWatchEnabled(): boolean;
   enrichmentProviders(): EnrichmentProvider[];
   enrichHealth(): ProviderHealthCache;
+  // Detect the importer kind for a filename+text (honours user-authored custom importers). A `const`
+  // arrow defined in createApp AFTER this ctx literal, so it's exposed as a live accessor — call
+  // ctx.resolveImportKind() INSIDE the handler to reach the current binding, then invoke the result.
+  resolveImportKind(): (filename: string, text: string) => string;
 }

--- a/companion/src/routes/pushNotify.ts
+++ b/companion/src/routes/pushNotify.ts
@@ -1,0 +1,174 @@
+import type { Express, Request, Response } from "express";
+import { parseMinSeverity } from "../analysis/severityFloor.js";
+import { generatePushToken } from "../analysis/pushTokenStore.js";
+import { resolvePushAuth } from "../analysis/pushAuth.js";
+import { extractPushPayload } from "../analysis/pushPayload.js";
+import { parseChannelInput, redactChannel } from "../analysis/notifications.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Push + notification routes: the generic external push-ingest endpoint (#84) with its per-case
+ * push-token management, and the global notification channel config (#58).
+ *
+ * Pure structural move out of createApp (see routes/system.ts for the conventions). The import
+ * pipeline itself stays in createApp — this module reaches it through the RouteContext members it
+ * was graduated onto: ingestStreamed (stable method) and resolveImportKind (live accessor; call
+ * ctx.resolveImportKind() INSIDE the handler). NOTE: the integration-push routes
+ * (/cases/:id/push/{iris,timesketch,misp,notion,clickup}) are NOT here — they belong to their own
+ * integration domains and stay in createApp.
+ */
+export function registerPushNotifyRoutes(app: Express, ctx: RouteContext): void {
+  const { store, options, serverLogger, hasAiProvider, ingestStreamed } = ctx;
+
+  // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved call
+  // sites stay verbatim.
+  const logLine = (msg: string): void => serverLogger.info(msg);
+
+  // ── Generic push ingest (#84) ─────────────────────────────────────────────────────────────────
+  // An external tool (SIEM webhook, Velociraptor client-event poller, custom script) POSTs an alert
+  // payload here with an X-DFIR-Key token. The body is any importDetect-routable shape (artifact-map,
+  // SIEM alert, Hayabusa line, { source, events }, raw text…). Runs the SAME import → diff →
+  // re-synthesize pipeline as the file Import button; responds 202 immediately, imports in background.
+  app.post("/cases/:id/push", async (req: Request, res: Response) => {
+    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
+    const caseId = req.params.id;
+    // Auth: global DFIR_PUSH_TOKEN and/or a per-case token. 403 when push is unconfigured, 401 on a bad key.
+    let caseToken: string | undefined;
+    if (options.pushTokenStore) { try { caseToken = (await options.pushTokenStore.get(caseId))?.token; } catch { /* none */ } }
+    const bearer = (req.get("authorization") || "").replace(/^Bearer\s+/i, "");
+    const presented = String(req.get("x-dfir-key") || bearer || "");
+    const auth = resolvePushAuth({ globalToken: options.pushToken, caseToken, presented });
+    if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
+
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
+
+    const { text, source, filename } = extractPushPayload(req.body);
+    if (!text.trim()) return res.status(400).json({ error: "empty push payload" });
+    const kind = ctx.resolveImportKind()(filename, text);
+    if (kind === "unknown") return res.status(400).json({ error: "could not detect the payload type — not recognized as any supported import shape" });
+    if ((kind === "csv" || kind === "log") && !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for CSV/log analysis" });
+
+    const minSeverity = parseMinSeverity(req.body?.minSeverity);
+    logLine(`[push] case ${caseId}: received "${source}" → ${kind}`);
+    res.status(202).json({ accepted: true, kind, source });
+    // Import in the background; the 202 already went out.
+    ingestStreamed(caseId, kind, text, filename, minSeverity)
+      .catch((err) => options.onAiStatus?.(caseId, { status: "error", at: new Date().toISOString(), detail: `push import failed: ${(err as Error).message}` }));
+  });
+
+  // Per-case push token management (#84). GET returns the case token's existence (NOT the secret on a
+  // plain GET — it's shown once on generate) plus whether a global token covers every case and the
+  // push URL. POST generates/rotates one; DELETE clears it.
+  app.get("/cases/:id/push-token", async (req: Request, res: Response) => {
+    const caseId = req.params.id;
+    const globalConfigured = !!(options.pushToken && options.pushToken.trim());
+    let rec: { token: string; createdAt: string } | null = null;
+    if (options.pushTokenStore) { try { rec = await options.pushTokenStore.get(caseId); } catch { /* none */ } }
+    const base = (options.dashboardBaseUrl || "").replace(/\/+$/, "");
+    return res.status(200).json({
+      configured: !!rec,
+      token: rec?.token ?? "",          // shown so Settings can display the active token + curl example
+      createdAt: rec?.createdAt ?? "",
+      globalConfigured,
+      storeAvailable: !!options.pushTokenStore,
+      pushUrl: `${base}/cases/${encodeURIComponent(caseId)}/push`,
+    });
+  });
+
+  app.post("/cases/:id/push-token/generate", async (req: Request, res: Response) => {
+    if (!options.pushTokenStore) return res.status(501).json({ error: "push token store not configured" });
+    const caseId = req.params.id;
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
+    try {
+      const token = generatePushToken();
+      const rec = await options.pushTokenStore.set(caseId, token, new Date().toISOString());
+      options.onPushToken?.(caseId);
+      return res.status(201).json({ token: rec.token, createdAt: rec.createdAt });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.delete("/cases/:id/push-token", async (req: Request, res: Response) => {
+    if (!options.pushTokenStore) return res.status(501).json({ error: "push token store not configured" });
+    try {
+      await options.pushTokenStore.clear(req.params.id);
+      options.onPushToken?.(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Notifications (issue #58) ─────────────────────────────────────────────────────────────
+  // Global channel config: Slack/Teams webhooks + SMTP email, with per-channel severity threshold
+  // and per-event-kind toggles. Opt-in (the store starts empty). Secrets (webhook URLs, SMTP
+  // passwords) are REDACTED in every response — the browser only learns whether each is set.
+
+  app.get("/notifications/status", (_req: Request, res: Response) => {
+    res.status(200).json({ configured: !!options.notificationStore, emailEnabled: !!options.notifyEmailEnabled });
+  });
+
+  app.get("/notifications", async (_req: Request, res: Response) => {
+    if (!options.notificationStore) return res.status(200).json([]);
+    try {
+      return res.status(200).json((await options.notificationStore.load()).map(redactChannel));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.post("/notifications", async (req: Request, res: Response) => {
+    if (!options.notificationStore) return res.status(501).json({ error: "notifications not configured" });
+    const parsed = parseChannelInput(req.body);
+    if (!parsed.ok || !parsed.draft) return res.status(400).json({ error: parsed.error ?? "invalid channel" });
+    try {
+      const channel = await options.notificationStore.add(parsed.draft);
+      logLine(`[notify] channel added: ${channel.type} "${channel.name}" (${channel.id})`);
+      return res.status(201).json(redactChannel(channel));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.put("/notifications/:id", async (req: Request, res: Response) => {
+    if (!options.notificationStore) return res.status(501).json({ error: "notifications not configured" });
+    try {
+      const existing = await options.notificationStore.get(req.params.id);
+      if (!existing) return res.status(404).json({ error: "notification channel not found" });
+      // Pass `existing` so a blank (redacted) webhook URL keeps the saved one.
+      const parsed = parseChannelInput(req.body, existing);
+      if (!parsed.ok || !parsed.draft) return res.status(400).json({ error: parsed.error ?? "invalid channel" });
+      const channel = await options.notificationStore.update(req.params.id, parsed.draft);
+      if (!channel) return res.status(404).json({ error: "notification channel not found" });
+      return res.status(200).json(redactChannel(channel));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.delete("/notifications/:id", async (req: Request, res: Response) => {
+    if (!options.notificationStore) return res.status(501).json({ error: "notifications not configured" });
+    try {
+      const removed = await options.notificationStore.remove(req.params.id);
+      if (!removed) return res.status(404).json({ error: "notification channel not found" });
+      return res.status(204).end();
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Send a test notification to one channel ({ channelId }) or all configured channels. Bypasses
+  // the enable/threshold/kind filters so a disabled or high-threshold channel can be verified.
+  app.post("/notifications/test", async (req: Request, res: Response) => {
+    if (!options.notificationStore || !options.notifier) return res.status(501).json({ error: "notifications not configured" });
+    try {
+      const channelId = typeof req.body?.channelId === "string" ? req.body.channelId : undefined;
+      const results = await options.notifier.test(channelId, new Date().toISOString());
+      if (!results.length) return res.status(404).json({ error: "no matching channel to test" });
+      return res.status(200).json({ results });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -16,6 +16,7 @@ import { atomicWrite } from "./storage/atomicWrite.js";
 import type { RouteContext } from "./routes/context.js";
 import { registerSystemRoutes } from "./routes/system.js";
 import { registerCaptureRoutes } from "./routes/captures.js";
+import { registerPushNotifyRoutes } from "./routes/pushNotify.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
 import { AiControlStore, type AiControl } from "./analysis/aiControl.js";
 import { JobManager } from "./analysis/jobManager.js";
@@ -214,9 +215,7 @@ import { VeloHuntStore, type VeloHuntJob } from "./analysis/veloHuntStore.js";
 import { VeloMonitorStore, monitorId, type VeloMonitor } from "./analysis/veloMonitorStore.js";
 import { pollMonitorOnce, monitorArtifactMap, type PollDeps } from "./integrations/velociraptor/monitorPoller.js";
 import { pollHuntStatusOnce, isHuntStoppedEarly, type HuntPollDeps } from "./integrations/velociraptor/huntStatusPoller.js";
-import { PushTokenStore, generatePushToken } from "./analysis/pushTokenStore.js";
-import { resolvePushAuth } from "./analysis/pushAuth.js";
-import { extractPushPayload } from "./analysis/pushPayload.js";
+import { PushTokenStore } from "./analysis/pushTokenStore.js";
 import { pushCaseToIris, type IrisPushOptions } from "./integrations/iris/irisPush.js";
 import { IrisExportStore, defaultIrisCaseName } from "./integrations/iris/irisExportStore.js";
 import { TimesketchClient } from "./integrations/timesketch/timesketchClient.js";
@@ -236,7 +235,7 @@ import { archiveCase } from "./analysis/caseArchive.js";
 import { NotificationConfigStore } from "./analysis/notificationStore.js";
 import { seedDemoCase } from "./analysis/seedDemoCase.js";
 import {
-  findingEventsFromDiff, milestoneEvent, parseChannelInput, playbookTaskEvent, redactChannel,
+  findingEventsFromDiff, milestoneEvent, playbookTaskEvent,
   type NotificationEvent,
 } from "./analysis/notifications.js";
 import { createNotifier, type Notifier } from "./integrations/notify/notifyDispatch.js";
@@ -744,6 +743,8 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     getControl,
     flush,
     indexCaptureText,
+    ingestStreamed,
+    resolveImportKind: () => resolveImportKind,
     captureBuffers: () => buffers,
     synthInFlight: () => synthInFlight,
     importerRegistry: () => importerRegistry,
@@ -754,6 +755,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   };
   registerSystemRoutes(app, ctx);
   registerCaptureRoutes(app, ctx);
+  registerPushNotifyRoutes(app, ctx);
 
   app.get("/cases/:id/lock-status", async (req: Request, res: Response) => {
     try {
@@ -4123,82 +4125,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     return res.status(204).end();
   });
 
-  // ── Generic push ingest (#84) ─────────────────────────────────────────────────────────────────
-  // An external tool (SIEM webhook, Velociraptor client-event poller, custom script) POSTs an alert
-  // payload here with an X-DFIR-Key token. The body is any importDetect-routable shape (artifact-map,
-  // SIEM alert, Hayabusa line, { source, events }, raw text…). Runs the SAME import → diff →
-  // re-synthesize pipeline as the file Import button; responds 202 immediately, imports in background.
-  app.post("/cases/:id/push", async (req: Request, res: Response) => {
-    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
-    const caseId = req.params.id;
-    // Auth: global DFIR_PUSH_TOKEN and/or a per-case token. 403 when push is unconfigured, 401 on a bad key.
-    let caseToken: string | undefined;
-    if (options.pushTokenStore) { try { caseToken = (await options.pushTokenStore.get(caseId))?.token; } catch { /* none */ } }
-    const bearer = (req.get("authorization") || "").replace(/^Bearer\s+/i, "");
-    const presented = String(req.get("x-dfir-key") || bearer || "");
-    const auth = resolvePushAuth({ globalToken: options.pushToken, caseToken, presented });
-    if (!auth.ok) return res.status(auth.status).json({ error: auth.error });
-
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
-
-    const { text, source, filename } = extractPushPayload(req.body);
-    if (!text.trim()) return res.status(400).json({ error: "empty push payload" });
-    const kind = resolveImportKind(filename, text);
-    if (kind === "unknown") return res.status(400).json({ error: "could not detect the payload type — not recognized as any supported import shape" });
-    if ((kind === "csv" || kind === "log") && !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for CSV/log analysis" });
-
-    const minSeverity = parseMinSeverity(req.body?.minSeverity);
-    logLine(`[push] case ${caseId}: received "${source}" → ${kind}`);
-    res.status(202).json({ accepted: true, kind, source });
-    // Import in the background; the 202 already went out.
-    ingestStreamed(caseId, kind, text, filename, minSeverity)
-      .catch((err) => options.onAiStatus?.(caseId, { status: "error", at: new Date().toISOString(), detail: `push import failed: ${(err as Error).message}` }));
-  });
-
-  // Per-case push token management (#84). GET returns the case token's existence (NOT the secret on a
-  // plain GET — it's shown once on generate) plus whether a global token covers every case and the
-  // push URL. POST generates/rotates one; DELETE clears it.
-  app.get("/cases/:id/push-token", async (req: Request, res: Response) => {
-    const caseId = req.params.id;
-    const globalConfigured = !!(options.pushToken && options.pushToken.trim());
-    let rec: { token: string; createdAt: string } | null = null;
-    if (options.pushTokenStore) { try { rec = await options.pushTokenStore.get(caseId); } catch { /* none */ } }
-    const base = (options.dashboardBaseUrl || "").replace(/\/+$/, "");
-    return res.status(200).json({
-      configured: !!rec,
-      token: rec?.token ?? "",          // shown so Settings can display the active token + curl example
-      createdAt: rec?.createdAt ?? "",
-      globalConfigured,
-      storeAvailable: !!options.pushTokenStore,
-      pushUrl: `${base}/cases/${encodeURIComponent(caseId)}/push`,
-    });
-  });
-
-  app.post("/cases/:id/push-token/generate", async (req: Request, res: Response) => {
-    if (!options.pushTokenStore) return res.status(501).json({ error: "push token store not configured" });
-    const caseId = req.params.id;
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
-    try {
-      const token = generatePushToken();
-      const rec = await options.pushTokenStore.set(caseId, token, new Date().toISOString());
-      options.onPushToken?.(caseId);
-      return res.status(201).json({ token: rec.token, createdAt: rec.createdAt });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.delete("/cases/:id/push-token", async (req: Request, res: Response) => {
-    if (!options.pushTokenStore) return res.status(501).json({ error: "push token store not configured" });
-    try {
-      await options.pushTokenStore.clear(req.params.id);
-      options.onPushToken?.(req.params.id);
-      return res.status(204).end();
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
   // Push a case to DFIR-IRIS: find-or-create the case by name, then push assets→assets,
   // IOCs→IOCs, forensic timeline→timeline, executive summary→case summary, everything else→notes.
   // Body: { caseName? } — an explicit override; otherwise the name from the last push is reused
@@ -4535,78 +4461,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     } catch (err) {
       logLine(`[clickup] ${caseId} push ERROR: ${(err as Error).message}`);
       return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // ── Notifications (issue #58) ─────────────────────────────────────────────────────────────
-  // Global channel config: Slack/Teams webhooks + SMTP email, with per-channel severity threshold
-  // and per-event-kind toggles. Opt-in (the store starts empty). Secrets (webhook URLs, SMTP
-  // passwords) are REDACTED in every response — the browser only learns whether each is set.
-
-  app.get("/notifications/status", (_req: Request, res: Response) => {
-    res.status(200).json({ configured: !!options.notificationStore, emailEnabled: !!options.notifyEmailEnabled });
-  });
-
-  app.get("/notifications", async (_req: Request, res: Response) => {
-    if (!options.notificationStore) return res.status(200).json([]);
-    try {
-      return res.status(200).json((await options.notificationStore.load()).map(redactChannel));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.post("/notifications", async (req: Request, res: Response) => {
-    if (!options.notificationStore) return res.status(501).json({ error: "notifications not configured" });
-    const parsed = parseChannelInput(req.body);
-    if (!parsed.ok || !parsed.draft) return res.status(400).json({ error: parsed.error ?? "invalid channel" });
-    try {
-      const channel = await options.notificationStore.add(parsed.draft);
-      logLine(`[notify] channel added: ${channel.type} "${channel.name}" (${channel.id})`);
-      return res.status(201).json(redactChannel(channel));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.put("/notifications/:id", async (req: Request, res: Response) => {
-    if (!options.notificationStore) return res.status(501).json({ error: "notifications not configured" });
-    try {
-      const existing = await options.notificationStore.get(req.params.id);
-      if (!existing) return res.status(404).json({ error: "notification channel not found" });
-      // Pass `existing` so a blank (redacted) webhook URL keeps the saved one.
-      const parsed = parseChannelInput(req.body, existing);
-      if (!parsed.ok || !parsed.draft) return res.status(400).json({ error: parsed.error ?? "invalid channel" });
-      const channel = await options.notificationStore.update(req.params.id, parsed.draft);
-      if (!channel) return res.status(404).json({ error: "notification channel not found" });
-      return res.status(200).json(redactChannel(channel));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.delete("/notifications/:id", async (req: Request, res: Response) => {
-    if (!options.notificationStore) return res.status(501).json({ error: "notifications not configured" });
-    try {
-      const removed = await options.notificationStore.remove(req.params.id);
-      if (!removed) return res.status(404).json({ error: "notification channel not found" });
-      return res.status(204).end();
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Send a test notification to one channel ({ channelId }) or all configured channels. Bypasses
-  // the enable/threshold/kind filters so a disabled or high-threshold channel can be verified.
-  app.post("/notifications/test", async (req: Request, res: Response) => {
-    if (!options.notificationStore || !options.notifier) return res.status(501).json({ error: "notifications not configured" });
-    try {
-      const channelId = typeof req.body?.channelId === "string" ? req.body.channelId : undefined;
-      const results = await options.notifier.test(channelId, new Date().toISOString());
-      if (!results.length) return res.status(404).json({ error: "no matching channel to test" });
-      return res.status(200).json({ results });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
     }
   });
 


### PR DESCRIPTION
Task 3 of the router split. Moves the push-notification + notification-config domain out of `createApp` into `src/routes/pushNotify.ts`. **Pure structural move — zero behavior change.**

## Routes moved (10, verbatim)
`POST /cases/:id/push`, `GET|POST(generate)|DELETE /cases/:id/push-token`, `GET /notifications/status`, `GET|POST /notifications`, `PUT|DELETE /notifications/:id`, `POST /notifications/test`.
Integration-push routes (`/push/{iris,timesketch,timesketch-super,misp,notion,clickup}`) correctly **remain** — they belong to their integration domains.

## RouteContext
Graduated `ingestStreamed` (stable helper) and `resolveImportKind` (**live accessor** — const arrow declared after the ctx literal, called inside the handler).

## Verification
- `tsc --noEmit` clean; `pushRoute` + `notificationRoutes` tests pass **unedited** (15/15)
- Route inventory **316 = 316**, identical multiset
- Full server suite green (52 files / 400 tests)
- Spec-reviewed: verbatim handlers, live-accessor correctness, integration routes preserved, dead-import safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)