### PR TITLE
feat: per-case prevalence/baseline index + rarity-biased selection (#15a)

### DIFF
--- a/INVESTIGATION_GUIDANCE_ROADMAP.md
+++ b/INVESTIGATION_GUIDANCE_ROADMAP.md
@@ -13,7 +13,9 @@
 > gitignored deployment artifacts — regenerate them with `npm run prompts:eject` so the deployment picks
 > up the built-in prompt (hypotheses / confidenceReason / structured-tag & attack-graph / #8 collect /
 > #11 evidenceRequests instructions). Until then the drift-detection check warns on every preflight and
-> synthesis run. **Tier 3 remaining: #15** (the last item) as specified below.
+> synthesis run. **Tier 3 #15 in progress (split into two PRs): #15a prevalence/baseline engine shipping now
+(prevalence.ts index + synthesis renderEvent baseline tags + rarity bias in the #4 selection fill);
+#15b (FP-pattern propagation + dashboard surfaces) to follow.**
 
 **Goal.** Make the Companion genuinely lead an investigation — better decisions, higher recall of
 what actually happened, better dot-connecting, a working FP / rabbit-hole / real-lead triage, the

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -173,6 +173,7 @@ import {
 } from "./secondLook.js";
 import { groundAndScoreFindings, capIntelOnlyFindings, corroborationLabel } from "./findingGrounding.js";
 import { scoreFindingsRelevance } from "./findingRelevance.js";
+import { buildPrevalenceIndex, eventPrevalence, prevalenceTag, rarityScore } from "./prevalence.js";
 import { reconsiderKeyQuestions, textMentionsFindingId } from "./fpCascade.js";
 import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
 import type { AiControlStore } from "./aiControl.js";
@@ -4247,9 +4248,15 @@ export class AnalysisPipeline {
     // still creates findings for any Critical/High event NOT shown here (eligibleIds below
     // is the full scoped set), so capping the prompt never loses a severe detection.
     const SYNTH_MAX_EVENTS = Number(process.env.DFIR_AI_SYNTH_MAX_EVENTS) || 300;
+    // Per-case prevalence/baseline (investigation-guidance #15): how common each activity PATTERN is
+    // across the WHOLE case timeline (not just the scoped subset — the baseline is a property of the
+    // corpus). Feeds a rarity bias into the selection fill (a 1-off wins a seat over 500× noise) and a
+    // common/rare tag into each rendered event so the model gets explicit baseline context.
+    const prevalenceIndex = buildPrevalenceIndex(state.forensicTimeline);
+    const rarityOf = (e: ForensicEvent): number => rarityScore(e, prevalenceIndex);
     // Stratified selection: all Critical/High + the earliest (initial-access) + an even
     // time-spread sample, chronologically — better kill-chain coverage than severity-only.
-    let promptEvents = selectSynthesisEvents(scopedEvents, SYNTH_MAX_EVENTS);
+    let promptEvents = selectSynthesisEvents(scopedEvents, SYNTH_MAX_EVENTS, rarityOf);
 
     // Analyst notebook context: when both notebookStore and aiControlStore are wired and the
     // analyst has opted in (includeNotebook: true in ai-control.json), append the notebook
@@ -4430,12 +4437,17 @@ export class AnalysisPipeline {
     // Each event carries its structured tags (host / process lineage / src→dst / corroborating-source
     // count) after the prose (investigation-guidance #5) — only when set, so a bare event costs no extra
     // tokens. This is what lets the model connect cross-host activity instead of guessing from prose.
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}`;
+    const renderEvent = (e: ForensicEvent) => {
+      // Prevalence baseline tag (#15): only the informative extremes (clearly common / clearly rare) are
+      // tagged, so the model knows a 500× pattern is routine and a 1-off is anomalous.
+      const p = eventPrevalence(e, prevalenceIndex);
+      const prevTag = p ? prevalenceTag(p) : "";
+      return `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}${prevTag ? ` ⟨${prevTag}⟩` : ""}`;
+    };
     const synthOverhead = estimateTokens(getSynthesisPrompt())
       + estimateTokens(scopeNote + contextBlock + graphBlock + beaconBlock + attackPhaseBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + satisfiedBlock + pinnedBlock + reanswerBlock + existingFindings + openThreads + falsePositiveBlock + authorizedContextBlock + (state.lastSummary || "")) + 400;
     const fit = fitItemsToBudget(promptEvents, renderEvent, Math.max(0, inputTokenBudget() - synthOverhead));
-    if (fit < promptEvents.length) promptEvents = selectSynthesisEvents(scopedEvents, fit);
+    if (fit < promptEvents.length) promptEvents = selectSynthesisEvents(scopedEvents, fit, rarityOf);
 
     const timelineText = promptEvents.map(renderEvent).join("\n");
     const truncatedNote = scopedEvents.length > promptEvents.length

--- a/companion/src/analysis/prevalence.ts
+++ b/companion/src/analysis/prevalence.ts
@@ -1,0 +1,120 @@
+// Per-case prevalence / baseline index (investigation-guidance #15). Marking one event a false positive
+// teaches the system nothing about how COMMON that pattern is; synthesis then re-grades the same
+// nightly-robocopy High every import because it has no baseline. This module computes, per case, how
+// often each normalized activity PATTERN occurs across the timeline — so a pattern seen 500× on 14 hosts
+// reads as routine and a 1-off reads as an anomaly worth a seat. Pure + deterministic, derived on read
+// from fields the importers already populate (NO persisted index, NO AI).
+//
+// The pattern KEY deliberately ignores the host and volatile tokens (numbers, paths, hashes-as-args,
+// GUIDs) so the SAME command shape on different hosts collapses to one pattern whose host-spread we can
+// then count. Content hashes (sha256/md5) are the strongest key when present.
+
+import type { ForensicEvent } from "./stateTypes.js";
+
+export interface PatternStats {
+  key: string;
+  count: number;        // total occurrences of this pattern in the corpus
+  hosts: Set<string>;   // distinct assets it appeared on
+  first: string;        // earliest dated occurrence (ISO); "" if all undated
+  last: string;         // latest dated occurrence (ISO); "" if all undated
+}
+export type PrevalenceIndex = Map<string, PatternStats>;
+
+export const RARE_MAX_DEFAULT = 2;    // ≤ this many occurrences → rare (anomaly-ish)
+export const COMMON_MIN_DEFAULT = 20; // ≥ this many occurrences → common (baseline noise)
+
+// Collapse a command line / description to a stable SHAPE: lowercase, and replace volatile tokens
+// (hashes, GUIDs, Windows + UNC + Unix paths, quoted strings, bare numbers) with placeholders, so
+// "robocopy C:\\data\\1 \\\\srv1\\bak /mir" and "robocopy C:\\data\\2 \\\\srv2\\bak /mir" fingerprint the
+// same. Order matters: paths/hashes before the bare-number pass. Bounded output length.
+export function commandShape(text: string): string {
+  let s = String(text ?? "").toLowerCase();
+  s = s.replace(/\b[a-f0-9]{32,64}\b/g, "<hash>");                          // md5/sha1/sha256 as args
+  s = s.replace(/\{?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}?/g, "<guid>");
+  s = s.replace(/\\\\[^\s"']+/g, "<unc>");                                  // \\server\share…
+  s = s.replace(/[a-z]:\\[^\s"']*/g, "<path>");                             // C:\dir\file
+  s = s.replace(/(?:\/[^\s"'/]+){2,}\/?/g, "<path>");                       // /usr/bin/… (≥2 segments)
+  s = s.replace(/"[^"]*"/g, "<str>").replace(/'[^']*'/g, "<str>");          // quoted strings
+  s = s.replace(/\b\d[\d.,:]*\b/g, "<n>");                                   // bare numbers / versions / times
+  s = s.replace(/\s+/g, " ").trim();
+  return s.slice(0, 200);
+}
+
+// The canonical pattern key for an event. A content hash is the strongest (same binary anywhere), else
+// process + command shape, else the bare description shape. Returns "" when the event has no stable
+// pattern (empty description, no hash/process) — such events are skipped from the index.
+export function patternKey(e: ForensicEvent): string {
+  const hash = (e.sha256 ?? e.md5 ?? "").trim().toLowerCase();
+  if (hash) return `hash:${hash}`;
+  const proc = (e.processName ?? "").trim().toLowerCase();
+  const shape = commandShape(e.description ?? "");
+  if (proc) return `proc:${proc}|${shape}`;
+  if (shape) return `desc:${shape}`;
+  return "";
+}
+
+// Build the per-case prevalence index over a corpus (pass the forensic timeline, optionally unioned with
+// the super-timeline for a fuller baseline). Undated events still count toward totals/host-spread.
+export function buildPrevalenceIndex(events: readonly ForensicEvent[]): PrevalenceIndex {
+  const index: PrevalenceIndex = new Map();
+  for (const e of events) {
+    const key = patternKey(e);
+    if (!key) continue;
+    let stats = index.get(key);
+    if (!stats) { stats = { key, count: 0, hosts: new Set(), first: "", last: "" }; index.set(key, stats); }
+    stats.count += 1;
+    const asset = (e.asset ?? "").trim();
+    if (asset) stats.hosts.add(asset.toLowerCase());
+    const t = Date.parse(e.timestamp);
+    if (!Number.isNaN(t)) {
+      if (!stats.first || t < Date.parse(stats.first)) stats.first = new Date(t).toISOString();
+      if (!stats.last || t > Date.parse(stats.last)) stats.last = new Date(t).toISOString();
+    }
+  }
+  return index;
+}
+
+export interface EventPrevalence {
+  count: number;
+  hostCount: number;
+  spanDays: number;   // whole days between first and last dated occurrence (0 when single/undated)
+}
+
+// Look up an event's prevalence. Returns null when the event has no stable pattern key.
+export function eventPrevalence(e: ForensicEvent, index: PrevalenceIndex): EventPrevalence | null {
+  const key = patternKey(e);
+  if (!key) return null;
+  const stats = index.get(key);
+  if (!stats) return null;
+  const spanMs = stats.first && stats.last ? Date.parse(stats.last) - Date.parse(stats.first) : 0;
+  return { count: stats.count, hostCount: stats.hosts.size, spanDays: Math.max(0, Math.floor(spanMs / 86_400_000)) };
+}
+
+export function isRare(p: EventPrevalence, rareMax = RARE_MAX_DEFAULT): boolean {
+  return p.count <= rareMax;
+}
+export function isCommon(p: EventPrevalence, commonMin = COMMON_MIN_DEFAULT): boolean {
+  return p.count >= commonMin;
+}
+
+// A compact human tag for a prompt line / dashboard chip. "" for the uninformative middle band (only the
+// extremes — clearly common baseline vs clearly rare — earn a tag so the prompt stays lean).
+export function prevalenceTag(
+  p: EventPrevalence,
+  opts: { rareMax?: number; commonMin?: number } = {},
+): string {
+  const rareMax = opts.rareMax ?? RARE_MAX_DEFAULT;
+  const commonMin = opts.commonMin ?? COMMON_MIN_DEFAULT;
+  const span = p.spanDays > 0 ? ` over ${p.spanDays}d` : "";
+  const hosts = p.hostCount > 0 ? ` on ${p.hostCount} host${p.hostCount === 1 ? "" : "s"}` : "";
+  if (p.count >= commonMin) return `common: seen ${p.count}×${hosts}${span}`;
+  if (p.count <= rareMax) return `rare: seen ${p.count}×${hosts}`;
+  return "";
+}
+
+// Rarity score for the synthesis selection bias (#4): higher = rarer = more worth a seat. 1/count so a
+// singleton scores 1.0 and a 500× pattern ~0.002. An event with no pattern key scores 0 (neutral).
+export function rarityScore(e: ForensicEvent, index: PrevalenceIndex): number {
+  const p = eventPrevalence(e, index);
+  return p && p.count > 0 ? 1 / p.count : 0;
+}

--- a/companion/src/analysis/synthSelect.ts
+++ b/companion/src/analysis/synthSelect.ts
@@ -23,6 +23,8 @@ const PER_ANCHOR_CONTEXT_CAP = 6;
 const BUDGET_ANCHOR_CONTEXT = 0.40;
 const BUDGET_CORROBORATED = 0.25;
 const BUDGET_TECHNIQUE = 0.15;
+const BUDGET_RARE = 0.15;          // prevalence #15: reserved seats for RARE (low-prevalence) events
+const RARE_SCORE_MIN = 0.34;       // rarityOf(e) ≥ this counts as rare (≈ ≤2 occurrences via 1/count)
 
 // Why an event earned a synthesis seat. "anchor" = Critical/High verdict; "earliest" = initial-access
 // context; the rest are the behavioral fills. Exposed (via the annotated selection) so the dashboard
@@ -33,6 +35,7 @@ export type SelectionClass =
   | "anchor_context"
   | "corroborated"
   | "technique"
+  | "rare"
   | "spread";
 
 export interface AnnotatedSelection {
@@ -43,7 +46,7 @@ export interface AnnotatedSelection {
 }
 
 function emptyCounts(): Record<SelectionClass, number> {
-  return { anchor: 0, earliest: 0, anchor_context: 0, corroborated: 0, technique: 0, spread: 0 };
+  return { anchor: 0, earliest: 0, anchor_context: 0, corroborated: 0, technique: 0, rare: 0, spread: 0 };
 }
 
 function eventMs(e: ForensicEvent): number | null {
@@ -112,7 +115,11 @@ function anchorContextCandidates(
 // earliest initial-access events) and then fills with reserved per-class budgets — same-host context
 // around each anchor, cross-source-corroborated events, and ATT&CK-technique-tagged events — before an
 // even/whole-burst spread. Returns CHRONOLOGICAL order so the model reads the attack as a story.
-export function selectSynthesisEventsAnnotated(events: ForensicEvent[], max: number): AnnotatedSelection {
+export function selectSynthesisEventsAnnotated(
+  events: ForensicEvent[],
+  max: number,
+  rarityOf?: (e: ForensicEvent) => number,   // prevalence #15: higher = rarer; omitted = no rarity bias
+): AnnotatedSelection {
   const byTime = [...events].sort(byEventTime);
   if (events.length <= max || max <= 0) {
     return { events: byTime, classOf: new Map(), counts: emptyCounts(), omitted: 0 };
@@ -164,6 +171,19 @@ export function selectSynthesisEventsAnnotated(events: ForensicEvent[], max: num
   // RESERVED FILL 3: ATT&CK-technique-tagged events regardless of severity (behavioral signal).
   fill(byTime.filter((e) => !classOf.has(e.id) && (e.mitreTechniques?.length ?? 0) > 0), Math.floor(remaining * BUDGET_TECHNIQUE), "technique");
 
+  // RESERVED FILL 4 (prevalence #15): RARE events — a low-prevalence pattern (seen once or twice in the
+  // whole case) is far more likely to be signal than the 500× nightly-robocopy baseline, yet grades Low
+  // and never won a seat. Only active when a rarity function is supplied; rarest first. Additive — with
+  // no rarityOf the selection is byte-identical to before.
+  if (rarityOf) {
+    const rareCandidates = byTime
+      .filter((e) => !classOf.has(e.id) && rarityOf(e) >= RARE_SCORE_MIN)
+      .sort((a, b) => rarityOf(b) - rarityOf(a) || byEventTime(a, b));
+    // Guarantee at least one rare seat when any rare candidate exists (the whole point: a 1-off must not
+    // be crowded out by baseline noise), even when the fractional budget rounds to 0 at a small cap.
+    if (rareCandidates.length) fill(rareCandidates, Math.max(1, Math.floor(remaining * BUDGET_RARE)), "rare");
+  }
+
   // SPREAD remainder: keep whole activity bursts (burstDetect phases) rather than shredding clusters
   // with an even sample; whatever budget is left after whole bursts is filled by an even time-spread.
   if (capacityLeft() > 0) {
@@ -198,8 +218,12 @@ export function selectSynthesisEventsAnnotated(events: ForensicEvent[], max: num
 
 // Backwards-compatible wrapper: the chosen events in chronological order. All existing callers use this;
 // the reserved-budget improvement flows through them automatically.
-export function selectSynthesisEvents(events: ForensicEvent[], max: number): ForensicEvent[] {
-  return selectSynthesisEventsAnnotated(events, max).events;
+export function selectSynthesisEvents(
+  events: ForensicEvent[],
+  max: number,
+  rarityOf?: (e: ForensicEvent) => number,
+): ForensicEvent[] {
+  return selectSynthesisEventsAnnotated(events, max, rarityOf).events;
 }
 
 // A compact context digest for the synthesis prompt: the compromised assets (host/account

--- a/companion/tests/analysis/prevalence.test.ts
+++ b/companion/tests/analysis/prevalence.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  commandShape,
+  patternKey,
+  buildPrevalenceIndex,
+  eventPrevalence,
+  prevalenceTag,
+  rarityScore,
+  isRare,
+  isCommon,
+} from "../../src/analysis/prevalence.js";
+import { selectSynthesisEventsAnnotated } from "../../src/analysis/synthSelect.js";
+import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+function ev(partial: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return { timestamp: "2026-01-02T10:00:00.000Z", description: "", severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...partial };
+}
+
+describe("commandShape", () => {
+  it("collapses volatile tokens so the same command on different hosts/paths fingerprints alike", () => {
+    const a = commandShape("robocopy C:\\data\\1 \\\\srv1\\bak /mir /R:5");
+    const b = commandShape("robocopy C:\\data\\2 \\\\srv2\\bak /mir /R:9");
+    expect(a).toBe(b);
+    expect(a).toContain("robocopy");
+    expect(a).toContain("<path>");
+    expect(a).toContain("<unc>");
+  });
+  it("masks hashes and guids", () => {
+    expect(commandShape("load a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")).toContain("<hash>");
+    expect(commandShape("id {12345678-1234-1234-1234-123456789abc}")).toContain("<guid>");
+  });
+});
+
+describe("patternKey", () => {
+  it("prefers a content hash, then process+shape, then description shape", () => {
+    expect(patternKey(ev({ id: "e", sha256: "ABCDEF" }))).toBe("hash:abcdef");
+    expect(patternKey(ev({ id: "e", processName: "robocopy.exe", description: "robocopy C:\\a \\\\s\\b" }))).toMatch(/^proc:robocopy\.exe\|/);
+    expect(patternKey(ev({ id: "e", description: "some line" }))).toMatch(/^desc:/);
+    expect(patternKey(ev({ id: "e" }))).toBe("");   // no stable pattern
+  });
+});
+
+describe("buildPrevalenceIndex + eventPrevalence", () => {
+  const events = [
+    ...Array.from({ length: 30 }, (_, i) => ev({ id: `r${i}`, processName: "robocopy.exe", description: `robocopy C:\\d\\${i} \\\\srv${i % 12}\\bak`, asset: `HOST-${i % 12}`, timestamp: `2026-01-${String((i % 9) + 1).padStart(2, "0")}T02:00:00.000Z` })),
+    ev({ id: "rare1", processName: "mimikatz.exe", description: "mimikatz sekurlsa::logonpasswords", asset: "DC01", timestamp: "2026-01-05T12:00:00.000Z" }),
+  ];
+  const index = buildPrevalenceIndex(events);
+
+  it("counts occurrences, distinct hosts, and the day span of a common pattern", () => {
+    const p = eventPrevalence(events[0], index)!;
+    expect(p.count).toBe(30);
+    expect(p.hostCount).toBe(12);
+    expect(p.spanDays).toBeGreaterThanOrEqual(7);
+    expect(isCommon(p)).toBe(true);
+    expect(prevalenceTag(p)).toMatch(/^common: seen 30× on 12 hosts over \d+d$/);
+  });
+
+  it("flags a one-off pattern as rare", () => {
+    const p = eventPrevalence(events[30], index)!;
+    expect(p.count).toBe(1);
+    expect(isRare(p)).toBe(true);
+    expect(prevalenceTag(p)).toBe("rare: seen 1× on 1 host");
+  });
+
+  it("gives no tag to a mid-band pattern and a higher rarityScore to the rarer event", () => {
+    const mid = Array.from({ length: 8 }, (_, i) => ev({ id: `m${i}`, description: "mid pattern here" }));
+    const idx = buildPrevalenceIndex(mid);
+    expect(prevalenceTag(eventPrevalence(mid[0], idx)!)).toBe("");
+    expect(rarityScore(events[30], index)).toBeGreaterThan(rarityScore(events[0], index));
+  });
+});
+
+describe("selectSynthesisEvents rarity bias (#15)", () => {
+  it("gives a rare Info event a seat it would otherwise lose, and is a no-op without rarityOf", () => {
+    // 40 common Info events + 1 rare Info event; cap forces selection.
+    const common = Array.from({ length: 40 }, (_, i) => ev({ id: `c${i}`, description: "nightly backup run", severity: "Info", timestamp: `2026-01-02T10:${String(i).padStart(2, "0")}:00.000Z` }));
+    const rare = ev({ id: "rareEvt", description: "psexec lateral tool copied", severity: "Info", timestamp: "2026-01-02T10:20:30.000Z" });
+    const all = [...common, rare];
+    const index = buildPrevalenceIndex(all);
+    const rarityOf = (e: ForensicEvent) => rarityScore(e, index);
+
+    const withBias = selectSynthesisEventsAnnotated(all, 20, rarityOf);
+    expect(withBias.events.some((e) => e.id === "rareEvt")).toBe(true);
+    expect(withBias.classOf.get("rareEvt")).toBe("rare");
+
+    // Without rarityOf the counts carry no 'rare' class (behavior unchanged).
+    const noBias = selectSynthesisEventsAnnotated(all, 20);
+    expect(noBias.counts.rare).toBe(0);
+  });
+});


### PR DESCRIPTION
## What & why

First half of the final roadmap item (#15, split into two PRs). Marking one event a false positive teaches the system nothing about how **common** that pattern is — so synthesis re-grades the same nightly-robocopy High every import with no baseline. `tradecraftRules.ts`'s unconditional-High robocopy/xcopy grade explicitly assumes an FP-suppression loop that doesn't exist. This PR adds the missing **baseline**: per case, how often each normalized activity *pattern* occurs across the timeline.

## How it works (all pure + derived on read — no persisted index, no AI)

- **`prevalence.ts`**:
  - `commandShape()` collapses volatile tokens (hashes, GUIDs, Windows/UNC/Unix paths, quoted strings, numbers) so `robocopy C:\data\1 \srv1\bak` and `robocopy C:\data\2 \srv2\bak` fingerprint the same.
  - `patternKey()` = content hash > `process + shape` > `desc shape`.
  - `buildPrevalenceIndex()` → per-pattern count, distinct-host spread, and day span.
  - `eventPrevalence` / `prevalenceTag` / `isRare` / `isCommon` / `rarityScore`.
- **`synthesize()`** builds the index over the whole case timeline and:
  - tags each rendered event for the informative extremes only — `⟨common: seen 214× on 12 hosts over 9d⟩` / `⟨rare: seen 1×⟩` — so the model gets explicit baseline context instead of guessing.
  - feeds a **rarity bias** into the selection fill.
- **`synthSelect.ts`** gains an optional `rarityOf` param + a reserved **"rare"** fill: a low-prevalence 1-off (likely signal) now earns a seat over 500× baseline noise (guaranteed ≥1 seat when a rare candidate exists). **Strictly additive** — with no `rarityOf`, selection is byte-identical to before.

## Files
- `analysis/prevalence.ts` (new), `analysis/synthSelect.ts`, `analysis/pipeline.ts`.

## Tests
- `tests/analysis/prevalence.test.ts` (7): shape/key normalization, index counts (occurrences, host-spread, day-span), rare/common tags, rarity score, and the selection rarity bias (a rare Info event that would lose its seat gets one; no-op without `rarityOf`).
- Full companion suite green (**3633**), clean `tsc`.

## Test plan
From `companion/` on this branch (`gh pr checkout <this-PR>` first):
- `npx vitest run tests/analysis/prevalence.test.ts tests/analysis/synthSelect.test.ts tests/analysis/synthSelectChain.test.ts`
- `npx vitest run` (full) · `npx tsc --noEmit`

## Follow-up
**#15b** (next PR): proactive FP-pattern propagation — `patternFingerprint` on FP markers + a post-import "N new events match FP pattern X — review & bulk-mark" import banner (one-click via the existing batch endpoint, never auto-applied) — plus the dashboard prevalence chip on timeline rows.

Part of #15 (roadmap Tier 3, final item).