### PR TITLE
Right-click 'Send to DFIR-Companion' context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Right-click "Send to DFIR-Companion"** — send a page's selected text, a table (nearest to the click), or a link's URL straight to the connected case from any page, not just recognized adapter consoles.
+
 ## [0.31.0] - 2026-07-10
 
 ### Added

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — DFIR Companion: Evidence Capture & Push
 
-_Last updated: 2026-06-20_
+_Last updated: 2026-07-10_
 
 This is the privacy policy for the **DFIR Companion — Evidence Capture & Push** browser
 extension (the "Extension"), published for Chrome and other Chromium browsers. It is part of
@@ -32,11 +32,18 @@ The Extension supports a forensic investigation workflow in two ways:
    button. This step only ever runs on your explicit click — nothing is sent automatically
    from these pages.
 
+3. **Right-click "Send to DFIR-Companion".** On any page, you can right-click a text
+   selection, a table, or a link and choose "Send to DFIR-Companion" to push that selected
+   text, the nearest table's rows, or the link's URL to your local companion. Like the Push
+   button above, this only ever runs when you explicitly choose it from the menu.
+
 ## What data is handled
 
 - **Screenshots** of the active tab (image data).
 - **Structured detection data** scraped from recognized DFIR consoles when you click Push
   (e.g. alert/event rows, hostnames, hashes, IP addresses contained in those results).
+- **Text you explicitly send via the right-click menu** — a page's selected text, a table's
+  rows, or a link's URL — only when you choose "Send to DFIR-Companion" from the menu.
 - **Extension settings and an offline send-queue**, stored locally via `chrome.storage`
   (e.g. the selected case, capture interval, the companion server URL, and any captures that
   could not be delivered yet because the companion was unreachable).
@@ -60,6 +67,7 @@ The Extension supports a forensic investigation workflow in two ways:
 | `tabs` | Identify the active tab and react to tab switches for event-driven capture. |
 | `webNavigation` | Capture on page navigations (so the timeline reflects what you browsed). |
 | `scripting` | Inject the small content script / page hook that powers the Push button and reads the console results you are viewing. |
+| `contextMenus` | Add the right-click "Send to DFIR-Companion" menu items (send selection / table / link). |
 | `storage` | Persist your settings and hold the offline send-queue locally. |
 | `alarms` | Drive the optional periodic-capture timer. |
 | `host_permissions: <all_urls>` | Evidence capture and the DFIR-console Push feature must work on any site or self-hosted console (security tools run on arbitrary hosts/ports), so the Extension needs access to all sites. It still only **sends** data to your local companion, and the Push feature only acts when you click it. |

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["tabs", "activeTab", "webNavigation", "storage", "alarms", "scripting"],
+  "permissions": ["tabs", "activeTab", "webNavigation", "storage", "alarms", "scripting", "contextMenus"],
   "host_permissions": ["<all_urls>"],
   "options_ui": { "page": "options.html", "open_in_tab": true },
   "background": { "service_worker": "serviceWorker.js", "type": "module" },

--- a/extension/src/artifactCapture.ts
+++ b/extension/src/artifactCapture.ts
@@ -178,7 +178,7 @@ function scrapeVisibleTable(): CapturedArtifact | null {
   return { adapterId: activeAdapter.id, rows: objs, sourceUrl: location.href, via: "scrape", label };
 }
 
