### PR TITLE
feat: rabbit-hole detection — connectedness + relevance verdict (#13)

### DIFF
--- a/INVESTIGATION_GUIDANCE_ROADMAP.md
+++ b/INVESTIGATION_GUIDANCE_ROADMAP.md
@@ -1,8 +1,9 @@
 # Making DFIR-Companion Lead the Investigation
 
-> **Implementation status (Tier 0–2 + Tier 3 #12 shipped and merged to master).** Proposals
-> #1–#12 are implemented, unit-tested, and merged (PRs #96–#99, #102, #103 for #1–#10; #11 = the
-> second-look loop; #12 = the immediate FP cascade). Full suite green (3609 tests), clean `tsc`. Deferred within those items (documented
+> **Implementation status (Tier 0–2 + Tier 3 #12–#13 shipped and merged to master).** Proposals
+> #1–#13 are implemented, unit-tested, and merged (PRs #96–#99, #102, #103 for #1–#10; #11 = the
+> second-look loop; #12 = the immediate FP cascade; #13 = rabbit-hole detection). Full suite green
+> (3620 tests), clean `tsc`. Deferred within those items (documented
 > in each commit): the `~` context-prefix prompt notation and per-class counts into synthMeta (#4); the
 > anchor-scoring bump retune and the auto-generated "corroborate `<ioc>`" nextStep (#7); #10 trigger (b)
 > cap-hit truncation; #11 report-side surfacing of collection leads (kept on the live dashboard only).
@@ -10,7 +11,7 @@
 > gitignored deployment artifacts — regenerate them with `npm run prompts:eject` so the deployment picks
 > up the built-in prompt (hypotheses / confidenceReason / structured-tag & attack-graph / #8 collect /
 > #11 evidenceRequests instructions). Until then the drift-detection check warns on every preflight and
-> synthesis run. **Tier 3 remaining: #13–#15** as specified below.
+> synthesis run. **Tier 3 remaining: #14–#15** as specified below.
 
 **Goal.** Make the Companion genuinely lead an investigation — better decisions, higher recall of
 what actually happened, better dot-connecting, a working FP / rabbit-hole / real-lead triage, the

--- a/companion/src/analysis/evidenceGraph.ts
+++ b/companion/src/analysis/evidenceGraph.ts
@@ -289,3 +289,70 @@ export function buildEvidenceGraph(state: InvestigationState): EvidenceGraph {
   const edges = [...edgeMap.values()].sort((a, b) => a.id.localeCompare(b.id));
   return { nodes, edges };
 }
+
+// One connected component of the evidence graph (rabbit-hole detection #13). `nodeIds`/`eventIds` are
+// the nodes and their backing forensic events; `critHighCount` is how many of its nodes carry a
+// Critical/High max-severity — the signal used to pick the MAIN component (the corroborated attack mass).
+export interface GraphComponent {
+  nodeIds: Set<string>;
+  eventIds: Set<string>;
+  nodeCount: number;
+  critHighCount: number;
+}
+
+// Undirected connected components over the evidence graph's edges. A node with no edge is its own
+// singleton component. Pure + deterministic. Union-find, so it's near-linear even on large graphs.
+export function connectedComponents(graph: EvidenceGraph): GraphComponent[] {
+  const parent = new Map<string, string>();
+  const find = (x: string): string => {
+    let r = x;
+    while (parent.get(r) !== r) r = parent.get(r)!;
+    // path-compress
+    let c = x;
+    while (parent.get(c) !== r) { const n = parent.get(c)!; parent.set(c, r); c = n; }
+    return r;
+  };
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n] as const));
+  for (const n of graph.nodes) parent.set(n.id, n.id);
+  const union = (a: string, b: string): void => {
+    if (!parent.has(a) || !parent.has(b)) return; // ignore an edge to a node that wasn't emitted
+    const ra = find(a), rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  };
+  for (const e of graph.edges) union(e.source, e.target);
+
+  const byRoot = new Map<string, GraphComponent>();
+  for (const n of graph.nodes) {
+    const root = find(n.id);
+    let comp = byRoot.get(root);
+    if (!comp) { comp = { nodeIds: new Set(), eventIds: new Set(), nodeCount: 0, critHighCount: 0 }; byRoot.set(root, comp); }
+    comp.nodeIds.add(n.id);
+    comp.nodeCount += 1;
+    const sev = nodeById.get(n.id)!.maxSeverity;
+    if (sev === "Critical" || sev === "High") comp.critHighCount += 1;
+    for (const eid of n.eventIds) comp.eventIds.add(eid);
+  }
+  return [...byRoot.values()];
+}
+
+// The MAIN component (rabbit-hole detection #13): the connected component that holds the corroborated
+// Critical/High attack mass — the most Crit/High nodes, tie-broken by most backing events then most
+// nodes. This is the "known attack path"; a finding with zero linkage to it is a rabbit-hole candidate.
+// Returns null when the graph has no edges/nodes (nothing to anchor relevance against).
+export function mainComponent(graph: EvidenceGraph): GraphComponent | null {
+  const comps = connectedComponents(graph);
+  if (!comps.length) return null;
+  return comps.slice().sort((a, b) =>
+    b.critHighCount - a.critHighCount ||
+    b.eventIds.size - a.eventIds.size ||
+    b.nodeCount - a.nodeCount)[0];
+}
+
+// The host labels in a component, for the "to link it, look for:" discriminator on a disconnected
+// finding — the entities that, if they appeared in the finding's evidence, would tie it to the attack.
+export function componentHostLabels(graph: EvidenceGraph, comp: GraphComponent, max = 4): string[] {
+  const labels = graph.nodes
+    .filter((n) => n.kind === "host" && comp.nodeIds.has(n.id))
+    .map((n) => n.label);
+  return [...new Set(labels)].sort().slice(0, max);
+}

--- a/companion/src/analysis/falsePositive.ts
+++ b/companion/src/analysis/falsePositive.ts
@@ -92,6 +92,29 @@ export function buildFalsePositiveContext(markers: FalsePositiveMarker[]): strin
   );
 }
 
+// Rabbit-hole detection (investigation-guidance #13): 'authorized-test' / 'known-good-tool' markers are
+// not just noise to erase — a sanctioned pentest or admin tool running during the incident window is
+// investigation-SHAPING context (it explains benign-looking activity AND is exactly what an attacker
+// hides behind). Retain them as a one-line CONTEXT block fed to synthesis, distinct from the pure-
+// exclusion block above. Returns "" when no such markers exist. Finding/IOC markers only (event markers
+// are opaque ids already removed from the timeline).
+export function buildAuthorizedContextBlock(markers: FalsePositiveMarker[]): string {
+  const relevant = markers.filter(
+    (m) => (m.reason === "authorized-test" || m.reason === "known-good-tool") && (m.kind === "finding" || m.kind === "ioc"),
+  );
+  if (relevant.length === 0) return "";
+  const lines = relevant
+    .map((m) => `- [${m.reason}] ${m.kind}: ${m.ref}${m.note ? ` — ${m.note}` : ""}`)
+    .join("\n");
+  return (
+    "SANCTIONED ACTIVITY CONTEXT (authorized test / known-good tooling the client flagged — NOT the " +
+    "incident, but it shapes it): treat matching activity as EXPECTED rather than malicious, yet REMEMBER " +
+    "attackers hide inside sanctioned tooling — if real incident evidence overlaps this window or these " +
+    "tools, call out the overlap explicitly instead of dismissing it:\n" +
+    lines
+  );
+}
+
 export class FalsePositiveStore {
   constructor(private readonly cases: CaseStore) {}
 

--- a/companion/src/analysis/findingRelevance.ts
+++ b/companion/src/analysis/findingRelevance.ts
@@ -1,0 +1,105 @@
+// Rabbit-hole detection (investigation-guidance #13). "Which findings are rabbit holes?" has no
+// taxonomy today — veridia's planted red herring became a High finding; halcyon's benign USB copy was
+// indistinguishable from the real exfil. This module answers it deterministically: a finding whose
+// supporting evidence sits in the evidence graph but in a DIFFERENT connected component than the
+// corroborated Critical/High attack mass (the "main component") has no causal link to the known attack
+// path — a rabbit-hole candidate. The AI adds a nuance the graph can't: a disconnected finding that is
+// nonetheless genuine-but-unrelated activity (a second, separate issue) vs undetermined noise.
+//
+// Crucially, "not in the main component" is only claimed for evidence that IS in the graph. A finding
+// whose events carry no graph-modeled relationship (no process chain / hash / account / network flow)
+// is 'undetermined', NOT 'disconnected' — we never brand a finding a rabbit hole just because its
+// evidence type isn't one the causal graph models.
+
+import type { Finding, ForensicEvent } from "./stateTypes.js";
+import { mainComponent, componentHostLabels, type EvidenceGraph } from "./evidenceGraph.js";
+
+export type FindingRelevance = "connected" | "disconnected" | "unrelated-but-real" | "undetermined";
+export type AiRelevance = "connected" | "unrelated-but-real" | "undetermined";
+
+// The three triage buckets the dashboard groups findings into.
+export type RelevanceBucket = "lead" | "rabbit-hole" | "parked";
+
+export function relevanceBucket(relevance: FindingRelevance | undefined): RelevanceBucket {
+  if (relevance === "disconnected") return "rabbit-hole";
+  if (relevance === "unrelated-but-real") return "parked";
+  return "lead"; // connected + undetermined default to the main list (never hide a possible lead)
+}
+
+// Gather the forensic-event ids a finding cites as evidence: its own relatedEventIds PLUS the reverse
+// links (events whose relatedFindingIds name it) — same two-way resolution groundAndScoreFindings uses,
+// so a confidence-backfill finding (linked only in reverse) still resolves.
+function findingEventIds(finding: Finding, reverseByFinding: ReadonlyMap<string, Set<string>>): string[] {
+  const ids = new Set<string>(finding.relatedEventIds ?? []);
+  for (const id of reverseByFinding.get(finding.id) ?? []) ids.add(id);
+  return [...ids];
+}
+
+// Combine the deterministic linkage verdict with the optional AI verdict. The graph is authoritative
+// about linkage (a real edge is a fact); the AI only refines a DISCONNECTED finding into a genuine-
+// but-unrelated issue vs undetermined noise, and classifies findings the graph couldn't place.
+function resolveRelevance(deterministic: FindingRelevance, ai: AiRelevance | undefined): FindingRelevance {
+  if (deterministic === "connected") return "connected";               // linkage is a fact; AI can't override
+  if (deterministic === "disconnected") {
+    if (ai === "unrelated-but-real") return "unrelated-but-real";       // real, but a separate issue → Parked
+    if (ai === "undetermined") return "undetermined";
+    if (ai === "connected") return "undetermined";                     // AI↔graph conflict → don't brand a rabbit hole
+    return "disconnected";                                              // no AI signal → rabbit-hole candidate
+  }
+  // deterministic 'undetermined' (evidence not in the causal graph): defer to the AI when it spoke.
+  return ai ?? "undetermined";
+}
+
+export interface ScoreRelevanceInput {
+  findings: readonly Finding[];
+  scopedEvents: readonly ForensicEvent[];  // in-scope events (for reverse finding links)
+  graph: EvidenceGraph;
+  aiRelevanceById?: ReadonlyMap<string, AiRelevance>;
+}
+
+// Score every finding's relevance + connectedness (0..1) against the main component, merging the AI
+// verdict, and attach a "to link it, look for:" discriminator to disconnected findings. Pure +
+// idempotent; only sets the three relevance fields. Returns NEW finding objects (never mutates).
+export function scoreFindingsRelevance(input: ScoreRelevanceInput): Finding[] {
+  const main = mainComponent(input.graph);
+  const allGraphEventIds = new Set<string>();
+  for (const n of input.graph.nodes) for (const eid of n.eventIds) allGraphEventIds.add(eid);
+  const mainEventIds = main?.eventIds ?? new Set<string>();
+
+  // Reverse index: finding id → set of event ids that name it (built once).
+  const reverseByFinding = new Map<string, Set<string>>();
+  for (const e of input.scopedEvents) {
+    for (const fid of e.relatedFindingIds ?? []) {
+      const set = reverseByFinding.get(fid) ?? new Set<string>();
+      set.add(e.id);
+      reverseByFinding.set(fid, set);
+    }
+  }
+
+  const hostHint = main ? componentHostLabels(input.graph, main) : [];
+  const discriminator = hostHint.length
+    ? `no causal link to the main attack path — to link it, look for a shared host (${hostHint.join(", ")}), binary hash, account, or network flow`
+    : "no causal link to the main attack path — look for a shared host, binary hash, account, or network flow that ties it in";
+
+  return input.findings.map((f) => {
+    const evs = findingEventIds(f, reverseByFinding);
+    const graphEvs = evs.filter((id) => allGraphEventIds.has(id));
+    let deterministic: FindingRelevance;
+    let connectedness: number;
+    if (!main || graphEvs.length === 0) {
+      // No main component, or the finding's evidence doesn't participate in the causal graph → can't
+      // judge linkage. Never a rabbit hole on that basis.
+      deterministic = "undetermined";
+      connectedness = 0;
+    } else {
+      const inMain = graphEvs.filter((id) => mainEventIds.has(id)).length;
+      connectedness = inMain / graphEvs.length;
+      deterministic = connectedness > 0 ? "connected" : "disconnected";
+    }
+    const relevance = resolveRelevance(deterministic, input.aiRelevanceById?.get(f.id));
+    const next: Finding = { ...f, relevance, connectedness: Math.round(connectedness * 100) / 100 };
+    if (relevance === "disconnected") next.relevanceDiscriminator = discriminator;
+    else delete next.relevanceDiscriminator;
+    return next;
+  });
+}

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -26,7 +26,7 @@ import { applySeverityFloor } from "./severityFloor.js";
 import { EXAMPLE_IMPORTER_SPEC } from "./importerSpec.js";
 import type { ExternalImporter } from "./declarativeImporter.js";
 import { parseJsonLoose } from "./extractJson.js";
-import { applyFalsePositive, buildFalsePositiveContext, filterFalsePositiveEvents, type FalsePositiveStore } from "./falsePositive.js";
+import { applyFalsePositive, buildFalsePositiveContext, buildAuthorizedContextBlock, filterFalsePositiveEvents, type FalsePositiveStore } from "./falsePositive.js";
 import { backfillHighSeverityFindings } from "./highSeverityFindings.js";
 import { checkConfiguredPromptDrift } from "./promptCapabilities.js";
 import { resolveSynthThinkingBudget, type SynthThinkingInput } from "./synthThinking.js";
@@ -172,6 +172,7 @@ import {
   deriveWindow, type ModelEvidenceRequest,
 } from "./secondLook.js";
 import { groundAndScoreFindings, capIntelOnlyFindings, corroborationLabel } from "./findingGrounding.js";
+import { scoreFindingsRelevance } from "./findingRelevance.js";
 import { reconsiderKeyQuestions, textMentionsFindingId } from "./fpCascade.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
@@ -626,11 +627,16 @@ export const SYNTHESIS_PROMPT = [
   "Every finding/ioc/technique/thread/question MUST be an object, never a bare string.",
   "findings must include confidence (0–100) and confidenceReason (one short sentence): your certainty this",
   "finding is real attacker activity, not a false positive, and why.",
+  "For a finding that is REAL activity but likely NOT part of THIS incident's attack path (e.g. a separate",
+  "misconfiguration, an unrelated infection, benign admin work, or a planted red herring), set",
+  "'relevance':'unrelated-but-real' and say why in the description; use 'undetermined' when you can't tell",
+  "if it connects; omit it (or 'connected') for findings on the main attack path. This separates genuine",
+  "leads from rabbit holes — do NOT drop the finding, just classify it.",
   "Shape:",
   "",
   JSON.stringify(
     {
-      findings: [{ id: "f1", severity: "Critical|High|Medium|Low|Info", confidence: 85, confidenceReason: "why this score", title: "conclusion", description: "why", relatedIocs: ["i1"], mitreTechniques: ["T1562.001"], status: "open|confirmed|dismissed", relatedEventIds: ["e3", "e7"] }],
+      findings: [{ id: "f1", severity: "Critical|High|Medium|Low|Info", confidence: 85, confidenceReason: "why this score", title: "conclusion", description: "why", relatedIocs: ["i1"], mitreTechniques: ["T1562.001"], status: "open|confirmed|dismissed", relatedEventIds: ["e3", "e7"], relevance: "connected|unrelated-but-real|undetermined" }],
       iocs: [{ id: "i1", type: "ip|domain|hash|file|process|url|other", value: "the indicator" }],
       mitreTechniques: [{ id: "T1562.001", name: "Impair Defenses: Disable or Modify Tools" }],
       attackerPath: "Initial access at <time> via …; then execution of …; persistence via …; impact at <time>.",
@@ -4328,6 +4334,9 @@ export class AnalysisPipeline {
       .map((t) => `[${t.id}] ${t.description}`)
       .join("\n") || "(none open)";
     const falsePositiveBlock = buildFalsePositiveContext(markers);
+    // Rabbit-hole detection (#13): authorized-test / known-good-tool markers are RETAINED as shaping
+    // context (a sanctioned pentest during the window is signal, not just noise), not merely erased.
+    const authorizedContextBlock = buildAuthorizedContextBlock(markers);
     // Compact, corroborated context (compromised assets + threat-intel verdicts + KEV hits)
     // so the model grounds findings/attacker-path in structure instead of inferring blind.
     const kevCatalog = await this.getKevCatalog();
@@ -4405,7 +4414,7 @@ export class AnalysisPipeline {
     const renderEvent = (e: ForensicEvent) =>
       `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}`;
     const synthOverhead = estimateTokens(getSynthesisPrompt())
-      + estimateTokens(scopeNote + contextBlock + graphBlock + beaconBlock + attackPhaseBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + satisfiedBlock + pinnedBlock + reanswerBlock + existingFindings + openThreads + falsePositiveBlock + (state.lastSummary || "")) + 400;
+      + estimateTokens(scopeNote + contextBlock + graphBlock + beaconBlock + attackPhaseBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + satisfiedBlock + pinnedBlock + reanswerBlock + existingFindings + openThreads + falsePositiveBlock + authorizedContextBlock + (state.lastSummary || "")) + 400;
     const fit = fitItemsToBudget(promptEvents, renderEvent, Math.max(0, inputTokenBudget() - synthOverhead));
     if (fit < promptEvents.length) promptEvents = selectSynthesisEvents(scopedEvents, fit);
 
@@ -4433,6 +4442,7 @@ export class AnalysisPipeline {
       `EXISTING FINDINGS (update by id, do not duplicate):\n${existingFindings}\n\n` +
       `CURRENTLY OPEN THREADS (close by id in threadsClosed when the evidence resolves them):\n${openThreads}\n\n` +
       (falsePositiveBlock ? `${falsePositiveBlock}\n\n` : "") +
+      (authorizedContextBlock ? `${authorizedContextBlock}\n\n` : "") +
       `Running notes: ${state.lastSummary || "(none)"}\n\nReturn the JSON conclusions.`;
 
     const synthStart = Date.now();
@@ -4570,14 +4580,26 @@ export class AnalysisPipeline {
     // Deterministic + idempotent; only ever lowers confidence. Runs last, so it grades the FINAL finding
     // set (incl. backfills + accepted second-opinion deltas).
     {
-      const graphLinkedEventIds = new Set(buildEvidenceGraph(next).edges.flatMap((e) => e.eventIds));
+      const evidenceGraph = buildEvidenceGraph(next);
+      const graphLinkedEventIds = new Set(evidenceGraph.edges.flatMap((e) => e.eventIds));
       const inScope = next.forensicTimeline.filter((e) => eligibleIds.has(e.id));
       const grounded = groundAndScoreFindings({ findings: next.findings, scopedEvents: inScope, iocs: next.iocs, graphLinkedEventIds });
       // Intel-verdict gate (investigation-guidance #7): floor an intel-ONLY High/Critical finding (no
       // behavioral corroboration, all its verdict IOCs lone-intel/conflicted) to Medium/≤60 — the
       // northpeak stale-CTI-on-own-server class. Runs after grounding so it sees the corroboration rollup.
       const hostNames = new Set(buildAssetGraph(next).assets.filter((a) => a.type === "host").map((a) => shortHost(a.name)));
-      next = { ...next, findings: capIntelOnlyFindings({ findings: grounded, iocs: next.iocs, scopedEvents: inScope, hostNames }) };
+      const capped = capIntelOnlyFindings({ findings: grounded, iocs: next.iocs, scopedEvents: inScope, hostNames });
+      // Rabbit-hole detection (investigation-guidance #13): place each finding relative to the corroborated
+      // main attack component. A finding whose graph-modeled evidence sits in a SEPARATE component is a
+      // rabbit-hole candidate ('disconnected'); the model's per-finding relevance verdict refines a
+      // disconnected one into 'unrelated-but-real' (a genuine separate issue) vs undetermined noise. The
+      // deterministic linkage is authoritative; the AI never upgrades a rabbit hole into a lead.
+      const aiRelevanceById = new Map(
+        (delta.findings ?? [])
+          .filter((f): f is typeof f & { relevance: "connected" | "unrelated-but-real" | "undetermined" } => !!f.relevance && surviving.has(f.id))
+          .map((f) => [f.id, f.relevance] as const),
+      );
+      next = { ...next, findings: scoreFindingsRelevance({ findings: capped, scopedEvents: inScope, graph: evidenceGraph, aiRelevanceById }) };
     }
 
     // What this run changed vs the pre-AI findings. Findings are FINAL here — neither persistLatest

--- a/companion/src/analysis/playbook.ts
+++ b/companion/src/analysis/playbook.ts
@@ -67,6 +67,12 @@ function normalizePriority(p: string): StepPriority {
   return (STEP_PRIORITIES as readonly string[]).includes(v) ? (v as StepPriority) : "medium";
 }
 
+// Drop a priority one notch (rabbit-hole down-weight, #13). "low" is the floor.
+function demotePriority(p: StepPriority): StepPriority {
+  const i = STEP_PRIORITIES.indexOf(p);
+  return STEP_PRIORITIES[Math.min(i + 1, STEP_PRIORITIES.length - 1)];
+}
+
 // A next step's `pointer` is free text (e.g. "finding f1; collect from ALClient07") but the LLM
 // consistently cites finding ids as bare "f<n>" tokens per the synthesis prompt's shape example.
 // Pull out the first token that matches a REAL finding id in this case (case-insensitive) — this
@@ -234,19 +240,27 @@ export function derivePlaybookTasks(state: InvestigationState, opts: DeriveOptio
     if (f.status === "dismissed") continue;
     const priority = PRIORITY_FROM_SEVERITY[f.severity] ?? "medium";
     if (priority !== "critical" && priority !== "high") continue;
+    // Rabbit-hole down-weight (investigation-guidance #13): a finding with no causal link to the main
+    // attack path ('disconnected') is a possible rabbit hole — DEMOTE its playbook priority one notch and
+    // reframe it as "verify before chasing" so guidance stops spending top-of-list budget on it, without
+    // hiding it. The deterministic relevance pass already decided this; here we only re-seat it.
+    const rabbitHole = f.relevance === "disconnected";
+    const seedPriority = rabbitHole ? demotePriority(priority) : priority;
     const foldedNotes = foldedNotesByFindingId.get(f.id) ?? [];
     if (opts.useTemplates) {
-      const templateSeeds = buildFindingTemplateSeeds(f);
+      const templateSeeds = buildFindingTemplateSeeds(f).map((t) => rabbitHole ? { ...t, priority: demotePriority(t.priority) } : t);
       appendFoldedNotes(templateSeeds, foldedNotes);
       seeds.push(...templateSeeds);
     } else {
-      const description = foldedNotes.length
-        ? [f.description, `Next step: ${foldedNotes.join("; ")}`].filter(Boolean).join("\n\n")
-        : f.description;
+      const rabbitNote = rabbitHole
+        ? `Possible rabbit hole — no causal link to the main attack path; verify before chasing.${f.relevanceDiscriminator ? ` (${f.relevanceDiscriminator})` : ""}`
+        : "";
+      const description = [f.description, rabbitNote, foldedNotes.length ? `Next step: ${foldedNotes.join("; ")}` : ""]
+        .filter(Boolean).join("\n\n");
       seeds.push({
-        title: `Investigate & remediate: ${f.title}`,
+        title: `${rabbitHole ? "Verify (possible rabbit hole)" : "Investigate & remediate"}: ${f.title}`,
         description,
-        priority,
+        priority: seedPriority,
         source: "finding",
         sourceKey: `finding:${f.id}`,
         relatedFindingId: f.id,

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -29,6 +29,11 @@ export const deltaSchema = z.object({
     // Synthesis only: the forensic-event ids this finding is based on. Used to
     // back-link events to the correct findings (extraction can't know finding ids).
     relatedEventIds: z.array(z.string()).optional(),
+    // Rabbit-hole detection (investigation-guidance #13): the model's relevance verdict for genuine-
+    // but-possibly-unrelated activity. 'unrelated-but-real' = real, but NOT part of THIS incident's
+    // attack path (a separate issue to park); 'undetermined' = unsure. The deterministic connectedness
+    // pass is authoritative for 'connected'/'disconnected'; this only refines a disconnected finding.
+    relevance: z.enum(["connected", "unrelated-but-real", "undetermined"]).optional().catch(undefined),
   })),
   iocs: z.array(z.object({
     id: z.string().min(1),

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -57,6 +57,16 @@ export interface Finding {
   // `corroboration` is the rollup above. Both recomputed every synthesis; persisted for display.
   ungrounded?: boolean;
   corroboration?: FindingCorroboration;
+  // Rabbit-hole detection (investigation-guidance #13). `relevance` places the finding relative to the
+  // corroborated main attack path: 'connected' (on it) → a lead; 'disconnected' (evidence sits in a
+  // separate graph component) → a possible rabbit hole; 'unrelated-but-real' (AI: genuine but a separate
+  // issue) → parked; 'undetermined' (evidence not in the causal graph, or unscored). `connectedness` is
+  // the 0–1 fraction of the finding's graph-modeled evidence that touches the main component.
+  // `relevanceDiscriminator` (disconnected only) names what to look for to tie it into the attack path.
+  // All recomputed every synthesis by scoreFindingsRelevance; persisted for display/grouping.
+  relevance?: "connected" | "disconnected" | "unrelated-but-real" | "undetermined";
+  connectedness?: number;
+  relevanceDiscriminator?: string;
   title: string;
   description: string;
   relatedIocs: string[];        // IOC ids

--- a/companion/tests/analysis/findingRelevance.test.ts
+++ b/companion/tests/analysis/findingRelevance.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { buildEvidenceGraph, connectedComponents, mainComponent } from "../../src/analysis/evidenceGraph.js";
+import { scoreFindingsRelevance, relevanceBucket, type AiRelevance } from "../../src/analysis/findingRelevance.js";
+import { emptyState, type Finding, type ForensicEvent, type InvestigationState } from "../../src/analysis/stateTypes.js";
+
+function ev(partial: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return { timestamp: "2026-01-02T10:00:00Z", description: "", severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...partial };
+}
+function finding(partial: Partial<Finding> & { id: string }): Finding {
+  return {
+    severity: "High", title: "f", description: "", relatedIocs: [], sourceScreenshots: [], mitreTechniques: [],
+    firstSeen: "2026-01-01T00:00:00Z", lastUpdated: "2026-01-01T00:00:00Z", status: "open", ...partial,
+  };
+}
+
+// Two disconnected islands: a HOST-A process tree (the corroborated Critical mass = main component) and
+// a separate HOST-B tree (a lesser, unconnected island).
+function twoIslandState(): InvestigationState {
+  const s = emptyState("c1");
+  s.forensicTimeline = [
+    ev({ id: "e1", asset: "HOST-A", parentName: "excel.exe", processName: "powershell.exe", severity: "Critical" }),
+    ev({ id: "e2", asset: "HOST-A", parentName: "powershell.exe", processName: "cmd.exe", severity: "High" }),
+    ev({ id: "e3", asset: "HOST-B", parentName: "chrome.exe", processName: "updater.exe", severity: "Medium" }),
+  ];
+  return s;
+}
+
+describe("connectedComponents / mainComponent", () => {
+  it("splits the graph into the two islands and picks the Crit/High mass as main", () => {
+    const graph = buildEvidenceGraph(twoIslandState());
+    const comps = connectedComponents(graph);
+    expect(comps.length).toBe(2);
+    const main = mainComponent(graph)!;
+    expect(main).not.toBeNull();
+    // The main component carries HOST-A's events (the Critical/High tree), not HOST-B's.
+    expect(main.eventIds.has("e1")).toBe(true);
+    expect(main.eventIds.has("e2")).toBe(true);
+    expect(main.eventIds.has("e3")).toBe(false);
+  });
+
+  it("returns null main for a graph with no edges", () => {
+    expect(mainComponent(buildEvidenceGraph(emptyState("c1")))).toBeNull();
+  });
+});
+
+describe("scoreFindingsRelevance (#13)", () => {
+  const state = twoIslandState();
+  const graph = buildEvidenceGraph(state);
+
+  it("marks a finding on the main path 'connected' (connectedness 1)", () => {
+    const [f] = scoreFindingsRelevance({ findings: [finding({ id: "fA", relatedEventIds: ["e1"] })], scopedEvents: state.forensicTimeline, graph });
+    expect(f.relevance).toBe("connected");
+    expect(f.connectedness).toBe(1);
+    expect(f.relevanceDiscriminator).toBeUndefined();
+  });
+
+  it("marks a finding whose evidence sits in a SEPARATE component 'disconnected' with a discriminator", () => {
+    const [f] = scoreFindingsRelevance({ findings: [finding({ id: "fB", relatedEventIds: ["e3"] })], scopedEvents: state.forensicTimeline, graph });
+    expect(f.relevance).toBe("disconnected");
+    expect(f.connectedness).toBe(0);
+    expect(f.relevanceDiscriminator).toContain("to link it, look for");
+    expect(relevanceBucket(f.relevance)).toBe("rabbit-hole");
+  });
+
+  it("marks a finding whose evidence is NOT in the causal graph 'undetermined' (never a false rabbit hole)", () => {
+    const [f] = scoreFindingsRelevance({ findings: [finding({ id: "fC", relatedEventIds: ["e9"] })], scopedEvents: state.forensicTimeline, graph });
+    expect(f.relevance).toBe("undetermined");
+    expect(relevanceBucket(f.relevance)).toBe("lead"); // undetermined stays a possible lead, not hidden
+  });
+
+  it("lets the AI refine a disconnected finding into 'unrelated-but-real' (Parked), but never a rabbit hole into a lead", () => {
+    const ai = new Map<string, AiRelevance>([["fB", "unrelated-but-real"], ["fA", "unrelated-but-real"]]);
+    const scored = scoreFindingsRelevance({ findings: [finding({ id: "fA", relatedEventIds: ["e1"] }), finding({ id: "fB", relatedEventIds: ["e3"] })], scopedEvents: state.forensicTimeline, graph, aiRelevanceById: ai });
+    expect(scored.find((f) => f.id === "fB")!.relevance).toBe("unrelated-but-real"); // disconnected + AI → parked
+    expect(scored.find((f) => f.id === "fA")!.relevance).toBe("connected");           // graph linkage wins over AI
+  });
+
+  it("resolves reverse finding links (event → finding) as evidence too", () => {
+    const s2 = twoIslandState();
+    s2.forensicTimeline[0].relatedFindingIds = ["fRev"]; // e1 (main) names fRev, which has no forward links
+    const [f] = scoreFindingsRelevance({ findings: [finding({ id: "fRev" })], scopedEvents: s2.forensicTimeline, graph: buildEvidenceGraph(s2) });
+    expect(f.relevance).toBe("connected");
+  });
+});

--- a/companion/tests/analysis/rabbitHoleSurfaces.test.ts
+++ b/companion/tests/analysis/rabbitHoleSurfaces.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { buildAuthorizedContextBlock, buildFalsePositiveContext, type FalsePositiveMarker } from "../../src/analysis/falsePositive.js";
+import { derivePlaybookTasks } from "../../src/analysis/playbook.js";
+import { emptyState, type Finding, type InvestigationState } from "../../src/analysis/stateTypes.js";
+
+function marker(partial: Partial<FalsePositiveMarker> & { kind: FalsePositiveMarker["kind"]; ref: string; reason: FalsePositiveMarker["reason"] }): FalsePositiveMarker {
+  return { id: `${partial.kind}:${partial.ref}`, note: "", markedAt: "2026-01-01T00:00:00Z", markedBy: "a", ...partial };
+}
+
+describe("buildAuthorizedContextBlock (#13 FP-context retention)", () => {
+  it("retains authorized-test / known-good-tool markers as shaping context, not erasure", () => {
+    const markers = [
+      marker({ kind: "finding", ref: "Nessus scan burst", reason: "authorized-test", note: "quarterly pentest" }),
+      marker({ kind: "ioc", ref: "10.0.0.9", reason: "known-good-tool", note: "vuln scanner" }),
+      marker({ kind: "finding", ref: "random noise", reason: "detection-misfire" }),   // not retained
+    ];
+    const block = buildAuthorizedContextBlock(markers);
+    expect(block).toContain("SANCTIONED ACTIVITY CONTEXT");
+    expect(block).toContain("Nessus scan burst");
+    expect(block).toContain("10.0.0.9");
+    expect(block).not.toContain("random noise");        // detection-misfire is pure exclusion, not context
+    // Attacker-hides-in-sanctioned-tooling caveat is present so overlap isn't dismissed.
+    expect(block.toLowerCase()).toContain("attackers hide");
+  });
+
+  it("returns '' when there are no authorized/known-good markers", () => {
+    expect(buildAuthorizedContextBlock([marker({ kind: "finding", ref: "x", reason: "duplicate" })])).toBe("");
+  });
+
+  it("does not change the pure-exclusion block's behavior", () => {
+    const m = [marker({ kind: "finding", ref: "malware X", reason: "authorized-test", note: "n" })];
+    // The exclusion block still lists it (belt and suspenders); the context block adds the nuance.
+    expect(buildFalsePositiveContext(m)).toContain("malware X");
+  });
+});
+
+describe("derivePlaybookTasks rabbit-hole down-weight (#13)", () => {
+  function highFinding(id: string, relevance?: Finding["relevance"]): Finding {
+    return {
+      id, severity: "High", title: `finding ${id}`, description: "d", relatedIocs: [], sourceScreenshots: [],
+      mitreTechniques: [], firstSeen: "2026-01-01T00:00:00Z", lastUpdated: "2026-01-01T00:00:00Z", status: "open",
+      ...(relevance ? { relevance } : {}),
+    };
+  }
+
+  it("demotes a disconnected High finding one notch and reframes it as verify-before-chasing", () => {
+    const state: InvestigationState = { ...emptyState("c1"), findings: [highFinding("f1"), highFinding("f2", "disconnected")] };
+    const seeds = derivePlaybookTasks(state);
+    const lead = seeds.find((s) => s.relatedFindingId === "f1")!;
+    const rabbit = seeds.find((s) => s.relatedFindingId === "f2")!;
+    expect(lead.priority).toBe("high");
+    expect(rabbit.priority).toBe("medium");            // High demoted one notch
+    expect(rabbit.title).toContain("possible rabbit hole");
+    expect(rabbit.description).toContain("no causal link");
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -931,6 +931,10 @@
     /* Immediate FP cascade (#12): a conclusion neutralized the instant a supporting finding was marked
        false positive, pending the queued re-synthesis. */
     .stale-badge { color: var(--c-ffd93b); font-size: 11px; font-weight: 600; white-space: nowrap; }
+    /* Rabbit-hole detection (#13): relevance chips on findings. */
+    .rel-chip { font-size: 10px; font-weight: 600; border-radius: 4px; padding: 0 6px; white-space: nowrap; cursor: help; }
+    .rel-rabbit { color: var(--c-ffb454, #ffb454); border: 1px solid var(--c-5a4a2a, #5a4a2a); background: var(--c-2a2410, #2a2410); }
+    .rel-parked { color: var(--c-9aa4b2); border: 1px solid var(--c-2a3146); background: var(--c-141821, #141821); }
     .hyp-needs-review { color: var(--c-ffd93b); font-size: 11px; font-weight: 600; margin-left: 6px; }
     /* Raw-file (EVTX/PCAP) prompt banner — prominent, at the top of the content. #211 */
     .raw-banner { font-size: 13px; color: var(--c-e6e9ef); margin: 0 0 12px; padding: 11px 14px;
@@ -13140,7 +13144,11 @@
       const notFp = fpFindingTitles.size
         ? (state.findings || []).filter(f => !isFindingFalsePositive(f.title, fpFindingTitles))
         : (state.findings || []);
-      const sorted = [...notFp].sort((a, b) => SEV.indexOf(a.severity) - SEV.indexOf(b.severity));
+      // Rabbit-hole grouping (investigation-guidance #13): leads (connected/undetermined) first, then
+      // Parked (unrelated-but-real), then Possible rabbit holes (disconnected) — so guidance sinks
+      // findings with no causal link to the attack path below the real leads. Severity orders within each.
+      const relRank = f => f.relevance === "disconnected" ? 2 : f.relevance === "unrelated-but-real" ? 1 : 0;
+      const sorted = [...notFp].sort((a, b) => (relRank(a) - relRank(b)) || (SEV.indexOf(a.severity) - SEV.indexOf(b.severity)));
       const minConf = parseInt(document.getElementById("confFilter").value, 10) || 0;
       // Corroboration lens (#35): a finding's sources are the union of its supporting events' tools.
       const _findingCorrob = (f) => {
@@ -13207,13 +13215,22 @@
           const chevron = `<button type="button" class="finding-chevron" data-fev-toggle="${escAttr(f.id)}" title="Expand evidence"${hasEvidence ? "" : " disabled"}>` +
             `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 3l5 5-5 5"/></svg></button>`;
           const tagPillsHtml = tagPills("finding", f.id);
+          // Rabbit-hole detection (investigation-guidance #13): a chip that names the finding's relation
+          // to the main attack path. 'disconnected' = possible rabbit hole (with the "look for" chip);
+          // 'unrelated-but-real' = parked (a genuine but separate issue). Leads carry no chip (default).
+          let relChip = "";
+          if (f.relevance === "disconnected") {
+            relChip = ` <span class="rel-chip rel-rabbit" title="${escAttr(f.relevanceDiscriminator || "No causal link to the main attack path — verify before chasing.")}">🕳️ possible rabbit hole — verify before chasing</span>`;
+          } else if (f.relevance === "unrelated-but-real") {
+            relChip = ` <span class="rel-chip rel-parked" title="Genuine activity, but not part of this incident's attack path — parked.">🅿️ parked — real but unrelated</span>`;
+          }
           return `<div class="finding${isSelFinding ? " finding-selected" : ""}" data-fid="${escAttr(f.id)}">` +
             chevron +
             `<input type="checkbox" class="finding-cb finding-row-cb" data-fid="${escAttr(f.id)}" ${isSelFinding ? "checked" : ""} title="Select finding" />` +
             `<span class="finding-sev-cell sev-${esc(f.severity)}"><span class="fsq"></span>${esc(f.severity)}</span>` +
             `<span class="finding-id-cell" title="${escAttr(f.id)}">${esc(f.id)}</span>` +
             `<span class="finding-main-cell">` +
-              `<span class="finding-title"><strong>${esc(f.title)}</strong>${auto}</span>` +
+              `<span class="finding-title"><strong>${esc(f.title)}</strong>${auto}${relChip}</span>` +
               `<span class="finding-desc" title="${escAttr(f.description)}">${esc(f.description)}</span>` +
               (tagPillsHtml ? `<span class="finding-tagline">${tagPillsHtml}</span>` : "") +
             `</span>` +


### PR DESCRIPTION
## What & why

Tier 3 item of the [investigation-guidance roadmap](INVESTIGATION_GUIDANCE_ROADMAP.md). The direct answer to **"which findings are rabbit holes?"** — a taxonomy that simply didn't exist. veridia's planted red herring became a High finding; halcyon's benign USB copy was indistinguishable from the real exfil.

## How it works

**Deterministic half** — `connectedComponents()` + `mainComponent()` on the evidence graph (the connected component holding the corroborated Critical/High attack mass). Per-finding **connectedness** = fraction of its graph-modeled evidence touching the main component:
- evidence in the main component → `connected` (a lead)
- evidence in a **separate** component → `disconnected` (a rabbit-hole candidate)
- evidence **not in the causal graph at all** → `undetermined` — we never brand a finding a rabbit hole just because its evidence type isn't one the graph models.

**AI half** — an optional per-finding `relevance` enum (`connected | unrelated-but-real | undetermined`) in the delta + a prompt section. The graph is authoritative about linkage (the AI can never upgrade a rabbit hole into a lead); the AI only refines a *disconnected* finding into a genuine-but-separate issue (**parked**) vs undetermined noise.

**FP-context retention** — `authorized-test` / `known-good-tool` markers become a retained **SANCTIONED ACTIVITY CONTEXT** block fed to synthesis (a pentest during the window is investigation-shaping context, and exactly what an attacker hides behind), instead of pure erasure.

## Surfaces
- **Findings list** sorts leads → parked → rabbit-holes, each with a chip: **"🕳️ possible rabbit hole — to link it, look for: `<shared host / hash / account / network flow>`"** or **"🅿️ parked — real but unrelated"**.
- **Playbook** demotes a disconnected finding one priority notch and reframes it "verify before chasing", so guidance stops spending top-of-list budget on it (without hiding it).

## Files
- `analysis/findingRelevance.ts` (new) — `scoreFindingsRelevance`, `relevanceBucket`.
- `analysis/evidenceGraph.ts` — `connectedComponents`, `mainComponent`, `componentHostLabels`.
- `analysis/falsePositive.ts` — `buildAuthorizedContextBlock`.
- `analysis/pipeline.ts` — relevance pass (reuses the grounding graph) + prompt + context block.
- `analysis/responseSchema.ts` — `relevance` enum on findings; `analysis/stateTypes.ts` — `relevance`/`connectedness`/`relevanceDiscriminator` on `Finding`.
- `analysis/playbook.ts` — rabbit-hole down-weight.
- `public/dashboard.html` — grouping sort + relevance chips.

## Tests
- `tests/analysis/findingRelevance.test.ts` (7): components/main, connected/disconnected/undetermined, AI refinement (graph wins over AI), reverse links.
- `tests/analysis/rabbitHoleSurfaces.test.ts` (4): authorized-context retention, playbook down-weight.
- Full companion suite green (**3620**), clean `tsc`.

## Test plan
From `companion/` on this branch (`gh pr checkout <this-PR>` first):
- `npx vitest run tests/analysis/findingRelevance.test.ts tests/analysis/rabbitHoleSurfaces.test.ts`
- `npx vitest run` (full) · `npx tsc --noEmit`

Part of #13 (roadmap Tier 3).