### PR TITLE
Investigation guidance: Tier 0 + Tier 1 (make the Companion lead the investigation)

### DIFF
--- a/INVESTIGATION_GUIDANCE_ROADMAP.md
+++ b/INVESTIGATION_GUIDANCE_ROADMAP.md
@@ -1,5 +1,16 @@
 # Making DFIR-Companion Lead the Investigation
 
+> **Implementation status (Tier 0 + Tier 1 shipped on this branch).** Proposals #1–#7 are
+> implemented, unit-tested, and committed here (one commit each). Full suite green: 2294 analysis +
+> 695 reports/server tests, clean `tsc`. Deferred within those items (documented in each commit):
+> the `~` context-prefix prompt notation and per-class counts into synthMeta (#4); the anchor-scoring
+> bump retune and the auto-generated "corroborate `<ioc>`" nextStep (#7, needs #8's structured collect
+> targets). **One operational step remains for #1:** the live `companion/prompts/*.txt` override files
+> are gitignored deployment artifacts — regenerate them with `npm run prompts:eject` so the deployment
+> picks up the built-in prompt (hypotheses / confidenceReason / the new structured-tag & attack-graph
+> instructions). Until then the new drift-detection check will warn on every preflight and synthesis
+> run. Tiers 2–3 (#8–#15) remain as specified below.
+
 **Goal.** Make the Companion genuinely lead an investigation — better decisions, higher recall of
 what actually happened, better dot-connecting, a working FP / rabbit-hole / real-lead triage, the
 right questions at the right time, and concrete "collect X from host Y, here's why" direction —

--- a/INVESTIGATION_GUIDANCE_ROADMAP.md
+++ b/INVESTIGATION_GUIDANCE_ROADMAP.md
@@ -1,0 +1,419 @@
+# Making DFIR-Companion Lead the Investigation
+
+**Goal.** Make the Companion genuinely lead an investigation — better decisions, higher recall of
+what actually happened, better dot-connecting, a working FP / rabbit-hole / real-lead triage, the
+right questions at the right time, and concrete "collect X from host Y, here's why" direction —
+by improving the intelligence and wiring of the loop that already exists, not by bolting on new
+features.
+
+**How this was produced.** A multi-agent audit: six readers mapped the synthesis pipeline, the
+existing guidance surfaces, the FP/triage machinery, the correlation layer, the investigator UX
+flow, and the full ground-truth benchmark history (fairhaven, halcyon, veridia, northpeak,
+branch-office, spillage, llm-injection). Four expert lenses (IR lead, detection engineering,
+LLM-pipeline engineering, intelligence-analysis methodology) proposed improvements; overlapping
+proposals were merged (convergence across independent lenses is noted — it is a strong quality
+signal); each merged proposal was then adversarially judged by skeptics instructed to refute it
+against the real code. Line references are to the state of the code at the time of the audit.
+
+---
+
+## The diagnosis: five structural reasons the guidance doesn't lead
+
+The individual guidance surfaces already exist and are individually well built — synthesis emits
+prioritized `nextSteps` with collection pointers and 12 standard `keyQuestions` with
+answered/partial/unknown status; there are status-tracked hypotheses with expected outcomes, gap
+hypotheses paired with deployable shadow-artifact collections, AI fleet-hunt suggestions with a
+real hit/miss feedback loop, and a memory next-step agent that emits exact Volatility commands.
+The problem is structural, not missing surfaces:
+
+1. **The AI sees a crippled view of the evidence.** Synthesis is one shot over ≤300 events chosen
+   by severity + earliest-15 + even time-spread (`synthSelect.ts`). The true attack chain in four
+   consecutive benchmarks was graded Low/Info and never won a context seat, while mis-graded noise
+   filled the cap — so the model narrated the noise (halcyon fabricated an APT story; fairhaven
+   invented 5 findings; northpeak's whole recon/exfil front half never surfaced). Each selected
+   event is rendered as one 240-char prose line: asset, process lineage, src/dst IP, and
+   corroborating-source count are all dropped. The deterministic causal attack graph
+   (`evidenceGraph.ts`/`graphContext.ts`) is fed to `ask()` and `suggestHunts()` but **not** to the
+   one call that writes findings and the attacker path. Beacon and burst detections never reach any
+   prompt.
+
+2. **The loop never closes.** The super-timeline (the complete raw record) is unreachable by
+   synthesis except via manual promotion; hypotheses name their own confirming evidence
+   (`expectedOutcome`) and unknown questions name hosts — and nothing searches the raw store for
+   those terms. Hunt hit/miss outcomes, playbook task completion, and refuted hypotheses are never
+   fed back into synthesis, so the tool re-recommends work the analyst already did and re-asserts
+   theories the analyst already killed.
+
+3. **Collection directives are free prose, so nothing can act on them.** `NextStep.pointer` and
+   `InvestigationQuestion.pointer` carry "pull Security.evtx 4624 on HOST07" as text. The rich
+   Velociraptor plumbing that already exists (collect-host, shadow-artifact deploys, hunt outcome
+   tracking) can't attach a Deploy button; nothing detects that a later import satisfied the
+   request, so stale "collect X" recommendations keep rendering after X was collected — the single
+   fastest way to teach analysts to ignore the guidance.
+
+4. **Nothing separates FP from rabbit hole from lead.** The taxonomy is binary live/FP. A
+   real-but-irrelevant artifact (veridia's rclone red herring, halcyon's benign USB copy) has no
+   representation. Finding confidence is an unverifiable model-emitted number; findings routinely
+   ship with zero `relatedEventIds` (unfalsifiable from the UI); corroboration is computed for IOCs
+   and merged events but never rolled up to findings; and one stale CTI verdict can still mint a
+   Critical finding against the org's own server (northpeak).
+
+5. **The deployed system silently disables its own intelligence.** The live prompt files in
+   `companion/prompts/` (which `.env` points at, overriding built-ins) are stale: `synthesis.txt`
+   contains no `hypotheses` section, no `confidenceReason`, no `keyQuestions.relatedFindingIds` —
+   so in the actual deployment, synthesis-driven hypothesis auto-generation never fires and
+   confidence ships unexplained. Separately, a 27K-line proxy log that yields **zero** events shows
+   up as a quiet "+0 events" — the tool cannot see, or warn about, its own blind spots.
+
+---
+
+## Recommendations, in build order
+
+Effort: S = hours-to-a-day, M = days, L = a week-plus. "Confirmed" = survived both adversarial
+judges; "verified" = premise checked directly against the code.
+
+### Tier 0 — Prerequisites and same-day wins
+
+#### 1. Re-eject the live prompt files + prompt-capability drift detection (S) — confirmed, prerequisite for everything prompt-touching
+- Regenerate `companion/prompts/synthesis.txt`, `system.txt`, `log.txt`, `csv.txt` from the current
+  built-ins (`npm run prompts:eject` to a temp dir, diff, port deliberate local edits forward).
+  This alone revives hypothesis auto-generation (#140), `confidenceReason`, and
+  `keyQuestions.relatedFindingIds` in the live deployment.
+- Add per-prompt `REQUIRED_MARKERS` lists (literal JSON field names, e.g. SYNTH →
+  `hypotheses`, `confidenceReason`, `relatedFindingIds`) next to the built-in constants. At startup
+  (server.ts preflight route feeding `preflight.ts`): (a) assert each marker appears in its own
+  built-in (so the marker list can't rot), (b) substring-check each configured override file and
+  emit one warning per drifted prompt: *"prompt override synthesis.txt is missing capabilities:
+  hypotheses, confidenceReason — model output will silently lack them."* Also log once per
+  synthesis run, since `_PROMPT_FILE` is re-read per call.
+- Files: `companion/prompts/*.txt`, `src/analysis/pipeline.ts`, `src/analysis/preflight.ts`.
+- Note: gap-driven hypotheses (GAPHYP path) still work today; it is the synthesis-driven
+  auto-generation that is dead live.
+
+#### 2. Condition synthesis on what the investigator already did (S) — confirmed
+Three cheap deterministic context blocks wired into `synthesize()`'s prompt **and** its
+skip-if-unchanged hash (so completing work triggers fresh advice):
+- `renderPriorHuntsBlock(outcomes)` — already imported in pipeline.ts, currently reaching only the
+  three hunt prompts. "A hunt that found nothing is negative evidence; a hit is a pivot point."
+- A capped playbook digest: DONE tasks → "do NOT re-recommend; build on results"; SKIPPED tasks →
+  "not investigated — re-raise only if evidence warrants" (skipped ≠ done).
+- A NEGATIVE KNOWLEDGE block of analyst-refuted hypotheses (cap ~15, analyst-touched only so
+  model-generated refutations don't self-reinforce): "REFUTED: <title> — do not re-assert or derive
+  findings/nextSteps from it." Today only *open* hypotheses are injected.
+- Post-parse safety net: a returned nextStep that overlaps a DONE task is demoted-and-annotated
+  ("similar to completed task <id>") — never silently dropped, and only when the host/artifact
+  entity tokens match (so "pull evtx on HOST09" survives when "…on HOST07" was done).
+- Files: `pipeline.ts`, `huntOutcomes.ts`, `playbook.ts`, `hypothesis.ts`, `hypothesisStore.ts`,
+  `falsePositiveSimilarity.ts`.
+- Directly attacks "never waste the investigator's time": the #157 hunt-outcome loop already proved
+  this feedback pattern works — hunts stopped re-proposing dead VQL; findings/nextSteps never got
+  the same treatment.
+
+#### 3. Answer-contradiction validator: keyQuestion answers may not contradict the deterministic timeline (S) — verified (halcyon)
+- Halcyon answered `q_exfiltration` "No data exfiltration confirmed" while xcopy-to-E: and 7z
+  staging commands sat verbatim, correctly technique-tagged, in the timeline. The most dangerous
+  single output an IR tool can produce is a flatly wrong negative conclusion delivered with
+  authority.
+- Deterministic post-parse pass beside the existing FP safety net: map standard question ids to
+  technique families (q_exfiltration → T1041/T1048/T1052/T1567; q_lateral_movement → T1021.*;
+  q_persistence → T1053/T1546/T1547; q_log_tampering → T1070.*). When an answer matches a negation
+  pattern ("no … confirmed/observed") but in-scope non-FP events carry those techniques, force
+  status to `partial` and rewrite the pointer to cite the contradicting event ids. Pure function
+  over tags that already exist (`tradecraftRules.ts`, `reconTechniques.ts`, `exfilCorrelate.ts`).
+- Surface as a visible "answer contradicted by timeline evidence" badge on the question card and in
+  reports.
+- Files: `pipeline.ts`, `stateTypes.ts`, dashboard, reports.
+
+### Tier 1 — Fix what the AI sees (the root cause of every fabricated narrative)
+
+#### 4. Chain-aware, corroboration-weighted synthesis event selection (M) — confirmed, impact 9, all four lenses converged
+Replace the pure severity+spread sampler in `selectSynthesisEvents()` with **reserved per-class
+budgets** (not just priority order, so classes survive even when Critical/High alone exceed the
+cap):
+- **Anchor context (~40%)**: for each Critical/High event, same-asset events within ±15 min (hard
+  cap ~6 per anchor, command-line/process events preferred) — so the Low-graded "what happened
+  right before/after on this host" chain rides in with its anchor.
+- **Corroborated (~25%)**: events with `sources.length ≥ 2` (already merged by `correlate.ts`),
+  ranked to prefer cross-source-*type* corroboration (endpoint+network) over same-family
+  duplicates.
+- **Technique-tagged (~15%)**: non-empty `mitreTechniques` regardless of severity — behavioral
+  signal the deterministic layer already computed.
+- **Remainder**: filled burst-by-burst via `burstDetect.ts` phases (keep whole bursts, drop whole
+  bursts) instead of an even spread that shreds clusters.
+- Return an annotated selection so `renderEvent` can prefix sampled context lines with `~` and emit
+  per-cluster omission markers ("~40 similar Medium events on HOST-X omitted, 3 shown") instead of
+  silent thinning; teach the `~` notation to the synthesis prompt (built-in **and** ejected file).
+  Degrade gracefully under the two-pass budget refit (trim per-anchor context before dropping
+  anchors). Record per-class counts in `synthMeta.ts` and show them on the "last synthesized" card
+  so the investigator knows what classes of evidence the AI actually saw.
+- Files: `synthSelect.ts`, `pipeline.ts`, `burstDetect.ts`, `synthMeta.ts`, prompts, dashboard.
+- Why: all four incident-story benchmarks failed at this layer, not at grading; the branch-office
+  corroboration lens (4,546 → 71 events, storyline surfaced) proved the missing signal already
+  works. Acceptance: re-run fairhaven/halcyon/veridia ground truth — the previously-excluded true
+  chains (sqlcmd/tar/curl PUT; robocopy/7z/xcopy; mysqldump) must appear in the selected set.
+
+#### 5. Give synthesize() the structured evidence it already owns (M) — confirmed, all four lenses converged
+Three prompt-side wirings, in priority order:
+1. Extend synthesize's `renderEvent` with compact structured tags after the prose, only when set
+   (the `<asset>` pattern from `suggestPlaybookHunts` already exists):
+   `<host:WS07> <proc:cmd.exe←powershell.exe> <net:10.1.2.3→52.1.1.1:443> <sources:3>`.
+   Apply the same to `ask()`'s identical renderEvent as a near-free follow-on.
+2. Feed `buildGraphContext(state)` — the deterministic causal attack graph of spawn chains, file
+   lineage, lateral movement — into `synthesize()` (today it reaches only `ask()`/`suggestHunts()`),
+   computed **after** the skip-if-unchanged hash, counted in `synthOverhead` so the existing budget
+   machinery pays for it. Fix `graphContext.ts` to render each edge's confidence + rule
+   (`[high, shared-hash]`) so hard lineage edges outweigh regex-scraped shared-account hints.
+3. Add two one-line digests to the synthesis context: statistically-confirmed beacon candidates
+   ("PERIODIC BEACON: WS04 → 203.0.113.7:443 every ~62s, 214 events") carrying `BEACON_CAVEAT`
+   verbatim and phrased as *candidate — verify*, cross-referenced against IOC enrichment verdicts;
+   and burst attack phases ("09:02–09:15 Discovery (41 ev), 11:30–11:38 Collection (12 ev)").
+   Beacon/burst digests are the lowest-priority piece — ship wirings 1+2 first if trimming.
+- Files: `pipeline.ts`, `graphContext.ts`, `synthSelect.ts`, `beaconDetect.ts`, `burstDetect.ts`.
+- Why: fairhaven's wrong-anchor credential finding and halcyon's cross-host fabrication are exactly
+  cross-host dot-connecting failures where the deterministic graph knew better than the prose the
+  model was given.
+
+#### 6. Deterministic per-finding grounding + corroboration rollup with confidence caps (M) — confirmed, all four lenses converged
+A deterministic pass right after `backfillHighSeverityFindings`:
+1. **Grounding**: filter each finding's `relatedEventIds` to ids present in scope. Findings left
+   empty get `ungrounded=true`, a "no cited evidence — hypothesis, not fact" badge (card +
+   reports), and a hard confidence cap (~45, named constant). Backfill only via **exact**
+   IOC-value/host token matches (reusing `iocCorroboration.ts`'s index) — never fuzzy
+   title/description matching, which fabricates grounding.
+2. **Rollup**: from the surviving related events compute
+   `{distinctTools, distinctHosts, maxSeverity, intelAgreement, graphLinked}` and persist as
+   structured `Finding.corroboration`.
+3. **Caps**: deterministically enforce what the prompt already asks but can't enforce —
+   single-tool + single-host + no corroborated IOC ⇒ confidence ≤ 65 with reason appended;
+   CTI-verdict-only findings can't stay Critical/High ⇒ floor to Medium and auto-append a nextStep
+   "corroborate <ioc> — pull <logSource> on <host>".
+4. **Surface**: "2 tools / 3 hosts / intel ✓" vs "uncorroborated" badges; rollup line echoed into
+   the next synthesis prompt so the model sees which of its own claims are weak. Keep hunt prompts
+   consuming ungrounded findings (annotated) — hunts exist to corroborate weak leads; don't exclude.
+- Files: `pipeline.ts`, `confidence.ts`, `stateTypes.ts`, `responseSchema.ts`,
+  `iocCorroboration.ts`, `evidenceGraph.ts`, dashboard, reports.
+- Why: halcyon shipped 0/7 findings with any cited events; northpeak's stale-CTI Critical was
+  patched with prompt warnings that the model ignored. This is the structural version of those
+  point fixes, and it changes real decisions: triage order, whether a Critical is trusted, and the
+  derived next collection step.
+
+#### 7. Deterministic intel-verdict corroboration gate (M) — confirmed
+- `verdictCorroboration(ioc, events, hostNames)` in `iocAnchors.ts` →
+  `corroborated` (2+ distinct providers agree — scan ALL enrichments, not just the first — or 1
+  provider + a linked ≥Medium behavioral event) | `lone-intel` | `conflicted` (matches the case's
+  own host assets or RFC1918/internal).
+- Consume in three places: the THREAT-INTEL VERDICTS prompt block annotates each line and moves
+  `conflicted` to an "INTEL CONFLICTS — do not treat as confirmed" sub-block; anchor scoring gives
+  conflicted 0 bump and lone-intel a reduced bump (but both **stay in the digest** — hiding fresh
+  single-provider C2 hits would hurt recall); a standalone post-synthesis pass caps intel-only
+  findings at Medium/60 with an explanatory `confidenceReason`.
+- Providers sharing feeds (OpenCTI ingesting MISP) are pseudo-independent: label "corroborated",
+  never "confirmed".
+- Files: `iocAnchors.ts`, `synthSelect.ts`, `pipeline.ts`, `enrichService.ts`, dashboard.
+- Why: northpeak's stale OpenCTI verdict on the org's own DB server produced a Critical "C2"
+  finding — the single most decision-distorting output the tool has generated in any benchmark, and
+  its current guard is advisory prose.
+
+### Tier 2 — Make the program direct collection (the "what/where/how to proceed" core)
+
+#### 8. Structured collection directives, wired to deploy, with import-satisfaction detection (L) — confirmed by both judges ("the difference between a report generator and a tool that leads collection")
+- Add optional `collect?: { host?, artifact?, logSource?, expectedOutcome? }` +
+  `relatedFindingIds` to `NextStep` and `InvestigationQuestion`; demand it in the synthesis prompt
+  (built-in **and** ejected file) for every `unknown` question and collection-type nextStep,
+  prioritizing questions that discriminate between open hypotheses; lenient `.catch` validation.
+- Three consumers:
+  1. `derivePlaybookTasks` consumes `collect.host/artifact` directly (replacing the bare-`f<n>`
+     prose scraping) and seeds tasks from unknown questions (sourceKey `question:<id>`).
+  2. Next-steps/key-questions panels render a **Deploy/Collect** button when Velociraptor is
+     configured — mapping artifact/logSource onto the `shadowArtifacts.ts` catalog or generic
+     file-collection VQL via the existing `/velociraptor/collect-host` route — and a copyable
+     manual-collection checklist when it is not. Guard: `collect.host` must validate against
+     `knownEndpoints(state)` (reuse playbookHunt's validator); unvalidated hosts render as text,
+     never as a button (hallucinated hostnames must not trigger dead collections).
+  3. On import, match new events against open collect targets requiring **both** host and
+     logSource/artifact-family. A match marks the step/question "evidence received — re-evaluating"
+     (never auto-answers or hides), injects the question into the existing `questionsToReanswer`
+     block, and adds a "SATISFIED COLLECTIONS — do not re-recommend" block to the next synthesis
+     prompt. Keyed by collect target in a per-case side store (nextStep ids don't survive
+     re-synthesis).
+- Phasing: schema+prompt+playbook first, satisfaction detection second, Deploy UI last.
+- Files: `stateTypes.ts`, `responseSchema.ts`, `pipeline.ts`, `playbook.ts`, `playbookHunt.ts`,
+  `importMeta.ts`, `stateMerge.ts`, `shadowArtifacts.ts`, `routes/velociraptor.ts`, prompts,
+  dashboard.
+- Why: the model already produces this information as prose — it is being thrown away as
+  unparseable text. The gap-hypothesis panel proves the full recommend→deploy→ingest pattern works
+  end-to-end today; this generalizes it to the two primary guidance surfaces. The
+  import-satisfaction piece is the single best anti-fatigue change available.
+
+#### 9. Kill-chain gap analysis that directs collection (M) — confirmed
+- `buildKnownUnknowns` — the system's only kill-chain-stage gap enumerator — is prompt-only: no
+  route, no panel; the investigator never sees the single best deterministic what-to-collect-next
+  signal the system derives. Its uncovered-tactic line also names no artifact or host.
+- Refactor to `buildKnownUnknownItems()` returning structured items
+  (`{kind, tactic?, window?, targetHosts[], artifacts[]}`) with the prompt string as a renderer
+  over it; extract the opts assembly shared with the synthesis path so panel and prompt provably
+  show the identical list.
+- Add a deterministic `TACTIC_EVIDENCE` table (mirroring `TACTIC_FOCUS` in playbook.ts):
+  Initial Access → mail/proxy/VPN logs + browser history on earliest-active assets and top-ranked
+  hosts; Lateral Movement → Security.evtx 4624 type-3/RDP on evidenceGraph lateral-edge host pairs;
+  C2 → DNS/proxy for connective IOCs; Exfiltration → SRUM/USN on staging hosts — reusing
+  `SHADOW_ARTIFACTS` where they map.
+- Expose `GET /cases/:id/known-unknowns`; render an "Evidence gaps — what this case is missing"
+  panel near the top of the dashboard (wired into section-visibility settings AND view profiles),
+  each item carrying its collection directive with one-click collect via the existing
+  shadow-artifact deploy plumbing; silence-gap items link to the existing Timeline Gaps panel
+  rather than duplicating its UI. Uncovered tactics also become playbook task seeds
+  (`ku:<tactic>`) so gap-driven collection is status-tracked. Add a report section.
+- Files: `knownUnknowns.ts`, `playbook.ts`, `shadowArtifacts.ts`, `routes/timeline.ts`,
+  `hostRanking.ts`, `iocAnchors.ts`, dashboard, reports.
+- Why: "no initial-access evidence" should generate "pull mail-gateway logs / browser history from
+  patient-zero candidate HOST-X" — nothing does that today, and no lead can point at evidence that
+  never entered the case.
+
+#### 10. Source-yield instrumentation: surface zero-yield imports and cap truncation (M) — confirmed
+- Extend `ImportRecord` with per-import `linesIn`, `eventsOut`, `iocsOut`, `capHit`,
+  `path (deterministic|ai)`; have `logAggregate` return a truncated flag.
+- v1 uses only three high-precision triggers (no generic yield-ratio floor — that's the one leg
+  with real fatigue risk): (a) `eventsOut==0` with `linesIn > ~1000` via the AI-triage path,
+  (b) `capHit=true`, (c) network telemetry imported with no detector feed in the case.
+- Consume in three existing surfaces: the import banner shows a persistent warning chip with a
+  directive next action ("proxy_access.log: 27,290 lines → 0 events via AI triage — re-run triage
+  or grep the raw file for the case's IOCs/hosts") instead of "+0 events"; `buildKnownUnknowns`
+  emits a fourth bullet class (source type → inferred missing phases, e.g. proxy →
+  Discovery/C2/Exfiltration) flowing into synthesis and hunt prompts; triggers (a)/(b) raise a
+  Medium coverage finding via the idempotent gap-finding path, while (c) stays a hint.
+- Files: `importMeta.ts`, `routes/import.ts`, `pipeline.ts`, `knownUnknowns.ts`, dashboard.
+- Why: northpeak's defining failure — 27K lines silently contributing nothing, read as "source
+  clean". The tool must be able to lead collection around its own blind spots.
+
+#### 11. Second-look loop: targeted re-query of raw evidence + one bounded re-synthesis (L) — three lenses converged
+- Post-synthesis executor with two input paths: (a) **deterministic harvest** — search terms from
+  open hypotheses (`relatedIocs`, host/process tokens in `expectedOutcome`), unknown questions'
+  collect targets, and top connective IOCs; (b) **model-issued** — an optional `evidenceRequests`
+  array (max 5: `{host?, timeWindow?, keywords[], reason}`) in the delta schema, with a prompt
+  section instructing the model to request evidence it wasn't shown.
+- Resolve terms against the scoped events the sampler omitted AND the super-timeline via the
+  existing `querySuper` filters, restricted to the case's active window. Auto-promote matches via
+  the existing `promoteSuperTimeline` path, capped (~50/term, ~200/sweep), each tagged
+  `[second-look: h2]` so the existing Promoted badge shows provenance.
+- If anything was promoted, queue exactly **one** background re-synthesis — bounded by the existing
+  input-hash plus a one-iteration flag. A request that matched nothing is itself surfaced as a
+  collection lead. Surface on the synth-meta card: "second look: 42 raw events matching hypothesis
+  h2 (rsync, nfs-01) promoted — conclusions updated."
+- Files: `pipeline.ts`, `superTimeline.ts`, `responseSchema.ts`, `hypothesis*.ts`, `iocAnchors.ts`,
+  `synthMeta.ts`, dashboard.
+- Why: the complete raw record is unreachable by the AI today no matter what hypotheses it forms;
+  northpeak's recon/clone/exfil story sat in raw rows synthesis never saw. This closes the
+  hypothesize → re-query → verify loop with existing plumbing and strict bounds.
+
+### Tier 3 — Triage intelligence: FP, rabbit holes, and learned baselines
+
+#### 12. Immediate deterministic FP cascade (M) — three lenses converged
+- Today FP feedback only takes effect at the *next* synthesis; between mark and re-run the
+  dashboard keeps showing answers/next-steps that rested on the FP'd finding.
+- Extract the question-invalidation logic out of `synthesize()` into a shared
+  `reconsiderKeyQuestions(state, markers)` called synchronously by the FP-mark route: affected
+  questions flip to "unknown — supporting finding rejected" with a "stale, re-synthesis queued"
+  badge immediately.
+- Same handler: recompute host ranking / connective-IOC ranking over FP-filtered events (a host
+  whose entire signal was FP'd must stop topping the ranking); flag hypotheses whose supporting
+  evidence intersects new FP markers (`needsReview`, pristine ones flip to `unknown`, respecting
+  the analyst-touched freeze contract).
+- Anomaly triage: one-click "mark this spike as FP" feeding `TimelineAnomaly.eventIds` (already
+  carried) into the existing batch-mark endpoint; annotate each anomaly with how many of its events
+  are already FP'd so dismissed spikes visibly deflate.
+- Files: `routes/findings.ts`, `falsePositive.ts`, `pipeline.ts`, `hostRanking.ts`, `iocAnchors.ts`,
+  `timelineAnomalies.ts`, `hypothesis*.ts`, dashboard.
+
+#### 13. Rabbit-hole detection: connectedness + "real-but-unrelated" relevance verdict (M) — three lenses converged
+- Deterministic half: `mainComponent()` on the evidence graph (the connected component holding the
+  corroborated Critical/High severity mass); per-finding connectedness = fraction of its related
+  events/IOCs touching that component via existing edges or shared connective IOCs; zero linkage ⇒
+  `relevance='disconnected'`.
+- AI half: per-finding `relevance` enum (`connected | unrelated-but-real | undetermined`) in the
+  delta schema + a prompt section asking the model to flag genuine-but-likely-unrelated activity
+  with a one-line reason.
+- FP-context retention: `authorized-test` / `known-good-tool` markers become a retained one-line
+  CONTEXT block ("sanctioned test activity during window X") instead of pure erasure — a pentest
+  running during the window is investigation-shaping context.
+- Surface: findings grouped **Leads / Possible rabbit holes — verify before chasing / Parked**,
+  with a "no causal link to main attack path — to link it, look for: <missing-edge discriminator>"
+  chip; disconnected findings down-weighted in playbook/hunt/nextStep seats so guidance stops
+  spending budget on them.
+- Files: `evidenceGraph.ts`, `pipeline.ts`, `responseSchema.ts`, `stateTypes.ts`,
+  `falsePositive.ts`, `playbook.ts`, prompts, dashboard.
+- Why: this is the direct answer to "which events are rabbit holes" — the taxonomy for it simply
+  doesn't exist today (veridia's red herring became a High finding; halcyon's benign USB copy was
+  indistinguishable from the real exfil).
+
+#### 14. ACH-style hypotheses: contradicting evidence, discriminators, hunt-miss exhaustion (M)
+- Extend the (revived, see #1) hypotheses output spec: per-hypothesis `supportingEventIds`,
+  `contradictingEventIds` ("events INCONSISTENT with this explanation"), and a `discriminator`
+  ("the single artifact that would best separate this hypothesis from the leading alternative —
+  name host + artifact").
+- Link hunts to hypotheses (`relatedHypothesisId` on suggestions/outcomes): a hunt that comes back
+  empty weakens the hypothesis it tested; after N misses against its `expectedOutcome`, mark it
+  `exhausted` → flows into the NEGATIVE KNOWLEDGE synthesis block (#2).
+- Rank the hypothesis panel ACH-style by *fewest contradictions*, not most support; discriminators
+  double as concrete collection directives and feed question prioritization in #8.
+- Files: `pipeline.ts`, `responseSchema.ts`, `hypothesis*.ts`, `huntSuggest.ts`, `huntOutcomes.ts`,
+  prompts, dashboard.
+- Why: red herrings become findings unopposed when nothing tracks what contradicts a theory; this
+  is the classic intelligence-analysis fix, attached to machinery that already exists.
+
+#### 15. Per-case prevalence/baseline index + proactive FP pattern propagation (L)
+- Prevalence: at import, compute per-case occurrence counts of normalized pattern keys
+  (process+command-shape, sha256, asset+pattern) across forensic + super timelines; stamp events
+  ("seen 214× on 12 hosts over 9 days"), feed rarity into the #4 selection fill, and render
+  common/rare tags in `renderEvent` so the model gets explicit baseline context instead of
+  guessing.
+- FP propagation: extend markers with an optional `patternFingerprint` derived from the anchor
+  event; after every import, run the existing `findSimilarEvents` scorer against the import diff
+  and, above a threshold, surface an import-banner suggestion "214 new events match FP pattern
+  nightly-robocopy — review and bulk-mark" (one-click via the existing batch endpoint; never
+  auto-applied).
+- Files: `falsePositiveSimilarity.ts`, `falsePositive.ts`, `stateMerge.ts`, `routes/import.ts`,
+  `importMeta.ts`, `synthSelect.ts`, dashboard.
+- Why: marking an FP currently teaches the system nothing lasting — the same nightly-robocopy
+  pattern re-arrives High after every import; `tradecraftRules.ts`'s unconditional-High
+  robocopy/xcopy grade explicitly depends on an FP-suppression loop that doesn't exist proactively.
+
+---
+
+## Measuring it
+
+Every Tier 1 change is directly measurable against the existing ground-truth benchmark corpus —
+that is the acceptance test, not unit tests alone:
+
+- **fairhaven**: the sqlcmd/tar/curl-PUT chain must reach the model's context (#4); the
+  Explicit-Credential-Use finding must anchor to the real 4648 pivot event (#5); zero findings with
+  empty `relatedEventIds` (#6).
+- **halcyon**: no cross-host APT narrative (#4/#5); `q_exfiltration` cannot answer "none confirmed"
+  while T1052/T1074 events exist (#3).
+- **northpeak**: the zero-yield proxy import must raise a visible coverage warning and a
+  known-unknown (#10); the stale-CTI finding on the org's own server must be capped by the intel
+  gate (#7).
+- **veridia**: the rclone red herring should land in "possible rabbit holes", not as a High lead
+  (#13).
+
+## Suggested sequencing
+
+1. **Week 1**: #1 (prompt re-eject + drift check) → #2 → #3. Small, independent, immediately
+   user-visible, and #1 unblocks everything else.
+2. **Weeks 2–3**: #4 + #5 together (they share the renderEvent/prompt work), then #6 + #7 (they
+   share the post-synthesis validator pattern). Re-run the benchmark corpus after each.
+3. **Weeks 4–6**: #8 phased (schema+prompt+playbook → satisfaction detection → Deploy UI), #9, #10.
+4. **Then**: #11–#15 in whatever order case experience prioritizes; #12 before #13 (the rabbit-hole
+   grouping builds on immediate FP recomputation), #14 after #8 (discriminators feed question
+   prioritization), #15 last (largest and most independent).
+
+## Verification status
+
+Proposals #1, #4, #5, #6, #8 were each confirmed by two independent adversarial judges (one
+attacking investigator value, one verifying every code citation against the repo); #2, #7, #9, #10
+by one judge each; #3, #11–#15 are supported by multi-lens convergence and direct code verification
+of their premises (stale live prompts, prose-only pointers, prompt-only knownUnknowns, support-only
+hypothesis links, exact-ref FP markers, binary FP taxonomy) but did not complete a full
+adversarial pass. No judged proposal was rejected; judge corrections (conservative grounding
+backfill only, host validation before Deploy buttons, no generic yield-ratio floor, skipped ≠ done,
+beacon caveats) are folded into the text above.

--- a/companion/src/analysis/answerContradiction.ts
+++ b/companion/src/analysis/answerContradiction.ts
@@ -1,0 +1,154 @@
+// Answer-contradiction validator (investigation-guidance #3). The most dangerous single output an IR
+// tool can produce is a flatly WRONG negative conclusion delivered with authority — e.g. halcyon
+// answered q_exfiltration "No data exfiltration has been confirmed" while the xcopy-to-E: and 7z
+// staging commands sat verbatim, correctly technique-tagged, in the timeline. Nothing validated the
+// answer against the deterministic technique tags the system already computed.
+//
+// This is a PURE, deterministic post-synthesis pass over data already in state: it maps each standard
+// DFIR question to the ATT&CK technique FAMILIES that would evidence it, and when a question's answer
+// ASSERTS AN ABSENCE but in-scope (non-FP) events carry those techniques, it forces the status to
+// "partial" and rewrites the pointer to cite the contradicting events, plus stamps a `contradicted`
+// flag the UI/report render as a badge. No AI call. It never fabricates a positive answer — it only
+// refuses to let an unqualified "no" stand against the timeline.
+
+import type { ForensicEvent, InvestigationQuestion } from "./stateTypes.js";
+
+// A question ↔ technique-family rule. A question matches when its id contains any `idPatterns` token OR
+// its text contains any `textKeywords` token (the model chooses ids freely past the four examples in the
+// synthesis prompt, so we match text too). `techniquePrefixes` are matched as PREFIXES, so "T1041"
+// covers "T1041.001". Kept deliberately to families where an absence claim is falsifiable by a tag.
+interface ContradictionRule {
+  key: string;
+  idPatterns: string[];
+  textKeywords: string[];
+  techniquePrefixes: string[];
+}
+
+export const CONTRADICTION_RULES: readonly ContradictionRule[] = [
+  {
+    key: "exfiltration",
+    idPatterns: ["exfil"],
+    textKeywords: ["exfiltrat", "data theft", "data was stolen", "data transfer out"],
+    // exfil channels + physical medium/USB + local & remote staging (halcyon: xcopy→E:, 7z archive)
+    techniquePrefixes: ["T1041", "T1048", "T1052", "T1567", "T1030", "T1020", "T1074", "T1560"],
+  },
+  {
+    key: "lateral_movement",
+    idPatterns: ["lateral"],
+    textKeywords: ["lateral movement", "moved between hosts", "pivot"],
+    techniquePrefixes: ["T1021", "T1570", "T1550", "T1563"],
+  },
+  {
+    key: "persistence",
+    idPatterns: ["persist"],
+    textKeywords: ["persistence", "maintain access", "foothold"],
+    techniquePrefixes: ["T1053", "T1543", "T1546", "T1547", "T1136", "T1098", "T1505", "T1574"],
+  },
+  {
+    key: "privilege_escalation",
+    idPatterns: ["priv", "escalat"],
+    textKeywords: ["privilege escalation", "elevated privileges", "escalate"],
+    techniquePrefixes: ["T1548", "T1068", "T1134", "T1484", "T1055"],
+  },
+  {
+    key: "credential_access",
+    idPatterns: ["cred"],
+    textKeywords: ["credential", "password", "hash dump", "kerberoast"],
+    techniquePrefixes: ["T1003", "T1110", "T1555", "T1552", "T1558", "T1556", "T1187"],
+  },
+  {
+    key: "command_and_control",
+    idPatterns: ["c2", "command_and_control", "command", "control"],
+    textKeywords: ["command & control", "command and control", "c2", "beacon"],
+    techniquePrefixes: ["T1071", "T1105", "T1572", "T1090", "T1568", "T1219", "T1102", "T1573"],
+  },
+  {
+    key: "initial_access",
+    idPatterns: ["initial"],
+    textKeywords: ["initial access", "how did they get in", "entry vector", "first compromise"],
+    techniquePrefixes: ["T1566", "T1190", "T1133", "T1189", "T1195", "T1078", "T1091", "T1200"],
+  },
+  {
+    key: "log_tampering",
+    idPatterns: ["log_tamper", "anti_forensic", "tamper"],
+    textKeywords: ["cleared logs", "log tampering", "anti-forensic", "deleted logs", "wiped logs"],
+    techniquePrefixes: ["T1070", "T1562", "T1027", "T1218"],
+  },
+];
+
+// Does the answer ASSERT AN ABSENCE (not merely "unknown")? Needs a negation token AND an absence/
+// confirmation word, so "No data exfiltration has been confirmed" trips it but "not only X but Y" and a
+// neutral answer do not. An empty answer is NOT an absence assertion ("we don't know" ≠ "it didn't
+// happen") — the caller also gates on a non-empty answer.
+const NEGATION_RE = /\b(no|not|never|none|without|nothing|didn'?t|wasn'?t|weren'?t|isn'?t|aren'?t|un(?:confirmed|observed|detected))\b/i;
+const ABSENCE_CONTEXT_RE =
+  /\b(evidence|confirmed?|observ\w*|found|detect\w*|identif\w*|occurr\w*|present|indication|sign|signs|activity|seen|no such|took place|happen\w*)\b/i;
+
+export function assertsAbsence(answer: string): boolean {
+  const a = String(answer ?? "").trim();
+  if (!a) return false;
+  return NEGATION_RE.test(a) && ABSENCE_CONTEXT_RE.test(a);
+}
+
+function matchesRule(q: Pick<InvestigationQuestion, "id" | "question">, rule: ContradictionRule): boolean {
+  const id = String(q.id ?? "").toLowerCase();
+  if (rule.idPatterns.some((p) => id.includes(p))) return true;
+  const text = String(q.question ?? "").toLowerCase();
+  return rule.textKeywords.some((k) => text.includes(k));
+}
+
+function eventHasPrefix(techniques: readonly string[] | undefined, prefixes: readonly string[]): string[] {
+  const hits: string[] = [];
+  for (const t of techniques ?? []) {
+    const up = String(t).toUpperCase();
+    if (prefixes.some((p) => up === p || up.startsWith(p + "."))) hits.push(up);
+  }
+  return hits;
+}
+
+const MAX_CITED_EVENTS = 3;
+
+// The techniques + a few event ids in `events` that contradict `rule` (i.e. evidence the question's
+// negative answer overlooked). Empty techniques ⇒ no contradiction.
+export function findContradictingEvents(
+  events: readonly ForensicEvent[],
+  rule: ContradictionRule,
+): { techniques: string[]; eventIds: string[] } {
+  const techniques = new Set<string>();
+  const eventIds: string[] = [];
+  for (const e of events ?? []) {
+    const hits = eventHasPrefix(e.mitreTechniques, rule.techniquePrefixes);
+    if (!hits.length) continue;
+    hits.forEach((h) => techniques.add(h));
+    if (eventIds.length < MAX_CITED_EVENTS) eventIds.push(e.id);
+  }
+  return { techniques: [...techniques].sort(), eventIds };
+}
+
+// For each question whose answer asserts an absence but whose technique family IS present in the
+// in-scope events, force status → "partial", stamp `contradicted`, and rewrite the pointer to cite the
+// contradicting events. `events` MUST already be the in-scope, non-false-positive set (the same the
+// model saw). Pure: returns new question objects, never mutates. A question already flagged is
+// recomputed idempotently (the flag is cleared first, so a since-corrected answer loses the badge).
+export function flagContradictedAnswers(
+  questions: readonly InvestigationQuestion[],
+  events: readonly ForensicEvent[],
+): InvestigationQuestion[] {
+  return (questions ?? []).map((q) => {
+    const { contradicted: _prev, ...clean } = q;   // recompute from scratch each pass
+    if (!assertsAbsence(clean.answer)) return clean;
+    const rule = CONTRADICTION_RULES.find((r) => matchesRule(clean, r));
+    if (!rule) return clean;
+    const { techniques, eventIds } = findContradictingEvents(events, rule);
+    if (!techniques.length) return clean;
+    const cite = eventIds.length ? ` [${eventIds.join(", ")}]` : "";
+    return {
+      ...clean,
+      status: "partial" as const,
+      pointer:
+        `Timeline contains ${techniques.join(", ")} events${cite} that contradict this negative answer — ` +
+        `review before concluding.` + (clean.pointer ? ` (was: ${clean.pointer})` : ""),
+      contradicted: { techniques, eventIds },
+    };
+  });
+}

--- a/companion/src/analysis/findingGrounding.ts
+++ b/companion/src/analysis/findingGrounding.ts
@@ -11,7 +11,8 @@
 //   CAPS       — a single-tool, single-host, uncorroborated finding can't keep a high confidence.
 // It only ever LOWERS confidence (never invents grounding, never raises a score) and is pure + idempotent.
 
-import type { Finding, ForensicEvent, IOC, FindingCorroboration } from "./stateTypes.js";
+import type { Finding, ForensicEvent, IOC, FindingCorroboration, Severity } from "./stateTypes.js";
+import { classifyVerdict, iocHasBehavioralEvent } from "./iocAnchors.js";
 
 // A finding with no cited in-scope evidence is a hypothesis — cap hard so it can't outrank grounded work.
 export const UNGROUNDED_CONFIDENCE_CAP = 45;
@@ -94,6 +95,53 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
       ...(ungrounded ? { ungrounded: true } : {}),
       ...(confidence !== undefined ? { confidence } : {}),
       ...(confidenceReason !== undefined ? { confidenceReason } : {}),
+    };
+  });
+}
+
+// An intel-only High/Critical finding can't keep its severity — the confidence cap (investigation-
+// guidance #7 coordinating with #6). A finding whose ONLY malicious signal is threat-intel (all its
+// verdict-carrying IOCs are lone-intel/conflicted) and which has no behavioral corroboration (≤1 tool,
+// not graph-linked) is floored to Medium / confidence ≤ 60 with a reason. This is the northpeak class:
+// a stale OpenCTI verdict on the org's own db-01 became a Critical "C2" finding on a benign connection.
+export const INTEL_ONLY_SEVERITY_FLOOR: Severity = "Medium";
+export const INTEL_ONLY_CONFIDENCE_CAP = 60;
+const SEV_ORDER: Record<Severity, number> = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4 };
+
+export interface IntelCapInput {
+  findings: readonly Finding[];
+  iocs: readonly IOC[];
+  scopedEvents: readonly ForensicEvent[];
+  hostNames: ReadonlySet<string>;          // the case's own host short-names (see iocAnchors.shortHost)
+}
+
+export function capIntelOnlyFindings(input: IntelCapInput): Finding[] {
+  const { findings, iocs, scopedEvents, hostNames } = input;
+  const iocById = new Map(iocs.map((i) => [i.id, i] as const));
+  return findings.map((f) => {
+    // Only High/Critical findings can be over-graded by intel; leave the rest.
+    if (SEV_ORDER[f.severity] > SEV_ORDER.High) return f;
+    // The finding's verdict-carrying related IOCs.
+    const verdictIocs = (f.relatedIocs ?? [])
+      .map((id) => iocById.get(id))
+      .filter((i): i is IOC => !!i && (i.enrichments ?? []).some((e) => e.verdict === "malicious" || e.verdict === "suspicious"));
+    if (!verdictIocs.length) return f;   // not intel-driven
+
+    const classes = verdictIocs.map((i) =>
+      classifyVerdict(i, { hasBehavioralEvent: iocHasBehavioralEvent(i.value, scopedEvents), hostNames }));
+    const intelOnly = classes.every((c) => c === "lone-intel" || c === "conflicted");
+    const hasConflict = classes.some((c) => c === "conflicted");
+    const behavioralGrounding = !!f.corroboration && (f.corroboration.distinctTools >= 2 || f.corroboration.graphLinked);
+    if (!intelOnly || behavioralGrounding) return f;
+
+    const note = hasConflict
+      ? "capped: rests on a threat-intel verdict about the case's OWN infrastructure — most likely stale/wrong, verify before acting"
+      : "capped: rests on uncorroborated single-provider threat-intel only — a lead, not a confirmed compromise; verify before acting";
+    return {
+      ...f,
+      severity: INTEL_ONLY_SEVERITY_FLOOR,
+      confidence: Math.min(f.confidence ?? INTEL_ONLY_CONFIDENCE_CAP, INTEL_ONLY_CONFIDENCE_CAP),
+      confidenceReason: appendReason(f.confidenceReason, note),
     };
   });
 }

--- a/companion/src/analysis/findingGrounding.ts
+++ b/companion/src/analysis/findingGrounding.ts
@@ -1,0 +1,112 @@
+// Per-finding grounding + corroboration rollup (investigation-guidance #6). A finding's `confidence`
+// was an unverifiable AI-emitted number, and findings routinely shipped with no cited events (halcyon:
+// 0/7), so a claim could not be checked from the UI and a single stale CTI verdict became a Critical
+// finding (northpeak). This deterministic pass, run after the finding backfills, does three things:
+//   GROUNDING  — resolve each finding's supporting IN-SCOPE events (via BOTH the finding's own
+//                relatedEventIds AND the reverse links on forensicTimeline[].relatedFindingIds, so the
+//                deterministic high-severity backfill findings — which carry only reverse links — are
+//                correctly grounded). A finding with no supporting event is `ungrounded`: a hypothesis,
+//                not a fact — confidence hard-capped and badged.
+//   ROLLUP     — from those events compute { distinctTools, distinctHosts, intelSources, graphLinked }.
+//   CAPS       — a single-tool, single-host, uncorroborated finding can't keep a high confidence.
+// It only ever LOWERS confidence (never invents grounding, never raises a score) and is pure + idempotent.
+
+import type { Finding, ForensicEvent, IOC, FindingCorroboration } from "./stateTypes.js";
+
+// A finding with no cited in-scope evidence is a hypothesis — cap hard so it can't outrank grounded work.
+export const UNGROUNDED_CONFIDENCE_CAP = 45;
+// A grounded but single-source (one tool, one host, no corroborating IOC/graph) finding is capped here —
+// it may be real, but it can't claim high confidence on one uncorroborated observation.
+export const SINGLE_SOURCE_CONFIDENCE_CAP = 65;
+
+function appendReason(existing: string | undefined, note: string): string {
+  const base = (existing ?? "").trim();
+  return base ? `${base} | ${note}` : note;
+}
+
+export interface GroundingInput {
+  findings: readonly Finding[];
+  scopedEvents: readonly ForensicEvent[];      // in-scope events, carrying relatedFindingIds (reverse links)
+  iocs: readonly IOC[];
+  graphLinkedEventIds: ReadonlySet<string>;     // event ids that participate in an evidence-graph edge
+}
+
+// The IOC ids that carry at least one malicious/suspicious intel verdict — the finding-level "intel
+// backs this" signal.
+function intelFlaggedIocIds(iocs: readonly IOC[]): Set<string> {
+  const out = new Set<string>();
+  for (const i of iocs) {
+    if ((i.enrichments ?? []).some((e) => e.verdict === "malicious" || e.verdict === "suspicious")) out.add(i.id);
+  }
+  return out;
+}
+
+export function groundAndScoreFindings(input: GroundingInput): Finding[] {
+  const { findings, scopedEvents, iocs, graphLinkedEventIds } = input;
+  const scopedById = new Map(scopedEvents.map((e) => [e.id, e] as const));
+  const intelIocs = intelFlaggedIocIds(iocs);
+
+  return findings.map((f) => {
+    // Supporting in-scope events: forward links (finding.relatedEventIds present in scope) UNION reverse
+    // links (a scoped event names this finding). De-duped, order-stable by scoped-event order.
+    const forward = new Set((f.relatedEventIds ?? []).filter((id) => scopedById.has(id)));
+    const supporting: ForensicEvent[] = [];
+    const seen = new Set<string>();
+    const push = (id: string): void => {
+      if (seen.has(id)) return;
+      const e = scopedById.get(id);
+      if (e) { seen.add(id); supporting.push(e); }
+    };
+    for (const id of forward) push(id);
+    for (const e of scopedEvents) if ((e.relatedFindingIds ?? []).includes(f.id)) push(e.id);
+
+    const distinctTools = new Set(supporting.flatMap((e) => e.sources ?? [])).size;
+    const distinctHosts = new Set(supporting.map((e) => e.asset).filter((a): a is string => !!a)).size;
+    const graphLinked = supporting.some((e) => graphLinkedEventIds.has(e.id));
+    const intelSources = (f.relatedIocs ?? []).filter((id) => intelIocs.has(id)).length;
+    const corroboration: FindingCorroboration = { distinctTools, distinctHosts, intelSources, graphLinked };
+
+    // Rewrite relatedEventIds to the resolved supporting set so the forward link is consistent and
+    // auditable (adds the reverse-linked backfill events; drops hallucinated ids).
+    const relatedEventIds = supporting.map((e) => e.id);
+
+    let confidence = f.confidence;
+    let confidenceReason = f.confidenceReason;
+    let ungrounded = false;
+
+    if (supporting.length === 0) {
+      ungrounded = true;
+      confidence = Math.min(confidence ?? UNGROUNDED_CONFIDENCE_CAP, UNGROUNDED_CONFIDENCE_CAP);
+      confidenceReason = appendReason(confidenceReason, "capped: no cited evidence in scope — treat as a hypothesis, not a fact");
+    } else if (distinctTools <= 1 && distinctHosts <= 1 && intelSources === 0 && !graphLinked) {
+      if ((confidence ?? 100) > SINGLE_SOURCE_CONFIDENCE_CAP) {
+        confidence = SINGLE_SOURCE_CONFIDENCE_CAP;
+        confidenceReason = appendReason(confidenceReason, "capped: single-source, uncorroborated");
+      }
+    }
+
+    // Clean the old flag first so a since-corrected finding loses `ungrounded` (idempotent recompute).
+    const { ungrounded: _prev, ...rest } = f;
+    return {
+      ...rest,
+      relatedEventIds,
+      corroboration,
+      ...(ungrounded ? { ungrounded: true } : {}),
+      ...(confidence !== undefined ? { confidence } : {}),
+      ...(confidenceReason !== undefined ? { confidenceReason } : {}),
+    };
+  });
+}
+
+// A compact one-liner for the existing-findings prompt echo and the report/dashboard, e.g.
+// "2 tools / 3 hosts / intel ✓" or "uncorroborated". Pure.
+export function corroborationLabel(f: Finding): string {
+  if (f.ungrounded) return "uncorroborated (no cited evidence)";
+  const c = f.corroboration;
+  if (!c) return "";
+  const parts = [`${c.distinctTools} tool${c.distinctTools === 1 ? "" : "s"}`, `${c.distinctHosts} host${c.distinctHosts === 1 ? "" : "s"}`];
+  if (c.intelSources > 0) parts.push("intel ✓");
+  if (c.graphLinked) parts.push("graph-linked");
+  const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked;
+  return `${parts.join(" / ")}${corroborated ? "" : " — uncorroborated"}`;
+}

--- a/companion/src/analysis/graphContext.ts
+++ b/companion/src/analysis/graphContext.ts
@@ -61,7 +61,9 @@ export function buildGraphContext(state: InvestigationState, opts: GraphContextO
     lines.push(`${TYPE_LABEL[type]}:`);
     for (const e of group) {
       const cites = e.eventIds.slice(0, CITES_PER_EDGE).join(", ");
-      lines.push(`- ${e.basis}${cites ? ` [${cites}]` : ""}`);
+      // Surface the edge's confidence + derivation rule (investigation-guidance #5) so the model can
+      // weigh a hard file-lineage/shared-hash edge above a regex-scraped shared-account hint.
+      lines.push(`- ${e.basis} [${e.confidence}, ${e.rule}]${cites ? ` [${cites}]` : ""}`);
     }
   }
   if (!lines.length) return "";

--- a/companion/src/analysis/iocAnchors.ts
+++ b/companion/src/analysis/iocAnchors.ts
@@ -40,6 +40,60 @@ export function isKnownHostAsset(value: string, hostNames: ReadonlySet<string>):
   return hostNames.has(shortHost(value));
 }
 
+// RFC1918 / loopback / link-local / CGNAT — a "verdict" on an internal address is almost always stale
+// or mis-attributed third-party data, not a real external indicator. A HINT toward "conflicted".
+const INTERNAL_IP =
+  /^(?:10\.|127\.|169\.254\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.)/;
+export function isInternalAddress(value: string): boolean {
+  return INTERNAL_IP.test(value.trim());
+}
+
+// The trust class of a threat-intel verdict on one IOC (investigation-guidance #7). The current guard
+// is prompt text plus a score-bump reduction, which the model can (and in northpeak DID) ignore — a
+// stale OpenCTI verdict on the org's OWN db-01 server became a Critical "C2" finding. This deterministic
+// classification is the gate:
+//   conflicted  — the value is one of the case's OWN host assets or an internal address: a verdict here
+//                 is likely stale/wrong; never treat as confirmed external infrastructure.
+//   corroborated— 2+ DISTINCT providers agree malicious/suspicious (scan ALL enrichments, not the first),
+//                 OR one provider PLUS a linked behavioral event (a real execution/transfer/connection).
+//   lone-intel  — a single provider with no behavioral corroboration: a lead worth mentioning, not a
+//                 confirmed compromise.
+//   none        — no malicious/suspicious verdict at all.
+export type VerdictClass = "corroborated" | "lone-intel" | "conflicted" | "none";
+
+export interface VerdictInput {
+  value: string;
+  enrichments?: Array<{ verdict?: string; source?: string; provider?: string }>;
+}
+
+export function classifyVerdict(
+  ioc: VerdictInput,
+  opts: { hasBehavioralEvent: boolean; hostNames: ReadonlySet<string> },
+): VerdictClass {
+  const hits = (ioc.enrichments ?? []).filter((e) => e.verdict === "malicious" || e.verdict === "suspicious");
+  if (!hits.length) return "none";
+  if (isKnownHostAsset(ioc.value, opts.hostNames) || isInternalAddress(ioc.value)) return "conflicted";
+  const providers = new Set(hits.map((e) => (e.provider || e.source || "").trim().toLowerCase()).filter(Boolean));
+  if (providers.size >= 2) return "corroborated";
+  if (providers.size >= 1 && opts.hasBehavioralEvent) return "corroborated";
+  return "lone-intel";
+}
+
+// Whether any Critical/High/Medium event in `events` references this IOC value in a structured field or
+// its description — the "behavioral corroboration" a lone intel verdict needs to be trusted. Pure.
+const BEHAVIORAL_SEVERITIES = new Set(["Critical", "High", "Medium"]);
+export function iocHasBehavioralEvent(value: string, events: readonly ForensicEvent[]): boolean {
+  const v = value.trim().toLowerCase();
+  if (!v) return false;
+  for (const e of events) {
+    if (!BEHAVIORAL_SEVERITIES.has(e.severity)) continue;
+    const fields = [e.dstIp, e.srcIp, e.path, e.sha256, e.md5, e.processName, e.parentName];
+    if (fields.some((f) => f && String(f).trim().toLowerCase() === v)) return true;
+    if ((e.description ?? "").toLowerCase().includes(v)) return true;
+  }
+  return false;
+}
+
 // High-abuse / commonly-malicious TLDs — a HINT, never a verdict.
 const RISKY_TLD = /\.(?:tk|top|bit|gq|ml|cf|ga|xyz|cloud|to|cc|pw|click|link|work|zip|mov)$/i;
 const DOMAIN_SHAPE = /^[a-z0-9.-]+\.[a-z]{2,}$/i;

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -162,6 +162,8 @@ import { flagContradictedAnswers } from "./answerContradiction.js";
 import { renderStructuredTags, buildBeaconDigest, buildAttackPhaseDigest } from "./synthEvidence.js";
 import { detectBeacons, beaconEnvOptions } from "./beaconDetect.js";
 import { buildAttackPhases } from "./burstDetect.js";
+import { buildEvidenceGraph } from "./evidenceGraph.js";
+import { groundAndScoreFindings, corroborationLabel } from "./findingGrounding.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
 import type { NotebookStore } from "./notebookStore.js";
@@ -4250,8 +4252,13 @@ export class AnalysisPipeline {
       ? `INVESTIGATION SCOPE: only consider activity from ${scope.start ?? "the beginning"} to ${scope.end ?? "now"}. ` +
         `Events outside this window have already been removed below.\n\n`
       : "";
-    // Cap the existing-findings echo too (a big import can produce 100s of auto-findings).
-    const existingFindings = state.findings.slice(0, 150).map((f) => `[${f.id}] ${f.title}`).join("\n") || "(none yet)";
+    // Cap the existing-findings echo too (a big import can produce 100s of auto-findings). Append the
+    // prior run's corroboration label (investigation-guidance #6) so the model sees which of its own
+    // earlier claims were weak/uncorroborated and can strengthen or drop them this run.
+    const existingFindings = state.findings.slice(0, 150).map((f) => {
+      const corr = corroborationLabel(f);
+      return `[${f.id}] ${f.title}${corr ? ` — ${corr}` : ""}`;
+    }).join("\n") || "(none yet)";
     const openThreads = state.openThreads
       .filter((t) => t.status === "open")
       .map((t) => `[${t.id}] ${t.description}`)
@@ -4482,6 +4489,18 @@ export class AnalysisPipeline {
     // on re-synthesis. Pure + idempotent; a no-op when the store or record is absent/empty.
     if (this.opts.secondOpinionStore) {
       next = applyAcceptedSecondOpinion(next, await this.opts.secondOpinionStore.load(caseId));
+    }
+
+    // Per-finding grounding + corroboration (investigation-guidance #6): resolve each finding's
+    // supporting in-scope events (forward relatedEventIds AND reverse forensicTimeline links, so the
+    // deterministic backfill findings ground correctly), roll up { tools, hosts, intel, graph-linked },
+    // flag an uncited finding as `ungrounded`, and CAP an ungrounded/single-source finding's confidence.
+    // Deterministic + idempotent; only ever lowers confidence. Runs last, so it grades the FINAL finding
+    // set (incl. backfills + accepted second-opinion deltas).
+    {
+      const graphLinkedEventIds = new Set(buildEvidenceGraph(next).edges.flatMap((e) => e.eventIds));
+      const inScope = next.forensicTimeline.filter((e) => eligibleIds.has(e.id));
+      next = { ...next, findings: groundAndScoreFindings({ findings: next.findings, scopedEvents: inScope, iocs: next.iocs, graphLinkedEventIds }) };
     }
 
     // What this run changed vs the pre-AI findings. Findings are FINAL here — neither persistLatest

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -28,6 +28,7 @@ import type { ExternalImporter } from "./declarativeImporter.js";
 import { parseJsonLoose } from "./extractJson.js";
 import { applyFalsePositive, buildFalsePositiveContext, filterFalsePositiveEvents, type FalsePositiveStore } from "./falsePositive.js";
 import { backfillHighSeverityFindings } from "./highSeverityFindings.js";
+import { checkConfiguredPromptDrift } from "./promptCapabilities.js";
 import { resolveSynthThinkingBudget, type SynthThinkingInput } from "./synthThinking.js";
 import { detectTimelineGaps, backfillSilenceGapFindings, gapEnvOptions } from "./gapDetect.js";
 import {
@@ -639,6 +640,13 @@ function resolvePrompt(name: "SYSTEM" | "CSV" | "LOG" | "SYNTH" | "ASK" | "EXEC"
   }
   return fallback;
 }
+
+// The built-in prompt text for each capability the drift check knows about (see promptCapabilities.ts),
+// keyed by resolvePrompt name. Exported so the rot-guard test can assert each built-in still contains
+// its own required markers (if a rewrite drops one, the drift check silently rots — the test catches it).
+export const BUILTIN_PROMPT_BY_NAME: Record<string, string> = {
+  SYNTH: SYNTHESIS_PROMPT,
+};
 
 // Answer a free-form analyst question about ONE case using only its evidence digest.
 export const ASK_PROMPT = [
@@ -1463,6 +1471,21 @@ export class AnalysisPipeline {
   // when nothing that affects the output has changed since the last run. In-memory: a
   // fresh process (or an explicit `force`) always synthesizes.
   private readonly lastSynthHash = new Map<string, string>();
+  // Warn ONCE per process when a configured synthesis-prompt override is missing shipped capabilities
+  // (investigation-guidance #1). Preflight surfaces the same drift in the UI; this covers a post-boot
+  // edit to the override file, and keeps the warning from spamming every synthesis run.
+  private warnedPromptDrift = false;
+
+  private warnOnPromptDrift(): void {
+    if (this.warnedPromptDrift) return;
+    this.warnedPromptDrift = true;
+    for (const d of checkConfiguredPromptDrift()) {
+      this.log.warn(
+        `[DFIR] prompt override ${d.file} is missing capabilities: ${d.missing.join(", ")} — ` +
+        `model output will silently lack them; re-run 'npm run prompts:eject' to refresh it`,
+      );
+    }
+  }
 
   async analyzeWindow(caseId: string, captures: CaptureMetadata[]): Promise<InvestigationState> {
     const provider = this.requireProvider("screenshot analysis");
@@ -4091,6 +4114,7 @@ export class AnalysisPipeline {
   // synthesis model for that run (model B). Both default off → normal, primary, persisted synthesis.
   async synthesize(caseId: string, opts: { force?: boolean; dryRun?: boolean; provider?: AIProvider; signal?: AbortSignal } & SynthThinkingInput = {}): Promise<InvestigationState> {
     const synthProvider = opts.provider ?? this.opts.synthesisProvider ?? this.requireProvider("synthesis");
+    this.warnOnPromptDrift();   // once per process: a stale synthesis-prompt override silently drops shipped capabilities
     const loaded = await this.opts.stateStore.load(caseId);
     if (loaded.forensicTimeline.length === 0) return loaded;
 

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -163,7 +163,9 @@ import { renderStructuredTags, buildBeaconDigest, buildAttackPhaseDigest } from 
 import { detectBeacons, beaconEnvOptions } from "./beaconDetect.js";
 import { buildAttackPhases } from "./burstDetect.js";
 import { buildEvidenceGraph } from "./evidenceGraph.js";
-import { groundAndScoreFindings, corroborationLabel } from "./findingGrounding.js";
+import { buildAssetGraph } from "./assetGraph.js";
+import { shortHost } from "./iocAnchors.js";
+import { groundAndScoreFindings, capIntelOnlyFindings, corroborationLabel } from "./findingGrounding.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
 import type { NotebookStore } from "./notebookStore.js";
@@ -4500,7 +4502,12 @@ export class AnalysisPipeline {
     {
       const graphLinkedEventIds = new Set(buildEvidenceGraph(next).edges.flatMap((e) => e.eventIds));
       const inScope = next.forensicTimeline.filter((e) => eligibleIds.has(e.id));
-      next = { ...next, findings: groundAndScoreFindings({ findings: next.findings, scopedEvents: inScope, iocs: next.iocs, graphLinkedEventIds }) };
+      const grounded = groundAndScoreFindings({ findings: next.findings, scopedEvents: inScope, iocs: next.iocs, graphLinkedEventIds });
+      // Intel-verdict gate (investigation-guidance #7): floor an intel-ONLY High/Critical finding (no
+      // behavioral corroboration, all its verdict IOCs lone-intel/conflicted) to Medium/≤60 — the
+      // northpeak stale-CTI-on-own-server class. Runs after grounding so it sees the corroboration rollup.
+      const hostNames = new Set(buildAssetGraph(next).assets.filter((a) => a.type === "host").map((a) => shortHost(a.name)));
+      next = { ...next, findings: capIntelOnlyFindings({ findings: grounded, iocs: next.iocs, scopedEvents: inScope, hostNames }) };
     }
 
     // What this run changed vs the pre-AI findings. Findings are FINAL here — neither persistLatest

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -159,6 +159,9 @@ import type { PlaybookTask } from "./playbook.js";
 import type { PlaybookStore } from "./playbookStore.js";
 import { renderPlaybookProgressBlock, renderRefutedHypothesesBlock, demoteCompletedNextSteps } from "./priorWork.js";
 import { flagContradictedAnswers } from "./answerContradiction.js";
+import { renderStructuredTags, buildBeaconDigest, buildAttackPhaseDigest } from "./synthEvidence.js";
+import { detectBeacons, beaconEnvOptions } from "./beaconDetect.js";
+import { buildAttackPhases } from "./burstDetect.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
 import type { NotebookStore } from "./notebookStore.js";
@@ -480,6 +483,16 @@ export const SYNTHESIS_PROMPT = [
   "Those are the analyst's work log — do NOT base any finding, IOC, technique, or attacker-path step",
   "on them. Base conclusions ONLY on real host/attacker activity (executions, logons, file/registry",
   "/network/persistence changes).",
+  "",
+  "Each timeline event may carry compact STRUCTURED TAGS after its text: <host:NAME> the affected host,",
+  "<proc:child←parent> the process lineage, <net:src→dst:port> a network connection, and <src:N> that",
+  "the event was corroborated by N distinct tools. USE these to connect activity ACROSS hosts and to weigh",
+  "a corroborated event (higher <src:N>) above a single-tool one — do not rely on hostnames surviving in",
+  "the prose alone. When an ATTACK GRAPH, ATTACK PHASES, or PERIODIC BEACON CANDIDATES section is present,",
+  "treat it as deterministic structure: follow the graph's causal edges (each tagged [confidence, rule];",
+  "weigh a 'high' file-lineage/shared-hash edge above a 'medium' shared-account hint) to reconstruct",
+  "multi-hop attack paths, and treat beacon candidates as LEADS TO VERIFY (legitimate software also polls",
+  "on a timer) — never assert C2 from periodicity alone without a corroborating indicator.",
   "",
   "Produce:",
   "- findings: produce a SEPARATE finding for EACH distinct attacker technique, tool, or behavior",
@@ -4254,6 +4267,14 @@ export class AnalysisPipeline {
     // above, so they never affect skip-if-unchanged.
     const knownUnknownsBlock = this.knownUnknownsBlock(state, scopedEvents);
     const adversaryBlock = this.adversaryHintBlock(state);
+    // Structured causal evidence (investigation-guidance #5), all DERIVED after the skip-hash so they
+    // never affect skip-if-unchanged: the deterministic ATTACK GRAPH (spawn/file-lineage/lateral/network
+    // edges with confidence+rule — previously fed only to ask()/suggestHunts(), never the call that
+    // writes findings), the statistically-confirmed periodic-beacon candidates, and the activity-phase
+    // digest. These give synthesis the cross-host structure it was inferring blind from truncated prose.
+    const graphBlock = buildGraphContext({ ...state, forensicTimeline: scopedEvents }, { maxEdges: DEFAULT_MAX_GRAPH_EDGES });
+    const beaconBlock = buildBeaconDigest(detectBeacons(scopedEvents, beaconEnvOptions()));
+    const attackPhaseBlock = buildAttackPhaseDigest(buildAttackPhases(scopedEvents));
     // Analyst-pinned open questions: tell the model to address each (answer when the evidence
     // now supports it) and keep them. They're re-merged into the output below so they persist.
     const pinnedQuestions = state.keyQuestions.filter((q) => q.pinned);
@@ -4294,10 +4315,13 @@ export class AnalysisPipeline {
     // (context block, findings echo, system prompt) is the fixed overhead. Re-select for the
     // smaller count so the kept events stay the most important; the high-severity backfill
     // still creates findings for any Critical/High event dropped here.
+    // Each event carries its structured tags (host / process lineage / src→dst / corroborating-source
+    // count) after the prose (investigation-guidance #5) — only when set, so a bare event costs no extra
+    // tokens. This is what lets the model connect cross-host activity instead of guessing from prose.
     const renderEvent = (e: ForensicEvent) =>
-      `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}`;
+      `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}`;
     const synthOverhead = estimateTokens(getSynthesisPrompt())
-      + estimateTokens(scopeNote + contextBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + pinnedBlock + reanswerBlock + existingFindings + openThreads + falsePositiveBlock + (state.lastSummary || "")) + 400;
+      + estimateTokens(scopeNote + contextBlock + graphBlock + beaconBlock + attackPhaseBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + pinnedBlock + reanswerBlock + existingFindings + openThreads + falsePositiveBlock + (state.lastSummary || "")) + 400;
     const fit = fitItemsToBudget(promptEvents, renderEvent, Math.max(0, inputTokenBudget() - synthOverhead));
     if (fit < promptEvents.length) promptEvents = selectSynthesisEvents(scopedEvents, fit);
 
@@ -4308,6 +4332,9 @@ export class AnalysisPipeline {
     const userPrompt =
       scopeNote +
       contextBlock +
+      graphBlock +
+      beaconBlock +
+      attackPhaseBlock +
       knownUnknownsBlock +
       adversaryBlock +
       notebookBlock +

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -156,6 +156,8 @@ import {
 } from "./queryTranslate.js";
 import { HUNT_PLATFORMS, type HuntPlatform } from "./huntPlatforms.js";
 import type { PlaybookTask } from "./playbook.js";
+import type { PlaybookStore } from "./playbookStore.js";
+import { renderPlaybookProgressBlock, renderRefutedHypothesesBlock, demoteCompletedNextSteps } from "./priorWork.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
 import type { NotebookStore } from "./notebookStore.js";
@@ -1264,6 +1266,9 @@ export interface PipelineOptions {
   // Per-case hypothesis store (issue #140). When set, synthesis merges the model's auto-generated
   // hypotheses into it (refresh-pristine / freeze-touched). Absent → no auto-generation (CLI/tests).
   hypothesisStore?: HypothesisStore;
+  // Per-case playbook store. When set, synthesis reads DONE/SKIPPED task status so it can build on
+  // completed work instead of re-recommending it (investigation-guidance #2). Absent → no digest.
+  playbookStore?: PlaybookStore;
 }
 
 // Whole-word (id-boundary) match of a finding id inside free text — used to catch a key question's
@@ -4181,8 +4186,12 @@ export class AnalysisPipeline {
     // analyst-authored or analyst-touched OPEN ones (pure inputs, never rewritten by synthesis),
     // so including them in the hash below can't cause a re-synthesis loop. Bounded for prompt size.
     let analystHypothesesBlock = "";
+    // Refuted hypotheses fed back as NEGATIVE KNOWLEDGE (investigation-guidance #2): a theory the
+    // analyst ruled out must not be re-asserted or re-opened. Loaded from the same store, once.
+    let refutedHypothesesBlock = "";
     if (this.opts.hypothesisStore) {
-      const open = (await this.opts.hypothesisStore.load(caseId))
+      const allHypotheses = await this.opts.hypothesisStore.load(caseId);
+      const open = allHypotheses
         .filter((h) => h.status === "open" && (h.source === "analyst" || h.analystTouched))
         .slice(0, 15);
       if (open.length) {
@@ -4193,7 +4202,16 @@ export class AnalysisPipeline {
           open.map((h) => `- ${h.title}${h.expectedOutcome ? ` (decided by: ${h.expectedOutcome})` : ""}`).join("\n") +
           "\n\n";
       }
+      refutedHypothesesBlock = renderRefutedHypothesesBlock(allHypotheses);
     }
+
+    // Prior-work feedback (investigation-guidance #2): the hunt hit/miss ledger (#157, previously fed
+    // only to the hunt prompts) and the playbook DONE/SKIPPED digest, so synthesis builds on completed
+    // work and dead hunts instead of re-recommending them. Loaded before the hash so completing a task
+    // or collecting a hunt triggers a fresh synthesis (a hit is a pivot; a miss is negative evidence).
+    const priorHuntsBlock = renderPriorHuntsBlock(await this.loadHuntOutcomes(caseId));
+    const playbookTasks = this.opts.playbookStore ? await this.opts.playbookStore.load(caseId) : [];
+    const playbookProgressBlock = renderPlaybookProgressBlock(playbookTasks);
 
     // Skip-if-unchanged: hash only the STABLE INPUTS to synthesis — the in-scope timeline,
     // the IOCs (value + intel verdicts), the scope, the legitimate markers, and (when opted
@@ -4207,6 +4225,10 @@ export class AnalysisPipeline {
       sc: scope, lg: markers.map((m) => m.id),
       nb: notebookBlock,
       hy: analystHypothesesBlock,
+      // Prior-work feedback (#2): completing a task, collecting a hunt, or refuting a hypothesis
+      // changes these strings, so an otherwise-identical timeline re-synthesizes to fold in the
+      // new negative knowledge instead of skipping. Pure inputs — synthesis never rewrites them.
+      pw: priorHuntsBlock + playbookProgressBlock + refutedHypothesesBlock,
     })).digest("hex");
     if (!opts.force && !opts.dryRun && this.lastSynthHash.get(caseId) === synthHash) return loaded;
 
@@ -4274,7 +4296,7 @@ export class AnalysisPipeline {
     const renderEvent = (e: ForensicEvent) =>
       `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}`;
     const synthOverhead = estimateTokens(getSynthesisPrompt())
-      + estimateTokens(scopeNote + contextBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + pinnedBlock + reanswerBlock + existingFindings + openThreads + falsePositiveBlock + (state.lastSummary || "")) + 400;
+      + estimateTokens(scopeNote + contextBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + pinnedBlock + reanswerBlock + existingFindings + openThreads + falsePositiveBlock + (state.lastSummary || "")) + 400;
     const fit = fitItemsToBudget(promptEvents, renderEvent, Math.max(0, inputTokenBudget() - synthOverhead));
     if (fit < promptEvents.length) promptEvents = selectSynthesisEvents(scopedEvents, fit);
 
@@ -4289,6 +4311,9 @@ export class AnalysisPipeline {
       adversaryBlock +
       notebookBlock +
       analystHypothesesBlock +
+      refutedHypothesesBlock +
+      priorHuntsBlock +
+      playbookProgressBlock +
       pinnedBlock +
       reanswerBlock +
       `FORENSIC TIMELINE (${scopedEvents.length} dated events${truncatedNote}):\n${timelineText}\n\n` +
@@ -4400,6 +4425,18 @@ export class AnalysisPipeline {
     // discovery phase (whoami/net group/findstr password/cat .env) tagged by the importers — still
     // appear in the case's MITRE table and report. Same scoped events synthesis saw; pure + idempotent.
     next = { ...next, mitreTechniques: unionEventTechniques(next.mitreTechniques, scopedEvents) };
+
+    // Prior-work safety net (investigation-guidance #2): even with the PLAYBOOK PROGRESS prompt block,
+    // the model may still echo a nextStep that repeats a COMPLETED task. Deterministically DEMOTE (not
+    // drop) any such step to priority "low" with an annotation, requiring a shared host/artifact token
+    // so a same-verb different-target step survives. Keeps the top of the next-steps list actionable.
+    if (playbookTasks.length) {
+      const doneTitles = playbookTasks.filter((t) => t.status === "done").map((t) => t.title);
+      if (doneTitles.length) {
+        const { steps, demotedIds } = demoteCompletedNextSteps(next.nextSteps, doneTitles);
+        if (demotedIds.length) next = { ...next, nextSteps: steps };
+      }
+    }
 
     // Dry run (second-opinion Pass 1): return model B's conclusions WITHOUT persisting or any side
     // effect — and WITHOUT folding in accepted deltas, so B stays an independent opinion.

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -158,6 +158,7 @@ import { HUNT_PLATFORMS, type HuntPlatform } from "./huntPlatforms.js";
 import type { PlaybookTask } from "./playbook.js";
 import type { PlaybookStore } from "./playbookStore.js";
 import { renderPlaybookProgressBlock, renderRefutedHypothesesBlock, demoteCompletedNextSteps } from "./priorWork.js";
+import { flagContradictedAnswers } from "./answerContradiction.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
 import type { NotebookStore } from "./notebookStore.js";
@@ -4419,6 +4420,13 @@ export class AnalysisPipeline {
           : { ...q, relatedFindingIds: related };
       }),
     };
+
+    // Answer-contradiction validator (investigation-guidance #3): a key question whose answer asserts
+    // an ABSENCE ("no data exfiltration confirmed") while in-scope events carry the matching ATT&CK
+    // techniques is a dangerous false negative. Force such answers to "partial" and cite the
+    // contradicting events. Runs AFTER the FP reset (so a reset-to-unknown answer isn't re-flagged) over
+    // the same scoped, non-FP events the model saw. Pure + idempotent.
+    next = { ...next, keyQuestions: flagContradictedAnswers(next.keyQuestions, scopedEvents) };
 
     // Union the deterministically-identified ATT&CK techniques carried by the (in-scope) timeline
     // into the synthesized MITRE table, so techniques the model didn't echo — especially the Info/Low

--- a/companion/src/analysis/priorWork.ts
+++ b/companion/src/analysis/priorWork.ts
@@ -1,0 +1,126 @@
+// Condition synthesis on what the investigator has ALREADY done (investigation-guidance #2). The one
+// AI call that writes findings / nextSteps / keyQuestions currently sees the notebook and OPEN analyst
+// hypotheses, but NOT: which playbook tasks are done/skipped, and which hypotheses the analyst REFUTED.
+// So it re-recommends completed work and re-asserts ruled-out theories — wasting the analyst's time.
+// The hunt-outcome block (huntOutcomes.renderPriorHuntsBlock, #157) already proved this feedback shape
+// works; this module adds the two missing negative-knowledge blocks plus a deterministic post-parse
+// safety net that demotes a returned nextStep which merely repeats a completed task.
+//
+// PURE — no I/O, no clock. Rendered blocks end in a blank line so they concatenate cleanly, and return
+// "" when there is nothing to add (costing zero tokens on a fresh case). Unit-tested in isolation.
+
+import type { PlaybookTask } from "./playbook.js";
+import type { Hypothesis } from "./hypothesis.js";
+import type { NextStep } from "./stateTypes.js";
+
+const MAX_PLAYBOOK_LINES = 20;   // a compact digest — the analyst's whole board would bloat the prompt
+const MAX_REFUTED = 15;          // bound the negative-knowledge block; refuted theories are few in practice
+
+// The playbook DONE/SKIPPED digest. DONE tasks are results to BUILD ON (do not re-recommend); SKIPPED
+// tasks were deliberately not investigated (may be re-raised only if new evidence warrants) — the two
+// must not be conflated, or the model would treat a skipped lead as a closed one. "" when nothing is
+// done or skipped (todo/in-progress tasks are the analyst's live queue, not prior work).
+export function renderPlaybookProgressBlock(tasks: readonly PlaybookTask[], limit = MAX_PLAYBOOK_LINES): string {
+  const done = (tasks ?? []).filter((t) => t.status === "done");
+  const skipped = (tasks ?? []).filter((t) => t.status === "skipped");
+  if (!done.length && !skipped.length) return "";
+  const cap = Math.max(1, Math.floor(limit));
+  const lines: string[] = [];
+  for (const t of done.slice(0, cap)) lines.push(`- [DONE] ${t.title}`);
+  for (const t of skipped.slice(0, Math.max(0, cap - done.length))) lines.push(`- [SKIPPED] ${t.title}`);
+  return (
+    "PLAYBOOK PROGRESS (work the investigator has already actioned — do NOT re-recommend a [DONE] task " +
+    "as a nextStep; build on its result instead. A [SKIPPED] task was deliberately not pursued — re-raise " +
+    "it only if new evidence now warrants):\n" +
+    lines.join("\n") + "\n\n"
+  );
+}
+
+// The NEGATIVE KNOWLEDGE block: hypotheses the analyst REFUTED (or that reached a refuted state and the
+// analyst has touched — never model-only refutations, which would let synthesis reinforce its own
+// mistakes). Telling the model a theory is dead stops it re-opening threads / deriving findings for it.
+// "" when there are no analyst-refuted hypotheses.
+export function renderRefutedHypothesesBlock(hypotheses: readonly Hypothesis[], limit = MAX_REFUTED): string {
+  const refuted = (hypotheses ?? []).filter(
+    (h) => h.status === "refuted" && (h.source === "analyst" || h.analystTouched),
+  );
+  if (!refuted.length) return "";
+  const cap = Math.max(1, Math.floor(limit));
+  const lines = refuted.slice(0, cap).map((h) => {
+    const note = (h.notes ?? "").replace(/\s+/g, " ").trim().slice(0, 160);
+    return `- ${h.title}${note ? ` — ${note}` : ""}`;
+  });
+  return (
+    "REFUTED HYPOTHESES (the investigator ruled these out — do NOT re-assert them, re-open threads for " +
+    "them, or derive findings/nextSteps from them; treat each as settled negative knowledge):\n" +
+    lines.join("\n") + "\n\n"
+  );
+}
+
+// --- Post-parse safety net: demote a nextStep that just repeats a completed task --------------------
+
+const GENERIC_MIN_LEN = 4; // ignore short/common words when measuring overlap (mirrors falsePositiveSimilarity)
+
+function significantWords(text: string): Set<string> {
+  return new Set(String(text ?? "").toLowerCase().split(/[^a-z0-9.\\/_-]+/i).filter((w) => w.length >= GENERIC_MIN_LEN));
+}
+
+// A "specific" token names a concrete collection TARGET — a host, artifact, filename, event id, path —
+// not a generic verb ("pull", "review"). Heuristic: contains a digit, a dot, or a path separator. Two
+// steps that share a specific token AND enough generic overlap are almost certainly the same task.
+function isSpecificToken(tok: string): boolean {
+  return /[0-9]/.test(tok) || tok.includes(".") || tok.includes("\\") || tok.includes("/");
+}
+
+// The text of a nextStep that identifies its target: action + pointer (the pointer carries the host/
+// artifact when the action is generic).
+function stepTargetText(s: NextStep): string {
+  return `${s.action} ${s.pointer}`;
+}
+
+export interface DemoteResult {
+  steps: NextStep[];
+  demotedIds: string[]; // ids of steps that were demoted (for logging / meta)
+}
+
+// Demote (never silently drop) any returned nextStep that repeats a COMPLETED playbook task: it must
+// share ≥2 significant words AND at least one SPECIFIC (host/artifact/id-like) token with a done task,
+// so "pull Security.evtx on ALCLIENT07" (done) suppresses a repeat but NOT "pull Security.evtx on
+// ALCLIENT09" (different host — the specific token 'alclient09' isn't shared). A demoted step drops to
+// priority "low" and its rationale is annotated, so the analyst still sees it — just not near the top.
+// Pure: returns new NextStep objects, never mutates the inputs.
+export function demoteCompletedNextSteps(
+  nextSteps: readonly NextStep[],
+  doneTaskTitles: readonly string[],
+): DemoteResult {
+  const doneWordSets = (doneTaskTitles ?? [])
+    .map((t) => ({ title: t, words: significantWords(t) }))
+    .filter((d) => d.words.size > 0);
+  if (!doneWordSets.length) return { steps: [...(nextSteps ?? [])], demotedIds: [] };
+
+  const demotedIds: string[] = [];
+  const steps = (nextSteps ?? []).map((s) => {
+    const stepWords = significantWords(stepTargetText(s));
+    const stepSpecific = [...stepWords].filter(isSpecificToken);
+    for (const done of doneWordSets) {
+      const shared = [...stepWords].filter((w) => done.words.has(w));
+      const sharedSpecific = shared.some(isSpecificToken);
+      // The step must introduce NO specific token the done task lacks — a new host/artifact/id token
+      // (e.g. ALCLIENT09 vs the done ALCLIENT07) means a genuinely different target, so it survives
+      // even though it shares the artifact/event-id tokens (security.evtx, 4624). This is what keeps a
+      // same-verb, different-host recommendation alive instead of being wrongly suppressed.
+      const introducesNewTarget = stepSpecific.some((t) => !done.words.has(t));
+      if (shared.length >= 2 && sharedSpecific && !introducesNewTarget) {
+        demotedIds.push(s.id);
+        const note = `[likely already done — matches completed task: "${done.title.slice(0, 120)}"]`;
+        return {
+          ...s,
+          priority: "low" as const,
+          rationale: s.rationale ? `${s.rationale} ${note}` : note,
+        };
+      }
+    }
+    return s;
+  });
+  return { steps, demotedIds };
+}

--- a/companion/src/analysis/promptCapabilities.ts
+++ b/companion/src/analysis/promptCapabilities.ts
@@ -1,0 +1,110 @@
+// Prompt capability-drift detection (investigation-guidance #1). A DFIR_AI_*_PROMPT_FILE override
+// REPLACES the built-in prompt wholesale (resolvePrompt in pipeline.ts), so a STALE ejected file
+// silently disables capabilities the built-in has since gained. The live case: an old synthesis.txt
+// ejected before issue #140 has no 'hypotheses' section, so hypothesis auto-generation never fires
+// and 'confidenceReason' is never produced — yet tests (which use the built-in) all pass, and nothing
+// warns the operator. This module NAMES the machine-checkable output markers each prompt must contain
+// and reports which a given override text is missing, so preflight can warn instead of failing silent.
+//
+// The core here is PURE (markers + matching). The one impure helper (checkConfiguredPromptDrift) reads
+// env + the override files and is called from startup preflight and once per synthesis run. Markers are
+// LITERAL substrings (JSON field names / section keywords the prompt must mention); a case-sensitive
+// `includes` is deliberately dumb so the check itself can't rot into false confidence.
+import { readFileSync } from "node:fs";
+
+export interface PromptCapability {
+  /** resolvePrompt name, e.g. "SYNTH". */
+  name: string;
+  /** The filename `npm run prompts:eject` writes, e.g. "synthesis.txt" — shown in the warning. */
+  file: string;
+  /** The override env var that activates a file, e.g. "DFIR_AI_SYNTH_PROMPT_FILE". */
+  envVar: string;
+  /** Substrings that MUST appear in the prompt for its shipped capabilities to work. */
+  markers: string[];
+}
+
+// Only prompts whose output has fields the pipeline DEPENDS ON deterministically are listed — a
+// missing marker here means a real, silent capability loss, not a style drift. Keep markers to literal
+// JSON field names / unmistakable section keywords so the check never false-positives on rewording.
+export const PROMPT_CAPABILITIES: readonly PromptCapability[] = [
+  {
+    name: "SYNTH",
+    file: "synthesis.txt",
+    envVar: "DFIR_AI_SYNTH_PROMPT_FILE",
+    // hypotheses      → issue #140 auto-generation (delta.hypotheses consumed in pipeline.ts)
+    // confidenceReason→ issue #226 (confidence.ts / finding cards)
+    // relatedFindingIds→ issue #222 FP→question re-answer wiring (else it degrades to prose matching)
+    markers: ["hypotheses", "confidenceReason", "relatedFindingIds"],
+  },
+];
+
+// The required markers absent from `text` (case-sensitive substring match). Empty = no drift.
+export function missingMarkers(text: string, markers: readonly string[]): string[] {
+  const hay = String(text ?? "");
+  return markers.filter((m) => !hay.includes(m));
+}
+
+// One drifted prompt override: the capability plus the markers its override file is missing.
+export interface PromptDrift {
+  name: string;
+  file: string;
+  envVar: string;
+  missing: string[];
+}
+
+// A human-readable one-line warning for a drift (used by preflight + the per-run log).
+export function driftMessage(d: PromptDrift): string {
+  return (
+    `prompt override ${d.file} is missing capabilities: ${d.missing.join(", ")} — ` +
+    `model output will silently lack them; re-run 'npm run prompts:eject' to refresh it`
+  );
+}
+
+// Read the RAW override for each capability whose DFIR_AI_*_PROMPT (inline) or DFIR_AI_*_PROMPT_FILE is
+// configured, and report which required markers it is missing. Deliberately checks the override CONTENT
+// directly rather than the resolved prompt: resolvePrompt (pipeline.ts) silently falls back to the
+// built-in on an unreadable/empty file, which would HIDE drift. Returns [] when no override is set (the
+// built-in is used and has every marker) or all markers are present. Impure (env + fs) but cheap.
+export function checkConfiguredPromptDrift(env: NodeJS.ProcessEnv = process.env): PromptDrift[] {
+  const out: PromptDrift[] = [];
+  for (const cap of PROMPT_CAPABILITIES) {
+    const inline = env[`DFIR_AI_${cap.name}_PROMPT`];
+    let text: string | undefined;
+    if (inline && inline.trim().length > 0) {
+      text = inline;
+    } else {
+      const file = env[`DFIR_AI_${cap.name}_PROMPT_FILE`];
+      if (!file || file.trim().length === 0) continue;   // no override → built-in is used
+      try {
+        const raw = readFileSync(file, "utf8");
+        if (raw.trim().length === 0) continue;            // empty file → resolvePrompt uses the built-in
+        text = raw;
+      } catch {
+        continue;                                          // unreadable → resolvePrompt uses the built-in
+      }
+    }
+    const missing = missingMarkers(text, cap.markers);
+    if (missing.length) out.push({ name: cap.name, file: cap.file, envVar: cap.envVar, missing });
+  }
+  return out;
+}
+
+// Rot-guard: assert every capability's OWN built-in prompt contains all its markers. If a built-in
+// prompt is reworded so a marker no longer literally appears, the marker list is stale and the whole
+// drift check becomes meaningless — this makes that fail loudly (called from a unit test with the
+// real built-ins). `builtinByName` maps a capability name to its built-in prompt text.
+export function assertBuiltinsHaveMarkers(builtinByName: Record<string, string>): void {
+  for (const cap of PROMPT_CAPABILITIES) {
+    const text = builtinByName[cap.name];
+    if (text === undefined) {
+      throw new Error(`promptCapabilities: no built-in prompt supplied for "${cap.name}"`);
+    }
+    const missing = missingMarkers(text, cap.markers);
+    if (missing.length) {
+      throw new Error(
+        `promptCapabilities: built-in ${cap.name} prompt is missing its own markers [${missing.join(", ")}] — ` +
+        `the marker list is stale, update PROMPT_CAPABILITIES to match the current prompt`,
+      );
+    }
+  }
+}

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -161,6 +161,14 @@ export interface InvestigationQuestion {
   // supporting finding was marked false-positive and force the question back to "unknown" instead
   // of silently keeping a stale answer — see applyFalsePositive/reconsiderKeyQuestions in pipeline.ts.
   relatedFindingIds?: string[];
+  // Deterministic contradiction flag (investigation-guidance #3): set when the answer asserts an
+  // ABSENCE ("no data exfiltration confirmed") but in-scope events carry the matching ATT&CK
+  // techniques — the timeline contradicts the answer. Set post-synthesis by flagContradictedAnswers;
+  // the UI/report render it as a "contradicted by timeline evidence" badge. Absent = no contradiction.
+  contradicted?: {
+    techniques: string[];   // the contradicting technique ids observed in-scope
+    eventIds: string[];     // the events that carry them (a few, for the pointer/badge)
+  };
 }
 
 export type StepPriority = "critical" | "high" | "medium" | "low";

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -36,11 +36,27 @@ export interface IOC {
   extractedFrom?: string[];
 }
 
+// Deterministic corroboration rollup for a finding (investigation-guidance #6), computed post-synthesis
+// from its supporting in-scope events + related IOCs. Lets the UI/report show "2 tools / 3 hosts / intel"
+// vs "uncorroborated", and drives the confidence caps — an unverifiable AI-emitted number alone let a
+// single stale CTI verdict mint a Critical finding (northpeak).
+export interface FindingCorroboration {
+  distinctTools: number;   // union of event.sources across the finding's supporting events
+  distinctHosts: number;   // distinct event.asset across them
+  intelSources: number;    // this finding's related IOCs carrying a malicious/suspicious intel verdict
+  graphLinked: boolean;    // any supporting event participates in an evidence-graph causal edge
+}
+
 export interface Finding {
   id: string;
   severity: Severity;
   confidence?: number;          // 0–100: AI certainty this finding is real (absent = unknown)
   confidenceReason?: string;    // one-sentence why (evidence strength, source corroboration, model certainty)
+  // Set post-synthesis by groundAndScoreFindings (investigation-guidance #6). `ungrounded` = no cited
+  // in-scope event supports it (a hypothesis, not a fact) → confidence hard-capped + badged.
+  // `corroboration` is the rollup above. Both recomputed every synthesis; persisted for display.
+  ungrounded?: boolean;
+  corroboration?: FindingCorroboration;
   title: string;
   description: string;
   relatedIocs: string[];        // IOC ids

--- a/companion/src/analysis/synthEvidence.ts
+++ b/companion/src/analysis/synthEvidence.ts
@@ -1,0 +1,86 @@
+// Structured evidence for the synthesis prompt (investigation-guidance #5). synthesize() is the one AI
+// call that writes findings / MITRE / attackerPath / keyQuestions, yet it saw each event as a single
+// prose line — asset, process lineage, src→dst network, and corroborating-source count were all dropped
+// (renderEvent in pipeline.ts). Cross-host dot-connecting then depended on hostnames surviving inside
+// truncated prose, which produced fairhaven's wrong-anchor finding and halcyon's fabricated cross-host
+// story. This module renders the compact structured tags + the beacon/attack-phase digests that give
+// synthesis the same structured signal ask()/suggestHunts() already get.
+//
+// PURE — no I/O. Tags append only fields that are set (empty events cost zero extra tokens).
+
+import type { ForensicEvent } from "./stateTypes.js";
+import type { BeaconCandidate } from "./beaconDetect.js";
+import { BEACON_CAVEAT } from "./beaconDetect.js";
+import type { AttackPhase } from "./burstDetect.js";
+
+const MAX_TAG_VALUE = 48; // keep one field from bloating a line; hostnames/paths can be long
+
+function clip(v: string): string {
+  const s = String(v ?? "").replace(/\s+/g, " ").trim();
+  return s.length > MAX_TAG_VALUE ? s.slice(0, MAX_TAG_VALUE) + "…" : s;
+}
+
+// Compact structured tags appended after an event's prose, e.g.
+//   <host:WS07> <proc:powershell.exe←excel.exe> <net:10.1.2.3→52.1.1.1:443> <src:3>
+// Only set fields are emitted. `src:N` (N≥2) flags cross-tool corroboration. Returns "" (no leading
+// space) when the event carries no structured fields, so a bare event line is unchanged.
+export function renderStructuredTags(e: ForensicEvent): string {
+  const tags: string[] = [];
+  if (e.asset) tags.push(`<host:${clip(e.asset)}>`);
+
+  if (e.processName || e.parentName) {
+    const child = e.processName ? clip(e.processName) : "";
+    const parent = e.parentName ? clip(e.parentName) : "";
+    tags.push(`<proc:${child}${parent ? `←${parent}` : ""}>`);
+  }
+
+  if (e.srcIp || e.dstIp) {
+    const src = e.srcIp ? clip(e.srcIp) : "?";
+    const dst = e.dstIp ? clip(e.dstIp) : "?";
+    const port = typeof e.port === "number" && Number.isFinite(e.port) ? `:${e.port}` : "";
+    tags.push(`<net:${src}→${dst}${port}>`);
+  }
+
+  const nSources = e.sources?.length ?? 0;
+  if (nSources >= 2) tags.push(`<src:${nSources}>`);
+
+  return tags.length ? " " + tags.join(" ") : "";
+}
+
+// One-line-per-beacon digest of the statistically-confirmed periodic callbacks (beaconDetect), phrased
+// as CANDIDATES to verify (never asserted C2) and carrying BEACON_CAVEAT — legitimate software also
+// polls on a timer, and synthesis over-anchoring on a suggestive line is a known failure mode. "" when
+// there are no candidates, so it costs no tokens.
+export function buildBeaconDigest(beacons: readonly BeaconCandidate[], limit = 8): string {
+  const list = (beacons ?? []).slice(0, Math.max(0, Math.floor(limit)));
+  if (!list.length) return "";
+  const lines = list.map((b) => {
+    const port = b.destPort ? `:${b.destPort}` : "";
+    const scope = b.external ? "external" : "internal";
+    const cites = b.eventIds.slice(0, 3).join(", ");
+    return `- ${b.source} → ${b.destIp}${port} every ~${b.intervalSeconds}s (±${b.jitterPct}% jitter, ${b.eventCount} conns, ${scope})${cites ? ` [${cites}]` : ""}`;
+  });
+  return (
+    `PERIODIC BEACON CANDIDATES (statistical regularity — a hunting LEAD to verify, NOT confirmed C2; ` +
+    `${BEACON_CAVEAT}):\n${lines.join("\n")}\n\n`
+  );
+}
+
+function hhmm(ts: string): string {
+  const d = Date.parse(ts);
+  if (Number.isNaN(d)) return ts || "(undated)";
+  return new Date(d).toISOString().slice(11, 16); // HH:MM (UTC)
+}
+
+// One-line-per-phase digest of the timeline's activity bursts (burstDetect), each labelled with its
+// dominant ATT&CK tactic and window, so synthesis sees the attack's PHASES instead of a flat list. Only
+// multi-event phases are shown (a single isolated event is not a "phase"). "" when there are none.
+export function buildAttackPhaseDigest(phases: readonly AttackPhase[], limit = 12): string {
+  const list = (phases ?? []).filter((p) => p.eventCount > 1).slice(0, Math.max(0, Math.floor(limit)));
+  if (!list.length) return "";
+  const lines = list.map((p) => {
+    const tech = p.inferredTechniques.length ? ` [${p.inferredTechniques.slice(0, 4).join(", ")}]` : "";
+    return `- ${hhmm(p.startTimestamp)}–${hhmm(p.endTimestamp)} ${p.label} (${p.eventCount} ev, ${p.maxSeverity})${tech}`;
+  });
+  return `ATTACK PHASES (deterministic activity bursts, worst-severity first — the shape of the intrusion over time):\n${lines.join("\n")}\n\n`;
+}

--- a/companion/src/analysis/synthSelect.ts
+++ b/companion/src/analysis/synthSelect.ts
@@ -3,7 +3,7 @@ import { byEventTime } from "./forensicSort.js";
 import { buildAttackPhases } from "./burstDetect.js";
 import { buildAssetGraph } from "./assetGraph.js";
 import { extractCveIds, matchKevEntries, buildKevDigest, type KevCatalog } from "./kev.js";
-import { rankConnectiveIocs, buildConnectiveIocDigest, shortHost, isKnownHostAsset } from "./iocAnchors.js";
+import { rankConnectiveIocs, buildConnectiveIocDigest, shortHost, isKnownHostAsset, classifyVerdict, iocHasBehavioralEvent } from "./iocAnchors.js";
 import { rankHosts, buildSignalConcentrationDigest } from "./hostRanking.js";
 
 const SEV_RANK: Record<string, number> = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4 };
@@ -223,17 +223,27 @@ export function buildSynthesisContext(
     return `- ${a.name} (${a.type})${iocs ? ` ← ${iocs}` : ""}`;
   });
 
-  const verdictLines = state.iocs
-    .filter((i) => (i.enrichments ?? []).some((e) => e.verdict === "malicious" || e.verdict === "suspicious"))
-    .slice(0, 25)
-    .map((i) => {
-      const e = (i.enrichments ?? []).find((x) => x.verdict === "malicious")
-        ?? (i.enrichments ?? []).find((x) => x.verdict === "suspicious");
-      const conflict = isKnownHostAsset(i.value, hostNames)
-        ? " ⚠ CONFLICT: also one of this case's OWN host assets — this verdict may be stale/wrong; requires independent corroboration before treating it as confirmed malicious"
-        : "";
-      return `- ${i.value} = ${e?.verdict}${e?.source ? ` (${e.source}${e.score ? ` ${e.score}` : ""})` : ""}${conflict}`;
-    });
+  // Threat-intel verdicts, classified by trust (investigation-guidance #7): a single stale provider
+  // verdict on the case's OWN infra flowed unchecked into a Critical finding (northpeak). Each verdict
+  // is tagged [corroborated] (2+ providers, or intel+behavioral evidence) vs [lone-intel] (single
+  // provider — a LEAD, not a compromise), and CONFLICTED verdicts (own-host/internal address) are moved
+  // to their own "do not treat as confirmed" block so the model can't read them as external C2.
+  const trustedVerdicts: string[] = [];
+  const conflictVerdicts: string[] = [];
+  for (const i of state.iocs) {
+    const hit = (i.enrichments ?? []).find((x) => x.verdict === "malicious")
+      ?? (i.enrichments ?? []).find((x) => x.verdict === "suspicious");
+    if (!hit) continue;
+    const cls = classifyVerdict(i, { hasBehavioralEvent: iocHasBehavioralEvent(i.value, scopedEvents), hostNames });
+    if (cls === "none") continue;
+    const base = `${i.value} = ${hit.verdict}${hit.source ? ` (${hit.source}${hit.score ? ` ${hit.score}` : ""})` : ""}`;
+    if (cls === "conflicted") {
+      conflictVerdicts.push(`- ${base} ⚠ CONFLICT: also one of this case's OWN host assets or an internal address — this verdict is most likely stale/wrong; do NOT treat it as confirmed malicious or as external C2`);
+    } else {
+      trustedVerdicts.push(`- ${base} [${cls}]`);
+    }
+    if (trustedVerdicts.length + conflictVerdicts.length >= 25) break;
+  }
 
   // KEV correlation: scan the scoped events + IOC values for CVE ids and cross-reference
   // against the loaded catalog. Only fires when a catalog is provided (opt-in, store starts
@@ -260,7 +270,8 @@ export function buildSynthesisContext(
   if (concentrationBlock) block += concentrationBlock;
   if (connectiveBlock) block += connectiveBlock;
   if (assetLines.length) block += `COMPROMISED ASSETS (host/account ← IoCs seen on it):\n${assetLines.join("\n")}\n\n`;
-  if (verdictLines.length) block += `THREAT-INTEL VERDICTS (third-party):\n${verdictLines.join("\n")}\n\n`;
+  if (trustedVerdicts.length) block += `THREAT-INTEL VERDICTS (third-party — [corroborated] = 2+ providers or intel PLUS behavioral evidence; [lone-intel] = a single provider with no corroborating activity, treat as a LEAD, not a confirmed compromise):\n${trustedVerdicts.join("\n")}\n\n`;
+  if (conflictVerdicts.length) block += `INTEL CONFLICTS (do NOT treat as confirmed — a verdict on the case's OWN infrastructure or an internal address, most likely stale/incorrect third-party data):\n${conflictVerdicts.join("\n")}\n\n`;
   if (kevBlock) block += kevBlock;
   return block;
 }

--- a/companion/src/analysis/synthSelect.ts
+++ b/companion/src/analysis/synthSelect.ts
@@ -1,5 +1,6 @@
-import type { ForensicEvent, InvestigationState } from "./stateTypes.js";
+import type { ForensicEvent, InvestigationState, Severity } from "./stateTypes.js";
 import { byEventTime } from "./forensicSort.js";
+import { buildAttackPhases } from "./burstDetect.js";
 import { buildAssetGraph } from "./assetGraph.js";
 import { extractCveIds, matchKevEntries, buildKevDigest, type KevCatalog } from "./kev.js";
 import { rankConnectiveIocs, buildConnectiveIocDigest, shortHost, isKnownHostAsset } from "./iocAnchors.js";
@@ -10,38 +11,195 @@ const SEV_RANK: Record<string, number> = { Critical: 0, High: 1, Medium: 2, Low:
 // How many of the earliest events to always keep (initial-access context).
 const EARLIEST_KEEP = 15;
 
-// Pick the events that best inform synthesis when the timeline exceeds the prompt budget.
-// Severity-only "top N" can bury the kill chain — early low-severity initial-access events
-// drop out, and one noisy host crowds out everything else. This keeps ALL Critical/High
-// events, the earliest events, and an even time-spread sample of the rest, returned in
-// CHRONOLOGICAL order so the model reads the attack as a story.
-export function selectSynthesisEvents(events: ForensicEvent[], max: number): ForensicEvent[] {
-  const byTime = [...events].sort(byEventTime);
-  if (events.length <= max || max <= 0) return byTime;
+// The window around a Critical/High "anchor" within which same-host events are pulled in as CONTEXT —
+// the low-graded "what happened right before/after on this host" chain that carries the real story
+// (fairhaven's sqlcmd→tar→curl-PUT, halcyon's robocopy/7z) but never won a seat under even-spread.
+const ANCHOR_WINDOW_MS = 15 * 60 * 1000;
+const PER_ANCHOR_CONTEXT_CAP = 6;
 
-  const chosen = new Set<string>();
-  byTime.slice(0, EARLIEST_KEEP).forEach((e) => chosen.add(e.id));                 // initial-access context
-  for (const e of events) if (e.severity === "Critical" || e.severity === "High") chosen.add(e.id);
+// Reserved fractions of the post-guaranteed budget for each behavioral class, so a burst of mis-graded
+// High noise can't starve the corroborated/technique-tagged evidence. Filled in order, each capped, so
+// an over-supplied earlier class can't consume a later class's share; unused capacity rolls to spread.
+const BUDGET_ANCHOR_CONTEXT = 0.40;
+const BUDGET_CORROBORATED = 0.25;
+const BUDGET_TECHNIQUE = 0.15;
 
-  if (chosen.size < max) {                                                          // even time-spread fill of the rest
-    const rest = byTime.filter((e) => !chosen.has(e.id));
-    const slots = max - chosen.size;
-    if (rest.length <= slots) {
-      rest.forEach((e) => chosen.add(e.id));
-    } else {
-      const step = rest.length / slots;
-      for (let i = 0; i < slots; i++) chosen.add(rest[Math.min(rest.length - 1, Math.floor(i * step))].id);
+// Why an event earned a synthesis seat. "anchor" = Critical/High verdict; "earliest" = initial-access
+// context; the rest are the behavioral fills. Exposed (via the annotated selection) so the dashboard
+// can show the analyst what CLASSES of evidence the model actually saw.
+export type SelectionClass =
+  | "anchor"
+  | "earliest"
+  | "anchor_context"
+  | "corroborated"
+  | "technique"
+  | "spread";
+
+export interface AnnotatedSelection {
+  events: ForensicEvent[];                       // chosen events, CHRONOLOGICAL (the model reads a story)
+  classOf: Map<string, SelectionClass>;          // event id → the class that claimed it (strongest wins)
+  counts: Record<SelectionClass, number>;        // per-class tally of the final selection
+  omitted: number;                               // scoped events NOT selected (still in the case)
+}
+
+function emptyCounts(): Record<SelectionClass, number> {
+  return { anchor: 0, earliest: 0, anchor_context: 0, corroborated: 0, technique: 0, spread: 0 };
+}
+
+function eventMs(e: ForensicEvent): number | null {
+  const t = Date.parse(e.timestamp);
+  return Number.isNaN(t) ? null : t;
+}
+
+function sameAsset(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+// Process/command-line-bearing events are the highest-value context around an anchor (they show what
+// ran), so they're preferred when an anchor has more nearby events than the per-anchor cap.
+function isProcessLike(e: ForensicEvent): boolean {
+  if (e.processName || e.parentName || e.action === "execute") return true;
+  return /\b(cmd|powershell|pwsh|bash|sh|wscript|cscript|rundll32|regsvr32|mshta|\.exe|\.ps1|\.dll|-enc|-e[nc]{0,2} |http)\b/i.test(e.description ?? "");
+}
+
+// The same-host events within ±ANCHOR_WINDOW of each anchor, best-first per anchor (process-like, then
+// nearest in time), interleaved ROUND-ROBIN across anchors so a single busy anchor can't hog the whole
+// context budget. Already-claimed events (anchors, earliest) are skipped by the caller's fill guard.
+function anchorContextCandidates(
+  byTime: ForensicEvent[],
+  anchors: ForensicEvent[],
+  claimed: ReadonlySet<string>,
+): ForensicEvent[] {
+  const perAnchor: ForensicEvent[][] = [];
+  for (const a of anchors) {
+    const am = eventMs(a);
+    if (am === null || !a.asset) continue;
+    const near = byTime.filter((e) => {
+      if (e.id === a.id || claimed.has(e.id)) return false;
+      if (!sameAsset(e.asset, a.asset)) return false;
+      const em = eventMs(e);
+      return em !== null && Math.abs(em - am) <= ANCHOR_WINDOW_MS;
+    });
+    near.sort((x, y) => {
+      const px = isProcessLike(x) ? 0 : 1;
+      const py = isProcessLike(y) ? 0 : 1;
+      if (px !== py) return px - py;
+      return Math.abs((eventMs(x) as number) - am) - Math.abs((eventMs(y) as number) - am);
+    });
+    if (near.length) perAnchor.push(near.slice(0, PER_ANCHOR_CONTEXT_CAP));
+  }
+  // Round-robin flatten, de-duped (a context event near two anchors appears once).
+  const out: ForensicEvent[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; ; i++) {
+    let progressed = false;
+    for (const list of perAnchor) {
+      if (i < list.length) {
+        progressed = true;
+        const e = list[i];
+        if (!seen.has(e.id)) { seen.add(e.id); out.push(e); }
+      }
     }
+    if (!progressed) break;
+  }
+  return out;
+}
+
+// Pick the events that best inform synthesis when the timeline exceeds the prompt budget. Severity-only
+// / even-spread selection buried the kill chain: the true attack steps often graded Low/Info while
+// mis-graded noise filled the cap. This keeps the GUARANTEED classes (all Critical/High anchors + the
+// earliest initial-access events) and then fills with reserved per-class budgets — same-host context
+// around each anchor, cross-source-corroborated events, and ATT&CK-technique-tagged events — before an
+// even/whole-burst spread. Returns CHRONOLOGICAL order so the model reads the attack as a story.
+export function selectSynthesisEventsAnnotated(events: ForensicEvent[], max: number): AnnotatedSelection {
+  const byTime = [...events].sort(byEventTime);
+  if (events.length <= max || max <= 0) {
+    return { events: byTime, classOf: new Map(), counts: emptyCounts(), omitted: 0 };
   }
 
-  let selected = byTime.filter((e) => chosen.has(e.id));
-  if (selected.length > max) {                                                      // too many Critical/High — keep severest, then earliest
-    selected = [...selected]
+  const classOf = new Map<string, SelectionClass>();
+  const claim = (id: string, c: SelectionClass): void => { if (!classOf.has(id)) classOf.set(id, c); };
+  const capacityLeft = (): number => max - classOf.size;
+
+  // GUARANTEED 1: anchors — every Critical/High event (the verdict-bearing rows).
+  for (const e of events) if (e.severity === "Critical" || e.severity === "High") claim(e.id, "anchor");
+
+  // Overflow: anchors alone exceed the budget → keep the severest, then earliest, chronological.
+  if (classOf.size > max) {
+    const anchorEvents = byTime.filter((e) => classOf.get(e.id) === "anchor");
+    const trimmed = [...anchorEvents]
       .sort((a, b) => (SEV_RANK[a.severity] - SEV_RANK[b.severity]) || byEventTime(a, b))
       .slice(0, max)
       .sort(byEventTime);
+    const counts = emptyCounts();
+    counts.anchor = trimmed.length;
+    return { events: trimmed, classOf: new Map(trimmed.map((e) => [e.id, "anchor" as const])), counts, omitted: events.length - trimmed.length };
   }
-  return selected;
+
+  // GUARANTEED 2: earliest events — initial-access context (guarded against the cap).
+  for (const e of byTime.slice(0, EARLIEST_KEEP)) {
+    if (capacityLeft() <= 0) break;
+    claim(e.id, "earliest");
+  }
+
+  const remaining = Math.max(0, max - classOf.size);
+  const fill = (candidates: ForensicEvent[], cap: number, cls: SelectionClass): void => {
+    let added = 0;
+    for (const e of candidates) {
+      if (added >= cap || capacityLeft() <= 0) break;
+      if (classOf.has(e.id)) continue;
+      classOf.set(e.id, cls);
+      added++;
+    }
+  };
+
+  // RESERVED FILL 1: same-host context around each anchor.
+  const anchors = events.filter((e) => classOf.get(e.id) === "anchor");
+  fill(anchorContextCandidates(byTime, anchors, new Set(classOf.keys())), Math.floor(remaining * BUDGET_ANCHOR_CONTEXT), "anchor_context");
+
+  // RESERVED FILL 2: cross-source-corroborated events (correlate.ts already merged their sources).
+  fill(byTime.filter((e) => !classOf.has(e.id) && (e.sources?.length ?? 0) >= 2), Math.floor(remaining * BUDGET_CORROBORATED), "corroborated");
+
+  // RESERVED FILL 3: ATT&CK-technique-tagged events regardless of severity (behavioral signal).
+  fill(byTime.filter((e) => !classOf.has(e.id) && (e.mitreTechniques?.length ?? 0) > 0), Math.floor(remaining * BUDGET_TECHNIQUE), "technique");
+
+  // SPREAD remainder: keep whole activity bursts (burstDetect phases) rather than shredding clusters
+  // with an even sample; whatever budget is left after whole bursts is filled by an even time-spread.
+  if (capacityLeft() > 0) {
+    const byId = new Map(byTime.map((e) => [e.id, e] as const));
+    const phases = buildAttackPhases(events);
+    const phaseRank = (p: { maxSeverity: Severity }): number => SEV_RANK[p.maxSeverity] ?? 9;
+    for (const p of [...phases].sort((a, b) => phaseRank(a) - phaseRank(b))) {
+      const pending = p.eventIds.map((id) => byId.get(id)).filter((e): e is ForensicEvent => !!e && !classOf.has(e.id));
+      if (!pending.length) continue;
+      if (pending.length <= capacityLeft()) {                    // keep the whole burst, or skip it whole
+        for (const e of pending) classOf.set(e.id, "spread");
+      }
+      if (capacityLeft() <= 0) break;
+    }
+  }
+  if (capacityLeft() > 0) {                                       // residual even time-spread of what's left
+    const rest = byTime.filter((e) => !classOf.has(e.id));
+    const slots = capacityLeft();
+    if (rest.length <= slots) {
+      rest.forEach((e) => classOf.set(e.id, "spread"));
+    } else {
+      const step = rest.length / slots;
+      for (let i = 0; i < slots; i++) classOf.set(rest[Math.min(rest.length - 1, Math.floor(i * step))].id, "spread");
+    }
+  }
+
+  const selected = byTime.filter((e) => classOf.has(e.id));
+  const counts = emptyCounts();
+  for (const e of selected) counts[classOf.get(e.id) as SelectionClass]++;
+  return { events: selected, classOf, counts, omitted: events.length - selected.length };
+}
+
+// Backwards-compatible wrapper: the chosen events in chronological order. All existing callers use this;
+// the reserved-budget improvement flows through them automatically.
+export function selectSynthesisEvents(events: ForensicEvent[], max: number): ForensicEvent[] {
+  return selectSynthesisEventsAnnotated(events, max).events;
 }
 
 // A compact context digest for the synthesis prompt: the compromised assets (host/account

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -568,7 +568,13 @@ function investigation(state: InvestigationState, lines: string[], exposure?: Cu
     const mark = (s: string) => (s === "answered" ? "✅" : s === "partial" ? "🟡" : "❓");
     lines.push("| | Question | Answer | Where to find it |", "| --- | --- | --- | --- |");
     for (const q of state.keyQuestions) {
-      lines.push(`| ${mark(q.status)} | ${cellMd(q.question)} | ${cellMd(q.answer || "_unknown_")} | ${cellMd(q.pointer || "—")} |`);
+      // A ⚠️ contradiction badge (investigation-guidance #3): the negative answer conflicts with
+      // ATT&CK-tagged events in the timeline — surface it so a wrong "no" is never read as settled.
+      const contra = q.contradicted?.techniques?.length
+        ? ` ⚠️ contradicted by timeline (${q.contradicted.techniques.join(", ")})`
+        : "";
+      const answerCell = (q.answer || "_unknown_") + contra;
+      lines.push(`| ${mark(q.status)} | ${cellMd(q.question)} | ${cellMd(answerCell)} | ${cellMd(q.pointer || "—")} |`);
     }
     lines.push("");
   }

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -10,6 +10,7 @@ import { buildGeoMap } from "../analysis/geoMap.js";
 import { detectTimelineGaps, gapEnvOptions, GAP_CAVEAT } from "../analysis/gapDetect.js";
 import { detectTimelineAnomalies, anomalyEnvOptions } from "../analysis/timelineAnomalies.js";
 import { deriveIocSources } from "../analysis/iocCorroboration.js";
+import { corroborationLabel } from "../analysis/findingGrounding.js";
 import { attackTechniqueMd } from "../analysis/attack.js";
 import { buildAdversaryHintsResult } from "../analysis/adversaryHints.js";
 import { ADVERSARY_EMULATION_CAVEAT } from "../analysis/adversaryEmulation.js";
@@ -514,6 +515,13 @@ function investigation(state: InvestigationState, lines: string[], exposure?: Cu
     for (const f of sorted) {
       const confLabel = f.confidence !== undefined ? ` [${f.confidence}% confidence]` : "";
       lines.push(`#### [${f.severity}]${confLabel} ${f.title} (${f.id})`);
+      // Corroboration/grounding badge (investigation-guidance #6): "2 tools / 3 hosts / intel ✓" or a
+      // prominent "⚠️ no cited evidence" for an ungrounded finding, so a hypothesis never reads as fact.
+      if (f.ungrounded) {
+        lines.push(`> ⚠️ **No cited evidence** — treat as a hypothesis, not a fact (confidence capped).`);
+      } else if (f.corroboration) {
+        lines.push(`- Corroboration: ${corroborationLabel(f)}`);
+      }
       lines.push(f.description || "_no description_");
       if (f.relatedIocs.length) lines.push(`- IOCs: ${f.relatedIocs.join(", ")}`);
       if (f.mitreTechniques.length) lines.push(`- MITRE: ${f.mitreTechniques.map(attackTechniqueMd).join(", ")}`);

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -11,6 +11,7 @@ import {
   buildPreflightReport, buildPreflightText,
   type PreflightItem, type PreflightReport,
 } from "../analysis/preflight.js";
+import { checkConfiguredPromptDrift } from "../analysis/promptCapabilities.js";
 import { getAppVersion } from "../version.js";
 import {
   resolveUpdateMode, buildUpdateStatus, DEFAULT_UPDATE_REPO, type UpdateMode,
@@ -400,6 +401,19 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
       } catch (err) {
         items.push({ name: "Velociraptor", ok: false, critical: false, detail: (err as Error).message });
       }
+    }
+
+    // 4. Prompt overrides — non-critical. A stale DFIR_AI_*_PROMPT_FILE (an old `prompts:eject` from
+    //    before a capability shipped) REPLACES the built-in wholesale, so shipped output (hypotheses,
+    //    confidenceReason, …) silently disappears with no error. Warn per drifted override; silent when
+    //    no override is set (the built-in has every capability) or all markers are present.
+    for (const d of checkConfiguredPromptDrift()) {
+      items.push({
+        name: `Prompt override: ${d.file}`,
+        ok: false,
+        critical: false,
+        detail: `missing capabilities: ${d.missing.join(", ")} — re-run 'npm run prompts:eject' to refresh it`,
+      });
     }
 
     const report = buildPreflightReport(items, new Date().toISOString(), Date.now() - startedAt);

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2721,6 +2721,7 @@ export function buildRuntimePipeline(params: RuntimePipelineParams): AnalysisPip
     correlationProfileStore: new CorrelationProfileStore(params.store),
     notebookStore: new NotebookStore(params.store),
     hypothesisStore: new HypothesisStore(params.store),     // #140 auto-generate hypotheses on synthesis
+    playbookStore: new PlaybookStore(params.store),         // #2 feed DONE/SKIPPED task status into synthesis
     aiControlStore: new AiControlStore(params.store),
     huntOutcomeStore: new HuntOutcomeStore(params.store),   // #157 hunting feedback loop
     superTimelineStore: new SuperTimelineStore(params.store, Number(process.env.DFIR_SUPERTIMELINE_MAX) || undefined),  // explainEvent falls back here for raw super-only events

--- a/companion/tests/analysis/answerContradiction.test.ts
+++ b/companion/tests/analysis/answerContradiction.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertsAbsence,
+  findContradictingEvents,
+  flagContradictedAnswers,
+  CONTRADICTION_RULES,
+} from "../../src/analysis/answerContradiction.js";
+import type { ForensicEvent, InvestigationQuestion } from "../../src/analysis/stateTypes.js";
+
+function ev(partial: Partial<ForensicEvent>): ForensicEvent {
+  return {
+    id: partial.id ?? "e1",
+    timestamp: "2026-01-01T00:00:00Z",
+    description: partial.description ?? "an event",
+    severity: partial.severity ?? "High",
+    mitreTechniques: partial.mitreTechniques ?? [],
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+    ...partial,
+  };
+}
+
+function q(partial: Partial<InvestigationQuestion>): InvestigationQuestion {
+  return {
+    id: partial.id ?? "q1",
+    question: partial.question ?? "a question",
+    status: partial.status ?? "answered",
+    answer: partial.answer ?? "",
+    pointer: partial.pointer ?? "",
+    ...partial,
+  };
+}
+
+describe("assertsAbsence", () => {
+  it("trips on a negative conclusion", () => {
+    expect(assertsAbsence("No data exfiltration has been confirmed")).toBe(true);
+    expect(assertsAbsence("No evidence of lateral movement was observed")).toBe(true);
+    expect(assertsAbsence("Persistence was not detected")).toBe(true);
+  });
+
+  it("does not trip on a positive/neutral answer", () => {
+    expect(assertsAbsence("Data was exfiltrated to mega.nz via rclone")).toBe(false);
+    expect(assertsAbsence("Lateral movement from HOST1 to HOST2 via RDP")).toBe(false);
+  });
+
+  it("treats an empty answer as not an absence assertion (unknown != absent)", () => {
+    expect(assertsAbsence("")).toBe(false);
+    expect(assertsAbsence("   ")).toBe(false);
+  });
+
+  it("does not trip on a negation that isn't an absence conclusion", () => {
+    expect(assertsAbsence("Not all hosts were patched")).toBe(false); // no absence-context word
+  });
+});
+
+describe("findContradictingEvents (prefix match)", () => {
+  const exfilRule = CONTRADICTION_RULES.find((r) => r.key === "exfiltration")!;
+
+  it("matches a sub-technique by prefix (T1052.001 under T1052)", () => {
+    const events = [ev({ id: "e5", mitreTechniques: ["T1052.001"] }), ev({ id: "e6", mitreTechniques: ["T1005"] })];
+    const res = findContradictingEvents(events, exfilRule);
+    expect(res.techniques).toContain("T1052.001");
+    expect(res.eventIds).toContain("e5");
+    expect(res.eventIds).not.toContain("e6");
+  });
+
+  it("returns empty when no event carries the family", () => {
+    const res = findContradictingEvents([ev({ mitreTechniques: ["T1059"] })], exfilRule);
+    expect(res.techniques).toEqual([]);
+    expect(res.eventIds).toEqual([]);
+  });
+});
+
+describe("flagContradictedAnswers", () => {
+  it("flags the halcyon case: 'no exfiltration' vs staged/copied data in the timeline", () => {
+    const questions = [q({ id: "q_exfiltration", question: "Was data exfiltrated?", status: "answered", answer: "No data exfiltration has been confirmed." })];
+    const events = [
+      ev({ id: "e10", description: "xcopy sensitive to E:", mitreTechniques: ["T1074.001"] }),
+      ev({ id: "e11", description: "7z archive of finance", mitreTechniques: ["T1560.001"] }),
+    ];
+    const out = flagContradictedAnswers(questions, events);
+    expect(out[0].status).toBe("partial");
+    expect(out[0].contradicted?.techniques).toEqual(["T1074.001", "T1560.001"]);
+    expect(out[0].contradicted?.eventIds).toEqual(["e10", "e11"]);
+    expect(out[0].pointer).toMatch(/contradict this negative answer/i);
+  });
+
+  it("matches by question TEXT when the id is non-standard", () => {
+    const questions = [q({ id: "custom1", question: "Did the attacker perform lateral movement?", answer: "No lateral movement was observed." })];
+    const events = [ev({ id: "e2", mitreTechniques: ["T1021.001"] })];
+    const out = flagContradictedAnswers(questions, events);
+    expect(out[0].status).toBe("partial");
+    expect(out[0].contradicted?.techniques).toEqual(["T1021.001"]);
+  });
+
+  it("leaves a positive answer untouched", () => {
+    const questions = [q({ id: "q_exfiltration", question: "exfiltration?", status: "answered", answer: "Data exfiltrated via rclone to S3." })];
+    const events = [ev({ mitreTechniques: ["T1567.002"] })];
+    const out = flagContradictedAnswers(questions, events);
+    expect(out[0].status).toBe("answered");
+    expect(out[0].contradicted).toBeUndefined();
+  });
+
+  it("leaves a negative answer untouched when NO matching evidence exists", () => {
+    const questions = [q({ id: "q_exfiltration", question: "exfiltration?", answer: "No exfiltration was observed." })];
+    const events = [ev({ mitreTechniques: ["T1059"] })];
+    const out = flagContradictedAnswers(questions, events);
+    expect(out[0].status).toBe("answered");
+    expect(out[0].contradicted).toBeUndefined();
+  });
+
+  it("does not flag an 'unknown'/empty answer", () => {
+    const questions = [q({ id: "q_exfiltration", question: "exfiltration?", status: "unknown", answer: "" })];
+    const events = [ev({ mitreTechniques: ["T1041"] })];
+    const out = flagContradictedAnswers(questions, events);
+    expect(out[0].contradicted).toBeUndefined();
+    expect(out[0].status).toBe("unknown");
+  });
+
+  it("is idempotent and clears a stale flag when the answer no longer contradicts", () => {
+    const stale = q({ id: "q_exfiltration", question: "exfiltration?", status: "partial", answer: "Confirmed: data exfiltrated.", contradicted: { techniques: ["T1041"], eventIds: ["x"] } });
+    const out = flagContradictedAnswers([stale], [ev({ mitreTechniques: ["T1041"] })]);
+    expect(out[0].contradicted).toBeUndefined(); // positive answer → flag cleared
+  });
+});

--- a/companion/tests/analysis/findingGrounding.test.ts
+++ b/companion/tests/analysis/findingGrounding.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  groundAndScoreFindings,
+  corroborationLabel,
+  UNGROUNDED_CONFIDENCE_CAP,
+  SINGLE_SOURCE_CONFIDENCE_CAP,
+} from "../../src/analysis/findingGrounding.js";
+import type { Finding, ForensicEvent, IOC, Severity } from "../../src/analysis/stateTypes.js";
+
+function f(p: Partial<Finding>): Finding {
+  return {
+    id: p.id ?? "f1", severity: p.severity ?? "High", title: p.title ?? "A finding", description: "",
+    relatedIocs: p.relatedIocs ?? [], sourceScreenshots: [], mitreTechniques: [], firstSeen: "", lastUpdated: "",
+    status: "open", ...p,
+  };
+}
+function ev(p: Partial<ForensicEvent>): ForensicEvent {
+  return {
+    id: p.id ?? "e1", timestamp: "2026-01-01T00:00:00Z", description: "x", severity: p.severity ?? "High" as Severity,
+    mitreTechniques: [], relatedFindingIds: p.relatedFindingIds ?? [], sourceScreenshots: [], ...p,
+  };
+}
+function ioc(p: Partial<IOC>): IOC {
+  return { id: p.id ?? "i1", type: p.type ?? "ip", value: p.value ?? "1.2.3.4", firstSeen: "", ...p };
+}
+
+describe("groundAndScoreFindings", () => {
+  it("flags a finding with no cited in-scope evidence as ungrounded and caps confidence", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 95, relatedEventIds: ["missing"] })],
+      scopedEvents: [ev({ id: "e1" })],
+      iocs: [],
+      graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].ungrounded).toBe(true);
+    expect(out[0].confidence).toBe(UNGROUNDED_CONFIDENCE_CAP);
+    expect(out[0].confidenceReason).toMatch(/no cited evidence/i);
+    expect(out[0].relatedEventIds).toEqual([]);
+  });
+
+  it("grounds a deterministic backfill finding via the REVERSE link (event.relatedFindingIds)", () => {
+    // backfillHighSeverityFindings sets no forward relatedEventIds — only the event points back.
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f-auto-e1", confidence: 100, relatedEventIds: [] })],
+      scopedEvents: [ev({ id: "e1", relatedFindingIds: ["f-auto-e1"], sources: ["Velociraptor", "THOR"], asset: "H1" })],
+      iocs: [],
+      graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].ungrounded).toBeUndefined();
+    expect(out[0].relatedEventIds).toEqual(["e1"]);
+    expect(out[0].corroboration).toEqual({ distinctTools: 2, distinctHosts: 1, intelSources: 0, graphLinked: false });
+    expect(out[0].confidence).toBe(100); // corroborated by 2 tools → not capped
+  });
+
+  it("caps a grounded but single-tool/single-host/uncorroborated finding at 65", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 90, relatedEventIds: ["e1"] })],
+      scopedEvents: [ev({ id: "e1", sources: ["OneTool"], asset: "H1" })],
+      iocs: [],
+      graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].confidence).toBe(SINGLE_SOURCE_CONFIDENCE_CAP);
+    expect(out[0].confidenceReason).toMatch(/single-source/i);
+  });
+
+  it("does not cap a single-tool finding that IS graph-linked", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 90, relatedEventIds: ["e1"] })],
+      scopedEvents: [ev({ id: "e1", sources: ["OneTool"], asset: "H1" })],
+      iocs: [],
+      graphLinkedEventIds: new Set(["e1"]),
+    });
+    expect(out[0].confidence).toBe(90);
+    expect(out[0].corroboration?.graphLinked).toBe(true);
+  });
+
+  it("counts intel-flagged related IOCs and does not cap when intel backs a single-tool finding", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 88, relatedEventIds: ["e1"], relatedIocs: ["i1"] })],
+      scopedEvents: [ev({ id: "e1", sources: ["OneTool"], asset: "H1" })],
+      iocs: [ioc({ id: "i1", enrichments: [{ source: "VT", verdict: "malicious", fetchedAt: "" }] })],
+      graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].corroboration?.intelSources).toBe(1);
+    expect(out[0].confidence).toBe(88); // intel corroboration → not capped
+  });
+
+  it("never RAISES confidence and is idempotent", () => {
+    const once = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 30, relatedEventIds: ["e1"] })],
+      scopedEvents: [ev({ id: "e1", sources: ["OneTool"], asset: "H1" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(once[0].confidence).toBe(30); // already below the cap — unchanged
+    const twice = groundAndScoreFindings({ findings: once, scopedEvents: [ev({ id: "e1", sources: ["OneTool"], asset: "H1" })], iocs: [], graphLinkedEventIds: new Set() });
+    expect(twice[0].confidence).toBe(30);
+    expect(twice[0].corroboration).toEqual(once[0].corroboration);
+  });
+});
+
+describe("corroborationLabel", () => {
+  it("labels an ungrounded finding", () => {
+    expect(corroborationLabel(f({ ungrounded: true }))).toMatch(/no cited evidence/i);
+  });
+  it("labels a multi-tool finding as corroborated (no warning)", () => {
+    const label = corroborationLabel(f({ corroboration: { distinctTools: 2, distinctHosts: 3, intelSources: 1, graphLinked: false } }));
+    expect(label).toContain("2 tools / 3 hosts / intel ✓");
+    expect(label).not.toMatch(/uncorroborated/);
+  });
+  it("marks a single-tool finding uncorroborated", () => {
+    expect(corroborationLabel(f({ corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 0, graphLinked: false } }))).toMatch(/uncorroborated/);
+  });
+});