-function readTableMatrix(table: HTMLTableElement): { headers: string[]; rows: string[][] } {
+export function readTableMatrix(table: HTMLTableElement): { headers: string[]; rows: string[][] } {
   const cellText = (c: Element) => (c.textContent ?? "").replace(/\s+/g, " ").trim();
   const trs = Array.from(table.querySelectorAll("tr"));
   let headers: string[] = [];

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,4 +1,5 @@
 import { initArtifactCapture } from "./artifactCapture.js";
+import { initContextMenuCapture } from "./contextMenuCapture.js";
 
 let lastKeyNotify = 0;
 
@@ -19,4 +20,6 @@ document.addEventListener("keydown", () => {
 // Automated artifact fetching (#102): on recognized DFIR consoles (Splunk / Velociraptor /
 // Elastic / CrowdStrike) inject a "Push to DFIR-Companion" button + the API-interception hook.
 // No-ops on every other site.
+// Context-menu send (#new): right-click-target tracking + toast rendering, active on every page.
+initContextMenuCapture();
 void initArtifactCapture();

--- a/extension/src/contextMenuCapture.ts
+++ b/extension/src/contextMenuCapture.ts
@@ -1,0 +1,69 @@
+// Context-menu send (right-click → "Send … to DFIR-Companion"). Runs on every page (content.js
+// already matches <all_urls>) so it works even where no adapter is registered — unlike the
+// adapter-driven floating push button in artifactCapture.ts.
+//
+// Chrome's contextMenus API gives no reference to the element under the cursor, so table
+// targeting uses the standard workaround: remember the element from the native "contextmenu"
+// event, then walk up to its nearest <table> ancestor when the service worker asks for it.
+
+import { readTableMatrix } from "./artifactCapture.js";
+import { matrixToRows } from "./adapters/domTable.js";
+import type { ContextPushResultMessage, ContextTableResult, GetContextTableMessage } from "./types.js";
+
+const TOAST_ID = "dfir-companion-toast";
+let toastTimer: ReturnType<typeof window.setTimeout> | undefined;
+let lastRightClickTarget: Element | null = null;
+
+export function initContextMenuCapture(): void {
+  // Capture phase so this fires even if a page's own contextmenu handler stops propagation.
+  document.addEventListener("contextmenu", (e) => {
+    lastRightClickTarget = e.target instanceof Element ? e.target : null;
+  }, true);
+
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    const kind = (msg as { kind?: string })?.kind;
+    if (kind === "get_context_table") {
+      sendResponse(findContextTable() satisfies ContextTableResult);
+      return; // synchronous response — no need to keep the channel open
+    }
+    if (kind === "context_push_result") {
+      const { ok, message } = msg as ContextPushResultMessage;
+      showToast(message, ok ? "#1a7f37" : "#b42318");
+      return;
+    }
+  });
+}
+
+// Exported for GetContextTableMessage's documented contract even though the message kind check
+// above is untyped at the listener boundary (chrome.runtime.onMessage has no generic payload).
+export type { GetContextTableMessage };
+
+function findContextTable(): ContextTableResult {
+  const table = lastRightClickTarget?.closest("table") ?? null;
+  if (!table) return { rows: null };
+  const { headers, rows } = readTableMatrix(table);
+  const objs = matrixToRows(headers, rows);
+  return { rows: objs.length ? objs : null };
+}
+
+// Small floating banner, independent of the adapter push button's #dfir-companion-push-btn — a
+// context-menu send can happen on any page, including ones with no adapter/button. Reuses the same
+// success/error colors as artifactCapture.ts's flash() for visual consistency.
+function showToast(message: string, color: string): void {
+  let el = document.getElementById(TOAST_ID);
+  if (!el) {
+    el = document.createElement("div");
+    el.id = TOAST_ID;
+    Object.assign(el.style, {
+      position: "fixed", top: "16px", right: "16px", zIndex: "2147483647",
+      padding: "10px 14px", borderRadius: "8px", font: "600 13px system-ui, sans-serif",
+      color: "#fff", boxShadow: "0 2px 8px rgba(0,0,0,.3)", maxWidth: "320px",
+      pointerEvents: "none",
+    } as Partial<CSSStyleDeclaration>);
+    (document.body || document.documentElement).appendChild(el);
+  }
+  el.textContent = message;
+  el.style.background = color;
+  if (toastTimer) window.clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => el?.remove(), 4000);
+}

--- a/extension/src/contextMenuCapture.ts
+++ b/extension/src/contextMenuCapture.ts
@@ -8,7 +8,7 @@
 
 import { readTableMatrix } from "./artifactCapture.js";
 import { matrixToRows } from "./adapters/domTable.js";
-import type { ContextPushResultMessage, ContextTableResult, GetContextTableMessage } from "./types.js";
+import type { ContextPushResultMessage, ContextTableResult } from "./types.js";
 
 const TOAST_ID = "dfir-companion-toast";
 let toastTimer: ReturnType<typeof window.setTimeout> | undefined;
@@ -33,10 +33,6 @@ export function initContextMenuCapture(): void {
     }
   });
 }
