### PR TITLE
feat: VolWeb adapter + manual tool override for the browser extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **VolWeb adapter + manual tool override** — the extension now auto-detects VolWeb alongside the existing six consoles, and the popup shows the detected tool with a dropdown to force a different adapter (or none) for the current tab.
+
 ## [0.31.0] - 2026-07-10
 
 ### Added

--- a/extension/src/adapters/override.ts
+++ b/extension/src/adapters/override.ts
@@ -1,0 +1,21 @@
+import { adapterById } from "./registry.js";
+
+// Sentinel override value meaning "force no adapter — plain screenshot only", distinct from ""
+// (no override / auto-detect). Shared between the content script (artifactCapture.ts) and the
+// popup's <select> option value.
+export const OVERRIDE_NONE = "__none__";
+
+/**
+ * Resolve which adapter id is actually in effect for a tab, given what matchUrl auto-detected and
+ * what the analyst forced via the popup's manual override. Pure — the content script
+ * (artifactCapture.ts) is the only caller.
+ *   - overrideId === ""            → no override, use the auto-detected adapter (may be null)
+ *   - overrideId === OVERRIDE_NONE → forced off — plain screenshot only, regardless of detection
+ *   - overrideId === <adapter id>  → forced to that adapter, IF it's a real registry id, else
+ *                                     fall back to auto-detect (a stale/bad override must not stick)
+ */
+export function resolveActiveAdapter(detectedId: string | null, overrideId: string): string | null {
+  if (overrideId === "") return detectedId;
+  if (overrideId === OVERRIDE_NONE) return null;
+  return adapterById(overrideId) ? overrideId : detectedId;
+}

--- a/extension/src/adapters/registry.ts
+++ b/extension/src/adapters/registry.ts
@@ -5,6 +5,7 @@ import { elasticAdapter } from "./elastic.js";
 import { crowdstrikeAdapter } from "./crowdstrike.js";
 import { securityOnionAdapter } from "./securityonion.js";
 import { socratesAdapter } from "./socrates.js";
+import { volwebAdapter } from "./volweb.js";
 
 // The known-tool registry. Order is significance-only (matchUrl is meant to be mutually exclusive
 // across these consoles); the first matching adapter wins.