--- a/companion/tests/analysis/intelVerdictGate.test.ts
+++ b/companion/tests/analysis/intelVerdictGate.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { classifyVerdict, iocHasBehavioralEvent, isInternalAddress } from "../../src/analysis/iocAnchors.js";
+import { capIntelOnlyFindings } from "../../src/analysis/findingGrounding.js";
+import type { Finding, ForensicEvent, IOC, Severity } from "../../src/analysis/stateTypes.js";
+
+const hostNames = new Set(["db-01"]);
+
+function ioc(p: Partial<IOC>): IOC {
+  return { id: p.id ?? "i1", type: p.type ?? "domain", value: p.value ?? "evil.example", firstSeen: "", ...p };
+}
+function ev(p: Partial<ForensicEvent>): ForensicEvent {
+  return { id: p.id ?? "e1", timestamp: "2026-01-01T00:00:00Z", description: p.description ?? "x", severity: p.severity ?? "High" as Severity,
+    mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...p };
+}
+function f(p: Partial<Finding>): Finding {
+  return { id: p.id ?? "f1", severity: p.severity ?? "Critical", title: p.title ?? "C2 via malicious domain", description: "",
+    relatedIocs: p.relatedIocs ?? [], sourceScreenshots: [], mitreTechniques: [], firstSeen: "", lastUpdated: "", status: "open", ...p };
+}
+
+describe("isInternalAddress", () => {
+  it("recognizes RFC1918 / loopback / CGNAT", () => {
+    expect(isInternalAddress("10.1.2.3")).toBe(true);
+    expect(isInternalAddress("192.168.0.5")).toBe(true);
+    expect(isInternalAddress("172.16.9.9")).toBe(true);
+    expect(isInternalAddress("127.0.0.1")).toBe(true);
+    expect(isInternalAddress("100.64.0.1")).toBe(true);
+    expect(isInternalAddress("8.8.8.8")).toBe(false);
+    expect(isInternalAddress("172.32.0.1")).toBe(false);
+  });
+});
+
+describe("classifyVerdict", () => {
+  const vt = { source: "VirusTotal", verdict: "malicious" };
+  it("flags a verdict on the case's own host asset as conflicted", () => {
+    const c = classifyVerdict(ioc({ value: "db-01.corp.local", enrichments: [{ source: "OpenCTI", verdict: "suspicious" }] }), { hasBehavioralEvent: false, hostNames });
+    expect(c).toBe("conflicted");
+  });
+  it("flags a verdict on an internal IP as conflicted", () => {
+    expect(classifyVerdict(ioc({ value: "10.0.0.5", enrichments: [{ source: "X", verdict: "malicious" }] }), { hasBehavioralEvent: true, hostNames })).toBe("conflicted");
+  });
+  it("is corroborated with two distinct providers", () => {
+    expect(classifyVerdict(ioc({ enrichments: [{ provider: "A", verdict: "malicious" }, { provider: "B", verdict: "suspicious" }] }), { hasBehavioralEvent: false, hostNames })).toBe("corroborated");
+  });
+  it("is corroborated with one provider PLUS a behavioral event", () => {
+    expect(classifyVerdict(ioc({ enrichments: [vt] }), { hasBehavioralEvent: true, hostNames })).toBe("corroborated");
+  });
+  it("is lone-intel with one provider and no behavioral event", () => {
+    expect(classifyVerdict(ioc({ enrichments: [vt] }), { hasBehavioralEvent: false, hostNames })).toBe("lone-intel");
+  });
+  it("is none with no malicious/suspicious verdict", () => {
+    expect(classifyVerdict(ioc({ enrichments: [{ source: "X", verdict: "harmless" }] }), { hasBehavioralEvent: false, hostNames })).toBe("none");
+  });
+});
+
+describe("iocHasBehavioralEvent", () => {
+  it("matches a value in a High-severity event's structured field or description", () => {
+    expect(iocHasBehavioralEvent("evil.exe", [ev({ severity: "Critical", description: "ran evil.exe" })])).toBe(true);
+    expect(iocHasBehavioralEvent("1.2.3.4", [ev({ severity: "Medium", dstIp: "1.2.3.4" })])).toBe(true);
+  });
+  it("ignores Low/Info events (not behavioral corroboration)", () => {
+    expect(iocHasBehavioralEvent("1.2.3.4", [ev({ severity: "Info", dstIp: "1.2.3.4" })])).toBe(false);
+  });
+});
+
+describe("capIntelOnlyFindings — northpeak class", () => {
+  it("floors a Critical finding driven only by a conflicted (own-server) verdict", () => {
+    const events = [ev({ id: "e1", severity: "Info", description: "connection to db-01.corp.local", asset: "db-01.corp.local", dstIp: "db-01.corp.local" })];
+    const finding = f({ id: "f1", severity: "Critical", confidence: 92, relatedIocs: ["i1"], corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 1, graphLinked: false } });
+    const out = capIntelOnlyFindings({
+      findings: [finding],
+      iocs: [ioc({ id: "i1", value: "db-01.corp.local", enrichments: [{ source: "OpenCTI", verdict: "suspicious" }] })],
+      scopedEvents: events, hostNames,
+    });
+    expect(out[0].severity).toBe("Medium");
+    expect(out[0].confidence).toBe(60);
+    expect(out[0].confidenceReason).toMatch(/OWN infrastructure/i);
+  });
+
+  it("does NOT floor a finding with behavioral corroboration (2 tools)", () => {
+    const finding = f({ id: "f1", severity: "Critical", confidence: 95, relatedIocs: ["i1"], corroboration: { distinctTools: 2, distinctHosts: 1, intelSources: 1, graphLinked: false } });
+    const out = capIntelOnlyFindings({
+      findings: [finding],
+      iocs: [ioc({ id: "i1", value: "evil.example", enrichments: [{ source: "VT", verdict: "malicious" }] })],
+      scopedEvents: [], hostNames,
+    });
+    expect(out[0].severity).toBe("Critical");
+    expect(out[0].confidence).toBe(95);
+  });
+
+  it("does NOT floor a finding not driven by intel at all", () => {
+    const finding = f({ id: "f1", severity: "High", confidence: 88, relatedIocs: ["i1"], corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 0, graphLinked: false } });
+    const out = capIntelOnlyFindings({
+      findings: [finding],
+      iocs: [ioc({ id: "i1", value: "plain.example", enrichments: [] })],
+      scopedEvents: [], hostNames,
+    });
+    expect(out[0].severity).toBe("High");
+  });
+
+  it("floors a lone-intel-only High finding to Medium/60", () => {
+    const finding = f({ id: "f1", severity: "High", confidence: 80, relatedIocs: ["i1"], corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 1, graphLinked: false } });
+    const out = capIntelOnlyFindings({
+      findings: [finding],
+      iocs: [ioc({ id: "i1", value: "lone.example", enrichments: [{ source: "VT", verdict: "malicious" }] })],
+      scopedEvents: [], hostNames,
+    });
+    expect(out[0].severity).toBe("Medium");
+    expect(out[0].confidence).toBe(60);
+    expect(out[0].confidenceReason).toMatch(/single-provider threat-intel/i);
+  });
+});

