### PR TITLE
feat: proactive FP-pattern propagation + prevalence chip (#15b)

### DIFF
--- a/INVESTIGATION_GUIDANCE_ROADMAP.md
+++ b/INVESTIGATION_GUIDANCE_ROADMAP.md
@@ -1,9 +1,10 @@
 # Making DFIR-Companion Lead the Investigation
 
-> **Implementation status (Tier 0–2 + Tier 3 #12–#14 shipped and merged to master).** Proposals
-> #1–#14 are implemented, unit-tested, and merged (PRs #96–#99, #102, #103 for #1–#10; #11 = the
-> second-look loop; #12 = the immediate FP cascade; #13 = rabbit-hole detection; #14 = ACH-style
-> hypotheses). Full suite green (3626 tests), clean `tsc`. Deferred within those items (documented
+> **Implementation status: ALL 15 proposals shipped and merged to master — the roadmap is COMPLETE.**
+> #1–#15 are implemented, unit-tested, and merged (PRs #96–#99, #102, #103 for #1–#10; #11 = second-look
+> loop; #12 = immediate FP cascade; #13 = rabbit-hole detection; #14 = ACH-style hypotheses; #15 =
+> per-case prevalence/baseline + proactive FP-pattern propagation, landed as #15a + #15b). Full suite
+> green (3638 tests), clean `tsc`. Deferred within those items (documented
 > in each commit): the `~` context-prefix prompt notation and per-class counts into synthMeta (#4); the
 > anchor-scoring bump retune and the auto-generated "corroborate `<ioc>`" nextStep (#7); #10 trigger (b)
 > cap-hit truncation; #11 report-side surfacing of collection leads (kept on the live dashboard only);
@@ -13,9 +14,7 @@
 > gitignored deployment artifacts — regenerate them with `npm run prompts:eject` so the deployment picks
 > up the built-in prompt (hypotheses / confidenceReason / structured-tag & attack-graph / #8 collect /
 > #11 evidenceRequests instructions). Until then the drift-detection check warns on every preflight and
-> synthesis run. **Tier 3 #15 in progress (split into two PRs): #15a prevalence/baseline engine shipping now
-(prevalence.ts index + synthesis renderEvent baseline tags + rarity bias in the #4 selection fill);
-#15b (FP-pattern propagation + dashboard surfaces) to follow.**
+> synthesis run. **The roadmap is fully delivered; no items remain.**
 
 **Goal.** Make the Companion genuinely lead an investigation — better decisions, higher recall of
 what actually happened, better dot-connecting, a working FP / rabbit-hole / real-lead triage, the

--- a/companion/src/analysis/falsePositive.ts
+++ b/companion/src/analysis/falsePositive.ts
@@ -34,6 +34,11 @@ export interface FalsePositiveMarker {
   markedAt: string;
   markedBy: string;              // analyst name/id; "anonymous" when not supplied
   label?: string;                // optional human-readable label (e.g. an event's description) for display
+  // Proactive FP-pattern propagation (investigation-guidance #15b): the normalized prevalence pattern key
+  // of the anchor event, captured when an EVENT is marked false positive. After each import, new events
+  // whose pattern key equals this are surfaced as a one-click bulk-mark suggestion (never auto-applied).
+  // Only set for event markers; absent for finding/IOC markers and older files.
+  patternFingerprint?: string;
 }
 
 export function markerId(kind: FalsePositiveKind, ref: string): string {

--- a/companion/src/analysis/fpPropagation.ts
+++ b/companion/src/analysis/fpPropagation.ts
@@ -1,0 +1,84 @@
+// Proactive false-positive pattern propagation (investigation-guidance #15b). Marking one event false
+// positive teaches the system nothing lasting — the same nightly-robocopy pattern re-arrives High after
+// every import. This closes that loop: an event marked FP stamps a `patternFingerprint` (the prevalence
+// pattern key of the anchor), and after each import we check the NEW events against those fingerprints.
+// When enough new events match a known FP pattern, the import banner suggests a one-click bulk-mark —
+// SUGGESTED, never auto-applied (the analyst always confirms; an attacker hiding inside a benign-looking
+// pattern must never be silently suppressed).
+//
+// Precision over recall on purpose: the match is EXACT on the normalized pattern key (same command shape
+// / same hash), not the fuzzy findSimilarEvents scorer — auto-suggesting a bulk FP mark on a loose "same
+// MITRE" match would be dangerous. The fuzzy scorer stays for the interactive mark-FP dialog.
+
+import type { ForensicEvent } from "./stateTypes.js";
+import type { FalsePositiveMarker } from "./falsePositive.js";
+import { patternKey } from "./prevalence.js";
+
+export interface FpPropagationSuggestion {
+  markerId: string;            // the FP marker this pattern came from
+  ref: string;                 // the marker's ref (the original anchor event id), for display
+  note: string;                // the marker's note/reason, for display
+  patternFingerprint: string;  // the matched normalized pattern key
+  count: number;               // how many NEW events match it
+  matchedEventIds: string[];   // the matching new-event ids (capped) — fed to the bulk-mark batch call
+  sampleLabel: string;         // a sample new-event description, for the banner
+}
+
+export interface FpPropagationOptions {
+  minMatches?: number;     // suggest only when at least this many new events match (default 3)
+  maxSuggestions?: number; // cap the number of distinct patterns surfaced (default 5)
+  maxIdsPerPattern?: number; // cap the id list per pattern (default 500 — the batch endpoint's practical bound)
+}
+
+const MIN_MATCHES_DEFAULT = 3;
+const MAX_SUGGESTIONS_DEFAULT = 5;
+const MAX_IDS_DEFAULT = 500;
+
+// Match freshly-imported events against the pattern fingerprints of existing false-positive markers.
+// Returns one suggestion per FP pattern that ≥ minMatches new events reproduce, most-matched first. Pure
+// + deterministic — no clock, no I/O.
+export function matchFpPropagation(
+  newEvents: readonly ForensicEvent[],
+  markers: readonly FalsePositiveMarker[],
+  opts: FpPropagationOptions = {},
+): FpPropagationSuggestion[] {
+  const minMatches = Math.max(1, Math.floor(opts.minMatches ?? MIN_MATCHES_DEFAULT));
+  const maxSuggestions = Math.max(1, Math.floor(opts.maxSuggestions ?? MAX_SUGGESTIONS_DEFAULT));
+  const maxIds = Math.max(1, Math.floor(opts.maxIdsPerPattern ?? MAX_IDS_DEFAULT));
+
+  // fingerprint → the (first) event marker that carries it. Only event markers with a fingerprint
+  // participate — a finding/IOC marker has no per-event pattern to propagate.
+  const byFingerprint = new Map<string, FalsePositiveMarker>();
+  for (const m of markers) {
+    if (m.kind !== "event" || !m.patternFingerprint) continue;
+    if (!byFingerprint.has(m.patternFingerprint)) byFingerprint.set(m.patternFingerprint, m);
+  }
+  if (!byFingerprint.size) return [];
+
+  const hits = new Map<string, { marker: FalsePositiveMarker; ids: string[]; sample: string }>();
+  for (const e of newEvents) {
+    const key = patternKey(e);
+    if (!key) continue;
+    const marker = byFingerprint.get(key);
+    if (!marker) continue;
+    let hit = hits.get(key);
+    if (!hit) { hit = { marker, ids: [], sample: e.description || e.id }; hits.set(key, hit); }
+    if (hit.ids.length < maxIds) hit.ids.push(e.id);
+  }
+
+  const suggestions: FpPropagationSuggestion[] = [];
+  for (const [key, hit] of hits) {
+    if (hit.ids.length < minMatches) continue;
+    suggestions.push({
+      markerId: hit.marker.id,
+      ref: hit.marker.ref,
+      note: (hit.marker.note ?? "").trim() || hit.marker.reason,
+      patternFingerprint: key,
+      count: hit.ids.length,
+      matchedEventIds: hit.ids,
+      sampleLabel: hit.sample.slice(0, 160),
+    });
+  }
+  suggestions.sort((a, b) => b.count - a.count || a.patternFingerprint.localeCompare(b.patternFingerprint));
+  return suggestions.slice(0, maxSuggestions);
+}

--- a/companion/src/analysis/importMeta.ts
+++ b/companion/src/analysis/importMeta.ts
@@ -48,6 +48,18 @@ export const importMetaSchema = z.object({
   // older import-meta.json files load with linesIn 0 / path "" and simply never trip the check.
   linesIn: z.number().catch(0),                                  // raw input lines/rows the import read
   path: z.enum(["deterministic", "ai", ""]).catch(""),           // "ai" = the log/CSV AI-triage path; "" = unknown/legacy
+  // Proactive FP-pattern propagation (investigation-guidance #15b): new events from THIS import that
+  // reproduce a known false-positive pattern, surfaced as a one-click "review & bulk-mark" banner
+  // suggestion (never auto-applied). Optional/lenient; absent on older files and imports with no match.
+  fpPropagation: z.array(z.object({
+    markerId: z.string().catch(""),
+    ref: z.string().catch(""),
+    note: z.string().catch(""),
+    patternFingerprint: z.string().catch(""),
+    count: z.number().catch(0),
+    matchedEventIds: z.array(z.string()).catch([]),
+    sampleLabel: z.string().catch(""),
+  })).catch([]),
 });
 
 export type ImportMeta = z.infer<typeof importMetaSchema>;
@@ -56,7 +68,7 @@ const EMPTY: ImportMeta = {
   lastImportedAt: "", lastImportKind: "", lastImportFile: "",
   addedCount: 0, removedCount: 0, lastDiff: null,
   iocsAddedCount: 0, iocsRemovedCount: 0, iocsDiff: null,
-  linesIn: 0, path: "",
+  linesIn: 0, path: "", fpPropagation: [],
 };
 
 // Cap how many added/removed events we store in the detail list — a single import can add
@@ -71,6 +83,7 @@ export interface ImportRecord {
   iocsDiff: IocsDiff;   // IOC diff
   linesIn?: number;                          // raw input lines/rows the import read (#10)
   path?: "deterministic" | "ai";             // which extraction path ran (#10)
+  fpPropagation?: ImportMeta["fpPropagation"]; // FP-pattern propagation suggestions (#15b)
 }
 
 export class ImportMetaStore {
@@ -109,6 +122,7 @@ export class ImportMetaStore {
       },
       linesIn: Math.max(0, Math.floor(rec.linesIn ?? 0)),
       path: rec.path ?? "",
+      fpPropagation: rec.fpPropagation ?? [],
     };
     await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
     return meta;

--- a/companion/src/routes/findings.ts
+++ b/companion/src/routes/findings.ts
@@ -5,6 +5,7 @@ import {
   applyFalsePositive, falsePositiveEventIds,
 } from "../analysis/falsePositive.js";
 import { reconsiderKeyQuestions, reconsiderNextSteps } from "../analysis/fpCascade.js";
+import { patternKey } from "../analysis/prevalence.js";
 import { findSimilarEvents, findSimilarFindings } from "../analysis/falsePositiveSimilarity.js";
 import { ScopeStore, type ScopeWindow } from "../analysis/scope.js";
 import { PinLimitError } from "../analysis/pinnedFindings.js";
@@ -133,10 +134,29 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
     }
   };
 
+  // Proactive FP-pattern propagation (#15b): stamp the anchor event's normalized prevalence pattern key
+  // onto each EVENT marker, so a later import can recognize the same pattern re-arriving and suggest a
+  // bulk-mark. One state load for the whole batch; best-effort (a lookup miss just leaves it unset).
+  const stampPatternFingerprints = async (caseId: string, markers: FalsePositiveMarker[]): Promise<void> => {
+    const needing = markers.filter((m) => m.kind === "event" && !m.patternFingerprint);
+    if (!needing.length || !options.stateStore) return;
+    try {
+      const state = await options.stateStore.load(caseId);
+      const byId = new Map(state.forensicTimeline.map((e) => [e.id, e] as const));
+      for (const m of needing) {
+        const ev = byId.get(m.ref);
+        if (!ev) continue;
+        const key = patternKey(ev);
+        if (key) m.patternFingerprint = key;
+      }
+    } catch { /* best-effort — leave fingerprints unset */ }
+  };
+
   app.post("/cases/:id/false-positive", async (req: Request, res: Response) => {
     try {
       const marker = buildFalsePositiveMarker(req.body ?? {});
       if (!marker) return res.status(400).json({ error: "ref is required (and note is required when reason is 'other')" });
+      await stampPatternFingerprints(req.params.id, [marker]);
       const markers = await falsePositives.load(req.params.id);
       const next = [...markers.filter((m) => m.id !== marker.id), marker];
       await falsePositives.save(req.params.id, next);
@@ -186,6 +206,7 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
           }))
         .filter((m: FalsePositiveMarker | null): m is FalsePositiveMarker => m !== null);
       if (!built.length) return res.status(400).json({ error: "at least one valid item (with a ref) is required" });
+      await stampPatternFingerprints(req.params.id, built);   // #15b: capture each event's pattern key
       const markers = await falsePositives.load(req.params.id);
       // De-dupe within the batch and against existing markers (last occurrence wins) by id.
       const byId = new Map<string, FalsePositiveMarker>(markers.map((m) => [m.id, m]));

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -25,6 +25,8 @@ import { parseSysdig, type SysdigImportOptions } from "../analysis/sysdigImport.
 import { parseWazuhAlerts, type WazuhImportOptions } from "../analysis/wazuhImport.js";
 import { parseMinSeverity } from "../analysis/severityFloor.js";
 import { diffTimeline, addedForensicEvents } from "../analysis/timelineDiff.js";
+import { FalsePositiveStore } from "../analysis/falsePositive.js";
+import { matchFpPropagation } from "../analysis/fpPropagation.js";
 import { diffIocs } from "../analysis/iocsDiff.js";
 import { logActivity } from "../analysis/activityLog.js";
 import { formatDropLogLines, appendDropLog, type DropLogEntry } from "../analysis/dropLog.js";
@@ -264,8 +266,20 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
               const s = await demoteForensicForCase(caseId);
               const tDiff = diffTimeline(stateBefore.forensicTimeline, s.forensicTimeline);
               const iDiff = diffIocs(stateBefore.iocs, s.iocs);
+              // Proactive FP-pattern propagation (#15b): does this import re-arrive with events matching a
+              // known false-positive pattern? Match the NEW forensic events against the FP markers'
+              // fingerprints and surface a one-click bulk-mark suggestion on the banner (never auto-mark).
+              let fpPropagation: Awaited<ReturnType<typeof matchFpPropagation>> = [];
+              try {
+                const beforeIds = new Set(stateBefore.forensicTimeline.map((e) => e.id));
+                const newEvents = s.forensicTimeline.filter((e) => !beforeIds.has(e.id));
+                if (newEvents.length) {
+                  const markers = await new FalsePositiveStore(store).load(caseId);
+                  fpPropagation = matchFpPropagation(newEvents, markers);
+                }
+              } catch { /* non-fatal — propagation is a suggestion, never blocks the import */ }
               if (options.importMetaStore) {
-                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff, linesIn: text.split(/\r?\n/).length, path: aiDependent ? "ai" : "deterministic" });
+                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff, linesIn: text.split(/\r?\n/).length, path: aiDependent ? "ai" : "deterministic", fpPropagation });
                 options.onImportMeta?.(caseId);
               }
               logActivity(options.activityLogStore, options.onActivity, caseId, {
@@ -437,8 +451,20 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
               const s = await demoteForensicForCase(caseId);
               const tDiff = diffTimeline(stateBefore.forensicTimeline, s.forensicTimeline);
               const iDiff = diffIocs(stateBefore.iocs, s.iocs);
+              // Proactive FP-pattern propagation (#15b): does this import re-arrive with events matching a
+              // known false-positive pattern? Match the NEW forensic events against the FP markers'
+              // fingerprints and surface a one-click bulk-mark suggestion on the banner (never auto-mark).
+              let fpPropagation: Awaited<ReturnType<typeof matchFpPropagation>> = [];
+              try {
+                const beforeIds = new Set(stateBefore.forensicTimeline.map((e) => e.id));
+                const newEvents = s.forensicTimeline.filter((e) => !beforeIds.has(e.id));
+                if (newEvents.length) {
+                  const markers = await new FalsePositiveStore(store).load(caseId);
+                  fpPropagation = matchFpPropagation(newEvents, markers);
+                }
+              } catch { /* non-fatal — propagation is a suggestion, never blocks the import */ }
               if (options.importMetaStore) {
-                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff, linesIn: text.split(/\r?\n/).length, path: aiDependent ? "ai" : "deterministic" });
+                await options.importMetaStore.record(caseId, { kind, file: storedName, diff: tDiff, iocsDiff: iDiff, linesIn: text.split(/\r?\n/).length, path: aiDependent ? "ai" : "deterministic", fpPropagation });
                 options.onImportMeta?.(caseId);
               }
               if (tDiff.added.length || tDiff.removed.length || iDiff.added.length || iDiff.removed.length) {

--- a/companion/tests/analysis/fpPropagation.test.ts
+++ b/companion/tests/analysis/fpPropagation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { matchFpPropagation } from "../../src/analysis/fpPropagation.js";
+import { patternKey } from "../../src/analysis/prevalence.js";
+import type { FalsePositiveMarker } from "../../src/analysis/falsePositive.js";
+import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+function ev(partial: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return { timestamp: "2026-01-02T10:00:00.000Z", description: "", severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...partial };
+}
+function marker(partial: Partial<FalsePositiveMarker> & { ref: string }): FalsePositiveMarker {
+  return { id: `event:${partial.ref}`, kind: "event", reason: "duplicate", note: "", markedAt: "2026-01-01T00:00:00Z", markedBy: "a", ...partial };
+}
+
+describe("matchFpPropagation (#15b)", () => {
+  it("surfaces a pattern reproduced by ≥minMatches new events, sorted most-matched first", () => {
+    // The FP marker's fingerprint is the anchor's pattern key.
+    const anchor = ev({ id: "old1", processName: "robocopy.exe", description: "robocopy C:\\data\\1 \\\\srv\\bak /mir" });
+    const m = marker({ ref: "old1", note: "nightly robocopy backup", patternFingerprint: patternKey(anchor) });
+
+    const newEvents = [
+      ev({ id: "n1", processName: "robocopy.exe", description: "robocopy C:\\data\\2 \\\\srv\\bak /mir" }),
+      ev({ id: "n2", processName: "robocopy.exe", description: "robocopy C:\\data\\3 \\\\srv2\\bak /mir" }),
+      ev({ id: "n3", processName: "robocopy.exe", description: "robocopy C:\\data\\4 \\\\srv3\\bak /mir" }),
+      ev({ id: "n4", processName: "powershell.exe", description: "iex (new-object net.webclient)" }), // unrelated
+    ];
+    const [s, ...rest] = matchFpPropagation(newEvents, [m], { minMatches: 3 });
+    expect(rest).toHaveLength(0);
+    expect(s.count).toBe(3);
+    expect(s.matchedEventIds.sort()).toEqual(["n1", "n2", "n3"]);
+    expect(s.note).toBe("nightly robocopy backup");
+    expect(s.ref).toBe("old1");
+  });
+
+  it("stays silent below the match threshold", () => {
+    const anchor = ev({ id: "old1", description: "some benign scan pattern" });
+    const m = marker({ ref: "old1", patternFingerprint: patternKey(anchor) });
+    const newEvents = [ev({ id: "n1", description: "some benign scan pattern" })]; // only 1 match, min 3
+    expect(matchFpPropagation(newEvents, [m], { minMatches: 3 })).toEqual([]);
+  });
+
+  it("ignores markers without a fingerprint and non-event markers", () => {
+    const newEvents = [ev({ id: "n1", description: "x pattern" }), ev({ id: "n2", description: "x pattern" }), ev({ id: "n3", description: "x pattern" })];
+    const noFp = marker({ ref: "old1" });                                   // event marker, no fingerprint
+    const findingM = marker({ ref: "some finding", kind: "finding", patternFingerprint: "desc:x pattern" }); // wrong kind
+    expect(matchFpPropagation(newEvents, [noFp, findingM], { minMatches: 1 })).toEqual([]);
+  });
+
+  it("caps matched ids per pattern", () => {
+    const anchor = ev({ id: "old1", description: "repeated line" });
+    const m = marker({ ref: "old1", patternFingerprint: patternKey(anchor) });
+    const many = Array.from({ length: 10 }, (_, i) => ev({ id: `n${i}`, description: "repeated line" }));
+    const [s] = matchFpPropagation(many, [m], { minMatches: 1, maxIdsPerPattern: 4 });
+    expect(s.count).toBe(4);
+    expect(s.matchedEventIds).toHaveLength(4);
+  });
+});

--- a/companion/tests/analysis/importMeta.test.ts
+++ b/companion/tests/analysis/importMeta.test.ts
@@ -35,7 +35,7 @@ describe("ImportMetaStore", () => {
       lastImportedAt: "", lastImportKind: "", lastImportFile: "",
       addedCount: 0, removedCount: 0, lastDiff: null,
       iocsAddedCount: 0, iocsRemovedCount: 0, iocsDiff: null,
-      linesIn: 0, path: "",
+      linesIn: 0, path: "", fpPropagation: [],
     });
   });
 