@@ -15,6 +16,7 @@ export const ADAPTERS: readonly Adapter[] = [
   socratesAdapter,
   elasticAdapter,
   crowdstrikeAdapter,
+  volwebAdapter,
 ];
 
 /**

--- a/extension/src/adapters/registry.ts
+++ b/extension/src/adapters/registry.ts
@@ -20,9 +20,10 @@ export const ADAPTERS: readonly Adapter[] = [
 ];
 
 /**
- * Return the adapter that recognizes this page URL, or null. Pure — used by the content script to
- * decide whether to activate at all (on an unrecognized site the extension does nothing, falling
- * back to plain screenshot capture). Invalid URLs yield null rather than throwing.
+ * Return the adapter that recognizes this page URL, or null. Pure — used by the content script as
+ * the DEFAULT activation decision (on an unrecognized site, plain screenshot capture is used
+ * unless the popup's manual override forces an adapter on — see adapters/override.ts). Invalid
+ * URLs yield null rather than throwing.
  */
 export function adapterForUrl(href: string): Adapter | null {
   let url: URL;

--- a/extension/src/adapters/volweb.ts
+++ b/extension/src/adapters/volweb.ts
@@ -1,0 +1,41 @@
+import type { Adapter } from "./types.js";
+import { asArray, isObject } from "./extractUtils.js";
+
+// VolWeb (https://github.com/k1nd0ne/VolWeb) — a Django + React memory-forensics platform (a
+// Volatility3 front end). Its analysis pages are the case/evidence detail views (/cases/:id,
+// /evidences/:id); the data API is GET /api/evidence/<id>/plugin/<plugin_name>/ (and the
+// equivalent .../plugin/<plugin_name>/artefacts/ unfiltered variant, same response shape),
+// returning { name, artefacts: [...] } — the volatility3 plugin's result rows (pslist, netscan,
+// filescan, etc.). VolWeb has no distinctive port (served via nginx on 80/443), so matchUrl falls
+// back to the case/evidence detail path when the hostname isn't self-evidently branded — the same
+// approach the Security Onion adapter already uses.
+export const volwebAdapter: Adapter = {
+  id: "volweb",
+  label: "VolWeb",
+
+  matchUrl(url: URL): boolean {
+    if (/volweb/i.test(url.hostname)) return true;
+    if (/^\/(cases|evidences)\/\d+/i.test(url.pathname)) return true;
+    return false;
+  },
+
+  apiPatterns: ["/api/evidence/\\d+/plugin/[^/]+/"],
+
+  extractRows(_url: string, body: unknown): unknown[] | null {
+    if (!isObject(body)) return null;
+    return asArray(body.artefacts);
+  },
+
+  sourceLabel: volwebSourceLabel,
+};
+
+const PLUGIN_NAME_RE = /\/plugin\/([^/]+)\//i;
+
+// Derive the source label from the volatility3 plugin name embedded in the API URL (e.g.
+// "windows.pslist.PsList"). Pure — unit-tested.
+export function volwebSourceLabel(opts: { apiUrl?: string }): string {
+  const { apiUrl = "" } = opts;
+  const m = PLUGIN_NAME_RE.exec(apiUrl);
+  if (!m) return "";
+  try { return decodeURIComponent(m[1]); } catch { return m[1]; }
+}

--- a/extension/src/artifactCapture.ts
+++ b/extension/src/artifactCapture.ts
@@ -14,19 +14,22 @@
 // All browser-only glue; the pure logic it calls (adapter matching/extraction, matrixToRows) is
 // unit-tested separately.
 
-import { adapterForUrl } from "./adapters/registry.js";
+import { adapterForUrl, adapterById } from "./adapters/registry.js";
 import type { Adapter, CapturedArtifact } from "./adapters/types.js";
+import { resolveActiveAdapter } from "./adapters/override.js";
 import { matrixToRows } from "./adapters/domTable.js";
 import { decodeCapturedBodies } from "./adapters/extractUtils.js";
 import { DFIR_CAPTURE_MSG, DFIR_CONFIG_MSG, DFIR_READY_MSG } from "./adapters/bridge.js";
 import { clampButtonPosition, isDrag, parseButtonPos, type ButtonPos } from "./buttonPosition.js";
-import type { EnsureHookMessage, PushArtifactMessage, PushArtifactResult } from "./types.js";
+import type { EnsureHookMessage, PushArtifactMessage, PushArtifactResult, CaptureStatusResult } from "./types.js";
 
 const BTN_ID = "dfir-companion-push-btn";
 // chrome.storage.local key holding the analyst's dragged button position (null = default corner).
 const POS_KEY = "pushButtonPos";
 
 let activeAdapter: Adapter | null = null;
+let detectedAdapterId: string | null = null;
+let overrideAdapterId = ""; // "" | OVERRIDE_NONE | an adapter id — see adapters/override.ts
 let latest: CapturedArtifact | null = null;
 let busy = false;
 // Cached case id — kept in sync so the MutationObserver below can re-inject the button
@@ -38,27 +41,27 @@ let buttonPos: ButtonPos | null = null;
 let suppressClick = false;
 
 export async function initArtifactCapture(): Promise<void> {
-  activeAdapter = adapterForUrl(location.href);
-  if (!activeAdapter) return;
+  detectedAdapterId = adapterForUrl(location.href)?.id ?? null;
 
-  // Attach the listener BEFORE requesting injection so we never miss the hook's "ready" handshake.
+  // Attach listeners BEFORE activating so we never miss the hook's "ready" handshake or a popup
+  // override sent immediately after injection.
   window.addEventListener("message", onPageMessage);
-  requestHookInjection();
-  sendConfig();
+  chrome.runtime.onMessage.addListener(onExtensionMessage);
+  applyAdapter();
 
   // Only show the push button when a case is selected — so the button stays hidden when the
   // analyst is not actively investigating and hasn't connected the extension to a case.
   const stored = await chrome.storage.local.get(["settings", POS_KEY]);
   currentCaseId = (stored.settings as { caseId?: string } | undefined)?.caseId ?? "";
   buttonPos = parseButtonPos(stored[POS_KEY]);
-  if (currentCaseId) ensureButton();
+  if (currentCaseId && activeAdapter) ensureButton();
 
   // Kibana (and other DFIR consoles) are React SPAs — their initial render can replace the
   // document body's children, removing the injected button. Watch for direct-child removal and
   // re-inject whenever the button disappears while a case is selected.
   const bodyTarget = document.body ?? document.documentElement;
   const bodyObserver = new MutationObserver(() => {
-    if (currentCaseId && !document.getElementById(BTN_ID)) ensureButton();
+    if (currentCaseId && activeAdapter && !document.getElementById(BTN_ID)) ensureButton();
   });
   bodyObserver.observe(bodyTarget, { childList: true });
 
@@ -72,12 +75,71 @@ export async function initArtifactCapture(): Promise<void> {
     }
     if (!changes.settings) return;
     currentCaseId = (changes.settings.newValue as { caseId?: string } | undefined)?.caseId ?? "";
-    if (currentCaseId) {
+    if (currentCaseId && activeAdapter) {
       ensureButton();
     } else {
       document.getElementById(BTN_ID)?.remove();
     }
   });
+}
+
+// (Re)compute which adapter is active from detection + override, reset captured state, and — when
+// an adapter is now active — (re)request the MAIN-world hook with its API patterns. Called once at
+// init, and again whenever the popup changes the override for this tab. Unlike before manual
+// override existed, this now runs (and the listeners above are registered) even on pages
+// adapterForUrl doesn't recognize — cheaply, since applyAdapter() itself no-ops until an adapter
+// is actually active — so a later popup override can still activate capture on that page.
+function applyAdapter(): void {
+  const id = resolveActiveAdapter(detectedAdapterId, overrideAdapterId);
+  if (id !== (activeAdapter?.id ?? null)) {
+    activeAdapter = id ? adapterById(id) : null;
+    latest = null;
+  }
+  if (activeAdapter) {
+    requestHookInjection();
+    sendConfig();
+  }
+  if (currentCaseId && activeAdapter) {
+    ensureButton();
+    renderButton();
+  } else {
+    document.getElementById(BTN_ID)?.remove();
+  }
+}
+
+// ── Manual override (popup ⇄ this content script) ────────────────────────────────────────────
+// The popup can't reach adapterForUrl's result directly — it lives here, in the tab. These two
+// message kinds (sent via chrome.tabs.sendMessage, which — unlike chrome.runtime.sendMessage from
+// a content script — targets THIS listener, not the service worker's onMessage in
+// serviceWorker.ts) let the popup read and override it. See adapters/override.ts for the
+// resolution rule and popup.ts for the UI.
+function onExtensionMessage(
+  msg: unknown,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response: CaptureStatusResult) => void,
+): boolean | undefined {
+  const m = msg as { kind?: string; overrideAdapterId?: string } | null;
+  if (!m || typeof m.kind !== "string") return undefined;
+  if (m.kind === "get_capture_status") {
+    sendResponse(captureStatus());
+    return true;
+  }
+  if (m.kind === "set_adapter_override") {
+    overrideAdapterId = typeof m.overrideAdapterId === "string" ? m.overrideAdapterId : "";
+    applyAdapter();
+    sendResponse(captureStatus());
+    return true;
+  }
+  return undefined;
+}
+
+function captureStatus(): CaptureStatusResult {
+  return {
+    detectedAdapterId,
+    overrideAdapterId,
+    activeLabel: activeAdapter?.label ?? null,
+    rowCount: latest?.rows.length ?? 0,
+  };
 }
 
 // ── MAIN-world hook injection + handshake ──────────────────────────────────────────────────────