-
-// Exported for GetContextTableMessage's documented contract even though the message kind check
-// above is untyped at the listener boundary (chrome.runtime.onMessage has no generic payload).
-export type { GetContextTableMessage };
 
 function findContextTable(): ContextTableResult {
   const table = lastRightClickTarget?.closest("table") ?? null;

--- a/extension/src/serviceWorker.ts
+++ b/extension/src/serviceWorker.ts
@@ -82,23 +82,30 @@ async function pushArtifact(msg: PushArtifactMessage): Promise<PushArtifactResul
   if (!settings.caseId) {
     return { ok: false, error: "No case selected — open the extension popup and pick a case." };
   }
-  const rows = Array.isArray(msg.rows) ? msg.rows : [];
-  if (!rows.length) return { ok: false, error: "No rows to push." };
+  const rows = Array.isArray(msg.rows) ? msg.rows : undefined;
+  const text = typeof msg.text === "string" ? msg.text : undefined;
+  if (!rows?.length && !text?.trim()) return { ok: false, error: "Nothing to push." };
 
   // Name the evidence file after the source artifact/notebook when known (nicer audit trail + a
   // Velociraptor-looking name keeps detectImportKind routing it to the Velociraptor importer).
   const filename = buildArtifactFilename(msg.sourceLabel?.trim() || msg.adapterId, new Date());
   const client = new CompanionClient(settings.companionUrl);
-  const result = await client.postImport(settings.caseId, { json: JSON.stringify(rows), filename });
+  // Exactly one of rows/text is set (context-menu selection/link pushes text; table pushes rows —
+  // see PushArtifactMessage). The companion's importDetect classifies either shape identically to
+  // an uploaded file, so no format hint beyond the filename is needed.
+  const result = rows?.length
+    ? await client.postImport(settings.caseId, { json: JSON.stringify(rows), filename })
+    : await client.postImport(settings.caseId, { text: text as string, filename });
 
+  const rowCount = rows?.length ?? 0;
   await chrome.storage.local.set({
     lastArtifactPush: {
-      at: new Date().toISOString(), adapterId: msg.adapterId, rows: rows.length,
+      at: new Date().toISOString(), adapterId: msg.adapterId, rows: rowCount,
       caseId: settings.caseId, ok: result.ok, status: result.status,
     },
   });
 
-  if (result.ok) return { ok: true, status: result.status, rows: rows.length, caseId: settings.caseId };
+  if (result.ok) return { ok: true, status: result.status, rows: rowCount, caseId: settings.caseId };
   const error = result.status === 0 ? `Companion offline at ${settings.companionUrl}`
     : result.status === 404 ? `Case "${settings.caseId}" not found — re-select it in the popup`
     : result.status === 400 ? "Companion couldn't detect the artifact format"

--- a/extension/src/serviceWorker.ts
+++ b/extension/src/serviceWorker.ts
@@ -3,7 +3,11 @@ import { CaptureQueue } from "./captureQueue.js";
 import { CaptureController } from "./captureController.js";
 import { setActionIcon } from "./actionIcon.js";
 import { buildArtifactFilename } from "./adapters/artifactName.js";
-import { DEFAULT_SETTINGS, type PushArtifactMessage, type PushArtifactResult, type Settings, type TriggerType } from "./types.js";
+import {
+  DEFAULT_SETTINGS, type ContextPushResultMessage, type ContextTableResult,
+  type GetContextTableMessage, type PushArtifactMessage, type PushArtifactResult,
+  type Settings, type TriggerType,
+} from "./types.js";
 
 const ALARM = "dfir-capture-timer";
 const queue = new CaptureQueue();
@@ -114,6 +118,82 @@ async function pushArtifact(msg: PushArtifactMessage): Promise<PushArtifactResul
   return { ok: false, status: result.status, error };
 }
 
