### PR TITLE
Investigation guidance #10: source-yield instrumentation (flag zero-yield imports)

### DIFF
--- a/companion/src/analysis/importMeta.ts
+++ b/companion/src/analysis/importMeta.ts
@@ -42,6 +42,12 @@ export const importMetaSchema = z.object({
     added: z.array(diffIocSchema).catch([]),
     removed: z.array(diffIocSchema).catch([]),
   }).nullable().catch(null),
+  // Source-yield instrumentation (investigation-guidance #10): the RAW input size and which extraction
+  // path ran, so a big file that produced ZERO events via AI triage (northpeak's 27,290-line proxy log,
+  // silently read as "clean") can be flagged instead of shown as a bland "+0 events". Optional/lenient —
+  // older import-meta.json files load with linesIn 0 / path "" and simply never trip the check.
+  linesIn: z.number().catch(0),                                  // raw input lines/rows the import read
+  path: z.enum(["deterministic", "ai", ""]).catch(""),           // "ai" = the log/CSV AI-triage path; "" = unknown/legacy
 });
 
 export type ImportMeta = z.infer<typeof importMetaSchema>;
@@ -50,6 +56,7 @@ const EMPTY: ImportMeta = {
   lastImportedAt: "", lastImportKind: "", lastImportFile: "",
   addedCount: 0, removedCount: 0, lastDiff: null,
   iocsAddedCount: 0, iocsRemovedCount: 0, iocsDiff: null,
+  linesIn: 0, path: "",
 };
 
 // Cap how many added/removed events we store in the detail list — a single import can add
@@ -62,6 +69,8 @@ export interface ImportRecord {
   file: string;   // stored filename of the imported evidence
   diff: TimelineDiff;   // forensic-timeline diff
   iocsDiff: IocsDiff;   // IOC diff
+  linesIn?: number;                          // raw input lines/rows the import read (#10)
+  path?: "deterministic" | "ai";             // which extraction path ran (#10)
 }
 
 export class ImportMetaStore {
@@ -98,6 +107,8 @@ export class ImportMetaStore {
         added: rec.iocsDiff.added.slice(0, MAX_LISTED),
         removed: rec.iocsDiff.removed.slice(0, MAX_LISTED),
       },
+      linesIn: Math.max(0, Math.floor(rec.linesIn ?? 0)),
+      path: rec.path ?? "",
     };
     await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
     return meta;
@@ -111,4 +122,50 @@ export class ImportMetaStore {
     await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
     return meta;
   }
+}
+
+// Source-yield anomaly (investigation-guidance #10). Trigger (a): a large file run through the AI-triage
+// path (log/CSV) that produced ZERO graded events — the northpeak failure, where a 27,290-line proxy
+// log contributed nothing and read as "source clean". Deterministic + pure over the persisted meta.
+export interface ImportYieldWarning {
+  reason: "zero_yield_ai";
+  file: string;
+  kind: string;
+  linesIn: number;
+  message: string;            // directive next-action for the analyst
+  inferredPhases: string[];   // ATT&CK phases this source type would have evidenced (for the gap panel)
+}
+
+export const ZERO_YIELD_MIN_LINES_DEFAULT = 500;
+
+// The ATT&CK phases a dropped source type would most likely have evidenced — so a zero-yield proxy log
+// becomes "you may be missing Discovery / C2 / Exfiltration", not just "0 events". Best-effort by name.
+function inferPhasesFromSource(kind: string, file: string): string[] {
+  const t = `${kind} ${file}`.toLowerCase();
+  if (/proxy|squid|bluecoat|web[_-]?access|http/.test(t)) return ["Discovery", "Command and Control", "Exfiltration"];
+  if (/\bdns\b/.test(t)) return ["Command and Control", "Exfiltration"];
+  if (/firewall|fw|netflow|flow|zeek|bro|conn/.test(t)) return ["Command and Control", "Exfiltration"];
+  if (/vpn|auth|radius|okta|sso/.test(t)) return ["Initial Access", "Lateral Movement"];
+  if (/mail|smtp|exchange|o365|m365/.test(t)) return ["Initial Access"];
+  return [];
+}
+
+export function classifyImportYield(
+  meta: Pick<ImportMeta, "path" | "addedCount" | "linesIn" | "lastImportKind" | "lastImportFile">,
+  opts: { minLines?: number } = {},
+): ImportYieldWarning | null {
+  const minLines = opts.minLines ?? ZERO_YIELD_MIN_LINES_DEFAULT;
+  if (meta.path !== "ai") return null;                 // only the AI-triage path can silently drop everything
+  if ((meta.addedCount ?? 0) > 0) return null;         // it produced events → not a blind spot
+  const linesIn = meta.linesIn ?? 0;
+  if (linesIn < minLines) return null;                 // a genuinely tiny/empty file isn't a coverage gap
+  const label = meta.lastImportFile || meta.lastImportKind || "an imported file";
+  return {
+    reason: "zero_yield_ai",
+    file: meta.lastImportFile,
+    kind: meta.lastImportKind,
+    linesIn,
+    message: `${label}: ${linesIn.toLocaleString()} lines → 0 events via AI triage — re-run triage or grep the raw file for the case's IOCs/hosts before treating this source as clean`,
+    inferredPhases: inferPhasesFromSource(meta.lastImportKind, meta.lastImportFile),
+  };
 }