--- a/extension/src/artifactCapture.ts
+++ b/extension/src/artifactCapture.ts
@@ -1,8 +1,9 @@
 // Content-script (isolated world) orchestration for automated artifact fetching (issue #102).
 //
 // Flow on a recognized DFIR console:
-//   1. adapterForUrl() decides if this tab is a known tool — if not, we do nothing (plain screenshot
-//      capture still works via content.ts).
+//   1. adapterForUrl() decides if this tab is a known tool. Unless the popup forces an override
+//      (see applyAdapter() / onExtensionMessage() below), an unrecognized page does nothing here
+//      — plain screenshot capture still works via content.ts.
 //   2. We ask the service worker to inject pageHook.js into the MAIN world (executeScript bypasses
 //      page CSP) and hand the hook the adapter's API URL patterns via postMessage.
 //   3. The hook forwards matching API response bodies back; we extract clean rows via the adapter and

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -17,6 +17,8 @@ document.addEventListener("keydown", () => {
 }, { capture: true, passive: true });
 
 // Automated artifact fetching (#102): on recognized DFIR consoles (Splunk / Velociraptor /
-// Elastic / CrowdStrike) inject a "Push to DFIR-Companion" button + the API-interception hook.
-// No-ops on every other site.
+// Security Onion / SO-CRATES / Elastic / CrowdStrike / VolWeb) inject a "Push to DFIR-Companion"
+// button + the API-interception hook. Every other site gets no button/hook by default, but the
+// popup's manual override (see popup.ts) can still force one on — so a lightweight listener is
+// always registered, even where nothing is currently detected.
 void initArtifactCapture();

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -16,6 +16,10 @@
 <body>
   <strong>DFIR Capture</strong>
   <label>Case <select id="caseId"></select></label>
