### PR TITLE
feat: second-look loop — bounded raw re-query + one re-synthesis (#11)

### DIFF
--- a/INVESTIGATION_GUIDANCE_ROADMAP.md
+++ b/INVESTIGATION_GUIDANCE_ROADMAP.md
@@ -1,15 +1,16 @@
 # Making DFIR-Companion Lead the Investigation
 
-> **Implementation status (Tier 0 + Tier 1 shipped on this branch).** Proposals #1–#7 are
-> implemented, unit-tested, and committed here (one commit each). Full suite green: 2294 analysis +
-> 695 reports/server tests, clean `tsc`. Deferred within those items (documented in each commit):
-> the `~` context-prefix prompt notation and per-class counts into synthMeta (#4); the anchor-scoring
-> bump retune and the auto-generated "corroborate `<ioc>`" nextStep (#7, needs #8's structured collect
-> targets). **One operational step remains for #1:** the live `companion/prompts/*.txt` override files
-> are gitignored deployment artifacts — regenerate them with `npm run prompts:eject` so the deployment
-> picks up the built-in prompt (hypotheses / confidenceReason / the new structured-tag & attack-graph
-> instructions). Until then the new drift-detection check will warn on every preflight and synthesis
-> run. Tiers 2–3 (#8–#15) remain as specified below.
+> **Implementation status (Tier 0 + Tier 1 + all of Tier 2 shipped and merged to master).** Proposals
+> #1–#11 are implemented, unit-tested, and merged (PRs #96–#99, #102, #103 for #1–#10; #11 = the
+> second-look loop). Full suite green (3596 tests), clean `tsc`. Deferred within those items (documented
+> in each commit): the `~` context-prefix prompt notation and per-class counts into synthMeta (#4); the
+> anchor-scoring bump retune and the auto-generated "corroborate `<ioc>`" nextStep (#7); #10 trigger (b)
+> cap-hit truncation; #11 report-side surfacing of collection leads (kept on the live dashboard only).
+> **One operational step remains for #1:** the live `companion/prompts/*.txt` override files are
+> gitignored deployment artifacts — regenerate them with `npm run prompts:eject` so the deployment picks
+> up the built-in prompt (hypotheses / confidenceReason / structured-tag & attack-graph / #8 collect /
+> #11 evidenceRequests instructions). Until then the drift-detection check warns on every preflight and
+> synthesis run. **Tier 3 (#12–#15) remains** as specified below.
 
 **Goal.** Make the Companion genuinely lead an investigation — better decisions, higher recall of
 what actually happened, better dot-connecting, a working FP / rabbit-hole / real-lead triage, the

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -66,7 +66,7 @@ import {
 } from "./secondOpinion.js";
 import { correlateEvents } from "./correlate.js";
 import { detectTool } from "./toolDetect.js";
-import { filterEventsByScope, hasScope, NO_SCOPE, type ScopeStore } from "./scope.js";
+import { filterEventsByScope, hasScope, NO_SCOPE, type ScopeStore, type ScopeWindow } from "./scope.js";
 import { parseCsv, chunkToCsvText } from "./csvImport.js";
 import { parseLogLines } from "./logImport.js";
 import { aggregateLogLines } from "./logAggregate.js";
@@ -166,7 +166,11 @@ import { detectBeacons, beaconEnvOptions } from "./beaconDetect.js";
 import { buildAttackPhases } from "./burstDetect.js";
 import { buildEvidenceGraph } from "./evidenceGraph.js";
 import { buildAssetGraph } from "./assetGraph.js";
-import { shortHost } from "./iocAnchors.js";
+import { shortHost, rankConnectiveIocs } from "./iocAnchors.js";
+import {
+  buildSecondLookRequests, resolveSecondLookRequests, buildSecondLookPlan, summarizeSecondLook,
+  deriveWindow, type ModelEvidenceRequest,
+} from "./secondLook.js";
 import { groundAndScoreFindings, capIntelOnlyFindings, corroborationLabel } from "./findingGrounding.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
@@ -609,6 +613,13 @@ export const SYNTHESIS_PROMPT = [
   "  'refuted' if it contradicts it, else 'open'), 'relatedTechniques' (ATT&CK ids), and the supporting",
   "  'relatedEventIds' / 'relatedIocIds'. Propose hypotheses even for gaps the evidence does NOT yet",
   "  resolve (status 'open') — those drive the next collection. Use the event/ioc ids shown below.",
+  "- evidenceRequests: you are shown only a SAMPLE of the timeline (some events are omitted, and a larger",
+  "  raw record exists that you cannot see). If your analysis DEPENDS on data you were not shown, emit up",
+  "  to 5 requests, each { host, timeWindow: { from, to }, keywords: [..], reason }. Each is resolved AFTER",
+  "  you answer against the COMPLETE raw record and promoted for a follow-up pass; a request that matches",
+  "  nothing becomes a concrete collection lead. Use SPECIFIC keywords (a host, process, filename, domain,",
+  "  IP, or command — e.g. 'rsync', 'nfs-01', '.zip', the C2 domain), not generic words. Omit when the",
+  "  shown timeline already suffices. This is how you pull in evidence to resolve an 'open' hypothesis.",
   "",
   "Return ONLY raw JSON (no markdown fences). Set forensicEvents to [] and timelineNote to \"\".",
   "Every finding/ioc/technique/thread/question MUST be an object, never a bare string.",
@@ -639,6 +650,9 @@ export const SYNTHESIS_PROMPT = [
       hypotheses: [
         { title: "Initial access was spear-phishing", expectedOutcome: "an .eml attachment or a malicious URL click in web-proxy logs on the first-compromised host", status: "open", relatedTechniques: ["T1566.001"], relatedEventIds: ["e3"], relatedIocIds: ["i1"] },
         { title: "Data was staged before exfiltration", expectedOutcome: "an archive (.zip/.7z/.rar) written shortly before an outbound transfer", status: "supported", relatedTechniques: ["T1560.001"], relatedEventIds: ["e7"], relatedIocIds: [] },
+      ],
+      evidenceRequests: [
+        { host: "FS01", timeWindow: { from: "2025-04-27T00:00Z", to: "2025-04-28T00:00Z" }, keywords: ["rsync", "nfs-01", ".zip"], reason: "confirm the staging→exfil hypothesis with archive-write + outbound-transfer rows not shown above" },
       ],
       forensicEvents: [],
       timelineNote: "",
@@ -1982,17 +1996,31 @@ export class AnalysisPipeline {
   async promoteSuperTimeline(
     caseId: string,
     events: ForensicEvent[],
-    opts: { importedAt: string },
+    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
   ): Promise<InvestigationState> {
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
       if (!events.length) return state;
       const delta = deltaSchema.parse({
         findings: [], iocs: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [],
-        timelineNote: `Promoted ${events.length} event(s) from the super-timeline`, summary: "",
+        timelineNote: opts.note ?? `Promoted ${events.length} event(s) from the super-timeline`, summary: "",
         forensicEvents: events.map((e) => ({ ...e })),
       });
       state = mergeDelta(state, delta, { windowSequence: -1, timestamp: opts.importedAt, sourceScreenshots: [] });
+      // Stamp provenance markers on the promoted rows (second-look #11) — mergeDelta carries no
+      // provenance through the delta schema, so apply them here by id (union with any existing). Lets the
+      // forensic timeline show WHY a raw row was pulled up ("[second-look: h2]").
+      if (opts.tagById) {
+        const tagged = new Set(Object.keys(opts.tagById));
+        state = {
+          ...state,
+          forensicTimeline: state.forensicTimeline.map((e) =>
+            tagged.has(e.id)
+              ? { ...e, provenance: [...new Set([...(e.provenance ?? []), ...opts.tagById![e.id]])] }
+              : e,
+          ),
+        };
+      }
       await this.opts.stateStore.save(state);
       this.opts.onState?.(state);
       return state;
@@ -4179,7 +4207,7 @@ export class AnalysisPipeline {
   // (no save, no synth-meta, no notifications, no accepted-delta re-apply) — used by the second
   // opinion (issue #116) to compute model B's analysis non-destructively. `provider` overrides the
   // synthesis model for that run (model B). Both default off → normal, primary, persisted synthesis.
-  async synthesize(caseId: string, opts: { force?: boolean; dryRun?: boolean; provider?: AIProvider; signal?: AbortSignal } & SynthThinkingInput = {}): Promise<InvestigationState> {
+  async synthesize(caseId: string, opts: { force?: boolean; dryRun?: boolean; provider?: AIProvider; signal?: AbortSignal; skipSecondLook?: boolean } & SynthThinkingInput = {}): Promise<InvestigationState> {
     const synthProvider = opts.provider ?? this.opts.synthesisProvider ?? this.requireProvider("synthesis");
     this.warnOnPromptDrift();   // once per process: a stale synthesis-prompt override silently drops shipped capabilities
     const loaded = await this.opts.stateStore.load(caseId);
@@ -4649,7 +4677,110 @@ export class AnalysisPipeline {
     // fails synthesis. Only on a real run, so a skipped (unchanged) re-synthesis sends nothing.
     this.opts.onSynth?.(caseId, findingsDiff, next);
     this.opts.onState?.(next);
+
+    // Second-look loop (investigation-guidance #11): now that this run has conclusions + (open)
+    // hypotheses + key questions, re-query the COMPLETE raw record (the super-timeline + the scoped
+    // events the sampler omitted) for the terms those open questions imply, promote the matches, and
+    // trigger EXACTLY ONE bounded re-synthesis so the conclusions fold them in. `skipSecondLook` on that
+    // re-synthesis (and on the second-opinion dryRun path, already returned above) is the one-iteration
+    // guard that makes this terminate. Best-effort: a sweep failure must never fail the synthesis.
+    if (!opts.skipSecondLook && this.opts.superTimelineStore) {
+      try {
+        const outcome = await this.runSecondLook(caseId, {
+          next, scopedEvents, promptEvents, scope, evidenceRequests: delta.evidenceRequests,
+        });
+        if (outcome) {
+          if (outcome.meta.promoted > 0) {
+            // Promotion changed the in-scope timeline → the synthHash differs → this re-synthesis runs
+            // (not skipped) and, with skipSecondLook, does NOT sweep again. Bounded to one extra AI call.
+            const resynth = await this.synthesize(caseId, {
+              force: true, skipSecondLook: true, ...(opts.signal ? { signal: opts.signal } : {}),
+            });
+            await this.opts.synthMetaStore?.recordSecondLook(caseId, outcome.meta);
+            return resynth;
+          }
+          // Nothing new to promote, but empty requests are still surfaced as collection leads.
+          await this.opts.synthMetaStore?.recordSecondLook(caseId, outcome.meta);
+        }
+      } catch (err) {
+        console.warn(`[DFIR] second-look sweep failed for case ${caseId}: ${(err as Error).message}`);
+      }
+    }
     return next;
+  }
+
+  // Second-look sweep (investigation-guidance #11) — the impure orchestration around the pure secondLook
+  // module. Mines the case's OPEN questions (open hypotheses, unknown/partial key questions with a
+  // collect target, top connective IOCs) plus the model's own evidenceRequests into concrete searches,
+  // resolves them against the omitted scoped events AND the super-timeline within the active window,
+  // promotes the not-yet-analyzed matches (capped, tagged with provenance), and returns a meta summary.
+  // Returns null when there was nothing to search for. Never re-synthesizes itself — the caller does.
+  private async runSecondLook(
+    caseId: string,
+    ctx: {
+      next: InvestigationState;
+      scopedEvents: ForensicEvent[];
+      promptEvents: ForensicEvent[];
+      scope: ScopeWindow;
+      evidenceRequests?: ModelEvidenceRequest[];
+    },
+  ): Promise<{ meta: import("./synthMeta.js").SecondLookMeta } | null> {
+    const superStore = this.opts.superTimelineStore;
+    if (!superStore) return null;
+
+    // Active window: the explicit scope when set, else the span of the dated in-scope events. Bounds the
+    // raw re-query so a huge super-timeline is searched only over the incident window.
+    const window = hasScope(ctx.scope)
+      ? { from: ctx.scope.start ?? undefined, to: ctx.scope.end ?? undefined }
+      : deriveWindow(ctx.scopedEvents);
+
+    const hypotheses = this.opts.hypothesisStore ? await this.opts.hypothesisStore.load(caseId) : [];
+    const iocValueById = new Map(ctx.next.iocs.map((i) => [i.id, i.value] as const));
+    const connectiveIocs = rankConnectiveIocs(ctx.next, ctx.scopedEvents, { max: 5 });
+
+    const requests = buildSecondLookRequests({
+      hypotheses,
+      iocValueById,
+      keyQuestions: ctx.next.keyQuestions,
+      connectiveIocs,
+      modelRequests: ctx.evidenceRequests,
+      window,
+    });
+    if (!requests.length) return null;
+
+    // Candidate pool: the scoped events the sampler OMITTED from the prompt + the super-timeline rows in
+    // the window (deduped by id). A super row that is a copy of a forensic event shares its id, so
+    // `forensicEventIds` (below) correctly marks it non-promotable — only genuinely-new raw rows promote.
+    const shownIds = new Set(ctx.promptEvents.map((e) => e.id));
+    const omitted = ctx.scopedEvents.filter((e) => !shownIds.has(e.id));
+    const superRows = (await superStore.query(caseId, { from: window.from, to: window.to })).events;
+    const byId = new Map<string, ForensicEvent>();
+    for (const e of [...omitted, ...superRows]) if (!byId.has(e.id)) byId.set(e.id, e);
+    const candidates = [...byId.values()];
+
+    const forensicEventIds = new Set(ctx.next.forensicTimeline.map((e) => e.id));
+    const resolutions = resolveSecondLookRequests(requests, candidates, forensicEventIds);
+    const plan = buildSecondLookPlan(resolutions);
+
+    if (plan.promotions.length) {
+      await this.promoteSuperTimeline(caseId, plan.promotions, {
+        importedAt: new Date().toISOString(),
+        tagById: plan.tagById,
+        note: `Second look: promoted ${plan.promotions.length} raw event(s) matching open questions`,
+      });
+    }
+
+    const matched = resolutions.filter((r) => r.matchedEventIds.length > 0).length;
+    return {
+      meta: {
+        promoted: plan.promotions.length,
+        requests: requests.length,
+        matched,
+        leads: plan.leads.map((l) => l.reason).slice(0, 10),
+        summary: summarizeSecondLook(plan),
+        at: new Date().toISOString(),
+      },
+    };
   }
 
   // Second LLM opinion (issue #116). On-demand QA cross-check: a DIFFERENT model independently

--- a/companion/src/analysis/promptCapabilities.ts
+++ b/companion/src/analysis/promptCapabilities.ts
@@ -38,7 +38,8 @@ export const PROMPT_CAPABILITIES: readonly PromptCapability[] = [
     //   name unique to the #8 `collect` instruction), NOT the bare word "collect" — that appears as
     //   prose in every older prompt ("collect email gateway logs"), so it silently PASSED a stale
     //   pre-#8 override that lacked the structured directive.
-    markers: ["hypotheses", "confidenceReason", "relatedFindingIds", "logSource"],
+    // evidenceRequests→ guidance #11 second-look loop (delta.evidenceRequests drives the raw re-query).
+    markers: ["hypotheses", "confidenceReason", "relatedFindingIds", "logSource", "evidenceRequests"],
   },
 ];
 

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -116,6 +116,20 @@ export const deltaSchema = z.object({
     relatedEventIds: z.array(z.string()).default([]).catch([]),
     relatedIocIds: z.array(z.string()).default([]).catch([]),
   })).optional(),
+  // Second-look loop (investigation-guidance #11): data the model knows it was NOT shown (only a
+  // sample of the timeline is included in the prompt). Each request is resolved AFTER synthesis against
+  // the complete raw record (super-timeline + omitted scoped events); matches are promoted for one
+  // bounded re-synthesis, and a request that matches nothing becomes a collection lead. Lenient/optional
+  // so a model that omits it (or fills it partially) still parses. Consumed in pipeline.ts, not merged.
+  evidenceRequests: z.array(z.object({
+    host: z.string().optional().catch(undefined),
+    timeWindow: z.object({
+      from: z.string().optional().catch(undefined),
+      to: z.string().optional().catch(undefined),
+    }).optional().catch(undefined),
+    keywords: z.array(z.string()).default([]).catch([]),
+    reason: z.string().default("").catch(""),
+  })).optional(),
 });
 
 export type AnalysisDelta = z.infer<typeof deltaSchema>;

--- a/companion/src/analysis/secondLook.ts
+++ b/companion/src/analysis/secondLook.ts
@@ -1,0 +1,378 @@
+// Second-look loop (investigation-guidance #11). The complete raw record (the super-timeline + the
+// scoped events the synthesis sampler omitted) is unreachable by the AI no matter what hypotheses it
+// forms — northpeak's recon/clone/exfil story sat in raw rows synthesis never saw. This module is the
+// PURE core of a post-synthesis executor that turns the case's OPEN questions into concrete search
+// requests, resolves them against that raw record, and decides what to promote for one bounded
+// re-synthesis. All I/O (querying the super-timeline, promoting, re-synthesizing) lives in pipeline.ts.
+//
+// Two request sources feed it: (a) DETERMINISTIC harvest — search terms mined from the open
+// hypotheses (their IOC values + signal tokens in title/expectedOutcome), the unknown/partial key
+// questions' structured collect targets, and the top connective IOCs; (b) MODEL-ISSUED — an optional
+// evidenceRequests array the synthesis prompt lets the model fill with data it knows it wasn't shown.
+//
+// The bounds are strict and everything is deterministic + idempotent: a request that matches nothing is
+// itself surfaced as a collection lead (a blind spot the tool can task around), matches are capped per
+// term and per sweep, and only events NOT already in the analyzed timeline are promotable (re-promoting
+// an event already present is a no-op that must never inflate the count).
+
+import type { ForensicEvent, InvestigationQuestion } from "./stateTypes.js";
+import type { Hypothesis } from "./hypothesis.js";
+import type { IocAnchor } from "./iocAnchors.js";
+import { shortHost } from "./iocAnchors.js";
+
+// A single concrete search issued by the second-look sweep. `keywords` are matched case-insensitively
+// (ANY keyword hits) across the event's searchable fields, optionally restricted to `host` and the
+// [from,to] window. `tag` is the provenance stamp written onto every event this request promotes so the
+// forensic timeline shows WHY the row was pulled up; `reason` becomes a collection lead when nothing
+// matched anywhere.
+export interface SecondLookRequest {
+  source: "hypothesis" | "question" | "connective-ioc" | "model";
+  tag: string;         // e.g. "[second-look: h2]"
+  label: string;       // human summary of what this request looked for
+  keywords: string[];  // lowercased, deduped, non-empty
+  host?: string;       // optional host restriction (matched against shortHost of event.asset)
+  from?: string;       // ISO lower bound (inclusive); undated events are kept
+  to?: string;         // ISO upper bound (inclusive)
+  reason: string;      // surfaced as a collection lead when matchedEventIds is empty
+}
+
+// One model-issued evidence request as parsed from the synthesis delta (all fields best-effort).
+export interface ModelEvidenceRequest {
+  host?: string;
+  timeWindow?: { from?: string; to?: string };
+  keywords?: string[];
+  reason?: string;
+}
+
+export interface SecondLookResolution {
+  request: SecondLookRequest;
+  matchedEventIds: string[];    // every matched candidate id (incl. events already in the timeline)
+  promotable: ForensicEvent[];  // matched events NOT already in the analyzed timeline (the real gain)
+}
+
+export interface SecondLookPlan {
+  promotions: ForensicEvent[];         // deduped across requests + capped to the sweep budget
+  tagById: Record<string, string[]>;   // event id → provenance tags to stamp on promotion
+  resolutions: SecondLookResolution[];
+  leads: SecondLookRequest[];          // requests that matched nothing anywhere — collection leads
+  truncated: boolean;                  // true when the sweep cap dropped some promotable events
+}
+
+export interface SecondLookCaps {
+  perTerm?: number;               // max events promoted from a single request (default 50)
+  sweep?: number;                 // max events promoted across the whole sweep (default 200)
+  maxHypotheses?: number;         // open hypotheses turned into requests (default 6)
+  maxQuestions?: number;          // unknown/partial collect-bearing questions → requests (default 6)
+  maxConnectiveIocs?: number;     // top connective IOCs → requests (default 5)
+  maxModel?: number;              // model evidenceRequests honored (default 5)
+  maxKeywordsPerRequest?: number; // keyword count cap per request (default 8)
+}
+
+export const SECOND_LOOK_PER_TERM_DEFAULT = 50;
+export const SECOND_LOOK_SWEEP_DEFAULT = 200;
+const MAX_HYPOTHESES_DEFAULT = 6;
+const MAX_QUESTIONS_DEFAULT = 6;
+const MAX_CONNECTIVE_IOCS_DEFAULT = 5;
+const MAX_MODEL_DEFAULT = 5;
+const MAX_KEYWORDS_DEFAULT = 8;
+
+// Common prose words that appear in an expectedOutcome ("an archive written shortly before an outbound
+// transfer") but carry no search signal. Kept deliberately small — only words that would otherwise
+// match half the timeline. Case-folded before lookup.
+const STOPWORDS = new Set([
+  "the", "and", "for", "with", "that", "this", "from", "into", "onto", "was", "were", "would", "could",
+  "should", "have", "has", "had", "been", "being", "will", "shall", "may", "might", "before", "after",
+  "shortly", "then", "than", "also", "when", "where", "which", "what", "whom", "whose", "there", "here",
+  "outbound", "inbound", "transfer", "activity", "evidence", "shows", "show", "showing", "confirm",
+  "confirms", "confirmed", "prove", "proves", "disprove", "indicat", "indicate", "indicates", "logs",
+  "log", "event", "events", "host", "hosts", "user", "users", "account", "accounts", "file", "files",
+  "malicious", "attacker", "collect", "collected", "check", "checks", "look", "looking", "written",
+  "write", "writes", "access", "click", "clicked", "session", "process", "processes", "command",
+  "commands", "network", "connection", "connections", "around", "first", "last", "same", "other",
+  "still", "unknown", "gateway", "proxy", "server", "servers", "client", "clients", "system", "systems",
+]);
+
+// Extract SPECIFIC identifier-like tokens from prose: hostnames, filenames, paths, IPs, domains,
+// process/command names — the things worth searching the raw record for. A token qualifies when it
+// carries structure (a dot/slash/backslash/colon or a digit — i.e. it looks like a name/path/address)
+// OR it is a reasonably long word that is not a generic stopword. Lowercased + deduped, bounded.
+export function extractSignalTokens(text: string | undefined, max = MAX_KEYWORDS_DEFAULT): string[] {
+  const raw = String(text ?? "");
+  const out: string[] = [];
+  const seen = new Set<string>();
+  // Optional leading dot so a bare file extension (".zip", ".7z") survives as a searchable token.
+  const matches = raw.match(/\.?[A-Za-z0-9][A-Za-z0-9._\-\\/:]{2,}/g) ?? [];
+  for (const m of matches) {
+    const tok = m.toLowerCase().replace(/[.,:;]+$/, ""); // strip trailing sentence punctuation
+    if (tok.length < 3) continue;
+    const structured = /[./\\:]/.test(tok) || /\d/.test(tok);
+    if (!structured) {
+      if (tok.length < 5) continue;          // short bare words are too noisy
+      if (STOPWORDS.has(tok)) continue;
+    }
+    if (seen.has(tok)) continue;
+    seen.add(tok);
+    out.push(tok);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+function cleanKeywords(values: readonly (string | undefined)[], max: number): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const v of values) {
+    const tok = String(v ?? "").trim().toLowerCase();
+    if (!tok || seen.has(tok)) continue;
+    seen.add(tok);
+    out.push(tok);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+// Signature that makes two requests with the same effective search identical, so we don't sweep the
+// same terms twice from different sources (a hypothesis and a question can both point at "nfs-01").
+function requestSignature(r: SecondLookRequest): string {
+  return `${(r.host ?? "").toLowerCase()}|${r.from ?? ""}|${r.to ?? ""}|${[...r.keywords].sort().join(",")}`;
+}
+
+export interface BuildRequestsInput {
+  hypotheses?: readonly Hypothesis[];
+  iocValueById?: ReadonlyMap<string, string>;   // ioc id → value, to resolve a hypothesis's relatedIocIds
+  keyQuestions?: readonly InvestigationQuestion[];
+  connectiveIocs?: readonly IocAnchor[];
+  modelRequests?: readonly ModelEvidenceRequest[];
+  window?: { from?: string; to?: string };      // the case's active window (scope or derived)
+  caps?: SecondLookCaps;
+}
+
+// Assemble the deterministic + model-issued search requests. Deterministic sources are mined from the
+// OPEN questions of the investigation; each request is scoped to the active window unless a model
+// request overrides it. Deduped by effective signature; requests with no keywords are dropped.
+export function buildSecondLookRequests(input: BuildRequestsInput): SecondLookRequest[] {
+  const caps = input.caps ?? {};
+  const maxKw = caps.maxKeywordsPerRequest ?? MAX_KEYWORDS_DEFAULT;
+  const win = input.window ?? {};
+  const out: SecondLookRequest[] = [];
+  const seen = new Set<string>();
+
+  const push = (r: SecondLookRequest): void => {
+    if (!r.keywords.length) return;
+    const sig = requestSignature(r);
+    if (seen.has(sig)) return;
+    seen.add(sig);
+    out.push(r);
+  };
+
+  // (a) Open hypotheses → their IOC values + signal tokens from title/expectedOutcome.
+  const open = (input.hypotheses ?? []).filter((h) => h.status === "open");
+  open.slice(0, caps.maxHypotheses ?? MAX_HYPOTHESES_DEFAULT).forEach((h, i) => {
+    const iocValues = (h.relatedIocIds ?? [])
+      .map((id) => input.iocValueById?.get(id))
+      .filter((v): v is string => !!v);
+    const tokens = [...extractSignalTokens(h.title, maxKw), ...extractSignalTokens(h.expectedOutcome, maxKw)];
+    const keywords = cleanKeywords([...iocValues, ...tokens], maxKw);
+    push({
+      source: "hypothesis",
+      tag: `[second-look: h${i + 1}]`,
+      label: `hypothesis: ${h.title}`.slice(0, 160),
+      keywords,
+      from: win.from,
+      to: win.to,
+      reason: h.expectedOutcome?.trim() || h.title,
+    });
+  });
+
+  // (b) Unknown/partial key questions that carry a structured collect target.
+  const openQ = (input.keyQuestions ?? []).filter(
+    (q) => (q.status === "unknown" || q.status === "partial") && q.collect,
+  );
+  openQ.slice(0, caps.maxQuestions ?? MAX_QUESTIONS_DEFAULT).forEach((q, i) => {
+    const c = q.collect!;
+    const keywords = cleanKeywords(
+      [
+        ...extractSignalTokens(c.artifact, maxKw),
+        ...extractSignalTokens(c.logSource, maxKw),
+        ...extractSignalTokens(c.expectedOutcome, maxKw),
+        ...extractSignalTokens(q.question, maxKw),
+      ],
+      maxKw,
+    );
+    push({
+      source: "question",
+      tag: `[second-look: q${i + 1}]`,
+      label: `question: ${q.question}`.slice(0, 160),
+      keywords,
+      host: c.host ? shortHost(c.host) : undefined,
+      from: win.from,
+      to: win.to,
+      reason: c.expectedOutcome?.trim() || q.question,
+    });
+  });
+
+  // (c) Top connective IOCs — the backbone indicators; search the raw record for every mention.
+  (input.connectiveIocs ?? []).slice(0, caps.maxConnectiveIocs ?? MAX_CONNECTIVE_IOCS_DEFAULT).forEach((a) => {
+    const keywords = cleanKeywords([a.value], maxKw);
+    push({
+      source: "connective-ioc",
+      tag: `[second-look: ${a.value.slice(0, 40)}]`,
+      label: `connective indicator: ${a.value}`.slice(0, 160),
+      keywords,
+      from: win.from,
+      to: win.to,
+      reason: `every raw mention of the connective indicator ${a.value}`,
+    });
+  });
+
+  // (d) Model-issued evidence requests — data the model knows it was not shown. Its own timeWindow
+  // (when given) overrides the active window; otherwise it inherits it.
+  (input.modelRequests ?? []).slice(0, caps.maxModel ?? MAX_MODEL_DEFAULT).forEach((m, i) => {
+    const keywords = cleanKeywords(m.keywords ?? [], maxKw);
+    push({
+      source: "model",
+      tag: `[second-look: model${i + 1}]`,
+      label: `model request: ${(m.reason || keywords.join(", ")).slice(0, 140)}`,
+      keywords,
+      host: m.host ? shortHost(m.host) : undefined,
+      from: m.timeWindow?.from ?? win.from,
+      to: m.timeWindow?.to ?? win.to,
+      reason: m.reason?.trim() || `evidence the model requested (${keywords.join(", ")})`,
+    });
+  });
+
+  return out;
+}
+
+// Combine an event's searchable fields into one lowercased haystack (broader than searchFilter's
+// eventMatchesSearch — includes message/path/process names/artifact, which carry recon/exfil signal).
+function eventHaystack(e: ForensicEvent): string {
+  return [
+    e.description, e.message, e.asset, e.path, e.processName, e.parentName, e.artifactName,
+    ...(e.sources ?? []), ...(e.mitreTechniques ?? []),
+  ]
+    .filter(Boolean)
+    .join("  ")
+    .toLowerCase();
+}
+
+function inWindow(e: ForensicEvent, from: string | undefined, to: string | undefined): boolean {
+  const t = Date.parse(e.timestamp);
+  if (Number.isNaN(t)) return true;                 // undated kept — can't be proven out of range
+  if (from) { const f = Date.parse(from); if (!Number.isNaN(f) && t < f) return false; }
+  if (to) { const u = Date.parse(to); if (!Number.isNaN(u) && t > u) return false; }
+  return true;
+}
+
+function hostMatches(e: ForensicEvent, host: string | undefined): boolean {
+  if (!host) return true;
+  if (!e.asset) return false;
+  return shortHost(e.asset).toLowerCase() === host.toLowerCase();
+}
+
+// Resolve each request against the candidate pool (the omitted scoped events + the super-timeline
+// within the window). matchedEventIds records EVERY hit (so a request that only re-finds events already
+// in the timeline is counted as satisfied, not a lead); promotable is the subset whose ids are NOT yet
+// in the analyzed timeline — the genuine recall gain. Per-request matches are capped and time-ordered.
+export function resolveSecondLookRequests(
+  requests: readonly SecondLookRequest[],
+  candidates: readonly ForensicEvent[],
+  forensicEventIds: ReadonlySet<string>,
+  caps: SecondLookCaps = {},
+): SecondLookResolution[] {
+  const perTerm = caps.perTerm ?? SECOND_LOOK_PER_TERM_DEFAULT;
+  // Precompute haystacks once — a sweep can scan tens of thousands of raw rows per request.
+  const hay = new Map<string, string>();
+  const ms = (e: ForensicEvent): number => { const t = Date.parse(e.timestamp); return Number.isNaN(t) ? Infinity : t; };
+  return requests.map((request) => {
+    const matched: ForensicEvent[] = [];
+    for (const e of candidates) {
+      if (!inWindow(e, request.from, request.to)) continue;
+      if (!hostMatches(e, request.host)) continue;
+      let h = hay.get(e.id);
+      if (h === undefined) { h = eventHaystack(e); hay.set(e.id, h); }
+      if (!request.keywords.some((k) => h!.includes(k))) continue;
+      matched.push(e);
+    }
+    // Undated rows sort last (Infinity) so a capped request keeps the dated, placeable evidence first.
+    matched.sort((a, b) => ms(a) - ms(b));
+    const capped = matched.slice(0, perTerm);
+    return {
+      request,
+      matchedEventIds: capped.map((e) => e.id),
+      promotable: capped.filter((e) => !forensicEventIds.has(e.id)),
+    };
+  });
+}
+
+// Turn resolutions into the final promotion plan: dedupe promotable events across requests (an event
+// pulled by two requests carries both provenance tags), enforce the sweep cap, and collect the
+// zero-match requests as collection leads. Deterministic — request order drives which events win the
+// budget, and the first request to claim an event owns its position.
+export function buildSecondLookPlan(
+  resolutions: readonly SecondLookResolution[],
+  caps: SecondLookCaps = {},
+): SecondLookPlan {
+  const sweep = caps.sweep ?? SECOND_LOOK_SWEEP_DEFAULT;
+  const promotions: ForensicEvent[] = [];
+  const tagById: Record<string, string[]> = {};
+  const index = new Map<string, number>(); // event id → position in promotions
+  let truncated = false;
+
+  for (const res of resolutions) {
+    for (const e of res.promotable) {
+      if (!(e.id in tagById)) {
+        if (promotions.length >= sweep) { truncated = true; continue; }
+        index.set(e.id, promotions.length);
+        promotions.push(e);
+        tagById[e.id] = [res.request.tag];
+      } else if (!tagById[e.id].includes(res.request.tag)) {
+        tagById[e.id].push(res.request.tag);
+      }
+    }
+  }
+
+  const leads = resolutions.filter((r) => r.matchedEventIds.length === 0).map((r) => r.request);
+  return { promotions, tagById, resolutions: [...resolutions], leads, truncated };
+}
+
+// Compact per-request promotion counts, for the human summary. e.g. "h2 (rsync, nfs-01) +42".
+function requestTally(res: SecondLookResolution): string {
+  const idTag = res.request.tag.replace(/^\[second-look:\s*/, "").replace(/\]$/, "");
+  const kw = res.request.keywords.slice(0, 3).join(", ");
+  return `${idTag}${kw ? ` (${kw})` : ""} +${res.promotable.length}`;
+}
+
+// One-line summary for the synth-meta card. Mirrors the roadmap's example phrasing:
+// "second look: 42 raw events matching hypothesis h2 (rsync, nfs-01) promoted — conclusions updated."
+export function summarizeSecondLook(plan: SecondLookPlan): string {
+  const promoted = plan.promotions.length;
+  if (!promoted) {
+    if (plan.leads.length) {
+      return `second look: 0 new events; ${plan.leads.length} request(s) matched nothing — collection lead(s) surfaced`;
+    }
+    return "second look: nothing new to promote";
+  }
+  const tallies = plan.resolutions
+    .filter((r) => r.promotable.length > 0)
+    .map(requestTally)
+    .slice(0, 5)
+    .join("; ");
+  const more = plan.truncated ? " (sweep cap reached)" : "";
+  return `second look: ${promoted} raw event(s) promoted — ${tallies}${more} — conclusions updated`;
+}
+
+// Derive the active window from a set of events when the case has no explicit scope: the earliest and
+// latest DATED event. Returns {} when nothing is dated (no bound is better than a wrong bound).
+export function deriveWindow(events: readonly ForensicEvent[]): { from?: string; to?: string } {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const e of events) {
+    const t = Date.parse(e.timestamp);
+    if (Number.isNaN(t)) continue;
+    if (t < min) min = t;
+    if (t > max) max = t;
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return {};
+  return { from: new Date(min).toISOString(), to: new Date(max).toISOString() };
+}

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -145,6 +145,11 @@ export interface ForensicEvent {
     method: string;    // how it was decoded: "powershell-enc" | "base64"
     iocs: string[];    // canonical IOC ids (i###) extracted from the decoded content
   };
+  // Provenance markers explaining WHY this event was pulled into the analyzed timeline by an automated
+  // pass rather than a normal import — currently the second-look loop (guidance #11), which stamps
+  // "[second-look: h2]" onto a raw super-timeline row it promoted to resolve an open hypothesis/question.
+  // Rendered as a small chip on the timeline row so the analyst sees the row is machine-surfaced.
+  provenance?: string[];
 }
 
 // Result of validating a parent→child process relationship against behavioral intel

--- a/companion/src/analysis/synthMeta.ts
+++ b/companion/src/analysis/synthMeta.ts
@@ -16,6 +16,20 @@ const severityChangeSchema = z.object({
   to: z.string(),
 });
 
+// Second-look sweep result (investigation-guidance #11): what the post-synthesis re-query of the raw
+// record promoted, and which requests came back empty (each an actionable collection lead). Surfaced on
+// the synth-meta card. Optional/lenient — absent on a run where the sweep didn't run or found nothing.
+const secondLookSchema = z.object({
+  promoted: z.number().catch(0),          // events pulled up from the raw record and re-synthesized
+  requests: z.number().catch(0),          // total search requests issued this sweep
+  matched: z.number().catch(0),           // requests that hit at least one event
+  leads: z.array(z.string()).catch([]),   // reasons of requests that matched nothing (collection leads)
+  summary: z.string().catch(""),          // one-line human summary for the card
+  at: z.string().catch(""),               // when the sweep ran
+});
+
+export type SecondLookMeta = z.infer<typeof secondLookSchema>;
+
 export const synthMetaSchema = z.object({
   lastSynthesizedAt: z.string().catch(""),
   lastDiff: z.object({
@@ -26,6 +40,7 @@ export const synthMetaSchema = z.object({
   durationMs: z.number().optional().catch(undefined),
   eventCount: z.number().optional().catch(undefined),
   iocCount: z.number().optional().catch(undefined),
+  secondLook: secondLookSchema.nullable().optional().catch(undefined),
 });
 
 export type SynthMeta = z.infer<typeof synthMetaSchema>;
@@ -58,6 +73,16 @@ export class SynthMetaStore {
   // optionally store performance metrics (duration, event/IOC counts).
   async record(caseId: string, diff: FindingsDiff, at: string = new Date().toISOString(), perf?: SynthPerfMetrics): Promise<SynthMeta> {
     const meta: SynthMeta = { lastSynthesizedAt: at, lastDiff: diff, ...perf };
+    await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
+    return meta;
+  }
+
+  // Stamp the second-look sweep result onto the CURRENT synth-meta (#11). Called AFTER the sweep and its
+  // (optional) re-synthesis, so it merges onto the latest record() write instead of being clobbered by
+  // it. Load-merge-save so the rest of the meta (time/diff/perf) is preserved. `null` clears it.
+  async recordSecondLook(caseId: string, secondLook: SecondLookMeta | null): Promise<SynthMeta> {
+    const cur = await this.load(caseId);
+    const meta: SynthMeta = { ...cur, secondLook };
     await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
     return meta;
   }

--- a/companion/tests/analysis/promptCapabilities.test.ts
+++ b/companion/tests/analysis/promptCapabilities.test.ts
@@ -62,7 +62,7 @@ describe("checkConfiguredPromptDrift", () => {
     const drift = checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file });
     expect(drift).toHaveLength(1);
     expect(drift[0].name).toBe("SYNTH");
-    expect(drift[0].missing).toEqual(["hypotheses", "confidenceReason", "relatedFindingIds", "logSource"]);
+    expect(drift[0].missing).toEqual(["hypotheses", "confidenceReason", "relatedFindingIds", "logSource", "evidenceRequests"]);
     expect(driftMessage(drift[0])).toContain("synthesis.txt");
   });
 
@@ -70,7 +70,7 @@ describe("checkConfiguredPromptDrift", () => {
     const file = join(tmp, "pre8-synthesis.txt");
     // A pre-#8 re-eject: has hypotheses/confidenceReason/relatedFindingIds AND the prose "collect email
     // gateway logs" — but NOT the structured `collect { logSource }` directive. Must still be flagged.
-    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds. pointer: 'collect email gateway logs'", "utf8");
+    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds, evidenceRequests. pointer: 'collect email gateway logs'", "utf8");
     const drift = checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file });
     expect(drift).toHaveLength(1);
     expect(drift[0].missing).toEqual(["logSource"]);
@@ -78,7 +78,7 @@ describe("checkConfiguredPromptDrift", () => {
 
   it("passes a fresh override file that contains every marker", () => {
     const file = join(tmp, "fresh-synthesis.txt");
-    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds, collect { logSource }", "utf8");
+    writeFileSync(file, "output: hypotheses, confidenceReason, relatedFindingIds, collect { logSource }, evidenceRequests", "utf8");
     expect(checkConfiguredPromptDrift({ DFIR_AI_SYNTH_PROMPT_FILE: file })).toEqual([]);
   });
 

--- a/companion/tests/analysis/secondLook.test.ts
+++ b/companion/tests/analysis/secondLook.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractSignalTokens,
+  buildSecondLookRequests,
+  resolveSecondLookRequests,
+  buildSecondLookPlan,
+  summarizeSecondLook,
+  deriveWindow,
+  type SecondLookRequest,
+} from "../../src/analysis/secondLook.js";
+import type { ForensicEvent, InvestigationQuestion } from "../../src/analysis/stateTypes.js";
+import type { Hypothesis } from "../../src/analysis/hypothesis.js";
+import type { IocAnchor } from "../../src/analysis/iocAnchors.js";
+
+function ev(partial: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return {
+    timestamp: "2026-01-02T10:00:00.000Z",
+    description: "",
+    severity: "Info",
+    mitreTechniques: [],
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+    ...partial,
+  };
+}
+
+function hyp(partial: Partial<Hypothesis> & { id: string; title: string }): Hypothesis {
+  return {
+    description: "",
+    expectedOutcome: "",
+    status: "open",
+    relatedTechniques: [],
+    relatedEventIds: [],
+    relatedIocIds: [],
+    assignee: "",
+    notes: "",
+    source: "synthesis",
+    analystTouched: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+describe("extractSignalTokens", () => {
+  it("keeps structured identifiers and drops prose stopwords", () => {
+    const tokens = extractSignalTokens(
+      "an archive .zip written shortly before an outbound transfer to nfs-01 via rsync",
+    );
+    expect(tokens).toContain("nfs-01");
+    expect(tokens).toContain("rsync");
+    expect(tokens).toContain(".zip");
+    expect(tokens).not.toContain("shortly");
+    expect(tokens).not.toContain("outbound");
+    expect(tokens).not.toContain("transfer");
+  });
+
+  it("captures hosts, domains, ips and paths", () => {
+    const tokens = extractSignalTokens("beacon to evil.com 10.0.0.5 from C:/temp/x.exe powershell.exe");
+    expect(tokens).toEqual(expect.arrayContaining(["evil.com", "10.0.0.5", "powershell.exe"]));
+    expect(tokens.some((t) => t.includes("temp"))).toBe(true);
+  });
+
+  it("returns [] for empty input and dedupes", () => {
+    expect(extractSignalTokens(undefined)).toEqual([]);
+    expect(extractSignalTokens("rsync rsync rsync")).toEqual(["rsync"]);
+  });
+});
+
+describe("buildSecondLookRequests", () => {
+  it("mines open hypotheses (ioc values + tokens), skipping non-open ones", () => {
+    const requests = buildSecondLookRequests({
+      hypotheses: [
+        hyp({ id: "h_a", title: "Data staged before exfil", expectedOutcome: "an archive to nfs-01 via rsync", relatedIocIds: ["i1"], status: "open" }),
+        hyp({ id: "h_b", title: "Refuted theory", status: "refuted" }),
+      ],
+      iocValueById: new Map([["i1", "evil.com"]]),
+      window: { from: "2026-01-01T00:00:00Z", to: "2026-01-31T00:00:00Z" },
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].source).toBe("hypothesis");
+    expect(requests[0].tag).toBe("[second-look: h1]");
+    expect(requests[0].keywords).toEqual(expect.arrayContaining(["evil.com", "nfs-01", "rsync"]));
+    expect(requests[0].from).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("mines unknown/partial questions that carry a collect target, with host", () => {
+    const questions: InvestigationQuestion[] = [
+      { id: "q1", question: "Was there exfil?", status: "unknown", answer: "", pointer: "",
+        collect: { host: "FS01.corp.local", artifact: "Windows.EventLogs.Evtx", logSource: "proxy access logs", expectedOutcome: "large POST to megaupload" } },
+      { id: "q2", question: "answered one", status: "answered", answer: "yes", pointer: "" },
+    ];
+    const requests = buildSecondLookRequests({ keyQuestions: questions });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].source).toBe("question");
+    expect(requests[0].host).toBe("fs01");             // shortHost of FS01.corp.local (lowercased)
+    expect(requests[0].keywords).toEqual(expect.arrayContaining(["megaupload"]));
+  });
+
+  it("turns top connective IOCs into per-value requests", () => {
+    const anchors: IocAnchor[] = [
+      { value: "10.10.10.10", type: "ip", hosts: ["a", "b"], accounts: [], tools: ["zeek"], malicious: true, suspicious: false, internalConflict: false, score: 12 },
+    ];
+    const requests = buildSecondLookRequests({ connectiveIocs: anchors });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].source).toBe("connective-ioc");
+    expect(requests[0].keywords).toEqual(["10.10.10.10"]);
+  });
+
+  it("honors model requests with their own time window overriding the active one", () => {
+    const requests = buildSecondLookRequests({
+      window: { from: "2026-01-01T00:00:00Z", to: "2026-01-31T00:00:00Z" },
+      modelRequests: [{ host: "DC01", keywords: ["kerberoast", "spn"], reason: "check for kerberoasting", timeWindow: { from: "2026-01-10T00:00:00Z" } }],
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].source).toBe("model");
+    expect(requests[0].from).toBe("2026-01-10T00:00:00Z");   // model window wins
+    expect(requests[0].to).toBe("2026-01-31T00:00:00Z");     // inherits active upper bound
+    expect(requests[0].host).toBe("dc01");
+  });
+
+  it("drops keyword-less requests and dedupes identical searches", () => {
+    const requests = buildSecondLookRequests({
+      hypotheses: [hyp({ id: "h_empty", title: "the and for", expectedOutcome: "with that this" })], // all stopwords → no keywords
+      connectiveIocs: [
+        { value: "evil.com", type: "domain", hosts: ["a"], accounts: [], tools: ["t"], malicious: true, suspicious: false, internalConflict: false, score: 5 },
+        { value: "evil.com", type: "domain", hosts: ["a"], accounts: [], tools: ["t"], malicious: true, suspicious: false, internalConflict: false, score: 5 },
+      ],
+    });
+    // hypothesis produced no keywords → dropped; two identical IOC requests → deduped to one
+    expect(requests).toHaveLength(1);
+    expect(requests[0].keywords).toEqual(["evil.com"]);
+  });
+});
+
+describe("resolveSecondLookRequests", () => {
+  const req: SecondLookRequest = {
+    source: "hypothesis", tag: "[second-look: h1]", label: "h1", keywords: ["rsync", "nfs-01"],
+    from: "2026-01-01T00:00:00Z", to: "2026-01-31T00:00:00Z", reason: "staging",
+  };
+
+  it("matches ANY keyword across broad fields and separates promotable (not-yet-in-timeline) events", () => {
+    const candidates = [
+      ev({ id: "s1", description: "rsync -a /data nfs-01:/backup", timestamp: "2026-01-05T00:00:00Z" }),
+      ev({ id: "s2", message: "connection to NFS-01 share", timestamp: "2026-01-06T00:00:00Z" }),
+      ev({ id: "s3", description: "unrelated login", timestamp: "2026-01-06T00:00:00Z" }),
+      ev({ id: "e9", description: "rsync already in timeline", timestamp: "2026-01-04T00:00:00Z" }),
+    ];
+    const [res] = resolveSecondLookRequests([req], candidates, new Set(["e9"]));
+    expect(res.matchedEventIds.sort()).toEqual(["e9", "s1", "s2"]);
+    expect(res.promotable.map((e) => e.id).sort()).toEqual(["s1", "s2"]); // e9 excluded (already present)
+  });
+
+  it("respects the time window (undated kept) and host restriction", () => {
+    const hostReq: SecondLookRequest = { ...req, host: "FS01", keywords: ["exfil"] };
+    const candidates = [
+      ev({ id: "a", description: "exfil", asset: "FS01.corp", timestamp: "2026-01-10T00:00:00Z" }),
+      ev({ id: "b", description: "exfil", asset: "DC01", timestamp: "2026-01-10T00:00:00Z" }),   // wrong host
+      ev({ id: "c", description: "exfil", asset: "FS01", timestamp: "2020-01-10T00:00:00Z" }),   // out of window
+      ev({ id: "d", description: "exfil", asset: "FS01", timestamp: "not-a-date" }),             // undated → kept
+    ];
+    const [res] = resolveSecondLookRequests([hostReq], candidates, new Set());
+    expect(res.promotable.map((e) => e.id).sort()).toEqual(["a", "d"]);
+  });
+
+  it("caps matches per request", () => {
+    const candidates = Array.from({ length: 10 }, (_, i) =>
+      ev({ id: `s${i}`, description: "rsync", timestamp: `2026-01-05T00:00:0${i}Z` }));
+    const [res] = resolveSecondLookRequests([req], candidates, new Set(), { perTerm: 3 });
+    expect(res.promotable).toHaveLength(3);
+  });
+});
+
+describe("buildSecondLookPlan", () => {
+  it("dedupes promoted events across requests, unions tags, and enforces the sweep cap", () => {
+    const shared = ev({ id: "s1", description: "rsync nfs-01" });
+    const resolutions = [
+      { request: { source: "hypothesis", tag: "[second-look: h1]", label: "", keywords: ["rsync"], reason: "" } as SecondLookRequest,
+        matchedEventIds: ["s1", "s2"], promotable: [shared, ev({ id: "s2" })] },
+      { request: { source: "question", tag: "[second-look: q1]", label: "", keywords: ["nfs-01"], reason: "" } as SecondLookRequest,
+        matchedEventIds: ["s1", "s3"], promotable: [shared, ev({ id: "s3" })] },
+    ];
+    const plan = buildSecondLookPlan(resolutions, { sweep: 2 });
+    expect(plan.promotions.map((e) => e.id)).toEqual(["s1", "s2"]); // s3 dropped by sweep cap
+    expect(plan.tagById["s1"]).toEqual(["[second-look: h1]", "[second-look: q1]"]); // both tags
+    expect(plan.truncated).toBe(true);
+  });
+
+  it("surfaces zero-match requests as collection leads", () => {
+    const resolutions = [
+      { request: { source: "model", tag: "[second-look: model1]", label: "", keywords: ["kerberoast"], reason: "check kerberoasting" } as SecondLookRequest,
+        matchedEventIds: [], promotable: [] },
+    ];
+    const plan = buildSecondLookPlan(resolutions);
+    expect(plan.promotions).toHaveLength(0);
+    expect(plan.leads).toHaveLength(1);
+    expect(plan.leads[0].reason).toBe("check kerberoasting");
+  });
+});
+
+describe("summarizeSecondLook", () => {
+  it("summarizes promotions with per-request tallies", () => {
+    const plan = buildSecondLookPlan([
+      { request: { source: "hypothesis", tag: "[second-look: h2]", label: "", keywords: ["rsync", "nfs-01"], reason: "" } as SecondLookRequest,
+        matchedEventIds: ["s1"], promotable: [ev({ id: "s1" }), ev({ id: "s2" })] },
+    ]);
+    const line = summarizeSecondLook(plan);
+    expect(line).toContain("2 raw event(s) promoted");
+    expect(line).toContain("h2 (rsync, nfs-01) +2");
+  });
+
+  it("reports leads when nothing was promoted", () => {
+    const plan = buildSecondLookPlan([
+      { request: { source: "model", tag: "[second-look: model1]", label: "", keywords: ["x"], reason: "r" } as SecondLookRequest,
+        matchedEventIds: [], promotable: [] },
+    ]);
+    expect(summarizeSecondLook(plan)).toContain("collection lead");
+  });
+});
+
+describe("deriveWindow", () => {
+  it("returns earliest and latest dated timestamps", () => {
+    const w = deriveWindow([
+      ev({ id: "a", timestamp: "2026-01-05T00:00:00.000Z" }),
+      ev({ id: "b", timestamp: "2026-01-01T00:00:00.000Z" }),
+      ev({ id: "c", timestamp: "bad" }),
+    ]);
+    expect(w.from).toBe("2026-01-01T00:00:00.000Z");
+    expect(w.to).toBe("2026-01-05T00:00:00.000Z");
+  });
+
+  it("returns {} when nothing is dated", () => {
+    expect(deriveWindow([ev({ id: "a", timestamp: "bad" })])).toEqual({});
+  });
+});

--- a/companion/tests/analysis/secondLookLoop.test.ts
+++ b/companion/tests/analysis/secondLookLoop.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { SynthMetaStore } from "../../src/analysis/synthMeta.js";
+import { MockProvider } from "../../src/providers/provider.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+// End-to-end second-look loop (investigation-guidance #11): a synthesis that emits an evidenceRequest
+// for data it wasn't shown triggers a raw re-query of the super-timeline, promotes the matching row,
+// and re-synthesizes ONCE. A request that matches nothing surfaces as a collection lead without any
+// re-synthesis. Uses MockProvider (fixed delta) so behavior is deterministic.
+
+let caseStore: CaseStore;
+let stateStore: StateStore;
+let superStore: SuperTimelineStore;
+let synthMetaStore: SynthMetaStore;
+
+function event(id: string, timestamp: string, description = "benign"): ForensicEvent {
+  return { id, timestamp, description, severity: "High", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [] };
+}
+
+// Synthesis delta with a model-issued evidenceRequest for "rsync" — the keyword the seeded raw
+// super-timeline row carries but the analyzed timeline does not.
+function deltaWithRequest(keyword: string): string {
+  return JSON.stringify({
+    findings: [{ id: "f1", severity: "High", title: "PS abuse", description: "d", relatedIocs: [], mitreTechniques: ["T1059"], status: "open", relatedEventIds: ["e1"] }],
+    iocs: [], mitreTechniques: [{ id: "T1059", name: "Command Interpreter" }],
+    attackerPath: "p", summary: "s", forensicEvents: [], threadsOpened: [], threadsClosed: [], timelineNote: "",
+    hypotheses: [{ title: "Data was staged before exfil", expectedOutcome: "an archive written before transfer", status: "open", relatedTechniques: ["T1560"], relatedEventIds: [], relatedIocIds: [] }],
+    evidenceRequests: [{ keywords: [keyword], reason: "confirm the staging/exfil hypothesis with rows not shown" }],
+  });
+}
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-secondlook-"));
+  caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+  stateStore = new StateStore(caseStore);
+  superStore = new SuperTimelineStore(caseStore);
+  synthMetaStore = new SynthMetaStore(caseStore);
+
+  const seeded = emptyState("c1");
+  seeded.forensicTimeline.push(event("e1", "2026-05-20T09:00:00.000Z"));
+  seeded.forensicTimeline.push(event("e2", "2026-05-20T11:00:00.000Z"));
+  await stateStore.save(seeded);
+});
+
+function makePipeline(delta: string) {
+  const provider = new MockProvider("mock", delta);
+  const analyze = vi.spyOn(provider, "analyze");
+  const pipeline = new AnalysisPipeline({
+    provider,
+    stateStore,
+    superTimelineStore: superStore,
+    synthMetaStore,
+    imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+  });
+  return { pipeline, analyze };
+}
+
+describe("second-look loop end-to-end (#11)", () => {
+  it("promotes a matching raw super-timeline row and re-synthesizes exactly once", async () => {
+    // A raw host-triage row that only lives in the super-timeline (not the analyzed timeline), within
+    // the incident window, carrying the keyword the model will request.
+    await superStore.append("c1", [
+      event("sraw1", "2026-05-20T10:00:00.000Z", "rsync -a /data nfs-01:/backup archive.zip"),
+      event("sraw2", "2026-05-20T10:05:00.000Z", "unrelated noise"),
+    ]);
+
+    const { pipeline, analyze } = makePipeline(deltaWithRequest("rsync"));
+    await pipeline.synthesize("c1");
+
+    // The raw row was promoted into the analyzed timeline …
+    const state = await stateStore.load("c1");
+    const promoted = state.forensicTimeline.find((e) => e.id === "sraw1");
+    expect(promoted).toBeDefined();
+    // … tagged with second-look provenance …
+    expect(promoted!.provenance?.some((p) => p.startsWith("[second-look:"))).toBe(true);
+    // … the unrelated raw row was NOT promoted …
+    expect(state.forensicTimeline.some((e) => e.id === "sraw2")).toBe(false);
+    // … exactly one bounded re-synthesis ran (2 AI calls total: initial + second look) …
+    expect(analyze).toHaveBeenCalledTimes(2);
+    // … and the sweep is recorded on the synth-meta card.
+    const meta = await synthMetaStore.load("c1");
+    expect(meta.secondLook?.promoted).toBe(1);
+    expect(meta.secondLook?.summary).toContain("promoted");
+  });
+
+  it("surfaces a zero-match evidence request as a collection lead without re-synthesizing", async () => {
+    await superStore.append("c1", [event("sraw1", "2026-05-20T10:00:00.000Z", "totally different content")]);
+
+    const { pipeline, analyze } = makePipeline(deltaWithRequest("kerberoast"));
+    await pipeline.synthesize("c1");
+
+    const state = await stateStore.load("c1");
+    expect(state.forensicTimeline.some((e) => e.id === "sraw1")).toBe(false); // nothing promoted
+    expect(analyze).toHaveBeenCalledTimes(1);                                 // no re-synthesis
+
+    const meta = await synthMetaStore.load("c1");
+    expect(meta.secondLook?.promoted).toBe(0);
+    expect(meta.secondLook?.leads.length).toBeGreaterThan(0);
+  });
+
+  it("does not sweep when superTimelineStore is not wired", async () => {
+    const provider = new MockProvider("mock", deltaWithRequest("rsync"));
+    const analyze = vi.spyOn(provider, "analyze");
+    const pipeline = new AnalysisPipeline({ provider, stateStore, synthMetaStore, imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }) });
+    await pipeline.synthesize("c1");
+    expect(analyze).toHaveBeenCalledTimes(1); // no second-look pass at all
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4693,6 +4693,11 @@
         const iocRefs = (e.deobfuscated.iocs || []).length ? ` (IOCs: ${e.deobfuscated.iocs.map(i => esc(i)).join(", ")})` : "";
         parts.push(`<div style="font-family:ui-monospace,Menlo,Consolas,monospace;white-space:pre-wrap;word-break:break-all">Decoded: ${esc(e.deobfuscated.decoded)}${iocRefs}</div>`);
       }
+      // Second-look provenance (#11): this raw row was pulled up from the super-timeline by the
+      // post-synthesis re-query — show WHY (which open question/hypothesis it answers).
+      if (Array.isArray(e.provenance) && e.provenance.length) {
+        parts.push(`<span style="color:#6bcB77" title="Promoted from the raw super-timeline by the second-look re-query">🔁 ${e.provenance.map(esc).join(" ")}</span>`);
+      }
       const ev = (show("evidence") && caseId) ? evidenceLinks(caseId, e.sourceScreenshots) : "";
       if (ev) parts.push(ev.replace(/^<br>/, ""));
       if (!parts.length) return { title, toggle: "", panel: "" };
@@ -8228,7 +8233,19 @@
       const largeAdvisory = (m.eventCount !== undefined && m.eventCount >= 5000)
         ? `<div style="margin-top:5px;color:var(--c-ffd93b);font-size:11px">⚠ Large case (${m.eventCount.toLocaleString()} events) — consider restricting the investigation scope to a date range for faster synthesis.</div>`
         : '';
-      el.innerHTML = `<div class="sm-line"><span>🧠 Last synthesized <strong>${esc(relTime(m.lastSynthesizedAt))}</strong></span>${perfSpan}<span>${summary}</span></div>${detail}${largeAdvisory}`;
+      // Second-look loop (#11): the post-synthesis raw re-query result. A green line when it pulled
+      // rows up and re-synthesized; a muted line listing collection leads when requests came back empty.
+      let secondLook = '';
+      const sl = m.secondLook;
+      if (sl && (sl.promoted > 0 || (sl.leads && sl.leads.length))) {
+        if (sl.promoted > 0) {
+          secondLook = `<div style="margin-top:5px;color:var(--c-6bcb77);font-size:11px" title="The tool re-queried the complete raw record for the open questions and folded new matches into the conclusions">🔁 ${esc(sl.summary || (sl.promoted + ' raw event(s) promoted'))}</div>`;
+        } else {
+          const leads = sl.leads.slice(0, 4).map(esc).join('; ');
+          secondLook = `<div style="margin-top:5px;color:var(--c-9aa4b2);font-size:11px" title="Second-look requests that matched nothing in the raw record — collect these to close the gap">🔎 Second look found no new evidence; collection leads: ${leads}${sl.leads.length > 4 ? ` +${sl.leads.length - 4} more` : ''}</div>`;
+        }
+      }
+      el.innerHTML = `<div class="sm-line"><span>🧠 Last synthesized <strong>${esc(relTime(m.lastSynthesizedAt))}</strong></span>${perfSpan}<span>${summary}</span></div>${detail}${secondLook}${largeAdvisory}`;
     }
 
     // --- Correlation profile (per-case cross-source event merge window) -------------------------


### PR DESCRIPTION
## What & why

The last Tier 2 item of the [investigation-guidance roadmap](INVESTIGATION_GUIDANCE_ROADMAP.md). Closes the **hypothesize → re-query → verify** loop.

Today the AI only ever sees a *sample* of the timeline (≤300 events) and never the raw super-timeline at all — so the complete record is unreachable no matter what hypotheses it forms. northpeak's recon/clone/exfil story sat in exactly those unseen raw rows. This adds a bounded post-synthesis executor that turns the case's **open questions** into concrete searches, resolves them against the complete raw record, promotes the matches, and folds them into the conclusions with **exactly one** extra AI call.

## How it works

1. **After** a real synthesis run, mine search requests from two sources:
   - **Deterministic harvest** — open hypotheses (their IOC values + signal tokens from title/`expectedOutcome`), unknown/partial key questions' structured `collect` targets, and the top connective IOCs.
   - **Model-issued** — a new optional `evidenceRequests` array (`{host?, timeWindow?, keywords[], reason}`, max 5) the synthesis prompt lets the model fill with data it knows it wasn't shown.
2. Resolve each request against the **omitted scoped events + the super-timeline** within the active window (scope, else derived from the dated in-scope span).
3. **Promote** the not-yet-analyzed matches — capped **50/term, 200/sweep**, tagged `[second-look: h2]` provenance — via the existing `promoteSuperTimeline` path.
4. If anything promoted, trigger **exactly one** re-synthesis. The promotion changes the in-scope timeline → the existing input-hash differs → the one extra run happens; a `skipSecondLook` guard on it stops any recursion. A request that matched **nothing** is surfaced as a concrete **collection lead**.

Bounded, deterministic, idempotent; a sweep failure is best-effort and never fails the synthesis.

## Surfaces
- **Synth-meta card**: green "🔁 second look: N raw event(s) promoted — …" line, or a muted "collection leads: …" line when requests came up empty.
- **Timeline row**: a "🔁 [second-look: …]" provenance chip on promoted rows (new `ForensicEvent.provenance` field).

## Files
- `analysis/secondLook.ts` — pure core (token extraction, request building, resolution, planning, summary, window derivation).
- `analysis/pipeline.ts` — `runSecondLook()` orchestration + `skipSecondLook` guard; `promoteSuperTimeline` gains `tagById`/`note`; prompt instruction.
- `analysis/responseSchema.ts` — lenient optional `evidenceRequests`.
- `analysis/synthMeta.ts` — `secondLook` record + `recordSecondLook()`.
- `analysis/promptCapabilities.ts` — `evidenceRequests` drift marker.
- `analysis/stateTypes.ts` — `ForensicEvent.provenance`.
- `public/dashboard.html` — card line + row chip.

## Tests
- `tests/analysis/secondLook.test.ts` — 17 unit tests over the pure core.
- `tests/analysis/secondLookLoop.test.ts` — 3 end-to-end pipeline tests: promote-and-re-synthesize-once, zero-match → collection lead + no re-synthesis, and no-op when the super-timeline store isn't wired.
- Full companion suite green (**3596**), clean `tsc`.

## Test plan
From `companion/` on this branch (`gh pr checkout <this-PR>` first):
- `npx vitest run tests/analysis/secondLook.test.ts tests/analysis/secondLookLoop.test.ts`
- `npx vitest run` (full suite)
- `npx tsc --noEmit`

## Operational follow-up
Re-run `npm run prompts:eject` in the live deployment so the ejected `companion/prompts/synthesis.txt` picks up the new `evidenceRequests` instruction (otherwise the #1 drift check warns and the model won't issue evidence requests).

Part of #11 (roadmap Tier 2).