### PR TITLE
Replace show-archived checkbox label with icon

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1447,8 +1447,9 @@
     <strong>DFIR Companion</strong>
     <input id="caseId" placeholder="caseId" list="caseList" autocomplete="off" />
     <datalist id="caseList"></datalist>
-    <label style="display:inline-flex;align-items:center;gap:4px;font-size:11px;color:var(--c-9aa4b2);cursor:pointer;white-space:nowrap" data-tip="Include archived cases in the case picker above (prefixed '[Archived]')">
-      <input type="checkbox" id="showArchivedToggle" style="margin:0;cursor:pointer" />Show archived
+    <label style="display:inline-flex;align-items:center;gap:2px;color:var(--c-9aa4b2);cursor:pointer;white-space:nowrap" data-tip="Include archived cases in the case picker above (prefixed '[Archived]')">
+      <input type="checkbox" id="showArchivedToggle" style="margin:0;cursor:pointer" />
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="5" rx="1"/><path d="M5 9v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9"/><path d="M10 13h4"/></svg>
     </label>
     <button id="connect" data-tip="Connect to (or create) the case named in the box, then load its dashboard">Connect</button>
     <button id="newCaseBtn" data-tip="Create a new case, then attach the capture extension to it">+ New case</button>


### PR DESCRIPTION
## Summary
- Swap the "Show archived" text label next to the case-picker checkbox for a compact archive-box icon, saving toolbar space. Tooltip is unchanged.

## Test plan
- [x] Verified in browser preview: checkbox renders with icon in place of text, no leftover label