--- a/companion/tests/analysis/priorWork.test.ts
+++ b/companion/tests/analysis/priorWork.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderPlaybookProgressBlock,
+  renderRefutedHypothesesBlock,
+  demoteCompletedNextSteps,
+} from "../../src/analysis/priorWork.js";
+import type { PlaybookTask } from "../../src/analysis/playbook.js";
+import type { Hypothesis } from "../../src/analysis/hypothesis.js";
+import type { NextStep } from "../../src/analysis/stateTypes.js";
+
+function task(partial: Partial<PlaybookTask>): PlaybookTask {
+  return {
+    id: partial.id ?? "t1",
+    title: partial.title ?? "A task",
+    description: "",
+    status: partial.status ?? "todo",
+    priority: "medium",
+    source: partial.source ?? "next_step",
+    order: 0,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...partial,
+  } as PlaybookTask;
+}
+
+function hyp(partial: Partial<Hypothesis>): Hypothesis {
+  return {
+    id: partial.id ?? "h1",
+    title: partial.title ?? "A hypothesis",
+    description: "",
+    expectedOutcome: "",
+    status: partial.status ?? "open",
+    relatedTechniques: [],
+    relatedEventIds: [],
+    relatedIocIds: [],
+    assignee: "",
+    notes: partial.notes ?? "",
+    source: partial.source ?? "analyst",
+    analystTouched: partial.analystTouched ?? false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...partial,
+  } as Hypothesis;
+}
+
+function step(partial: Partial<NextStep>): NextStep {
+  return {
+    id: partial.id ?? "n1",
+    priority: partial.priority ?? "high",
+    action: partial.action ?? "do something",
+    rationale: partial.rationale ?? "because",
+    pointer: partial.pointer ?? "",
+    ...partial,
+  };
+}
+
+describe("renderPlaybookProgressBlock", () => {
+  it("returns '' when nothing is done or skipped", () => {
+    expect(renderPlaybookProgressBlock([task({ status: "todo" }), task({ status: "in_progress" })])).toBe("");
+  });
+
+  it("lists DONE and SKIPPED tasks under distinct labels", () => {
+    const block = renderPlaybookProgressBlock([
+      task({ id: "a", title: "Pull Security.evtx on HOST7", status: "done" }),
+      task({ id: "b", title: "Sandbox foo.exe", status: "skipped" }),
+      task({ id: "c", title: "todo one", status: "todo" }),
+    ]);
+    expect(block).toContain("[DONE] Pull Security.evtx on HOST7");
+    expect(block).toContain("[SKIPPED] Sandbox foo.exe");
+    expect(block).not.toContain("todo one");
+    expect(block).toMatch(/do NOT re-recommend/i);
+  });
+});
+
+describe("renderRefutedHypothesesBlock", () => {
+  it("returns '' when there are no analyst-refuted hypotheses", () => {
+    expect(renderRefutedHypothesesBlock([hyp({ status: "open" })])).toBe("");
+  });
+
+  it("includes analyst-authored refuted hypotheses with notes", () => {
+    const block = renderRefutedHypothesesBlock([
+      hyp({ title: "Access was RDP from DMZ", status: "refuted", source: "analyst", notes: "no 4624 type 10" }),
+    ]);
+    expect(block).toContain("Access was RDP from DMZ");
+    expect(block).toContain("no 4624 type 10");
+    expect(block).toMatch(/do NOT re-assert/i);
+  });
+
+  it("excludes model-only refutations (not analyst-touched)", () => {
+    const block = renderRefutedHypothesesBlock([
+      hyp({ title: "model theory", status: "refuted", source: "synthesis", analystTouched: false }),
+    ]);
+    expect(block).toBe("");
+  });
+
+  it("includes a synthesis hypothesis the analyst touched", () => {
+    const block = renderRefutedHypothesesBlock([
+      hyp({ title: "touched theory", status: "refuted", source: "synthesis", analystTouched: true }),
+    ]);
+    expect(block).toContain("touched theory");
+  });
+});
+
+describe("demoteCompletedNextSteps", () => {
+  it("demotes a step that repeats a completed task (shared specific token)", () => {
+    const steps = [step({ id: "n1", action: "Pull Security.evtx 4624 on ALCLIENT07", priority: "high" })];
+    const { steps: out, demotedIds } = demoteCompletedNextSteps(steps, ["Pull Security.evtx 4624 on ALCLIENT07 and timeline it"]);
+    expect(demotedIds).toEqual(["n1"]);
+    expect(out[0].priority).toBe("low");
+    expect(out[0].rationale).toMatch(/already done/i);
+  });
+
+  it("does NOT demote a same-verb step targeting a different host", () => {
+    const steps = [step({ id: "n1", action: "Pull Security.evtx 4624 on ALCLIENT09", priority: "high" })];
+    const { demotedIds } = demoteCompletedNextSteps(steps, ["Pull Security.evtx 4624 on ALCLIENT07"]);
+    expect(demotedIds).toEqual([]);
+  });
+
+  it("does NOT demote when only generic verbs overlap (no specific token)", () => {
+    const steps = [step({ id: "n1", action: "review the findings again", priority: "high" })];
+    const { demotedIds } = demoteCompletedNextSteps(steps, ["review the timeline"]);
+    expect(demotedIds).toEqual([]);
+  });
+
+  it("uses the pointer to identify the target when the action is generic", () => {
+    const steps = [step({ id: "n1", action: "collect logs", pointer: "pull $MFT on WKSTN-DB-01", priority: "critical" })];
+    const { demotedIds, steps: out } = demoteCompletedNextSteps(steps, ["Pull $MFT on WKSTN-DB-01"]);
+    expect(demotedIds).toEqual(["n1"]);
+    expect(out[0].priority).toBe("low");
+  });
+
+  it("returns inputs unchanged when there are no done titles", () => {
+    const steps = [step({ id: "n1" })];
+    const { steps: out, demotedIds } = demoteCompletedNextSteps(steps, []);
+    expect(demotedIds).toEqual([]);
+    expect(out).toEqual(steps);
+  });
+});