+// ── Context-menu send (#new) ──────────────────────────────────────────────────────────────────
+const MENU_PARENT = "dfir-companion-menu";
+const MENU_SELECTION = "dfir-send-selection";
+const MENU_TABLE = "dfir-send-table";
+const MENU_LINK = "dfir-send-link";
+
+// Menu items persist across service-worker restarts once created, so this only needs to run on
+// install/update — removeAll() first makes it idempotent (Chrome throws "duplicate id" otherwise).
+function registerContextMenus(): void {
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({ id: MENU_PARENT, title: "DFIR-Companion", contexts: ["page", "selection", "link"] });
+    chrome.contextMenus.create({ id: MENU_SELECTION, parentId: MENU_PARENT, title: "Send selection to DFIR-Companion", contexts: ["selection"] });
+    chrome.contextMenus.create({ id: MENU_TABLE, parentId: MENU_PARENT, title: "Send table to DFIR-Companion", contexts: ["page"] });
+    chrome.contextMenus.create({ id: MENU_LINK, parentId: MENU_PARENT, title: "Send link to DFIR-Companion", contexts: ["link"] });
+  });
+}
+
+// Best-effort toast delivery — a tab that can't receive messages (chrome://, a PDF viewer, or one
+// that navigated away before the push resolved) just doesn't show a toast; the push itself already
+// completed (or failed) server-side regardless.
+async function sendContextToast(tabId: number, ok: boolean, message: string): Promise<void> {
+  const payload: ContextPushResultMessage = { kind: "context_push_result", ok, message };
+  try { await chrome.tabs.sendMessage(tabId, payload); } catch { /* tab unreachable */ }
+}
+
+async function handleContextMenuClick(
+  info: chrome.contextMenus.OnClickData,
+  tab: chrome.tabs.Tab | undefined,
+): Promise<void> {
+  if (!tab?.id) return;
+  const tabId = tab.id;
+
+  let text: string | undefined;
+  let rows: unknown[] | undefined;
+  let sourceLabel: string;
+
+  if (info.menuItemId === MENU_SELECTION) {
+    text = info.selectionText ?? "";
+    sourceLabel = "context-menu:selection";
+  } else if (info.menuItemId === MENU_LINK) {
+    text = info.linkUrl ?? "";
+    sourceLabel = "context-menu:link";
+  } else if (info.menuItemId === MENU_TABLE) {
+    sourceLabel = "context-menu:table";
+    let result: ContextTableResult | undefined;
+    try {
+      const req: GetContextTableMessage = { kind: "get_context_table" };
+      result = await chrome.tabs.sendMessage(tabId, req);
+    } catch {
+      result = undefined; // content script unreachable on this tab
+    }
+    if (!result?.rows?.length) {
+      void sendContextToast(tabId, false, "No table found at that location.");
+      return;
+    }
+    rows = result.rows;
+  } else {
+    return; // not one of our menu items
+  }
+
+  if (!rows?.length && !text?.trim()) {
+    void sendContextToast(tabId, false, "Nothing to send.");
+    return;
+  }
+
+  const msg: PushArtifactMessage = {
+    kind: "push_artifact",
+    adapterId: "context-menu",
+    sourceUrl: tab.url ?? "",
+    sourceLabel,
+    ...(rows ? { rows } : { text }),
+  };
+  const res = await pushArtifact(msg);
+  void sendContextToast(tabId, res.ok, res.ok ? `Pushed to "${res.caseId}"` : (res.error ?? "Push failed"));
+}
+
 async function rescheduleAlarm(): Promise<void> {
   const settings = await getSettings();
   await chrome.alarms.clear(ALARM);
@@ -155,8 +235,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     return true;
   }
 });
-chrome.runtime.onInstalled.addListener(() => void rescheduleAlarm());
+chrome.runtime.onInstalled.addListener(() => { void rescheduleAlarm(); registerContextMenus(); });
 chrome.runtime.onStartup.addListener(() => void rescheduleAlarm());
