### PR TITLE
refactor: extract tool-runner + forensic-gate routes into routes/tools.ts (router split, Task 5)

### DIFF
--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -10,6 +10,8 @@ import type { EnrichmentProvider } from "../enrichment/provider.js";
 import type { ProviderHealthCache } from "../enrichment/providerHealth.js";
 import type { ImporterFailure, AiError } from "../analysis/diagnostics.js";
 import type { Severity } from "../analysis/stateTypes.js";
+import type { ToolConfig } from "../integrations/tools/toolConfig.js";
+import type { CustomTool } from "../integrations/tools/customToolStore.js";
 
 /**
  * Dependencies shared across more than one route domain, built once in createApp and passed to
@@ -53,6 +55,16 @@ export interface RouteContext {
   ingestStreamed(
     caseId: string, kind: string, text: string, originalName: string, minSeverity?: Severity,
   ): Promise<{ storedName: string; addedEvents: number; addedIocs: number; analyzed: boolean }>;
+  // External-tool runner machinery shared between the drop-folder auto-run path + the drop batch route
+  // (both still in createApp) and routes/tools.ts. Stable (hoisted function declarations bound at
+  // construction), so safe to destructure at registration scope:
+  //   runToolAndIngest — run a configured tool against a contained raw file and ingest its output
+  //                      through the same chain as the Import button (with an optional undo checkpoint).
+  //   reloadCustomTools — refresh the in-memory custom-tool list after a custom-tool CRUD mutation.
+  runToolAndIngest(
+    caseId: string, toolId: string, targetPath: string, opts?: { undoLabel?: string },
+  ): Promise<{ storedName: string; addedEvents: number; addedIocs: number; analyzed: boolean }>;
+  reloadCustomTools(): Promise<void>;
 
   // ── LIVE accessors ───────────────────────────────────────────────────────────────────
   // Call these INSIDE the request handler (or inside per-request logic like a preflight run),
@@ -70,4 +82,13 @@ export interface RouteContext {
   // arrow defined in createApp AFTER this ctx literal, so it's exposed as a live accessor — call
   // ctx.resolveImportKind() INSIDE the handler to reach the current binding, then invoke the result.
   resolveImportKind(): (filename: string, text: string) => string;
+  // External-tool config + custom-tool list, both shared with the drop-folder code still in createApp
+  // (resolveToolForExt/rawExtClaimed read customTools; the drop batch route + poller read
+  // liveToolConfigs). Exposed as live accessors because they're built AFTER this ctx literal:
+  //   liveToolConfigs   — a `const` arrow returning the merged built-in+custom tool config map read
+  //                       LIVE from env; call ctx.liveToolConfigs() INSIDE the handler, then invoke it.
+  //   customTools       — a mutable array reassigned by the async initial load + reloadCustomTools;
+  //                       call ctx.customTools() per request to read the current list.
+  liveToolConfigs(): () => Map<string, ToolConfig>;
+  customTools(): CustomTool[];
 }

--- a/companion/src/routes/tools.ts
+++ b/companion/src/routes/tools.ts
@@ -1,0 +1,222 @@
+import type { Express, Request, Response } from "express";
+import { join, basename } from "node:path";
+import { writeFile, rm, mkdir, mkdtemp } from "node:fs/promises";
+import { reloadEnvPrefix } from "../settings/envManager.js";
+import { TOOL_DEFS, type ToolId } from "../integrations/tools/toolConfig.js";
+import { updateToolRules } from "../integrations/tools/runToolImport.js";
+import { resolveForensicMinSeverity } from "../analysis/forensicGate.js";
+import { logActivity } from "../analysis/activityLog.js";
+import type { Severity } from "../analysis/stateTypes.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * External-tool runner + forensic-gate routes: the top-level /tools* config/registry and custom-tool
+ * CRUD (#211), the per-case /cases/:id/tools/:toolId/{run,run-upload,update-rules} runner endpoints,
+ * and the per-case /cases/:id/forensic-gate severity-cut config.
+ *
+ * Pure structural move out of createApp (see routes/system.ts for the conventions). The tool-runner
+ * machinery itself stays in createApp — the drop-folder auto-run poller and the drop batch route
+ * (/cases/:id/drop/run-pending) also drive it, so this module reaches it through the RouteContext
+ * members it was graduated onto: runToolAndIngest + reloadCustomTools (stable methods) and the
+ * liveToolConfigs + customTools live accessors (call ctx.liveToolConfigs()/ctx.customTools() INSIDE
+ * the handler). NOTE: /cases/:id/drop/run-pending is NOT here — it belongs to the drop-folder domain
+ * and stays in createApp even though it sits amid the tool routes.
+ */
+export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
+  const { store, options, recordImportFailure, runToolAndIngest, reloadCustomTools } = ctx;
+
+  // A tool id is known when it's a configured built-in or a defined custom tool. Rebuilt here (the
+  // createApp original read its closure `customTools`); the live custom-tool list comes from ctx.
+  const isKnownTool = (toolId: string): boolean => toolId in TOOL_DEFS || ctx.customTools().some((t) => t.id === toolId);
+
+  // ── External forensic tools (#211) ────────────────────────────────────────────────────────────
+  // Per-tool configured/auto-run status for the Settings → Tools tab (no secret values). Derived LIVE
+  // from env so it reflects settings just saved + reconnected.
+  app.get("/tools/status", (_req: Request, res: Response) => {
+    const configured = ctx.liveToolConfigs()();
+    const builtins = (Object.keys(TOOL_DEFS) as ToolId[]).map((id) => {
+      const cfg = configured.get(id);
+      return {
+        id,
+        label: TOOL_DEFS[id].label,
+        repoUrl: TOOL_DEFS[id].repoUrl,
+        importKind: TOOL_DEFS[id].importKind,
+        extensions: TOOL_DEFS[id].extensions,
+        configured: !!cfg,
+        autoRun: cfg?.autoRun ?? false,
+        hasUpdate: !!cfg?.updateCommand,
+        custom: false,
+      };
+    });
+    const custom = ctx.customTools().map((t) => ({
+      id: t.id,
+      label: t.name,
+      importKind: "auto",
+      extensions: t.extensions,
+      configured: true,
+      autoRun: t.autoRun,
+      hasUpdate: !!(t.updateCommand && t.updateCommand.trim()),
+      custom: true,
+    }));
+    res.status(200).json({ enabled: !!options.toolRunner, tools: [...builtins, ...custom] });
+  });
+
+  // Re-read DFIR_TOOL_* from .env (settings saved via the dashboard only write the file) so the tool
+  // paths/args/toggles apply WITHOUT the #1-gotcha restart. The runner is stateless (binary is a per-call
+  // arg) so there's nothing to rebuild — the next liveToolConfigs() sees the reloaded env. Always 200.
+  app.post("/tools/reconnect", async (_req: Request, res: Response) => {
+    try {
+      const applied = await reloadEnvPrefix("DFIR_TOOL_");
+      const configured = [...ctx.liveToolConfigs()().keys()];
+      return res.status(200).json({ ok: true, enabled: !!options.toolRunner, configured, applied });
+    } catch (err) {
+      return res.status(500).json({ ok: false, error: (err as Error).message });
+    }
+  });
+
+  // Manually run a configured tool against a raw file on disk (the drop-folder banner's "Run <tool>", or
+  // any case-relative path) and ingest its output through the normal import chain. 501 when tools are off,
+  // 400 on a bad tool id / path (containment enforced by resolveContainedPath).
+  app.post("/cases/:id/tools/:toolId/run", async (req: Request, res: Response) => {
+    const caseId = req.params.id;
+    const toolId = req.params.toolId;
+    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
+    if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
+    const path = typeof req.body?.path === "string" ? req.body.path.trim() : "";
+    if (!path) return res.status(400).json({ error: "path is required" });
+    try {
+      const r = await runToolAndIngest(caseId, toolId, path, { undoLabel: `Tool: ${toolId} — ${basename(path)}` });
+      return res.status(200).json({ ok: true, tool: toolId, storedName: r.storedName, addedEvents: r.addedEvents, addedIocs: r.addedIocs, analyzed: r.analyzed });
+    } catch (err) {
+      recordImportFailure(caseId, toolId, path, err);
+      return res.status(400).json({ ok: false, error: (err as Error).message });
+    }
+  });
+
+  // Run a tool against a raw file UPLOADED from the dashboard Import dialog (the browser has the bytes
+  // but the server can't read an arbitrary local path, and a binary can't go through the text /import
+  // body). The bytes are staged into a server-owned dir INSIDE the case (so path-containment holds),
+  // the tool runs, its output is imported, and the staged raw file is deleted (the Companion keeps the
+  // tool OUTPUT as evidence, not the raw binary). For files too large for the body cap, the analyst uses
+  // the drop folder instead. 501 tools off / 400 bad tool or input. #211
+  app.post("/cases/:id/tools/:toolId/run-upload", async (req: Request, res: Response) => {
+    const caseId = req.params.id;
+    const toolId = req.params.toolId;
+    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
+    if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
+    const filename = String(req.body?.filename ?? "").trim();
+    const dataBase64 = typeof req.body?.dataBase64 === "string" ? req.body.dataBase64 : "";
+    if (!filename || !dataBase64) return res.status(400).json({ error: "filename and dataBase64 are required" });
+    if (!ctx.liveToolConfigs()().get(toolId)) return res.status(400).json({ error: `tool "${toolId}" is not configured` });
+    // Stage into a FRESH per-upload dir under the file's ORIGINAL basename (no collisions, so no need to
+    // mangle the name) — folder-root tools (Velociraptor --ROOT) detect the EVTX channel from the filename.
+    const toolWork = join(store.caseDir(caseId), ".toolwork");
+    const safe = basename(filename).replace(/[^\w.\-]+/g, "_").slice(0, 120) || "raw.bin";
+    let stageDir = "";
+    try {
+      await mkdir(toolWork, { recursive: true });
+      stageDir = await mkdtemp(join(toolWork, "up-"));
+      const staged = join(stageDir, safe);
+      await writeFile(staged, Buffer.from(dataBase64, "base64"));
+      const r = await runToolAndIngest(caseId, toolId, staged, { undoLabel: `Tool: ${toolId} — ${basename(filename)}` });
+      return res.status(200).json({ ok: true, tool: toolId, addedEvents: r.addedEvents, addedIocs: r.addedIocs, analyzed: r.analyzed });
+    } catch (err) {
+      recordImportFailure(caseId, toolId, filename, err);
+      return res.status(400).json({ ok: false, error: (err as Error).message });
+    } finally {
+      if (stageDir) await rm(stageDir, { recursive: true, force: true }).catch(() => { /* best-effort cleanup */ });
+    }
+  });
+
+  // Run a tool's "update rules" command (Settings → Tools). Does NOT touch case data — a rule update is
+  // not evidence; returns the command output for a UI toast. 501 when tools off, 400 when no update
+  // command is configured for the tool.
+  app.post("/cases/:id/tools/:toolId/update-rules", async (req: Request, res: Response) => {
+    const toolId = req.params.toolId;
+    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
+    if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
+    const cfg = ctx.liveToolConfigs()().get(toolId);
+    if (!cfg) return res.status(400).json({ error: `tool "${toolId}" is not configured` });
+    try {
+      const output = await updateToolRules(cfg, options.toolRunner);
+      return res.status(200).json({ ok: true, tool: toolId, output });
+    } catch (err) {
+      return res.status(400).json({ ok: false, error: (err as Error).message });
+    }
+  });
+
+  // Custom tools (#211) — analyst-defined tools (name/binary/command/update/extensions) beyond the
+  // built-ins. GLOBAL store; the list is refreshed in memory on each mutation so liveToolConfigs/status
+  // reflect it immediately. 501 when the custom-tool store isn't wired.
+  app.get("/tools/custom", async (_req: Request, res: Response) => {
+    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
+    return res.status(200).json({ tools: await options.customToolStore.load() });
+  });
+  app.post("/tools/custom", async (req: Request, res: Response) => {
+    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
+    try {
+      const tool = await options.customToolStore.add(req.body ?? {});
+      await reloadCustomTools();
+      return res.status(201).json({ ok: true, tool });
+    } catch (err) {
+      return res.status(400).json({ ok: false, error: (err as Error).message });
+    }
+  });
+  app.put("/tools/custom/:id", async (req: Request, res: Response) => {
+    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
+    try {
+      const tool = await options.customToolStore.update(req.params.id, req.body ?? {});
+      if (!tool) return res.status(404).json({ error: `custom tool "${req.params.id}" not found` });
+      await reloadCustomTools();
+      return res.status(200).json({ ok: true, tool });
+    } catch (err) {
+      return res.status(400).json({ ok: false, error: (err as Error).message });
+    }
+  });
+  app.delete("/tools/custom/:id", async (req: Request, res: Response) => {
+    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
+    const removed = await options.customToolStore.remove(req.params.id);
+    await reloadCustomTools();
+    return res.status(200).json({ ok: true, removed });
+  });
+
+  // Forensic-timeline severity cut: the per-case override for which events stay in the forensic timeline
+  // (Low+ by default) vs. are demoted to the super-timeline only. `minSeverity: null` = defer to the
+  // global DFIR_FORENSIC_MIN_SEVERITY. GET returns the raw per-case override + the effective (resolved)
+  // value; PUT sets/clears it.
+  const FORENSIC_GATE_SEVERITIES: readonly Severity[] = ["Critical", "High", "Medium", "Low", "Info"];
+  app.get("/cases/:id/forensic-gate", async (req: Request, res: Response) => {
+    if (!options.forensicGateControlStore) return res.status(501).json({ error: "forensic gate not configured" });
+    try {
+      const perCase = (await options.forensicGateControlStore.load(req.params.id)).minSeverity ?? null;
+      const effective = resolveForensicMinSeverity(perCase ?? undefined, process.env.DFIR_FORENSIC_MIN_SEVERITY);
+      return res.status(200).json({ minSeverity: perCase, effective });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.put("/cases/:id/forensic-gate", async (req: Request, res: Response) => {
+    if (!options.forensicGateControlStore) return res.status(501).json({ error: "forensic gate not configured" });
+    const raw = req.body?.minSeverity;
+    // Accept one of the 5 severities, or null/omitted to clear the per-case override.
+    const cleared = raw === null || raw === undefined || raw === "";
+    if (!cleared && !FORENSIC_GATE_SEVERITIES.includes(raw)) {
+      return res.status(400).json({ error: `minSeverity must be one of ${FORENSIC_GATE_SEVERITIES.join(", ")} or null` });
+    }
+    try {
+      await options.forensicGateControlStore.set(req.params.id, { minSeverity: cleared ? undefined : (raw as Severity) });
+      options.onForensicGate?.(req.params.id);
+      const perCase = (await options.forensicGateControlStore.load(req.params.id)).minSeverity ?? null;
+      const effective = resolveForensicMinSeverity(perCase ?? undefined, process.env.DFIR_FORENSIC_MIN_SEVERITY);
+      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
+        category: "settings", action: "forensic-gate", detail: perCase === null ? "forensic gate cleared (using global default)" : `forensic gate set to ${perCase}`,
+      });
+      return res.status(200).json({ minSeverity: perCase, effective });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -18,6 +18,7 @@ import { registerSystemRoutes } from "./routes/system.js";
 import { registerCaptureRoutes } from "./routes/captures.js";
 import { registerPushNotifyRoutes } from "./routes/pushNotify.js";
 import { registerTemplatesViewsRoutes } from "./routes/templatesViews.js";
+import { registerToolsRoutes } from "./routes/tools.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
 import { AiControlStore, type AiControl } from "./analysis/aiControl.js";
 import { JobManager } from "./analysis/jobManager.js";
@@ -171,10 +172,10 @@ import {
 } from "./analysis/dropScan.js";
 import { formatDropLogLines, appendDropLog, buildSweepLogEntries, type DropLogEntry } from "./analysis/dropLog.js";
 import {
-  loadAllToolConfigs, toolForExtension, suggestedToolForExtension, TOOL_DEFS, type ToolId, type ToolConfig,
+  loadAllToolConfigs, toolForExtension, suggestedToolForExtension, type ToolId, type ToolConfig,
 } from "./integrations/tools/toolConfig.js";
 import { spawnToolRunner, type ToolRunner } from "./integrations/tools/toolRunner.js";
-import { runToolAgainstFile, updateToolRules, resolveContainedPath } from "./integrations/tools/runToolImport.js";
+import { runToolAgainstFile, resolveContainedPath } from "./integrations/tools/runToolImport.js";
 import { CustomToolStore, customToolToConfig, normalizeExt, type CustomTool } from "./integrations/tools/customToolStore.js";
 import { TemplateStore, buildInitialQuestions, buildInitialNextSteps } from "./analysis/templateStore.js";
 import { diffTimeline, addedForensicEvents } from "./analysis/timelineDiff.js";
@@ -744,6 +745,8 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     flush,
     indexCaptureText,
     ingestStreamed,
+    runToolAndIngest,
+    reloadCustomTools,
     resolveImportKind: () => resolveImportKind,
     captureBuffers: () => buffers,
     synthInFlight: () => synthInFlight,
@@ -752,11 +755,14 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     dropWatchEnabled: () => dropWatchEnabled,
     enrichmentProviders: () => allProviders,
     enrichHealth: () => enrichHealth,
+    liveToolConfigs: () => liveToolConfigs,
+    customTools: () => customTools,
   };
   registerSystemRoutes(app, ctx);
   registerCaptureRoutes(app, ctx);
   registerPushNotifyRoutes(app, ctx);
   registerTemplatesViewsRoutes(app, ctx);
+  registerToolsRoutes(app, ctx);
 
   app.get("/cases/:id/lock-status", async (req: Request, res: Response) => {
     try {
@@ -2117,107 +2123,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     }
   });
 
-  // ── External forensic tools (#211) ────────────────────────────────────────────────────────────
-  // Per-tool configured/auto-run status for the Settings → Tools tab (no secret values). Derived LIVE
-  // from env so it reflects settings just saved + reconnected.
-  app.get("/tools/status", (_req: Request, res: Response) => {
-    const configured = liveToolConfigs();
-    const builtins = (Object.keys(TOOL_DEFS) as ToolId[]).map((id) => {
-      const cfg = configured.get(id);
-      return {
-        id,
-        label: TOOL_DEFS[id].label,
-        repoUrl: TOOL_DEFS[id].repoUrl,
-        importKind: TOOL_DEFS[id].importKind,
-        extensions: TOOL_DEFS[id].extensions,
-        configured: !!cfg,
-        autoRun: cfg?.autoRun ?? false,
-        hasUpdate: !!cfg?.updateCommand,
-        custom: false,
-      };
-    });
-    const custom = customTools.map((t) => ({
-      id: t.id,
-      label: t.name,
-      importKind: "auto",
-      extensions: t.extensions,
-      configured: true,
-      autoRun: t.autoRun,
-      hasUpdate: !!(t.updateCommand && t.updateCommand.trim()),
-      custom: true,
-    }));
-    res.status(200).json({ enabled: !!options.toolRunner, tools: [...builtins, ...custom] });
-  });
-
-  // Re-read DFIR_TOOL_* from .env (settings saved via the dashboard only write the file) so the tool
-  // paths/args/toggles apply WITHOUT the #1-gotcha restart. The runner is stateless (binary is a per-call
-  // arg) so there's nothing to rebuild — the next liveToolConfigs() sees the reloaded env. Always 200.
-  app.post("/tools/reconnect", async (_req: Request, res: Response) => {
-    try {
-      const applied = await reloadEnvPrefix("DFIR_TOOL_");
-      const configured = [...liveToolConfigs().keys()];
-      return res.status(200).json({ ok: true, enabled: !!options.toolRunner, configured, applied });
-    } catch (err) {
-      return res.status(500).json({ ok: false, error: (err as Error).message });
-    }
-  });
-
-  // Manually run a configured tool against a raw file on disk (the drop-folder banner's "Run <tool>", or
-  // any case-relative path) and ingest its output through the normal import chain. 501 when tools are off,
-  // 400 on a bad tool id / path (containment enforced by resolveContainedPath).
-  app.post("/cases/:id/tools/:toolId/run", async (req: Request, res: Response) => {
-    const caseId = req.params.id;
-    const toolId = req.params.toolId;
-    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
-    if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
-    const path = typeof req.body?.path === "string" ? req.body.path.trim() : "";
-    if (!path) return res.status(400).json({ error: "path is required" });
-    try {
-      const r = await runToolAndIngest(caseId, toolId, path, { undoLabel: `Tool: ${toolId} — ${basename(path)}` });
-      return res.status(200).json({ ok: true, tool: toolId, storedName: r.storedName, addedEvents: r.addedEvents, addedIocs: r.addedIocs, analyzed: r.analyzed });
-    } catch (err) {
-      recordImportFailure(caseId, toolId, path, err);
-      return res.status(400).json({ ok: false, error: (err as Error).message });
-    }
-  });
-
-  // Run a tool against a raw file UPLOADED from the dashboard Import dialog (the browser has the bytes
-  // but the server can't read an arbitrary local path, and a binary can't go through the text /import
-  // body). The bytes are staged into a server-owned dir INSIDE the case (so path-containment holds),
-  // the tool runs, its output is imported, and the staged raw file is deleted (the Companion keeps the
-  // tool OUTPUT as evidence, not the raw binary). For files too large for the body cap, the analyst uses
-  // the drop folder instead. 501 tools off / 400 bad tool or input. #211
-  app.post("/cases/:id/tools/:toolId/run-upload", async (req: Request, res: Response) => {
-    const caseId = req.params.id;
-    const toolId = req.params.toolId;
-    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
-    if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
-    const filename = String(req.body?.filename ?? "").trim();
-    const dataBase64 = typeof req.body?.dataBase64 === "string" ? req.body.dataBase64 : "";
-    if (!filename || !dataBase64) return res.status(400).json({ error: "filename and dataBase64 are required" });
-    if (!liveToolConfigs().get(toolId)) return res.status(400).json({ error: `tool "${toolId}" is not configured` });
-    // Stage into a FRESH per-upload dir under the file's ORIGINAL basename (no collisions, so no need to
-    // mangle the name) — folder-root tools (Velociraptor --ROOT) detect the EVTX channel from the filename.
-    const toolWork = join(store.caseDir(caseId), ".toolwork");
-    const safe = basename(filename).replace(/[^\w.\-]+/g, "_").slice(0, 120) || "raw.bin";
-    let stageDir = "";
-    try {
-      await mkdir(toolWork, { recursive: true });
-      stageDir = await mkdtemp(join(toolWork, "up-"));
-      const staged = join(stageDir, safe);
-      await writeFile(staged, Buffer.from(dataBase64, "base64"));
-      const r = await runToolAndIngest(caseId, toolId, staged, { undoLabel: `Tool: ${toolId} — ${basename(filename)}` });
-      return res.status(200).json({ ok: true, tool: toolId, addedEvents: r.addedEvents, addedIocs: r.addedIocs, analyzed: r.analyzed });
-    } catch (err) {
-      recordImportFailure(caseId, toolId, filename, err);
-      return res.status(400).json({ ok: false, error: (err as Error).message });
-    } finally {
-      if (stageDir) await rm(stageDir, { recursive: true, force: true }).catch(() => { /* best-effort cleanup */ });
-    }
-  });
-
   // Batch-run EVERY pending raw drop file through its matching tool — the "Run tools on these N files"
   // button on the drop banner (ONE confirmation for the whole batch). Each ran/failed file is moved out
   // of drop/ (to _processed/_failed); files with no configured tool stay pending. Updates the drop
@@ -2277,58 +2182,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     } finally {
       dropScanning.delete(caseId);
     }
-  });
-
-  // Run a tool's "update rules" command (Settings → Tools). Does NOT touch case data — a rule update is
-  // not evidence; returns the command output for a UI toast. 501 when tools off, 400 when no update
-  // command is configured for the tool.
-  app.post("/cases/:id/tools/:toolId/update-rules", async (req: Request, res: Response) => {
-    const toolId = req.params.toolId;
-    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
-    if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
-    const cfg = liveToolConfigs().get(toolId);
-    if (!cfg) return res.status(400).json({ error: `tool "${toolId}" is not configured` });
-    try {
-      const output = await updateToolRules(cfg, options.toolRunner);
-      return res.status(200).json({ ok: true, tool: toolId, output });
-    } catch (err) {
-      return res.status(400).json({ ok: false, error: (err as Error).message });
-    }
-  });
-
-  // Custom tools (#211) — analyst-defined tools (name/binary/command/update/extensions) beyond the
-  // built-ins. GLOBAL store; the list is refreshed in memory on each mutation so liveToolConfigs/status
-  // reflect it immediately. 501 when the custom-tool store isn't wired.
-  app.get("/tools/custom", async (_req: Request, res: Response) => {
-    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
-    return res.status(200).json({ tools: await options.customToolStore.load() });
-  });
-  app.post("/tools/custom", async (req: Request, res: Response) => {
-    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
-    try {
-      const tool = await options.customToolStore.add(req.body ?? {});
-      await reloadCustomTools();
-      return res.status(201).json({ ok: true, tool });
-    } catch (err) {
-      return res.status(400).json({ ok: false, error: (err as Error).message });
-    }
-  });
-  app.put("/tools/custom/:id", async (req: Request, res: Response) => {
-    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
-    try {
-      const tool = await options.customToolStore.update(req.params.id, req.body ?? {});
-      if (!tool) return res.status(404).json({ error: `custom tool "${req.params.id}" not found` });
-      await reloadCustomTools();
-      return res.status(200).json({ ok: true, tool });
-    } catch (err) {
-      return res.status(400).json({ ok: false, error: (err as Error).message });
-    }
-  });
-  app.delete("/tools/custom/:id", async (req: Request, res: Response) => {
-    if (!options.customToolStore) return res.status(501).json({ error: "custom tools not enabled" });
-    const removed = await options.customToolStore.remove(req.params.id);
-    await reloadCustomTools();
-    return res.status(200).json({ ok: true, removed });
   });
 
   // Launch the VQL as a single-endpoint COLLECTION on ONE host (issue #70 — the playbook-hunt deploy