--- a/companion/src/analysis/knownUnknowns.ts
+++ b/companion/src/analysis/knownUnknowns.ts
@@ -22,6 +22,7 @@ import { rankHosts } from "./hostRanking.js";
 import { rankConnectiveIocs } from "./iocAnchors.js";
 import { buildEvidenceGraph } from "./evidenceGraph.js";
 import { byEventTime } from "./forensicSort.js";
+import type { ImportYieldWarning } from "./importMeta.js";
 
 // The kill-chain phases an intrusion usually touches. A case with real (Critical/High) findings that
 // has NO finding covering one of these is a conspicuous gap worth calling out ("how did they get
@@ -41,6 +42,7 @@ const CORE_TACTICS: readonly IrisTactic[] = [
 export interface KnownUnknownsOptions {
   gapOptions?: GapOptions;                      // forwarded to detectTimelineGaps
   nextTechniques?: readonly NextTechnique[];    // from adversaryEmulation — caller supplies (needs the offline dataset)
+  yieldWarning?: ImportYieldWarning | null;     // source-yield #10 trigger (a): a zero-yield AI import (caller loads importMeta)
   maxGaps?: number;                             // cap on coverage-gap lines (default 3)
   maxNextTechniques?: number;                   // cap on likely-next-technique lines (default 5)
   max?: number;                                 // hard cap on TOTAL bullets in the rendered block (default 10)
@@ -51,7 +53,7 @@ const DEFAULT_MAX_NEXT = 5;
 const DEFAULT_MAX_TOTAL = 10;
 const MAX_HOSTS_PER_TACTIC = 3;
 
-export type KnownUnknownKind = "uncovered_tactic" | "silence_gap" | "likely_next_technique";
+export type KnownUnknownKind = "uncovered_tactic" | "silence_gap" | "likely_next_technique" | "yield_gap";
 
 // One structured gap the case is missing. `collect` carries deterministic "where to look" directives
 // (only for uncovered_tactic — silence gaps link to the existing Timeline Gaps panel, and likely-next
@@ -171,8 +173,37 @@ function uncoveredTacticLabel(tactic: IrisTactic): string {
   return `No finding yet explains ${tactic}${where ? ` — collect ${where}` : ""}.`;
 }
 
+// Source-yield trigger (c) (investigation-guidance #10): the case carries network telemetry (Zeek /
+// proxy / firewall / netflow) but NO endpoint-detector feed (EDR / Sigma / AV / EVTX-rule engine), so
+// on-host execution/persistence is likely invisible. A soft LEAD, gated on a real finding so a quiet
+// case doesn't nag. Heuristic over event sources/artifact names; conservative (needs net present AND
+// detector fully absent). "" when it doesn't apply.
+const NETWORK_TELEMETRY_RE = /zeek|\bbro\b|conn\.log|proxy|squid|bluecoat|firewall|netflow|\bflow\b|\bpcap\b|http[_-]?access/i;
+const DETECTOR_RE = /sigma|\bedr\b|velociraptor|\bthor\b|crowdstrike|defender|carbonblack|sentinel|hayabusa|chainsaw|\byara\b|antivirus|\bav\b|snort|suricata|\bids\b|sysmon|evtx|security\.evtx|windows event/i;
+
+function sourceText(e: ForensicEvent): string {
+  return `${(e.sources ?? []).join(" ")} ${e.artifactName ?? ""} ${e.description ?? ""}`;
+}
+
+export function networkTelemetryWithoutDetector(state: InvestigationState): string | null {
+  const serious = state.findings.some((f) => f.severity === "Critical" || f.severity === "High");
+  if (!serious) return null;
+  let hasNet = false;
+  let hasDetector = false;
+  for (const e of state.forensicTimeline ?? []) {
+    const t = sourceText(e);
+    if (!hasNet && NETWORK_TELEMETRY_RE.test(t)) hasNet = true;
+    if (!hasDetector && DETECTOR_RE.test(t)) hasDetector = true;
+    if (hasNet && hasDetector) return null;
+  }
+  if (hasNet && !hasDetector) {
+    return "Network telemetry is present but NO endpoint-detector feed (EDR / Sigma / Sysmon / EVTX rules) — on-host execution and persistence may be invisible; collect endpoint detections on the active hosts to corroborate the network activity.";
+  }
+  return null;
+}
+
 // The STRUCTURED known-unknowns for a case: uncovered kill-chain phases (each with a collection
-// directive), silence gaps, and lookalike-actor likely-next techniques. Pure + offline.
+// directive), silence gaps, source-yield gaps, and lookalike-actor likely-next techniques. Pure + offline.
 export function buildKnownUnknownItems(
   state: InvestigationState,
   scopedEvents: ForensicEvent[],
@@ -207,7 +238,19 @@ export function buildKnownUnknownItems(
     });
   }
 
-  // 3. Likely-next techniques — what lookalike actors use that this case hasn't shown (predictive hunt
+  // 3. Source-yield gaps (investigation-guidance #10) — a source the case has but can't SEE.
+  //    (a) a large file that produced ZERO events via AI triage (caller supplies the classified
+  //    warning from importMeta — the northpeak proxy-log failure); (b) network telemetry present but no
+  //    endpoint-detector feed. Both are coverage blind spots: the collection ran, the signal didn't land.
+  if (opts.yieldWarning) {
+    const w = opts.yieldWarning;
+    const phases = w.inferredPhases.length ? ` This source would typically evidence ${w.inferredPhases.join(", ")}.` : "";
+    items.push({ kind: "yield_gap", label: `${w.message}.${phases}`, collect: [] });
+  }
+  const netGap = networkTelemetryWithoutDetector(state);
+  if (netGap) items.push({ kind: "yield_gap", label: netGap, collect: [] });
+
+  // 4. Likely-next techniques — what lookalike actors use that this case hasn't shown (predictive hunt
   //    priorities; statistical similarity, NOT attribution). Caller supplies them.
   const maxNext = Math.max(0, opts.maxNextTechniques ?? DEFAULT_MAX_NEXT);
   for (const nt of (opts.nextTechniques ?? []).slice(0, maxNext)) {
@@ -234,7 +277,7 @@ export function renderKnownUnknowns(items: readonly KnownUnknownItem[], max: num
   if (uncovered.length) bullets.push(`No finding yet explains these ATT&CK phases: ${uncovered.join(", ")}.`);
 
   for (const i of items) {
-    if (i.kind === "silence_gap" || i.kind === "likely_next_technique") bullets.push(i.label);
+    if (i.kind === "silence_gap" || i.kind === "likely_next_technique" || i.kind === "yield_gap") bullets.push(i.label);
   }
 
   if (!bullets.length) return "";

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -46,6 +46,7 @@ import {
 import { SHADOW_ARTIFACTS } from "./shadowArtifacts.js";
 import { diffFindings, type FindingsDiff } from "./findingsDiff.js";
 import { buildKnownUnknownItems, renderKnownUnknowns, type KnownUnknownItem } from "./knownUnknowns.js";
+import { classifyImportYield, type ImportMetaStore, type ImportYieldWarning } from "./importMeta.js";
 import { buildAdversaryHintsResult } from "./adversaryHints.js";
 import { loadAdversaryGroupsDataset, adversaryHintEnvOptions } from "./adversaryGroupsData.js";
 import type { SynthMetaStore } from "./synthMeta.js";
@@ -1298,6 +1299,9 @@ export interface PipelineOptions {
   // Per-case playbook store. When set, synthesis reads DONE/SKIPPED task status so it can build on
   // completed work instead of re-recommending it (investigation-guidance #2). Absent → no digest.
   playbookStore?: PlaybookStore;
+  // Per-case import-meta store. When set, synthesis + the evidence-gap panel flag a zero-yield AI
+  // import (a source read as "clean" that actually dropped everything — investigation-guidance #10).
+  importMetaStore?: ImportMetaStore;
 }
 
 // Whole-word (id-boundary) match of a finding id inside free text — used to catch a key question's
@@ -3664,21 +3668,34 @@ export class AnalysisPipeline {
   // The STRUCTURED known-unknowns for a case (investigation-guidance #9) — the SINGLE source the
   // synthesis prompt block AND the GET /cases/:id/known-unknowns panel both consume, so the model and
   // the analyst provably see the same gap list. Defensive: a failure here must never break synthesis.
-  private knownUnknownItems(state: InvestigationState, scopedEvents: ForensicEvent[]): KnownUnknownItem[] {
+  private knownUnknownItems(state: InvestigationState, scopedEvents: ForensicEvent[], yieldWarning?: ImportYieldWarning | null): KnownUnknownItem[] {
     try {
       const hints = buildAdversaryHintsResult(state, loadAdversaryGroupsDataset(), adversaryHintEnvOptions());
       return buildKnownUnknownItems(state, scopedEvents, {
         gapOptions: gapEnvOptions(),
         nextTechniques: hints.nextTechniques,
+        yieldWarning,
       });
     } catch {
       return [];
     }
   }
 
-  private knownUnknownsBlock(state: InvestigationState, scopedEvents: ForensicEvent[]): string {
+  // The classified source-yield warning for the LAST import (investigation-guidance #10) — a large file
+  // that yielded ZERO events via AI triage (the northpeak blind spot). Defensive: null when no store,
+  // no import-meta, or nothing anomalous.
+  private async loadYieldWarning(caseId: string): Promise<ImportYieldWarning | null> {
+    if (!this.opts.importMetaStore) return null;
+    try {
+      return classifyImportYield(await this.opts.importMetaStore.load(caseId));
+    } catch {
+      return null;
+    }
+  }
+
+  private async knownUnknownsBlock(state: InvestigationState, scopedEvents: ForensicEvent[], caseId: string): Promise<string> {
     const max = Math.max(0, Number(process.env.DFIR_SYNTH_KNOWN_UNKNOWNS_MAX) || 10);
-    return renderKnownUnknowns(this.knownUnknownItems(state, scopedEvents), max);
+    return renderKnownUnknowns(this.knownUnknownItems(state, scopedEvents, await this.loadYieldWarning(caseId)), max);
   }
 
   // Read-only: the structured evidence-gap items for a case (scope + false-positive filtered, exactly
@@ -3688,7 +3705,7 @@ export class AnalysisPipeline {
     const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
     const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
     const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-    return this.knownUnknownItems(loaded, scopedEvents);
+    return this.knownUnknownItems(loaded, scopedEvents, await this.loadYieldWarning(caseId));
   }
 
   // Candidate-threat-actor preamble (#165), OFF by default (DFIR_SYNTH_ADVERSARY_HINTS). Feeds the
@@ -3753,7 +3770,7 @@ export class AnalysisPipeline {
     const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
     // Known unknowns (#165): the gaps in the story (silent windows, uncovered ATT&CK phases, likely-
     // next techniques) so suggested hunts target what's MISSING, not just re-confirm what's known.
-    const knownUnknownsBlock = this.knownUnknownsBlock(loaded, scopedEvents);
+    const knownUnknownsBlock = await this.knownUnknownsBlock(loaded, scopedEvents, caseId);
 
     // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
     const overhead = estimateTokens(getHuntSuggestPrompt())
@@ -4301,7 +4318,7 @@ export class AnalysisPipeline {
     // next techniques) so the model builds on what's MISSING instead of glossing over it. Plus the
     // (env-gated, default OFF) candidate-actor block. Both DERIVED — computed AFTER the skip-hash
     // above, so they never affect skip-if-unchanged.
-    const knownUnknownsBlock = this.knownUnknownsBlock(state, scopedEvents);
+    const knownUnknownsBlock = await this.knownUnknownsBlock(state, scopedEvents, caseId);
     const adversaryBlock = this.adversaryHintBlock(state);
     // Structured causal evidence (investigation-guidance #5), all DERIVED after the skip-hash so they
     // never affect skip-if-unchanged: the deterministic ATTACK GRAPH (spawn/file-lineage/lateral/network

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -340,13 +340,18 @@ function timelineAnomalies(state: InvestigationState, lines: string[]): void {
 // panel. Only the uncovered-tactic items are rendered here (silent windows already have §3.3, and
 // lookalike-actor next techniques are §4.6.1); "" when the case has none.
 function evidenceGaps(state: InvestigationState, lines: string[]): void {
-  const items = buildKnownUnknownItems(state, state.forensicTimeline).filter((i) => i.kind === "uncovered_tactic");
-  if (!items.length) return;
-  lines.push("#### 4.6.2 Evidence gaps — uncovered kill-chain phases", "");
-  lines.push("_A real (Critical/High) finding exists but no finding explains these phases. Collect the named evidence to close each gap — a lead, not proof._", "");
-  for (const i of items) {
+  const all = buildKnownUnknownItems(state, state.forensicTimeline);
+  const uncovered = all.filter((i) => i.kind === "uncovered_tactic");
+  const yieldGaps = all.filter((i) => i.kind === "yield_gap");   // #10 source-yield blind spots
+  if (!uncovered.length && !yieldGaps.length) return;
+  lines.push("#### 4.6.2 Evidence gaps — what this case is missing", "");
+  lines.push("_Coverage gaps derived from the case (a lead, not proof). Collect the named evidence to close each._", "");
+  for (const i of uncovered) {
     lines.push(`- **${i.tactic}** — ${cellMd(i.label)}`);
     for (const c of i.collect) lines.push(`  - ${cellMd(collectSummary(c))}`);
+  }
+  for (const i of yieldGaps) {
+    lines.push(`- **Source blind spot** — ${cellMd(i.label)}`);
   }
   lines.push("");
 }

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -265,7 +265,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
               const tDiff = diffTimeline(stateBefore.forensicTimeline, s.forensicTimeline);
               const iDiff = diffIocs(stateBefore.iocs, s.iocs);
               if (options.importMetaStore) {
-                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff });
+                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff, linesIn: text.split(/\r?\n/).length, path: aiDependent ? "ai" : "deterministic" });
                 options.onImportMeta?.(caseId);
               }
               logActivity(options.activityLogStore, options.onActivity, caseId, {
@@ -438,7 +438,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
               const tDiff = diffTimeline(stateBefore.forensicTimeline, s.forensicTimeline);
               const iDiff = diffIocs(stateBefore.iocs, s.iocs);
               if (options.importMetaStore) {
-                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff });
+                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff, linesIn: text.split(/\r?\n/).length, path: aiDependent ? "ai" : "deterministic" });
                 options.onImportMeta?.(caseId);
               }
               if (tDiff.added.length || tDiff.removed.length || iDiff.added.length || iDiff.removed.length) {

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2722,6 +2722,7 @@ export function buildRuntimePipeline(params: RuntimePipelineParams): AnalysisPip
     notebookStore: new NotebookStore(params.store),
     hypothesisStore: new HypothesisStore(params.store),     // #140 auto-generate hypotheses on synthesis
     playbookStore: new PlaybookStore(params.store),         // #2 feed DONE/SKIPPED task status into synthesis
+    importMetaStore: new ImportMetaStore(params.store),      // #10 flag a zero-yield AI import as a coverage gap
     aiControlStore: new AiControlStore(params.store),
     huntOutcomeStore: new HuntOutcomeStore(params.store),   // #157 hunting feedback loop
     superTimelineStore: new SuperTimelineStore(params.store, Number(process.env.DFIR_SUPERTIMELINE_MAX) || undefined),  // explainEvent falls back here for raw super-only events

--- a/companion/tests/analysis/importMeta.test.ts
+++ b/companion/tests/analysis/importMeta.test.ts
@@ -35,6 +35,7 @@ describe("ImportMetaStore", () => {
       lastImportedAt: "", lastImportKind: "", lastImportFile: "",
       addedCount: 0, removedCount: 0, lastDiff: null,
       iocsAddedCount: 0, iocsRemovedCount: 0, iocsDiff: null,
+      linesIn: 0, path: "",
     });
   });
 
@@ -73,6 +74,7 @@ describe("ImportMetaStore", () => {
       lastImportedAt: "", lastImportKind: "", lastImportFile: "",
       addedCount: 0, removedCount: 0, lastDiff: null,
       iocsAddedCount: 0, iocsRemovedCount: 0, iocsDiff: null,
+      linesIn: 0, path: "",
     });
   });
 

--- a/companion/tests/analysis/sourceYield.test.ts
+++ b/companion/tests/analysis/sourceYield.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { classifyImportYield, ZERO_YIELD_MIN_LINES_DEFAULT, type ImportMeta } from "../../src/analysis/importMeta.js";
+import { buildKnownUnknownItems, networkTelemetryWithoutDetector } from "../../src/analysis/knownUnknowns.js";
+import { emptyState, type Finding, type ForensicEvent, type InvestigationState } from "../../src/analysis/stateTypes.js";
+
+function meta(p: Partial<ImportMeta>): ImportMeta {
+  return {
+    lastImportedAt: "2026-05-20T00:00:00Z", lastImportKind: p.lastImportKind ?? "log", lastImportFile: p.lastImportFile ?? "proxy_access.log",
+    addedCount: p.addedCount ?? 0, removedCount: 0, lastDiff: null,
+    iocsAddedCount: 0, iocsRemovedCount: 0, iocsDiff: null,
+    linesIn: p.linesIn ?? 0, path: p.path ?? "ai",
+  };
+}
+function finding(sev: Finding["severity"]): Finding {
+  return { id: "f1", severity: sev, title: "x", description: "", relatedIocs: [], sourceScreenshots: [], mitreTechniques: ["T1486"],
+    firstSeen: "", lastUpdated: "", status: "open" };
+}
+function ev(p: Partial<ForensicEvent>): ForensicEvent {
+  return { id: p.id ?? "e1", timestamp: "2026-05-20T09:00:00Z", description: p.description ?? "", severity: p.severity ?? "Info",
+    mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...p };
+}
+
+describe("classifyImportYield (trigger a — zero-yield AI import)", () => {
+  it("flags a large AI-triage import that produced zero events (the northpeak proxy-log case)", () => {
+    const w = classifyImportYield(meta({ lastImportFile: "proxy_access.log", linesIn: 27290, path: "ai", addedCount: 0 }));
+    expect(w).not.toBeNull();
+    expect(w!.reason).toBe("zero_yield_ai");
+    expect(w!.linesIn).toBe(27290);
+    expect(w!.message).toMatch(/27,290 lines → 0 events/);
+    expect(w!.inferredPhases).toContain("Command and Control"); // proxy → C2/Exfil/Discovery
+  });
+  it("does NOT flag a deterministic import (only the AI path can silently drop everything)", () => {
+    expect(classifyImportYield(meta({ path: "deterministic", linesIn: 99999, addedCount: 0 }))).toBeNull();
+  });
+  it("does NOT flag an AI import that produced events", () => {
+    expect(classifyImportYield(meta({ path: "ai", linesIn: 5000, addedCount: 12 }))).toBeNull();
+  });
+  it("does NOT flag a tiny AI import below the line threshold", () => {
+    expect(classifyImportYield(meta({ path: "ai", linesIn: ZERO_YIELD_MIN_LINES_DEFAULT - 1, addedCount: 0 }))).toBeNull();
+  });
+});
+
+describe("networkTelemetryWithoutDetector (trigger c)", () => {
+  const serious = (): InvestigationState => { const s = emptyState("c"); s.findings = [finding("Critical")]; return s; };
+  it("flags network telemetry with no endpoint detector", () => {
+    const s = serious();
+    s.forensicTimeline = [ev({ id: "e1", sources: ["Zeek"], description: "conn.log flow" })];
+    expect(networkTelemetryWithoutDetector(s)).toMatch(/NO endpoint-detector feed/);
+  });
+  it("returns null when a detector feed IS present", () => {
+    const s = serious();
+    s.forensicTimeline = [ev({ id: "e1", sources: ["Zeek"] }), ev({ id: "e2", sources: ["Sysmon"] })];
+    expect(networkTelemetryWithoutDetector(s)).toBeNull();
+  });
+  it("returns null for a non-serious case (no Critical/High finding)", () => {
+    const s = emptyState("c"); s.forensicTimeline = [ev({ id: "e1", sources: ["proxy"] })];
+    expect(networkTelemetryWithoutDetector(s)).toBeNull();
+  });
+});
+
+describe("buildKnownUnknownItems — yield_gap items (#10)", () => {
+  it("emits a yield_gap from a supplied zero-yield warning", () => {
+    const warning = classifyImportYield(meta({ lastImportFile: "proxy.log", linesIn: 10000, path: "ai", addedCount: 0 }))!;
+    const items = buildKnownUnknownItems(emptyState("c"), [], { yieldWarning: warning });
+    const yg = items.filter((i) => i.kind === "yield_gap");
+    expect(yg.length).toBe(1);
+    expect(yg[0].label).toMatch(/0 events via AI triage/);
+    expect(yg[0].collect).toEqual([]);
+  });
+  it("emits a yield_gap for network-telemetry-without-detector", () => {
+    const s = emptyState("c"); s.findings = [finding("High")];
+    s.forensicTimeline = [ev({ id: "e1", sources: ["proxy"], description: "web access" })];
+    const items = buildKnownUnknownItems(s, s.forensicTimeline);
+    expect(items.some((i) => i.kind === "yield_gap")).toBe(true);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3562,6 +3562,7 @@
       #sec-evidence-gaps .eg-item{background:var(--c-161b22);border:1px solid var(--c-232a33);border-left:3px solid var(--c-b5651d);border-radius:6px;padding:8px 10px}
       #sec-evidence-gaps .eg-item.eg-gap{border-left-color:var(--c-ffb454)}
       #sec-evidence-gaps .eg-item.eg-next{border-left-color:var(--c-6aa9ff)}
+      #sec-evidence-gaps .eg-item.eg-yield{border-left-color:var(--c-ff6b6b,#ff6b6b)}
       #sec-evidence-gaps .eg-kind{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--c-9aa4b2);margin-right:6px}
       #sec-evidence-gaps .eg-label{color:var(--c-d6deea)}
       #sec-evidence-gaps .eg-collect{display:flex;align-items:center;flex-wrap:wrap;gap:8px;margin-top:6px;font-size:12px}
@@ -8558,7 +8559,15 @@
         const more = remaining > 0 ? `<span class="sm-item" style="color:var(--c-9aa4b2)">…and ${remaining} more</span>` : "";
         detail = `<details><summary>what this import added to the timeline</summary>${items}${more}</details>`;
       }
-      el.innerHTML = `<div class="sm-line"><span>📥 Last import <strong>${esc(relTime(m.lastImportedAt))}</strong>${src}${kind}</span><span>${summary}</span></div>${detail}`;
+      // Source-yield warning (investigation-guidance #10): a large file run through the AI-triage path
+      // that produced ZERO events is a blind spot, not a clean source — say so with a directive action,
+      // instead of a bland "no new events". Mirrors the server classifyImportYield (path ai / +0 / >=500).
+      let yieldWarn = "";
+      if (m.path === "ai" && (m.addedCount || 0) === 0 && (m.linesIn || 0) >= 500) {
+        const label = m.lastImportFile || m.lastImportKind || "this file";
+        yieldWarn = `<div class="sm-line" style="color:var(--c-ff6b6b,#ff6b6b);font-weight:600">⚠️ ${esc(label)}: ${(m.linesIn).toLocaleString()} lines → 0 events via AI triage — re-run triage or grep the raw file for the case's IOCs/hosts before treating this source as clean.</div>`;
+      }
+      el.innerHTML = `<div class="sm-line"><span>📥 Last import <strong>${esc(relTime(m.lastImportedAt))}</strong>${src}${kind}</span><span>${summary}</span></div>${yieldWarn}${detail}`;
     }
     function paintIocImportMeta(m) {
       const el = document.getElementById("iocImportMeta");
@@ -10098,6 +10107,11 @@
         }
         if (it.kind === "likely_next_technique") {
           return `<div class="eg-item eg-next"><span class="eg-kind">likely next</span><span class="eg-label">${esc(it.label)}</span></div>`;
+        }
+        if (it.kind === "yield_gap") {
+          // Source-yield gap (investigation-guidance #10): a source that was collected but yielded nothing,
+          // or a telemetry type with no detector to corroborate it — a blind spot, not a clean source.
+          return `<div class="eg-item eg-yield"><span class="eg-kind">blind spot</span><span class="eg-label">${esc(it.label)}</span></div>`;
         }
         const collects = (it.collect || []).map(collectBtn).join("");
         return `<div class="eg-item"><span class="eg-kind">uncovered phase</span><span class="eg-label">${esc(it.label)}</span>${collects}</div>`;


### PR DESCRIPTION
Implements Tier 2 **#10 — surface zero-yield imports as coverage gaps**. northpeak's *defining* failure: a 27,290-line proxy log run through AI triage yielded **zero** events and was shown as a bland "+0 events", silently deleting the recon/exfil front half of the incident. `gapDetect` reasons only about *time* gaps — the tool couldn't see its own blind spots.

Builds on merged #1–#9. Full suite green: **3038 analysis + server + reports tests, clean `tsc`.**

## What's here
- **`importMeta.ts`**: record per-import `linesIn` + `path` (`deterministic`|`ai`); `classifyImportYield()` — **trigger (a)**: a large file on the AI-triage path that produced 0 events → a directive warning ("re-run triage or grep the raw file for the case's IOCs/hosts") plus the ATT&CK phases that source type would have evidenced.
- **`routes/import.ts`**: populate `linesIn` (raw line count) + `path` (from the existing `aiDependent` flag) at both record sites.
- **`knownUnknowns.ts`**: new `yield_gap` item kind. Trigger (a) via `opts.yieldWarning`; **trigger (c)** `networkTelemetryWithoutDetector()` — network telemetry present but no EDR/Sigma/Sysmon feed (pure over state, gated on a serious finding). Both flow into the synthesis prompt **and** the #9 Evidence Gaps panel.
- **`pipeline.ts`**: `importMetaStore` opt + `loadYieldWarning()`; wired in `buildRuntimePipeline`.
- **dashboard**: the import banner shows a red zero-yield warning (mirrors the server classifier); the Evidence Gaps panel renders `yield_gap` as a "blind spot" row.
- **report §4.6.2** renders source blind spots.

## Surfaces (the fix for "no surface told the investigator")
1. Immediate — import banner warning at import time.
2. Synthesis — the model is told the source is a blind spot (via known-unknowns) and directs re-collection.
3. Panel + report — the gap is visible and status-trackable.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/analysis tests/server tests/reports` — 3038 pass (9 new)
- [ ] Live drive of the banner (needs a real AI provider + a large log that yields nothing; logic is unit-tested and the banner mirrors the tested server classifier)

## Deferred (documented)
- **Trigger (b) cap-hit truncation** (llm-injection's 2,000-row aggregation cap) — needs importer surgery to thread the truncation flag up from `logAggregate`. Follow-up.

## Roadmap
Closes **#10**. Remaining: **#11** second-look loop, then Tier 3 (#12–#15).