@@ -74,7 +74,7 @@ describe("ImportMetaStore", () => {
       lastImportedAt: "", lastImportKind: "", lastImportFile: "",
       addedCount: 0, removedCount: 0, lastDiff: null,
       iocsAddedCount: 0, iocsRemovedCount: 0, iocsDiff: null,
-      linesIn: 0, path: "",
+      linesIn: 0, path: "", fpPropagation: [],
     });
   });
 

--- a/companion/tests/server/fpPropagationStamp.test.ts
+++ b/companion/tests/server/fpPropagationStamp.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { patternKey } from "../../src/analysis/prevalence.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+// #15b: marking an EVENT false positive stamps the anchor's prevalence pattern key onto the marker, so a
+// later import can recognize the same pattern re-arriving and suggest a bulk-mark.
+
+function ev(partial: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return { timestamp: "2026-05-20T09:00:00Z", description: "", severity: "High", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...partial };
+}
+
+describe("POST /cases/:id/false-positive stamps patternFingerprint (#15b)", () => {
+  it("captures the anchor event's pattern key on the event marker (and not on IOC markers)", async () => {
+    const store = new CaseStore(await mkdtemp(join(tmpdir(), "dfir-fpprop-")));
+    const stateStore = new StateStore(store);
+    const app = createApp(store, { stateStore });
+    await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+
+    const anchor = ev({ id: "e1", processName: "robocopy.exe", description: "robocopy C:\\data\\1 \\\\srv\\bak /mir" });
+    const state = emptyState("c1");
+    state.forensicTimeline.push(anchor);
+    await stateStore.save(state);
+
+    await request(app).post("/cases/c1/false-positive").send({ kind: "event", ref: "e1", reason: "duplicate" });
+    await request(app).post("/cases/c1/false-positive").send({ kind: "ioc", ref: "1.2.3.4", reason: "duplicate" });
+
+    const res = await request(app).get("/cases/c1/false-positive");
+    const eventMarker = res.body.find((m: { kind: string }) => m.kind === "event");
+    const iocMarker = res.body.find((m: { kind: string }) => m.kind === "ioc");
+    expect(eventMarker.patternFingerprint).toBe(patternKey(anchor));
+    expect(eventMarker.patternFingerprint).toMatch(/^proc:robocopy\.exe\|/);
+    expect(iocMarker.patternFingerprint).toBeUndefined();   // only event markers carry a fingerprint
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -942,6 +942,10 @@
     .hyp.exhausted { opacity: 0.7; }
     .hyp-discriminator { font-size: 12px; color: var(--c-9fd0ff, #9fd0ff); margin: 3px 0; }
     .hyp-ach-note { color: var(--c-6b7280); font-size: 10px; font-weight: 400; }
+    /* Prevalence baseline chips (#15b). */
+    .prev-chip { font-size: 10px; font-weight: 600; border-radius: 4px; padding: 0 6px; white-space: nowrap; cursor: help; }
+    .prev-common { color: var(--c-9aa4b2); border: 1px solid var(--c-2a3146); }
+    .prev-rare { color: var(--c-ffb454, #ffb454); border: 1px solid var(--c-5a4a2a, #5a4a2a); }
     /* Raw-file (EVTX/PCAP) prompt banner — prominent, at the top of the content. #211 */
     .raw-banner { font-size: 13px; color: var(--c-e6e9ef); margin: 0 0 12px; padding: 11px 14px;
       border: 1px solid #7a5c1a; border-left: 4px solid #e0a72c; border-radius: 8px; background: #241a08; }
@@ -4712,6 +4716,9 @@
       if (Array.isArray(e.provenance) && e.provenance.length) {
         parts.push(`<span style="color:#6bcB77" title="Promoted from the raw super-timeline by the second-look re-query">🔁 ${e.provenance.map(esc).join(" ")}</span>`);
       }
+      // Prevalence baseline (#15b): how common this activity pattern is across the case.
+      const prevChip = prevalenceChip(e);
+      if (prevChip) parts.push(prevChip);
       const ev = (show("evidence") && caseId) ? evidenceLinks(caseId, e.sourceScreenshots) : "";
       if (ev) parts.push(ev.replace(/^<br>/, ""));
       if (!parts.length) return { title, toggle: "", panel: "" };
@@ -8617,7 +8624,31 @@
         const label = m.lastImportFile || m.lastImportKind || "this file";
         yieldWarn = `<div class="sm-line" style="color:var(--c-ff6b6b,#ff6b6b);font-weight:600">⚠️ ${esc(label)}: ${(m.linesIn).toLocaleString()} lines → 0 events via AI triage — re-run triage or grep the raw file for the case's IOCs/hosts before treating this source as clean.</div>`;
       }
-      el.innerHTML = `<div class="sm-line"><span>📥 Last import <strong>${esc(relTime(m.lastImportedAt))}</strong>${src}${kind}</span><span>${summary}</span></div>${yieldWarn}${detail}`;
+      // Proactive FP-pattern propagation (#15b): new events reproduce a known false-positive pattern —
+      // offer a one-click bulk-mark (SUGGESTED, never auto-applied). data-evids drives the batch call.
+      let fpProp = "";
+      const props = Array.isArray(m.fpPropagation) ? m.fpPropagation.filter(p => p && (p.count || 0) > 0) : [];
+      if (props.length) {
+        fpProp = props.map(p => {
+          const what = esc((p.note || p.ref || "a marked-FP pattern").slice(0, 80));
+          return `<div class="sm-line" style="color:var(--c-ffb454,#ffb454);font-weight:600" title="These new events match the pattern of a finding/event you previously marked false positive. Review, then bulk-mark — never auto-applied.">`
+            + `🔁 ${p.count} new event${p.count === 1 ? "" : "s"} match FP pattern “${what}” `
+            + `<a href="#" class="fp-propagate" data-evids="${escAttr((p.matchedEventIds || []).join(","))}" data-label="${escAttr(p.note || p.ref || "FP pattern")}" style="color:var(--c-6aa9ff);margin-left:6px">review &amp; bulk-mark →</a>`
+            + `</div>`;
+        }).join("");
+      }
+      el.innerHTML = `<div class="sm-line"><span>📥 Last import <strong>${esc(relTime(m.lastImportedAt))}</strong>${src}${kind}</span><span>${summary}</span></div>${yieldWarn}${fpProp}${detail}`;
+    }
+    // #15b: bulk-mark every new event matching a propagated FP pattern (one confirm → batch endpoint).
+    function propagateFalsePositive(ids, label) {
+      const caseId = document.getElementById("caseId").value.trim();
+      if (!caseId || !ids.length) return;
+      if (!confirm(`Mark all ${ids.length} new event(s) matching the “${label}” pattern as false positive?`)) return;
+      const items = ids.map(id => ({ kind: "event", ref: id, reason: "duplicate" }));
+      fetch(`/cases/${caseId}/false-positive/batch`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items, reason: "duplicate", note: `matches previously-marked FP pattern (${label})` }),
+      }).then(() => { const c = document.getElementById("caseId").value.trim(); if (c) fetch(`/cases/${c}/import-meta`).then(r => r.json()).then(renderImportMeta).catch(() => {}); }).catch(() => {});
     }
     function paintIocImportMeta(m) {
       const el = document.getElementById("iocImportMeta");
@@ -12569,7 +12600,50 @@
       }).join("");
     }
 
+    // Per-case prevalence chip (#15b, client mirror of prevalence.ts): how common each activity pattern
+    // is across the loaded timeline, so a row can show "seen 214×" (baseline) vs "rare 1×" (anomaly). A
+    // lightweight approximation of the server key — a display hint, not the authoritative synthesis index.
+    let prevIndexClient = new Map();
+    function clientCommandShape(text) {
+      return String(text || "").toLowerCase()
+        .replace(/\b[a-f0-9]{32,64}\b/g, "<hash>")
+        .replace(/\{?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}?/g, "<guid>")
+        .replace(/\\\\[^\s"']+/g, "<unc>").replace(/[a-z]:\\[^\s"']*/g, "<path>")
+        .replace(/(?:\/[^\s"'/]+){2,}\/?/g, "<path>")
+        .replace(/"[^"]*"/g, "<str>").replace(/'[^']*'/g, "<str>")
+        .replace(/\b\d[\d.,:]*\b/g, "<n>").replace(/\s+/g, " ").trim().slice(0, 200);
+    }
+    function clientPatternKey(e) {
+      const hash = String(e.sha256 || e.md5 || "").trim().toLowerCase();
+      if (hash) return "hash:" + hash;
+      const proc = String(e.processName || "").trim().toLowerCase();
+      const shape = clientCommandShape(e.description);
+      if (proc) return "proc:" + proc + "|" + shape;
+      return shape ? "desc:" + shape : "";
+    }
+    function buildClientPrevalence(events) {
+      const idx = new Map();
+      for (const e of (events || [])) {
+        const k = clientPatternKey(e);
+        if (!k) continue;
+        let st = idx.get(k);
+        if (!st) { st = { count: 0, hosts: new Set() }; idx.set(k, st); }
+        st.count++; if (e.asset) st.hosts.add(String(e.asset).toLowerCase());
+      }
+      return idx;
+    }
+    function prevalenceChip(e) {
+      const st = prevIndexClient.get(clientPatternKey(e));
+      if (!st) return "";
+      const hosts = st.hosts.size ? ` on ${st.hosts.size} host${st.hosts.size === 1 ? "" : "s"}` : "";
+      if (st.count >= 20) return `<span class="prev-chip prev-common" title="This pattern is common in this case — likely routine baseline activity.">≈ seen ${st.count}×${esc(hosts)}</span>`;
+      if (st.count <= 2) return `<span class="prev-chip prev-rare" title="This pattern is rare in this case — more likely to be signal than noise.">◆ rare (${st.count}×)</span>`;
+      return "";
+    }
     function renderTimelineEvents(ft) {
+      // Build the prevalence index over the full loaded timeline (baseline is a corpus property), not the
+      // filtered/paged subset, so counts are stable as the analyst filters.
+      prevIndexClient = buildClientPrevalence((lastState && lastState.forensicTimeline) ? lastState.forensicTimeline : ft);
       if (!_tlKeepPage) tlPage = 0;
       _tlKeepPage = false;
       // When the corroboration lens is on, scope the Sources menu to the tools present on events that
@@ -14206,6 +14280,14 @@
         e.preventDefault();
         const ids = (afp.getAttribute("data-evids") || "").split(",").filter(Boolean);
         markAnomalySpikeFalsePositive(ids, afp.getAttribute("data-label") || "");
+        return;
+      }
+      // Import-banner "review & bulk-mark" link (#15b) → batch-mark the new events matching an FP pattern.
+      const fpp = e.target.closest && e.target.closest(".fp-propagate");
+      if (fpp) {
+        e.preventDefault();
+        const ids = (fpp.getAttribute("data-evids") || "").split(",").filter(Boolean);
+        propagateFalsePositive(ids, fpp.getAttribute("data-label") || "FP pattern");
         return;
       }
       const chip = e.target.closest && e.target.closest(".comment-chip");


### PR DESCRIPTION
## What & why

Second half of the final roadmap item — **completing all 15 proposals**. Marking one event false positive taught the system nothing lasting: the same nightly-robocopy pattern re-arrived High after every import. This closes the loop, building on #15a's prevalence engine.

## How it works

- **`fpPropagation.ts`** — `matchFpPropagation()` matches freshly-imported events against the prevalence **pattern key** of existing FP markers, returning a "N new events reproduce this FP pattern" suggestion per pattern (most-matched first, capped). Match is **exact on the pattern key**, not the fuzzy `findSimilarEvents` scorer — a bulk FP suggestion must be precise (a loose "same MITRE" match could silently suppress an attacker); the fuzzy scorer stays for the interactive mark-FP dialog.
- **Capture** — the FP-mark routes (single + batch) stamp the anchor event's `patternKey` onto each event marker (`FalsePositiveMarker.patternFingerprint`).
- **Detect** — after each import, new events are matched against the FP markers and the suggestions stored in import-meta (best-effort; never blocks the import).
- **Surface** — the import banner shows **"🔁 N new events match FP pattern X — review & bulk-mark"** with a one-click (existing batch endpoint, one confirm — **never auto-applied**). Plus a **prevalence chip** on timeline rows (`≈ seen 214×` baseline / `◆ rare (1×)`), a client mirror of `prevalence.ts`.

## Files
- `analysis/fpPropagation.ts` (new), `analysis/falsePositive.ts` (`patternFingerprint`), `analysis/importMeta.ts` (`fpPropagation` record), `routes/findings.ts` (stamp), `routes/import.ts` (detect), `public/dashboard.html` (banner + chip).

## Tests
- `tests/analysis/fpPropagation.test.ts` (4): threshold, most-matched sort, ignores no-fingerprint / non-event markers, per-pattern id cap.
- `tests/server/fpPropagationStamp.test.ts` (1): the FP-mark route stamps `patternFingerprint` on event markers (and not on IOC markers).
- Full companion suite green (**3638**), clean `tsc`.

## Test plan
From `companion/` on this branch (`gh pr checkout <this-PR>` first):
- `npx vitest run tests/analysis/fpPropagation.test.ts tests/server/fpPropagationStamp.test.ts tests/analysis/importMeta.test.ts`
- `npx vitest run` (full) · `npx tsc --noEmit`

## Milestone
With #15a, this completes proposal **#15** and the **entire 15-item investigation-guidance roadmap**.

Part of #15 (roadmap Tier 3, final item).