### PR TITLE
fix: tighten #8 prompt-drift marker (logSource, not the bare word collect)

### DIFF
--- a/companion/src/analysis/promptCapabilities.ts
+++ b/companion/src/analysis/promptCapabilities.ts
@@ -34,8 +34,11 @@ export const PROMPT_CAPABILITIES: readonly PromptCapability[] = [
     // hypotheses      → issue #140 auto-generation (delta.hypotheses consumed in pipeline.ts)
     // confidenceReason→ issue #226 (confidence.ts / finding cards)
     // relatedFindingIds→ issue #222 FP→question re-answer wiring (else it degrades to prose matching)
-    // collect         → guidance #8 structured collection directives (deploy button + import-satisfaction)
-    markers: ["hypotheses", "confidenceReason", "relatedFindingIds", "collect"],
+    // logSource       → guidance #8 structured collection directives. NOTE: use "logSource" (a field
+    //   name unique to the #8 `collect` instruction), NOT the bare word "collect" — that appears as
+    //   prose in every older prompt ("collect email gateway logs"), so it silently PASSED a stale
+    //   pre-#8 override that lacked the structured directive.
+    markers: ["hypotheses", "confidenceReason", "relatedFindingIds", "logSource"],
   },
 ];
 

--- a/companion/tests/analysis/promptCapabilities.test.ts
+++ b/companion/tests/analysis/promptCapabilities.test.ts
@@ -62,13 +62,23 @@ describe("checkConfiguredPromptDrift", () => {
     const drift = checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file });
     expect(drift).toHaveLength(1);
     expect(drift[0].name).toBe("SYNTH");
-    expect(drift[0].missing).toEqual(["hypotheses", "confidenceReason", "relatedFindingIds", "collect"]);
+    expect(drift[0].missing).toEqual(["hypotheses", "confidenceReason", "relatedFindingIds", "logSource"]);
     expect(driftMessage(drift[0])).toContain("synthesis.txt");
+  });
+
+  it("flags a stale pre-#8 override whose only 'collect' is prose (the bare-word false-pass bug)", () => {
+    const file = join(tmp, "pre8-synthesis.txt");
+    // A pre-#8 re-eject: has hypotheses/confidenceReason/relatedFindingIds AND the prose "collect email
+    // gateway logs" — but NOT the structured `collect { logSource }` directive. Must still be flagged.
+    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds. pointer: 'collect email gateway logs'", "utf8");
+    const drift = checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file });
+    expect(drift).toHaveLength(1);
+    expect(drift[0].missing).toEqual(["logSource"]);
   });
 
   it("passes a fresh override file that contains every marker", () => {
     const file = join(tmp, "fresh-synthesis.txt");
-    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds, collect", "utf8");
+    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds, collect { logSource }", "utf8");
     expect(checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file })).toEqual([]);
   });
 


### PR DESCRIPTION
Follow-up fix surfaced while debugging why key-question collection directives didn't render on a live deployment.

**Root cause of the false pass:** the `#8` capability marker was the bare word `"collect"`, which appears as *prose* in every pre-`#8` prompt (`"collect email gateway logs"`). So a stale pre-`#8` `synthesis.txt` override that lacked the structured `collect { host, logSource, … }` directive silently **passed** the drift check — the operator got no warning, and the AI never emitted collection directives.

**Fix:** use `"logSource"` as the marker — a field name unique to the `#8` instruction. Adds a regression test reproducing the bare-word false-pass; the rot-guard confirms the current built-in still contains `logSource`.

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/analysis/promptCapabilities.test.ts` — 12 pass