+chrome.contextMenus.onClicked.addListener((info, tab) => void handleContextMenuClick(info, tab));
 // Keyboard shortcut (default Ctrl+Shift+S / Cmd+Shift+S) to toggle capture on/off.
 chrome.commands?.onCommand.addListener((command) => {
   if (command === "toggle-capture") void toggleCapture();

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -44,8 +44,12 @@ export interface ConnectionStatus {
 // ── Automated artifact fetching (issue #102) ──────────────────────────────────────────────────
 // Body for POST /cases/:id/import — the unified, unauthenticated, localhost import route the
 // extension pushes intercepted/scraped tool data through (mirrors the dashboard Import button).
+// Exactly one of json/text is populated: json for a table push (stringified row array), text for
+// a raw string push (context-menu selection or link URL) — the companion's importDetect.ts
+// classifies either shape the same way it classifies an uploaded file.
 export interface ImportPayload {
-  json: string;            // stringified array of rows
+  json?: string;           // stringified array of rows
+  text?: string;           // raw text (context-menu selection / link push)
   filename: string;        // synthetic name (adapter id + timestamp) — detection hint + audit label
   minSeverity?: string;
 }
@@ -56,11 +60,14 @@ export interface EnsureHookMessage {
   kind: "ensure_hook";
 }
 
-// content script → service worker: push a captured artifact to the companion.
+// content script → service worker: push a captured artifact to the companion. Exactly one of
+// rows/text is populated: rows for a table push (adapter-scraped or context-menu table), text for
+// a raw string push (context-menu selection or link URL).
 export interface PushArtifactMessage {
   kind: "push_artifact";
   adapterId: string;
-  rows: unknown[];
+  rows?: unknown[];
+  text?: string;
   sourceUrl: string;
   sourceLabel?: string;  // artifact / notebook the rows came from (for the evidence filename)
 }
@@ -72,4 +79,25 @@ export interface PushArtifactResult {
   rows?: number;
   caseId?: string;
   error?: string;
+}
+
+// ── Context-menu send (#new) ──────────────────────────────────────────────────────────────────
+// service worker → content script: Chrome's contextMenus API gives no reference to the element
+// under the cursor, so table targeting asks the content script (which remembered the element from
+// the native "contextmenu" event) to walk up to its nearest <table> ancestor.
+export interface GetContextTableMessage {
+  kind: "get_context_table";
+}
+
+// content script → service worker: the table rows found (or null when no <table> ancestor, or the
+// table had no data rows).
+export interface ContextTableResult {
+  rows: Record<string, string>[] | null;
+}
+
+// service worker → content script: the outcome of a context-menu push, rendered as a toast.
+export interface ContextPushResultMessage {
+  kind: "context_push_result";
+  ok: boolean;
+  message: string;
 }

--- a/extension/tests/companionClient.test.ts
+++ b/extension/tests/companionClient.test.ts
@@ -64,4 +64,13 @@ describe("CompanionClient", () => {
     const client = new CompanionClient("http://127.0.0.1:4773", fetchFn);
     expect(await client.postImport("c1", { json: "[]", filename: "f.json" })).toEqual({ ok: false, status: 0 });
   });
+
+  it("postImport posts a text payload (context-menu push) without a json field", async () => {
+    const fetchFn = vi.fn(async () => new Response("{}", { status: 202 }));
+    const client = new CompanionClient("http://127.0.0.1:4773", fetchFn);
+    const payload = { text: "https://evil.example/payload", filename: "context-menu-link-2026.json" };
+    expect(await client.postImport("c1", payload)).toEqual({ ok: true, status: 202 });
+    const [, init] = fetchFn.mock.calls[0];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual(payload);
+  });
 });

--- a/extension/tests/manifest.test.ts
+++ b/extension/tests/manifest.test.ts
@@ -17,3 +17,9 @@ describe("manifest.json commands", () => {
     expect(manifest.commands["_execute_action"].description).toBeTruthy();
   });
 });
+
+describe("manifest.json permissions", () => {
+  it("requests contextMenus for the right-click send feature", () => {
+    expect(manifest.permissions).toContain("contextMenus");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a right-click context menu (parent "DFIR-Companion" with 3 sub-items) to the capture extension so an analyst can push a page's selected text, the table nearest the click, or a link's URL to the connected case from any page — not just recognized adapter consoles.
- No server-side changes needed: reuses the companion's existing `POST /cases/:id/import` route, which already auto-detects format from a raw `{ text }` body the same way it classifies an uploaded file.
- Widens `PushArtifactMessage`/`ImportPayload` to carry `text` alongside the existing `rows`, extends `pushArtifact()` to handle both, and adds a lightweight content-script module for right-click-target tracking, nearest-`<table>` lookup, and a transient result toast.
- Updates `CHANGELOG.md` and `extension/PRIVACY.md` (new `contextMenus` permission + the new data-handling bullet).

## Test plan
- [x] `npm test` — 106/106 passing (`extension/`)
- [x] `npm run build` — clean, verified the built `dist/manifest.json`/`content.js`/`serviceWorker.js` actually contain the new permission and menu code
- [x] Manual: loaded unpacked `extension/dist`, right-clicked a text selection → green toast, event landed in the case timeline
- [x] Manual: right-clicked inside the second of two `<table>`s on a page → correct table's rows pushed (confirms nearest-to-click targeting, not "largest table on page")
- [x] Manual: right-clicked a link → URL pushed as text
- [x] Manual: no case selected → red toast with the expected message; nothing sent
- [x] Manual: right-clicked with no table nearby → "No table found at that location." toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)