--- a/companion/tests/analysis/promptCapabilities.test.ts
+++ b/companion/tests/analysis/promptCapabilities.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PROMPT_CAPABILITIES,
+  missingMarkers,
+  assertBuiltinsHaveMarkers,
+  driftMessage,
+  checkConfiguredPromptDrift,
+} from "../../src/analysis/promptCapabilities.js";
+import { BUILTIN_PROMPT_BY_NAME } from "../../src/analysis/pipeline.js";
+
+describe("missingMarkers", () => {
+  it("returns the markers absent from the text (case-sensitive)", () => {
+    expect(missingMarkers("has hypotheses and confidenceReason", ["hypotheses", "relatedFindingIds"]))
+      .toEqual(["relatedFindingIds"]);
+  });
+
+  it("returns [] when every marker is present", () => {
+    expect(missingMarkers("a b c", ["a", "c"])).toEqual([]);
+  });
+
+  it("treats undefined/empty text as missing everything", () => {
+    expect(missingMarkers("", ["x"])).toEqual(["x"]);
+    expect(missingMarkers(undefined as unknown as string, ["x"])).toEqual(["x"]);
+  });
+});
+
+describe("assertBuiltinsHaveMarkers (rot guard)", () => {
+  it("passes for the real shipped built-in prompts", () => {
+    // If a prompt rewrite drops a marker the pipeline still depends on, this fails loudly.
+    expect(() => assertBuiltinsHaveMarkers(BUILTIN_PROMPT_BY_NAME)).not.toThrow();
+  });
+
+  it("throws when a built-in is missing one of its own markers", () => {
+    expect(() => assertBuiltinsHaveMarkers({ SYNTH: "no markers here" })).toThrow(/missing its own markers/);
+  });
+
+  it("throws when a built-in is not supplied", () => {
+    expect(() => assertBuiltinsHaveMarkers({})).toThrow(/no built-in prompt supplied/);
+  });
+});
+
+describe("checkConfiguredPromptDrift", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "prompt-drift-"));
+  afterEach(() => {
+    // isolate env between cases
+    for (const cap of PROMPT_CAPABILITIES) {
+      delete process.env[`DFIR_AI_${cap.name}_PROMPT`];
+      delete process.env[`DFIR_AI_${cap.name}_PROMPT_FILE`];
+    }
+  });
+
+  it("reports nothing when no override is configured (built-in is used)", () => {
+    expect(checkConfiguredPromptDrift({})).toEqual([]);
+  });
+
+  it("flags a stale synthesis override file missing capabilities", () => {
+    const file = join(tmp, "stale-synthesis.txt");
+    writeFileSync(file, "You are a DFIR analyst. Produce findings and keyQuestions.", "utf8");
+    const drift = checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file });
+    expect(drift).toHaveLength(1);
+    expect(drift[0].name).toBe("SYNTH");
+    expect(drift[0].missing).toEqual(["hypotheses", "confidenceReason", "relatedFindingIds"]);
+    expect(driftMessage(drift[0])).toContain("synthesis.txt");
+  });
+
+  it("passes a fresh override file that contains every marker", () => {
+    const file = join(tmp, "fresh-synthesis.txt");
+    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds", "utf8");
+    expect(checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file })).toEqual([]);
+  });
+
+  it("does not flag an unreadable/empty override (resolvePrompt falls back to the built-in)", () => {
+    const empty = join(tmp, "empty.txt");
+    writeFileSync(empty, "   \n", "utf8");
+    expect(checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: empty })).toEqual([]);
+    expect(checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: join(tmp, "does-not-exist.txt") })).toEqual([]);
+  });
+
+  it("checks an inline *_PROMPT override too", () => {
+    const drift = checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT: "findings only, no other sections" });
+    expect(drift).toHaveLength(1);
+    expect(drift[0].missing).toContain("hypotheses");
+  });
+});

