### PR TITLE
refactor: extract velociraptor routes into routes/velociraptor.ts (router split, Task 7)

### DIFF
--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -12,6 +12,9 @@ import type { ImporterFailure, AiError } from "../analysis/diagnostics.js";
 import type { Severity, InvestigationState } from "../analysis/stateTypes.js";
 import type { ToolConfig } from "../integrations/tools/toolConfig.js";
 import type { CustomTool } from "../integrations/tools/customToolStore.js";
+import type { VeloMonitor } from "../analysis/veloMonitorStore.js";
+import type { HuntDeployInput } from "../analysis/huntOutcomes.js";
+import type { HuntUpload } from "../integrations/velociraptor/velociraptorApi.js";
 
 /**
  * Dependencies shared across more than one route domain, built once in createApp and passed to
@@ -99,6 +102,48 @@ export interface RouteContext {
   applyNsrlToCase(caseId: string): Promise<{ matchedIocs: number; matchedEvents: number; added: number }>;
   applyDeobfuscationToCase(caseId: string): Promise<{ deobfuscated: number; newIocs: number }>;
   moveDropFile(dropDir: string, relpath: string, ok: boolean): Promise<void>;
+  // Velociraptor domain machinery shared with routes/velociraptor.ts. The live-monitor + hunt-status
+  // subsystems are self-rescheduling timer loops that must survive a restart, so their RESUME functions
+  // (resumeVeloMonitors / resumeVeloHuntStatusPolls) run once at the END of createApp AND from POST
+  // /velociraptor/reconnect. A route module can't be invoked at startup, so the whole schedule/poll/
+  // resume/collect machinery STAYS in createApp and the moved routes reach the pieces they need through
+  // these graduated members. The monitor/status timer MAPS (veloMonitorTimers / veloStatusTimers) stay
+  // fully PRIVATE to createApp — no route mutates them directly (they go through the helpers below); only
+  // veloHuntTimers is exposed (live accessor, further down) because two routes set a collect timer on it.
+  // All hoisted `function` declarations, so safe to bind at construction:
+  //   refreshVeloClients          — snapshot the enrolled fleet into the persisted client inventory.
+  //   resumeVeloMonitors / resumeVeloHuntStatusPolls — re-arm persisted monitors / hunt-status polls
+  //                                 (the reconnect route reuses the SAME functions createApp fires at boot).
+  //   scheduleVeloMonitor / pollVeloMonitor / stopVeloMonitorTimer — arm / run-once / cancel a monitor.
+  //   scheduleVeloHuntStatusPoll / pollVeloHuntStatus — arm / run-once a hunt-status poll.
+  //   importVeloHuntResults       — collect a hunt + import through the normal chain (also fired on a timer).
+  //   ingestVeloArtifactMap / ingestVeloUploads — the /import-external hunt/flow-map + uploads ingest cores.
+  //   createVeloMonitor           — build + persist + schedule one monitor (manual + auto-monitor routes).
+  //   recordHuntDeploy            — record a deployed hunt in the #157 hunting-feedback-loop ledger.
+  refreshVeloClients(): Promise<number>;
+  resumeVeloMonitors(): Promise<void>;
+  resumeVeloHuntStatusPolls(): Promise<void>;
+  scheduleVeloMonitor(caseId: string, monitor: VeloMonitor): void;
+  pollVeloMonitor(caseId: string, id: string): Promise<void>;
+  stopVeloMonitorTimer(caseId: string, id: string): void;
+  scheduleVeloHuntStatusPoll(caseId: string, huntId: string): void;
+  pollVeloHuntStatus(caseId: string, huntId: string): Promise<void>;
+  importVeloHuntResults(caseId: string, huntId: string): Promise<void>;
+  ingestVeloArtifactMap(
+    caseId: string,
+    mapJson: string,
+    opts: { label: string; idBase: string; superOnly?: boolean; minSeverity?: Severity; hostFallback?: string; veloUrl?: string },
+  ): Promise<{ addedEvents: number; addedIocs: number; storedName: string }>;
+  ingestVeloUploads(
+    caseId: string,
+    uploads: HuntUpload[],
+    opts: { minSeverity?: Severity; label: string },
+  ): Promise<{ addedEvents: number; addedIocs: number; imported: string[]; skipped: string[] }>;
+  createVeloMonitor(
+    caseId: string,
+    spec: { clientId: string; artifact: string; pollSeconds: number; hostname?: string; minSeverity?: Severity; allClients?: boolean },
+  ): Promise<VeloMonitor>;
+  recordHuntDeploy(caseId: string, input: HuntDeployInput): Promise<void>;
 
   // ── LIVE accessors ───────────────────────────────────────────────────────────────────
   // Call these INSIDE the request handler (or inside per-request logic like a preflight run),
@@ -136,4 +181,9 @@ export interface RouteContext {
   dropSeen(): Map<string, Map<string, { size: number; mtimeMs: number }>>;
   dropScanning(): Set<string>;
   dropPendingLogged(): Map<string, Set<string>>;
+  // Fixed-delay hunt auto-collect timers, keyed by huntId. SHARED between the moved run-bundle /
+  // deploy-hunt routes (which set a collect timer on it) and importVeloHuntResults (which clears it on
+  // collect, still in createApp) — exposed as a live accessor so the routes mutate the SAME Map; call
+  // ctx.veloHuntTimers() INSIDE the handler and set/delete on the returned map.
+  veloHuntTimers(): Map<string, NodeJS.Timeout>;
 }

--- a/companion/src/routes/velociraptor.ts
+++ b/companion/src/routes/velociraptor.ts
@@ -1,0 +1,712 @@
+import type { Express, Request, Response } from "express";
+import { reloadEnvPrefix } from "../settings/envManager.js";
+import { logActivity } from "../analysis/activityLog.js";
+import { parseMinSeverity } from "../analysis/severityFloor.js";
+import { parseVeloRef } from "../analysis/veloRef.js";
+import { buildVelociraptorClient, matchClient, ALL_CLIENTS, normalizeHuntExpirySeconds, type HuntTarget } from "../integrations/velociraptor/velociraptorApi.js";
+import type { VeloMonitor } from "../analysis/veloMonitorStore.js";
+import type { VeloHuntJob } from "../analysis/veloHuntStore.js";
+import type { HuntOutcomeSource } from "../analysis/huntOutcomes.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Velociraptor endpoint-integration routes: the top-level /velociraptor/* API surface (run VQL, launch
+ * hunts, client inventory, reconnect, single-host collections, triage-bundle artifacts, live-event
+ * artifacts) and the per-case /cases/:id/velociraptor/* surface (suggest-hunts, run-bundle, collect,
+ * import-external, hunt-jobs + status polling, deploy-hunt #157, hunt-rows, and the live CLIENT_EVENT
+ * monitor CRUD #84).
+ *
+ * Pure structural move out of createApp (see routes/system.ts for the conventions). The stateful
+ * machinery these routes drive — the self-rescheduling live-monitor + hunt-status timer loops and the
+ * hunt-collect/ingest cores — STAYS in createApp because its RESUME functions run once at startup and
+ * from POST /velociraptor/reconnect (a route module can't be called at boot). This module reaches that
+ * machinery through the RouteContext members it was graduated onto: refreshVeloClients, resumeVelo*,
+ * scheduleVeloMonitor/pollVeloMonitor/stopVeloMonitorTimer, scheduleVeloHuntStatusPoll/pollVeloHuntStatus,
+ * importVeloHuntResults, ingestVeloArtifactMap/ingestVeloUploads, createVeloMonitor, recordHuntDeploy
+ * (stable methods) plus the veloHuntTimers() live accessor (the run-bundle/deploy-hunt routes set a
+ * fixed-delay collect timer on that shared Map). The monitor/status timer Maps stay private to createApp.
+ *
+ * NOTE: import-velociraptor (generic JSON import) is NOT here — it lives in routes/import.ts. Only the
+ * /velociraptor/* and /cases/:id/velociraptor/* endpoints moved.
+ */
+export function registerVelociraptorRoutes(app: Express, ctx: RouteContext): void {
+  const { store, options, hasAiProvider } = ctx;
+  // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved handler
+  // bodies keep their original `logLine(...)` calls verbatim.
+  const logLine = (msg: string): void => ctx.serverLogger.info(msg);
+  // Normalize a label/tag input that may arrive as a comma-separated string or an array of strings.
+  // Module-private copy of createApp's toStringArray (a non-exported server.ts helper) so the moved
+  // run-bundle / deploy-hunt bodies keep their original calls without importing across the route seam.
+  const toStringArray = (v: unknown): string[] => {
+    if (typeof v === "string") return v.split(",").map((s) => s.trim()).filter(Boolean);
+    if (Array.isArray(v)) return v.map((s) => String(s).trim()).filter(Boolean);
+    return [];
+  };
+  // Builds the Velociraptor client from current env (used by POST /velociraptor/reconnect). Defaults
+  // to the env-based factory; tests inject a stub so no process is spawned.
+  const rebuildVelo = options.rebuildVelociraptorClient ?? buildVelociraptorClient;
+
+  // Resolve a hostname → client_id from the persisted inventory (refreshing once on a miss) and launch a
+  // single-client collection. Throws when no client matches. Shared by the global /velociraptor/collect-host
+  // route and the case-scoped /cases/:id/velociraptor/deploy-hunt route (#157). Requires the API client set.
+  async function collectHostResolved(hostname: string, vql: string, description: string) {
+    const client = options.velociraptorClient!;
+    const store = options.velociraptorClientStore;
+    if (store) {
+      // Resolve from the inventory file; if the host isn't there yet, refresh once and retry (self-healing).
+      let rec = matchClient((await store.load()).clients, hostname);
+      if (!rec) { await ctx.refreshVeloClients(); rec = matchClient((await store.load()).clients, hostname); }
+      if (!rec) throw new Error(`No enrolled Velociraptor client matches host "${hostname}" — refresh the client list (Settings → Velociraptor) or run a fleet hunt instead`);
+      return await client.collectOnClient(rec.clientId, vql, description, hostname);
+    }
+    return await client.collectFromHost(hostname, vql, description);
+  }
+
+  // Run a VQL query against the configured Velociraptor server (via its API) and return the rows.
+  // Powers the hunt-pivot modal's "Run in Velociraptor" button. 501 when not configured. The VQL is
+  // analyst-authored (from the generated pivots) — localhost only, opt-in via DFIR_VELOCIRAPTOR_*.
+  app.post("/velociraptor/run", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
+    if (!vql) return res.status(400).json({ error: "vql is required" });
+    try {
+      logLine(`[velociraptor] run query (${vql.length} chars)`);
+      const result = await options.velociraptorClient.run(vql);
+      logLine(`[velociraptor] query DONE -> ${result.total} rows${result.truncated ? " (truncated)" : ""}`);
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[velociraptor] query ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Launch a HUNT that runs the pivot VQL on ALL enrolled endpoints (packages it as a CLIENT
+  // artifact, then creates the hunt). This is the dashboard's "Run hunt on all clients" action.
+  app.post("/velociraptor/hunt", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
+    const description = typeof req.body?.description === "string" ? req.body.description : "";
+    if (!vql) return res.status(400).json({ error: "vql is required" });
+    const expirySeconds = normalizeHuntExpirySeconds(req.body?.expirySeconds);   // relative; defaults to one hour
+    try {
+      logLine(`[velociraptor] launch hunt: ${description.slice(0, 80)} (expires in ${expirySeconds}s)`);
+      const result = await options.velociraptorClient.launchHunt(vql, description, { expirySeconds });
+      logLine(`[velociraptor] hunt launched -> ${result.huntId} (artifact ${result.artifact}, ${result.sources.length} source(s))`);
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[velociraptor] hunt ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Read a launched hunt's results (rows collected from the endpoints so far). Polled by the dashboard.
+  app.post("/velociraptor/hunt-results", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    const huntId = typeof req.body?.huntId === "string" ? req.body.huntId.trim() : "";
+    const artifact = typeof req.body?.artifact === "string" ? req.body.artifact.trim() : "";
+    const sources = Array.isArray(req.body?.sources) ? req.body.sources.filter((s: unknown): s is string => typeof s === "string") : [];
+    if (!huntId || !artifact) return res.status(400).json({ error: "huntId and artifact are required" });
+    try {
+      const result = await options.velociraptorClient.huntResults(huntId, artifact, sources);
+      return res.status(200).json(result);
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Read the persisted client inventory (host ↔ client_id map). Empty when never refreshed.
+  app.get("/velociraptor/clients", async (_req: Request, res: Response) => {
+    if (!options.velociraptorClientStore) return res.status(200).json({ updatedAt: "", clients: [] });
+    try {
+      return res.status(200).json(await options.velociraptorClientStore.load());
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Refresh the client inventory now (Settings → Velociraptor "Refresh client list"). 501 when the
+  // API / store isn't configured; 502 on a query failure.
+  app.post("/velociraptor/clients/refresh", async (_req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.velociraptorClientStore) return res.status(501).json({ error: "client inventory store not configured" });
+    try {
+      const count = await ctx.refreshVeloClients();
+      const inv = await options.velociraptorClientStore.load();
+      return res.status(200).json({ count, updatedAt: inv.updatedAt, clients: inv.clients });
+    } catch (err) {
+      logLine(`[velociraptor] client refresh ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Diagnostics for the live-monitor features when the picker / auto-discovery come back empty on a
+  // real server (#84): the actual artifact `type` strings + counts, and the raw
+  // GetClientMonitoringState() shape. Hit it in a browser (localhost) and share the JSON to pin down a
+  // version's monitoring proto. 501 when the API isn't configured.
+  app.get("/velociraptor/diag", async (_req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    try {
+      return res.status(200).json(await options.velociraptorClient.diagnostics());
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Whether the Velociraptor API is configured + the inventory's freshness (so the dashboard can show
+  // connection state without a probe). `configured` reflects the LIVE client (reconnect can flip it).
+  app.get("/velociraptor/status", async (_req: Request, res: Response) => {
+    let updatedAt = "", clientCount = 0;
+    if (options.velociraptorClientStore) {
+      try { const inv = await options.velociraptorClientStore.load(); updatedAt = inv.updatedAt; clientCount = inv.clients.length; } catch { /* empty */ }
+    }
+    return res.status(200).json({ configured: !!options.velociraptorClient, updatedAt, clients: clientCount });
+  });
+
+  // Re-read DFIR_VELOCIRAPTOR_* from .env (settings saved via the dashboard only write the file),
+  // REBUILD the client, and refresh the client inventory — which doubles as a reachability probe
+  // (`clients()` round-trips to the server). Lets the analyst connect after configuring Velociraptor,
+  // or after the Velociraptor server comes back online, WITHOUT the #1-gotcha restart (the client is
+  // stateless — it spawns the binary per query — but a rebuild also applies newly-saved config and
+  // flips it on if the config path wasn't set at boot). Also re-arms any persisted live monitors that
+  // couldn't be scheduled while the client was absent. Always 200; the body says configured/reachable.
+  app.post("/velociraptor/reconnect", async (_req: Request, res: Response) => {
+    try {
+      await reloadEnvPrefix("DFIR_VELOCIRAPTOR_");
+      options.velociraptorClient = rebuildVelo();
+      if (!options.velociraptorClient) {
+        return res.status(200).json({ configured: false, ok: false, error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+      }
+      try {
+        const count = await ctx.refreshVeloClients();
+        const inv = options.velociraptorClientStore ? await options.velociraptorClientStore.load() : { updatedAt: "", clients: [] };
+        void ctx.resumeVeloMonitors();   // arm monitors that couldn't start while the client was absent
+        void ctx.resumeVeloHuntStatusPolls();   // and any hunt status polling that couldn't start either
+        logLine(`[velociraptor] reconnected — ${count} enrolled client(s)`);
+        return res.status(200).json({ configured: true, ok: true, clients: count, updatedAt: inv.updatedAt });
+      } catch (err) {
+        return res.status(200).json({ configured: true, ok: false, error: (err as Error).message });
+      }
+    } catch (err) {
+      return res.status(500).json({ configured: false, ok: false, error: (err as Error).message });
+    }
+  });
+
+  // Launch the VQL as a single-endpoint COLLECTION on ONE host (issue #70 — the playbook-hunt deploy
+  // path for a task tied to exactly one endpoint). Resolves the host → client_id from the persisted
+  // INVENTORY (refreshing it once on a miss), then runs collect_client on that client; returns the
+  // flow + a GUI deep link. 501 when the Velociraptor API is off; 502 when no client matches the host.
+  app.post("/velociraptor/collect-host", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    const hostname = typeof req.body?.hostname === "string" ? req.body.hostname.trim() : "";
+    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
+    const description = typeof req.body?.description === "string" ? req.body.description : "";
+    if (!hostname) return res.status(400).json({ error: "hostname is required" });
+    if (!vql) return res.status(400).json({ error: "vql is required" });
+    try {
+      logLine(`[velociraptor] collect on host ${hostname}: ${description.slice(0, 80)}`);
+      const result = await collectHostResolved(hostname, vql, description);
+      logLine(`[velociraptor] collection launched -> flow ${result.flowId} on ${result.clientId} (${result.hostname})`);
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[velociraptor] collect ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Read a single COLLECTION flow's result rows so the dashboard can show them inline + auto-poll (the
+  // per-flow analog of /velociraptor/hunt-results). Body `{ clientId, flowId, artifact, sources }`.
+  app.post("/velociraptor/collect-results", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    const clientId = typeof req.body?.clientId === "string" ? req.body.clientId.trim() : "";
+    const flowId = typeof req.body?.flowId === "string" ? req.body.flowId.trim() : "";
+    const artifact = typeof req.body?.artifact === "string" ? req.body.artifact.trim() : "";
+    const sources = Array.isArray(req.body?.sources) ? req.body.sources.filter((s: unknown): s is string => typeof s === "string") : [];
+    if (!clientId || !flowId || !artifact) return res.status(400).json({ error: "clientId, flowId and artifact are required" });
+    try {
+      const result = await options.velociraptorClient.collectionResults(clientId, flowId, artifact, sources);
+      // Also report the flow's terminal STATE so the dashboard can surface an endpoint-side failure
+      // (e.g. a bad plugin arg) instead of polling "no results yet". Best-effort — never fail the read.
+      let flowState = "";
+      let flowError = "";
+      try {
+        const st = await options.velociraptorClient.flowStatus(clientId, flowId);
+        flowState = st.state;
+        flowError = st.error;
+      } catch { /* status read is best-effort */ }
+      return res.status(200).json({ ...result, flowState, flowError });
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // AI-suggest proactive Velociraptor VQL fleet-hunts from the case findings (issue #57). Single
+  // text-only AI call, EPHEMERAL (no state change) — the dashboard shows each hunt's VQL + rationale
+  // for review, then deploys the chosen one through POST /velociraptor/hunt (launchHunt). Needs an AI
+  // provider; does NOT need the Velociraptor API (the VQL is useful to copy even when deploy is off).
+  app.post("/cases/:id/velociraptor/suggest-hunts", async (req: Request, res: Response) => {
+    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
+    try {
+      // Optional excludeVql → regenerate a DIFFERENT take (the per-card ↻ Regenerate button), mirroring
+      // the playbook-hunt regen. Absent → a normal full suggestion pass.
+      const excludeVql = typeof req.body?.excludeVql === "string" && req.body.excludeVql.trim() ? req.body.excludeVql : undefined;
+      const suggestions = await options.pipeline.suggestHunts(req.params.id, excludeVql ? { excludeVql } : undefined);
+      logLine(`[velociraptor] suggested ${suggestions.length} fleet-hunt(s) for ${req.params.id}`);
+      return res.status(200).json({ suggestions });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Velociraptor triage bundles ───────────────────────────────────────────────────────────
+  // On-demand: list collectable CLIENT artifacts → build/save named bundles → run a bundle as a hunt
+  // → after a delay, collect results, auto-import (deterministic Velociraptor importer) + synthesize.
+
+  // List the server's collectable CLIENT artifacts (the bundle builder's picker source).
+  app.get("/velociraptor/artifacts", async (_req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    try {
+      const artifacts = await options.velociraptorClient.listClientArtifacts();
+      return res.status(200).json({ artifacts });
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Run a saved bundle as a hunt (optionally scoped by label/OS), schedule auto-collect after
+  // waitMinutes (default DFIR_VELO_HUNT_WAIT_MIN / bundle default / 10; clamped 1..1440), and respond
+  // immediately. The hunt stays open on the server until its expiry — we just snapshot results later.
+  app.post("/cases/:id/velociraptor/run-bundle", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.artifactBundleStore || !options.veloHuntStore) return res.status(501).json({ error: "bundle store not configured" });
+    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
+    const caseId = req.params.id;
+    const bundleId = String(req.body?.bundleId ?? "").trim();
+    if (!bundleId) return res.status(400).json({ error: "bundleId is required" });
+    try {
+      const bundle = await options.artifactBundleStore.get(bundleId);
+      if (!bundle) return res.status(404).json({ error: `bundle "${bundleId}" not found` });
+      if (!bundle.artifacts.length) return res.status(400).json({ error: "bundle has no artifacts" });
+
+      const fallback = Number(process.env.DFIR_VELO_HUNT_WAIT_MIN) || bundle.defaultWaitMinutes || 10;
+      const reqWait = Number(req.body?.waitMinutes);
+      const waitMinutes = Math.min(1440, Math.max(1, Number.isFinite(reqWait) && reqWait > 0 ? reqWait : fallback));
+      const os = ["windows", "linux", "darwin"].includes(String(req.body?.os)) ? (req.body.os as HuntTarget["os"]) : undefined;
+      const target: HuntTarget = {
+        includeLabels: toStringArray(req.body?.includeLabels),
+        excludeLabels: toStringArray(req.body?.excludeLabels),
+        os,
+      };
+      const minSeverity = parseMinSeverity(req.body?.minSeverity);   // applied to the import at collect time
+      // A dwell-window-gated bundle (e.g. Dwell-Time Triage) records which window it was launched for,
+      // and must not run untargeted — those raw host artifacts are only meaningful for a bounded window.
+      const dwellWindowId = typeof req.body?.dwellWindowId === "string" && req.body.dwellWindowId.trim() ? req.body.dwellWindowId.trim() : undefined;
+      // Per-collection timeout (seconds): run override > bundle default > Velociraptor's own default (600s).
+      const reqTimeout = Number(req.body?.timeoutSeconds);
+      const rawTimeout = Number.isFinite(reqTimeout) && reqTimeout > 0 ? reqTimeout : bundle.timeoutSeconds;
+      const timeoutSeconds = typeof rawTimeout === "number" && rawTimeout > 0 ? Math.min(86_400, Math.max(60, Math.floor(rawTimeout))) : undefined;
+      // Relative hunt expiry (seconds): run override > bundle default > the one-hour default.
+      const expirySeconds = normalizeHuntExpirySeconds(
+        Number(req.body?.expirySeconds) > 0 ? req.body.expirySeconds : bundle.expirySeconds,
+      );
+
+      // Pre-flight: Velociraptor's hunt() rejects the ENTIRE hunt if any named artifact doesn't exist
+      // on the server, so one stale/misspelled name in a bundle (e.g. a starter list not yet verified
+      // against THIS server) fails the whole run with an opaque "no hunt id". Intersect with the
+      // server's known client artifacts, launch with the valid subset, and report which were unknown.
+      // (Named `unknownArtifacts`, distinct from the JOB's collect-time `skippedArtifacts` = artifacts
+      // that launched but failed to FETCH.) Best-effort: if the catalog lookup itself fails, launch the
+      // bundle as-is rather than block on a diagnostics query.
+      let artifactsToRun = bundle.artifacts;
+      let unknownArtifacts: string[] = [];
+      try {
+        const known = new Set((await options.velociraptorClient.listClientArtifacts("client")).map((a) => a.name));
+        if (known.size) {
+          const valid = bundle.artifacts.filter((a) => known.has(a));
+          unknownArtifacts = bundle.artifacts.filter((a) => !known.has(a));
+          if (!valid.length) {
+            return res.status(400).json({ error: `none of this bundle's artifacts exist on the Velociraptor server — check the names in the bundle editor: ${bundle.artifacts.join(", ")}` });
+          }
+          artifactsToRun = valid;
+          if (unknownArtifacts.length) logLine(`[velociraptor] bundle "${bundle.name}": skipping ${unknownArtifacts.length} artifact(s) not on this server: ${unknownArtifacts.join(", ")}`);
+        }
+      } catch (e) {
+        logLine(`[velociraptor] artifact catalog check failed (launching bundle as-is): ${(e as Error).message}`);
+      }
+
+      logLine(`[velociraptor] run bundle "${bundle.name}" (${artifactsToRun.length} artifact(s)${unknownArtifacts.length ? `, ${unknownArtifacts.length} skipped` : ""}), collect in ${waitMinutes}m, expires in ${expirySeconds}s${minSeverity ? `, min severity ${minSeverity}` : ""}${timeoutSeconds ? `, timeout ${timeoutSeconds}s` : ""}`);
+      const launch = await options.velociraptorClient.launchArtifactHunt(artifactsToRun, bundle.name, target, { timeoutSeconds, params: bundle.params, expirySeconds });
+      const collectAt = new Date(Date.now() + waitMinutes * 60_000).toISOString();
+      const job: VeloHuntJob = {
+        bundleId: bundle.id, bundleName: bundle.name, artifacts: launch.artifacts,
+        huntId: launch.huntId, guiUrl: launch.guiUrl,
+        launchedAt: new Date().toISOString(), waitMinutes, collectAt,
+        status: "running", target, minSeverity, timeoutSeconds, expirySeconds, filters: bundle.filters, dwellWindowId,
+      };
+      // Append this hunt (concurrent hunts are kept side by side, keyed by huntId) + its own timer.
+      await options.veloHuntStore.upsert(caseId, job);
+      // #157: record the bundle deploy (no VQL — bundles are artifact lists; outcome filled on collect).
+      await ctx.recordHuntDeploy(caseId, { source: "bundle", title: bundle.name, huntId: launch.huntId, deployedAt: new Date().toISOString() });
+      options.onVeloHunt?.(caseId);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "hunt", action: "run-bundle", detail: `ran bundle "${bundle.name}" (${artifactsToRun.length} artifact(s))`,
+      });
+
+      const timer = setTimeout(() => { void ctx.importVeloHuntResults(caseId, launch.huntId); }, waitMinutes * 60_000);
+      timer.unref?.();
+      ctx.veloHuntTimers().set(launch.huntId, timer);
+      ctx.scheduleVeloHuntStatusPoll(caseId, launch.huntId);
+
+      return res.status(202).json({ huntId: launch.huntId, guiUrl: launch.guiUrl, collectAt, waitMinutes, artifacts: launch.artifacts, unknownArtifacts });
+    } catch (err) {
+      logLine(`[velociraptor] run bundle ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Import an EXTERNAL Velociraptor hunt/flow (launched in the Velociraptor GUI, not by the Companion).
+  // Paste a hunt id / flow / GUI URL; discover what it collected (for a flow, resolve the host) and
+  // import via the SAME chain as every other Velociraptor import — optionally to the super-timeline only.
+  app.post("/cases/:id/velociraptor/import-external", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
+    const caseId = req.params.id;
+    const ref = parseVeloRef(String(req.body?.ref ?? ""));
+    if (!ref) return res.status(400).json({ error: "paste a hunt id (H.…), a flow (C.…/F.…), or a Velociraptor GUI URL" });
+    // A notebook URL shows the analyst's OWN filtered VQL query results — this server can only pull the
+    // flow/hunt's complete raw collected rows (a different, much larger row set), which silently imports
+    // far more than the analyst is looking at. Only the browser extension's "Push rows" button captures
+    // the notebook's actual rendered/filtered results (it reads the GUI's own table), so redirect there.
+    if (ref.isNotebookUrl) {
+      return res.status(400).json({
+        error: "this is a Velociraptor NOTEBOOK URL — importing it here would pull the flow/hunt's complete raw results, not your notebook's filtered query. Open the notebook in your browser and use the DFIR Companion extension's \"Push rows → DFIR-Companion\" button instead, which imports exactly what the notebook shows.",
+      });
+    }
+    const minSeverity = parseMinSeverity(req.body?.minSeverity);
+    const superOnly = req.body?.superTimelineOnly === true;
+    // Uploaded reports (THOR/Hayabusa) only have a forensic-merge importer (dispatchImport) — routing
+    // them to the super-timeline-only path would leak into the forensic timeline and break its
+    // invariant (mirrors the same guard on the bundle-collect uploads step).
+    if (ref.isUploadsUrl && superOnly) {
+      return res.status(400).json({ error: "uploaded-file import doesn't support super-timeline-only mode — collect upload-based artifacts via a normal (forensic-timeline) import instead" });
+    }
+    const client = options.velociraptorClient;
+    try {
+      if (ref.kind === "hunt") {
+        if (ref.isUploadsUrl) {
+          const uploads = await client.huntUploads(ref.huntId);
+          if (!uploads.length) {
+            return res.status(200).json({ kind: "hunt", huntId: ref.huntId, addedEvents: 0, addedIocs: 0, uploadsOnly: true, note: "no uploaded report files found for this hunt yet (or none matched a supported format)" });
+          }
+          const out = await ctx.ingestVeloUploads(caseId, uploads, { minSeverity, label: `velo-hunt-uploads_${ref.huntId}` });
+          options.onVeloHunt?.(caseId);
+          return res.status(200).json({
+            kind: "hunt", huntId: ref.huntId, uploadsOnly: true, imported: out.imported, skipped: out.skipped,
+            addedEvents: out.addedEvents, addedIocs: out.addedIocs,
+            ...(out.imported.length === 0 ? { note: "found uploaded file(s) but none could be imported — unsupported format, or an AI-dependent format (CSV/log) while AI is off for this case" } : {}),
+          });
+        }
+        const arts = await client.getHuntArtifacts(ref.huntId);
+        if (!arts.length) return res.status(404).json({ error: `hunt ${ref.huntId} not found on the server, or it collected no artifacts` });
+        const { results } = await client.huntResultsByArtifact(ref.huntId, arts);
+        if (!Object.keys(results).length) return res.status(200).json({ kind: "hunt", huntId: ref.huntId, artifacts: arts, addedEvents: 0, addedIocs: 0, superTimelineOnly: superOnly, note: "the hunt returned no rows yet" });
+        const out = await ctx.ingestVeloArtifactMap(caseId, JSON.stringify(results), { label: `velo-hunt_${ref.huntId}.json`, idBase: ref.huntId, superOnly, minSeverity, veloUrl: client.huntGuiUrlFor(ref.huntId) });
+        options.onVeloHunt?.(caseId);
+        return res.status(200).json({ kind: "hunt", huntId: ref.huntId, artifacts: Object.keys(results), addedEvents: out.addedEvents, addedIocs: out.addedIocs, superTimelineOnly: superOnly });
+      }
+      if (ref.isUploadsUrl) {
+        const uploads = await client.flowUploads(ref.clientId, ref.flowId);
+        if (!uploads.length) {
+          return res.status(200).json({ kind: "flow", clientId: ref.clientId, flowId: ref.flowId, addedEvents: 0, addedIocs: 0, uploadsOnly: true, note: "no uploaded report files found for this flow yet (or none matched a supported format)" });
+        }
+        const out = await ctx.ingestVeloUploads(caseId, uploads, { minSeverity, label: `velo-flow-uploads_${ref.flowId}` });
+        options.onVeloHunt?.(caseId);
+        return res.status(200).json({
+          kind: "flow", clientId: ref.clientId, flowId: ref.flowId, uploadsOnly: true, imported: out.imported, skipped: out.skipped,
+          addedEvents: out.addedEvents, addedIocs: out.addedIocs,
+          ...(out.imported.length === 0 ? { note: "found uploaded file(s) but none could be imported — unsupported format, or an AI-dependent format (CSV/log) while AI is off for this case" } : {}),
+        });
+      }
+      const info = await client.getFlowInfo(ref.clientId, ref.flowId);
+      if (!info.artifacts.length) return res.status(404).json({ error: `flow ${ref.flowId} on ${ref.clientId} not found, or it collected no artifacts` });
+      const map: Record<string, unknown[]> = {};
+      for (const art of info.artifacts) {
+        try { const r = await client.collectionResults(ref.clientId, ref.flowId, art); if (r.rows.length) map[art] = r.rows; }
+        catch (e) { logLine(`[velociraptor] external flow ${ref.flowId}: artifact ${art} read failed: ${(e as Error).message}`); }
+      }
+      if (!Object.keys(map).length) return res.status(200).json({ kind: "flow", clientId: ref.clientId, flowId: ref.flowId, hostname: info.hostname, artifacts: info.artifacts, addedEvents: 0, addedIocs: 0, superTimelineOnly: superOnly, note: "the flow returned no rows" });
+      const out = await ctx.ingestVeloArtifactMap(caseId, JSON.stringify(map), { label: `velo-flow_${ref.flowId}.json`, idBase: ref.flowId, superOnly, minSeverity, hostFallback: info.hostname, veloUrl: client.flowGuiUrlFor(ref.clientId, ref.flowId) });
+      options.onVeloHunt?.(caseId);
+      return res.status(200).json({ kind: "flow", clientId: ref.clientId, flowId: ref.flowId, hostname: info.hostname, artifacts: Object.keys(map), addedEvents: out.addedEvents, addedIocs: out.addedIocs, superTimelineOnly: superOnly });
+    } catch (err) {
+      logLine(`[velociraptor] import-external ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // All bundle hunts for a case (newest first) — status + countdown + outcome per hunt. [] when none.
+  app.get("/cases/:id/velociraptor/hunt-jobs", async (req: Request, res: Response) => {
+    if (!options.veloHuntStore) return res.status(200).json([]);
+    try {
+      return res.status(200).json(await options.veloHuntStore.list(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Collect a specific hunt NOW (don't wait for its timer). Body `{ huntId }`; defaults to the most
+  // recent hunt when omitted. Runs in the background; poll hunt-jobs. 404 when there's nothing to collect.
+  app.post("/cases/:id/velociraptor/collect", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.veloHuntStore) return res.status(501).json({ error: "hunt store not configured" });
+    const caseId = req.params.id;
+    const wantedHuntId = String(req.body?.huntId ?? "").trim();
+    const jobs = await options.veloHuntStore.list(caseId);
+    const job = wantedHuntId ? jobs.find((j) => j.huntId === wantedHuntId) : jobs[0];
+    if (!job) return res.status(404).json({ error: wantedHuntId ? `no Velociraptor hunt ${wantedHuntId} for this case` : "no Velociraptor hunt to collect for this case" });
+    res.status(202).json({ accepted: true, huntId: job.huntId });
+    void ctx.importVeloHuntResults(caseId, job.huntId);
+  });
+
+  // Manually run one status-poll tick for a hunt NOW instead of waiting for the next scheduled tick
+  // (mirrors the live-monitor .../poll route) — used by ops to force a check, and by tests instead of
+  // waiting out DFIR_VELO_HUNT_POLL_S. Awaits the poll so the response already reflects its outcome.
+  app.post("/cases/:id/velociraptor/hunt-jobs/:huntId/poll-status", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.veloHuntStore) return res.status(501).json({ error: "hunt store not configured" });
+    const caseId = req.params.id;
+    const huntId = req.params.huntId;
+    await ctx.pollVeloHuntStatus(caseId, huntId);
+    const job = await options.veloHuntStore.get(caseId, huntId);
+    if (!job) return res.status(404).json({ error: `no Velociraptor hunt ${huntId} for this case` });
+    return res.status(200).json(job);
+  });
+
+  // ── Hunting feedback loop (#157) ─────────────────────────────────────────────────────────────
+
+  // Deploy a SUGGESTED hunt for a case and record it in the hunting feedback loop. Two modes:
+  //  - "hunt" (default): launch a fleet HUNT, register a VeloHuntJob, and schedule auto-collect after
+  //    DFIR_VELO_HUNT_WAIT_MIN (like a bundle) so the outcome fills on its own; "Collect now" pulls early.
+  //  - "collection": run a single-host COLLECTION (the playbook per-endpoint deploy path).
+  // Either way the deployed VQL is recorded (so it's never re-proposed) and shows in the profile.
+  // Body: { vql, title, description?, source?, mitreTechniques?, mode?, hostname?, waitMinutes? }.
+  app.post("/cases/:id/velociraptor/deploy-hunt", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    const caseId = req.params.id;
+    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
+    const title = typeof req.body?.title === "string" ? req.body.title.trim() : "";
+    const description = typeof req.body?.description === "string" && req.body.description.trim() ? req.body.description : title;
+    const rawSource = String(req.body?.source ?? "");
+    const allowedSources: HuntOutcomeSource[] = ["fleet", "playbook", "technique"];   // "bundle" is server-set, not client-supplied
+    const source: HuntOutcomeSource = allowedSources.includes(rawSource as HuntOutcomeSource) ? (rawSource as HuntOutcomeSource) : "fleet";
+    const mitreTechniques = toStringArray(req.body?.mitreTechniques);
+    const mode = req.body?.mode === "collection" ? "collection" : "hunt";
+    const hostname = typeof req.body?.hostname === "string" ? req.body.hostname.trim() : "";
+    if (!vql) return res.status(400).json({ error: "vql is required" });
+    if (!title) return res.status(400).json({ error: "title is required" });
+    try {
+      if (mode === "collection") {
+        if (!hostname) return res.status(400).json({ error: "hostname is required for a collection" });
+        logLine(`[velociraptor] deploy-hunt collection "${title}" on ${hostname}`);
+        const result = await collectHostResolved(hostname, vql, description);
+        // A collection is a per-host FLOW (no huntId), so its outcome isn't auto-collected — but recording
+        // the deploy still excludes it from re-proposal and surfaces it in the hunting profile.
+        await ctx.recordHuntDeploy(caseId, { source, title, vql, mitreTechniques, deployedAt: new Date().toISOString() });
+        options.onVeloHunt?.(caseId);
+        logActivity(options.activityLogStore, options.onActivity, caseId, {
+          category: "hunt", action: "deploy-collection", detail: `collection "${title}" on ${hostname}`,
+        });
+        return res.status(200).json({ mode, ...result });
+      }
+      const expirySeconds = normalizeHuntExpirySeconds(req.body?.expirySeconds);   // relative; defaults to one hour
+      logLine(`[velociraptor] deploy-hunt fleet "${title}" (expires in ${expirySeconds}s)`);
+      const launch = await options.velociraptorClient.launchHunt(vql, description, { expirySeconds });
+      // Register a collectible job AND schedule auto-collect (the same flow bundle hunts use) so the
+      // outcome fills by huntId without the analyst remembering to collect — fleet hunt results trickle
+      // in as clients check in, so we pull after the wait (and "Collect now" can pull early / re-pull).
+      const reqWait = Number(req.body?.waitMinutes);
+      const waitMinutes = Math.min(1440, Math.max(1, Number.isFinite(reqWait) && reqWait > 0 ? reqWait : (Number(process.env.DFIR_VELO_HUNT_WAIT_MIN) || 10)));
+      if (options.veloHuntStore) {
+        const now = new Date();
+        const job: VeloHuntJob = {
+          bundleId: `suggested:${source}`, bundleName: title, artifacts: launch.artifact ? [launch.artifact] : [],
+          sources: launch.sources,   // #157: the Custom.Hunt artifact's named sources (Pivot0…) so collect reads `artifact/source`
+          huntId: launch.huntId, guiUrl: launch.guiUrl, launchedAt: now.toISOString(), waitMinutes,
+          collectAt: new Date(now.getTime() + waitMinutes * 60_000).toISOString(), status: "running", expirySeconds,
+        };
+        await options.veloHuntStore.upsert(caseId, job);
+        const timer = setTimeout(() => { void ctx.importVeloHuntResults(caseId, launch.huntId); }, waitMinutes * 60_000);
+        timer.unref?.();
+        ctx.veloHuntTimers().set(launch.huntId, timer);
+        ctx.scheduleVeloHuntStatusPoll(caseId, launch.huntId);
+      }
+      await ctx.recordHuntDeploy(caseId, { source, title, vql, mitreTechniques, huntId: launch.huntId, deployedAt: new Date().toISOString() });
+      options.onVeloHunt?.(caseId);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "hunt", action: "deploy-hunt", detail: `fleet hunt "${title}" deployed (${source})`,
+      });
+      return res.status(200).json({ mode, waitMinutes, ...launch });
+    } catch (err) {
+      logLine(`[velociraptor] deploy-hunt ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Read a recorded hunt's result rows ON DEMAND for the Hunting Profile's expandable view (#157) —
+  // resolves the hunt's artifact(s)+sources from the persisted job (the profile only carries the hunt
+  // id), so the analyst can review what a hunt found from the persistent profile after the ephemeral
+  // suggestion card is gone. 404 when the job aged out of the (capped) list; 501 without the API.
+  app.post("/cases/:id/velociraptor/hunt-rows", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.veloHuntStore) return res.status(501).json({ error: "hunt store not configured" });
+    const huntId = String(req.body?.huntId ?? "").trim();
+    if (!huntId) return res.status(400).json({ error: "huntId is required" });
+    try {
+      const job = await options.veloHuntStore.get(req.params.id, huntId);
+      if (!job) return res.status(404).json({ error: "this hunt is no longer tracked (it aged out of the job list) — re-run it to see results" });
+      const sourcesByArtifact = (job.sources?.length && job.artifacts.length === 1) ? { [job.artifacts[0]]: job.sources } : undefined;
+      const { results, skipped } = await options.velociraptorClient.huntResultsByArtifact(job.huntId, job.artifacts, job.filters, sourcesByArtifact);
+      const rows = Object.values(results).flat();
+      return res.status(200).json({ rows, total: rows.length, artifacts: Object.keys(results), skipped });
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Live Velociraptor CLIENT_EVENT monitoring (#84) ───────────────────────────────────────────
+
+  // List the server's CLIENT_EVENT (continuous monitoring) artifacts for the Monitor-mode picker.
+  app.get("/velociraptor/event-artifacts", async (_req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    try {
+      return res.status(200).json({ artifacts: await options.velociraptorClient.listClientArtifacts("client_event") });
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // All live monitors for a case (with status + running stats). [] when monitoring isn't configured.
+  app.get("/cases/:id/velociraptor/monitors", async (req: Request, res: Response) => {
+    if (!options.veloMonitorStore) return res.status(200).json([]);
+    try {
+      return res.status(200).json(await options.veloMonitorStore.list(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Start a live monitor: poll a CLIENT_EVENT artifact on one client and stream new rows into the case.
+  // Body `{ clientId, artifact, pollSeconds?, hostname?, minSeverity? }`. Idempotent per (client,
+  // artifact) — re-adding the same pair updates it in place. The cursor starts at "now" so only events
+  // that arrive AFTER the monitor is created are ingested (no history backfill).
+  app.post("/cases/:id/velociraptor/monitors", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
+    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
+    const caseId = req.params.id;
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
+    // `allClients` (or clientId === "*") watches the artifact across EVERY enrolled client in one
+    // monitor — no specific endpoint to pick. Otherwise a real client id is required.
+    const wantsAll = req.body?.allClients === true || String(req.body?.clientId ?? "").trim() === ALL_CLIENTS;
+    const clientId = wantsAll ? ALL_CLIENTS : String(req.body?.clientId ?? "").trim();
+    const artifact = String(req.body?.artifact ?? "").trim();
+    if (!wantsAll && !/^C\.[A-Za-z0-9]+$/.test(clientId)) return res.status(400).json({ error: "a valid Velociraptor clientId (C....) is required, or set allClients:true" });
+    if (!/^[A-Za-z0-9._]+$/.test(artifact)) return res.status(400).json({ error: "a valid CLIENT_EVENT artifact name is required" });
+    try {
+      const fallback = Number(options.veloMonitorPollSeconds) || 30;
+      const reqPoll = Number(req.body?.pollSeconds);
+      const pollSeconds = Math.min(3600, Math.max(5, Number.isFinite(reqPoll) && reqPoll > 0 ? Math.floor(reqPoll) : fallback));
+      const hostname = String(req.body?.hostname ?? "").trim() || undefined;
+      const minSeverity = parseMinSeverity(req.body?.minSeverity);
+      const monitor = await ctx.createVeloMonitor(caseId, { clientId, artifact, pollSeconds, hostname, minSeverity, allClients: wantsAll });
+      return res.status(202).json({ accepted: true, monitor });
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Auto-monitor every client-event artifact ALREADY enabled in Velociraptor's client monitoring table
+  // (#84 follow-up) — discovers them via GetClientMonitoringState() and starts an ALL-clients monitor
+  // for each (idempotent: an existing monitor for the same artifact is refreshed, not duplicated). 422
+  // with guidance when nothing is configured / the version's proto differs (set the override env var).
+  app.post("/cases/:id/velociraptor/monitors/auto", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
+    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
+    const caseId = req.params.id;
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
+    try {
+      const discovered = await options.velociraptorClient.listMonitoredArtifacts();
+      if (!discovered.length) {
+        // Capture the RAW monitoring-state shape (which varies by version) — logged AND returned in the
+        // response so the analyst can see it in the dashboard and we can model DFIR_VELOCIRAPTOR_MONITORED_VQL.
+        let rawSample = "";
+        try {
+          const raw = await options.velociraptorClient.monitoringStateRaw();
+          rawSample = JSON.stringify(raw).slice(0, 2000);
+          logLine(`[velo-monitor] auto: monitoring table returned no artifacts. Raw get_client_monitoring() shape: ${rawSample}`);
+        } catch (e) { rawSample = `(read failed: ${(e as Error).message})`; logLine(`[velo-monitor] auto: monitoring-state read failed: ${(e as Error).message}`); }
+        return res.status(422).json({ error: "no client-event artifacts found in Velociraptor's client monitoring table — enable some in Velociraptor → Client Monitoring first, or (if your version's monitoring proto differs) open /velociraptor/diag and share the output to set DFIR_VELOCIRAPTOR_MONITORED_VQL", discovered: [], rawSample });
+      }
+      const fallback = Number(options.veloMonitorPollSeconds) || 30;
+      const reqPoll = Number(req.body?.pollSeconds);
+      const pollSeconds = Math.min(3600, Math.max(5, Number.isFinite(reqPoll) && reqPoll > 0 ? Math.floor(reqPoll) : fallback));
+      const minSeverity = parseMinSeverity(req.body?.minSeverity);
+      const started: VeloMonitor[] = [];
+      for (const artifact of discovered) {
+        started.push(await ctx.createVeloMonitor(caseId, { clientId: ALL_CLIENTS, artifact, pollSeconds, minSeverity, allClients: true }));
+      }
+      logLine(`[velo-monitor] auto-started ${started.length} all-clients monitor(s) from the Velociraptor monitoring table for case ${caseId}`);
+      return res.status(202).json({ accepted: true, discovered, started });
+    } catch (err) {
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Stop a monitor (clears its timer + marks it stopped, but keeps the row so it can be resumed).
+  app.post("/cases/:id/velociraptor/monitors/:mid/stop", async (req: Request, res: Response) => {
+    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
+    const caseId = req.params.id, id = req.params.mid;
+    const monitor = await options.veloMonitorStore.get(caseId, id);
+    if (!monitor) return res.status(404).json({ error: "monitor not found" });
+    ctx.stopVeloMonitorTimer(caseId, id);
+    await options.veloMonitorStore.upsert(caseId, { ...monitor, status: "stopped" });
+    options.onVeloMonitor?.(caseId);
+    return res.status(200).json({ ok: true });
+  });
+
+  // Resume a stopped monitor (re-arms its timer; keeps the persisted cursor so no re-ingest).
+  app.post("/cases/:id/velociraptor/monitors/:mid/start", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
+    const caseId = req.params.id, id = req.params.mid;
+    const monitor = await options.veloMonitorStore.get(caseId, id);
+    if (!monitor) return res.status(404).json({ error: "monitor not found" });
+    const resumed = { ...monitor, status: "active" as const, lastError: undefined };
+    await options.veloMonitorStore.upsert(caseId, resumed);
+    ctx.scheduleVeloMonitor(caseId, resumed);
+    options.onVeloMonitor?.(caseId);
+    return res.status(200).json({ ok: true });
+  });
+
+  // Poll a monitor NOW (don't wait for its timer) — a "check now" for the analyst. Runs one poll cycle
+  // (which also re-arms an active monitor's timer) and returns the updated monitor.
+  app.post("/cases/:id/velociraptor/monitors/:mid/poll", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
+    const caseId = req.params.id, id = req.params.mid;
+    const monitor = await options.veloMonitorStore.get(caseId, id);
+    if (!monitor) return res.status(404).json({ error: "monitor not found" });
+    await ctx.pollVeloMonitor(caseId, id);
+    return res.status(200).json({ ok: true, monitor: await options.veloMonitorStore.get(caseId, id) });
+  });
+
+  // Delete a monitor entirely (stop + remove the row).
+  app.delete("/cases/:id/velociraptor/monitors/:mid", async (req: Request, res: Response) => {
+    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
+    const caseId = req.params.id, id = req.params.mid;
+    ctx.stopVeloMonitorTimer(caseId, id);
+    await options.veloMonitorStore.remove(caseId, id);
+    options.onVeloMonitor?.(caseId);
+    return res.status(204).end();
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -20,6 +20,7 @@ import { registerPushNotifyRoutes } from "./routes/pushNotify.js";
 import { registerTemplatesViewsRoutes } from "./routes/templatesViews.js";
 import { registerToolsRoutes } from "./routes/tools.js";
 import { registerImportRoutes } from "./routes/import.js";
+import { registerVelociraptorRoutes } from "./routes/velociraptor.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
 import { AiControlStore, type AiControl } from "./analysis/aiControl.js";
 import { JobManager } from "./analysis/jobManager.js";
@@ -67,7 +68,6 @@ import { parseImporterSpec } from "./analysis/importerSpec.js";
 import { getImporterPrompt } from "./analysis/pipeline.js";
 import { getEnvForSettings, updateEnv as updateEnvFile, reloadEnvPrefix, resolveEnvFilePath } from "./settings/envManager.js";
 import { parseMinSeverity, applySeverityFloor } from "./analysis/severityFloor.js";
-import { parseVeloRef } from "./analysis/veloRef.js";
 import { enrichIocs, hasEnrichableWork, type EnrichLookupEvent } from "./enrichment/enrichService.js";
 import { EnrichControlStore, resolveEnabledProviders } from "./enrichment/enrichControl.js";
 import { ProviderHealthCache } from "./enrichment/providerHealth.js";
@@ -119,7 +119,7 @@ import { PLAYBOOK_STATUSES, playbookStats, type PlaybookStatus, type PlaybookTas
 import { PlaybookHuntStore } from "./analysis/playbookHuntStore.js";
 import { selectFreshHunts, pendingHuntTasks, mergePersistedHunts, EMPTY_PERSISTED_HUNTS, PLAYBOOK_HUNT_SUGGEST_MAX_DEFAULT } from "./analysis/playbookHunt.js";
 import { HuntOutcomeStore } from "./analysis/huntOutcomeStore.js";
-import { recordDeploy, fillOutcome, buildHuntingProfile, HUNT_OUTCOME_MAX_DEFAULT, type HuntOutcomeSource, type HuntDeployInput } from "./analysis/huntOutcomes.js";
+import { recordDeploy, fillOutcome, buildHuntingProfile, HUNT_OUTCOME_MAX_DEFAULT, type HuntDeployInput } from "./analysis/huntOutcomes.js";
 import { PlaybookControlStore, DEFAULT_PLAYBOOK_CONTROL, type PlaybookControl } from "./analysis/playbookControl.js";
 import { AssetOverridesStore } from "./analysis/assetOverrides.js";
 import type { AssetType } from "./analysis/assetGraph.js";
@@ -171,7 +171,7 @@ import {
 } from "./analysis/customerExposure.js";
 import { byEventTime } from "./analysis/forensicSort.js";
 import { IrisClient } from "./integrations/iris/irisClient.js";
-import { VelociraptorClient, buildVelociraptorClient, matchClient, ALL_CLIENTS, normalizeHuntExpirySeconds, type HuntTarget, type HuntUpload } from "./integrations/velociraptor/velociraptorApi.js";
+import { VelociraptorClient, buildVelociraptorClient, ALL_CLIENTS, type HuntUpload } from "./integrations/velociraptor/velociraptorApi.js";
 import { ArtifactBundleStore } from "./analysis/artifactBundleStore.js";
 import { VelociraptorClientStore } from "./analysis/velociraptorClientStore.js";
 import { VeloHuntStore, type VeloHuntJob } from "./analysis/veloHuntStore.js";
@@ -546,13 +546,6 @@ export interface AppOptions {
   onPreflightReady?: (run: () => Promise<PreflightReport>) => void;
 }
 
-// Normalize a label/tag input that may arrive as a comma-separated string or an array of strings.
-function toStringArray(v: unknown): string[] {
-  if (typeof v === "string") return v.split(",").map((s) => s.trim()).filter(Boolean);
-  if (Array.isArray(v)) return v.map((s) => String(s).trim()).filter(Boolean);
-  return [];
-}
-
 export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   const app = express();
   // Signs/verifies case-unlock cookies (issue: case password protection). Persisted next to
@@ -727,9 +720,25 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     applyNsrlToCase,
     applyDeobfuscationToCase,
     moveDropFile,
+    // Velociraptor machinery (routes/velociraptor.ts). All hoisted `function` declarations defined later
+    // in createApp, so binding them here (before their textual definition) is safe.
+    refreshVeloClients,
+    resumeVeloMonitors,
+    resumeVeloHuntStatusPolls,
+    scheduleVeloMonitor,
+    pollVeloMonitor,
+    stopVeloMonitorTimer,
+    scheduleVeloHuntStatusPoll,
+    pollVeloHuntStatus,
+    importVeloHuntResults,
+    ingestVeloArtifactMap,
+    ingestVeloUploads,
+    createVeloMonitor,
+    recordHuntDeploy,
     dropSeen: () => dropSeen,
     dropScanning: () => dropScanning,
     dropPendingLogged: () => dropPendingLogged,
+    veloHuntTimers: () => veloHuntTimers,
   };
   registerSystemRoutes(app, ctx);
   registerCaptureRoutes(app, ctx);
@@ -737,6 +746,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerTemplatesViewsRoutes(app, ctx);
   registerToolsRoutes(app, ctx);
   registerImportRoutes(app, ctx);
+  registerVelociraptorRoutes(app, ctx);
 
   app.get("/cases/:id/lock-status", async (req: Request, res: Response) => {
     try {
@@ -1952,58 +1962,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     }
   });
 
-  // Run a VQL query against the configured Velociraptor server (via its API) and return the rows.
-  // Powers the hunt-pivot modal's "Run in Velociraptor" button. 501 when not configured. The VQL is
-  // analyst-authored (from the generated pivots) — localhost only, opt-in via DFIR_VELOCIRAPTOR_*.
-  app.post("/velociraptor/run", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
-    if (!vql) return res.status(400).json({ error: "vql is required" });
-    try {
-      logLine(`[velociraptor] run query (${vql.length} chars)`);
-      const result = await options.velociraptorClient.run(vql);
-      logLine(`[velociraptor] query DONE -> ${result.total} rows${result.truncated ? " (truncated)" : ""}`);
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[velociraptor] query ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Launch a HUNT that runs the pivot VQL on ALL enrolled endpoints (packages it as a CLIENT
-  // artifact, then creates the hunt). This is the dashboard's "Run hunt on all clients" action.
-  app.post("/velociraptor/hunt", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
-    const description = typeof req.body?.description === "string" ? req.body.description : "";
-    if (!vql) return res.status(400).json({ error: "vql is required" });
-    const expirySeconds = normalizeHuntExpirySeconds(req.body?.expirySeconds);   // relative; defaults to one hour
-    try {
-      logLine(`[velociraptor] launch hunt: ${description.slice(0, 80)} (expires in ${expirySeconds}s)`);
-      const result = await options.velociraptorClient.launchHunt(vql, description, { expirySeconds });
-      logLine(`[velociraptor] hunt launched -> ${result.huntId} (artifact ${result.artifact}, ${result.sources.length} source(s))`);
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[velociraptor] hunt ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Read a launched hunt's results (rows collected from the endpoints so far). Polled by the dashboard.
-  app.post("/velociraptor/hunt-results", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    const huntId = typeof req.body?.huntId === "string" ? req.body.huntId.trim() : "";
-    const artifact = typeof req.body?.artifact === "string" ? req.body.artifact.trim() : "";
-    const sources = Array.isArray(req.body?.sources) ? req.body.sources.filter((s: unknown): s is string => typeof s === "string") : [];
-    if (!huntId || !artifact) return res.status(400).json({ error: "huntId and artifact are required" });
-    try {
-      const result = await options.velociraptorClient.huntResults(huntId, artifact, sources);
-      return res.status(200).json(result);
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
   // Snapshot the enrolled fleet into the persisted client inventory (issue #70). Best-effort; returns
   // the count. No-op (count 0) when the API or store isn't configured.
   async function refreshVeloClients(): Promise<number> {
@@ -2015,169 +1973,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     logLine(`[velociraptor] client inventory refreshed — ${clients.length} enrolled client(s)`);
     return clients.length;
   }
-
-  // Read the persisted client inventory (host ↔ client_id map). Empty when never refreshed.
-  app.get("/velociraptor/clients", async (_req: Request, res: Response) => {
-    if (!options.velociraptorClientStore) return res.status(200).json({ updatedAt: "", clients: [] });
-    try {
-      return res.status(200).json(await options.velociraptorClientStore.load());
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Refresh the client inventory now (Settings → Velociraptor "Refresh client list"). 501 when the
-  // API / store isn't configured; 502 on a query failure.
-  app.post("/velociraptor/clients/refresh", async (_req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.velociraptorClientStore) return res.status(501).json({ error: "client inventory store not configured" });
-    try {
-      const count = await refreshVeloClients();
-      const inv = await options.velociraptorClientStore.load();
-      return res.status(200).json({ count, updatedAt: inv.updatedAt, clients: inv.clients });
-    } catch (err) {
-      logLine(`[velociraptor] client refresh ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Builds the Velociraptor client from current env (used by POST /velociraptor/reconnect). Defaults
-  // to the env-based factory; tests inject a stub so no process is spawned.
-  const rebuildVelo = options.rebuildVelociraptorClient ?? buildVelociraptorClient;
-
-  // Diagnostics for the live-monitor features when the picker / auto-discovery come back empty on a
-  // real server (#84): the actual artifact `type` strings + counts, and the raw
-  // GetClientMonitoringState() shape. Hit it in a browser (localhost) and share the JSON to pin down a
-  // version's monitoring proto. 501 when the API isn't configured.
-  app.get("/velociraptor/diag", async (_req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    try {
-      return res.status(200).json(await options.velociraptorClient.diagnostics());
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Whether the Velociraptor API is configured + the inventory's freshness (so the dashboard can show
-  // connection state without a probe). `configured` reflects the LIVE client (reconnect can flip it).
-  app.get("/velociraptor/status", async (_req: Request, res: Response) => {
-    let updatedAt = "", clientCount = 0;
-    if (options.velociraptorClientStore) {
-      try { const inv = await options.velociraptorClientStore.load(); updatedAt = inv.updatedAt; clientCount = inv.clients.length; } catch { /* empty */ }
-    }
-    return res.status(200).json({ configured: !!options.velociraptorClient, updatedAt, clients: clientCount });
-  });
-
-  // Re-read DFIR_VELOCIRAPTOR_* from .env (settings saved via the dashboard only write the file),
-  // REBUILD the client, and refresh the client inventory — which doubles as a reachability probe
-  // (`clients()` round-trips to the server). Lets the analyst connect after configuring Velociraptor,
-  // or after the Velociraptor server comes back online, WITHOUT the #1-gotcha restart (the client is
-  // stateless — it spawns the binary per query — but a rebuild also applies newly-saved config and
-  // flips it on if the config path wasn't set at boot). Also re-arms any persisted live monitors that
-  // couldn't be scheduled while the client was absent. Always 200; the body says configured/reachable.
-  app.post("/velociraptor/reconnect", async (_req: Request, res: Response) => {
-    try {
-      await reloadEnvPrefix("DFIR_VELOCIRAPTOR_");
-      options.velociraptorClient = rebuildVelo();
-      if (!options.velociraptorClient) {
-        return res.status(200).json({ configured: false, ok: false, error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-      }
-      try {
-        const count = await refreshVeloClients();
-        const inv = options.velociraptorClientStore ? await options.velociraptorClientStore.load() : { updatedAt: "", clients: [] };
-        void resumeVeloMonitors();   // arm monitors that couldn't start while the client was absent
-        void resumeVeloHuntStatusPolls();   // and any hunt status polling that couldn't start either
-        logLine(`[velociraptor] reconnected — ${count} enrolled client(s)`);
-        return res.status(200).json({ configured: true, ok: true, clients: count, updatedAt: inv.updatedAt });
-      } catch (err) {
-        return res.status(200).json({ configured: true, ok: false, error: (err as Error).message });
-      }
-    } catch (err) {
-      return res.status(500).json({ configured: false, ok: false, error: (err as Error).message });
-    }
-  });
-
-  // Launch the VQL as a single-endpoint COLLECTION on ONE host (issue #70 — the playbook-hunt deploy
-  // path for a task tied to exactly one endpoint). Resolves the host → client_id from the persisted
-  // INVENTORY (refreshing it once on a miss), then runs collect_client on that client; returns the
-  // flow + a GUI deep link. 501 when the Velociraptor API is off; 502 when no client matches the host.
-  // Resolve a hostname → client_id from the persisted inventory (refreshing once on a miss) and launch a
-  // single-client collection. Throws when no client matches. Shared by the global /velociraptor/collect-host
-  // route and the case-scoped /cases/:id/velociraptor/deploy-hunt route (#157). Requires the API client set.
-  async function collectHostResolved(hostname: string, vql: string, description: string) {
-    const client = options.velociraptorClient!;
-    const store = options.velociraptorClientStore;
-    if (store) {
-      // Resolve from the inventory file; if the host isn't there yet, refresh once and retry (self-healing).
-      let rec = matchClient((await store.load()).clients, hostname);
-      if (!rec) { await refreshVeloClients(); rec = matchClient((await store.load()).clients, hostname); }
-      if (!rec) throw new Error(`No enrolled Velociraptor client matches host "${hostname}" — refresh the client list (Settings → Velociraptor) or run a fleet hunt instead`);
-      return await client.collectOnClient(rec.clientId, vql, description, hostname);
-    }
-    return await client.collectFromHost(hostname, vql, description);
-  }
-
-  app.post("/velociraptor/collect-host", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    const hostname = typeof req.body?.hostname === "string" ? req.body.hostname.trim() : "";
-    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
-    const description = typeof req.body?.description === "string" ? req.body.description : "";
-    if (!hostname) return res.status(400).json({ error: "hostname is required" });
-    if (!vql) return res.status(400).json({ error: "vql is required" });
-    try {
-      logLine(`[velociraptor] collect on host ${hostname}: ${description.slice(0, 80)}`);
-      const result = await collectHostResolved(hostname, vql, description);
-      logLine(`[velociraptor] collection launched -> flow ${result.flowId} on ${result.clientId} (${result.hostname})`);
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[velociraptor] collect ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Read a single COLLECTION flow's result rows so the dashboard can show them inline + auto-poll (the
-  // per-flow analog of /velociraptor/hunt-results). Body `{ clientId, flowId, artifact, sources }`.
-  app.post("/velociraptor/collect-results", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    const clientId = typeof req.body?.clientId === "string" ? req.body.clientId.trim() : "";
-    const flowId = typeof req.body?.flowId === "string" ? req.body.flowId.trim() : "";
-    const artifact = typeof req.body?.artifact === "string" ? req.body.artifact.trim() : "";
-    const sources = Array.isArray(req.body?.sources) ? req.body.sources.filter((s: unknown): s is string => typeof s === "string") : [];
-    if (!clientId || !flowId || !artifact) return res.status(400).json({ error: "clientId, flowId and artifact are required" });
-    try {
-      const result = await options.velociraptorClient.collectionResults(clientId, flowId, artifact, sources);
-      // Also report the flow's terminal STATE so the dashboard can surface an endpoint-side failure
-      // (e.g. a bad plugin arg) instead of polling "no results yet". Best-effort — never fail the read.
-      let flowState = "";
-      let flowError = "";
-      try {
-        const st = await options.velociraptorClient.flowStatus(clientId, flowId);
-        flowState = st.state;
-        flowError = st.error;
-      } catch { /* status read is best-effort */ }
-      return res.status(200).json({ ...result, flowState, flowError });
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // AI-suggest proactive Velociraptor VQL fleet-hunts from the case findings (issue #57). Single
-  // text-only AI call, EPHEMERAL (no state change) — the dashboard shows each hunt's VQL + rationale
-  // for review, then deploys the chosen one through POST /velociraptor/hunt (launchHunt). Needs an AI
-  // provider; does NOT need the Velociraptor API (the VQL is useful to copy even when deploy is off).
-  app.post("/cases/:id/velociraptor/suggest-hunts", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
-    try {
-      // Optional excludeVql → regenerate a DIFFERENT take (the per-card ↻ Regenerate button), mirroring
-      // the playbook-hunt regen. Absent → a normal full suggestion pass.
-      const excludeVql = typeof req.body?.excludeVql === "string" && req.body.excludeVql.trim() ? req.body.excludeVql : undefined;
-      const suggestions = await options.pipeline.suggestHunts(req.params.id, excludeVql ? { excludeVql } : undefined);
-      logLine(`[velociraptor] suggested ${suggestions.length} fleet-hunt(s) for ${req.params.id}`);
-      return res.status(200).json({ suggestions });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
 
   // AI-suggest a Velociraptor VQL hunt for ONE adversary-emulation "likely next technique" (issue
   // #121). The technique hasn't been observed yet; this turns the suggestion into a runnable, fleet-
@@ -2213,21 +2008,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       return res.status(200).json({ suggestions });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // ── Velociraptor triage bundles ───────────────────────────────────────────────────────────
-  // On-demand: list collectable CLIENT artifacts → build/save named bundles → run a bundle as a hunt
-  // → after a delay, collect results, auto-import (deterministic Velociraptor importer) + synthesize.
-
-  // List the server's collectable CLIENT artifacts (the bundle builder's picker source).
-  app.get("/velociraptor/artifacts", async (_req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    try {
-      const artifacts = await options.velociraptorClient.listClientArtifacts();
-      return res.status(200).json({ artifacts });
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
     }
   });
 
@@ -3248,285 +3028,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     }
   }
 
-  // Run a saved bundle as a hunt (optionally scoped by label/OS), schedule auto-collect after
-  // waitMinutes (default DFIR_VELO_HUNT_WAIT_MIN / bundle default / 10; clamped 1..1440), and respond
-  // immediately. The hunt stays open on the server until its expiry — we just snapshot results later.
-  app.post("/cases/:id/velociraptor/run-bundle", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.artifactBundleStore || !options.veloHuntStore) return res.status(501).json({ error: "bundle store not configured" });
-    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
-    const caseId = req.params.id;
-    const bundleId = String(req.body?.bundleId ?? "").trim();
-    if (!bundleId) return res.status(400).json({ error: "bundleId is required" });
-    try {
-      const bundle = await options.artifactBundleStore.get(bundleId);
-      if (!bundle) return res.status(404).json({ error: `bundle "${bundleId}" not found` });
-      if (!bundle.artifacts.length) return res.status(400).json({ error: "bundle has no artifacts" });
-
-      const fallback = Number(process.env.DFIR_VELO_HUNT_WAIT_MIN) || bundle.defaultWaitMinutes || 10;
-      const reqWait = Number(req.body?.waitMinutes);
-      const waitMinutes = Math.min(1440, Math.max(1, Number.isFinite(reqWait) && reqWait > 0 ? reqWait : fallback));
-      const os = ["windows", "linux", "darwin"].includes(String(req.body?.os)) ? (req.body.os as HuntTarget["os"]) : undefined;
-      const target: HuntTarget = {
-        includeLabels: toStringArray(req.body?.includeLabels),
-        excludeLabels: toStringArray(req.body?.excludeLabels),
-        os,
-      };
-      const minSeverity = parseMinSeverity(req.body?.minSeverity);   // applied to the import at collect time
-      // A dwell-window-gated bundle (e.g. Dwell-Time Triage) records which window it was launched for,
-      // and must not run untargeted — those raw host artifacts are only meaningful for a bounded window.
-      const dwellWindowId = typeof req.body?.dwellWindowId === "string" && req.body.dwellWindowId.trim() ? req.body.dwellWindowId.trim() : undefined;
-      // Per-collection timeout (seconds): run override > bundle default > Velociraptor's own default (600s).
-      const reqTimeout = Number(req.body?.timeoutSeconds);
-      const rawTimeout = Number.isFinite(reqTimeout) && reqTimeout > 0 ? reqTimeout : bundle.timeoutSeconds;
-      const timeoutSeconds = typeof rawTimeout === "number" && rawTimeout > 0 ? Math.min(86_400, Math.max(60, Math.floor(rawTimeout))) : undefined;
-      // Relative hunt expiry (seconds): run override > bundle default > the one-hour default.
-      const expirySeconds = normalizeHuntExpirySeconds(
-        Number(req.body?.expirySeconds) > 0 ? req.body.expirySeconds : bundle.expirySeconds,
-      );
-
-      // Pre-flight: Velociraptor's hunt() rejects the ENTIRE hunt if any named artifact doesn't exist
-      // on the server, so one stale/misspelled name in a bundle (e.g. a starter list not yet verified
-      // against THIS server) fails the whole run with an opaque "no hunt id". Intersect with the
-      // server's known client artifacts, launch with the valid subset, and report which were unknown.
-      // (Named `unknownArtifacts`, distinct from the JOB's collect-time `skippedArtifacts` = artifacts
-      // that launched but failed to FETCH.) Best-effort: if the catalog lookup itself fails, launch the
-      // bundle as-is rather than block on a diagnostics query.
-      let artifactsToRun = bundle.artifacts;
-      let unknownArtifacts: string[] = [];
-      try {
-        const known = new Set((await options.velociraptorClient.listClientArtifacts("client")).map((a) => a.name));
-        if (known.size) {
-          const valid = bundle.artifacts.filter((a) => known.has(a));
-          unknownArtifacts = bundle.artifacts.filter((a) => !known.has(a));
-          if (!valid.length) {
-            return res.status(400).json({ error: `none of this bundle's artifacts exist on the Velociraptor server — check the names in the bundle editor: ${bundle.artifacts.join(", ")}` });
-          }
-          artifactsToRun = valid;
-          if (unknownArtifacts.length) logLine(`[velociraptor] bundle "${bundle.name}": skipping ${unknownArtifacts.length} artifact(s) not on this server: ${unknownArtifacts.join(", ")}`);
-        }
-      } catch (e) {
-        logLine(`[velociraptor] artifact catalog check failed (launching bundle as-is): ${(e as Error).message}`);
-      }
-
-      logLine(`[velociraptor] run bundle "${bundle.name}" (${artifactsToRun.length} artifact(s)${unknownArtifacts.length ? `, ${unknownArtifacts.length} skipped` : ""}), collect in ${waitMinutes}m, expires in ${expirySeconds}s${minSeverity ? `, min severity ${minSeverity}` : ""}${timeoutSeconds ? `, timeout ${timeoutSeconds}s` : ""}`);
-      const launch = await options.velociraptorClient.launchArtifactHunt(artifactsToRun, bundle.name, target, { timeoutSeconds, params: bundle.params, expirySeconds });
-      const collectAt = new Date(Date.now() + waitMinutes * 60_000).toISOString();
-      const job: VeloHuntJob = {
-        bundleId: bundle.id, bundleName: bundle.name, artifacts: launch.artifacts,
-        huntId: launch.huntId, guiUrl: launch.guiUrl,
-        launchedAt: new Date().toISOString(), waitMinutes, collectAt,
-        status: "running", target, minSeverity, timeoutSeconds, expirySeconds, filters: bundle.filters, dwellWindowId,
-      };
-      // Append this hunt (concurrent hunts are kept side by side, keyed by huntId) + its own timer.
-      await options.veloHuntStore.upsert(caseId, job);
-      // #157: record the bundle deploy (no VQL — bundles are artifact lists; outcome filled on collect).
-      await recordHuntDeploy(caseId, { source: "bundle", title: bundle.name, huntId: launch.huntId, deployedAt: new Date().toISOString() });
-      options.onVeloHunt?.(caseId);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "hunt", action: "run-bundle", detail: `ran bundle "${bundle.name}" (${artifactsToRun.length} artifact(s))`,
-      });
-
-      const timer = setTimeout(() => { void importVeloHuntResults(caseId, launch.huntId); }, waitMinutes * 60_000);
-      timer.unref?.();
-      veloHuntTimers.set(launch.huntId, timer);
-      scheduleVeloHuntStatusPoll(caseId, launch.huntId);
-
-      return res.status(202).json({ huntId: launch.huntId, guiUrl: launch.guiUrl, collectAt, waitMinutes, artifacts: launch.artifacts, unknownArtifacts });
-    } catch (err) {
-      logLine(`[velociraptor] run bundle ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Import an EXTERNAL Velociraptor hunt/flow (launched in the Velociraptor GUI, not by the Companion).
-  // Paste a hunt id / flow / GUI URL; discover what it collected (for a flow, resolve the host) and
-  // import via the SAME chain as every other Velociraptor import — optionally to the super-timeline only.
-  app.post("/cases/:id/velociraptor/import-external", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
-    const caseId = req.params.id;
-    const ref = parseVeloRef(String(req.body?.ref ?? ""));
-    if (!ref) return res.status(400).json({ error: "paste a hunt id (H.…), a flow (C.…/F.…), or a Velociraptor GUI URL" });
-    // A notebook URL shows the analyst's OWN filtered VQL query results — this server can only pull the
-    // flow/hunt's complete raw collected rows (a different, much larger row set), which silently imports
-    // far more than the analyst is looking at. Only the browser extension's "Push rows" button captures
-    // the notebook's actual rendered/filtered results (it reads the GUI's own table), so redirect there.
-    if (ref.isNotebookUrl) {
-      return res.status(400).json({
-        error: "this is a Velociraptor NOTEBOOK URL — importing it here would pull the flow/hunt's complete raw results, not your notebook's filtered query. Open the notebook in your browser and use the DFIR Companion extension's \"Push rows → DFIR-Companion\" button instead, which imports exactly what the notebook shows.",
-      });
-    }
-    const minSeverity = parseMinSeverity(req.body?.minSeverity);
-    const superOnly = req.body?.superTimelineOnly === true;
-    // Uploaded reports (THOR/Hayabusa) only have a forensic-merge importer (dispatchImport) — routing
-    // them to the super-timeline-only path would leak into the forensic timeline and break its
-    // invariant (mirrors the same guard on the bundle-collect uploads step).
-    if (ref.isUploadsUrl && superOnly) {
-      return res.status(400).json({ error: "uploaded-file import doesn't support super-timeline-only mode — collect upload-based artifacts via a normal (forensic-timeline) import instead" });
-    }
-    const client = options.velociraptorClient;
-    try {
-      if (ref.kind === "hunt") {
-        if (ref.isUploadsUrl) {
-          const uploads = await client.huntUploads(ref.huntId);
-          if (!uploads.length) {
-            return res.status(200).json({ kind: "hunt", huntId: ref.huntId, addedEvents: 0, addedIocs: 0, uploadsOnly: true, note: "no uploaded report files found for this hunt yet (or none matched a supported format)" });
-          }
-          const out = await ingestVeloUploads(caseId, uploads, { minSeverity, label: `velo-hunt-uploads_${ref.huntId}` });
-          options.onVeloHunt?.(caseId);
-          return res.status(200).json({
-            kind: "hunt", huntId: ref.huntId, uploadsOnly: true, imported: out.imported, skipped: out.skipped,
-            addedEvents: out.addedEvents, addedIocs: out.addedIocs,
-            ...(out.imported.length === 0 ? { note: "found uploaded file(s) but none could be imported — unsupported format, or an AI-dependent format (CSV/log) while AI is off for this case" } : {}),
-          });
-        }
-        const arts = await client.getHuntArtifacts(ref.huntId);
-        if (!arts.length) return res.status(404).json({ error: `hunt ${ref.huntId} not found on the server, or it collected no artifacts` });
-        const { results } = await client.huntResultsByArtifact(ref.huntId, arts);
-        if (!Object.keys(results).length) return res.status(200).json({ kind: "hunt", huntId: ref.huntId, artifacts: arts, addedEvents: 0, addedIocs: 0, superTimelineOnly: superOnly, note: "the hunt returned no rows yet" });
-        const out = await ingestVeloArtifactMap(caseId, JSON.stringify(results), { label: `velo-hunt_${ref.huntId}.json`, idBase: ref.huntId, superOnly, minSeverity, veloUrl: client.huntGuiUrlFor(ref.huntId) });
-        options.onVeloHunt?.(caseId);
-        return res.status(200).json({ kind: "hunt", huntId: ref.huntId, artifacts: Object.keys(results), addedEvents: out.addedEvents, addedIocs: out.addedIocs, superTimelineOnly: superOnly });
-      }
-      if (ref.isUploadsUrl) {
-        const uploads = await client.flowUploads(ref.clientId, ref.flowId);
-        if (!uploads.length) {
-          return res.status(200).json({ kind: "flow", clientId: ref.clientId, flowId: ref.flowId, addedEvents: 0, addedIocs: 0, uploadsOnly: true, note: "no uploaded report files found for this flow yet (or none matched a supported format)" });
-        }
-        const out = await ingestVeloUploads(caseId, uploads, { minSeverity, label: `velo-flow-uploads_${ref.flowId}` });
-        options.onVeloHunt?.(caseId);
-        return res.status(200).json({
-          kind: "flow", clientId: ref.clientId, flowId: ref.flowId, uploadsOnly: true, imported: out.imported, skipped: out.skipped,
-          addedEvents: out.addedEvents, addedIocs: out.addedIocs,
-          ...(out.imported.length === 0 ? { note: "found uploaded file(s) but none could be imported — unsupported format, or an AI-dependent format (CSV/log) while AI is off for this case" } : {}),
-        });
-      }
-      const info = await client.getFlowInfo(ref.clientId, ref.flowId);
-      if (!info.artifacts.length) return res.status(404).json({ error: `flow ${ref.flowId} on ${ref.clientId} not found, or it collected no artifacts` });
-      const map: Record<string, unknown[]> = {};
-      for (const art of info.artifacts) {
-        try { const r = await client.collectionResults(ref.clientId, ref.flowId, art); if (r.rows.length) map[art] = r.rows; }
-        catch (e) { logLine(`[velociraptor] external flow ${ref.flowId}: artifact ${art} read failed: ${(e as Error).message}`); }
-      }
-      if (!Object.keys(map).length) return res.status(200).json({ kind: "flow", clientId: ref.clientId, flowId: ref.flowId, hostname: info.hostname, artifacts: info.artifacts, addedEvents: 0, addedIocs: 0, superTimelineOnly: superOnly, note: "the flow returned no rows" });
-      const out = await ingestVeloArtifactMap(caseId, JSON.stringify(map), { label: `velo-flow_${ref.flowId}.json`, idBase: ref.flowId, superOnly, minSeverity, hostFallback: info.hostname, veloUrl: client.flowGuiUrlFor(ref.clientId, ref.flowId) });
-      options.onVeloHunt?.(caseId);
-      return res.status(200).json({ kind: "flow", clientId: ref.clientId, flowId: ref.flowId, hostname: info.hostname, artifacts: Object.keys(map), addedEvents: out.addedEvents, addedIocs: out.addedIocs, superTimelineOnly: superOnly });
-    } catch (err) {
-      logLine(`[velociraptor] import-external ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // All bundle hunts for a case (newest first) — status + countdown + outcome per hunt. [] when none.
-  app.get("/cases/:id/velociraptor/hunt-jobs", async (req: Request, res: Response) => {
-    if (!options.veloHuntStore) return res.status(200).json([]);
-    try {
-      return res.status(200).json(await options.veloHuntStore.list(req.params.id));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Collect a specific hunt NOW (don't wait for its timer). Body `{ huntId }`; defaults to the most
-  // recent hunt when omitted. Runs in the background; poll hunt-jobs. 404 when there's nothing to collect.
-  app.post("/cases/:id/velociraptor/collect", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.veloHuntStore) return res.status(501).json({ error: "hunt store not configured" });
-    const caseId = req.params.id;
-    const wantedHuntId = String(req.body?.huntId ?? "").trim();
-    const jobs = await options.veloHuntStore.list(caseId);
-    const job = wantedHuntId ? jobs.find((j) => j.huntId === wantedHuntId) : jobs[0];
-    if (!job) return res.status(404).json({ error: wantedHuntId ? `no Velociraptor hunt ${wantedHuntId} for this case` : "no Velociraptor hunt to collect for this case" });
-    res.status(202).json({ accepted: true, huntId: job.huntId });
-    void importVeloHuntResults(caseId, job.huntId);
-  });
-
-  // Manually run one status-poll tick for a hunt NOW instead of waiting for the next scheduled tick
-  // (mirrors the live-monitor .../poll route) — used by ops to force a check, and by tests instead of
-  // waiting out DFIR_VELO_HUNT_POLL_S. Awaits the poll so the response already reflects its outcome.
-  app.post("/cases/:id/velociraptor/hunt-jobs/:huntId/poll-status", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.veloHuntStore) return res.status(501).json({ error: "hunt store not configured" });
-    const caseId = req.params.id;
-    const huntId = req.params.huntId;
-    await pollVeloHuntStatus(caseId, huntId);
-    const job = await options.veloHuntStore.get(caseId, huntId);
-    if (!job) return res.status(404).json({ error: `no Velociraptor hunt ${huntId} for this case` });
-    return res.status(200).json(job);
-  });
-
-  // ── Hunting feedback loop (#157) ─────────────────────────────────────────────────────────────
-
-  // Deploy a SUGGESTED hunt for a case and record it in the hunting feedback loop. Two modes:
-  //  - "hunt" (default): launch a fleet HUNT, register a VeloHuntJob, and schedule auto-collect after
-  //    DFIR_VELO_HUNT_WAIT_MIN (like a bundle) so the outcome fills on its own; "Collect now" pulls early.
-  //  - "collection": run a single-host COLLECTION (the playbook per-endpoint deploy path).
-  // Either way the deployed VQL is recorded (so it's never re-proposed) and shows in the profile.
-  // Body: { vql, title, description?, source?, mitreTechniques?, mode?, hostname?, waitMinutes? }.
-  app.post("/cases/:id/velociraptor/deploy-hunt", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    const caseId = req.params.id;
-    const vql = typeof req.body?.vql === "string" ? req.body.vql.trim() : "";
-    const title = typeof req.body?.title === "string" ? req.body.title.trim() : "";
-    const description = typeof req.body?.description === "string" && req.body.description.trim() ? req.body.description : title;
-    const rawSource = String(req.body?.source ?? "");
-    const allowedSources: HuntOutcomeSource[] = ["fleet", "playbook", "technique"];   // "bundle" is server-set, not client-supplied
-    const source: HuntOutcomeSource = allowedSources.includes(rawSource as HuntOutcomeSource) ? (rawSource as HuntOutcomeSource) : "fleet";
-    const mitreTechniques = toStringArray(req.body?.mitreTechniques);
-    const mode = req.body?.mode === "collection" ? "collection" : "hunt";
-    const hostname = typeof req.body?.hostname === "string" ? req.body.hostname.trim() : "";
-    if (!vql) return res.status(400).json({ error: "vql is required" });
-    if (!title) return res.status(400).json({ error: "title is required" });
-    try {
-      if (mode === "collection") {
-        if (!hostname) return res.status(400).json({ error: "hostname is required for a collection" });
-        logLine(`[velociraptor] deploy-hunt collection "${title}" on ${hostname}`);
-        const result = await collectHostResolved(hostname, vql, description);
-        // A collection is a per-host FLOW (no huntId), so its outcome isn't auto-collected — but recording
-        // the deploy still excludes it from re-proposal and surfaces it in the hunting profile.
-        await recordHuntDeploy(caseId, { source, title, vql, mitreTechniques, deployedAt: new Date().toISOString() });
-        options.onVeloHunt?.(caseId);
-        logActivity(options.activityLogStore, options.onActivity, caseId, {
-          category: "hunt", action: "deploy-collection", detail: `collection "${title}" on ${hostname}`,
-        });
-        return res.status(200).json({ mode, ...result });
-      }
-      const expirySeconds = normalizeHuntExpirySeconds(req.body?.expirySeconds);   // relative; defaults to one hour
-      logLine(`[velociraptor] deploy-hunt fleet "${title}" (expires in ${expirySeconds}s)`);
-      const launch = await options.velociraptorClient.launchHunt(vql, description, { expirySeconds });
-      // Register a collectible job AND schedule auto-collect (the same flow bundle hunts use) so the
-      // outcome fills by huntId without the analyst remembering to collect — fleet hunt results trickle
-      // in as clients check in, so we pull after the wait (and "Collect now" can pull early / re-pull).
-      const reqWait = Number(req.body?.waitMinutes);
-      const waitMinutes = Math.min(1440, Math.max(1, Number.isFinite(reqWait) && reqWait > 0 ? reqWait : (Number(process.env.DFIR_VELO_HUNT_WAIT_MIN) || 10)));
-      if (options.veloHuntStore) {
-        const now = new Date();
-        const job: VeloHuntJob = {
-          bundleId: `suggested:${source}`, bundleName: title, artifacts: launch.artifact ? [launch.artifact] : [],
-          sources: launch.sources,   // #157: the Custom.Hunt artifact's named sources (Pivot0…) so collect reads `artifact/source`
-          huntId: launch.huntId, guiUrl: launch.guiUrl, launchedAt: now.toISOString(), waitMinutes,
-          collectAt: new Date(now.getTime() + waitMinutes * 60_000).toISOString(), status: "running", expirySeconds,
-        };
-        await options.veloHuntStore.upsert(caseId, job);
-        const timer = setTimeout(() => { void importVeloHuntResults(caseId, launch.huntId); }, waitMinutes * 60_000);
-        timer.unref?.();
-        veloHuntTimers.set(launch.huntId, timer);
-        scheduleVeloHuntStatusPoll(caseId, launch.huntId);
-      }
-      await recordHuntDeploy(caseId, { source, title, vql, mitreTechniques, huntId: launch.huntId, deployedAt: new Date().toISOString() });
-      options.onVeloHunt?.(caseId);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "hunt", action: "deploy-hunt", detail: `fleet hunt "${title}" deployed (${source})`,
-      });
-      return res.status(200).json({ mode, waitMinutes, ...launch });
-    } catch (err) {
-      logLine(`[velociraptor] deploy-hunt ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
   // The per-case hunting profile (what was hunted, what hit / missed / is pending). Always 200 — an
   // empty profile when no store / no outcomes — so the dashboard panel renders without special-casing.
   app.get("/cases/:id/hunt-outcomes", async (req: Request, res: Response) => {
@@ -3536,165 +3037,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
-  });
-
-  // Read a recorded hunt's result rows ON DEMAND for the Hunting Profile's expandable view (#157) —
-  // resolves the hunt's artifact(s)+sources from the persisted job (the profile only carries the hunt
-  // id), so the analyst can review what a hunt found from the persistent profile after the ephemeral
-  // suggestion card is gone. 404 when the job aged out of the (capped) list; 501 without the API.
-  app.post("/cases/:id/velociraptor/hunt-rows", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.veloHuntStore) return res.status(501).json({ error: "hunt store not configured" });
-    const huntId = String(req.body?.huntId ?? "").trim();
-    if (!huntId) return res.status(400).json({ error: "huntId is required" });
-    try {
-      const job = await options.veloHuntStore.get(req.params.id, huntId);
-      if (!job) return res.status(404).json({ error: "this hunt is no longer tracked (it aged out of the job list) — re-run it to see results" });
-      const sourcesByArtifact = (job.sources?.length && job.artifacts.length === 1) ? { [job.artifacts[0]]: job.sources } : undefined;
-      const { results, skipped } = await options.velociraptorClient.huntResultsByArtifact(job.huntId, job.artifacts, job.filters, sourcesByArtifact);
-      const rows = Object.values(results).flat();
-      return res.status(200).json({ rows, total: rows.length, artifacts: Object.keys(results), skipped });
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // ── Live Velociraptor CLIENT_EVENT monitoring (#84) ───────────────────────────────────────────
-
-  // List the server's CLIENT_EVENT (continuous monitoring) artifacts for the Monitor-mode picker.
-  app.get("/velociraptor/event-artifacts", async (_req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    try {
-      return res.status(200).json({ artifacts: await options.velociraptorClient.listClientArtifacts("client_event") });
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // All live monitors for a case (with status + running stats). [] when monitoring isn't configured.
-  app.get("/cases/:id/velociraptor/monitors", async (req: Request, res: Response) => {
-    if (!options.veloMonitorStore) return res.status(200).json([]);
-    try {
-      return res.status(200).json(await options.veloMonitorStore.list(req.params.id));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Start a live monitor: poll a CLIENT_EVENT artifact on one client and stream new rows into the case.
-  // Body `{ clientId, artifact, pollSeconds?, hostname?, minSeverity? }`. Idempotent per (client,
-  // artifact) — re-adding the same pair updates it in place. The cursor starts at "now" so only events
-  // that arrive AFTER the monitor is created are ingested (no history backfill).
-  app.post("/cases/:id/velociraptor/monitors", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
-    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
-    const caseId = req.params.id;
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
-    // `allClients` (or clientId === "*") watches the artifact across EVERY enrolled client in one
-    // monitor — no specific endpoint to pick. Otherwise a real client id is required.
-    const wantsAll = req.body?.allClients === true || String(req.body?.clientId ?? "").trim() === ALL_CLIENTS;
-    const clientId = wantsAll ? ALL_CLIENTS : String(req.body?.clientId ?? "").trim();
-    const artifact = String(req.body?.artifact ?? "").trim();
-    if (!wantsAll && !/^C\.[A-Za-z0-9]+$/.test(clientId)) return res.status(400).json({ error: "a valid Velociraptor clientId (C....) is required, or set allClients:true" });
-    if (!/^[A-Za-z0-9._]+$/.test(artifact)) return res.status(400).json({ error: "a valid CLIENT_EVENT artifact name is required" });
-    try {
-      const fallback = Number(options.veloMonitorPollSeconds) || 30;
-      const reqPoll = Number(req.body?.pollSeconds);
-      const pollSeconds = Math.min(3600, Math.max(5, Number.isFinite(reqPoll) && reqPoll > 0 ? Math.floor(reqPoll) : fallback));
-      const hostname = String(req.body?.hostname ?? "").trim() || undefined;
-      const minSeverity = parseMinSeverity(req.body?.minSeverity);
-      const monitor = await createVeloMonitor(caseId, { clientId, artifact, pollSeconds, hostname, minSeverity, allClients: wantsAll });
-      return res.status(202).json({ accepted: true, monitor });
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Auto-monitor every client-event artifact ALREADY enabled in Velociraptor's client monitoring table
-  // (#84 follow-up) — discovers them via GetClientMonitoringState() and starts an ALL-clients monitor
-  // for each (idempotent: an existing monitor for the same artifact is refreshed, not duplicated). 422
-  // with guidance when nothing is configured / the version's proto differs (set the override env var).
-  app.post("/cases/:id/velociraptor/monitors/auto", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
-    if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
-    const caseId = req.params.id;
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
-    try {
-      const discovered = await options.velociraptorClient.listMonitoredArtifacts();
-      if (!discovered.length) {
-        // Capture the RAW monitoring-state shape (which varies by version) — logged AND returned in the
-        // response so the analyst can see it in the dashboard and we can model DFIR_VELOCIRAPTOR_MONITORED_VQL.
-        let rawSample = "";
-        try {
-          const raw = await options.velociraptorClient.monitoringStateRaw();
-          rawSample = JSON.stringify(raw).slice(0, 2000);
-          logLine(`[velo-monitor] auto: monitoring table returned no artifacts. Raw get_client_monitoring() shape: ${rawSample}`);
-        } catch (e) { rawSample = `(read failed: ${(e as Error).message})`; logLine(`[velo-monitor] auto: monitoring-state read failed: ${(e as Error).message}`); }
-        return res.status(422).json({ error: "no client-event artifacts found in Velociraptor's client monitoring table — enable some in Velociraptor → Client Monitoring first, or (if your version's monitoring proto differs) open /velociraptor/diag and share the output to set DFIR_VELOCIRAPTOR_MONITORED_VQL", discovered: [], rawSample });
-      }
-      const fallback = Number(options.veloMonitorPollSeconds) || 30;
-      const reqPoll = Number(req.body?.pollSeconds);
-      const pollSeconds = Math.min(3600, Math.max(5, Number.isFinite(reqPoll) && reqPoll > 0 ? Math.floor(reqPoll) : fallback));
-      const minSeverity = parseMinSeverity(req.body?.minSeverity);
-      const started: VeloMonitor[] = [];
-      for (const artifact of discovered) {
-        started.push(await createVeloMonitor(caseId, { clientId: ALL_CLIENTS, artifact, pollSeconds, minSeverity, allClients: true }));
-      }
-      logLine(`[velo-monitor] auto-started ${started.length} all-clients monitor(s) from the Velociraptor monitoring table for case ${caseId}`);
-      return res.status(202).json({ accepted: true, discovered, started });
-    } catch (err) {
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Stop a monitor (clears its timer + marks it stopped, but keeps the row so it can be resumed).
-  app.post("/cases/:id/velociraptor/monitors/:mid/stop", async (req: Request, res: Response) => {
-    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
-    const caseId = req.params.id, id = req.params.mid;
-    const monitor = await options.veloMonitorStore.get(caseId, id);
-    if (!monitor) return res.status(404).json({ error: "monitor not found" });
-    stopVeloMonitorTimer(caseId, id);
-    await options.veloMonitorStore.upsert(caseId, { ...monitor, status: "stopped" });
-    options.onVeloMonitor?.(caseId);
-    return res.status(200).json({ ok: true });
-  });
-
-  // Resume a stopped monitor (re-arms its timer; keeps the persisted cursor so no re-ingest).
-  app.post("/cases/:id/velociraptor/monitors/:mid/start", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
-    const caseId = req.params.id, id = req.params.mid;
-    const monitor = await options.veloMonitorStore.get(caseId, id);
-    if (!monitor) return res.status(404).json({ error: "monitor not found" });
-    const resumed = { ...monitor, status: "active" as const, lastError: undefined };
-    await options.veloMonitorStore.upsert(caseId, resumed);
-    scheduleVeloMonitor(caseId, resumed);
-    options.onVeloMonitor?.(caseId);
-    return res.status(200).json({ ok: true });
-  });
-
-  // Poll a monitor NOW (don't wait for its timer) — a "check now" for the analyst. Runs one poll cycle
-  // (which also re-arms an active monitor's timer) and returns the updated monitor.
-  app.post("/cases/:id/velociraptor/monitors/:mid/poll", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
-    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
-    const caseId = req.params.id, id = req.params.mid;
-    const monitor = await options.veloMonitorStore.get(caseId, id);
-    if (!monitor) return res.status(404).json({ error: "monitor not found" });
-    await pollVeloMonitor(caseId, id);
-    return res.status(200).json({ ok: true, monitor: await options.veloMonitorStore.get(caseId, id) });
-  });
-
-  // Delete a monitor entirely (stop + remove the row).
-  app.delete("/cases/:id/velociraptor/monitors/:mid", async (req: Request, res: Response) => {
-    if (!options.veloMonitorStore) return res.status(501).json({ error: "monitor store not configured" });
-    const caseId = req.params.id, id = req.params.mid;
-    stopVeloMonitorTimer(caseId, id);
-    await options.veloMonitorStore.remove(caseId, id);
-    options.onVeloMonitor?.(caseId);
-    return res.status(204).end();
   });
 
   // Push a case to DFIR-IRIS: find-or-create the case by name, then push assets→assets,


### PR DESCRIPTION
Task 7 of the router split. Moves the ~27 Velociraptor integration routes (top-level `/velociraptor/*` and per-case `/cases/:id/velociraptor/*`: collect, run-bundle, deploy-hunt, hunt monitors, import-external, etc.) out of `createApp` into `src/routes/velociraptor.ts`. **Pure structural move — zero behavior change.**

## Timer/monitor state (the correctness-critical part)
- `veloMonitorTimers`, `veloStatusTimers`, `collectingNow` **stay private** in `createApp` — used only by the startup resumers (`resumeVeloMonitors`/`resumeVeloHuntStatusPolls`) and pollers that remain.
- `veloHuntTimers` **graduated as a live accessor** — the moved `run-bundle`/`deploy-hunt` routes set collect timers on the **same Map instance** that the retained `importVeloHuntResults` clears (verified — no split-brain).
- 13 velo helper methods graduated (all still called by retained startup/resume/report code).

## Exclusions preserved
Routes interleaved in the same source region but belonging elsewhere correctly **remain** in `server.ts`: `/cases/:id/adversary-hints/hunt-technique`, `/cases/:id/memory/next-steps`, `GET /cases/:id/hunt-outcomes`. (`import-velociraptor` already lives in `import.ts`.)

## Verification
- `tsc --noEmit` clean; `veloMonitor` + `veloReconnect` + `veloBundle` pass **unedited** (31+/pass)
- Route inventory **316 = 316**, identical multiset
- Full server suite green (52 files / 400 tests)
- Spec-reviewed: shared-Map timer correctness, no foreign route swept in, verbatim handlers, graduation justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)