+  <div id="toolRow">
+    <label>Detected tool <select id="toolOverride"></select></label>
+    <div id="toolHint" class="hint"></div>
+  </div>
   <label>Companion URL <input id="companionUrl" /></label>
   <label>Interval (seconds) <input id="intervalSeconds" type="number" min="5" /></label>
   <label>Dedup threshold <input id="dedupThreshold" type="number" min="0" /></label>

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -1,8 +1,64 @@
 import { DEFAULT_SETTINGS, normalizeCompanionUrl, type Settings } from "./types.js";
+import { ADAPTERS } from "./adapters/registry.js";
+import { OVERRIDE_NONE } from "./adapters/override.js";
+import type { CaptureStatusResult, GetCaptureStatusMessage, SetAdapterOverrideMessage } from "./types.js";
 
 const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
 const caseSelect = () => document.getElementById("caseId") as HTMLSelectElement;
 const statusEl = () => document.getElementById("status") as HTMLDivElement;
+
+const toolSelect = () => document.getElementById("toolOverride") as HTMLSelectElement;
+const toolHint = () => document.getElementById("toolHint") as HTMLDivElement;
+
+async function activeTabId(): Promise<number | null> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab?.id ?? null;
+}
+
+function populateToolOptions(sel: HTMLSelectElement): void {
+  sel.innerHTML = "";
+  sel.appendChild(new Option("Auto-detect", ""));
+  for (const a of ADAPTERS) sel.appendChild(new Option(a.label, a.id));
+  sel.appendChild(new Option("None — plain screenshot", OVERRIDE_NONE));
+}
+
+function describeStatus(status: CaptureStatusResult): string {
+  const detected = status.detectedAdapterId
+    ? ADAPTERS.find((a) => a.id === status.detectedAdapterId)?.label ?? status.detectedAdapterId
+    : "not recognized";
+  return status.activeLabel ? `detected: ${detected} — capturing as ${status.activeLabel}` : `detected: ${detected}`;
+}
+
+// Populate the "Detected tool" row from the active tab's content script, and wire the override
+// <select> to push changes back to it. Hides the row entirely when the active tab has no content
+// script to talk to (a chrome:// page, or a page loaded before the extension was installed) —
+// same catch-and-degrade pattern loadCases() below uses for an offline companion.
+async function initToolOverride(): Promise<void> {
+  const row = document.getElementById("toolRow");
+  const sel = toolSelect();
+  if (!row || !sel) return;
+  const tabId = await activeTabId();
+  if (!tabId) { row.style.display = "none"; return; }
+  try {
+    const msg: GetCaptureStatusMessage = { kind: "get_capture_status" };
+    const status = (await chrome.tabs.sendMessage(tabId, msg)) as CaptureStatusResult;
+    populateToolOptions(sel);
+    sel.value = status.overrideAdapterId;
+    toolHint().textContent = describeStatus(status);
+  } catch {
+    row.style.display = "none";
+    return;
+  }
+  sel.onchange = async () => {
+    try {
+      const msg: SetAdapterOverrideMessage = { kind: "set_adapter_override", overrideAdapterId: sel.value };
+      const status = (await chrome.tabs.sendMessage(tabId, msg)) as CaptureStatusResult;
+      toolHint().textContent = describeStatus(status);
+    } catch {
+      toolHint().textContent = "override failed — reload the page and try again";
+    }
+  };
+}
 
 async function load(): Promise<Settings> {
   const stored = await chrome.storage.local.get("settings");
@@ -114,6 +170,7 @@ async function init() {
   await refreshStatus(s);
   await showLastCapture();
   await showHotkey();
+  await initToolOverride();
 
   // Auto-save the case selection immediately on change so the analyst can switch cases
   // (or clear them) without pressing Start — screenshots stay in their current state.

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -26,7 +26,9 @@ function describeStatus(status: CaptureStatusResult): string {
   const detected = status.detectedAdapterId
     ? ADAPTERS.find((a) => a.id === status.detectedAdapterId)?.label ?? status.detectedAdapterId
     : "not recognized";
-  return status.activeLabel ? `detected: ${detected} — capturing as ${status.activeLabel}` : `detected: ${detected}`;
+  if (!status.activeLabel) return `detected: ${detected}`;
+  const rows = status.rowCount > 0 ? ` (${status.rowCount} rows captured)` : "";
+  return `detected: ${detected} — capturing as ${status.activeLabel}${rows}`;
 }
 
 // Populate the "Detected tool" row from the active tab's content script, and wire the override

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -73,3 +73,26 @@ export interface PushArtifactResult {
   caseId?: string;
   error?: string;
 }
+
+// ── Manual adapter override (popup ⇄ content script) ──────────────────────────────────────────
+// popup → content script: read the current auto-detected/overridden adapter for this tab.
+export interface GetCaptureStatusMessage {
+  kind: "get_capture_status";
+}
+
+// popup → content script: force (or clear) which adapter is active for this tab. Session-only —
+// held in the content script's in-memory state, so it resets on navigation/tab close.
+// overrideAdapterId: "" = no override (auto-detect) | OVERRIDE_NONE (adapters/override.ts) =
+// force no adapter | else an adapter id.
+export interface SetAdapterOverrideMessage {
+  kind: "set_adapter_override";
+  overrideAdapterId: string;
+}
+
+// content script → popup: reply to both messages above.
+export interface CaptureStatusResult {
+  detectedAdapterId: string | null;
+  overrideAdapterId: string;  // mirrors the popup <select> value — see SetAdapterOverrideMessage
+  activeLabel: string | null; // the adapter actually in effect (detected, unless overridden)
+  rowCount: number;           // rows captured so far under the active adapter
+}

--- a/extension/tests/adapters.test.ts
+++ b/extension/tests/adapters.test.ts
@@ -6,6 +6,7 @@ import { elasticAdapter } from "../src/adapters/elastic.js";
 import { crowdstrikeAdapter } from "../src/adapters/crowdstrike.js";
 import { securityOnionAdapter } from "../src/adapters/securityonion.js";
 import { socratesAdapter } from "../src/adapters/socrates.js";
+import { volwebAdapter, volwebSourceLabel } from "../src/adapters/volweb.js";
 import { parseResponseBodies, decodeCapturedBodies } from "../src/adapters/extractUtils.js";
 import { deflateSync, gzipSync } from "node:zlib";
 
@@ -64,11 +65,23 @@ describe("adapterForUrl", () => {
     expect(adapterForUrl("http://localhost:9888/index.html")).toBeNull();
   });
 
-  it("adapterById resolves and the registry holds the six tools", () => {
-    expect(ADAPTERS.map((a) => a.id).sort()).toEqual(["crowdstrike", "elastic", "securityonion", "socrates", "splunk", "velociraptor"]);
+  it("matches VolWeb by host and case/evidence detail paths", () => {
+    expect(adapterForUrl("https://volweb.corp.local/cases/3")?.id).toBe("volweb");
+    expect(adapterForUrl("https://forensics.example.com/evidences/12")?.id).toBe("volweb");
+    expect(adapterForUrl("https://10.0.0.4/evidences/7/")?.id).toBe("volweb");
+  });
+
+  it("does not match VolWeb's list pages (no id) on a generic host", () => {
+    expect(adapterForUrl("https://forensics.example.com/cases")).toBeNull();
+    expect(adapterForUrl("https://forensics.example.com/evidences")).toBeNull();
+  });
+
+  it("adapterById resolves and the registry holds the seven tools", () => {
+    expect(ADAPTERS.map((a) => a.id).sort()).toEqual(["crowdstrike", "elastic", "securityonion", "socrates", "splunk", "velociraptor", "volweb"]);
     expect(adapterById("splunk")?.label).toBe("Splunk");
     expect(adapterById("securityonion")?.label).toBe("Security Onion");
     expect(adapterById("socrates")?.label).toBe("SO-CRATES");
+    expect(adapterById("volweb")?.label).toBe("VolWeb");
     expect(adapterById("nope")).toBeNull();
   });
 });
@@ -492,5 +505,39 @@ describe("socrates.extractRows / matchUrl / sourceLabel", () => {
   it("sourceLabel is SO-CRATES and apiPatterns cover both feeds", () => {
     expect(socratesAdapter.sourceLabel?.({ apiUrl: "/api/events", pageUrl: "http://x/socrates.html", domInputs: [], domHeadings: [], rows: [] })).toBe("SO-CRATES");
     expect([...socratesAdapter.apiPatterns]).toEqual(["/api/events", "/api/sigma-alerts"]);
+  });
+});
+
+describe("volweb.extractRows", () => {
+  it("returns the artefacts array from the plugin-detail envelope", () => {
+    const body = { name: "windows.pslist.PsList", artefacts: [{ PID: 4, ImageFileName: "System" }, { PID: 88, ImageFileName: "smss.exe" }] };
+    expect(volwebAdapter.extractRows("/api/evidence/12/plugin/windows.pslist.PsList/", body)).toEqual(body.artefacts);
+  });
+
+  it("returns the artefacts array from the timeliner (unfiltered) variant", () => {
+    const body = { name: "windows.netscan.NetScan", artefacts: [{ LocalAddr: "10.0.0.5" }] };
+    expect(volwebAdapter.extractRows("/api/evidence/12/plugin/windows.netscan.NetScan/artefacts/", body)).toEqual(body.artefacts);
+  });
+
+  it("returns null when artefacts is empty or missing, and for non-object bodies", () => {
+    expect(volwebAdapter.extractRows("u", { name: "x", artefacts: [] })).toBeNull();
+    expect(volwebAdapter.extractRows("u", { name: "x" })).toBeNull();
+    expect(volwebAdapter.extractRows("u", "nope")).toBeNull();
+  });
+});
+
+describe("volwebSourceLabel", () => {
+  it("derives the plugin name from the plugin-artefacts API URL", () => {
+    expect(volwebSourceLabel({ apiUrl: "/api/evidence/12/plugin/windows.pslist.PsList/" })).toBe("windows.pslist.PsList");
+  });
+  it("derives the plugin name from the timeliner artefacts URL variant", () => {
+    expect(volwebSourceLabel({ apiUrl: "/api/evidence/12/plugin/windows.netscan.NetScan/artefacts/" })).toBe("windows.netscan.NetScan");
+  });
+  it("returns empty when the URL doesn't carry a plugin name", () => {
+    expect(volwebSourceLabel({ apiUrl: "/api/evidence/12/plugins/" })).toBe("");
+    expect(volwebSourceLabel({})).toBe("");
+  });
+  it("is wired onto the adapter", () => {
+    expect(typeof volwebAdapter.sourceLabel).toBe("function");
   });
 });

--- a/extension/tests/override.test.ts
+++ b/extension/tests/override.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { resolveActiveAdapter, OVERRIDE_NONE } from "../src/adapters/override.js";
+
+describe("resolveActiveAdapter", () => {
+  it("uses the detected adapter when there is no override", () => {
+    expect(resolveActiveAdapter("splunk", "")).toBe("splunk");
+    expect(resolveActiveAdapter(null, "")).toBeNull();
+  });
+
+  it("forces no adapter when the override is the explicit none sentinel", () => {
+    expect(resolveActiveAdapter("splunk", OVERRIDE_NONE)).toBeNull();
+    expect(resolveActiveAdapter(null, OVERRIDE_NONE)).toBeNull();
+  });
+
+  it("forces a specific adapter when the override names a real registry id", () => {
+    expect(resolveActiveAdapter(null, "velociraptor")).toBe("velociraptor");
+    expect(resolveActiveAdapter("splunk", "elastic")).toBe("elastic");
+  });
+
+  it("falls back to the detected adapter when the override id is not a real adapter", () => {
+    expect(resolveActiveAdapter("splunk", "not-a-real-adapter")).toBe("splunk");
+    expect(resolveActiveAdapter(null, "not-a-real-adapter")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a VolWeb (memory-forensics platform) site adapter to the extension's auto-detect registry, alongside the existing six (Splunk, Velociraptor, Security Onion, SO-CRATES, Elastic, CrowdStrike).
- Add a manual tool-override UI to the popup: shows the detected/active adapter for the current tab and lets the analyst force a different one (or none), session-only.
- Investigation found the original feature request ("auto-detect Velociraptor/Splunk/Security Onion/VolWeb/Splunk4DFIR + source tag + capture-mode suggestion + manual override") was already ~80% built — only VolWeb and the manual override were actually missing. "Splunk4DFIR" is covered by the existing Splunk adapter; "suggested capture mode per tool" doesn't map to anything in this architecture (capture mode is already fully automatic) and was dropped.

## Test plan
- [x] `npm test` — 117/117 passing (`extension/`)
- [x] `npm run build` — clean build, no errors
- [x] Full plan executed via subagent-driven development: 5 tasks, each independently spec-reviewed and code-quality-reviewed; one Important issue (a data-loss bug where toggling the override could silently drop already-captured rows) was found in review and fixed before merge
- [x] Final cross-cutting review across the whole diff: no scope creep, correct end-to-end integration, no state-desync issues
- [ ] Manual smoke test in Chrome (load unpacked, verify detection + override on a live tab) — steps in `docs/superpowers/plans/2026-07-10-siem-tool-auto-detect.md` Task 5, not run as part of this automated flow

Design spec and implementation plan (local-only, not part of the shipped project — see `.gitignore`): `docs/superpowers/specs/2026-07-10-siem-tool-auto-detect-design.md`, `docs/superpowers/plans/2026-07-10-siem-tool-auto-detect.md`