### PR TITLE
refactor: extract case-lifecycle + password routes into routes/ — server.ts is now thin wiring (router split, final)

### DIFF
--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -1,0 +1,1012 @@
+import type { Express, Request, Response } from "express";
+import { readFile } from "node:fs/promises";
+import { ZodError } from "zod";
+import { isValidCaseId } from "../storage/caseStore.js";
+import { sanitizeCaseMeta } from "../analysis/casePassword.js";
+import { buildInitialQuestions, buildInitialNextSteps } from "../analysis/templateStore.js";
+import { milestoneEvent } from "../analysis/notifications.js";
+import { seedDemoCase } from "../analysis/seedDemoCase.js";
+import { archiveCase } from "../analysis/caseArchive.js";
+import {
+  exportEncryptedCase,
+  importEncryptedCase,
+  CaseImportConflictError,
+  MIN_PASSWORD_LENGTH,
+  dfircaseFilename,
+} from "../analysis/caseExportArchive.js";
+import { DecryptionError } from "../analysis/caseEncryption.js";
+import { computeCaseStats } from "../analysis/caseStats.js";
+import { logActivity, ACTIVITY_CATEGORIES, type ActivityCategory } from "../analysis/activityLog.js";
+import { buildManualEvent } from "../analysis/manualEntry.js";
+import { byEventTime } from "../analysis/forensicSort.js";
+import { parseImporterSpec } from "../analysis/importerSpec.js";
+import { getImporterPrompt } from "../analysis/pipeline.js";
+import { getEnvForSettings, updateEnv as updateEnvFile, reloadEnvPrefix } from "../settings/envManager.js";
+import { readPublicAsset } from "../serverAssets.js";
+import { defaultIrisCaseName } from "../integrations/iris/irisExportStore.js";
+import { pushCaseToIris } from "../integrations/iris/irisPush.js";
+import { pushCaseToTimesketch, pushSuperTimelineToTimesketch } from "../integrations/timesketch/timesketchPush.js";
+import { pushCaseToMisp } from "../integrations/misp/mispPush.js";
+import { pushCaseToNotion, type NotionPushTarget } from "../integrations/notion/notionPush.js";
+import { parseNotionPageId } from "../integrations/notion/notionClient.js";
+import { pushPlaybookToClickUp } from "../integrations/clickup/clickupPush.js";
+import type { Severity } from "../analysis/stateTypes.js";
+import type { ImportMetadata } from "../types.js";
+import type { IocBlocklistFormat, IocBlocklistOptions, BlocklistIocType } from "../reports/iocBlocklist.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Case-core "everything else" domain — the FINAL router-split extraction. Everything that remained in
+ * createApp after the 15 prior domain modules, minus the password/unlock routes (routes/casePassword.ts).
+ * Pure structural move out of createApp (see routes/system.ts for the conventions) — no handler logic
+ * changed. This is the catch-all case-core surface; groups:
+ *   - case lifecycle — GET/POST /cases (list/create), POST /cases/seed-demo, PATCH /cases/:id/status,
+ *     POST /cases/:id/{archive,restore,delete}, GET /cases/:id/{state,stats}.
+ *   - whole-case archives — GET /cases/:id/export/ioc-blocklist, POST /cases/:id/export/encrypted,
+ *     POST /cases/import/encrypted, GET /cases/:id/backups, POST /cases/:id/restore-backup.
+ *   - integration pushes + status/reconnect — /cases/:id/push/{iris,timesketch,timesketch-super,misp,
+ *     notion,clickup} and the /{timesketch,misp,notion,clickup}/status + /timesketch/reconnect endpoints.
+ *   - manual timeline event — POST /cases/:id/events.
+ *   - declarative importers CRUD — GET/POST/DELETE /importers, /importers/{prompt,reload,precedence}.
+ *   - background jobs — GET /api/jobs, GET /api/jobs/:id, POST /api/jobs/:id/cancel.
+ *   - activity log — GET /cases/:id/activity-log.
+ *   - settings/env + setup — GET/POST /settings/env, POST /settings/{ai-reload,reload}, GET /setup/status.
+ *   - static app shell — GET /, /dashboard, /mobile, /manifest.webmanifest, /sw.js (these five were
+ *     registered in startServer AFTER createApp returned; moved here so server.ts holds zero literal
+ *     route registrations. The dynamic favicon/vendor loops (app.get(variable, …)) stay put — they are
+ *     not literal-path registrations. NOTE: /dashboard and /mobile have no try/catch and now sit BEFORE
+ *     the terminal error handler, so an (unreachable in a real install) asset-read failure yields the
+ *     standard JSON 500 instead of Express's default HTML page — the only observable delta.)
+ *
+ * Module-private helpers moved verbatim (used only by routes here): removeCaseFromActiveListBestEffort,
+ * deleteCaseFolderBestEffort (case archive/delete plumbing) and the RELOADABLE_PREFIXES allowlist.
+ * logLine/errLine mirror createApp's (serverLogger.info/error) so the moved call sites stay verbatim.
+ *
+ * Shared surface — reuses stable ctx fields (store, options, serverLogger, hasAiProvider), stable helpers
+ * (dispatchNotify, resynthesizeInBackground, syncPlaybook) and the live irisClient() accessor, plus five
+ * members GRADUATED for this domain (see context.ts):
+ *   - ensureDropFolders — create-case makes the drop inbox; the drop watcher (stays) also calls it.
+ *   - runStateExclusive — the manual-event write serializes on the per-case state mutex the staying
+ *     import/enrich/synthesis paths also use.
+ *   - reloadImporters + importerPrecedence()/setImporterPrecedence — the importer CRUD routes mutate the
+ *     in-memory registry + precedence that the staying detection seam (dispatchImport/resolveImportKind)
+ *     reads, so the reload function + precedence accessor/setter were graduated rather than moved.
+ *   - rebuildTimesketchClient — /timesketch/reconnect rebuilds the client from .env (mirrors
+ *     ctx.rebuildIrisClient); the reconnect reassigns options.timesketchClient, which the push routes read.
+ */
+export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): void {
+  const {
+    store, options, serverLogger, hasAiProvider,
+    dispatchNotify, ensureDropFolders, runStateExclusive, resynthesizeInBackground,
+    syncPlaybook, reloadImporters,
+  } = ctx;
+  // Module-private wrappers mirroring createApp's logLine/errLine (serverLogger.info/error) so the
+  // moved call sites stay verbatim.
+  const logLine = (msg: string): void => serverLogger.info(msg);
+  const errLine = (msg: string): void => serverLogger.error(msg);
+
+  // List existing cases (newest first) so the extension can present a picker of cases
+  // to attach to — case CREATION lives in the dashboard, the extension only connects.
+  app.get("/cases", async (_req: Request, res: Response) => {
+    try {
+      return res.status(200).json((await store.listCases()).map(sanitizeCaseMeta));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Create a case. This is the one place a case is born (the dashboard's New case form and
+  // `npm run`-style tooling call it); the extension no longer creates cases. Rejects a
+  // duplicate id so the form can't silently clobber an existing case's metadata/evidence.
+  // Optional `templateId`: pre-populates key questions from the named template.
+  app.post("/cases", async (req: Request, res: Response) => {
+    try {
+      const { caseId, name, investigator, aiProvider, templateId } = req.body ?? {};
+      if (!caseId || !name) return res.status(400).json({ error: "caseId and name are required" });
+      if (typeof caseId !== "string" || !isValidCaseId(caseId)) return res.status(400).json({ error: "caseId must use only letters, numbers, dots, dashes, or underscores, and may not contain path traversal" });
+      if (await store.caseExists(caseId)) return res.status(409).json({ error: `case ${caseId} already exists` });
+      const meta = await store.createCase({
+        caseId, name, investigator: investigator ?? "unknown", aiProvider: aiProvider ?? null,
+      });
+      if (templateId && options.templateStore && options.stateStore) {
+        const template = await options.templateStore.get(String(templateId));
+        if (template && (template.initialKeyQuestions.length || template.initialNextSteps?.length)) {
+          const state = await options.stateStore.load(caseId);
+          if (template.initialKeyQuestions.length) state.keyQuestions = buildInitialQuestions(template);
+          if (template.initialNextSteps?.length) state.nextSteps = buildInitialNextSteps(template);
+          state.updatedAt = new Date().toISOString();
+          await options.stateStore.save(state);
+        }
+      }
+      dispatchNotify(milestoneEvent(caseId, `Investigation opened: ${name}`, [`Investigator: ${investigator ?? "unknown"}`], new Date().toISOString()));
+      // Create the evidence drop folder for every new case (best-effort — never block case creation).
+      await ensureDropFolders(caseId).catch(() => { /* the watcher re-ensures on its next poll */ });
+      return res.status(201).json(sanitizeCaseMeta(meta));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Seed the built-in demo case ("GlobalTech Industries — BEC & Ransomware Precursor").
+  // Accepts optional { caseId?: string, force?: boolean } in the body.
+  // Returns 409 when the case already exists and force is not set; 201 on success.
+  // Available in both the dev server and the portable EXE so users don't need tsx/Node installed.
+  app.post("/cases/seed-demo", async (req: Request, res: Response) => {
+    try {
+      const caseId = typeof req.body?.caseId === "string" ? req.body.caseId : undefined;
+      const force  = req.body?.force === true;
+      const result = await seedDemoCase(store.casesRoot, { caseId, force });
+      return res.status(201).json(result);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code === "EEXIST") return res.status(409).json({ error: e.message });
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Case lifecycle (#119) ──────────────────────────────────────────────────────────────
+  // Set a case's lifecycle status (open / closed). A closed case is eligible for archiving.
+  app.patch("/cases/:id/status", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      if (!await store.caseExists(id)) return res.status(404).json({ error: `case ${id} not found` });
+      const { status } = req.body ?? {};
+      if (status !== "open" && status !== "closed") return res.status(400).json({ error: "status must be 'open' or 'closed'" });
+      const updated = await store.updateCaseMeta(id, { status });
+      logLine(`[lifecycle] case=${id} status=${status}`);
+      return res.status(200).json(sanitizeCaseMeta(updated));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Best-effort: moves a case out of the active list (into _archived/) and flips its status,
+  // AFTER the caller has already fully built the archive/export bytes. Failure here must NOT
+  // undo or discard the archive/export itself — the caller already has (or is about to send)
+  // their file; it just means the case stays visible in the active list until retried.
+  async function removeCaseFromActiveListBestEffort(
+    id: string,
+    logPrefix: string,
+  ): Promise<{ removed: boolean; error?: string }> {
+    try {
+      await store.archiveCaseFolder(id);
+      await store.updateCaseMeta(id, { status: "archived" });
+      logLine(`${logPrefix} case=${id} removed from active list (moved to _archived/)`);
+      return { removed: true };
+    } catch (err) {
+      errLine(`${logPrefix} case=${id} failed to remove from active list: ${(err as Error).message}`);
+      return { removed: false, error: (err as Error).message };
+    }
+  }
+
+  // Archive a case to a ZIP file (<casesRoot>/<caseId or name> (no password).zip). Intended for
+  // closed cases. Returns the archive path and a manifest of archived files + checksums. With
+  // { removeFromList: true }, additionally moves the case folder to _archived/ and sets
+  // status: "archived" — non-destructive and reversible via POST /cases/:id/restore.
+  app.post("/cases/:id/archive", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      const meta = await store.getCaseMeta(id);
+      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
+      if (meta.status === "archived") return res.status(400).json({ error: `case ${id} is already archived` });
+      const removeFromList = (req.body as { removeFromList?: unknown })?.removeFromList === true;
+      logLine(`[archive] starting archive for case=${id}`);
+      const result = await archiveCase(store.casesRoot, id, {}, meta.name, store.caseDir(id));
+      logLine(`[archive] done case=${id} files=${result.manifest.totalFiles} bytes=${result.manifest.totalBytes} path=${result.archivePath}`);
+      let removedFromList = false;
+      let removeFromListError: string | undefined;
+      if (removeFromList) {
+        const outcome = await removeCaseFromActiveListBestEffort(id, "[archive]");
+        removedFromList = outcome.removed;
+        removeFromListError = outcome.error;
+      }
+      return res.status(200).json({
+        ...result,
+        removedFromList,
+        ...(removeFromListError ? { removeFromListError } : {}),
+      });
+    } catch (err) {
+      errLine(`[archive] error case=${req.params.id}: ${(err as Error).message}`);
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Restore a case previously archived via the removeFromList option: moves it back from
+  // _archived/ into the active cases root and sets status to "closed" (the state it must have
+  // been in to be archived) — use PATCH /cases/:id/status afterward to reopen it if needed.
+  app.post("/cases/:id/restore", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      const meta = await store.getCaseMeta(id);
+      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
+      if (meta.status !== "archived") return res.status(400).json({ error: `case ${id} is not archived` });
+      await store.restoreCaseFolder(id);
+      const updated = await store.updateCaseMeta(id, { status: "closed" });
+      logLine(`[restore] case=${id} restored from _archived/`);
+      return res.status(200).json(updated);
+    } catch (err) {
+      errLine(`[restore] error case=${req.params.id}: ${(err as Error).message}`);
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Best-effort: permanently deletes a case's folder AFTER the caller has already fully built any
+  // requested archive. Failure here must NOT be treated as though the archive itself failed — the
+  // caller already has (or is about to send) that file; this just means the case's folder remains
+  // on disk until deletion is retried.
+  async function deleteCaseFolderBestEffort(id: string): Promise<{ deleted: boolean; error?: string }> {
+    try {
+      await store.deleteCaseFolder(id);
+      logLine(`[delete] case=${id} deleted`);
+      return { deleted: true };
+    } catch (err) {
+      const message = (err as Error).message;
+      errLine(`[delete] case=${id} failed to delete: ${message}`);
+      return { deleted: false, error: message };
+    }
+  }
+
+  // Permanently delete a case: optionally archives it first (ZIP or encrypted), then removes its
+  // folder from disk entirely — irreversible. Only allowed once a case is closed or archived (an
+  // open case must be closed first, mirroring the restriction on archiving). If the archive step
+  // is requested and succeeds but the delete step then fails, the response still reflects the
+  // successful archive (never silently discarded) — same principle as
+  // removeCaseFromActiveListBestEffort above.
+  // Known limitation: per-case in-memory state (capture buffers, synth timers/in-flight flags,
+  // Velociraptor hunt timers, drop-folder scan trackers — all keyed by caseId) is never explicitly
+  // cleared on delete, same pre-existing gap as archiveCaseFolder. A write already in flight when
+  // a case is closed→archived→deleted in quick succession could still try to touch the now-gone
+  // folder and error out. Accepted for now (writes are already blocked once closed/archived; this
+  // is a single-user localhost tool) — not fixed here to avoid scope creep into unrelated timers.
+  app.post("/cases/:id/delete", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      const meta = await store.getCaseMeta(id);
+      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
+      if (meta.status !== "closed" && meta.status !== "archived") {
+        return res.status(400).json({ error: `case ${id} must be closed or archived before it can be deleted` });
+      }
+      const body = (req.body ?? {}) as { archiveFirst?: unknown; password?: unknown };
+      const archiveFirst = body.archiveFirst;
+      if (archiveFirst !== "none" && archiveFirst !== "zip" && archiveFirst !== "encrypted") {
+        return res.status(400).json({ error: `archiveFirst must be 'none', 'zip', or 'encrypted'` });
+      }
+
+      if (archiveFirst === "encrypted") {
+        const password = body.password;
+        if (typeof password !== "string" || password.length < MIN_PASSWORD_LENGTH) {
+          return res.status(400).json({ error: `password must be at least ${MIN_PASSWORD_LENGTH} characters` });
+        }
+        const archive = await exportEncryptedCase(store, id, password);
+        const filename = dfircaseFilename(id, meta.name);
+        const { deleted } = await deleteCaseFolderBestEffort(id);
+        res.type("application/octet-stream");
+        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+        res.setHeader("Cache-Control", "private, no-cache");
+        res.setHeader("X-Case-Deleted", String(deleted));
+        return res.send(archive);
+      }
+
+      let archiveResult: Awaited<ReturnType<typeof archiveCase>> | undefined;
+      if (archiveFirst === "zip") {
+        archiveResult = await archiveCase(store.casesRoot, id, {}, meta.name, store.caseDir(id));
+        logLine(`[delete] case=${id} archived to ZIP before deletion: ${archiveResult.archivePath}`);
+      }
+
+      const { deleted, error: deleteError } = await deleteCaseFolderBestEffort(id);
+
+      return res.status(200).json({
+        deleted,
+        ...(deleteError ? { deleteError } : {}),
+        ...(archiveResult ? { archivePath: archiveResult.archivePath, manifest: archiveResult.manifest } : {}),
+      });
+    } catch (err) {
+      if ((err as Error).message.includes("does not exist")) {
+        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
+      }
+      errLine(`[delete] error case=${req.params.id}: ${(err as Error).message}`);
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.get("/cases/:id/state", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    try {
+      if (!(await store.caseExists(req.params.id))) {
+        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
+      }
+      const state = await options.stateStore.load(req.params.id);
+      return res.status(200).json(state);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Per-IOC corroboration: { iocId: [tools that observed it] }, derived on demand by matching each
+  // IOC value against the forensic events' sources (same scope/legitimate filtering as the report).
+  // Powers the dashboard's "⊕ N sources" badge on IOCs (#35 Phase 3).
+  // Case introspection stats (#241): totals, event-count-by-source, and daily import velocity for
+  // the CURRENT case only — powers the Diagnostics tab "Case Statistics" panel. Derived on read,
+  // no caching (same as host-ranking below). Disk usage is intentionally NOT included here — it's
+  // global, not per-case, and already served by GET /disk-stats.
+  app.get("/cases/:id/stats", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    try {
+      if (!(await store.caseExists(req.params.id))) {
+        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
+      }
+      const state = await options.stateStore.load(req.params.id);
+      const importLog: ImportMetadata[] = [];
+      try {
+        const log = await readFile(store.importsLogPath(req.params.id), "utf8");
+        for (const line of log.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try { importLog.push(JSON.parse(trimmed) as ImportMetadata); } catch { /* skip a malformed audit line */ }
+        }
+      } catch { /* no imports for this case yet */ }
+      return res.status(200).json(computeCaseStats(state, importLog));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Export a clean IOC block-list for network/firewall teams (issue #87). Supports three formats:
+  // txt (one value per line, grouped by type, with header comments), csv (minimal columnar format
+  // for TIP ingestion/ticketing), and stix (indicators-only STIX 2.1 bundle). Severity is derived
+  // from the worst enrichment verdict; scope/legitimate filters always apply.
+  //
+  // Query params: format (txt|csv|stix, default txt), minSeverity (Critical|High|Medium|Low|Info,
+  // default Medium), types (comma-separated ip,domain,url,hash,email), verdictOnly (true|false).
+  app.get("/cases/:id/export/ioc-blocklist", async (req: Request, res: Response) => {
+    if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
+    const fmt = String(req.query.format ?? "txt");
+    if (fmt !== "txt" && fmt !== "csv" && fmt !== "stix") {
+      return res.status(400).json({ error: "format must be txt, csv, or stix" });
+    }
+    const opts: IocBlocklistOptions = {};
+    const VALID_SEV: Severity[] = ["Critical", "High", "Medium", "Low", "Info"];
+    const VALID_TYPES: BlocklistIocType[] = ["ip", "domain", "url", "hash", "email"];
+    const { minSeverity, types, verdictOnly } = req.query;
+    if (typeof minSeverity === "string" && VALID_SEV.includes(minSeverity as Severity)) {
+      opts.minSeverity = minSeverity as Severity;
+    }
+    if (typeof types === "string" && types) {
+      opts.types = types.split(",").filter((t): t is BlocklistIocType => VALID_TYPES.includes(t as BlocklistIocType));
+    }
+    if (verdictOnly === "true") opts.verdictOnly = true;
+    try {
+      const data = await options.reportWriter.iocBlocklist(req.params.id, fmt as IocBlocklistFormat, opts);
+      const cid = req.params.id;
+      res.setHeader("Cache-Control", "private, no-cache");
+      if (fmt === "stix") {
+        res.type("application/json; charset=utf-8");
+        res.setHeader("Content-Disposition", `attachment; filename="ioc-blocklist-${cid}.stix.json"`);
+        return res.send(JSON.stringify(data, null, 2));
+      } else if (fmt === "csv") {
+        res.type("text/csv; charset=utf-8");
+        res.setHeader("Content-Disposition", `attachment; filename="ioc-blocklist-${cid}.csv"`);
+        return res.send(data as string);
+      } else {
+        res.type("text/plain; charset=utf-8");
+        res.setHeader("Content-Disposition", `attachment; filename="ioc-blocklist-${cid}.txt"`);
+        return res.send(data as string);
+      }
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Export the ENTIRE case as a password-encrypted archive (replaces issue #56's JSON-only
+  // snapshot, which never included screenshots or raw evidence bytes — only references to them).
+  // The whole case directory is zipped, then AES-256-GCM encrypted under a password the analyst
+  // chooses. Only openable via another DFIR Companion's Import (see analysis/caseEncryption.ts +
+  // caseExportArchive.ts). Password travels in the POST body, not the URL/query string.
+  app.post("/cases/:id/export/encrypted", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      const password = (req.body as { password?: unknown })?.password;
+      if (typeof password !== "string" || password.length < MIN_PASSWORD_LENGTH) {
+        return res.status(400).json({ error: `password must be at least ${MIN_PASSWORD_LENGTH} characters` });
+      }
+      const meta = await store.getCaseMeta(id);
+      if (meta?.status === "archived") return res.status(400).json({ error: `case ${id} is already archived` });
+      const removeFromList = (req.body as { removeFromList?: unknown })?.removeFromList === true;
+      const archive = await exportEncryptedCase(store, id, password);
+      const filename = dfircaseFilename(id, meta?.name);
+      let removedFromList = false;
+      if (removeFromList) {
+        const outcome = await removeCaseFromActiveListBestEffort(id, "[export]");
+        removedFromList = outcome.removed;
+      }
+      res.type("application/octet-stream");
+      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+      res.setHeader("Cache-Control", "private, no-cache");
+      res.setHeader("X-Case-Removed-From-List", String(removedFromList));
+      return res.send(archive);
+    } catch (err) {
+      if ((err as Error).message.includes("does not exist")) {
+        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
+      }
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Import a `.dfircase` encrypted archive into a NEW case (replaces issue #56's snapshot
+  // import). Body: { data: base64, password, targetCaseId? } — base64-in-JSON, matching this
+  // codebase's existing convention for binary uploads elsewhere (no multipart/multer). 409 if the
+  // target id already exists (the dashboard re-prompts with a new id), 400 on a wrong password,
+  // corrupt archive, or malformed payload.
+  app.post("/cases/import/encrypted", async (req: Request, res: Response) => {
+    try {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const { data, password, targetCaseId } = body;
+      if (typeof data !== "string" || !data.trim()) {
+        return res.status(400).json({ error: "data (base64) is required" });
+      }
+      if (typeof password !== "string" || !password) {
+        return res.status(400).json({ error: "password is required" });
+      }
+      const fileBuffer = Buffer.from(data, "base64");
+      const { meta, counts } = await importEncryptedCase(store, fileBuffer, password, {
+        targetCaseId: typeof targetCaseId === "string" && targetCaseId.trim() ? targetCaseId.trim() : undefined,
+      });
+      // An archived case.json is written back byte-for-byte on import (see
+      // caseExportArchive.ts), so an exported case that had a case-lock password carries
+      // its salt+hash into the archive. Sanitize before responding — never let it reach
+      // the client, same as every other route that serializes a CaseMeta.
+      return res.status(201).json({ ...sanitizeCaseMeta(meta), counts });
+    } catch (err) {
+      if (err instanceof CaseImportConflictError) {
+        return res.status(409).json({ error: err.message, caseId: err.caseId });
+      }
+      if (err instanceof DecryptionError) {
+        return res.status(400).json({ error: err.message });
+      }
+      const msg = (err as Error).message;
+      if (/not a valid case archive|invalid target case id/i.test(msg)) {
+        return res.status(400).json({ error: msg });
+      }
+      return res.status(500).json({ error: msg });
+    }
+  });
+
+  // ── State backups (#180) ─────────────────────────────────────────────────────────────────────
+  // Automatic snapshots of SNAPSHOT_STATE_FILES before synthesis + on a timer.
+  // List: GET /cases/:id/backups → { backups: BackupInfo[], summary: BackupSummary }
+  // Restore: POST /cases/:id/restore-backup { filename } → { restored: string[] }
+  // Both 404 when backupManager is absent (opt-in feature).
+
+  app.get("/cases/:id/backups", async (req: Request, res: Response) => {
+    if (!options.backupManager) return res.status(404).json({ error: "backup not configured — restart the server" });
+    const caseId = req.params.id;
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
+    try {
+      const [backups, summary] = await Promise.all([
+        options.backupManager.listBackups(caseId),
+        options.backupManager.summary(caseId),
+      ]);
+      return res.status(200).json({ backups, summary });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.post("/cases/:id/restore-backup", async (req: Request, res: Response) => {
+    if (!options.backupManager) return res.status(404).json({ error: "backup not configured — restart the server" });
+    const caseId = req.params.id;
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
+    const filename = (req.body as { filename?: unknown })?.filename;
+    if (typeof filename !== "string" || !filename.trim()) {
+      return res.status(400).json({ error: "filename is required" });
+    }
+    try {
+      const result = await options.backupManager.restoreBackup(caseId, filename.trim());
+      return res.status(200).json(result);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("not found") || msg.includes("invalid backup")) {
+        return res.status(404).json({ error: msg });
+      }
+      return res.status(500).json({ error: msg });
+    }
+  });
+  // Push a case to DFIR-IRIS: find-or-create the case by name, then push assets→assets,
+  // IOCs→IOCs, forensic timeline→timeline, executive summary→case summary, everything else→notes.
+  // Body: { caseName? } — an explicit override; otherwise the name from the last push is reused
+  // (irisExportStore), falling back to "<case id> — <friendly name>" on the very first push.
+  app.post("/cases/:id/push/iris", async (req: Request, res: Response) => {
+    const irisClient = ctx.irisClient(); // live accessor — POST /iris/reconnect can rebuild it at runtime
+    if (!irisClient) return res.status(501).json({ error: "DFIR-IRIS not configured (set DFIR_IRIS_URL and DFIR_IRIS_KEY)" });
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    const caseId = req.params.id;
+    try {
+      const state = await options.stateStore.load(caseId);
+      const meta = options.reportMetaStore ? await options.reportMetaStore.load(caseId) : undefined;
+      // Push the analyst-curated playbook (status-aware) when available, else the raw next steps.
+      const playbookTasks = options.playbookStore ? await syncPlaybook(caseId) : undefined;
+      const caseMeta = await store.getCaseMeta(caseId).catch(() => null);
+      const saved = options.irisExportStore ? await options.irisExportStore.load(caseId) : { caseName: "" };
+      const requested = typeof req.body?.caseName === "string" ? req.body.caseName.trim() : "";
+      let targetCaseName: string;
+      if (requested) {
+        targetCaseName = requested;
+      } else if (saved.caseName) {
+        targetCaseName = saved.caseName;
+      } else {
+        // First push under the new naming scheme — check whether this case was already pushed
+        // under the OLD bare-case-id scheme (pre-dates the case-name override feature) so we
+        // don't fork a duplicate IRIS case; only fall back to the computed default if not.
+        const legacy = await irisClient.findCaseByName(caseId).catch(() => null);
+        targetCaseName = legacy ? caseId : defaultIrisCaseName(caseId, caseMeta?.name);
+      }
+      logLine(`[iris] ${caseId} push START -> "${targetCaseName}"`);
+      const result = await pushCaseToIris(
+        irisClient,
+        { caseName: targetCaseName, state, meta, playbookTasks: playbookTasks?.length ? playbookTasks : undefined },
+        options.irisOptions,
+      );
+      if (options.irisExportStore) await options.irisExportStore.record(caseId, targetCaseName);
+      logLine(`[iris] ${caseId} push DONE -> case ${result.caseId} (${result.created ? "created" : "updated"}); ` +
+        `assets +${result.assets.added}/${result.assets.existing}, iocs +${result.iocs.added}/${result.iocs.existing}, ` +
+        `timeline +${result.timeline.added}/${result.timeline.existing}, tasks +${result.tasks.added}/${result.tasks.existing}, ` +
+        `notes ${result.notes}, warnings ${result.warnings.length}`);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "export", action: "push-iris", detail: `pushed to DFIR-IRIS case ${result.caseId} (${result.created ? "created" : "updated"})`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[iris] ${caseId} push ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+  // Whether a Timesketch push target is configured (so the dashboard can show/hide the button).
+  app.get("/timesketch/status", (_req: Request, res: Response) => {
+    res.status(200).json({ configured: !!options.timesketchClient, baseUrl: options.timesketchOptions?.baseUrl });
+  });
+
+  // Re-read DFIR_TIMESKETCH_* from .env (Settings only writes the file), rebuild the client, and log
+  // in to verify connectivity — so the Setup wizard / Settings can connect after configuring Timesketch
+  // (or after it comes back online) WITHOUT the #1-gotcha restart. Mirrors /iris/reconnect. Always 200;
+  // the body says whether it's configured and reachable.
+  app.post("/timesketch/reconnect", async (_req: Request, res: Response) => {
+    try {
+      await reloadEnvPrefix("DFIR_TIMESKETCH_");
+      options.timesketchClient = ctx.rebuildTimesketchClient();
+      if (!options.timesketchClient) {
+        return res.status(200).json({ configured: false, ok: false, error: "DFIR_TIMESKETCH_URL, DFIR_TIMESKETCH_USER and DFIR_TIMESKETCH_PASSWORD are not all set" });
+      }
+      try {
+        await options.timesketchClient.login();
+        return res.status(200).json({ configured: true, ok: true, baseUrl: process.env.DFIR_TIMESKETCH_URL });
+      } catch (err) {
+        return res.status(200).json({ configured: true, ok: false, baseUrl: process.env.DFIR_TIMESKETCH_URL, error: (err as Error).message });
+      }
+    } catch (err) {
+      return res.status(500).json({ configured: false, ok: false, error: (err as Error).message });
+    }
+  });
+
+  // Push a case to Timesketch: log in, find-or-create the sketch by name (= the Companion case id),
+  // then upload the forensic timeline as a timeline. The managed timeline is clean-replaced so a
+  // re-push never duplicates events.
+  app.post("/cases/:id/push/timesketch", async (req: Request, res: Response) => {
+    if (!options.timesketchClient) return res.status(501).json({ error: "Timesketch not configured (set DFIR_TIMESKETCH_URL, DFIR_TIMESKETCH_USER and DFIR_TIMESKETCH_PASSWORD)" });
+    if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
+    const caseId = req.params.id;
+    try {
+      const state = await options.reportWriter.filteredState(caseId);
+      logLine(`[timesketch] ${caseId} push START`);
+      const result = await pushCaseToTimesketch(options.timesketchClient, { sketchName: caseId, state }, options.timesketchOptions);
+      logLine(`[timesketch] ${caseId} push DONE -> sketch ${result.sketchId} (${result.created ? "created" : "updated"}); ` +
+        `timeline "${result.timelineName}" events ${result.events}${result.replacedTimeline ? " (replaced)" : ""}, warnings ${result.warnings.length}`);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "export", action: "push-timesketch", detail: `pushed to Timesketch sketch ${result.sketchId} (${result.created ? "created" : "updated"})`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[timesketch] ${caseId} push ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Push the super-timeline (forensic timeline + raw host-triage artifacts) to Timesketch: same
+  // sketch as the forensic push (named after the case id), but a SEPARATE timeline inside it
+  // ("DFIR Companion super timeline") so the two pushes never clean-replace each other. NOT
+  // scope/false-positive filtered — the super-timeline is the raw complete record.
+  app.post("/cases/:id/push/timesketch-super", async (req: Request, res: Response) => {
+    if (!options.timesketchClient) return res.status(501).json({ error: "Timesketch not configured (set DFIR_TIMESKETCH_URL, DFIR_TIMESKETCH_USER and DFIR_TIMESKETCH_PASSWORD)" });
+    if (!options.superTimelineStore) return res.status(501).json({ error: "super-timeline not configured" });
+    const caseId = req.params.id;
+    try {
+      const { events } = await options.superTimelineStore.query(caseId, { limit: Number.MAX_SAFE_INTEGER });
+      logLine(`[timesketch] ${caseId} super-timeline push START`);
+      const result = await pushSuperTimelineToTimesketch(options.timesketchClient, { sketchName: caseId, events }, options.timesketchOptions);
+      logLine(`[timesketch] ${caseId} super-timeline push DONE -> sketch ${result.sketchId} (${result.created ? "created" : "updated"}); ` +
+        `timeline "${result.timelineName}" events ${result.events}${result.replacedTimeline ? " (replaced)" : ""}, warnings ${result.warnings.length}`);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "export", action: "push-timesketch-super", detail: `pushed super-timeline to Timesketch sketch ${result.sketchId} (${result.created ? "created" : "updated"})`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[timesketch] ${caseId} super-timeline push ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Whether a MISP push target is configured (so the dashboard can show/hide the button).
+  app.get("/misp/status", (_req: Request, res: Response) => {
+    res.status(200).json({ configured: !!options.mispPushClient, baseUrl: options.mispPushOptions?.baseUrl });
+  });
+
+  // Push a case to MISP: find-or-create the event by the idempotency tag, then push
+  // IOCs as attributes and MITRE techniques as tags. Idempotent: re-push adds only
+  // what's missing (attributes deduplicated by value).
+  app.post("/cases/:id/push/misp", async (req: Request, res: Response) => {
+    if (!options.mispPushClient) return res.status(501).json({ error: "MISP not configured (set DFIR_MISP_URL and DFIR_MISP_KEY)" });
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    const caseId = req.params.id;
+    try {
+      const state = await options.stateStore.load(caseId);
+      logLine(`[misp] ${caseId} push START`);
+      const result = await pushCaseToMisp(options.mispPushClient, { caseId, state }, options.mispPushOptions);
+      logLine(`[misp] ${caseId} push DONE -> event ${result.eventId} (${result.created ? "created" : "updated"}); ` +
+        `attributes +${result.attributes.added}/${result.attributes.existing}, tags +${result.tags}, warnings ${result.warnings.length}`);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "export", action: "push-misp", detail: `pushed to MISP event ${result.eventId} (${result.created ? "created" : "updated"})`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[misp] ${caseId} push ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Whether a Notion export target is configured (so the dashboard can show/hide the option and
+  // decide whether to ask for a parent in the "new page" modal).
+  app.get("/notion/status", (_req: Request, res: Response) => {
+    res.status(200).json({
+      configured: !!options.notionClient,
+      hasDatabase: !!options.notionOptions?.databaseId,
+      hasParent: !!options.notionOptions?.parentPageId,
+    });
+  });
+
+  // Export a case into a Notion page. The Companion writes ALL its content inside ONE managed
+  // toggle block it owns; a re-export refreshes that block and never touches the investigators'
+  // own notes/screenshots. Body: { mode: "new"|"existing", page?, parent?, database? }.
+  app.post("/cases/:id/push/notion", async (req: Request, res: Response) => {
+    if (!options.notionClient) return res.status(501).json({ error: "Notion not configured (set DFIR_NOTION_TOKEN)" });
+    if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
+    if (!options.notionExportStore) return res.status(501).json({ error: "notion export store not configured" });
+    const caseId = req.params.id;
+    const body = req.body ?? {};
+    const mode = body.mode === "existing" ? "existing" : "new";
+
+    const target: NotionPushTarget = { mode };
+    if (mode === "existing") {
+      const pageId = parseNotionPageId(typeof body.page === "string" ? body.page : "");
+      if (!pageId) return res.status(400).json({ error: "could not read a Notion page id from the supplied page URL/ID" });
+      target.pageId = pageId;
+    } else {
+      const parent = typeof body.parent === "string" ? parseNotionPageId(body.parent) : null;
+      const database = typeof body.database === "string" ? parseNotionPageId(body.database) : null;
+      if (parent) target.parentPageId = parent;
+      if (database) target.databaseId = database;
+    }
+
+    try {
+      const state = await options.reportWriter.filteredState(caseId);
+      const meta = options.reportMetaStore ? await options.reportMetaStore.load(caseId) : undefined;
+      logLine(`[notion] ${caseId} export START (${mode})`);
+      const result = await pushCaseToNotion(
+        options.notionClient,
+        { caseName: caseId, state, meta },
+        target,
+        options.notionOptions,
+        options.notionExportStore,
+      );
+      logLine(`[notion] ${caseId} export DONE -> page ${result.pageId} (${result.created ? "created" : "updated"}); ` +
+        `+${result.blocksAppended} block(s) in ${result.batches} batch(es), archived ${result.blocksArchived}, warnings ${result.warnings.length}`);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "export", action: "push-notion", detail: `pushed to Notion page ${result.pageId} (${result.created ? "created" : "updated"})`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[notion] ${caseId} export ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // Whether a ClickUp push target is configured (so the dashboard can show/hide the option).
+  app.get("/clickup/status", (_req: Request, res: Response) => {
+    res.status(200).json({
+      configured: !!options.clickupClient,
+      hasDefaultList: !!options.clickupOptions?.defaultListId,
+      defaultListId: options.clickupOptions?.defaultListId ?? "",
+    });
+  });
+
+  // Push the Response Playbook to a ClickUp list as tasks. Body { listId? } — falls back to the
+  // saved list, then the configured default. Re-export UPDATES the tasks it created (by remembered
+  // id) instead of duplicating.
+  app.post("/cases/:id/push/clickup", async (req: Request, res: Response) => {
+    if (!options.clickupClient) return res.status(501).json({ error: "ClickUp not configured (set DFIR_CLICKUP_TOKEN)" });
+    if (!options.clickupExportStore) return res.status(501).json({ error: "clickup export store not configured" });
+    if (!options.playbookStore || !options.stateStore) return res.status(501).json({ error: "playbook not configured" });
+    const caseId = req.params.id;
+    try {
+      const saved = await options.clickupExportStore.load(caseId);
+      const requested = typeof req.body?.listId === "string" ? req.body.listId.trim() : "";
+      const listId = requested || saved.listId || options.clickupOptions?.defaultListId || "";
+      if (!listId) return res.status(400).json({ error: "a ClickUp list id is required" });
+      const tasks = await syncPlaybook(caseId);
+      if (!tasks.length) return res.status(400).json({ error: "the playbook is empty — run synthesis or add tasks first" });
+      logLine(`[clickup] ${caseId} push START -> list ${listId} (${tasks.length} tasks)`);
+      const result = await pushPlaybookToClickUp(
+        options.clickupClient,
+        { caseId, listId, tasks },
+        options.clickupExportStore,
+        new Date().toISOString(),
+      );
+      logLine(`[clickup] ${caseId} push DONE: +${result.created} created, ${result.updated} updated, ${result.skipped} skipped, warnings ${result.warnings.length}`);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "export", action: "push-clickup", detail: `pushed playbook to ClickUp list ${listId} — +${result.created} created, ${result.updated} updated`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      logLine(`[clickup] ${caseId} push ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+  // Manually add a forensic event the AI didn't catch. Appended to the timeline (kept sorted by
+  // event time), then re-synthesized so it weaves into findings/MITRE (a high-severity manual
+  // event earns a finding via the backfill). Synthesis preserves the timeline, so it survives.
+  app.post("/cases/:id/events", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    const caseId = req.params.id;
+    try {
+      const event = buildManualEvent(req.body);
+      const stateStore = options.stateStore;
+      await runStateExclusive(caseId, async () => {
+        const state = await stateStore.load(caseId);
+        const forensicTimeline = [...state.forensicTimeline, event].sort(byEventTime);
+        const next = { ...state, forensicTimeline, updatedAt: new Date().toISOString() };
+        await stateStore.save(next);
+        options.onState?.(next);
+      });
+      resynthesizeInBackground(caseId);
+      logLine(`[manual] ${caseId} added event ${event.id} (${event.severity})`);
+      return res.status(201).json(event);
+    } catch (err) {
+      if (err instanceof ZodError) return res.status(400).json({ error: err.issues.map((i) => i.message).join("; ") });
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+  // User-authored declarative importers (external plugin layer). GLOBAL, shared across cases — these
+  // CRUD the registry of import shapes the analyst can add without code. Unconfigured ⇒ empty list /
+  // 501 on writes. A save/delete/reload re-reads the on-disk registry (reloadImporters) so the in-
+  // memory copy + the detection seam (resolveImportKind) stay current without the #1-gotcha restart.
+  app.get("/importers", async (_req: Request, res: Response) => {
+    if (!options.importerStore) return res.status(200).json({ importers: [], precedence: "builtin-first", errors: [] });
+    return res.status(200).json({ importers: ctx.importerRegistry().meta, precedence: ctx.importerPrecedence(), errors: ctx.importerRegistry().errors });
+  });
+
+  app.get("/importers/prompt", (_req: Request, res: Response) => {
+    if (!options.pipeline) return res.status(501).json({ error: "pipeline not configured" });
+    return res.status(200).json({ prompt: getImporterPrompt() });
+  });
+
+  app.post("/importers", async (req: Request, res: Response) => {
+    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
+    const body = req.body?.spec ?? req.body;
+    const parsed = parseImporterSpec(body);
+    if (!parsed.ok) return res.status(400).json({ error: "invalid importer", errors: parsed.errors });
+    try {
+      await options.importerStore.save(parsed.spec);
+      await reloadImporters();
+      return res.status(201).json({ id: parsed.spec.id });
+    } catch (err) { return res.status(500).json({ error: (err as Error).message }); }
+  });
+
+  app.delete("/importers/:id", async (req: Request, res: Response) => {
+    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
+    try {
+      const removed = await options.importerStore.delete(req.params.id);
+      if (!removed) return res.status(404).json({ error: "importer not found" });
+      await reloadImporters();
+      return res.status(200).json({ removed: true });
+    } catch (err) { return res.status(500).json({ error: (err as Error).message }); }
+  });
+
+  app.post("/importers/reload", async (_req: Request, res: Response) => {
+    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
+    try { await reloadImporters(); return res.status(200).json({ importers: ctx.importerRegistry().meta, errors: ctx.importerRegistry().errors }); }
+    catch (err) { return res.status(500).json({ error: (err as Error).message }); }
+  });
+
+  app.put("/importers/precedence", async (req: Request, res: Response) => {
+    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
+    const p = req.body?.precedence;
+    if (p !== "builtin-first" && p !== "external-first") return res.status(400).json({ error: "precedence must be 'builtin-first' or 'external-first'" });
+    try { await options.importerStore.setPrecedence(p); ctx.setImporterPrecedence(p); options.onImporters?.(); return res.status(200).json({ precedence: p }); }
+    catch (err) { return res.status(500).json({ error: (err as Error).message }); }
+  });
+  // Background jobs (#225): list + inspect + cancel the heavy async operations (import / synthesis /
+  // enrichment) tracked by the JobManager, so the dashboard can render a Jobs panel and stop a
+  // long/stuck run. Read-only when no jobManager is wired (createApp-only unit tests) — empty list.
+  app.get("/api/jobs", (req: Request, res: Response) => {
+    const caseId = typeof req.query.caseId === "string" ? req.query.caseId : undefined;
+    return res.status(200).json({ jobs: options.jobManager?.list(caseId) ?? [] });
+  });
+  app.get("/api/jobs/:id", (req: Request, res: Response) => {
+    const job = options.jobManager?.get(req.params.id);
+    if (!job) return res.status(404).json({ error: `unknown job: ${req.params.id}` });
+    return res.status(200).json(job);
+  });
+  app.post("/api/jobs/:id/cancel", (req: Request, res: Response) => {
+    if (!options.jobManager) return res.status(501).json({ error: "job manager not configured" });
+    const result = options.jobManager.cancel(req.params.id);
+    if (result.ok) return res.status(200).json(result.job);
+    if (result.reason === "unknown") return res.status(404).json({ error: `unknown job: ${req.params.id}` });
+    if (result.reason === "terminal") return res.status(409).json({ error: "job already finished" });
+    return res.status(422).json({ error: "this job cannot be cancelled" });
+  });
+
+  // Per-case investigation activity log (#238): every security-relevant action taken on this
+  // case, newest first. Filter by category; cap by limit (default 200, so a long-lived case
+  // doesn't dump its entire history in one response).
+  app.get("/cases/:id/activity-log", async (req: Request, res: Response) => {
+    if (!options.activityLogStore) return res.status(501).json({ error: "activity log not configured" });
+    const rawCategory = typeof req.query.category === "string" ? req.query.category : "";
+    const category = (ACTIVITY_CATEGORIES as readonly string[]).includes(rawCategory) ? (rawCategory as ActivityCategory) : undefined;
+    const rawLimit = Number(req.query.limit);
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(1000, Math.floor(rawLimit)) : 200;
+    try {
+      return res.status(200).json(await options.activityLogStore.load(req.params.id, { category, limit }));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+  // Settings: read/write the .env file so the dashboard can configure the companion.
+  app.get("/settings/env", async (_req: Request, res: Response) => {
+    try {
+      const env = await getEnvForSettings();
+      return res.json({ env });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.post("/settings/env", async (req: Request, res: Response) => {
+    try {
+      const updates = req.body?.updates;
+      if (!updates || typeof updates !== "object" || Array.isArray(updates)) {
+        return res.status(400).json({ error: "updates must be an object" });
+      }
+      await updateEnvFile(updates as Record<string, string>);
+      return res.json({ ok: true });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Apply the just-saved DFIR_AI_* values from .env into process.env WITHOUT a full restart, so the
+  // first-run wizard (#181) can save → reload → POST /diagnostics/ai-test in one flow (buildProvider()
+  // reads process.env live). This does NOT rebuild the analysis pipeline — /health.aiEnabled stays
+  // false until a restart — it only lets the live connectivity probe see the new config. Mirrors the
+  // IRIS/Velociraptor reconnect routes' reloadEnvPrefix pattern.
+  app.post("/settings/ai-reload", async (_req: Request, res: Response) => {
+    try {
+      const applied = await reloadEnvPrefix("DFIR_AI_");
+      return res.json({ ok: true, applied });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Generic counterpart of /settings/ai-reload for the comprehensive Setup wizard (#181): apply a
+  // just-saved DFIR_<PREFIX>_* group from .env into process.env without a restart, so a "Save & test"
+  // step sees the new config. ALLOWLISTED — the prefix must be a known integration group, so a request
+  // can't reload arbitrary env (and the route never reads/returns secret VALUES, only the applied keys).
+  const RELOADABLE_PREFIXES = new Set([
+    "DFIR_AI_", "DFIR_IRIS_", "DFIR_VELOCIRAPTOR_", "DFIR_TIMESKETCH_", "DFIR_NOTION_", "DFIR_CLICKUP_",
+    "DFIR_VT_", "DFIR_ABUSEIPDB_", "DFIR_HUNTINGCH_", "DFIR_MB_", "DFIR_CROWDSTRIKE_", "DFIR_SHODAN_",
+    "DFIR_MISP_", "DFIR_YETI_", "DFIR_OPENCTI_", "DFIR_ROCKYRACCOON_", "DFIR_GEOIP_",
+    "DFIR_LEAKCHECK_", "DFIR_HIBP_", "DFIR_DEHASHED_", "DFIR_PUSH_TOKEN", "DFIR_NSRL_", "DFIR_TOOL_",
+  ]);
+  app.post("/settings/reload", async (req: Request, res: Response) => {
+    try {
+      const prefix = typeof req.body?.prefix === "string" ? req.body.prefix.trim() : "";
+      if (!prefix) return res.status(400).json({ error: "prefix is required" });
+      if (!RELOADABLE_PREFIXES.has(prefix)) {
+        return res.status(400).json({ error: `prefix not in the reloadable allowlist: ${prefix}` });
+      }
+      const applied = await reloadEnvPrefix(prefix);
+      return res.json({ ok: true, applied });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Aggregate "is this integration configured?" status for the Setup wizard's progress (✓/○) — derived
+  // live from process.env so it reflects values just saved+reloaded (no restart). Required-config groups
+  // only: each entry is configured when its mandatory key(s) are present. No external calls, no secret
+  // values — only booleans. (Per-feature deep status/connectivity lives in /iris/status etc.)
+  app.get("/setup/status", (_req: Request, res: Response) => {
+    const has = (k: string): boolean => !!(process.env[k] && process.env[k]!.trim());
+    res.status(200).json({
+      ai: !!hasAiProvider() || has("DFIR_AI_PROVIDER"),
+      velociraptor: !!options.velociraptorClient || has("DFIR_VELOCIRAPTOR_API_CONFIG"),
+      iris: !!ctx.irisClient() || (has("DFIR_IRIS_URL") && has("DFIR_IRIS_KEY")),
+      timesketch: !!options.timesketchClient || (has("DFIR_TIMESKETCH_URL") && has("DFIR_TIMESKETCH_USER") && has("DFIR_TIMESKETCH_PASSWORD")),
+      notion: !!options.notionClient || has("DFIR_NOTION_TOKEN"),
+      clickup: !!options.clickupClient || has("DFIR_CLICKUP_TOKEN"),
+      push: !!options.pushTokenStore || has("DFIR_PUSH_TOKEN"),
+      notifications: !!options.notificationStore,
+      enrichment: {
+        virustotal: has("DFIR_VT_KEY"),
+        abuseipdb: has("DFIR_ABUSEIPDB_KEY"),
+        huntingch: has("DFIR_HUNTINGCH_KEY") || has("DFIR_MB_KEY"),
+        crowdstrike: has("DFIR_CROWDSTRIKE_CLIENT_ID") && has("DFIR_CROWDSTRIKE_CLIENT_SECRET"),
+        shodan: has("DFIR_SHODAN_KEY"),
+        misp: has("DFIR_MISP_URL") && has("DFIR_MISP_KEY"),
+        yeti: has("DFIR_YETI_URL") && has("DFIR_YETI_KEY"),
+        opencti: has("DFIR_OPENCTI_URL") && has("DFIR_OPENCTI_KEY"),
+        rockyraccoon: has("DFIR_ROCKYRACCOON_KEY"),
+        geoip: has("DFIR_GEOIP_KEY"),
+      },
+      exposure: {
+        leakcheck: has("DFIR_LEAKCHECK_KEY"),
+        hibp: has("DFIR_HIBP_KEY"),
+        dehashed: has("DFIR_DEHASHED_KEY"),
+        shodan: has("DFIR_SHODAN_KEY"),
+      },
+      nsrl: has("DFIR_NSRL_DB") || has("DFIR_NSRL_FILE") || !!options.nsrlStore,
+    });
+  });
+  // Redirect root to the dashboard.
+  app.get("/", (_req, res) => {
+    res.redirect("/dashboard");
+  });
+
+  // Serve the dashboard.
+  app.get("/dashboard", async (_req, res) => {
+    const html = await readPublicAsset("dashboard.html", "utf8");
+    res.type("html").send(html);
+  });
+
+  // Mobile companion (#59): a read-only, phone-optimized view (timeline / findings / IOCs / status)
+  // for quick glances during IR away from the workstation. It's a PWA — installable via the
+  // web manifest + a minimal service worker (offline app-shell). All three are static files in
+  // public/; the SW is served at root so its default control scope covers /mobile.
+  app.get("/mobile", async (_req, res) => {
+    const html = await readPublicAsset("mobile.html", "utf8");
+    res.type("html").send(html);
+  });
+
+  app.get("/manifest.webmanifest", async (_req, res) => {
+    try {
+      const json = await readPublicAsset("manifest.webmanifest", "utf8");
+      res.type("application/manifest+json").set("Cache-Control", "no-cache").send(json);
+    } catch {
+      res.status(404).end();
+    }
+  });
+
+  app.get("/sw.js", async (_req, res) => {
+    try {
+      const js = await readPublicAsset("sw.js", "utf8");
+      // no-cache + a same-origin allowed scope so the SW can control /mobile even if it's
+      // ever moved into a subdirectory; browsers re-check sw.js on every navigation anyway.
+      res.type("application/javascript").set("Cache-Control", "no-cache").set("Service-Worker-Allowed", "/").send(js);
+    } catch {
+      res.status(404).end();
+    }
+  });
+}

--- a/companion/src/routes/casePassword.ts
+++ b/companion/src/routes/casePassword.ts
@@ -1,0 +1,123 @@
+import type { Express, Request, Response, CookieOptions } from "express";
+import { isValidCaseId } from "../storage/caseStore.js";
+import {
+  hashCasePassword,
+  verifyCasePassword,
+  sanitizeCaseMeta,
+  signUnlockToken,
+  unlockCookieName,
+  MIN_CASE_PASSWORD_LENGTH,
+} from "../analysis/casePassword.js";
+import type { RouteContext } from "./context.js";
+
+// Cookie TTLs for a case-unlock token. Moved verbatim from createApp (they were used only by the
+// unlock route below): a "remember on this computer" unlock is long-lived; a plain unlock rides a
+// session cookie with a 12h backstop. The case-lock GATE (createCaseLockGate, still mounted in
+// server.ts) and readUnlockState (ctx) verify these tokens; they don't need these TTLs.
+const UNLOCK_TTL_REMEMBER_MS = 365 * 24 * 60 * 60 * 1000; // ~1 year — "remember on this computer"
+const UNLOCK_TTL_SESSION_MS = 12 * 60 * 60 * 1000;        // 12h backstop for a browser-session cookie
+
+/**
+ * Case-password protection domain: set / change / clear a case password, unlock a case (issuing the
+ * signed unlock cookie), explicitly forget this browser's unlock, and report lock status. Pure
+ * structural move out of createApp (see routes/system.ts for the conventions) — no handler logic
+ * changed.
+ *
+ * BOUNDARY: the case-lock GATE middleware (app.use("/cases/:id", createCaseLockGate(...))) STAYS in
+ * server.ts — it's middleware, not a route, and it must be mounted before every /cases/:id route.
+ * This module only owns the password/unlock/lock ROUTES.
+ *
+ * Shared surface:
+ *   - store — stable ctx field.
+ *   - instanceSecret — GRADUATED to ctx (a stable readonly value): the HMAC secret that signs/verifies
+ *     unlock cookies. The staying case-lock gate + ctx.readUnlockState both use the SAME secret, so it
+ *     was graduated (not moved) rather than recomputed here; the unlock route signs a fresh token with it.
+ *   - readUnlockState — already-graduated stable helper: reports whether this request already carries a
+ *     valid unlock for a case (and whether it was "remember"-signed), used by the lock-status route.
+ */
+export function registerCasePasswordRoutes(app: Express, ctx: RouteContext): void {
+  const { store, instanceSecret, readUnlockState } = ctx;
+
+  app.get("/cases/:id/lock-status", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const meta = await store.getCaseMeta(id);
+      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
+      const hasPassword = Boolean(meta.password);
+      if (!hasPassword) return res.status(200).json({ hasPassword: false, unlocked: true, remembered: false });
+      const state = readUnlockState(req, id, meta.password!.salt);
+      return res.status(200).json({ hasPassword: true, ...state });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.post("/cases/:id/unlock", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const meta = await store.getCaseMeta(id);
+      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
+      if (!meta.password) return res.status(200).json({ ok: true }); // nothing to unlock
+      const password = (req.body as { password?: unknown })?.password;
+      const remember = (req.body as { remember?: unknown })?.remember === true;
+      if (typeof password !== "string" || !verifyCasePassword(password, meta.password)) {
+        return res.status(401).json({ error: "incorrect password" });
+      }
+      const ttl = remember ? UNLOCK_TTL_REMEMBER_MS : UNLOCK_TTL_SESSION_MS;
+      const token = signUnlockToken(id, meta.password.salt, instanceSecret, ttl, remember);
+      const cookieOpts: CookieOptions = { httpOnly: true, sameSite: "strict", path: "/" };
+      if (remember) cookieOpts.maxAge = ttl;
+      res.cookie(unlockCookieName(id), token, cookieOpts);
+      return res.status(200).json({ ok: true });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.post("/cases/:id/password", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      if (!(await store.caseExists(id))) return res.status(404).json({ error: `case ${id} not found` });
+      const newPassword = (req.body as { newPassword?: unknown })?.newPassword;
+      if (typeof newPassword !== "string" || newPassword.length < MIN_CASE_PASSWORD_LENGTH) {
+        return res.status(400).json({ error: `password must be at least ${MIN_CASE_PASSWORD_LENGTH} characters` });
+      }
+      const password = hashCasePassword(newPassword);
+      const updated = await store.updateCaseMeta(id, { password });
+      // Deliberately does NOT auto-unlock the browser that just set/changed it: setting a
+      // password (or changing one, which rotates the salt and invalidates the caller's own
+      // existing cookie) should require going through the real unlock prompt afterward, same
+      // as anyone else — matching the analyst's expectation that setting a password protects
+      // the case immediately, not just for other people.
+      return res.status(200).json(sanitizeCaseMeta(updated));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.delete("/cases/:id/password", async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      if (!(await store.caseExists(id))) return res.status(404).json({ error: `case ${id} not found` });
+      const updated = await store.updateCaseMeta(id, { password: undefined });
+      res.clearCookie(unlockCookieName(id), { path: "/" });
+      return res.status(200).json(sanitizeCaseMeta(updated));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Explicitly forget THIS browser's unlock for a case, without touching the password
+  // itself. The dashboard calls this when navigating away from a case that was unlocked
+  // without "remember on this computer" — a session cookie survives switching cases within
+  // the same tab (only a real browser close clears it), so without this, a not-remembered
+  // unlock would silently stay valid for the rest of the browser session. No case-existence
+  // check: clearing a cookie that may not exist for a case that may not exist is harmless
+  // and always idempotent, and this route works even while the case is already locked.
+  app.post("/cases/:id/lock", (req: Request, res: Response) => {
+    res.clearCookie(unlockCookieName(req.params.id), { path: "/" });
+    return res.status(200).json({ ok: true });
+  });
+}

--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -4,8 +4,9 @@ import type { Logger } from "../logging/logger.js";
 import type { AppOptions } from "../server.js";
 import type { CaptureMetadata } from "../types.js";
 import type { AiControl } from "../analysis/aiControl.js";
-import type { ImporterRegistry } from "../analysis/importerStore.js";
+import type { ImporterRegistry, ImporterPrecedence } from "../analysis/importerStore.js";
 import type { IrisClient } from "../integrations/iris/irisClient.js";
+import type { TimesketchClient } from "../integrations/timesketch/timesketchClient.js";
 import type { EnrichmentProvider } from "../enrichment/provider.js";
 import type { ProviderHealthCache } from "../enrichment/providerHealth.js";
 import type { NsrlDb } from "../analysis/nsrlDb.js";
@@ -53,6 +54,10 @@ export interface RouteContext {
   readonly appStartedAt: number;
   readonly recentImportFailures: ImporterFailure[]; // diagnostics ring, mutated in place by recordImportFailure
   readonly recentAiErrors: AiError[]; // diagnostics ring, mutated in place by recordAiError
+  // The HMAC secret (persisted next to the cases root) that signs/verifies case-unlock cookies. Graduated
+  // for routes/casePassword.ts's unlock route: the staying case-lock GATE (createCaseLockGate) + readUnlockState
+  // use the SAME secret, so it's graduated (a stable readonly value), not recomputed per module.
+  readonly instanceSecret: Buffer;
 
   // ── Stable helper methods ────────────────────────────────────────────────────────────
   // Pure/stateless-facing helpers bound at construction; safe to destructure at registration scope.
@@ -60,6 +65,20 @@ export interface RouteContext {
   recordAiError(caseId: string, phase: string, err: unknown): void;
   readUnlockState(req: Request, id: string, salt: string): { unlocked: boolean; remembered: boolean };
   hasAiProvider(): boolean;
+  // Per-case state mutex + drop-folder + importer-reload helpers graduated for routes/caseLifecycle.ts.
+  // All defined in createApp and SHARED with code that stays (the state lock backs every import/enrich/
+  // synthesis write; the drop watcher re-ensures the inbox; dispatchImport/resolveImportKind read the
+  // in-memory importer registry + precedence that reloadImporters/setImporterPrecedence mutate), so they
+  // were graduated rather than moved. runStateExclusive is a `const` arrow bound at construction;
+  // ensureDropFolders/reloadImporters are hoisted `async function` declarations (safe to bind before
+  // their textual definition, like the velociraptor set):
+  //   runStateExclusive  — serialize a case's load→save critical section (manual-event add here).
+  //   ensureDropFolders  — create the evidence drop inbox for a case (fired on case creation).
+  //   reloadImporters    — re-read the on-disk declarative-importer registry into the in-memory copy +
+  //                        precedence, then fire onImporters (the importer CRUD writes call it).
+  runStateExclusive<T>(caseId: string, fn: () => Promise<T>): Promise<T>;
+  ensureDropFolders(caseId: string): Promise<void>;
+  reloadImporters(): Promise<void>;
   // Capture→analyze machinery shared with the drop-watch ingest path and the AI-control routes
   // (all still in createApp). Graduated for routes/captures.ts's POST /captures handler:
   //   getControl         — read the per-case AI on/off + last-analyzed-seq control record.
@@ -202,6 +221,12 @@ export interface RouteContext {
   captureBuffers(): Map<string, CaptureMetadata[]>;
   synthInFlight(): Set<string>;
   importerRegistry(): ImporterRegistry;
+  // The active importer precedence (builtin-first / external-first). A `let` in createApp read live by
+  // dispatchImport/resolveImportKind (stay) and the moved GET /importers route; PUT /importers/precedence
+  // rewrites it via setImporterPrecedence. Read via importerPrecedence() INSIDE the handler (mirrors
+  // importerRegistry()); the setter reassigns the SAME createApp binding the detection seam reads.
+  importerPrecedence(): ImporterPrecedence;
+  setImporterPrecedence(precedence: ImporterPrecedence): void;
   irisClient(): IrisClient | undefined;
   // The DFIR-IRIS client is a MUTABLE shared handle: POST /iris/reconnect (routes/reportsExport.ts)
   // rebuilds it at runtime and createApp's /cases/:id/push/iris reads it. Mirrors nsrlDb()/setNsrlDb():
@@ -212,6 +237,12 @@ export interface RouteContext {
   //                       inside server.ts (no route module imports a value from ../server.js).
   setIrisClient(client: IrisClient | undefined): void;
   rebuildIrisClient(): IrisClient | undefined;
+  // Rebuild the Timesketch client from the current .env (mirrors rebuildIrisClient). Graduated for
+  // routes/caseLifecycle.ts's POST /timesketch/reconnect, which reassigns options.timesketchClient with the
+  // result; the timesketch push routes read options.timesketchClient live. Wraps createApp's
+  // `options.rebuildTimesketchClient ?? buildTimesketchClient` so buildTimesketchClient's use stays in
+  // server.ts (no route module imports a value from ../server.js). Call INSIDE the handler.
+  rebuildTimesketchClient(): TimesketchClient | undefined;
   dropWatchEnabled(): boolean;
   enrichmentProviders(): EnrichmentProvider[];
   enrichHealth(): ProviderHealthCache;

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -29,6 +29,8 @@ import { registerFindingsRoutes } from "./routes/findings.js";
 import { registerPlaybookHuntsRoutes } from "./routes/playbookHunts.js";
 import { registerAiSynthesisRoutes } from "./routes/aiSynthesis.js";
 import { registerReportsExportRoutes } from "./routes/reportsExport.js";
+import { registerCasePasswordRoutes } from "./routes/casePassword.js";
+import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
 import { AiControlStore, type AiControl } from "./analysis/aiControl.js";
 import { JobManager } from "./analysis/jobManager.js";
@@ -41,7 +43,6 @@ import { extractOcrText, isOcrSearchEnabled } from "./analysis/ocrSearch.js";
 import { FalsePositiveStore, markerId, type FalsePositiveMarker } from "./analysis/falsePositive.js";
 import { ScopeStore, type ScopeWindow } from "./analysis/scope.js";
 import { CorrelationProfileStore } from "./analysis/correlationProfile.js";
-import { DecryptionError } from "./analysis/caseEncryption.js";
 import {
   exportEncryptedCase,
   importEncryptedCase,
@@ -50,15 +51,10 @@ import {
   dfircaseFilename,
 } from "./analysis/caseExportArchive.js";
 import {
-  hashCasePassword,
-  verifyCasePassword,
-  sanitizeCaseMeta,
-  signUnlockToken,
   verifyUnlockToken,
   isRememberedUnlockToken,
   unlockCookieName,
   parseCookieHeader,
-  MIN_CASE_PASSWORD_LENGTH,
 } from "./analysis/casePassword.js";
 import { loadOrCreateInstanceSecret } from "./analysis/instanceSecret.js";
 import { createCaseLockGate } from "./analysis/caseLockGate.js";
@@ -67,9 +63,7 @@ import { resolveHuntPlatforms, type HuntPlatform } from "./analysis/huntPlatform
 import { parseVelociraptorJson } from "./analysis/velociraptorImport.js";
 import { detectImportWithCustom } from "./analysis/importDetect.js";
 import { ImporterStore, type ImporterRegistry, type ImporterPrecedence } from "./analysis/importerStore.js";
-import { parseImporterSpec } from "./analysis/importerSpec.js";
-import { getImporterPrompt } from "./analysis/pipeline.js";
-import { getEnvForSettings, updateEnv as updateEnvFile, reloadEnvPrefix, resolveEnvFilePath } from "./settings/envManager.js";
+import { resolveEnvFilePath } from "./settings/envManager.js";
 import { applySeverityFloor } from "./analysis/severityFloor.js";
 import { enrichIocs, hasEnrichableWork, type EnrichLookupEvent } from "./enrichment/enrichService.js";
 import { EnrichControlStore, resolveEnabledProviders } from "./enrichment/enrichControl.js";
@@ -92,7 +86,7 @@ import { buildTlsFetch } from "./enrichment/tlsFetch.js";
 import { validateProcessChains, hasChainWork, type ChainSummary } from "./enrichment/chainValidate.js";
 import type { AnalysisPipeline } from "./analysis/pipeline.js";
 import type { InvestigationState, Severity, ForensicEvent, IOC, Finding } from "./analysis/stateTypes.js";
-import type { CaptureMetadata, ImportMetadata } from "./types.js";
+import type { CaptureMetadata } from "./types.js";
 import type { StateStore } from "./analysis/stateStore.js";
 import type { ReportWriter } from "./reports/reportWriter.js";
 import type { IocBlocklistFormat, IocBlocklistOptions, BlocklistIocType } from "./reports/iocBlocklist.js";
@@ -100,7 +94,7 @@ import { ReportMetaStore } from "./reports/reportMeta.js";
 import { ReportTemplateStore } from "./reports/reportTemplateStore.js";
 import { ReportTemplateControlStore } from "./reports/reportTemplateControl.js";
 import { DashboardViewStore } from "./analysis/dashboardViewStore.js";
-import { ActivityLogStore, ACTIVITY_CATEGORIES, logActivity, type ActivityCategory } from "./analysis/activityLog.js";
+import { ActivityLogStore } from "./analysis/activityLog.js";
 import { CommentsStore } from "./analysis/comments.js";
 import { TagsStore, type Tag } from "./analysis/tags.js";
 import { PinnedFindingsStore } from "./analysis/pinnedFindings.js";
@@ -108,7 +102,6 @@ import { NotebookStore } from "./analysis/notebookStore.js";
 import { HypothesisStore } from "./analysis/hypothesisStore.js";
 import { DwellWindowStore } from "./analysis/dwellWindowStore.js";
 import { SuperTimelineStore } from "./analysis/superTimelineStore.js";
-import { computeCaseStats } from "./analysis/caseStats.js";
 import { ForensicGateControlStore } from "./analysis/forensicGateControl.js";
 import { demoteBelowSeverity, resolveForensicMinSeverity } from "./analysis/forensicGate.js";
 import { ConfidenceControlStore } from "./analysis/confidenceControl.js";
@@ -135,7 +128,7 @@ import {
 import { spawnToolRunner, type ToolRunner } from "./integrations/tools/toolRunner.js";
 import { runToolAgainstFile, resolveContainedPath } from "./integrations/tools/runToolImport.js";
 import { CustomToolStore, customToolToConfig, normalizeExt, type CustomTool } from "./integrations/tools/customToolStore.js";
-import { TemplateStore, buildInitialQuestions, buildInitialNextSteps } from "./analysis/templateStore.js";
+import { TemplateStore } from "./analysis/templateStore.js";
 import { diffTimeline, addedForensicEvents } from "./analysis/timelineDiff.js";
 import { diffIocs } from "./analysis/iocsDiff.js";
 import { ImportUndoStore, pushCheckpoint } from "./analysis/importUndo.js";
@@ -156,12 +149,10 @@ import { StateLock } from "./analysis/stateLock.js";
 import { NsrlDb, loadNsrlDbPath } from "./analysis/nsrlDb.js";
 import { applyDeobfuscation } from "./analysis/applyDeobfuscation.js";
 import { readPublicAsset, isSeaRuntime } from "./serverAssets.js";
-import { buildManualEvent } from "./analysis/manualEntry.js";
 import {
   CustomerExposureStore,
   type CustomerExposureProvider,
 } from "./analysis/customerExposure.js";
-import { byEventTime } from "./analysis/forensicSort.js";
 import { IrisClient } from "./integrations/iris/irisClient.js";
 import { VelociraptorClient, buildVelociraptorClient, ALL_CLIENTS, type HuntUpload } from "./integrations/velociraptor/velociraptorApi.js";
 import { ArtifactBundleStore } from "./analysis/artifactBundleStore.js";
@@ -171,21 +162,19 @@ import { VeloMonitorStore, monitorId, type VeloMonitor } from "./analysis/veloMo
 import { pollMonitorOnce, monitorArtifactMap, type PollDeps } from "./integrations/velociraptor/monitorPoller.js";
 import { pollHuntStatusOnce, isHuntStoppedEarly, type HuntPollDeps } from "./integrations/velociraptor/huntStatusPoller.js";
 import { PushTokenStore } from "./analysis/pushTokenStore.js";
-import { pushCaseToIris, type IrisPushOptions } from "./integrations/iris/irisPush.js";
-import { IrisExportStore, defaultIrisCaseName } from "./integrations/iris/irisExportStore.js";
+import { type IrisPushOptions } from "./integrations/iris/irisPush.js";
+import { IrisExportStore } from "./integrations/iris/irisExportStore.js";
 import { TimesketchClient } from "./integrations/timesketch/timesketchClient.js";
-import { pushCaseToTimesketch, pushSuperTimelineToTimesketch, type TimesketchPushOptions } from "./integrations/timesketch/timesketchPush.js";
+import { type TimesketchPushOptions } from "./integrations/timesketch/timesketchPush.js";
 import { MispPushClient } from "./integrations/misp/mispPushClient.js";
-import { pushCaseToMisp, type MispPushOptions } from "./integrations/misp/mispPush.js";
-import { NotionClient, parseNotionPageId } from "./integrations/notion/notionClient.js";
-import { pushCaseToNotion, type NotionPushOptions, type NotionPushTarget } from "./integrations/notion/notionPush.js";
+import { type MispPushOptions } from "./integrations/misp/mispPush.js";
+import { NotionClient } from "./integrations/notion/notionClient.js";
+import { type NotionPushOptions } from "./integrations/notion/notionPush.js";
 import { NotionExportStore } from "./integrations/notion/notionExportStore.js";
 import { ClickUpClient } from "./integrations/clickup/clickupClient.js";
 import { ClickUpExportStore } from "./integrations/clickup/clickupExportStore.js";
-import { pushPlaybookToClickUp } from "./integrations/clickup/clickupPush.js";
 import type { ImporterFailure, AiError } from "./analysis/diagnostics.js";
 import type { PreflightReport } from "./analysis/preflight.js";
-import { archiveCase } from "./analysis/caseArchive.js";
 import { NotificationConfigStore } from "./analysis/notificationStore.js";
 import { seedDemoCase } from "./analysis/seedDemoCase.js";
 import {
@@ -216,7 +205,6 @@ export function setServerLogger(logger: Logger): void { serverLogger = logger; }
 export function getServerLogger(): Logger { return serverLogger; }
 function logLine(msg: string): void { serverLogger.info(msg); }
 function warnLine(msg: string): void { serverLogger.warn(msg); }
-function errLine(msg: string): void { serverLogger.error(msg); }
 
 // Truncate a long indicator (e.g. a SHA-256) for a readable one-line log entry.
 function shortValue(value: string): string {
@@ -645,9 +633,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // matching. See docs/superpowers/specs/2026-07-09-case-password-protection-design.md.
   app.use("/cases/:id", createCaseLockGate(store, instanceSecret));
 
-  const UNLOCK_TTL_REMEMBER_MS = 365 * 24 * 60 * 60 * 1000; // ~1 year — "remember on this computer"
-  const UNLOCK_TTL_SESSION_MS = 12 * 60 * 60 * 1000;        // 12h backstop for a browser-session cookie
-
   // Whether this request already carries a valid unlock for `id` (used by /lock-status), and
   // whether that unlock — if present — was signed with "remember on this computer". The
   // dashboard needs the latter to know whether it's safe to explicitly forget the unlock when
@@ -672,6 +657,20 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     recentImportFailures,
     recentAiErrors,
     hasAiProvider,
+    // Case-lifecycle graduations (routes/caseLifecycle.ts + routes/casePassword.ts): the unlock-cookie
+    // secret, the per-case state mutex, the drop-inbox creator, the importer registry-reload + precedence
+    // accessor/setter, and the runtime Timesketch-client rebuild — all shared with code that STAYS in
+    // createApp (see context.ts for why each was graduated rather than moved). instanceSecret +
+    // runStateExclusive are bound at construction (defined above); ensureDropFolders/reloadImporters are
+    // hoisted async functions; importerPrecedence is a live accessor over the `let` below; buildTimesketchClient
+    // is a module-level function (kept in server.ts so no route imports a value from ../server.js).
+    instanceSecret,
+    runStateExclusive,
+    ensureDropFolders,
+    reloadImporters,
+    importerPrecedence: () => importerPrecedence,
+    setImporterPrecedence: (precedence) => { importerPrecedence = precedence; },
+    rebuildTimesketchClient: () => (options.rebuildTimesketchClient ?? buildTimesketchClient)(),
     getControl,
     setControl,
     backfill,
@@ -750,89 +749,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerPlaybookHuntsRoutes(app, ctx);
   registerAiSynthesisRoutes(app, ctx);
   registerReportsExportRoutes(app, ctx);
-
-  app.get("/cases/:id/lock-status", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      const meta = await store.getCaseMeta(id);
-      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
-      const hasPassword = Boolean(meta.password);
-      if (!hasPassword) return res.status(200).json({ hasPassword: false, unlocked: true, remembered: false });
-      const state = readUnlockState(req, id, meta.password!.salt);
-      return res.status(200).json({ hasPassword: true, ...state });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.post("/cases/:id/unlock", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      const meta = await store.getCaseMeta(id);
-      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
-      if (!meta.password) return res.status(200).json({ ok: true }); // nothing to unlock
-      const password = (req.body as { password?: unknown })?.password;
-      const remember = (req.body as { remember?: unknown })?.remember === true;
-      if (typeof password !== "string" || !verifyCasePassword(password, meta.password)) {
-        return res.status(401).json({ error: "incorrect password" });
-      }
-      const ttl = remember ? UNLOCK_TTL_REMEMBER_MS : UNLOCK_TTL_SESSION_MS;
-      const token = signUnlockToken(id, meta.password.salt, instanceSecret, ttl, remember);
-      const cookieOpts: CookieOptions = { httpOnly: true, sameSite: "strict", path: "/" };
-      if (remember) cookieOpts.maxAge = ttl;
-      res.cookie(unlockCookieName(id), token, cookieOpts);
-      return res.status(200).json({ ok: true });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.post("/cases/:id/password", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
-      if (!(await store.caseExists(id))) return res.status(404).json({ error: `case ${id} not found` });
-      const newPassword = (req.body as { newPassword?: unknown })?.newPassword;
-      if (typeof newPassword !== "string" || newPassword.length < MIN_CASE_PASSWORD_LENGTH) {
-        return res.status(400).json({ error: `password must be at least ${MIN_CASE_PASSWORD_LENGTH} characters` });
-      }
-      const password = hashCasePassword(newPassword);
-      const updated = await store.updateCaseMeta(id, { password });
-      // Deliberately does NOT auto-unlock the browser that just set/changed it: setting a
-      // password (or changing one, which rotates the salt and invalidates the caller's own
-      // existing cookie) should require going through the real unlock prompt afterward, same
-      // as anyone else — matching the analyst's expectation that setting a password protects
-      // the case immediately, not just for other people.
-      return res.status(200).json(sanitizeCaseMeta(updated));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.delete("/cases/:id/password", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
-      if (!(await store.caseExists(id))) return res.status(404).json({ error: `case ${id} not found` });
-      const updated = await store.updateCaseMeta(id, { password: undefined });
-      res.clearCookie(unlockCookieName(id), { path: "/" });
-      return res.status(200).json(sanitizeCaseMeta(updated));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Explicitly forget THIS browser's unlock for a case, without touching the password
-  // itself. The dashboard calls this when navigating away from a case that was unlocked
-  // without "remember on this computer" — a session cookie survives switching cases within
-  // the same tab (only a real browser close clears it), so without this, a not-remembered
-  // unlock would silently stay valid for the rest of the browser session. No case-existence
-  // check: clearing a cookie that may not exist for a case that may not exist is harmless
-  // and always idempotent, and this route works even while the case is already locked.
-  app.post("/cases/:id/lock", (req: Request, res: Response) => {
-    res.clearCookie(unlockCookieName(req.params.id), { path: "/" });
-    return res.status(200).json({ ok: true });
-  });
+  // Case-password routes first (mirrors their original registration order, right after the case-lock gate),
+  // then the case-core catch-all (lifecycle, archives, integration pushes, importers, jobs, settings, static
+  // app shell). Both register before the terminal error handler at the end of createApp.
+  registerCasePasswordRoutes(app, ctx);
+  registerCaseLifecycleRoutes(app, ctx);
 
   const windowSize = options.windowSize ?? 4;
   const buffers = new Map<string, CaptureMetadata[]>();
@@ -1039,438 +960,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       options.onAiStatus?.(caseId, { status: "error", at: new Date().toISOString(), detail: (err as Error).message });
     }
   }
-
-  // List existing cases (newest first) so the extension can present a picker of cases
-  // to attach to — case CREATION lives in the dashboard, the extension only connects.
-  app.get("/cases", async (_req: Request, res: Response) => {
-    try {
-      return res.status(200).json((await store.listCases()).map(sanitizeCaseMeta));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Create a case. This is the one place a case is born (the dashboard's New case form and
-  // `npm run`-style tooling call it); the extension no longer creates cases. Rejects a
-  // duplicate id so the form can't silently clobber an existing case's metadata/evidence.
-  // Optional `templateId`: pre-populates key questions from the named template.
-  app.post("/cases", async (req: Request, res: Response) => {
-    try {
-      const { caseId, name, investigator, aiProvider, templateId } = req.body ?? {};
-      if (!caseId || !name) return res.status(400).json({ error: "caseId and name are required" });
-      if (typeof caseId !== "string" || !isValidCaseId(caseId)) return res.status(400).json({ error: "caseId must use only letters, numbers, dots, dashes, or underscores, and may not contain path traversal" });
-      if (await store.caseExists(caseId)) return res.status(409).json({ error: `case ${caseId} already exists` });
-      const meta = await store.createCase({
-        caseId, name, investigator: investigator ?? "unknown", aiProvider: aiProvider ?? null,
-      });
-      if (templateId && options.templateStore && options.stateStore) {
-        const template = await options.templateStore.get(String(templateId));
-        if (template && (template.initialKeyQuestions.length || template.initialNextSteps?.length)) {
-          const state = await options.stateStore.load(caseId);
-          if (template.initialKeyQuestions.length) state.keyQuestions = buildInitialQuestions(template);
-          if (template.initialNextSteps?.length) state.nextSteps = buildInitialNextSteps(template);
-          state.updatedAt = new Date().toISOString();
-          await options.stateStore.save(state);
-        }
-      }
-      dispatchNotify(milestoneEvent(caseId, `Investigation opened: ${name}`, [`Investigator: ${investigator ?? "unknown"}`], new Date().toISOString()));
-      // Create the evidence drop folder for every new case (best-effort — never block case creation).
-      await ensureDropFolders(caseId).catch(() => { /* the watcher re-ensures on its next poll */ });
-      return res.status(201).json(sanitizeCaseMeta(meta));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Seed the built-in demo case ("GlobalTech Industries — BEC & Ransomware Precursor").
-  // Accepts optional { caseId?: string, force?: boolean } in the body.
-  // Returns 409 when the case already exists and force is not set; 201 on success.
-  // Available in both the dev server and the portable EXE so users don't need tsx/Node installed.
-  app.post("/cases/seed-demo", async (req: Request, res: Response) => {
-    try {
-      const caseId = typeof req.body?.caseId === "string" ? req.body.caseId : undefined;
-      const force  = req.body?.force === true;
-      const result = await seedDemoCase(store.casesRoot, { caseId, force });
-      return res.status(201).json(result);
-    } catch (err) {
-      const e = err as NodeJS.ErrnoException;
-      if (e.code === "EEXIST") return res.status(409).json({ error: e.message });
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // ── Case lifecycle (#119) ──────────────────────────────────────────────────────────────
-  // Set a case's lifecycle status (open / closed). A closed case is eligible for archiving.
-  app.patch("/cases/:id/status", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
-      if (!await store.caseExists(id)) return res.status(404).json({ error: `case ${id} not found` });
-      const { status } = req.body ?? {};
-      if (status !== "open" && status !== "closed") return res.status(400).json({ error: "status must be 'open' or 'closed'" });
-      const updated = await store.updateCaseMeta(id, { status });
-      logLine(`[lifecycle] case=${id} status=${status}`);
-      return res.status(200).json(sanitizeCaseMeta(updated));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Best-effort: moves a case out of the active list (into _archived/) and flips its status,
-  // AFTER the caller has already fully built the archive/export bytes. Failure here must NOT
-  // undo or discard the archive/export itself — the caller already has (or is about to send)
-  // their file; it just means the case stays visible in the active list until retried.
-  async function removeCaseFromActiveListBestEffort(
-    id: string,
-    logPrefix: string,
-  ): Promise<{ removed: boolean; error?: string }> {
-    try {
-      await store.archiveCaseFolder(id);
-      await store.updateCaseMeta(id, { status: "archived" });
-      logLine(`${logPrefix} case=${id} removed from active list (moved to _archived/)`);
-      return { removed: true };
-    } catch (err) {
-      errLine(`${logPrefix} case=${id} failed to remove from active list: ${(err as Error).message}`);
-      return { removed: false, error: (err as Error).message };
-    }
-  }
-
-  // Archive a case to a ZIP file (<casesRoot>/<caseId or name> (no password).zip). Intended for
-  // closed cases. Returns the archive path and a manifest of archived files + checksums. With
-  // { removeFromList: true }, additionally moves the case folder to _archived/ and sets
-  // status: "archived" — non-destructive and reversible via POST /cases/:id/restore.
-  app.post("/cases/:id/archive", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
-      const meta = await store.getCaseMeta(id);
-      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
-      if (meta.status === "archived") return res.status(400).json({ error: `case ${id} is already archived` });
-      const removeFromList = (req.body as { removeFromList?: unknown })?.removeFromList === true;
-      logLine(`[archive] starting archive for case=${id}`);
-      const result = await archiveCase(store.casesRoot, id, {}, meta.name, store.caseDir(id));
-      logLine(`[archive] done case=${id} files=${result.manifest.totalFiles} bytes=${result.manifest.totalBytes} path=${result.archivePath}`);
-      let removedFromList = false;
-      let removeFromListError: string | undefined;
-      if (removeFromList) {
-        const outcome = await removeCaseFromActiveListBestEffort(id, "[archive]");
-        removedFromList = outcome.removed;
-        removeFromListError = outcome.error;
-      }
-      return res.status(200).json({
-        ...result,
-        removedFromList,
-        ...(removeFromListError ? { removeFromListError } : {}),
-      });
-    } catch (err) {
-      errLine(`[archive] error case=${req.params.id}: ${(err as Error).message}`);
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Restore a case previously archived via the removeFromList option: moves it back from
-  // _archived/ into the active cases root and sets status to "closed" (the state it must have
-  // been in to be archived) — use PATCH /cases/:id/status afterward to reopen it if needed.
-  app.post("/cases/:id/restore", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
-      const meta = await store.getCaseMeta(id);
-      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
-      if (meta.status !== "archived") return res.status(400).json({ error: `case ${id} is not archived` });
-      await store.restoreCaseFolder(id);
-      const updated = await store.updateCaseMeta(id, { status: "closed" });
-      logLine(`[restore] case=${id} restored from _archived/`);
-      return res.status(200).json(updated);
-    } catch (err) {
-      errLine(`[restore] error case=${req.params.id}: ${(err as Error).message}`);
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Best-effort: permanently deletes a case's folder AFTER the caller has already fully built any
-  // requested archive. Failure here must NOT be treated as though the archive itself failed — the
-  // caller already has (or is about to send) that file; this just means the case's folder remains
-  // on disk until deletion is retried.
-  async function deleteCaseFolderBestEffort(id: string): Promise<{ deleted: boolean; error?: string }> {
-    try {
-      await store.deleteCaseFolder(id);
-      logLine(`[delete] case=${id} deleted`);
-      return { deleted: true };
-    } catch (err) {
-      const message = (err as Error).message;
-      errLine(`[delete] case=${id} failed to delete: ${message}`);
-      return { deleted: false, error: message };
-    }
-  }
-
-  // Permanently delete a case: optionally archives it first (ZIP or encrypted), then removes its
-  // folder from disk entirely — irreversible. Only allowed once a case is closed or archived (an
-  // open case must be closed first, mirroring the restriction on archiving). If the archive step
-  // is requested and succeeds but the delete step then fails, the response still reflects the
-  // successful archive (never silently discarded) — same principle as
-  // removeCaseFromActiveListBestEffort above.
-  // Known limitation: per-case in-memory state (capture buffers, synth timers/in-flight flags,
-  // Velociraptor hunt timers, drop-folder scan trackers — all keyed by caseId) is never explicitly
-  // cleared on delete, same pre-existing gap as archiveCaseFolder. A write already in flight when
-  // a case is closed→archived→deleted in quick succession could still try to touch the now-gone
-  // folder and error out. Accepted for now (writes are already blocked once closed/archived; this
-  // is a single-user localhost tool) — not fixed here to avoid scope creep into unrelated timers.
-  app.post("/cases/:id/delete", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
-      const meta = await store.getCaseMeta(id);
-      if (!meta) return res.status(404).json({ error: `case ${id} not found` });
-      if (meta.status !== "closed" && meta.status !== "archived") {
-        return res.status(400).json({ error: `case ${id} must be closed or archived before it can be deleted` });
-      }
-      const body = (req.body ?? {}) as { archiveFirst?: unknown; password?: unknown };
-      const archiveFirst = body.archiveFirst;
-      if (archiveFirst !== "none" && archiveFirst !== "zip" && archiveFirst !== "encrypted") {
-        return res.status(400).json({ error: `archiveFirst must be 'none', 'zip', or 'encrypted'` });
-      }
-
-      if (archiveFirst === "encrypted") {
-        const password = body.password;
-        if (typeof password !== "string" || password.length < MIN_PASSWORD_LENGTH) {
-          return res.status(400).json({ error: `password must be at least ${MIN_PASSWORD_LENGTH} characters` });
-        }
-        const archive = await exportEncryptedCase(store, id, password);
-        const filename = dfircaseFilename(id, meta.name);
-        const { deleted } = await deleteCaseFolderBestEffort(id);
-        res.type("application/octet-stream");
-        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
-        res.setHeader("Cache-Control", "private, no-cache");
-        res.setHeader("X-Case-Deleted", String(deleted));
-        return res.send(archive);
-      }
-
-      let archiveResult: Awaited<ReturnType<typeof archiveCase>> | undefined;
-      if (archiveFirst === "zip") {
-        archiveResult = await archiveCase(store.casesRoot, id, {}, meta.name, store.caseDir(id));
-        logLine(`[delete] case=${id} archived to ZIP before deletion: ${archiveResult.archivePath}`);
-      }
-
-      const { deleted, error: deleteError } = await deleteCaseFolderBestEffort(id);
-
-      return res.status(200).json({
-        deleted,
-        ...(deleteError ? { deleteError } : {}),
-        ...(archiveResult ? { archivePath: archiveResult.archivePath, manifest: archiveResult.manifest } : {}),
-      });
-    } catch (err) {
-      if ((err as Error).message.includes("does not exist")) {
-        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
-      }
-      errLine(`[delete] error case=${req.params.id}: ${(err as Error).message}`);
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.get("/cases/:id/state", async (req: Request, res: Response) => {
-    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
-    try {
-      if (!(await store.caseExists(req.params.id))) {
-        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
-      }
-      const state = await options.stateStore.load(req.params.id);
-      return res.status(200).json(state);
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Per-IOC corroboration: { iocId: [tools that observed it] }, derived on demand by matching each
-  // IOC value against the forensic events' sources (same scope/legitimate filtering as the report).
-  // Powers the dashboard's "⊕ N sources" badge on IOCs (#35 Phase 3).
-  // Case introspection stats (#241): totals, event-count-by-source, and daily import velocity for
-  // the CURRENT case only — powers the Diagnostics tab "Case Statistics" panel. Derived on read,
-  // no caching (same as host-ranking below). Disk usage is intentionally NOT included here — it's
-  // global, not per-case, and already served by GET /disk-stats.
-  app.get("/cases/:id/stats", async (req: Request, res: Response) => {
-    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
-    try {
-      if (!(await store.caseExists(req.params.id))) {
-        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
-      }
-      const state = await options.stateStore.load(req.params.id);
-      const importLog: ImportMetadata[] = [];
-      try {
-        const log = await readFile(store.importsLogPath(req.params.id), "utf8");
-        for (const line of log.split("\n")) {
-          const trimmed = line.trim();
-          if (!trimmed) continue;
-          try { importLog.push(JSON.parse(trimmed) as ImportMetadata); } catch { /* skip a malformed audit line */ }
-        }
-      } catch { /* no imports for this case yet */ }
-      return res.status(200).json(computeCaseStats(state, importLog));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Export a clean IOC block-list for network/firewall teams (issue #87). Supports three formats:
-  // txt (one value per line, grouped by type, with header comments), csv (minimal columnar format
-  // for TIP ingestion/ticketing), and stix (indicators-only STIX 2.1 bundle). Severity is derived
-  // from the worst enrichment verdict; scope/legitimate filters always apply.
-  //
-  // Query params: format (txt|csv|stix, default txt), minSeverity (Critical|High|Medium|Low|Info,
-  // default Medium), types (comma-separated ip,domain,url,hash,email), verdictOnly (true|false).
-  app.get("/cases/:id/export/ioc-blocklist", async (req: Request, res: Response) => {
-    if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
-    const fmt = String(req.query.format ?? "txt");
-    if (fmt !== "txt" && fmt !== "csv" && fmt !== "stix") {
-      return res.status(400).json({ error: "format must be txt, csv, or stix" });
-    }
-    const opts: IocBlocklistOptions = {};
-    const VALID_SEV: Severity[] = ["Critical", "High", "Medium", "Low", "Info"];
-    const VALID_TYPES: BlocklistIocType[] = ["ip", "domain", "url", "hash", "email"];
-    const { minSeverity, types, verdictOnly } = req.query;
-    if (typeof minSeverity === "string" && VALID_SEV.includes(minSeverity as Severity)) {
-      opts.minSeverity = minSeverity as Severity;
-    }
-    if (typeof types === "string" && types) {
-      opts.types = types.split(",").filter((t): t is BlocklistIocType => VALID_TYPES.includes(t as BlocklistIocType));
-    }
-    if (verdictOnly === "true") opts.verdictOnly = true;
-    try {
-      const data = await options.reportWriter.iocBlocklist(req.params.id, fmt as IocBlocklistFormat, opts);
-      const cid = req.params.id;
-      res.setHeader("Cache-Control", "private, no-cache");
-      if (fmt === "stix") {
-        res.type("application/json; charset=utf-8");
-        res.setHeader("Content-Disposition", `attachment; filename="ioc-blocklist-${cid}.stix.json"`);
-        return res.send(JSON.stringify(data, null, 2));
-      } else if (fmt === "csv") {
-        res.type("text/csv; charset=utf-8");
-        res.setHeader("Content-Disposition", `attachment; filename="ioc-blocklist-${cid}.csv"`);
-        return res.send(data as string);
-      } else {
-        res.type("text/plain; charset=utf-8");
-        res.setHeader("Content-Disposition", `attachment; filename="ioc-blocklist-${cid}.txt"`);
-        return res.send(data as string);
-      }
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Export the ENTIRE case as a password-encrypted archive (replaces issue #56's JSON-only
-  // snapshot, which never included screenshots or raw evidence bytes — only references to them).
-  // The whole case directory is zipped, then AES-256-GCM encrypted under a password the analyst
-  // chooses. Only openable via another DFIR Companion's Import (see analysis/caseEncryption.ts +
-  // caseExportArchive.ts). Password travels in the POST body, not the URL/query string.
-  app.post("/cases/:id/export/encrypted", async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
-      const password = (req.body as { password?: unknown })?.password;
-      if (typeof password !== "string" || password.length < MIN_PASSWORD_LENGTH) {
-        return res.status(400).json({ error: `password must be at least ${MIN_PASSWORD_LENGTH} characters` });
-      }
-      const meta = await store.getCaseMeta(id);
-      if (meta?.status === "archived") return res.status(400).json({ error: `case ${id} is already archived` });
-      const removeFromList = (req.body as { removeFromList?: unknown })?.removeFromList === true;
-      const archive = await exportEncryptedCase(store, id, password);
-      const filename = dfircaseFilename(id, meta?.name);
-      let removedFromList = false;
-      if (removeFromList) {
-        const outcome = await removeCaseFromActiveListBestEffort(id, "[export]");
-        removedFromList = outcome.removed;
-      }
-      res.type("application/octet-stream");
-      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
-      res.setHeader("Cache-Control", "private, no-cache");
-      res.setHeader("X-Case-Removed-From-List", String(removedFromList));
-      return res.send(archive);
-    } catch (err) {
-      if ((err as Error).message.includes("does not exist")) {
-        return res.status(404).json({ error: `case ${req.params.id} does not exist` });
-      }
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Import a `.dfircase` encrypted archive into a NEW case (replaces issue #56's snapshot
-  // import). Body: { data: base64, password, targetCaseId? } — base64-in-JSON, matching this
-  // codebase's existing convention for binary uploads elsewhere (no multipart/multer). 409 if the
-  // target id already exists (the dashboard re-prompts with a new id), 400 on a wrong password,
-  // corrupt archive, or malformed payload.
-  app.post("/cases/import/encrypted", async (req: Request, res: Response) => {
-    try {
-      const body = (req.body ?? {}) as Record<string, unknown>;
-      const { data, password, targetCaseId } = body;
-      if (typeof data !== "string" || !data.trim()) {
-        return res.status(400).json({ error: "data (base64) is required" });
-      }
-      if (typeof password !== "string" || !password) {
-        return res.status(400).json({ error: "password is required" });
-      }
-      const fileBuffer = Buffer.from(data, "base64");
-      const { meta, counts } = await importEncryptedCase(store, fileBuffer, password, {
-        targetCaseId: typeof targetCaseId === "string" && targetCaseId.trim() ? targetCaseId.trim() : undefined,
-      });
-      // An archived case.json is written back byte-for-byte on import (see
-      // caseExportArchive.ts), so an exported case that had a case-lock password carries
-      // its salt+hash into the archive. Sanitize before responding — never let it reach
-      // the client, same as every other route that serializes a CaseMeta.
-      return res.status(201).json({ ...sanitizeCaseMeta(meta), counts });
-    } catch (err) {
-      if (err instanceof CaseImportConflictError) {
-        return res.status(409).json({ error: err.message, caseId: err.caseId });
-      }
-      if (err instanceof DecryptionError) {
-        return res.status(400).json({ error: err.message });
-      }
-      const msg = (err as Error).message;
-      if (/not a valid case archive|invalid target case id/i.test(msg)) {
-        return res.status(400).json({ error: msg });
-      }
-      return res.status(500).json({ error: msg });
-    }
-  });
-
-  // ── State backups (#180) ─────────────────────────────────────────────────────────────────────
-  // Automatic snapshots of SNAPSHOT_STATE_FILES before synthesis + on a timer.
-  // List: GET /cases/:id/backups → { backups: BackupInfo[], summary: BackupSummary }
-  // Restore: POST /cases/:id/restore-backup { filename } → { restored: string[] }
-  // Both 404 when backupManager is absent (opt-in feature).
-
-  app.get("/cases/:id/backups", async (req: Request, res: Response) => {
-    if (!options.backupManager) return res.status(404).json({ error: "backup not configured — restart the server" });
-    const caseId = req.params.id;
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
-    try {
-      const [backups, summary] = await Promise.all([
-        options.backupManager.listBackups(caseId),
-        options.backupManager.summary(caseId),
-      ]);
-      return res.status(200).json({ backups, summary });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.post("/cases/:id/restore-backup", async (req: Request, res: Response) => {
-    if (!options.backupManager) return res.status(404).json({ error: "backup not configured — restart the server" });
-    const caseId = req.params.id;
-    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
-    const filename = (req.body as { filename?: unknown })?.filename;
-    if (typeof filename !== "string" || !filename.trim()) {
-      return res.status(400).json({ error: "filename is required" });
-    }
-    try {
-      const result = await options.backupManager.restoreBackup(caseId, filename.trim());
-      return res.status(200).json(result);
-    } catch (err) {
-      const msg = (err as Error).message;
-      if (msg.includes("not found") || msg.includes("invalid backup")) {
-        return res.status(404).json({ error: msg });
-      }
-      return res.status(500).json({ error: msg });
-    }
-  });
 
   // The active DFIR-IRIS client. Mutable: POST /iris/reconnect (routes/reportsExport.ts) can rebuild
   // it at runtime — via ctx.setIrisClient() — without a server restart (config saved via Settings, or
@@ -2507,260 +1996,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     }
   }
 
-  // Push a case to DFIR-IRIS: find-or-create the case by name, then push assets→assets,
-  // IOCs→IOCs, forensic timeline→timeline, executive summary→case summary, everything else→notes.
-  // Body: { caseName? } — an explicit override; otherwise the name from the last push is reused
-  // (irisExportStore), falling back to "<case id> — <friendly name>" on the very first push.
-  app.post("/cases/:id/push/iris", async (req: Request, res: Response) => {
-    if (!irisClient) return res.status(501).json({ error: "DFIR-IRIS not configured (set DFIR_IRIS_URL and DFIR_IRIS_KEY)" });
-    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
-    const caseId = req.params.id;
-    try {
-      const state = await options.stateStore.load(caseId);
-      const meta = options.reportMetaStore ? await options.reportMetaStore.load(caseId) : undefined;
-      // Push the analyst-curated playbook (status-aware) when available, else the raw next steps.
-      const playbookTasks = options.playbookStore ? await syncPlaybook(caseId) : undefined;
-      const caseMeta = await store.getCaseMeta(caseId).catch(() => null);
-      const saved = options.irisExportStore ? await options.irisExportStore.load(caseId) : { caseName: "" };
-      const requested = typeof req.body?.caseName === "string" ? req.body.caseName.trim() : "";
-      let targetCaseName: string;
-      if (requested) {
-        targetCaseName = requested;
-      } else if (saved.caseName) {
-        targetCaseName = saved.caseName;
-      } else {
-        // First push under the new naming scheme — check whether this case was already pushed
-        // under the OLD bare-case-id scheme (pre-dates the case-name override feature) so we
-        // don't fork a duplicate IRIS case; only fall back to the computed default if not.
-        const legacy = await irisClient.findCaseByName(caseId).catch(() => null);
-        targetCaseName = legacy ? caseId : defaultIrisCaseName(caseId, caseMeta?.name);
-      }
-      logLine(`[iris] ${caseId} push START -> "${targetCaseName}"`);
-      const result = await pushCaseToIris(
-        irisClient,
-        { caseName: targetCaseName, state, meta, playbookTasks: playbookTasks?.length ? playbookTasks : undefined },
-        options.irisOptions,
-      );
-      if (options.irisExportStore) await options.irisExportStore.record(caseId, targetCaseName);
-      logLine(`[iris] ${caseId} push DONE -> case ${result.caseId} (${result.created ? "created" : "updated"}); ` +
-        `assets +${result.assets.added}/${result.assets.existing}, iocs +${result.iocs.added}/${result.iocs.existing}, ` +
-        `timeline +${result.timeline.added}/${result.timeline.existing}, tasks +${result.tasks.added}/${result.tasks.existing}, ` +
-        `notes ${result.notes}, warnings ${result.warnings.length}`);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "export", action: "push-iris", detail: `pushed to DFIR-IRIS case ${result.caseId} (${result.created ? "created" : "updated"})`,
-      });
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[iris] ${caseId} push ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // The active Timesketch client. Mutable: POST /timesketch/reconnect can rebuild it at runtime
-  // (config saved via Settings, or Timesketch coming back online) without a restart. Routes read
-  // options.timesketchClient at call time, so the reconnect reassigns that field (mirrors velo).
-  const rebuildTimesketch = options.rebuildTimesketchClient ?? buildTimesketchClient;
-
-  // Whether a Timesketch push target is configured (so the dashboard can show/hide the button).
-  app.get("/timesketch/status", (_req: Request, res: Response) => {
-    res.status(200).json({ configured: !!options.timesketchClient, baseUrl: options.timesketchOptions?.baseUrl });
-  });
-
-  // Re-read DFIR_TIMESKETCH_* from .env (Settings only writes the file), rebuild the client, and log
-  // in to verify connectivity — so the Setup wizard / Settings can connect after configuring Timesketch
-  // (or after it comes back online) WITHOUT the #1-gotcha restart. Mirrors /iris/reconnect. Always 200;
-  // the body says whether it's configured and reachable.
-  app.post("/timesketch/reconnect", async (_req: Request, res: Response) => {
-    try {
-      await reloadEnvPrefix("DFIR_TIMESKETCH_");
-      options.timesketchClient = rebuildTimesketch();
-      if (!options.timesketchClient) {
-        return res.status(200).json({ configured: false, ok: false, error: "DFIR_TIMESKETCH_URL, DFIR_TIMESKETCH_USER and DFIR_TIMESKETCH_PASSWORD are not all set" });
-      }
-      try {
-        await options.timesketchClient.login();
-        return res.status(200).json({ configured: true, ok: true, baseUrl: process.env.DFIR_TIMESKETCH_URL });
-      } catch (err) {
-        return res.status(200).json({ configured: true, ok: false, baseUrl: process.env.DFIR_TIMESKETCH_URL, error: (err as Error).message });
-      }
-    } catch (err) {
-      return res.status(500).json({ configured: false, ok: false, error: (err as Error).message });
-    }
-  });
-
-  // Push a case to Timesketch: log in, find-or-create the sketch by name (= the Companion case id),
-  // then upload the forensic timeline as a timeline. The managed timeline is clean-replaced so a
-  // re-push never duplicates events.
-  app.post("/cases/:id/push/timesketch", async (req: Request, res: Response) => {
-    if (!options.timesketchClient) return res.status(501).json({ error: "Timesketch not configured (set DFIR_TIMESKETCH_URL, DFIR_TIMESKETCH_USER and DFIR_TIMESKETCH_PASSWORD)" });
-    if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
-    const caseId = req.params.id;
-    try {
-      const state = await options.reportWriter.filteredState(caseId);
-      logLine(`[timesketch] ${caseId} push START`);
-      const result = await pushCaseToTimesketch(options.timesketchClient, { sketchName: caseId, state }, options.timesketchOptions);
-      logLine(`[timesketch] ${caseId} push DONE -> sketch ${result.sketchId} (${result.created ? "created" : "updated"}); ` +
-        `timeline "${result.timelineName}" events ${result.events}${result.replacedTimeline ? " (replaced)" : ""}, warnings ${result.warnings.length}`);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "export", action: "push-timesketch", detail: `pushed to Timesketch sketch ${result.sketchId} (${result.created ? "created" : "updated"})`,
-      });
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[timesketch] ${caseId} push ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Push the super-timeline (forensic timeline + raw host-triage artifacts) to Timesketch: same
-  // sketch as the forensic push (named after the case id), but a SEPARATE timeline inside it
-  // ("DFIR Companion super timeline") so the two pushes never clean-replace each other. NOT
-  // scope/false-positive filtered — the super-timeline is the raw complete record.
-  app.post("/cases/:id/push/timesketch-super", async (req: Request, res: Response) => {
-    if (!options.timesketchClient) return res.status(501).json({ error: "Timesketch not configured (set DFIR_TIMESKETCH_URL, DFIR_TIMESKETCH_USER and DFIR_TIMESKETCH_PASSWORD)" });
-    if (!options.superTimelineStore) return res.status(501).json({ error: "super-timeline not configured" });
-    const caseId = req.params.id;
-    try {
-      const { events } = await options.superTimelineStore.query(caseId, { limit: Number.MAX_SAFE_INTEGER });
-      logLine(`[timesketch] ${caseId} super-timeline push START`);
-      const result = await pushSuperTimelineToTimesketch(options.timesketchClient, { sketchName: caseId, events }, options.timesketchOptions);
-      logLine(`[timesketch] ${caseId} super-timeline push DONE -> sketch ${result.sketchId} (${result.created ? "created" : "updated"}); ` +
-        `timeline "${result.timelineName}" events ${result.events}${result.replacedTimeline ? " (replaced)" : ""}, warnings ${result.warnings.length}`);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "export", action: "push-timesketch-super", detail: `pushed super-timeline to Timesketch sketch ${result.sketchId} (${result.created ? "created" : "updated"})`,
-      });
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[timesketch] ${caseId} super-timeline push ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Whether a MISP push target is configured (so the dashboard can show/hide the button).
-  app.get("/misp/status", (_req: Request, res: Response) => {
-    res.status(200).json({ configured: !!options.mispPushClient, baseUrl: options.mispPushOptions?.baseUrl });
-  });
-
-  // Push a case to MISP: find-or-create the event by the idempotency tag, then push
-  // IOCs as attributes and MITRE techniques as tags. Idempotent: re-push adds only
-  // what's missing (attributes deduplicated by value).
-  app.post("/cases/:id/push/misp", async (req: Request, res: Response) => {
-    if (!options.mispPushClient) return res.status(501).json({ error: "MISP not configured (set DFIR_MISP_URL and DFIR_MISP_KEY)" });
-    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
-    const caseId = req.params.id;
-    try {
-      const state = await options.stateStore.load(caseId);
-      logLine(`[misp] ${caseId} push START`);
-      const result = await pushCaseToMisp(options.mispPushClient, { caseId, state }, options.mispPushOptions);
-      logLine(`[misp] ${caseId} push DONE -> event ${result.eventId} (${result.created ? "created" : "updated"}); ` +
-        `attributes +${result.attributes.added}/${result.attributes.existing}, tags +${result.tags}, warnings ${result.warnings.length}`);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "export", action: "push-misp", detail: `pushed to MISP event ${result.eventId} (${result.created ? "created" : "updated"})`,
-      });
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[misp] ${caseId} push ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Whether a Notion export target is configured (so the dashboard can show/hide the option and
-  // decide whether to ask for a parent in the "new page" modal).
-  app.get("/notion/status", (_req: Request, res: Response) => {
-    res.status(200).json({
-      configured: !!options.notionClient,
-      hasDatabase: !!options.notionOptions?.databaseId,
-      hasParent: !!options.notionOptions?.parentPageId,
-    });
-  });
-
-  // Export a case into a Notion page. The Companion writes ALL its content inside ONE managed
-  // toggle block it owns; a re-export refreshes that block and never touches the investigators'
-  // own notes/screenshots. Body: { mode: "new"|"existing", page?, parent?, database? }.
-  app.post("/cases/:id/push/notion", async (req: Request, res: Response) => {
-    if (!options.notionClient) return res.status(501).json({ error: "Notion not configured (set DFIR_NOTION_TOKEN)" });
-    if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
-    if (!options.notionExportStore) return res.status(501).json({ error: "notion export store not configured" });
-    const caseId = req.params.id;
-    const body = req.body ?? {};
-    const mode = body.mode === "existing" ? "existing" : "new";
-
-    const target: NotionPushTarget = { mode };
-    if (mode === "existing") {
-      const pageId = parseNotionPageId(typeof body.page === "string" ? body.page : "");
-      if (!pageId) return res.status(400).json({ error: "could not read a Notion page id from the supplied page URL/ID" });
-      target.pageId = pageId;
-    } else {
-      const parent = typeof body.parent === "string" ? parseNotionPageId(body.parent) : null;
-      const database = typeof body.database === "string" ? parseNotionPageId(body.database) : null;
-      if (parent) target.parentPageId = parent;
-      if (database) target.databaseId = database;
-    }
-
-    try {
-      const state = await options.reportWriter.filteredState(caseId);
-      const meta = options.reportMetaStore ? await options.reportMetaStore.load(caseId) : undefined;
-      logLine(`[notion] ${caseId} export START (${mode})`);
-      const result = await pushCaseToNotion(
-        options.notionClient,
-        { caseName: caseId, state, meta },
-        target,
-        options.notionOptions,
-        options.notionExportStore,
-      );
-      logLine(`[notion] ${caseId} export DONE -> page ${result.pageId} (${result.created ? "created" : "updated"}); ` +
-        `+${result.blocksAppended} block(s) in ${result.batches} batch(es), archived ${result.blocksArchived}, warnings ${result.warnings.length}`);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "export", action: "push-notion", detail: `pushed to Notion page ${result.pageId} (${result.created ? "created" : "updated"})`,
-      });
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[notion] ${caseId} export ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
-  // Whether a ClickUp push target is configured (so the dashboard can show/hide the option).
-  app.get("/clickup/status", (_req: Request, res: Response) => {
-    res.status(200).json({
-      configured: !!options.clickupClient,
-      hasDefaultList: !!options.clickupOptions?.defaultListId,
-      defaultListId: options.clickupOptions?.defaultListId ?? "",
-    });
-  });
-
-  // Push the Response Playbook to a ClickUp list as tasks. Body { listId? } — falls back to the
-  // saved list, then the configured default. Re-export UPDATES the tasks it created (by remembered
-  // id) instead of duplicating.
-  app.post("/cases/:id/push/clickup", async (req: Request, res: Response) => {
-    if (!options.clickupClient) return res.status(501).json({ error: "ClickUp not configured (set DFIR_CLICKUP_TOKEN)" });
-    if (!options.clickupExportStore) return res.status(501).json({ error: "clickup export store not configured" });
-    if (!options.playbookStore || !options.stateStore) return res.status(501).json({ error: "playbook not configured" });
-    const caseId = req.params.id;
-    try {
-      const saved = await options.clickupExportStore.load(caseId);
-      const requested = typeof req.body?.listId === "string" ? req.body.listId.trim() : "";
-      const listId = requested || saved.listId || options.clickupOptions?.defaultListId || "";
-      if (!listId) return res.status(400).json({ error: "a ClickUp list id is required" });
-      const tasks = await syncPlaybook(caseId);
-      if (!tasks.length) return res.status(400).json({ error: "the playbook is empty — run synthesis or add tasks first" });
-      logLine(`[clickup] ${caseId} push START -> list ${listId} (${tasks.length} tasks)`);
-      const result = await pushPlaybookToClickUp(
-        options.clickupClient,
-        { caseId, listId, tasks },
-        options.clickupExportStore,
-        new Date().toISOString(),
-      );
-      logLine(`[clickup] ${caseId} push DONE: +${result.created} created, ${result.updated} updated, ${result.skipped} skipped, warnings ${result.warnings.length}`);
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "export", action: "push-clickup", detail: `pushed playbook to ClickUp list ${listId} — +${result.created} created, ${result.updated} updated`,
-      });
-      return res.status(200).json(result);
-    } catch (err) {
-      logLine(`[clickup] ${caseId} push ERROR: ${(err as Error).message}`);
-      return res.status(502).json({ error: (err as Error).message });
-    }
-  });
-
   // Client-confirmed false-positive findings/IOCs. Marking one re-runs synthesis so the AI
   // re-derives its conclusions without it.
   const falsePositives = new FalsePositiveStore(store);
@@ -2955,31 +2190,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     } catch { /* non-fatal */ }
   }
 
-  // Manually add a forensic event the AI didn't catch. Appended to the timeline (kept sorted by
-  // event time), then re-synthesized so it weaves into findings/MITRE (a high-severity manual
-  // event earns a finding via the backfill). Synthesis preserves the timeline, so it survives.
-  app.post("/cases/:id/events", async (req: Request, res: Response) => {
-    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
-    const caseId = req.params.id;
-    try {
-      const event = buildManualEvent(req.body);
-      const stateStore = options.stateStore;
-      await runStateExclusive(caseId, async () => {
-        const state = await stateStore.load(caseId);
-        const forensicTimeline = [...state.forensicTimeline, event].sort(byEventTime);
-        const next = { ...state, forensicTimeline, updatedAt: new Date().toISOString() };
-        await stateStore.save(next);
-        options.onState?.(next);
-      });
-      resynthesizeInBackground(caseId);
-      logLine(`[manual] ${caseId} added event ${event.id} (${event.severity})`);
-      return res.status(201).json(event);
-    } catch (err) {
-      if (err instanceof ZodError) return res.status(400).json({ error: err.issues.map((i) => i.message).join("; ") });
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
   // ── IOC whitelist (Phase 2 of #35) ─────────────────────────────────────────────────────────
   // A GLOBAL, environment-level set of "known-good" patterns the analyst maintains (internal IP
   // ranges as CIDR, known-good hashes, regexes for internal domains). An IOC matching a rule is
@@ -3029,56 +2239,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     });
   }
 
-  // User-authored declarative importers (external plugin layer). GLOBAL, shared across cases — these
-  // CRUD the registry of import shapes the analyst can add without code. Unconfigured ⇒ empty list /
-  // 501 on writes. A save/delete/reload re-reads the on-disk registry (reloadImporters) so the in-
-  // memory copy + the detection seam (resolveImportKind) stay current without the #1-gotcha restart.
-  app.get("/importers", async (_req: Request, res: Response) => {
-    if (!options.importerStore) return res.status(200).json({ importers: [], precedence: "builtin-first", errors: [] });
-    return res.status(200).json({ importers: importerRegistry.meta, precedence: importerPrecedence, errors: importerRegistry.errors });
-  });
-
-  app.get("/importers/prompt", (_req: Request, res: Response) => {
-    if (!options.pipeline) return res.status(501).json({ error: "pipeline not configured" });
-    return res.status(200).json({ prompt: getImporterPrompt() });
-  });
-
-  app.post("/importers", async (req: Request, res: Response) => {
-    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
-    const body = req.body?.spec ?? req.body;
-    const parsed = parseImporterSpec(body);
-    if (!parsed.ok) return res.status(400).json({ error: "invalid importer", errors: parsed.errors });
-    try {
-      await options.importerStore.save(parsed.spec);
-      await reloadImporters();
-      return res.status(201).json({ id: parsed.spec.id });
-    } catch (err) { return res.status(500).json({ error: (err as Error).message }); }
-  });
-
-  app.delete("/importers/:id", async (req: Request, res: Response) => {
-    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
-    try {
-      const removed = await options.importerStore.delete(req.params.id);
-      if (!removed) return res.status(404).json({ error: "importer not found" });
-      await reloadImporters();
-      return res.status(200).json({ removed: true });
-    } catch (err) { return res.status(500).json({ error: (err as Error).message }); }
-  });
-
-  app.post("/importers/reload", async (_req: Request, res: Response) => {
-    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
-    try { await reloadImporters(); return res.status(200).json({ importers: importerRegistry.meta, errors: importerRegistry.errors }); }
-    catch (err) { return res.status(500).json({ error: (err as Error).message }); }
-  });
-
-  app.put("/importers/precedence", async (req: Request, res: Response) => {
-    if (!options.importerStore) return res.status(501).json({ error: "custom importers not configured" });
-    const p = req.body?.precedence;
-    if (p !== "builtin-first" && p !== "external-first") return res.status(400).json({ error: "precedence must be 'builtin-first' or 'external-first'" });
-    try { await options.importerStore.setPrecedence(p); importerPrecedence = p; options.onImporters?.(); return res.status(200).json({ precedence: p }); }
-    catch (err) { return res.status(500).json({ error: (err as Error).message }); }
-  });
-
   // ── NSRL known-good hashes (#63) ───────────────────────────────────────────────────────────────
   // A GLOBAL set of known-software file hashes (NIST NSRL / RDS). A forensic event whose file hash —
   // or an IOC whose value — is in the set is a known-good file, auto-marked a FALSE POSITIVE to
@@ -3122,43 +2282,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     return { matchedIocs: iocMatches.length, matchedEvents: eventMatches.length, added };
   }
 
-  // Background jobs (#225): list + inspect + cancel the heavy async operations (import / synthesis /
-  // enrichment) tracked by the JobManager, so the dashboard can render a Jobs panel and stop a
-  // long/stuck run. Read-only when no jobManager is wired (createApp-only unit tests) — empty list.
-  app.get("/api/jobs", (req: Request, res: Response) => {
-    const caseId = typeof req.query.caseId === "string" ? req.query.caseId : undefined;
-    return res.status(200).json({ jobs: options.jobManager?.list(caseId) ?? [] });
-  });
-  app.get("/api/jobs/:id", (req: Request, res: Response) => {
-    const job = options.jobManager?.get(req.params.id);
-    if (!job) return res.status(404).json({ error: `unknown job: ${req.params.id}` });
-    return res.status(200).json(job);
-  });
-  app.post("/api/jobs/:id/cancel", (req: Request, res: Response) => {
-    if (!options.jobManager) return res.status(501).json({ error: "job manager not configured" });
-    const result = options.jobManager.cancel(req.params.id);
-    if (result.ok) return res.status(200).json(result.job);
-    if (result.reason === "unknown") return res.status(404).json({ error: `unknown job: ${req.params.id}` });
-    if (result.reason === "terminal") return res.status(409).json({ error: "job already finished" });
-    return res.status(422).json({ error: "this job cannot be cancelled" });
-  });
-
-  // Per-case investigation activity log (#238): every security-relevant action taken on this
-  // case, newest first. Filter by category; cap by limit (default 200, so a long-lived case
-  // doesn't dump its entire history in one response).
-  app.get("/cases/:id/activity-log", async (req: Request, res: Response) => {
-    if (!options.activityLogStore) return res.status(501).json({ error: "activity log not configured" });
-    const rawCategory = typeof req.query.category === "string" ? req.query.category : "";
-    const category = (ACTIVITY_CATEGORIES as readonly string[]).includes(rawCategory) ? (rawCategory as ActivityCategory) : undefined;
-    const rawLimit = Number(req.query.limit);
-    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(1000, Math.floor(rawLimit)) : 200;
-    try {
-      return res.status(200).json(await options.activityLogStore.load(req.params.id, { category, limit }));
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
   // Per-case playbook derivation helpers (issue #36). The playbook + hunt-suggestion/outcome ROUTES
   // moved to routes/playbookHunts.ts; these two helpers stay because the POST /cases/:id/push/iris
   // route below also calls syncPlaybook. Hoisted `function` declarations so they can be bound onto ctx
@@ -3174,104 +2297,6 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     const { useTemplates } = await loadPlaybookControl(caseId);
     return options.playbookStore.sync(caseId, state, { useTemplates });
   }
-
-  // Settings: read/write the .env file so the dashboard can configure the companion.
-  app.get("/settings/env", async (_req: Request, res: Response) => {
-    try {
-      const env = await getEnvForSettings();
-      return res.json({ env });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  app.post("/settings/env", async (req: Request, res: Response) => {
-    try {
-      const updates = req.body?.updates;
-      if (!updates || typeof updates !== "object" || Array.isArray(updates)) {
-        return res.status(400).json({ error: "updates must be an object" });
-      }
-      await updateEnvFile(updates as Record<string, string>);
-      return res.json({ ok: true });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Apply the just-saved DFIR_AI_* values from .env into process.env WITHOUT a full restart, so the
-  // first-run wizard (#181) can save → reload → POST /diagnostics/ai-test in one flow (buildProvider()
-  // reads process.env live). This does NOT rebuild the analysis pipeline — /health.aiEnabled stays
-  // false until a restart — it only lets the live connectivity probe see the new config. Mirrors the
-  // IRIS/Velociraptor reconnect routes' reloadEnvPrefix pattern.
-  app.post("/settings/ai-reload", async (_req: Request, res: Response) => {
-    try {
-      const applied = await reloadEnvPrefix("DFIR_AI_");
-      return res.json({ ok: true, applied });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Generic counterpart of /settings/ai-reload for the comprehensive Setup wizard (#181): apply a
-  // just-saved DFIR_<PREFIX>_* group from .env into process.env without a restart, so a "Save & test"
-  // step sees the new config. ALLOWLISTED — the prefix must be a known integration group, so a request
-  // can't reload arbitrary env (and the route never reads/returns secret VALUES, only the applied keys).
-  const RELOADABLE_PREFIXES = new Set([
-    "DFIR_AI_", "DFIR_IRIS_", "DFIR_VELOCIRAPTOR_", "DFIR_TIMESKETCH_", "DFIR_NOTION_", "DFIR_CLICKUP_",
-    "DFIR_VT_", "DFIR_ABUSEIPDB_", "DFIR_HUNTINGCH_", "DFIR_MB_", "DFIR_CROWDSTRIKE_", "DFIR_SHODAN_",
-    "DFIR_MISP_", "DFIR_YETI_", "DFIR_OPENCTI_", "DFIR_ROCKYRACCOON_", "DFIR_GEOIP_",
-    "DFIR_LEAKCHECK_", "DFIR_HIBP_", "DFIR_DEHASHED_", "DFIR_PUSH_TOKEN", "DFIR_NSRL_", "DFIR_TOOL_",
-  ]);
-  app.post("/settings/reload", async (req: Request, res: Response) => {
-    try {
-      const prefix = typeof req.body?.prefix === "string" ? req.body.prefix.trim() : "";
-      if (!prefix) return res.status(400).json({ error: "prefix is required" });
-      if (!RELOADABLE_PREFIXES.has(prefix)) {
-        return res.status(400).json({ error: `prefix not in the reloadable allowlist: ${prefix}` });
-      }
-      const applied = await reloadEnvPrefix(prefix);
-      return res.json({ ok: true, applied });
-    } catch (err) {
-      return res.status(500).json({ error: (err as Error).message });
-    }
-  });
-
-  // Aggregate "is this integration configured?" status for the Setup wizard's progress (✓/○) — derived
-  // live from process.env so it reflects values just saved+reloaded (no restart). Required-config groups
-  // only: each entry is configured when its mandatory key(s) are present. No external calls, no secret
-  // values — only booleans. (Per-feature deep status/connectivity lives in /iris/status etc.)
-  app.get("/setup/status", (_req: Request, res: Response) => {
-    const has = (k: string): boolean => !!(process.env[k] && process.env[k]!.trim());
-    res.status(200).json({
-      ai: !!hasAiProvider() || has("DFIR_AI_PROVIDER"),
-      velociraptor: !!options.velociraptorClient || has("DFIR_VELOCIRAPTOR_API_CONFIG"),
-      iris: !!irisClient || (has("DFIR_IRIS_URL") && has("DFIR_IRIS_KEY")),
-      timesketch: !!options.timesketchClient || (has("DFIR_TIMESKETCH_URL") && has("DFIR_TIMESKETCH_USER") && has("DFIR_TIMESKETCH_PASSWORD")),
-      notion: !!options.notionClient || has("DFIR_NOTION_TOKEN"),
-      clickup: !!options.clickupClient || has("DFIR_CLICKUP_TOKEN"),
-      push: !!options.pushTokenStore || has("DFIR_PUSH_TOKEN"),
-      notifications: !!options.notificationStore,
-      enrichment: {
-        virustotal: has("DFIR_VT_KEY"),
-        abuseipdb: has("DFIR_ABUSEIPDB_KEY"),
-        huntingch: has("DFIR_HUNTINGCH_KEY") || has("DFIR_MB_KEY"),
-        crowdstrike: has("DFIR_CROWDSTRIKE_CLIENT_ID") && has("DFIR_CROWDSTRIKE_CLIENT_SECRET"),
-        shodan: has("DFIR_SHODAN_KEY"),
-        misp: has("DFIR_MISP_URL") && has("DFIR_MISP_KEY"),
-        yeti: has("DFIR_YETI_URL") && has("DFIR_YETI_KEY"),
-        opencti: has("DFIR_OPENCTI_URL") && has("DFIR_OPENCTI_KEY"),
-        rockyraccoon: has("DFIR_ROCKYRACCOON_KEY"),
-        geoip: has("DFIR_GEOIP_KEY"),
-      },
-      exposure: {
-        leakcheck: has("DFIR_LEAKCHECK_KEY"),
-        hibp: has("DFIR_HIBP_KEY"),
-        dehashed: has("DFIR_DEHASHED_KEY"),
-        shodan: has("DFIR_SHODAN_KEY"),
-      },
-      nsrl: has("DFIR_NSRL_DB") || has("DFIR_NSRL_FILE") || !!options.nsrlStore,
-    });
-  });
 
   // Re-arm any persisted live Velociraptor monitors so streaming survives a restart (#84). Fire-and-
   // forget + self-gating (no store/client or no persisted monitors → no-op), so it's a safe no-op for
@@ -4073,46 +3098,6 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
       }
     });
   }
-
-  // Redirect root to the dashboard.
-  app.get("/", (_req, res) => {
-    res.redirect("/dashboard");
-  });
-
-  // Serve the dashboard.
-  app.get("/dashboard", async (_req, res) => {
-    const html = await readPublicAsset("dashboard.html", "utf8");
-    res.type("html").send(html);
-  });
-
-  // Mobile companion (#59): a read-only, phone-optimized view (timeline / findings / IOCs / status)
-  // for quick glances during IR away from the workstation. It's a PWA — installable via the
-  // web manifest + a minimal service worker (offline app-shell). All three are static files in
-  // public/; the SW is served at root so its default control scope covers /mobile.
-  app.get("/mobile", async (_req, res) => {
-    const html = await readPublicAsset("mobile.html", "utf8");
-    res.type("html").send(html);
-  });
-
-  app.get("/manifest.webmanifest", async (_req, res) => {
-    try {
-      const json = await readPublicAsset("manifest.webmanifest", "utf8");
-      res.type("application/manifest+json").set("Cache-Control", "no-cache").send(json);
-    } catch {
-      res.status(404).end();
-    }
-  });
-
-  app.get("/sw.js", async (_req, res) => {
-    try {
-      const js = await readPublicAsset("sw.js", "utf8");
-      // no-cache + a same-origin allowed scope so the SW can control /mobile even if it's
-      // ever moved into a subdirectory; browsers re-check sw.js on every navigation anyway.
-      res.type("application/javascript").set("Cache-Control", "no-cache").set("Service-Worker-Allowed", "/").send(js);
-    } catch {
-      res.status(404).end();
-    }
-  });
 
   // Bind host. Defaults to 127.0.0.1 (localhost-only — the OPSEC invariant for native runs).
   // Inside a container set DFIR_HOST=0.0.0.0 so the published port is reachable; the compose


### PR DESCRIPTION
**Final step of the router split.** Moves the remaining 51 case-core route registrations out of `createApp` into two modules — `src/routes/caseLifecycle.ts` (46: case CRUD, archive/restore, backups, encrypted export/import, integration pushes, importers CRUD, jobs, settings, app-shell) and `src/routes/casePassword.ts` (5: password/lock/unlock/lock-status). **Pure structural move — zero behavior change.**

After this, **`createApp` has zero literal route registrations** — `server.ts` is thin wiring (store construction, the case-lock gate mount, body-parser + terminal error handlers, `startServer`, the graduated shared helpers, and the ordered `registerXRoutes(app, ctx)` calls). `server.ts`: 4273 → 3258 lines (from ~10,413 at the start of the refactor).

## Security & state (verified byte-identical / single-instance)
- Password/lock/unlock handlers are **byte-identical** to the originals — hashing, token signing/verification, cookie flags (`httpOnly`, `sameSite:strict`), unlock TTLs, and status codes all unchanged.
- `instanceSecret` graduated as the same Buffer the case-lock gate + `readUnlockState` use (tokens verify against the gate).
- `runStateExclusive` (per-case state mutex) confirmed **not split** — all writes serialize on the one `options.stateLock`.
- Graduated `ensureDropFolders`, `reloadImporters`, `importerPrecedence`/`setImporterPrecedence`, `rebuildTimesketchClient` (single shared bindings).

## Note
The static app-shell routes (`/`, `/dashboard`, `/mobile`, manifest, sw.js) moved from `startServer` into a route module (verbatim bodies). One benign, unreachable-in-practice delta: on a corrupt-install asset-read failure, `/dashboard`/`/mobile` now return JSON 500 via the terminal handler instead of Express's default HTML — reviewed and accepted.

## Verification
- `tsc --noEmit` clean; `caseLifecycleRoutes` + `casePasswordRoutes` + `encryptedCaseRoutes` + `backupManager` pass **unedited** (75/75)
- Route inventory **316 = 316**, identical multiset; **zero** `app.<verb>(` literals left in `server.ts`
- Full server suite green (52 files / 400 tests)
- Spec-reviewed with maximal rigor (auth-touching): password routes byte-identical, single-instance secret/mutex, EOL integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)