### PR TITLE
Investigation guidance #8 Phase 3: one-click Deploy for collection directives

### DIFF
--- a/companion/src/analysis/collectDirectiveResolve.ts
+++ b/companion/src/analysis/collectDirectiveResolve.ts
@@ -1,0 +1,57 @@
+// Resolve a structured collection directive (investigation-guidance #8, phase 3) to a deployable
+// Velociraptor CLIENT VQL, so the dashboard Deploy button can launch the exact collection the AI
+// recommended. PURE — no I/O. Returns null when nothing maps (the UI then falls back to a copyable
+// manual checklist rather than deploying a guessed artifact).
+//
+// Priority: (1) an explicit Velociraptor artifact name the model gave (collect.artifact) is used
+// verbatim; (2) otherwise keywords in artifact/logSource map onto a known built-in — the forensic
+// artifacts come from the verified SHADOW_ARTIFACTS catalog, plus a small hand-verified extra list for
+// the common non-anti-forensic sources (event logs, netstat, scheduled tasks). Every artifact name
+// here is a real, standard Velociraptor built-in that runs parameterless on a client.
+
+import { SHADOW_ARTIFACTS } from "./shadowArtifacts.js";
+import type { CollectDirective } from "./stateTypes.js";
+
+export interface ResolvedCollection {
+  vql: string;        // a single deployable CLIENT-side VQL statement
+  artifact: string;   // the Velociraptor artifact name it collects (for display + the deploy record)
+}
+
+// Looks like a dotted Velociraptor artifact name, e.g. "Windows.EventLogs.Evtx" (optionally "Artifact."-prefixed).
+function artifactName(raw: string): string | null {
+  const s = raw.trim().replace(/^Artifact\./i, "");
+  return /^[A-Za-z][A-Za-z0-9]*(?:\.[A-Za-z0-9]+)+$/.test(s) ? s : null;
+}
+
+// Hand-verified common built-ins NOT covered by the anti-forensic SHADOW_ARTIFACTS catalog. Keywords are
+// matched case-insensitively against the combined artifact + logSource text.
+const EXTRA_ARTIFACTS: ReadonlyArray<{ re: RegExp; artifact: string }> = [
+  { re: /(security\.evtx|system\.evtx|application\.evtx|\bevtx\b|event ?logs?|\b4624\b|\b4672\b|\b4688\b|\b4648\b|\b4634\b|\b4104\b|\b7045\b)/i, artifact: "Windows.EventLogs.Evtx" },
+  { re: /(\bnetstat\b|network connections?|active connections?)/i, artifact: "Windows.Network.Netstat" },
+  { re: /(scheduled tasks?|\bschtasks\b|task scheduler)/i, artifact: "Windows.System.TaskScheduler" },
+  { re: /(process list|running processes?|\bpslist\b|process listing)/i, artifact: "Windows.System.Pslist" },
+];
+
+// Build shadow-catalog keyword matchers once: match on the kebab id, the id with spaces, and the first
+// word of the display name (e.g. "usn-journal" / "usn journal" / "usn").
+const SHADOW_MATCHERS = SHADOW_ARTIFACTS.map((a) => ({
+  keys: [a.id, a.id.replace(/-/g, " "), a.name.toLowerCase().split(/[^a-z0-9$]+/i)[0]].filter(Boolean),
+  vql: a.vql,
+  artifact: a.velociraptorArtifact,
+}));
+
+export function resolveCollectVql(collect: CollectDirective | undefined): ResolvedCollection | null {
+  if (!collect) return null;
+  const explicit = collect.artifact ? artifactName(collect.artifact) : null;
+  if (explicit) return { vql: `SELECT * FROM Artifact.${explicit}()`, artifact: explicit };
+
+  const text = `${collect.artifact ?? ""} ${collect.logSource ?? ""}`;
+  for (const e of EXTRA_ARTIFACTS) {
+    if (e.re.test(text)) return { vql: `SELECT * FROM Artifact.${e.artifact}()`, artifact: e.artifact };
+  }
+  const lower = text.toLowerCase();
+  for (const m of SHADOW_MATCHERS) {
+    if (m.keys.some((k) => k.length >= 3 && lower.includes(k))) return { vql: m.vql, artifact: m.artifact };
+  }
+  return null;
+}