--- a/companion/tests/analysis/synthEvidence.test.ts
+++ b/companion/tests/analysis/synthEvidence.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { renderStructuredTags, buildBeaconDigest, buildAttackPhaseDigest } from "../../src/analysis/synthEvidence.js";
+import type { ForensicEvent, Severity } from "../../src/analysis/stateTypes.js";
+import type { BeaconCandidate } from "../../src/analysis/beaconDetect.js";
+import type { AttackPhase } from "../../src/analysis/burstDetect.js";
+
+function ev(p: Partial<ForensicEvent>): ForensicEvent {
+  return {
+    id: p.id ?? "e1", timestamp: p.timestamp ?? "2026-01-01T00:00:00Z", description: p.description ?? "x",
+    severity: p.severity ?? "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...p,
+  };
+}
+
+describe("renderStructuredTags", () => {
+  it("emits host/proc/net/src tags only for set fields", () => {
+    const t = renderStructuredTags(ev({ asset: "WS07", processName: "powershell.exe", parentName: "excel.exe", srcIp: "10.1.2.3", dstIp: "52.1.1.1", port: 443, sources: ["a", "b", "c"] }));
+    expect(t).toContain("<host:WS07>");
+    expect(t).toContain("<proc:powershell.exe←excel.exe>");
+    expect(t).toContain("<net:10.1.2.3→52.1.1.1:443>");
+    expect(t).toContain("<src:3>");
+  });
+
+  it("returns '' for a bare event (no structured fields)", () => {
+    expect(renderStructuredTags(ev({ description: "just prose" }))).toBe("");
+  });
+
+  it("omits <src:N> when fewer than 2 sources (no corroboration to flag)", () => {
+    expect(renderStructuredTags(ev({ sources: ["only-one"] }))).toBe("");
+  });
+
+  it("handles a process with no parent and a dst-only connection", () => {
+    const t = renderStructuredTags(ev({ processName: "cmd.exe", dstIp: "8.8.8.8" }));
+    expect(t).toContain("<proc:cmd.exe>");
+    expect(t).not.toContain("←");
+    expect(t).toContain("<net:?→8.8.8.8>");
+  });
+});
+
+function beacon(p: Partial<BeaconCandidate>): BeaconCandidate {
+  return {
+    id: p.id ?? "beacon-1", source: p.source ?? "WS04", destIp: p.destIp ?? "203.0.113.7", destPort: p.destPort,
+    eventCount: p.eventCount ?? 214, intervalSeconds: p.intervalSeconds ?? 62, jitterSeconds: p.jitterSeconds ?? 1,
+    jitterPct: p.jitterPct ?? 3, firstSeen: "", lastSeen: "", severity: p.severity ?? "High",
+    external: p.external ?? true, eventIds: p.eventIds ?? ["e1", "e2"],
+  };
+}
+
+describe("buildBeaconDigest", () => {
+  it("renders a candidate line with the verify caveat", () => {
+    const out = buildBeaconDigest([beacon({ destPort: 443 })]);
+    expect(out).toContain("PERIODIC BEACON CANDIDATES");
+    expect(out).toContain("WS04 → 203.0.113.7:443 every ~62s");
+    expect(out).toMatch(/LEAD to verify/i);
+    expect(out).toMatch(/not a verdict|not confirmed C2/i);
+  });
+
+  it("returns '' when there are no beacons", () => {
+    expect(buildBeaconDigest([])).toBe("");
+  });
+});
+
+function phase(p: Partial<AttackPhase>): AttackPhase {
+  return {
+    id: p.id ?? "phase-1", label: p.label ?? "Discovery", startTimestamp: p.startTimestamp ?? "2026-05-20T09:02:00Z",
+    endTimestamp: p.endTimestamp ?? "2026-05-20T09:15:00Z", eventIds: p.eventIds ?? ["e1", "e2"],
+    inferredTechniques: p.inferredTechniques ?? ["T1087"], eventCount: p.eventCount ?? 41, maxSeverity: p.maxSeverity ?? "Medium",
+  };
+}
+
+describe("buildAttackPhaseDigest", () => {
+  it("renders a phase line with window, label, count and techniques", () => {
+    const out = buildAttackPhaseDigest([phase({})]);
+    expect(out).toContain("ATTACK PHASES");
+    expect(out).toContain("09:02–09:15 Discovery (41 ev, Medium)");
+    expect(out).toContain("T1087");
+  });
+
+  it("skips single-event phases and empty input", () => {
+    expect(buildAttackPhaseDigest([phase({ eventCount: 1 })])).toBe("");
+    expect(buildAttackPhaseDigest([])).toBe("");
+  });
+});

