### PR TITLE
Dashboard UI cleanups + synthesis job/status races + drag-order regression

### DIFF
--- a/companion/src/analysis/jobManager.ts
+++ b/companion/src/analysis/jobManager.ts
@@ -40,6 +40,9 @@ export interface RegisterInput {
   label?: string;
   detail?: string;
   cancellable?: boolean;
+  // Cancel any other non-terminal job of the same kind for this case before starting this one —
+  // e.g. two synthesis runs for the same case racing serves no purpose; the newer supersedes.
+  exclusive?: boolean;
 }
 
 export interface RegisteredJob {
@@ -67,6 +70,11 @@ export class JobManager {
   }
 
   register(input: RegisterInput): RegisteredJob {
+    if (input.exclusive) {
+      for (const j of listJobs(this.table, { caseId: input.caseId })) {
+        if (j.kind === input.kind && !isTerminal(j.status)) this.cancel(j.id);
+      }
+    }
     const jobId = `job_${++this.counter}`;
     this.table = capJobs(
       createJob(this.table, {
@@ -119,6 +127,13 @@ export class JobManager {
 
   list(caseId?: string): Job[] {
     return listJobs(this.table, caseId ? { caseId } : {});
+  }
+
+  // Is any non-terminal job of this kind still running for the case? Callers use this to avoid
+  // announcing a stale "idle" status after their own (superseded) job was cancelled out from under
+  // them by a newer exclusive registration — see aiSynthesis.ts / scheduleSynthesis.
+  hasActive(caseId: string, kind: JobKind): boolean {
+    return listJobs(this.table, { caseId }).some((j) => j.kind === kind && !isTerminal(j.status));
   }
 
   get(jobId: string): Job | undefined {

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -136,7 +136,9 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
     const thinkingTokens = Number.isFinite(reqThinking) && reqThinking > 0 ? Math.floor(reqThinking) : undefined;
     options.onAiStatus?.(caseId, { status: "analyzing", at: new Date().toISOString(), detail: deepReasoning ? "synthesizing (deep reasoning)" : "synthesizing conclusions" });
     // #225: track this manual synthesis as a cancellable job so the analyst can abort a long run.
-    const job = options.jobManager?.register({ caseId, kind: "synthesis", label: "synthesis", cancellable: true });
+    // exclusive: a second re-synthesize for the same case (double-click, or racing the "Generate
+    // hypotheses" button / a live auto-synthesis) supersedes rather than running alongside it.
+    const job = options.jobManager?.register({ caseId, kind: "synthesis", label: "synthesis", cancellable: true, exclusive: true });
     // Pre-synthesis backup (#180): snapshot state before overwriting conclusions. Best-effort.
     if (options.backupManager) {
       await options.backupManager.createBackup(caseId, "pre-synthesis").catch(() => {});
@@ -170,7 +172,11 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
       const aborted = job?.signal?.aborted === true;
       if (job) options.jobManager?.fail(job.jobId, err); // no-op if a cancel already marked it cancelled
       if (aborted) {
-        options.onAiStatus?.(caseId, { status: "idle", at: new Date().toISOString(), detail: "synthesis cancelled" });
+        // A newer exclusive registration may have superseded this run (see above) — if a synthesis
+        // job for this case is still active, that newer run owns the status; don't stomp it to idle.
+        if (!options.jobManager?.hasActive(caseId, "synthesis")) {
+          options.onAiStatus?.(caseId, { status: "idle", at: new Date().toISOString(), detail: "synthesis cancelled" });
+        }
         return res.status(499).json({ error: "synthesis cancelled" });
       }
       options.onAiStatus?.(caseId, { status: "error", at: new Date().toISOString(), detail: (err as Error).message });

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -840,16 +840,22 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       // #225: this debounced/auto path (live re-synth after captures, and the AI off→on backfill
       // catch-up) previously ran outside the job registry, so it never showed up in the Jobs panel
       // or offered a Cancel button — only the manual "re-synthesize" button did. Track it the same way.
-      const job = options.jobManager?.register({ caseId, kind: "synthesis", label: "live synthesis", cancellable: true });
+      // exclusive: a manual re-synthesize racing this live run (synthInFlight only serializes
+      // auto-vs-auto) supersedes rather than running alongside it.
+      const job = options.jobManager?.register({ caseId, kind: "synthesis", label: "live synthesis", cancellable: true, exclusive: true });
       options.pipeline!.synthesize(caseId, job?.signal ? { signal: job.signal } : {})
         .then(() => { if (job) options.jobManager?.finish(job.jobId); options.onAiStatus?.(caseId, { status: "idle", at: new Date().toISOString() }); autoEnrichIfEnabled(caseId); })
         .catch((err) => {
           const aborted = job?.signal?.aborted === true;
           if (job) options.jobManager?.fail(job.jobId, err); // no-op if already cancelled
           recordAiError(caseId, "synthesizing", err);
-          options.onAiStatus?.(caseId, aborted
-            ? { status: "idle", at: new Date().toISOString(), detail: "synthesis cancelled" }
-            : { status: "error", at: new Date().toISOString(), detail: (err as Error).message });
+          // A newer exclusive registration may have superseded this run — if a synthesis job for
+          // this case is still active, that newer run owns the status; don't stomp it to idle.
+          if (!(aborted && options.jobManager?.hasActive(caseId, "synthesis"))) {
+            options.onAiStatus?.(caseId, aborted
+              ? { status: "idle", at: new Date().toISOString(), detail: "synthesis cancelled" }
+              : { status: "error", at: new Date().toISOString(), detail: (err as Error).message });
+          }
         })
         .finally(() => synthInFlight.delete(caseId));
     }, synthDebounceMs));

--- a/companion/tests/analysis/jobManager.test.ts
+++ b/companion/tests/analysis/jobManager.test.ts
@@ -95,4 +95,58 @@ describe("JobManager", () => {
     const m = new JobManager({ onJob: () => { throw new Error("ws down"); }, now: mkClock() });
     expect(() => m.register({ caseId: "c1", kind: "import" })).not.toThrow();
   });
+
+  describe("exclusive registration", () => {
+    it("cancels a running same-kind job for the same case and aborts its signal", () => {
+      const m = new JobManager({ now: mkClock() });
+      const first = m.register({ caseId: "c1", kind: "synthesis", cancellable: true, exclusive: true });
+      const second = m.register({ caseId: "c1", kind: "synthesis", cancellable: true, exclusive: true });
+      expect(m.get(first.jobId)!.status).toBe("cancelled");
+      expect(first.signal!.aborted).toBe(true);
+      expect(m.get(second.jobId)!.status).toBe("running");
+    });
+
+    it("leaves other cases and other kinds alone", () => {
+      const m = new JobManager({ now: mkClock() });
+      const otherCase = m.register({ caseId: "c2", kind: "synthesis", cancellable: true });
+      const otherKind = m.register({ caseId: "c1", kind: "import", cancellable: true });
+      m.register({ caseId: "c1", kind: "synthesis", cancellable: true, exclusive: true });
+      expect(m.get(otherCase.jobId)!.status).toBe("running");
+      expect(m.get(otherKind.jobId)!.status).toBe("running");
+    });
+
+    it("does not touch an already-terminal same-kind job", () => {
+      const m = new JobManager({ now: mkClock() });
+      const first = m.register({ caseId: "c1", kind: "synthesis", cancellable: true });
+      m.finish(first.jobId);
+      const second = m.register({ caseId: "c1", kind: "synthesis", cancellable: true, exclusive: true });
+      expect(m.get(first.jobId)!.status).toBe("done"); // untouched, not re-marked cancelled
+      expect(m.get(second.jobId)!.status).toBe("running");
+    });
+
+    it("without exclusive, two same-kind jobs for the same case both stay running", () => {
+      const m = new JobManager({ now: mkClock() });
+      const first = m.register({ caseId: "c1", kind: "synthesis", cancellable: true });
+      const second = m.register({ caseId: "c1", kind: "synthesis", cancellable: true });
+      expect(m.get(first.jobId)!.status).toBe("running");
+      expect(m.get(second.jobId)!.status).toBe("running");
+    });
+  });
+
+  describe("hasActive", () => {
+    it("is true while a non-terminal job of that kind exists for the case", () => {
+      const m = new JobManager({ now: mkClock() });
+      const { jobId } = m.register({ caseId: "c1", kind: "synthesis", cancellable: true });
+      expect(m.hasActive("c1", "synthesis")).toBe(true);
+      m.finish(jobId);
+      expect(m.hasActive("c1", "synthesis")).toBe(false);
+    });
+
+    it("is false for a different case or a different kind", () => {
+      const m = new JobManager({ now: mkClock() });
+      m.register({ caseId: "c1", kind: "synthesis", cancellable: true });
+      expect(m.hasActive("c2", "synthesis")).toBe(false);
+      expect(m.hasActive("c1", "import")).toBe(false);
+    });
+  });
 });

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -155,6 +155,25 @@ describe("dashboard.html", () => {
     expect(html).not.toContain("new/unknown sections go to the end");
   });
 
+  it("marks the layout Custom on a manual drag reorder, so a page refresh doesn't re-apply the active dashboard-view preset over it", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    // applySavedViewForCase() runs on every case connect (including the auto-reconnect on page
+    // refresh) and, for any case without an explicit view choice, re-applies a preset's canned
+    // section order — clobbering a manual drag unless the drag itself records a Custom choice.
+    // Both drag-reorder call sites (the in-page grip, and the Settings section-list drag) must
+    // call applyDashboardView(null, ...) right after saveSectionsOrder(...) to persist that choice.
+    const markCustom = 'if (typeof applyDashboardView === "function") applyDashboardView(null, { persist: true, rerender: false });';
+    expect(html.split(markCustom).length - 1).toBe(2); // exactly the two drag-reorder sites
+    const gripDrop = html.indexOf('saveSectionsOrder([...main.querySelectorAll(":scope > section[id]")]');
+    const gripMark = html.indexOf(markCustom, gripDrop);
+    expect(gripMark).toBeGreaterThan(gripDrop);
+    expect(gripMark - gripDrop).toBeLessThan(600); // the very next thing the handler does
+    const settingsDrop = html.indexOf('saveSectionsOrder([...container.querySelectorAll(".sec-check")]');
+    const settingsMark = html.indexOf(markCustom, settingsDrop);
+    expect(settingsMark).toBeGreaterThan(settingsDrop);
+    expect(settingsMark - settingsDrop).toBeLessThan(400);
+  });
+
   it("offers a unified multi-file import (images → /captures, data → /import)", async () => {
     const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
     expect(html).toContain('id="importBtn"');

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -815,8 +815,14 @@
     .ev-row:hover { background: var(--c-0d1117); }
     .ev-row.ev-selected { background: var(--c-142038); }
     .ev-row.ev-focused { outline: 2px solid var(--c-6aa9ff); outline-offset: -2px; border-radius: 3px; }
-    .ev-col-ctrl { display: flex; align-items: center; gap: 2px; flex-shrink: 0; width: 162px; padding-top: 1px; }
-    .ev-col-ctrl .comment-chip, .ev-col-ctrl .tag-add, .ev-col-ctrl .hunt-add, .ev-col-ctrl .explain-btn { margin-left: 0; }
+    .ev-col-ctrl { display: flex; align-items: center; gap: 2px; flex-shrink: 0; width: 178px; margin-right: 6px; padding-top: 1px; }
+    /* Buttons default to flex-shrink:1, which silently compresses (and can visually clip) their
+       icon/count once the row's icon set (star/comment/tag/hunt/explain/geo) nears the column's
+       width budget — pin them to their natural size instead; the column's own width + margin above
+       is sized with headroom so this never overflows into the adjacent timestamp column. */
+    .ev-col-ctrl .comment-chip, .ev-col-ctrl .tag-add, .ev-col-ctrl .hunt-add, .ev-col-ctrl .explain-btn, .ev-col-ctrl .ev-geo {
+      margin-left: 0; flex-shrink: 0;
+    }
     /* Action icons hidden (Settings → Timeline row display) → reclaim the control column's width, keep just the checkbox. */
     #forensicTimeline.tl-no-icons .ev-col-ctrl, #forensicTimeline.tl-no-icons .ev-header-ctrl { width: 22px; }
     .ev-checkbox { width: 13px; height: 13px; cursor: pointer; accent-color: var(--c-6aa9ff); flex-shrink: 0; margin: 0; }
@@ -838,7 +844,7 @@
     .ev-details-panel { margin-top: 4px; padding: 6px 8px; background: var(--c-0d1117, #0d1117); border-left: 2px solid var(--c-2a4a6b); border-radius: 2px; font-size: 11px; color: var(--c-c9d1d9); }
     .ev-details-panel > * + * { margin-top: 4px; }
     .ev-header-row { display: flex; align-items: center; padding: 2px 0 5px; border-bottom: 1px solid var(--c-2a2f3a); margin-bottom: 1px; font-size: 11px; color: var(--c-6b7280); }
-    .ev-header-ctrl { width: 162px; flex-shrink: 0; display: flex; align-items: center; gap: 4px; }
+    .ev-header-ctrl { width: 178px; margin-right: 6px; flex-shrink: 0; display: flex; align-items: center; gap: 4px; }
     .ev-header-time { width: 192px; flex-shrink: 0; }
     .tl-pagesize-wrap { margin-left: auto; flex-shrink: 0; }
     .tl-pagesize-sel { background: var(--c-1e2330); border: 1px solid var(--c-3a4050); color: var(--c-9aa4b2); border-radius: 4px; padding: 1px 5px; font-size: 11px; cursor: pointer; }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1431,9 +1431,6 @@
     #ocrSearchResults .ocr-hit .ocr-snippet { font-size: 12px; margin-top: 2px; }
     #ocrSearchResults .ocr-hit mark { background: var(--c-ffd93b); color: #000; padding: 0 1px; border-radius: 2px; }
     #ocrSearchResults .ocr-empty { color: var(--c-9aa4b2); font-size: 12px; padding: 4px; }
-    /* Toolbar is tight on real estate: on narrower screens collapse the "deep" label to just the
-       🧠 checkbox (the tooltip still explains it). */
-    @media (max-width: 1440px) { #deepReasoningLabel .dr-text { display: none; } }
   </style>
 </head>
 <body>
@@ -1465,7 +1462,7 @@
     <button id="synthesize" data-tip="Re-derive the case conclusions — findings, MITRE ATT&CK, attacker path, narrative, key questions and next steps — from the in-scope forensic timeline. Replaces the previous conclusions but keeps the timeline, IOCs and threads.">AI Re-synthesize</button>
     <button id="secondOpinion" style="display:none" data-tip="Second LLM opinion: refreshes the primary synthesis (only if the timeline changed), then runs a DIFFERENT model over the same case as an independent QA cross-check, and shows where it disagrees with the primary (findings it adds/drops, severity, ATT&CK technique) for you to accept or reject each. On-demand; non-destructive until you accept. Needs DFIR_AI_SECOND_OPINION_MODEL — ideally a different provider.">2nd opinion</button>
     <label id="deepReasoningLabel" style="display:inline-flex;align-items:center;gap:4px;font-size:11px;color:var(--c-9aa4b2);cursor:pointer;white-space:nowrap" data-tip="Deep reasoning (Chain-of-Thought): have the model think step-by-step (extended thinking) before writing findings — better on complex multi-hop cases, but slower and costs extra output tokens. Applies to the NEXT AI Re-synthesize and 2nd opinion on this case only. Off by default; no .env edit or restart needed. Needs an Anthropic or OpenRouter reasoning-capable synthesis model.">
-      <input type="checkbox" id="deepReasoning" style="margin:0;cursor:pointer" />🧠<span class="dr-text">&nbsp;deep</span>
+      <input type="checkbox" id="deepReasoning" style="margin:0;cursor:pointer" />🧠
     </label>
     <input id="importFile" type="file" multiple accept=".json,.jsonl,.ndjson,.csv,.log,.txt,.eve,.xml,.eml,.msg,.bash_history,.zsh_history,.history,.evtx,.evt,.pcap,.pcapng,message/rfc822,application/vnd.ms-outlook,application/json,text/csv,text/plain,text/xml,application/xml,image/png,image/jpeg,image/webp" style="display:none" />
     <button id="importBtn" data-tip="Import any evidence file — the server auto-detects the type (THOR, SIEM/EDR, Windows Event Log XML, Chainsaw/EVTX, Hayabusa, Velociraptor, Suricata/Zeek, KAPE/EZ, Cyber Triage, M365/Entra, AWS CloudTrail, GCP/Azure, Plaso, CAPEv2/Falcon sandbox reports, Volatility 3 / Rekall memory output, email .eml/.msg, Linux shell history, auditd, journald JSON, sysdig/Falco, CSV, logs) and routes it to the right importer. Select multiple at once; images (PNG/JPEG/WebP) are stored as screenshots.">Import</button>
@@ -3618,7 +3615,7 @@
       <div id="swimlaneTooltip"></div>
     </section>
     <section id="sec-assets" style="grid-column: 1 / -1">
-      <h2>Compromised Assets &amp; IoC Graph<button class="add-toggle" type="button" title="Add / edit assets and links manually" aria-label="Add asset">+</button></h2>
+      <h2>Compromised Assets &amp; IoC Graph<span class="ev-sub">assets and IOCs derived from findings and the timeline, plus any you add by hand — edges show how they connect</span><button class="add-toggle" type="button" title="Add / edit assets and links manually" aria-label="Add asset">+</button></h2>
       <div class="manual-add" hidden>
         <form class="manual-form" onsubmit="return false">
           <span style="color:var(--c-9aa4b2)">Add asset:</span>
@@ -3766,9 +3763,9 @@
         </div>
         <div id="customerExposure">—</div>
       </div></section>
-    <section id="sec-questions" style="grid-column: 1 / -1"><h2>Key Investigative Questions</h2><div id="keyQuestions">—</div></section>
+    <section id="sec-questions" style="grid-column: 1 / -1"><h2>Key Investigative Questions<span class="ev-sub">open questions the AI is tracking — answered automatically once the evidence supports them</span></h2><div id="keyQuestions">—</div></section>
     <section id="sec-huntprofile" style="grid-column: 1 / -1"><h2>Hunting Profile<span class="ev-sub">What has been hunted in this case and whether it found anything</span></h2><div id="huntProfile">—</div></section>
-    <section id="sec-threads"><h2>Investigation Threads</h2><div id="openThreads">—</div><div id="closedThreads"></div></section>
+    <section id="sec-threads"><h2>Investigation Threads<span class="ev-sub">open leads the AI tracks across re-synthesis runs — closed automatically once the evidence resolves them</span></h2><div id="openThreads">—</div><div id="closedThreads"></div></section>
     <section id="sec-mitre"><h2>MITRE ATT&amp;CK</h2><div id="mitre">—</div></section>
     <section id="sec-adversary" style="grid-column: 1 / -1"><h2>Adversary Hints<span class="ev-sub">known ATT&amp;CK groups by technique overlap + their likely next techniques — hypothesis fuel, not attribution (derived, no AI)</span></h2><div id="adversaryHints">—</div></section>
     <style>
@@ -4096,7 +4093,7 @@
         </div>
       </div>
     </section>
-    <section id="sec-inv-log" style="grid-column: 1 / -1"><h2>Investigation Log</h2><div id="timeline">—</div></section>
+    <section id="sec-inv-log" style="grid-column: 1 / -1"><h2>Investigation Log<span class="ev-sub">import events and AI notes merged with analyst quick-action entries, in chronological order</span></h2><div id="timeline">—</div></section>
     <section id="sec-activity" style="grid-column: 1 / -1"><h2>Activity Log<span class="ev-sub">Every security-relevant action taken on this case</span></h2>
       <div style="margin-bottom:8px">
         <select id="activityFilter" style="font-size:12px">
@@ -15249,6 +15246,10 @@
           // and its up/down arrows reflect the new order too.
           saveSectionsOrder([...main.querySelectorAll(":scope > section[id]")].map(s => s.id));
           if (typeof renderSecChecks === "function") renderSecChecks();
+          // A manual drag makes this a Custom layout — otherwise the next page load's
+          // applySavedViewForCase() re-applies the active preset's canned order over this one,
+          // silently discarding the drag (the layout looked "reset" after refresh).
+          if (typeof applyDashboardView === "function") applyDashboardView(null, { persist: true, rerender: false });
         });
       });
       // The initial order is applied by applySectionsVis() → applySecOrder() (runs last in init),
@@ -15422,6 +15423,9 @@
             container.insertBefore(dragSrc, row);
             saveSectionsOrder([...container.querySelectorAll(".sec-check")].map(r => r.dataset.id));
             applySecOrder();
+            // Same as the in-page drag grip: a manual reorder here makes this a Custom layout, so
+            // the next load's applySavedViewForCase() doesn't overwrite it with the active preset.
+            if (typeof applyDashboardView === "function") applyDashboardView(null, { persist: true, rerender: false });
           }
         });
         row.addEventListener("dragend", () => {


### PR DESCRIPTION
## Summary
- Timeline row action icons (star/comment/tag/hunt/explain/geo) had no safety margin against the timestamp column — widened the icon column and stopped the icon buttons from silently compressing/overlapping.
- Removed the redundant "deep" text label next to the 🧠 deep-reasoning checkbox (icon + tooltip already explain it).
- Added the missing panel-header explanation to Key Investigative Questions, Investigation Threads, Compromised Assets & IoC Graph, and Investigation Log, matching the pattern already used on other panels.
- `JobManager.register()` gains an `exclusive` option that cancels any other running job of the same kind for the case first. Wired into both synthesis entry points (manual "AI Re-synthesize" and the debounced live auto-synthesis) so a second re-synthesize supersedes rather than racing the first — fixes two concurrent synthesis jobs showing in the Background Jobs panel.
- Added `JobManager.hasActive()` and used it to stop a superseded run's abort handler from stomping the newer run's "analyzing" status back to "idle" while it's still working — fixes the AI status badge showing "idle" during an active synthesis.
- Fixed panel drag-reorder not surviving a page refresh: the dashboard-view preset re-apply (`applySavedViewForCase()`, which runs on every case connect including the refresh auto-reconnect) was overwriting the saved section order with the active preset's canned order whenever no explicit view choice was recorded. Both drag-reorder handlers now mark the layout Custom on drop, same as picking "Custom" from the dashboard view menu, so the preset re-apply is skipped.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite (3447 tests) passes
- [x] Live-verified the icon/timestamp fix and the drag-reorder fix against a running dev server (DOM geometry measurements + simulated reconnect reproducing then fixing the regression)