--- a/companion/src/routes/velociraptor.ts
+++ b/companion/src/routes/velociraptor.ts
@@ -7,6 +7,7 @@ import { buildVelociraptorClient, matchClient, ALL_CLIENTS, normalizeHuntExpiryS
 import type { VeloMonitor } from "../analysis/veloMonitorStore.js";
 import type { VeloHuntJob } from "../analysis/veloHuntStore.js";
 import type { HuntOutcomeSource } from "../analysis/huntOutcomes.js";
+import { resolveCollectVql } from "../analysis/collectDirectiveResolve.js";
 import type { RouteContext } from "./context.js";
 
 /**
@@ -547,6 +548,39 @@ export function registerVelociraptorRoutes(app: Express, ctx: RouteContext): voi
       return res.status(200).json({ mode, waitMinutes, ...launch });
     } catch (err) {
       logLine(`[velociraptor] deploy-hunt ERROR: ${(err as Error).message}`);
+      return res.status(502).json({ error: (err as Error).message });
+    }
+  });
+
+  // One-click deploy of a structured collection directive (investigation-guidance #8, phase 3). The
+  // dashboard next-steps / key-questions Deploy button posts { hostname, artifact?, logSource? }; we
+  // resolve those to a real client artifact VQL (collectDirectiveResolve) and launch a per-host
+  // collection via the same collectHostResolved path deploy-hunt uses — which itself refuses a host that
+  // isn't an enrolled client, the server-side backstop to the dashboard's own known-host gating. 400
+  // when the directive names nothing collectable (the UI then shows a manual checklist instead).
+  app.post("/cases/:id/velociraptor/collect-directive", async (req: Request, res: Response) => {
+    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    const caseId = req.params.id;
+    const hostname = typeof req.body?.hostname === "string" ? req.body.hostname.trim() : "";
+    const artifact = typeof req.body?.artifact === "string" ? req.body.artifact.trim() : "";
+    const logSource = typeof req.body?.logSource === "string" ? req.body.logSource.trim() : "";
+    if (!hostname) return res.status(400).json({ error: "hostname is required" });
+    const resolved = resolveCollectVql({ artifact: artifact || undefined, logSource: logSource || undefined });
+    if (!resolved) {
+      return res.status(400).json({ error: `could not map "${artifact || logSource}" to a Velociraptor artifact — collect it manually` });
+    }
+    const title = `Collect ${resolved.artifact} on ${hostname}`;
+    try {
+      logLine(`[velociraptor] collect-directive ${resolved.artifact} on ${hostname}`);
+      const result = await collectHostResolved(hostname, resolved.vql, title);
+      await ctx.recordHuntDeploy(caseId, { source: "playbook", title, vql: resolved.vql, deployedAt: new Date().toISOString() });
+      options.onVeloHunt?.(caseId);
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "hunt", action: "deploy-collection", detail: `collection ${resolved.artifact} on ${hostname}`,
+      });
+      return res.status(200).json({ ...result, artifact: resolved.artifact, vql: resolved.vql });
+    } catch (err) {
+      logLine(`[velociraptor] collect-directive ERROR: ${(err as Error).message}`);
       return res.status(502).json({ error: (err as Error).message });
     }
   });

--- a/companion/tests/analysis/collectDirectiveResolve.test.ts
+++ b/companion/tests/analysis/collectDirectiveResolve.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { resolveCollectVql } from "../../src/analysis/collectDirectiveResolve.js";
+
+describe("resolveCollectVql", () => {
+  it("uses an explicit Velociraptor artifact name verbatim", () => {
+    expect(resolveCollectVql({ artifact: "Windows.EventLogs.Evtx" }))
+      .toEqual({ vql: "SELECT * FROM Artifact.Windows.EventLogs.Evtx()", artifact: "Windows.EventLogs.Evtx" });
+  });
+
+  it("strips an 'Artifact.' prefix from an explicit name", () => {
+    expect(resolveCollectVql({ artifact: "Artifact.Windows.Forensics.Prefetch" })?.artifact).toBe("Windows.Forensics.Prefetch");
+  });
+
+  it("maps event-log log sources (evtx / event ids) to Windows.EventLogs.Evtx", () => {
+    expect(resolveCollectVql({ logSource: "Security.evtx 4624/4672" })?.artifact).toBe("Windows.EventLogs.Evtx");
+    expect(resolveCollectVql({ logSource: "pull the Windows event logs" })?.artifact).toBe("Windows.EventLogs.Evtx");
+  });
+
+  it("maps $MFT to the shadow-catalog MFT artifact", () => {
+    expect(resolveCollectVql({ logSource: "$MFT" })?.artifact).toBe("Windows.NTFS.MFT");
+  });
+
+  it("maps forensic keywords onto the shadow catalog", () => {
+    expect(resolveCollectVql({ logSource: "prefetch" })?.artifact).toBe("Windows.Forensics.Prefetch");
+    expect(resolveCollectVql({ logSource: "amcache hive" })?.artifact).toBe("Windows.Forensics.Amcache");
+    expect(resolveCollectVql({ logSource: "SRUM database" })?.artifact).toBe("Windows.Forensics.SRUM");
+    expect(resolveCollectVql({ logSource: "USN journal" })?.artifact).toBe("Windows.Forensics.Usn");
+  });
+
+  it("maps netstat / scheduled tasks to their built-ins", () => {
+    expect(resolveCollectVql({ logSource: "netstat / active connections" })?.artifact).toBe("Windows.Network.Netstat");
+    expect(resolveCollectVql({ logSource: "scheduled tasks" })?.artifact).toBe("Windows.System.TaskScheduler");
+  });
+
+  it("prefers an explicit artifact over a keyword in logSource", () => {
+    expect(resolveCollectVql({ artifact: "Windows.NTFS.MFT", logSource: "prefetch" })?.artifact).toBe("Windows.NTFS.MFT");
+  });
+
+  it("returns null when nothing maps (UI falls back to a manual checklist)", () => {
+    expect(resolveCollectVql({ logSource: "ask the SOC team about the firewall" })).toBeNull();
+    expect(resolveCollectVql({})).toBeNull();
+    expect(resolveCollectVql(undefined)).toBeNull();
+  });
+
+  it("produces a runnable single-statement VQL", () => {
+    const r = resolveCollectVql({ artifact: "Windows.Forensics.Bam" });
+    expect(r!.vql).toMatch(/^SELECT \* FROM Artifact\.[A-Za-z0-9.]+\(\)$/);
+  });
+});

--- a/companion/tests/server/collectDirective.test.ts
+++ b/companion/tests/server/collectDirective.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, buildRuntimePipeline } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { VeloHuntStore } from "../../src/analysis/veloHuntStore.js";
+import { HuntOutcomeStore } from "../../src/analysis/huntOutcomeStore.js";
+import { VelociraptorClient, type VqlRunner, type VelociraptorApiConfig } from "../../src/integrations/velociraptor/velociraptorApi.js";
+
+const veloCfg: VelociraptorApiConfig = {
+  apiConfigPath: "/x/api.yaml", binary: "velociraptor", timeoutMs: 5000, maxRows: 1000, maxOutputBytes: 1024 * 1024,
+  guiUrl: "https://velo.example/",
+};
+const runner: VqlRunner = async () => ({ rows: [], raw: "" });
+
+async function makeApp(opts: { withVelo?: boolean } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "dfir-collectdir-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const pipeline = buildRuntimePipeline({ stateStore, store, imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }) });
+  const app = createApp(store, {
+    pipeline, stateStore,
+    veloHuntStore: new VeloHuntStore(store),
+    huntOutcomeStore: new HuntOutcomeStore(store),
+    aiConfigured: false,
+    ...(opts.withVelo === false ? {} : { velociraptorClient: new VelociraptorClient(veloCfg, runner) }),
+  });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app };
+}
+
+describe("POST /cases/:id/velociraptor/collect-directive (#8 phase 3)", () => {
+  it("is 501 when Velociraptor is not configured", async () => {
+    const { app } = await makeApp({ withVelo: false });
+    const res = await request(app).post("/cases/c1/velociraptor/collect-directive").send({ hostname: "DC01", artifact: "Windows.NTFS.MFT" });
+    expect(res.status).toBe(501);
+  });
+
+  it("is 400 when the hostname is missing", async () => {
+    const { app } = await makeApp();
+    const res = await request(app).post("/cases/c1/velociraptor/collect-directive").send({ artifact: "Windows.NTFS.MFT" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/hostname/i);
+  });
+
+  it("is 400 when the directive maps to no Velociraptor artifact", async () => {
+    const { app } = await makeApp();
+    const res = await request(app).post("/cases/c1/velociraptor/collect-directive")
+      .send({ hostname: "DC01", logSource: "ask the network team about the firewall" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/could not map|manually/i);
+  });
+
+  it("resolves a valid artifact and attempts the collection (host not enrolled → 502, not a resolve failure)", async () => {
+    const { app } = await makeApp();
+    // The mock client store has no enrolled 'DC01', so collectHostResolved throws → 502. This proves the
+    // route resolved the artifact VQL and reached the deploy path (a resolve failure would be a 400).
+    const res = await request(app).post("/cases/c1/velociraptor/collect-directive")
+      .send({ hostname: "DC01", logSource: "Security.evtx 4624" });
+    expect([200, 502]).toContain(res.status);
+    expect(res.status).not.toBe(400);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1057,6 +1057,13 @@
     .qrow .q-head { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; font-size: 13px; }
     .qrow .q-answer, .qrow .q-pointer { display: block; margin-top: 3px; font-size: 12px; color: var(--c-9aa4b2); }
     .qrow .q-pointer { color: var(--c-6aa9ff); }
+    /* Structured collection directive + one-click Deploy (investigation-guidance #8, phase 3). */
+    .collect-directive { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-top: 4px; font-size: 12px; }
+    .collect-directive .collect-what { color: var(--c-e0a458, #e0a458); }
+    .collect-deploy { background: var(--c-2f8f4e, #2f8f4e); border: 0; color: #fff; border-radius: 5px; padding: 2px 10px; font-size: 11px; cursor: pointer; }
+    .collect-deploy:disabled { opacity: .6; cursor: default; }
+    .collect-deploy.collect-done { background: var(--c-3a6ea5, #3a6ea5); }
+    .collect-manual { color: var(--c-9aa4b2); font-style: italic; }
     .q-status { font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
     .q-status-answered { color: var(--c-6bcb77); }
     .q-status-partial { color: var(--c-e0b84a); }
@@ -12867,6 +12874,36 @@
       if (caseId) saveConfidenceControl(caseId, parseInt(this.value, 10) || 0);
     });
 
+    // One-click deploy of a structured collection directive (investigation-guidance #8, phase 3).
+    // Delegated (the next-steps / key-questions HTML is re-rendered on every synthesis). Confirms, then
+    // POSTs to the case collect-directive route which resolves the artifact VQL and launches the
+    // collection on the (known, enrolled) host. The Deploy button is only rendered for a known case host.
+    document.addEventListener("click", async (ev) => {
+      const btn = ev.target && ev.target.closest && ev.target.closest(".collect-deploy");
+      if (!btn || btn.disabled) return;
+      const host = btn.getAttribute("data-host");
+      const artifact = btn.getAttribute("data-artifact") || "";
+      const logSource = btn.getAttribute("data-logsource") || "";
+      const caseId = document.getElementById("caseId").value.trim();
+      if (!caseId || !host) return;
+      if (!confirm(`Deploy a Velociraptor collection on ${host}?\n\nArtifact/source: ${artifact || logSource || "(auto)"}`)) return;
+      const orig = btn.textContent;
+      btn.disabled = true; btn.textContent = "deploying…";
+      try {
+        const r = await fetch(`/cases/${encodeURIComponent(caseId)}/velociraptor/collect-directive`, {
+          method: "POST", headers: { "content-type": "application/json" },
+          body: JSON.stringify({ hostname: host, artifact, logSource }),
+        });
+        const j = await r.json().catch(() => ({}));
+        if (!r.ok) throw new Error(j.error || `HTTP ${r.status}`);
+        btn.textContent = `✓ ${j.artifact || "collection"} launched`;
+        btn.classList.add("collect-done");
+      } catch (e) {
+        btn.disabled = false; btn.textContent = orig;
+        alert(`Collection failed: ${e.message}`);
+      }
+    });
+
     function render(rawState) {
       // Keep the raw state so scope-preset clicks can re-project without a refetch.
       lastState = rawState;
@@ -12876,6 +12913,24 @@
       document.getElementById("narrativeView").textContent = state.narrativeTimeline || "—";
 
       const PRIO = { critical: "#ff5c5c", high: "#ff9f43", medium: "#ffd93b", low: "#6bcB77" };
+
+      // Structured collection directives (investigation-guidance #8, phase 3): render a one-click
+      // Deploy for a collect target on a KNOWN case host when Velociraptor is configured, else a
+      // copyable manual-collection line. Host is matched on its short name (mirrors the server's
+      // shortHost) against the case's observed assets, so a hallucinated hostname never gets a button.
+      const shortHostJs = (v) => String(v || "").toLowerCase().replace(/^https?:\/\//, "").split(/[\/:?]/)[0].split(".")[0];
+      const knownHostKeys = new Set((state.forensicTimeline || []).map(e => shortHostJs(e.asset)).filter(Boolean));
+      const collectDirectiveHtml = (c) => {
+        if (!c || !c.host) return "";
+        const what = c.logSource || c.artifact || "";
+        const summary = `collect ${esc(what)}${what ? " " : ""}from ${esc(c.host)}` + (c.expectedOutcome ? ` — expected: ${esc(c.expectedOutcome)}` : "");
+        const deployable = veloEnabled && knownHostKeys.has(shortHostJs(c.host));
+        const btn = deployable
+          ? `<button class="collect-deploy" data-host="${escAttr(c.host)}" data-artifact="${escAttr(c.artifact || "")}" data-logsource="${escAttr(c.logSource || "")}" title="Launch this collection on ${escAttr(c.host)} via Velociraptor">⬇ Collect on ${esc(c.host)}</button>`
+          : `<span class="collect-manual" title="${veloEnabled ? 'Host not seen in this case — collect manually' : 'Velociraptor API not configured — collect manually'}">manual collection</span>`;
+        return `<span class="collect-directive"><span class="collect-what">📥 ${summary}</span> ${btn}</span>`;
+      };
+
       const ns = state.nextSteps || [];
       document.getElementById("nextSteps").innerHTML = ns.length
         ? ns.map(s => {
@@ -12884,6 +12939,7 @@
               `<span class="step-priority">${esc(String(s.priority || "").toUpperCase())}</span> ${esc(s.action)}` +
               (s.rationale ? `<span class="step-rationale">${esc(s.rationale)}</span>` : "") +
               (s.pointer ? `<span class="step-pointer">→ ${esc(s.pointer)}</span>` : "") +
+              collectDirectiveHtml(s.collect) +
               `</div>`;
           }).join("")
         : "<div style='color:var(--c-9aa4b2)'>Not assessed yet — run Synthesize.</div>";
@@ -12904,6 +12960,7 @@
                 ? ` <span class="q-contradicted" style="color:var(--c-ff6b6b,#ff6b6b);font-weight:600" title="The timeline contains events tagged ${esc(q.contradicted.techniques.join(', '))} that contradict this negative answer — review before concluding.">⚠️ contradicted by timeline (${esc(q.contradicted.techniques.join(', '))})</span>`
                 : "") +
               (q.pointer ? `<span class="q-pointer">→ ${esc(q.pointer)}</span>` : "") +
+              (q.status !== "answered" ? collectDirectiveHtml(q.collect) : "") +
               `</div>`;
           }).join("")
         : "<div style='color:var(--c-9aa4b2)'>Not assessed yet — run Synthesize.</div>";


### PR DESCRIPTION
Completes **#8** (structured collection directives) by turning a *displayed* collect target into a *launchable* collection — the last hop that makes the tool lead collection rather than just describe it. Phases 1–2 (merged in #97) made the directives structured and self-clearing; this adds the button.

Builds on master (Tier 0+1 = #96, #8 phases 1–2 = #97). Full suite green: **3017 analysis + server + reports tests, clean `tsc`.**

## What's here
- **`collectDirectiveResolve.ts`** (pure, 9 tests): `resolveCollectVql` maps a `CollectDirective` to a deployable Velociraptor CLIENT artifact VQL. An explicit artifact name is used verbatim; otherwise keywords in `artifact`/`logSource` map onto the verified `SHADOW_ARTIFACTS` catalog plus a small hand-verified list (event logs, netstat, scheduled tasks, pslist). Returns `null` when nothing maps → the UI shows a manual checklist instead of deploying a guessed artifact.
- **`POST /cases/:id/velociraptor/collect-directive`** (4 route tests): resolves the VQL and launches a per-host collection via the same `collectHostResolved` path `deploy-hunt` uses — which refuses a host that isn't an enrolled client (the server-side backstop). `400` when unresolvable, `501` when Velociraptor is off.
- **Dashboard:** the next-steps and unknown/partial key-questions panels render the collect target; a one-click **"Collect on <host>"** button appears only when Velociraptor is configured **and** the host is a known case asset (short-host match, so a hallucinated hostname never gets a button), else a "manual collection" note. Delegated click → confirm → POST → inline status.

## Host-validation guard (defense in depth)
Enforced twice: the dashboard only renders the button for a host seen in the case timeline, and the server refuses a host that isn't an enrolled Velociraptor client.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/analysis tests/server tests/reports` — 3017 pass
- [ ] Manual UI drive with a live Velociraptor + a case carrying a collect directive (couldn't configure a real Velociraptor here; logic is covered by the resolver + route + dashboard-HTML structural tests)

## Roadmap status
This closes **#8** in full. Remaining Tier 2: **#9** kill-chain gap panel, **#10** source-yield instrumentation, **#11** second-look loop (+ Tier 3 #12–#15) per `INVESTIGATION_GUIDANCE_ROADMAP.md`.