--- a/companion/tests/analysis/synthSelect.test.ts
+++ b/companion/tests/analysis/synthSelect.test.ts
@@ -72,9 +72,30 @@ describe("buildSynthesisContext", () => {
       severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], asset: "db-01.northpeaklabs.com" });
 
     const ctx = buildSynthesisContext(s, s.forensicTimeline);
-    expect(ctx).toContain("THREAT-INTEL VERDICTS");
+    // #7: a conflicted verdict (own-host asset) is moved to the dedicated INTEL CONFLICTS block so the
+    // model can't read it as confirmed external C2 — not the trusted THREAT-INTEL VERDICTS list.
+    expect(ctx).toContain("INTEL CONFLICTS");
     expect(ctx).toContain("db-01.northpeaklabs.com = suspicious (OpenCTI)");
     expect(ctx).toContain("CONFLICT");
     expect(ctx).toContain("also one of this case's OWN host assets");
+  });
+
+  it("tags a corroborated verdict (provider + behavioral event) as [corroborated]", () => {
+    const s = emptyState("c1");
+    s.iocs.push({ id: "i1", type: "process", value: "evil.exe", firstSeen: "",
+      enrichments: [{ source: "VirusTotal", verdict: "malicious", score: "52/73", fetchedAt: "" }] });
+    s.forensicTimeline.push({ id: "e1", timestamp: "2026-05-20T09:00:00Z", description: "evil.exe run", severity: "Critical",
+      mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], asset: "WIN-01" });
+    const ctx = buildSynthesisContext(s, s.forensicTimeline);
+    expect(ctx).toContain("THREAT-INTEL VERDICTS");
+    expect(ctx).toContain("evil.exe = malicious (VirusTotal 52/73) [corroborated]");
+  });
+
+  it("tags a single-provider verdict with no behavioral evidence as [lone-intel]", () => {
+    const s = emptyState("c1");
+    s.iocs.push({ id: "i1", type: "domain", value: "evil-c2.example", firstSeen: "",
+      enrichments: [{ source: "VirusTotal", verdict: "suspicious", score: "", fetchedAt: "" }] });
+    const ctx = buildSynthesisContext(s, s.forensicTimeline);
+    expect(ctx).toContain("[lone-intel]");
   });
 });

