### PR TITLE
fix: show persistent "Promoted" badge on super-timeline rows

### DIFF
--- a/companion/src/routes/timeline.ts
+++ b/companion/src/routes/timeline.ts
@@ -144,7 +144,14 @@ export function registerTimelineRoutes(app: Express, ctx: RouteContext): void {
         offset: num(req.query.offset),
         limit: num(req.query.limit),
       }, tagLabelMap);
-      return res.status(200).json(result);
+      // Mark rows already pulled into the forensic timeline (promote's mergeDelta dedups by id, so
+      // "promoted" means this event's id is already there) so the UI can show persistent state instead
+      // of a fire-and-forget button that gives no lasting feedback.
+      const promotedIds = options.stateStore
+        ? new Set((await options.stateStore.load(req.params.id)).forensicTimeline.map((e) => e.id))
+        : new Set<string>();
+      const events = result.events.map((e) => ({ ...e, promoted: promotedIds.has(e.id) }));
+      return res.status(200).json({ ...result, events });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/tests/server/superTimeline.test.ts
+++ b/companion/tests/server/superTimeline.test.ts
@@ -323,6 +323,8 @@ describe("super-timeline promote route", () => {
     const listed = await request(app).get(`/cases/c1/super-timeline`);
     expect(listed.body.events.length).toBeGreaterThan(0);
     const id = listed.body.events[0].id;
+    // Not yet promoted: GET marks the row unpromoted so the UI has no false-positive badge.
+    expect(listed.body.events.find((e: { id: string }) => e.id === id).promoted).toBe(false);
 
     const res = await request(app).post(`/cases/c1/super-timeline/promote`).send({ eventIds: [id] });
     expect(res.status).toBe(200);
@@ -330,6 +332,11 @@ describe("super-timeline promote route", () => {
 
     const state1 = await stateStore.load("c1");
     expect(state1.forensicTimeline.some((e) => e.id === id)).toBe(true);
+
+    // The row now carries a persistent "promoted" flag (survives reload/paging), which is what lets
+    // the UI show a lasting "✓ Promoted" mark instead of only a one-time toast.
+    const afterPromote = await request(app).get(`/cases/c1/super-timeline`);
+    expect(afterPromote.body.events.find((e: { id: string }) => e.id === id).promoted).toBe(true);
 
     // idempotent: promoting again does not duplicate
     await request(app).post(`/cases/c1/super-timeline/promote`).send({ eventIds: [id] });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -964,8 +964,9 @@
     /* "New since last import" highlight on forensic-timeline / IOC rows + its badge (see #importMeta) */
     .ev-row.ev-new { box-shadow: inset 3px 0 0 var(--c-6bcb77); }
     .ioc-new { box-shadow: inset 3px 0 0 var(--c-6bcb77); padding-left: 6px; border-radius: 3px; }
-    .ev-new-badge, .ev-badge-count, .ev-badge-corro { border-radius:4px; padding:0 5px; font-size:10px; font-weight:bold; }
+    .ev-new-badge, .ev-badge-count, .ev-badge-corro, .ev-promoted-badge { border-radius:4px; padding:0 5px; font-size:10px; font-weight:bold; }
     .ev-new-badge { background:var(--c-13331f); color:var(--c-6bcb77); border:1px solid var(--c-1f5a35); }
+    .ev-promoted-badge { background:var(--c-13331f); color:var(--c-6bcb77); border:1px solid var(--c-1f5a35); }
     .ev-badge-count { background: var(--c-3a2f1a); color: var(--c-ffd93b); border: 1px solid var(--c-5a4a1a); }
     .ev-badge-corro { background: var(--c-13331f); color: var(--c-6bcb77); border: 1px solid var(--c-1f5a35); }
     .ev-chain-badge { display: inline-flex; align-items: center; gap: 3px; border-radius: 4px; padding: 0 5px; font-size: 10px; text-decoration: none; }
@@ -6006,6 +6007,12 @@
           desc = desc.replace(new RegExp("^\\s*(?:\\S+\\s+)?\\[" + escOrigin + "\\]\\s*[:\\-]?\\s*", "i"), "");
         }
         const host = e.asset ? `<span class="ev-host" title="Affected host / asset">${ICON_HOST} ${esc(e.asset)}</span> ` : "";
+        // Persistent state so the promote button gives lasting feedback instead of a fire-and-forget
+        // "promoting…" toast: once an event's id lands in the forensic timeline, every subsequent load
+        // of the super-timeline marks it, even after paging away or reloading the page.
+        const promotedBadge = e.promoted
+          ? `<span class="ev-promoted-badge" title="Already pulled into the forensic timeline — promoting again is safe but a no-op">✓ Promoted</span> `
+          : "";
         // Per-row controls unified with the forensic timeline: star, comment, tag (all keyed by
         // ("event", e.id)). The delegated click handler on <main> already routes these for super rows.
         // Context button: scope From/To to this event's timestamp ± a window. Data-attr carries the ISO ts.
@@ -6032,7 +6039,7 @@
           `</div>` +
           `<div class="ev-col-time"><span class="sev-${escAttr(sev)}">${esc(e.timestamp || "")}</span></div>` +
           `<div class="ev-col-content">` +
-          `<span class="ev-origin" title="origin">${esc(origin)}</span> ` +
+          `<span class="ev-origin" title="origin">${esc(origin)}</span> ${promotedBadge}` +
           `${superTagPills("event", e.id)}${host}${details.toggle} ${descHtml(details.title)}${veloLink}` +
           `${details.panel}` +
           `</div>` +


### PR DESCRIPTION
## Summary
- Promoting an event from the Super Timeline into the Forensic Timeline was already idempotent server-side (dedups by event id, no duplicates), but the UI gave no lasting indication that an event had actually been promoted — re-clicking looked like nothing happened.
- `GET /cases/:id/super-timeline` now flags each event as `promoted: true/false` by checking whether its id already exists in the case's current forensic timeline.
- The dashboard's Super Timeline rows show a persistent "✓ Promoted" badge (matching the existing "NEW" badge style) when that flag is true, and it survives page reloads/paging since it's computed server-side from actual state.

## Test plan
- [x] Extended `companion/tests/server/superTimeline.test.ts` to assert the `promoted` flag flips `false → true` after promotion.
- [x] `npx vitest run tests/server` — 483/484 passing (the 1 unrelated timeout in `secondOpinion.test.ts` passes cleanly in isolation, pre-existing flakiness under parallel load).
- [x] Verified live end-to-end: seeded Super Timeline events, promoted one via the real dashboard UI, confirmed the badge appears, did a full page reload (badge persists), re-clicked promote again (badge stays, no duplicate row in forensic timeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)