### PR TITLE
feat: ACH-style hypotheses — contradictions, discriminators, exhaustion (#14)

### DIFF
--- a/INVESTIGATION_GUIDANCE_ROADMAP.md
+++ b/INVESTIGATION_GUIDANCE_ROADMAP.md
@@ -1,17 +1,19 @@
 # Making DFIR-Companion Lead the Investigation
 
-> **Implementation status (Tier 0–2 + Tier 3 #12–#13 shipped and merged to master).** Proposals
-> #1–#13 are implemented, unit-tested, and merged (PRs #96–#99, #102, #103 for #1–#10; #11 = the
-> second-look loop; #12 = the immediate FP cascade; #13 = rabbit-hole detection). Full suite green
-> (3620 tests), clean `tsc`. Deferred within those items (documented
+> **Implementation status (Tier 0–2 + Tier 3 #12–#14 shipped and merged to master).** Proposals
+> #1–#14 are implemented, unit-tested, and merged (PRs #96–#99, #102, #103 for #1–#10; #11 = the
+> second-look loop; #12 = the immediate FP cascade; #13 = rabbit-hole detection; #14 = ACH-style
+> hypotheses). Full suite green (3626 tests), clean `tsc`. Deferred within those items (documented
 > in each commit): the `~` context-prefix prompt notation and per-class counts into synthMeta (#4); the
 > anchor-scoring bump retune and the auto-generated "corroborate `<ioc>`" nextStep (#7); #10 trigger (b)
-> cap-hit truncation; #11 report-side surfacing of collection leads (kept on the live dashboard only).
+> cap-hit truncation; #11 report-side surfacing of collection leads (kept on the live dashboard only);
+> #14 threading an explicit `relatedHypothesisId` through the hunt-DEPLOY route/UI (exhaustion works
+> today via technique-overlap matching; the explicit link field exists but isn't set from the UI yet).
 > **One operational step remains for #1:** the live `companion/prompts/*.txt` override files are
 > gitignored deployment artifacts — regenerate them with `npm run prompts:eject` so the deployment picks
 > up the built-in prompt (hypotheses / confidenceReason / structured-tag & attack-graph / #8 collect /
 > #11 evidenceRequests instructions). Until then the drift-detection check warns on every preflight and
-> synthesis run. **Tier 3 remaining: #14–#15** as specified below.
+> synthesis run. **Tier 3 remaining: #15** (the last item) as specified below.
 
 **Goal.** Make the Companion genuinely lead an investigation — better decisions, higher recall of
 what actually happened, better dot-connecting, a working FP / rabbit-hole / real-lead triage, the

--- a/companion/src/analysis/huntOutcomes.ts
+++ b/companion/src/analysis/huntOutcomes.ts
@@ -31,6 +31,10 @@ export interface HuntOutcome {
   deployedAt: string;         // ISO
   status: HuntOutcomeStatus;
   foundEvidence?: boolean;    // collected: did the hunt return ANY rows / add any new events or IOCs
+  // ACH-style hypotheses (investigation-guidance #14): the hypothesis this hunt was deployed to test, so
+  // a hunt that comes back empty counts as a MISS against it (→ eventual `exhausted`). Optional — most
+  // hunts aren't tied to a specific hypothesis and fall back to technique-overlap matching.
+  relatedHypothesisId?: string;
   resultRows?: number;        // collected: total rows the hunt returned (what the analyst sees) — a snapshot, not cumulative
   addedEvents?: number;       // collected: events NEW to the case after dedup (cumulative across re-collects)
   addedIocs?: number;         // collected: IOCs new to the case (cumulative)
@@ -79,6 +83,7 @@ export interface HuntDeployInput {
   vql?: string;
   mitreTechniques?: string[];
   huntId?: string;
+  relatedHypothesisId?: string;  // ACH (#14): the hypothesis this hunt tests, when deployed from one
   deployedAt: string;         // ISO (the route stamps it — keeps this module time-free)
 }
 
@@ -101,6 +106,7 @@ export function recordDeploy(
     vqlPreview: input.vql ? normalizeVql(input.vql).slice(0, MAX_VQL_PREVIEW_LEN) : "",
     mitreTechniques: dedupeStrings((input.mitreTechniques ?? []).map((t) => String(t).trim()).filter(Boolean)).slice(0, 20),
     ...(huntId ? { huntId } : {}),
+    ...(input.relatedHypothesisId ? { relatedHypothesisId: String(input.relatedHypothesisId).trim() } : {}),
     deployedAt: input.deployedAt,
     status: "deployed",
   };

--- a/companion/src/analysis/hypothesis.ts
+++ b/companion/src/analysis/hypothesis.ts
@@ -39,6 +39,17 @@ export const hypothesisSchema = z.object({
   relatedTechniques: z.array(z.string()).default([]).catch([]), // ATT&CK ids (T1566, T1021.006…)
   relatedEventIds: z.array(z.string()).default([]).catch([]),   // supporting forensic-event ids
   relatedIocIds: z.array(z.string()).default([]).catch([]),     // implicated IOC ids
+  // ACH-style analysis (investigation-guidance #14). `contradictingEventIds` are events INCONSISTENT
+  // with this explanation — tracked so a hypothesis is judged by fewest contradictions (ACH), not most
+  // support, and a red herring can't sail through unopposed. `discriminator` names the single artifact
+  // (host + artifact) that would best separate this hypothesis from the leading alternative — it doubles
+  // as a concrete collection directive. `exhausted` is set deterministically once N linked hunts came
+  // back empty against `expectedOutcome` (see markExhaustedHypotheses) → it feeds the negative-knowledge
+  // synthesis block; `exhaustedReason` is the human one-liner.
+  contradictingEventIds: z.array(z.string()).default([]).catch([]),
+  discriminator: z.string().default("").catch(""),
+  exhausted: z.boolean().default(false).catch(false),
+  exhaustedReason: z.string().default("").catch(""),
   assignee: z.string().default("").catch(""),
   notes: z.string().default("").catch(""),
   source: z.enum(HYPOTHESIS_SOURCES).default("analyst").catch("analyst"),
@@ -71,6 +82,8 @@ export interface HypothesisSeed {
   relatedTechniques: string[];
   relatedEventIds: string[];
   relatedIocIds: string[];
+  contradictingEventIds: string[]; // ACH (#14): events inconsistent with this explanation
+  discriminator: string;           // ACH (#14): the artifact (host + artifact) that best separates it
 }
 
 // Fields an analyst may set when creating a hypothesis by hand (or promoting a notebook entry).
@@ -98,6 +111,8 @@ export type HypothesisPatch = Partial<
     | "relatedTechniques"
     | "relatedEventIds"
     | "relatedIocIds"
+    | "contradictingEventIds"
+    | "discriminator"
     | "assignee"
     | "notes"
   >
@@ -164,6 +179,9 @@ export function sanitizeHypotheses(
       relatedTechniques: dedupeStrings(h.relatedTechniques as string[]).slice(0, MAX_TECHNIQUES),
       relatedEventIds: dedupeStrings(h.relatedEventIds as string[]).filter((id) => validEventIds.has(id)).slice(0, MAX_LINKS),
       relatedIocIds: dedupeStrings(h.relatedIocIds as string[]).filter((id) => validIocIds.has(id)).slice(0, MAX_LINKS),
+      // ACH (#14): contradicting events must be REAL case events too (no invented refs); discriminator is prose.
+      contradictingEventIds: dedupeStrings(h.contradictingEventIds as string[]).filter((id) => validEventIds.has(id)).slice(0, MAX_LINKS),
+      discriminator: String(h.discriminator ?? "").trim().slice(0, MAX_TEXT_LEN),
     });
     if (out.length >= cap) break;
   }
@@ -187,9 +205,11 @@ function seedDiffersFrom(h: Hypothesis, seed: HypothesisSeed): boolean {
     h.description !== seed.description ||
     h.expectedOutcome !== seed.expectedOutcome ||
     h.status !== seed.status ||
-    h.relatedTechniques.join(" ") !== seed.relatedTechniques.join(" ") ||
-    h.relatedEventIds.join(" ") !== seed.relatedEventIds.join(" ") ||
-    h.relatedIocIds.join(" ") !== seed.relatedIocIds.join(" ")
+    h.relatedTechniques.join(" ") !== seed.relatedTechniques.join(" ") ||
+    h.relatedEventIds.join(" ") !== seed.relatedEventIds.join(" ") ||
+    h.relatedIocIds.join(" ") !== seed.relatedIocIds.join(" ") ||
+    h.contradictingEventIds.join(" ") !== (seed.contradictingEventIds ?? []).join(" ") ||
+    h.discriminator !== (seed.discriminator ?? "")
   );
 }
 
@@ -223,6 +243,8 @@ export function mergeHypotheses(
           relatedTechniques: [...seed.relatedTechniques],
           relatedEventIds: [...seed.relatedEventIds],
           relatedIocIds: [...seed.relatedIocIds],
+          contradictingEventIds: [...(seed.contradictingEventIds ?? [])],   // ACH (#14)
+          discriminator: seed.discriminator ?? "",
           needsReview: false,   // authoritative refresh clears any interim FP-cascade flag (#12)
           updatedAt: now,
         };
@@ -238,6 +260,10 @@ export function mergeHypotheses(
         relatedTechniques: [...seed.relatedTechniques],
         relatedEventIds: [...seed.relatedEventIds],
         relatedIocIds: [...seed.relatedIocIds],
+        contradictingEventIds: [...(seed.contradictingEventIds ?? [])],   // ACH (#14)
+        discriminator: seed.discriminator ?? "",
+        exhausted: false,
+        exhaustedReason: "",
         assignee: "",
         notes: "",
         source: "synthesis",
@@ -297,6 +323,10 @@ export function buildAnalystHypothesis(
     relatedTechniques: dedupeStrings(input.relatedTechniques).slice(0, MAX_TECHNIQUES),
     relatedEventIds: dedupeStrings(input.relatedEventIds).slice(0, MAX_LINKS),
     relatedIocIds: dedupeStrings(input.relatedIocIds).slice(0, MAX_LINKS),
+    contradictingEventIds: [],
+    discriminator: "",
+    exhausted: false,
+    exhaustedReason: "",
     assignee: String(input.assignee ?? "").trim(),
     notes: String(input.notes ?? "").trim().slice(0, MAX_TEXT_LEN),
     source: "analyst",
@@ -320,6 +350,8 @@ export function applyHypothesisPatch(h: Hypothesis, patch: HypothesisPatch, now:
     ...(patch.relatedTechniques !== undefined ? { relatedTechniques: dedupeStrings(patch.relatedTechniques).slice(0, MAX_TECHNIQUES) } : {}),
     ...(patch.relatedEventIds !== undefined ? { relatedEventIds: dedupeStrings(patch.relatedEventIds).slice(0, MAX_LINKS) } : {}),
     ...(patch.relatedIocIds !== undefined ? { relatedIocIds: dedupeStrings(patch.relatedIocIds).slice(0, MAX_LINKS) } : {}),
+    ...(patch.contradictingEventIds !== undefined ? { contradictingEventIds: dedupeStrings(patch.contradictingEventIds).slice(0, MAX_LINKS) } : {}),
+    ...(patch.discriminator !== undefined ? { discriminator: String(patch.discriminator).trim().slice(0, MAX_TEXT_LEN) } : {}),
     ...(patch.assignee !== undefined ? { assignee: String(patch.assignee).trim() } : {}),
     ...(patch.notes !== undefined ? { notes: String(patch.notes).trim().slice(0, MAX_TEXT_LEN) } : {}),
     analystTouched: true,
@@ -362,6 +394,71 @@ export function reconsiderHypotheses(
       ...h,
       needsReview: true,
       ...(flipStatus ? { status: "unknown" as HypothesisStatus } : {}),
+      updatedAt: now,
+    };
+  });
+  return { hypotheses: next, changed };
+}
+
+// ACH ranking (investigation-guidance #14). Analysis of Competing Hypotheses ranks by FEWEST
+// contradictions, not most support — the explanation that survives the most disconfirming evidence
+// wins, which is exactly what stops a well-supported-but-wrong red herring from topping the list.
+// Exhausted / refuted hypotheses sink (they're negative knowledge). Pure; returns a sorted COPY.
+export function rankHypothesesAch(hypotheses: readonly Hypothesis[]): Hypothesis[] {
+  const dead = (h: Hypothesis): number => (h.exhausted || h.status === "refuted" ? 1 : 0);
+  return hypotheses.slice().sort((a, b) =>
+    dead(a) - dead(b) ||
+    a.contradictingEventIds.length - b.contradictingEventIds.length ||   // fewest contradictions first
+    b.relatedEventIds.length - a.relatedEventIds.length ||               // then most support
+    a.title.localeCompare(b.title));
+}
+
+// One hunting signal against a hypothesis (investigation-guidance #14): a collected hunt either tied to
+// the hypothesis explicitly (`relatedHypothesisId`) or matched to it by shared ATT&CK technique, and
+// whether it MISSED (returned no evidence for the thing the hypothesis predicted).
+export interface HypothesisHuntSignal {
+  relatedHypothesisId?: string;
+  techniques: string[];
+  missed: boolean;      // true = the hunt came back empty (negative evidence for what it tested)
+  title?: string;       // for the exhaustion reason
+}
+
+export interface MarkExhaustedResult {
+  hypotheses: Hypothesis[];
+  changed: boolean;
+}
+
+// Mark a hypothesis `exhausted` once enough hunts that tested it came back EMPTY (investigation-guidance
+// #14): its `expectedOutcome` has been hunted for and not found. A hunt matches a hypothesis by an
+// explicit `relatedHypothesisId`, else by shared ATT&CK technique. Only OPEN hypotheses are exhausted
+// (a supported/refuted one is already resolved). `exhausted` is an orthogonal flag, NOT a status change,
+// so it respects the analyst-freeze contract while still feeding the negative-knowledge synthesis block.
+// Pure + idempotent — re-running with the same signals is a no-op.
+export function markExhaustedHypotheses(
+  hypotheses: readonly Hypothesis[],
+  signals: readonly HypothesisHuntSignal[],
+  now: string,
+  minMisses = 2,
+): MarkExhaustedResult {
+  const threshold = Math.max(1, Math.floor(minMisses));
+  let changed = false;
+  const next = hypotheses.map((h) => {
+    if (h.status !== "open" || h.exhausted) return h;
+    const techniqueSet = new Set(h.relatedTechniques);
+    let misses = 0;
+    for (const s of signals) {
+      if (!s.missed) continue;
+      const matches = s.relatedHypothesisId
+        ? s.relatedHypothesisId === h.id
+        : s.techniques.some((t) => techniqueSet.has(t));
+      if (matches) misses += 1;
+    }
+    if (misses < threshold) return h;
+    changed = true;
+    return {
+      ...h,
+      exhausted: true,
+      exhaustedReason: `${misses} hunt(s) for its expected outcome came back empty — no supporting evidence found`,
       updatedAt: now,
     };
   });

--- a/companion/src/analysis/hypothesisStore.ts
+++ b/companion/src/analysis/hypothesisStore.ts
@@ -9,11 +9,13 @@ import {
   type NewHypothesis,
   type HypothesisPatch,
   type ReconsiderHypothesesInput,
+  type HypothesisHuntSignal,
   hypothesesSchema,
   mergeHypotheses,
   buildAnalystHypothesis,
   applyHypothesisPatch,
   reconsiderHypotheses,
+  markExhaustedHypotheses,
 } from "./hypothesis.js";
 
 // Per-case hypothesis store (issue #140). Persists `state/hypotheses.json` via the atomic-write
@@ -98,6 +100,21 @@ export class HypothesisStore {
   ): Promise<{ changed: boolean; hypotheses: Hypothesis[] }> {
     const existing = await this.load(caseId);
     const { hypotheses, changed } = reconsiderHypotheses(existing, input, now);
+    if (changed) await this.save(caseId, hypotheses);
+    return { changed, hypotheses };
+  }
+
+  // ACH exhaustion (investigation-guidance #14): flag open hypotheses whose linked/technique-matched
+  // hunts have come back empty enough times (see markExhaustedHypotheses). Persists only when something
+  // changed. Called from synthesis so the negative-knowledge block reflects it.
+  async applyExhaustion(
+    caseId: string,
+    signals: readonly HypothesisHuntSignal[],
+    now: string = new Date().toISOString(),
+    minMisses?: number,
+  ): Promise<{ changed: boolean; hypotheses: Hypothesis[] }> {
+    const existing = await this.load(caseId);
+    const { hypotheses, changed } = markExhaustedHypotheses(existing, signals, now, minMisses);
     if (changed) await this.save(caseId, hypotheses);
     return { changed, hypotheses };
   }

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -615,6 +615,11 @@ export const SYNTHESIS_PROMPT = [
   "  'refuted' if it contradicts it, else 'open'), 'relatedTechniques' (ATT&CK ids), and the supporting",
   "  'relatedEventIds' / 'relatedIocIds'. Propose hypotheses even for gaps the evidence does NOT yet",
   "  resolve (status 'open') — those drive the next collection. Use the event/ioc ids shown below.",
+  "  ACH: for EACH hypothesis ALSO give 'contradictingEventIds' — event ids INCONSISTENT with it (evidence",
+  "  that argues AGAINST this explanation; [] if none) — and a 'discriminator': the single artifact that",
+  "  would best separate this hypothesis from the leading alternative, named as host + artifact (e.g.",
+  "  'Security.evtx 4648 on FS01'). Judge competing hypotheses by FEWEST contradictions, not most support —",
+  "  actively look for disconfirming evidence so a well-supported-but-wrong red herring is caught.",
   "- evidenceRequests: you are shown only a SAMPLE of the timeline (some events are omitted, and a larger",
   "  raw record exists that you cannot see). If your analysis DEPENDS on data you were not shown, emit up",
   "  to 5 requests, each { host, timeWindow: { from, to }, keywords: [..], reason }. Each is resolved AFTER",
@@ -655,8 +660,8 @@ export const SYNTHESIS_PROMPT = [
         { id: "n2", priority: "high", action: "Sandbox-detonate Bubeus.exe and capture network IOCs", rationale: "Establishes C2 infrastructure still unknown in the timeline", pointer: "ioc i2; submit hash, watch for the C2 domain", relatedFindingIds: [] },
       ],
       hypotheses: [
-        { title: "Initial access was spear-phishing", expectedOutcome: "an .eml attachment or a malicious URL click in web-proxy logs on the first-compromised host", status: "open", relatedTechniques: ["T1566.001"], relatedEventIds: ["e3"], relatedIocIds: ["i1"] },
-        { title: "Data was staged before exfiltration", expectedOutcome: "an archive (.zip/.7z/.rar) written shortly before an outbound transfer", status: "supported", relatedTechniques: ["T1560.001"], relatedEventIds: ["e7"], relatedIocIds: [] },
+        { title: "Initial access was spear-phishing", expectedOutcome: "an .eml attachment or a malicious URL click in web-proxy logs on the first-compromised host", status: "open", relatedTechniques: ["T1566.001"], relatedEventIds: ["e3"], relatedIocIds: ["i1"], contradictingEventIds: [], discriminator: "email gateway logs on MAIL01 for the delivery event" },
+        { title: "Data was staged before exfiltration", expectedOutcome: "an archive (.zip/.7z/.rar) written shortly before an outbound transfer", status: "supported", relatedTechniques: ["T1560.001"], relatedEventIds: ["e7"], relatedIocIds: [], contradictingEventIds: ["e9"], discriminator: "$MFT on FS01 for the archive-creation timestamp" },
       ],
       evidenceRequests: [
         { host: "FS01", timeWindow: { from: "2025-04-27T00:00Z", to: "2025-04-28T00:00Z" }, keywords: ["rsync", "nfs-01", ".zip"], reason: "confirm the staging→exfil hypothesis with archive-write + outbound-transfer rows not shown above" },
@@ -4276,9 +4281,23 @@ export class AnalysisPipeline {
     // analyst ruled out must not be re-asserted or re-opened. Loaded from the same store, once.
     let refutedHypothesesBlock = "";
     if (this.opts.hypothesisStore) {
+      // ACH exhaustion (investigation-guidance #14): before reading, flag hypotheses whose linked or
+      // technique-matched hunts have come back empty — so the negative-knowledge block below and the
+      // "to test" list reflect them. Derived from collected hunt outcomes; persisted; idempotent.
+      const exhaustionOutcomes = await this.loadHuntOutcomes(caseId);
+      const huntSignals = exhaustionOutcomes
+        .filter((o) => o.status === "collected")
+        .map((o) => ({
+          ...(o.relatedHypothesisId ? { relatedHypothesisId: o.relatedHypothesisId } : {}),
+          techniques: o.mitreTechniques ?? [],
+          missed: o.foundEvidence === false,
+          title: o.title,
+        }));
+      if (huntSignals.some((s) => s.missed)) await this.opts.hypothesisStore.applyExhaustion(caseId, huntSignals);
+
       const allHypotheses = await this.opts.hypothesisStore.load(caseId);
       const open = allHypotheses
-        .filter((h) => h.status === "open" && (h.source === "analyst" || h.analystTouched))
+        .filter((h) => h.status === "open" && !h.exhausted && (h.source === "analyst" || h.analystTouched))
         .slice(0, 15);
       if (open.length) {
         analystHypothesesBlock =

--- a/companion/src/analysis/priorWork.ts
+++ b/companion/src/analysis/priorWork.ts
@@ -44,16 +44,26 @@ export function renderRefutedHypothesesBlock(hypotheses: readonly Hypothesis[], 
   const refuted = (hypotheses ?? []).filter(
     (h) => h.status === "refuted" && (h.source === "analyst" || h.analystTouched),
   );
-  if (!refuted.length) return "";
+  // ACH exhaustion (investigation-guidance #14): a hypothesis whose hunts all came back empty is
+  // negative knowledge too — the model should stop deriving findings for a theory the evidence hunt
+  // exhausted, exactly like a refuted one. `exhausted` is set deterministically (markExhaustedHypotheses)
+  // so it needs no analyst-touch gate.
+  const exhausted = (hypotheses ?? []).filter((h) => h.exhausted && h.status !== "refuted");
+  if (!refuted.length && !exhausted.length) return "";
   const cap = Math.max(1, Math.floor(limit));
-  const lines = refuted.slice(0, cap).map((h) => {
+  const refutedLines = refuted.slice(0, cap).map((h) => {
     const note = (h.notes ?? "").replace(/\s+/g, " ").trim().slice(0, 160);
-    return `- ${h.title}${note ? ` — ${note}` : ""}`;
+    return `- [refuted] ${h.title}${note ? ` — ${note}` : ""}`;
+  });
+  const exhaustedLines = exhausted.slice(0, cap).map((h) => {
+    const why = (h.exhaustedReason ?? "").replace(/\s+/g, " ").trim().slice(0, 160);
+    return `- [exhausted] ${h.title}${why ? ` — ${why}` : ""}`;
   });
   return (
-    "REFUTED HYPOTHESES (the investigator ruled these out — do NOT re-assert them, re-open threads for " +
-    "them, or derive findings/nextSteps from them; treat each as settled negative knowledge):\n" +
-    lines.join("\n") + "\n\n"
+    "REFUTED / EXHAUSTED HYPOTHESES (the investigator ruled these out, or hunts for them came back empty — " +
+    "do NOT re-assert them, re-open threads for them, or derive findings/nextSteps from them; treat each as " +
+    "settled negative knowledge):\n" +
+    [...refutedLines, ...exhaustedLines].join("\n") + "\n\n"
   );
 }
 

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -120,6 +120,10 @@ export const deltaSchema = z.object({
     relatedTechniques: z.array(z.string()).default([]).catch([]),
     relatedEventIds: z.array(z.string()).default([]).catch([]),
     relatedIocIds: z.array(z.string()).default([]).catch([]),
+    // ACH-style analysis (investigation-guidance #14): events INCONSISTENT with this explanation, and
+    // the single artifact (host + artifact) that would best separate it from the leading alternative.
+    contradictingEventIds: z.array(z.string()).default([]).catch([]),
+    discriminator: z.string().default("").catch(""),
   })).optional(),
   // Second-look loop (investigation-guidance #11): data the model knows it was NOT shown (only a
   // sample of the timeline is included in the prompt). Each request is resolved AFTER synthesis against

--- a/companion/tests/analysis/achHypotheses.test.ts
+++ b/companion/tests/analysis/achHypotheses.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeHypotheses,
+  rankHypothesesAch,
+  markExhaustedHypotheses,
+  type Hypothesis,
+  type HypothesisHuntSignal,
+} from "../../src/analysis/hypothesis.js";
+import { renderRefutedHypothesesBlock } from "../../src/analysis/priorWork.js";
+
+function h(partial: Partial<Hypothesis> & { id: string; title: string }): Hypothesis {
+  return {
+    description: "", expectedOutcome: "", status: "open", relatedTechniques: [], relatedEventIds: [],
+    relatedIocIds: [], contradictingEventIds: [], discriminator: "", exhausted: false, exhaustedReason: "",
+    assignee: "", notes: "", source: "synthesis", analystTouched: false, needsReview: false,
+    createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", ...partial,
+  };
+}
+const NOW = "2026-02-02T00:00:00Z";
+
+describe("sanitizeHypotheses ACH fields (#14)", () => {
+  it("keeps contradictingEventIds (filtered to real events) + discriminator", () => {
+    const [seed] = sanitizeHypotheses(
+      [{ title: "T", relatedEventIds: ["e1"], contradictingEventIds: ["e2", "ghost"], discriminator: "  $MFT on FS01  " }],
+      new Set(["e1", "e2"]),
+      new Set(),
+    );
+    expect(seed.contradictingEventIds).toEqual(["e2"]);   // "ghost" dropped (not a real event)
+    expect(seed.discriminator).toBe("$MFT on FS01");
+  });
+});
+
+describe("rankHypothesesAch (#14)", () => {
+  it("orders by fewest contradictions, then most support; sinks exhausted/refuted", () => {
+    const ranked = rankHypothesesAch([
+      h({ id: "wellSupportedButWrong", title: "A", relatedEventIds: ["e1", "e2", "e3"], contradictingEventIds: ["e8", "e9"] }),
+      h({ id: "clean", title: "B", relatedEventIds: ["e1"], contradictingEventIds: [] }),
+      h({ id: "exhausted", title: "C", contradictingEventIds: [], exhausted: true }),
+      h({ id: "oneContra", title: "D", relatedEventIds: ["e1", "e2"], contradictingEventIds: ["e8"] }),
+    ]);
+    expect(ranked.map((x) => x.id)).toEqual(["clean", "oneContra", "wellSupportedButWrong", "exhausted"]);
+  });
+});
+
+describe("markExhaustedHypotheses (#14)", () => {
+  const hyps = [
+    h({ id: "hp_explicit", title: "explicit", relatedTechniques: ["T1048"] }),
+    h({ id: "hp_tech", title: "by technique", relatedTechniques: ["T1021"] }),
+    h({ id: "hp_supported", title: "supported", status: "supported", relatedTechniques: ["T1021"] }),
+  ];
+
+  it("exhausts an OPEN hypothesis after N empty hunts (explicit link or technique match); freezes status", () => {
+    const signals: HypothesisHuntSignal[] = [
+      { relatedHypothesisId: "hp_explicit", techniques: [], missed: true },
+      { relatedHypothesisId: "hp_explicit", techniques: [], missed: true },
+      { techniques: ["T1021"], missed: true },   // matches hp_tech AND hp_supported by technique
+      { techniques: ["T1021"], missed: true },
+      { techniques: ["T1021"], missed: false },  // a hit — not counted
+    ];
+    const { hypotheses: out, changed } = markExhaustedHypotheses(hyps, signals, NOW, 2);
+    expect(changed).toBe(true);
+    expect(out.find((x) => x.id === "hp_explicit")!.exhausted).toBe(true);
+    expect(out.find((x) => x.id === "hp_tech")!.exhausted).toBe(true);
+    // A supported hypothesis is already resolved — exhaustion doesn't apply.
+    expect(out.find((x) => x.id === "hp_supported")!.exhausted).toBe(false);
+  });
+
+  it("does not exhaust below the miss threshold and is idempotent", () => {
+    const one: HypothesisHuntSignal[] = [{ relatedHypothesisId: "hp_explicit", techniques: [], missed: true }];
+    expect(markExhaustedHypotheses(hyps, one, NOW, 2).changed).toBe(false);
+    const many: HypothesisHuntSignal[] = [
+      { relatedHypothesisId: "hp_explicit", techniques: [], missed: true },
+      { relatedHypothesisId: "hp_explicit", techniques: [], missed: true },
+    ];
+    const first = markExhaustedHypotheses(hyps, many, NOW, 2);
+    const second = markExhaustedHypotheses(first.hypotheses, many, "2026-03-03T00:00:00Z", 2);
+    expect(second.changed).toBe(false);   // already exhausted → no re-stamp
+  });
+});
+
+describe("renderRefutedHypothesesBlock includes exhausted (#14)", () => {
+  it("lists both refuted (analyst) and exhausted hypotheses as negative knowledge", () => {
+    const block = renderRefutedHypothesesBlock([
+      h({ id: "r", title: "ruled out", status: "refuted", analystTouched: true, source: "analyst" }),
+      h({ id: "e", title: "hunted dry", exhausted: true, exhaustedReason: "3 hunts came back empty" }),
+    ]);
+    expect(block).toContain("[refuted] ruled out");
+    expect(block).toContain("[exhausted] hunted dry");
+    expect(block).toContain("settled negative knowledge");
+  });
+
+  it("returns '' when there is neither", () => {
+    expect(renderRefutedHypothesesBlock([h({ id: "o", title: "open one" })])).toBe("");
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -936,6 +936,12 @@
     .rel-rabbit { color: var(--c-ffb454, #ffb454); border: 1px solid var(--c-5a4a2a, #5a4a2a); background: var(--c-2a2410, #2a2410); }
     .rel-parked { color: var(--c-9aa4b2); border: 1px solid var(--c-2a3146); background: var(--c-141821, #141821); }
     .hyp-needs-review { color: var(--c-ffd93b); font-size: 11px; font-weight: 600; margin-left: 6px; }
+    /* ACH-style hypotheses (#14). */
+    .hyp-contra { color: var(--c-ff7a7a) !important; border-color: var(--c-5a2a2a, #5a2a2a) !important; }
+    .hyp-exhausted { color: var(--c-9aa4b2); font-size: 11px; font-weight: 600; margin-left: 6px; }
+    .hyp.exhausted { opacity: 0.7; }
+    .hyp-discriminator { font-size: 12px; color: var(--c-9fd0ff, #9fd0ff); margin: 3px 0; }
+    .hyp-ach-note { color: var(--c-6b7280); font-size: 10px; font-weight: 400; }
     /* Raw-file (EVTX/PCAP) prompt banner — prominent, at the top of the content. #211 */
     .raw-banner { font-size: 13px; color: var(--c-e6e9ef); margin: 0 0 12px; padding: 11px 14px;
       border: 1px solid #7a5c1a; border-left: 4px solid #e0a72c; border-radius: 8px; background: #241a08; }
@@ -5745,11 +5751,19 @@
         badge.textContent = hypotheses.length ? " — " + counts.join(" · ") : "";
       }
       if (!hypotheses.length) { el.innerHTML = "<div style='color:var(--c-9aa4b2);font-size:12px'>No hypotheses yet — they're auto-generated whenever synthesis runs (after each import). Click <strong>✨ Generate</strong> in the section title to run synthesis now, or add one below.</div>"; return; }
+      // ACH ranking (investigation-guidance #14): within each status group, order by FEWEST
+      // contradictions first (the explanation that survives the most disconfirming evidence wins), then
+      // most support — and sink exhausted hypotheses (hunts came back empty) to the bottom.
+      const achSort = (a, b) =>
+        ((a.exhausted ? 1 : 0) - (b.exhausted ? 1 : 0)) ||
+        ((a.contradictingEventIds || []).length - (b.contradictingEventIds || []).length) ||
+        ((b.relatedEventIds || []).length - (a.relatedEventIds || []).length) ||
+        String(a.title).localeCompare(String(b.title));
       let html = "";
       for (const [v, label] of HYP_STATUS) {
-        const group = hypotheses.filter(h => h.status === v);
+        const group = hypotheses.filter(h => h.status === v).sort(achSort);
         if (!group.length) continue;
-        html += `<div class="hyp-grouphdr">${esc(label)} (${group.length})</div>`;
+        html += `<div class="hyp-grouphdr">${esc(label)} (${group.length})<span class="hyp-ach-note" title="Analysis of Competing Hypotheses: ranked by fewest contradictions, not most support"> · ranked by fewest contradictions</span></div>`;
         html += group.map(renderHypCard).join("");
       }
       el.innerHTML = html;
@@ -5763,18 +5777,26 @@
       const chips = [];
       (h.relatedTechniques || []).forEach(t => chips.push(`<span class="hyp-chip">${esc(t)}</span>`));
       if ((h.relatedEventIds || []).length) chips.push(`<span class="hyp-chip" title="supporting forensic events">↳ ${h.relatedEventIds.length} event${h.relatedEventIds.length === 1 ? "" : "s"}</span>`);
+      // ACH (#14): contradicting-event count is the primary ranking signal — show it prominently (red).
+      const contraN = (h.contradictingEventIds || []).length;
+      if (contraN) chips.push(`<span class="hyp-chip hyp-contra" title="events INCONSISTENT with this explanation (ACH: judged by fewest contradictions)">⊖ ${contraN} contradicting</span>`);
       if ((h.relatedIocIds || []).length) chips.push(`<span class="hyp-chip" title="implicated IOCs">${h.relatedIocIds.length} IOC${h.relatedIocIds.length === 1 ? "" : "s"}</span>`);
       const meta = chips.length ? `<div class="hyp-meta">${chips.join("")}</div>` : "";
+      // ACH (#14): the discriminator — the single artifact that best separates this hypothesis from the
+      // leading alternative. Doubles as a concrete collection directive.
+      const discrim = h.discriminator ? `<div class="hyp-discriminator" title="The artifact that would best separate this hypothesis from the leading alternative — collect it next"><b>🔬 Discriminator:</b> ${esc(h.discriminator)}</div>` : "";
       const id = escAttr(h.id);
       // Immediate FP cascade (#12): supporting evidence was marked false positive — flag for re-judging.
       // A pristine hypothesis was also flipped to 'unknown'; editing it (any field) clears the flag.
       const review = h.needsReview ? `<span class="hyp-needs-review" title="An event or IOC that supported this hypothesis was marked false positive — re-judge it. Editing any field clears this flag.">⚠️ needs review</span>` : "";
-      return `<div class="hyp ${escAttr(h.status)}${h.needsReview ? " needs-review" : ""}" data-id="${id}">` +
+      // ACH exhaustion (#14): hunts for this hypothesis came back empty → treated as negative knowledge.
+      const exhausted = h.exhausted ? `<span class="hyp-exhausted" title="${escAttr(h.exhaustedReason || "Hunts for this hypothesis came back empty — treated as settled negative knowledge.")}">⊘ exhausted</span>` : "";
+      return `<div class="hyp ${escAttr(h.status)}${h.needsReview ? " needs-review" : ""}${h.exhausted ? " exhausted" : ""}" data-id="${id}">` +
         `<div class="hyp-row1">` +
           `<select class="hyp-status" onchange="hypPatch('${id}',{status:this.value})">${opts}</select>` +
-          `<span class="hyp-title">${esc(h.title)}</span>${src}${review}` +
+          `<span class="hyp-title">${esc(h.title)}</span>${src}${review}${exhausted}` +
           `<button class="hyp-del" onclick="hypDelete('${id}')" title="Delete">✕</button>` +
-        `</div>${outcome}${desc}${meta}` +
+        `</div>${outcome}${desc}${discrim}${meta}` +
         `<div class="hyp-row2">` +
           `<input class="hyp-assignee" placeholder="assignee" value="${escAttr(h.assignee || "")}" onchange="hypPatch('${id}',{assignee:this.value})" />` +
           `<input class="hyp-notes" placeholder="notes" value="${escAttr(h.notes || "")}" onchange="hypPatch('${id}',{notes:this.value})" />` +


### PR DESCRIPTION
## What & why

Tier 3 item of the [investigation-guidance roadmap](INVESTIGATION_GUIDANCE_ROADMAP.md). Red herrings become findings **unopposed** when nothing tracks what *contradicts* a theory (veridia's planted red herring; halcyon's benign USB copy). This adds the classic intelligence-analysis fix — **Analysis of Competing Hypotheses** — onto the hypothesis machinery revived in #1.

## What's added

**Per-hypothesis ACH fields** (`hypothesis.ts` + `responseSchema.ts` + prompt):
- `contradictingEventIds` — events INCONSISTENT with the explanation (evidence *against* it).
- `discriminator` — the single **host + artifact** that would best separate this hypothesis from the leading alternative; doubles as a concrete collection directive.
- `exhausted` — set deterministically once hunts for it come back empty.

**ACH ranking** — `rankHypothesesAch()` (and the dashboard) order by **fewest contradictions first**, then most support; exhausted/refuted sink. The explanation that survives the most disconfirming evidence wins, so a well-supported-but-wrong theory can't top the list.

**Hunt-miss exhaustion** — `HuntOutcome`/`HuntDeployInput` gain `relatedHypothesisId`. `markExhaustedHypotheses()` flips an **open** hypothesis to `exhausted` once **N** linked (or ATT&CK-technique-matched) hunts came back empty — `exhausted` is an orthogonal flag, so it respects the analyst-freeze contract. `synthesize()` runs it from collected hunt outcomes, drops exhausted hypotheses from the "to test" list, and the **negative-knowledge block** now feeds both refuted *and* exhausted hypotheses to the model so it stops deriving findings for a hunted-dry theory.

## Surfaces
- Dashboard hypotheses ranked ACH-style within each status group, with a red **"⊖ N contradicting"** chip, a **"🔬 Discriminator"** line, and a **"⊘ exhausted"** badge.

## Files
- `analysis/hypothesis.ts` — fields + `rankHypothesesAch` + `markExhaustedHypotheses` (+ sanitize/merge/patch threading).
- `analysis/hypothesisStore.ts` — `applyExhaustion`.
- `analysis/huntOutcomes.ts` — `relatedHypothesisId`.
- `analysis/priorWork.ts` — negative-knowledge block includes exhausted.
- `analysis/pipeline.ts` — exhaustion pass + prompt.
- `analysis/responseSchema.ts` — delta hypotheses fields.
- `public/dashboard.html` — ACH ordering + chips.

Incidentally fixed a pre-existing quirk: `seedDiffersFrom` used a NUL (`\0`) join separator — normalized to a space (functionally identical).

## Tests
- `tests/analysis/achHypotheses.test.ts` (6): sanitize fields, ACH ranking (fewest contradictions wins), exhaustion (explicit + technique match, threshold, idempotent), negative-knowledge block.
- Existing hypothesis tests still green; full companion suite green (**3626**), clean `tsc`.

## Test plan
From `companion/` on this branch (`gh pr checkout <this-PR>` first):
- `npx vitest run tests/analysis/achHypotheses.test.ts tests/analysis/hypothesis.test.ts`
- `npx vitest run` (full) · `npx tsc --noEmit`

## Deferred
Threading an explicit `relatedHypothesisId` through the hunt-**deploy** route/UI — exhaustion works today via technique-overlap matching; the link field exists but isn't set from the UI yet.

Part of #14 (roadmap Tier 3).