--- a/companion/tests/analysis/synthSelectChain.test.ts
+++ b/companion/tests/analysis/synthSelectChain.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { selectSynthesisEventsAnnotated } from "../../src/analysis/synthSelect.js";
+import type { ForensicEvent, Severity } from "../../src/analysis/stateTypes.js";
+
+// A richer event builder than the base synthSelect test's — lets us set asset/sources/techniques.
+function ev(partial: Partial<ForensicEvent> & { id: string; timestamp: string; severity: Severity }): ForensicEvent {
+  return {
+    description: partial.id,
+    mitreTechniques: [],
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+    ...partial,
+  };
+}
+
+describe("selectSynthesisEventsAnnotated — chain-aware reserved budgets", () => {
+  it("pulls low-severity same-host events near a Critical anchor in as anchor_context", () => {
+    const events: ForensicEvent[] = [];
+    // Fill the timeline with unrelated Info noise on a different host so even-spread would normally win.
+    for (let i = 0; i < 200; i++) {
+      const hh = String(i % 24).padStart(2, "0");
+      const mm = String(i % 60).padStart(2, "0");
+      events.push(ev({ id: `noise${i}`, timestamp: `2026-05-20T${hh}:${mm}:00Z`, severity: "Info", asset: "NOISEHOST" }));
+    }
+    // The real chain: a Critical anchor on HOST7 plus three Low steps within 15 minutes on HOST7.
+    events.push(ev({ id: "anchor", timestamp: "2026-05-20T12:00:00Z", severity: "Critical", asset: "HOST7", description: "malware detected" }));
+    events.push(ev({ id: "step_sqlcmd", timestamp: "2026-05-20T11:58:00Z", severity: "Low", asset: "HOST7", processName: "sqlcmd.exe", description: "sqlcmd export of db" }));
+    events.push(ev({ id: "step_tar", timestamp: "2026-05-20T12:03:00Z", severity: "Low", asset: "HOST7", processName: "tar.exe", description: "tar czf dump.tgz" }));
+    events.push(ev({ id: "step_curl", timestamp: "2026-05-20T12:05:00Z", severity: "Low", asset: "HOST7", processName: "curl.exe", description: "curl -T dump.tgz https://x" }));
+
+    const sel = selectSynthesisEventsAnnotated(events, 40);
+    const ids = new Set(sel.events.map((e) => e.id));
+    expect(ids.has("anchor")).toBe(true);
+    // The Low chain steps ride in with their anchor even though they'd lose an even-spread lottery.
+    expect(ids.has("step_sqlcmd")).toBe(true);
+    expect(ids.has("step_tar")).toBe(true);
+    expect(ids.has("step_curl")).toBe(true);
+    expect(sel.classOf.get("step_curl")).toBe("anchor_context");
+    expect(sel.counts.anchor_context).toBeGreaterThanOrEqual(3);
+  });
+
+  it("gives corroborated (2+ source) events a reserved seat over uncorroborated noise", () => {
+    const events: ForensicEvent[] = [];
+    for (let i = 0; i < 300; i++) {
+      events.push(ev({ id: `n${i}`, timestamp: `2026-05-20T00:00:${String(i % 60).padStart(2, "0")}Z`, severity: "Info", asset: "H" }));
+    }
+    const corr = ev({ id: "corroborated", timestamp: "2026-05-20T23:59:00Z", severity: "Medium", asset: "H", sources: ["Velociraptor", "THOR"] });
+    events.push(corr);
+    const sel = selectSynthesisEventsAnnotated(events, 30);
+    const picked = sel.events.find((e) => e.id === "corroborated");
+    expect(picked).toBeDefined();
+    expect(sel.classOf.get("corroborated")).toBe("corroborated");
+  });
+
+  it("gives a technique-tagged Info event a reserved seat", () => {
+    const events: ForensicEvent[] = [];
+    for (let i = 0; i < 300; i++) {
+      events.push(ev({ id: `n${i}`, timestamp: `2026-05-20T00:00:${String(i % 60).padStart(2, "0")}Z`, severity: "Info", asset: "H" }));
+    }
+    events.push(ev({ id: "tagged", timestamp: "2026-05-20T23:58:00Z", severity: "Info", asset: "H", mitreTechniques: ["T1048"] }));
+    const sel = selectSynthesisEventsAnnotated(events, 30);
+    expect(sel.events.some((e) => e.id === "tagged")).toBe(true);
+    expect(sel.classOf.get("tagged")).toBe("technique");
+  });
+
+  it("still keeps ALL Critical/High anchors and never exceeds max", () => {
+    const events: ForensicEvent[] = [];
+    for (let i = 0; i < 60; i++) events.push(ev({ id: `hi${i}`, timestamp: `2026-05-20T${String(i % 24).padStart(2, "0")}:00:00Z`, severity: "High", asset: "H" }));
+    for (let i = 0; i < 200; i++) events.push(ev({ id: `lo${i}`, timestamp: `2026-05-21T${String(i % 24).padStart(2, "0")}:00:00Z`, severity: "Info", asset: "H" }));
+    const sel = selectSynthesisEventsAnnotated(events, 100);
+    expect(sel.events.length).toBeLessThanOrEqual(100);
+    // all 60 High anchors present
+    for (let i = 0; i < 60; i++) expect(sel.events.some((e) => e.id === `hi${i}`)).toBe(true);
+  });
+
+  it("reports per-class counts and the omitted total", () => {
+    const events: ForensicEvent[] = [];
+    for (let i = 0; i < 100; i++) events.push(ev({ id: `e${i}`, timestamp: `2026-05-20T${String(i % 24).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}:00Z`, severity: "Info", asset: "H" }));
+    const sel = selectSynthesisEventsAnnotated(events, 20);
+    expect(sel.events.length).toBe(20);
+    expect(sel.omitted).toBe(80);
+    const total = Object.values(sel.counts).reduce((a, b) => a + b, 0);
+    expect(total).toBe(20);
+  });
+
+  it("returns everything with zero omitted when under budget", () => {
+    const events = [ev({ id: "a", timestamp: "2026-05-20T09:00:00Z", severity: "Low" }), ev({ id: "b", timestamp: "2026-05-20T10:00:00Z", severity: "Low" })];
+    const sel = selectSynthesisEventsAnnotated(events, 300);
+    expect(sel.events.map((e) => e.id)).toEqual(["a", "b"]);
+    expect(sel.omitted).toBe(0);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -12885,6 +12885,11 @@
               (q.pinned ? ` <span class="icon-pinned" title="Pinned">${ICON_PIN}</span>` : "") +
               ` <span class="q-status q-status-${st}">${QSTATUS[st]}</span> <strong>${esc(q.question)}</strong></div>` +
               `<span class="q-answer">${esc(q.answer || "unknown")}</span>` +
+              // Contradiction badge (investigation-guidance #3): the negative answer conflicts with
+              // ATT&CK-tagged events in the timeline — flag it so a wrong "no" is never read as settled.
+              (q.contradicted && q.contradicted.techniques && q.contradicted.techniques.length
+                ? ` <span class="q-contradicted" style="color:var(--c-ff6b6b,#ff6b6b);font-weight:600" title="The timeline contains events tagged ${esc(q.contradicted.techniques.join(', '))} that contradict this negative answer — review before concluding.">⚠️ contradicted by timeline (${esc(q.contradicted.techniques.join(', '))})</span>`
+                : "") +
               (q.pointer ? `<span class="q-pointer">→ ${esc(q.pointer)}</span>` : "") +
               `</div>`;
           }).join("")

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -9795,6 +9795,19 @@
       if (f.confidenceReason) {
         rows.push(`<div class="fev-row"><span class="fev-k">Confidence</span><span class="fev-v">${f.confidence !== undefined ? esc(String(f.confidence)) + "% — " : ""}${esc(f.confidenceReason)}</span></div>`);
       }
+      // Grounding/corroboration (investigation-guidance #6): flag an ungrounded finding prominently, else
+      // show the tools/hosts/intel rollup so a single-source claim is visibly distinguishable from a
+      // multi-tool one.
+      if (f.ungrounded) {
+        rows.push(`<div class="fev-row"><span class="fev-k">Grounding</span><span class="fev-v" style="color:var(--c-ff6b6b,#ff6b6b);font-weight:600">⚠️ no cited evidence — treat as a hypothesis, not a fact (confidence capped)</span></div>`);
+      } else if (f.corroboration) {
+        const c = f.corroboration;
+        const parts = [`${c.distinctTools} tool${c.distinctTools === 1 ? "" : "s"}`, `${c.distinctHosts} host${c.distinctHosts === 1 ? "" : "s"}`];
+        if (c.intelSources > 0) parts.push("intel ✓");
+        if (c.graphLinked) parts.push("graph-linked");
+        const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked;
+        rows.push(`<div class="fev-row"><span class="fev-k">Corroboration</span><span class="fev-v"${corroborated ? "" : ' style="color:var(--c-e0a458,#e0a458)"'}>${esc(parts.join(" / "))}${corroborated ? "" : " — uncorroborated"}</span></div>`);
+      }
       const byVal = new Map((iocs || []).map(i => [String(i.value).trim().toLowerCase(), i.value]));
       const vals = new Set();
       for (const id of (f.relatedIocs || [])) { const ioc = (iocs || []).find(x => x.id === id); if (ioc) vals.add(ioc.value); }


### PR DESCRIPTION
Implements Tier 0 + Tier 1 of the investigation-guidance roadmap — deepening the intelligence and wiring of the EXISTING synthesis loop (no new bolt-on features) so the Companion makes better decisions, connects the dots across hosts, tells apart false positives / rabbit holes / real leads, and stops wasting the investigator's time.

Each proposal is one commit with unit tests. Full suite green: **2294 analysis + 695 reports/server tests, clean `tsc`.**

## Tier 0 — stop wasting the investigator's time
- **#1 Prompt-capability drift detection** (`promptCapabilities.ts`) — a stale `DFIR_AI_*_PROMPT_FILE` override silently disabled shipped output (hypotheses auto-gen #140, confidenceReason #226, keyQuestions.relatedFindingIds #222). Preflight item + once-per-run warning + a rot-guard test asserting the built-in still contains its markers.
- **#2 Condition synthesis on prior work** (`priorWork.ts`) — feed the hunt hit/miss ledger (#157, previously hunt-prompts only), the playbook DONE/SKIPPED digest, and refuted hypotheses into `synthesize()` and its skip-hash; entity-aware demote of a next-step that repeats a completed task (a different-host step survives).
- **#3 Answer-contradiction validator** (`answerContradiction.ts`) — a keyQuestion answer asserting an absence ("No data exfiltration confirmed") while in-scope events carry the matching ATT&CK techniques is forced to `partial` with a "contradicted by timeline" badge (halcyon's exact failure).

## Tier 1 — make the AI's conclusions trustworthy
- **#4 Chain-aware event selection** (`synthSelect.ts`) — reserved per-class budgets (anchor-context ±15min same-host / corroborated / technique-tagged / whole-burst spread) on top of the kept all-Critical/High + earliest guarantees, so the Low-graded true attack chain reaches the model instead of even-spread noise.
- **#5 Structured evidence into synthesis** (`synthEvidence.ts`) — `<host>/<proc>/<net>/<src:N>` tags per event; the causal attack graph (now with `[confidence, rule]`) fed to `synthesize()` (was ask()/hunts only); beacon + attack-phase digests; prompt taught to use them and to treat beacons as leads not confirmed C2.
- **#6 Per-finding grounding + corroboration** (`findingGrounding.ts`) — ungrounded findings badged + confidence-capped; a tools/hosts/intel/graph rollup drives caps. Uses reverse `forensicTimeline` links so deterministic backfill findings ground correctly.
- **#7 Intel-verdict gate** (`iocAnchors.ts` + `findingGrounding.ts`) — `classifyVerdict` (corroborated / lone-intel / conflicted) + an intel-only High/Critical severity floor: kills the northpeak "Critical C2 on your own DB server" class deterministically. INTEL CONFLICTS prompt sub-block.

## Measured against ground truth
Every Tier 1 change is verifiable against the existing benchmark corpus (fairhaven, halcyon, veridia, northpeak): the previously-missed chains should now surface and the previously-fabricated stories should be gone.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/analysis` — 2294 pass
- [x] `npx vitest run tests/reports tests/server` — 695 pass
- [ ] Re-run ground-truth benchmark scoring (fairhaven/halcyon/veridia/northpeak) to confirm recall/precision gains

## Notes
- New pure modules: `promptCapabilities.ts`, `priorWork.ts`, `answerContradiction.ts`, `synthEvidence.ts`, `findingGrounding.ts`.
- **Operational follow-up (not in this PR — gitignored):** run `npm run prompts:eject` in the deployment so the live `companion/prompts/*.txt` picks up the built-in prompt; until then the new drift check warns on every preflight/synthesis run.
- Deferred within items (documented in commits): the `~` context-prefix notation + synthMeta per-class counts (#4); anchor-scoring retune + auto "corroborate <ioc>" next-step (#7, needs Tier 2 #8). Tiers 2–3 (#8–#15) remain as specified in `INVESTIGATION_GUIDANCE_ROADMAP.md`.