@@ -2695,8 +2548,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     for (const t of customTools) out.set(t.id, customToolToConfig(t));
     return out;
   };
-  // A tool id is known when it's a configured built-in or a defined custom tool.
-  const isKnownTool = (toolId: string): boolean => toolId in TOOL_DEFS || customTools.some((t) => t.id === toolId);
   // Resolve which CONFIGURED tool handles a file extension: built-in preference first (via TOOL_DEFS),
   // then a custom tool that claims the extension.
   const resolveToolForExt = (ext: string, configured: Map<string, ToolConfig>): string | null => {
@@ -8273,22 +8124,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     }
   });
 
-  // Forensic-timeline severity cut: the per-case override for which events stay in the forensic timeline
-  // (Low+ by default) vs. are demoted to the super-timeline only. `minSeverity: null` = defer to the
-  // global DFIR_FORENSIC_MIN_SEVERITY. GET returns the raw per-case override + the effective (resolved)
-  // value; PUT sets/clears it.
-  const FORENSIC_GATE_SEVERITIES: readonly Severity[] = ["Critical", "High", "Medium", "Low", "Info"];
-  app.get("/cases/:id/forensic-gate", async (req: Request, res: Response) => {
-    if (!options.forensicGateControlStore) return res.status(501).json({ error: "forensic gate not configured" });
-    try {
-      const perCase = (await options.forensicGateControlStore.load(req.params.id)).minSeverity ?? null;
-      const effective = resolveForensicMinSeverity(perCase ?? undefined, process.env.DFIR_FORENSIC_MIN_SEVERITY);
-      return res.status(200).json({ minSeverity: perCase, effective });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
   // Findings min-confidence display floor (#226): a per-case setting, persisted so it survives a
   // page reload — purely a display preference (nothing is removed from state). `minConfidence: null`
   // means "show all" (0). GET returns the current value; PUT sets/clears it.
@@ -8317,28 +8152,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
         category: "settings", action: "confidence-control", detail: minConfidence === null ? "minConfidence cleared" : `minConfidence set to ${minConfidence}`,
       });
       return res.status(200).json({ minConfidence });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.put("/cases/:id/forensic-gate", async (req: Request, res: Response) => {
-    if (!options.forensicGateControlStore) return res.status(501).json({ error: "forensic gate not configured" });
-    const raw = req.body?.minSeverity;
-    // Accept one of the 5 severities, or null/omitted to clear the per-case override.
-    const cleared = raw === null || raw === undefined || raw === "";
-    if (!cleared && !FORENSIC_GATE_SEVERITIES.includes(raw)) {
-      return res.status(400).json({ error: `minSeverity must be one of ${FORENSIC_GATE_SEVERITIES.join(", ")} or null` });
-    }
-    try {
-      await options.forensicGateControlStore.set(req.params.id, { minSeverity: cleared ? undefined : (raw as Severity) });
-      options.onForensicGate?.(req.params.id);
-      const perCase = (await options.forensicGateControlStore.load(req.params.id)).minSeverity ?? null;
-      const effective = resolveForensicMinSeverity(perCase ?? undefined, process.env.DFIR_FORENSIC_MIN_SEVERITY);
-      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
-        category: "settings", action: "forensic-gate", detail: perCase === null ? "forensic gate cleared (using global default)" : `forensic gate set to ${perCase}`,
-      });
-      return res.status(200).json({ minSeverity: perCase, effective });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }


### PR DESCRIPTION
Task 5 of the router split. Moves the external tool-runner and forensic-severity-gate routes out of `createApp` into `src/routes/tools.ts`. **Pure structural move — zero behavior change.**

## Routes moved (11, verbatim)
`GET /tools/status`, `POST /tools/reconnect`, `POST /cases/:id/tools/:toolId/run`, `.../run-upload`, `.../update-rules`, `GET|POST /tools/custom`, `PUT|DELETE /tools/custom/:id`, `GET|PUT /cases/:id/forensic-gate`.
Routes physically interspersed but belonging elsewhere correctly **remain**: `POST /cases/:id/drop/run-pending` (drop) and `GET|PUT /cases/:id/confidence-control` (which sits between the two forensic-gate routes).

## RouteContext
Graduated `runToolAndIngest`, `reloadCustomTools` (stable helpers) and `liveToolConfigs`, `customTools` (**live accessors** — `customTools` wraps a reassigned `let`, read per-request).

## Verification
- `tsc --noEmit` clean; `tools` + `forensicGate` tests pass **unedited** (14/14)
- Route inventory **316 = 316**, identical multiset
- Full server suite green (52 files / 400 tests)
- Spec-reviewed: interspersed excluded routes preserved, mutable-`let` live-accessor correctness, verbatim tool-run handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)