### PR TITLE
feat: configurable event ingestion limits via environment variables

### DIFF
--- a/companion/src/analysis/auditdImport.ts
+++ b/companion/src/analysis/auditdImport.ts
@@ -31,6 +31,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Fields = Record<string, string>;
@@ -444,7 +445,7 @@ export function parseAuditdLog(text: string, opts: AuditdImportOptions = {}): Au
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/auditdImport.ts
+++ b/companion/src/analysis/auditdImport.ts
@@ -444,7 +444,7 @@ export function parseAuditdLog(text: string, opts: AuditdImportOptions = {}): Au
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/awsImport.ts
+++ b/companion/src/analysis/awsImport.ts
@@ -193,7 +193,7 @@ export function parseCloudTrail(text: string, opts: AwsImportOptions = {}): AwsP
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/awsImport.ts
+++ b/companion/src/analysis/awsImport.ts
@@ -27,6 +27,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -193,7 +194,7 @@ export function parseCloudTrail(text: string, opts: AwsImportOptions = {}): AwsP
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/bashHistoryImport.ts
+++ b/companion/src/analysis/bashHistoryImport.ts
@@ -12,6 +12,7 @@
 import {
   addIoc, aggregateEvents, cleanIp, hasPlausibleTld,
   type MappedEvent, type SiemImportOptions, type SiemIoc, type SiemParseResult,
+  maxEventsDefault,
 } from "./siemImport.js";
 import type { Severity } from "./stateTypes.js";
 import { reconTechniques } from "./reconTechniques.js";
@@ -181,7 +182,7 @@ export function parseShellHistoryFile(text: string, opts: BashHistoryImportOptio
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const maxIocs = opts.maxIocs ?? 5000;

--- a/companion/src/analysis/bashHistoryImport.ts
+++ b/companion/src/analysis/bashHistoryImport.ts
@@ -181,7 +181,7 @@ export function parseShellHistoryFile(text: string, opts: BashHistoryImportOptio
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const maxIocs = opts.maxIocs ?? 5000;

--- a/companion/src/analysis/chainsawImport.ts
+++ b/companion/src/analysis/chainsawImport.ts
@@ -54,7 +54,7 @@ export interface ChainsawImportOptions {
   aggregate?: boolean;
   // Drop events below this severity floor. Default undefined = keep everything.
   minSeverity?: Severity;
-  // Safety cap on emitted events (most-severe first). Default 2000.
+  // Safety cap on emitted events. Default 2000 (overridable via DFIR_MAX_EVENTS).
   maxEvents?: number;
   // Safety cap on emitted IOCs. Default 5000.
   maxIocs?: number;
@@ -311,7 +311,7 @@ export function parseChainsawReport(text: string, opts: ChainsawImportOptions = 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/chainsawImport.ts
+++ b/companion/src/analysis/chainsawImport.ts
@@ -45,6 +45,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -311,7 +312,7 @@ export function parseChainsawReport(text: string, opts: ChainsawImportOptions = 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/ciscoAsaImport.ts
+++ b/companion/src/analysis/ciscoAsaImport.ts
@@ -175,7 +175,7 @@ export function parseCiscoAsaLog(text: string, opts: CiscoAsaImportOptions = {})
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/ciscoAsaImport.ts
+++ b/companion/src/analysis/ciscoAsaImport.ts
@@ -22,7 +22,9 @@
 // siemImport's aggregation + IOC sink.
 
 import type { Severity } from "./stateTypes.js";
-import { aggregateEvents, addIoc, cleanIp, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult } from "./siemImport.js";
+import { aggregateEvents, addIoc, cleanIp, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult,
+  maxEventsDefault,
+} from "./siemImport.js";
 
 export interface CiscoAsaImportOptions {
   aggregate?: boolean;
@@ -175,7 +177,7 @@ export function parseCiscoAsaLog(text: string, opts: CiscoAsaImportOptions = {})
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/cloudActivityImport.ts
+++ b/companion/src/analysis/cloudActivityImport.ts
@@ -212,7 +212,7 @@ export function parseCloudActivity(text: string, opts: CloudActivityImportOption
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/cloudActivityImport.ts
+++ b/companion/src/analysis/cloudActivityImport.ts
@@ -29,6 +29,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -212,7 +213,7 @@ export function parseCloudActivity(text: string, opts: CloudActivityImportOption
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/combinedLogImport.ts
+++ b/companion/src/analysis/combinedLogImport.ts
@@ -186,7 +186,7 @@ export function parseCombinedLog(text: string, opts: CombinedLogImportOptions = 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/combinedLogImport.ts
+++ b/companion/src/analysis/combinedLogImport.ts
@@ -48,7 +48,9 @@
 // here (that cap is shared code, not specific to this format).
 
 import type { Severity } from "./stateTypes.js";
-import { aggregateEvents, addIoc, mergeRowIocs, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult } from "./siemImport.js";
+import { aggregateEvents, addIoc, mergeRowIocs, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult,
+  maxEventsDefault,
+} from "./siemImport.js";
 
 export interface CombinedLogImportOptions {
   aggregate?: boolean;
@@ -186,7 +188,7 @@ export function parseCombinedLog(text: string, opts: CombinedLogImportOptions = 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/cybertriageImport.ts
+++ b/companion/src/analysis/cybertriageImport.ts
@@ -331,7 +331,7 @@ export function parseCybertriage(text: string, opts: CybertriageImportOptions = 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/cybertriageImport.ts
+++ b/companion/src/analysis/cybertriageImport.ts
@@ -41,6 +41,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -331,7 +332,7 @@ export function parseCybertriage(text: string, opts: CybertriageImportOptions = 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/ecarImport.ts
+++ b/companion/src/analysis/ecarImport.ts
@@ -50,7 +50,7 @@ type Row = Record<string, unknown>;
 export interface EcarImportOptions {
   aggregate?: boolean;   // collapse repetitive identical events into one counted row. Default true.
   minSeverity?: Severity; // drop events below this floor. Default undefined = keep everything.
-  maxEvents?: number;    // safety cap on emitted events (most-severe first). Default 2000.
+  maxEvents?: number;    // safety cap on emitted events (most-severe first). Default 2000 (overridable via DFIR_MAX_EVENTS).
   maxIocs?: number;      // safety cap on emitted IOCs. Default 5000.
 }
 
@@ -333,7 +333,7 @@ export function parseEcarJson(text: string, opts: EcarImportOptions = {}): EcarP
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/ecarImport.ts
+++ b/companion/src/analysis/ecarImport.ts
@@ -41,6 +41,7 @@ import {
   type SiemEvent,
   type SiemIoc,
   type SiemParseResult,
+  maxEventsDefault,
 } from "./siemImport.js";
 import { reconTechniques } from "./reconTechniques.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
@@ -333,7 +334,7 @@ export function parseEcarJson(text: string, opts: EcarImportOptions = {}): EcarP
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/hayabusaImport.ts
+++ b/companion/src/analysis/hayabusaImport.ts
@@ -39,6 +39,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -263,7 +264,7 @@ export function parseHayabusaTimeline(text: string, opts: HayabusaImportOptions 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/hayabusaImport.ts
+++ b/companion/src/analysis/hayabusaImport.ts
@@ -263,7 +263,7 @@ export function parseHayabusaTimeline(text: string, opts: HayabusaImportOptions 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/journaldImport.ts
+++ b/companion/src/analysis/journaldImport.ts
@@ -188,7 +188,7 @@ export function parseJournald(text: string, opts: JournaldImportOptions = {}): J
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/journaldImport.ts
+++ b/companion/src/analysis/journaldImport.ts
@@ -31,6 +31,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -188,7 +189,7 @@ export function parseJournald(text: string, opts: JournaldImportOptions = {}): J
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/k8sAuditImport.ts
+++ b/companion/src/analysis/k8sAuditImport.ts
@@ -27,6 +27,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -186,7 +187,7 @@ export function parseK8sAudit(text: string, opts: K8sAuditImportOptions = {}): K
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/k8sAuditImport.ts
+++ b/companion/src/analysis/k8sAuditImport.ts
@@ -186,7 +186,7 @@ export function parseK8sAudit(text: string, opts: K8sAuditImportOptions = {}): K
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/kapeImport.ts
+++ b/companion/src/analysis/kapeImport.ts
@@ -288,7 +288,7 @@ export function parseKapeCsv(text: string, opts: KapeImportOptions = {}): KapePa
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/kapeImport.ts
+++ b/companion/src/analysis/kapeImport.ts
@@ -27,6 +27,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -288,7 +289,7 @@ export function parseKapeCsv(text: string, opts: KapeImportOptions = {}): KapePa
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/m365Import.ts
+++ b/companion/src/analysis/m365Import.ts
@@ -34,6 +34,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -297,7 +298,7 @@ export function parseM365Audit(text: string, opts: M365ImportOptions = {}): M365
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/m365Import.ts
+++ b/companion/src/analysis/m365Import.ts
@@ -297,7 +297,7 @@ export function parseM365Audit(text: string, opts: M365ImportOptions = {}): M365
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/memoryImport.ts
+++ b/companion/src/analysis/memoryImport.ts
@@ -802,7 +802,7 @@ function parseMemoryFindevil(text: string, opts: MemoryImportOptions): MemoryPar
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -867,7 +867,7 @@ function parseMemoryFindevilCsv(text: string, opts: MemoryImportOptions): Memory
   const sink = new Map<string, SiemIoc>();
   const mapped = mapFindevil(findevilRows, sink);
   const { events, groups } = aggregateEvents(mapped, {
-    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? 2000,
+    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -928,7 +928,7 @@ function parseMemoryYaraCsv(text: string, opts: MemoryImportOptions): MemoryPars
   }
 
   const { events, groups } = aggregateEvents(mapped, {
-    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? 2000,
+    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -1121,7 +1121,7 @@ function parseMemoryMemprocfsTimeline(text: string, opts: MemoryImportOptions): 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate:   opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents:   opts.maxEvents ?? 2000,
+    maxEvents:   opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -1191,7 +1191,7 @@ export function parseMemory(text: string, opts: MemoryImportOptions = {}): Memor
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/memoryImport.ts
+++ b/companion/src/analysis/memoryImport.ts
@@ -47,6 +47,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 import { parseCsv } from "./csvImport.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
@@ -802,7 +803,7 @@ function parseMemoryFindevil(text: string, opts: MemoryImportOptions): MemoryPar
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -867,7 +868,7 @@ function parseMemoryFindevilCsv(text: string, opts: MemoryImportOptions): Memory
   const sink = new Map<string, SiemIoc>();
   const mapped = mapFindevil(findevilRows, sink);
   const { events, groups } = aggregateEvents(mapped, {
-    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -928,7 +929,7 @@ function parseMemoryYaraCsv(text: string, opts: MemoryImportOptions): MemoryPars
   }
 
   const { events, groups } = aggregateEvents(mapped, {
-    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    aggregate: opts.aggregate, minSeverity: opts.minSeverity, maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -1121,7 +1122,7 @@ function parseMemoryMemprocfsTimeline(text: string, opts: MemoryImportOptions): 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate:   opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents:   opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents:   opts.maxEvents ?? maxEventsDefault(),
   });
   const maxIocs = opts.maxIocs ?? 5000;
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -1191,7 +1192,7 @@ export function parseMemory(text: string, opts: MemoryImportOptions = {}): Memor
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/networkImport.ts
+++ b/companion/src/analysis/networkImport.ts
@@ -305,7 +305,7 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/networkImport.ts
+++ b/companion/src/analysis/networkImport.ts
@@ -30,6 +30,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -305,7 +306,7 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/osqueryImport.ts
+++ b/companion/src/analysis/osqueryImport.ts
@@ -32,6 +32,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
 import { reconTechniques } from "./reconTechniques.js";
@@ -177,7 +178,7 @@ export function parseOsqueryLog(text: string, opts: OsqueryImportOptions = {}): 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/osqueryImport.ts
+++ b/companion/src/analysis/osqueryImport.ts
@@ -177,7 +177,7 @@ export function parseOsqueryLog(text: string, opts: OsqueryImportOptions = {}): 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/plasoImport.ts
+++ b/companion/src/analysis/plasoImport.ts
@@ -26,6 +26,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -205,7 +206,7 @@ export function parsePlasoCsv(text: string, opts: PlasoImportOptions = {}): Plas
   const { events, groups } = aggregateEvents(mappedGen(), {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -246,7 +247,7 @@ export async function parsePlasoFromLines(
   const agg = createEventAggregator({
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   for await (const cols of records) {
     total++;

--- a/companion/src/analysis/plasoImport.ts
+++ b/companion/src/analysis/plasoImport.ts
@@ -205,7 +205,7 @@ export function parsePlasoCsv(text: string, opts: PlasoImportOptions = {}): Plas
   const { events, groups } = aggregateEvents(mappedGen(), {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
@@ -246,7 +246,7 @@ export async function parsePlasoFromLines(
   const agg = createEventAggregator({
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   for await (const cols of records) {
     total++;

--- a/companion/src/analysis/sandboxImport.ts
+++ b/companion/src/analysis/sandboxImport.ts
@@ -275,7 +275,7 @@ export function parseSandboxReport(text: string, opts: SandboxImportOptions = {}
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const format = sawCape && sawFalcon ? "mixed" : sawCape ? "capev2" : sawFalcon ? "falcon" : "empty";

--- a/companion/src/analysis/sandboxImport.ts
+++ b/companion/src/analysis/sandboxImport.ts
@@ -26,6 +26,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -275,7 +276,7 @@ export function parseSandboxReport(text: string, opts: SandboxImportOptions = {}
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const format = sawCape && sawFalcon ? "mixed" : sawCape ? "capev2" : sawFalcon ? "falcon" : "empty";

--- a/companion/src/analysis/securityOnionImport.ts
+++ b/companion/src/analysis/securityOnionImport.ts
@@ -223,7 +223,7 @@ export function parseSecurityOnion(text: string, opts: SecurityOnionImportOption
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/securityOnionImport.ts
+++ b/companion/src/analysis/securityOnionImport.ts
@@ -30,6 +30,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -223,7 +224,7 @@ export function parseSecurityOnion(text: string, opts: SecurityOnionImportOption
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -95,6 +95,15 @@ type Row = Record<string, unknown>;
 
 const SEVERITY_RANK: Record<Severity, number> = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4 };
 
+// Safety cap on emitted events, shared by every importer. Overridable via DFIR_MAX_EVENTS
+// (must be a positive integer to take effect; unset/invalid/non-positive values keep the
+// default so a typo or DFIR_MAX_EVENTS=0 can't silently reintroduce the cap analysts meant to lift).
+const DEFAULT_MAX_EVENTS = 2000;
+export function maxEventsDefault(): number {
+  const n = Number(process.env.DFIR_MAX_EVENTS);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_MAX_EVENTS;
+}
+
 // ───────────────────────────── small value helpers ─────────────────────────────
 
 export function isObject(v: unknown): v is Row {
@@ -977,7 +986,7 @@ export function createEventAggregator(
   opts: { aggregate?: boolean; minSeverity?: Severity; maxEvents?: number } = {},
 ): EventAggregator {
   const aggregate = opts.aggregate ?? true;
-  const maxEvents = opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000);
+  const maxEvents = opts.maxEvents ?? maxEventsDefault();
   const floorRank = opts.minSeverity ? SEVERITY_RANK[opts.minSeverity] : Infinity;
 
   const byKey = new Map<string, SiemEvent>();
@@ -1082,7 +1091,7 @@ export function buildSiemResult(records: Row[], format: string, opts: SiemImport
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -32,7 +32,7 @@ export interface SiemImportOptions {
   // Drop events below this severity floor (e.g. "Low" drops Info noise like logoffs /
   // process-terminated). Default undefined = keep everything.
   minSeverity?: Severity;
-  // Safety cap on emitted events (most-severe first). Default 2000.
+  // Safety cap on emitted events. Default 2000 (overridable via DFIR_MAX_EVENTS).
   maxEvents?: number;
   // Safety cap on emitted IOCs. Default 5000.
   maxIocs?: number;
@@ -977,7 +977,7 @@ export function createEventAggregator(
   opts: { aggregate?: boolean; minSeverity?: Severity; maxEvents?: number } = {},
 ): EventAggregator {
   const aggregate = opts.aggregate ?? true;
-  const maxEvents = opts.maxEvents ?? 2000;
+  const maxEvents = opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000);
   const floorRank = opts.minSeverity ? SEVERITY_RANK[opts.minSeverity] : Infinity;
 
   const byKey = new Map<string, SiemEvent>();
@@ -1082,7 +1082,7 @@ export function buildSiemResult(records: Row[], format: string, opts: SiemImport
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/snortImport.ts
+++ b/companion/src/analysis/snortImport.ts
@@ -130,7 +130,7 @@ export function parseSnortLog(text: string, opts: SnortImportOptions = {}): Snor
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/snortImport.ts
+++ b/companion/src/analysis/snortImport.ts
@@ -13,7 +13,9 @@
 // the ECAR/network importers, to keep the IOC list tight). Pure, no AI. Reuses siemImport's helpers.
 
 import type { Severity } from "./stateTypes.js";
-import { aggregateEvents, addIoc, cleanIp, oneLine, type MappedEvent, type SiemEvent, type SiemIoc, type SiemParseResult } from "./siemImport.js";
+import { aggregateEvents, addIoc, cleanIp, oneLine, type MappedEvent, type SiemEvent, type SiemIoc, type SiemParseResult,
+  maxEventsDefault,
+} from "./siemImport.js";
 
 export interface SnortImportOptions {
   aggregate?: boolean;
@@ -130,7 +132,7 @@ export function parseSnortLog(text: string, opts: SnortImportOptions = {}): Snor
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/socratesImport.ts
+++ b/companion/src/analysis/socratesImport.ts
@@ -23,6 +23,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 import { parseNetworkLogs } from "./networkImport.js";
 
@@ -215,7 +216,7 @@ function mapSigma(row: Row, sink: Map<string, SiemIoc>): MappedEvent {
 }
 
 export function parseSocrates(text: string, opts: SocratesImportOptions = {}): SocratesParseResult {
-  const maxEvents = opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000);
+  const maxEvents = opts.maxEvents ?? maxEventsDefault();
   const maxIocs = opts.maxIocs ?? 5000;
   const { records } = extractRecords(text);
   const total = records.length;

--- a/companion/src/analysis/socratesImport.ts
+++ b/companion/src/analysis/socratesImport.ts
@@ -215,7 +215,7 @@ function mapSigma(row: Row, sink: Map<string, SiemIoc>): MappedEvent {
 }
 
 export function parseSocrates(text: string, opts: SocratesImportOptions = {}): SocratesParseResult {
-  const maxEvents = opts.maxEvents ?? 2000;
+  const maxEvents = opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000);
   const maxIocs = opts.maxIocs ?? 5000;
   const { records } = extractRecords(text);
   const total = records.length;

--- a/companion/src/analysis/sysdigImport.ts
+++ b/companion/src/analysis/sysdigImport.ts
@@ -31,6 +31,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -229,7 +230,7 @@ export function parseSysdig(text: string, opts: SysdigImportOptions = {}): Sysdi
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/sysdigImport.ts
+++ b/companion/src/analysis/sysdigImport.ts
@@ -229,7 +229,7 @@ export function parseSysdig(text: string, opts: SysdigImportOptions = {}): Sysdi
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/syslogImport.ts
+++ b/companion/src/analysis/syslogImport.ts
@@ -207,7 +207,7 @@ export function parseSyslog(text: string, opts: SyslogImportOptions = {}): Syslo
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/syslogImport.ts
+++ b/companion/src/analysis/syslogImport.ts
@@ -27,7 +27,9 @@
 // tag (see importDetect.ts), so an ASA export never reaches here.
 
 import type { Severity } from "./stateTypes.js";
-import { aggregateEvents, addIoc, cleanIp, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult } from "./siemImport.js";
+import { aggregateEvents, addIoc, cleanIp, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult,
+  maxEventsDefault,
+} from "./siemImport.js";
 
 export interface SyslogImportOptions {
   aggregate?: boolean;
@@ -207,7 +209,7 @@ export function parseSyslog(text: string, opts: SyslogImportOptions = {}): Syslo
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/theHiveImport.ts
+++ b/companion/src/analysis/theHiveImport.ts
@@ -266,7 +266,7 @@ export function parseTheHive(text: string, opts: TheHiveImportOptions = {}): The
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/theHiveImport.ts
+++ b/companion/src/analysis/theHiveImport.ts
@@ -26,6 +26,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -266,7 +267,7 @@ export function parseTheHive(text: string, opts: TheHiveImportOptions = {}): The
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/thorImport.ts
+++ b/companion/src/analysis/thorImport.ts
@@ -9,6 +9,7 @@
 // below. Only scored findings (Alert/Warning/Notice from real scan modules) survive.
 
 import type { Severity } from "./stateTypes.js";
+import { maxEventsDefault } from "./siemImport.js";
 
 // Modules that report scan lifecycle / app status, not host findings — dropped by default.
 const LIFECYCLE_MODULES = new Set(["Init", "Startup", "Control", "ThorDB", "Report"]);
@@ -138,7 +139,7 @@ const SEVERITY_RANK: Record<Severity, number> = { Critical: 0, High: 1, Medium: 
 export function parseThorReport(jsonText: string, opts: ThorImportOptions = {}): ThorParseResult {
   const dropInfo = opts.dropInfo ?? true;
   const dropLifecycle = opts.dropLifecycleModules ?? true;
-  const maxEvents = opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000);
+  const maxEvents = opts.maxEvents ?? maxEventsDefault();
 
   const lines = jsonText.split(/\r\n|\r|\n/).map((l) => l.trim()).filter(Boolean);
   let total = 0;

--- a/companion/src/analysis/thorImport.ts
+++ b/companion/src/analysis/thorImport.ts
@@ -34,7 +34,7 @@ export interface ThorImportOptions {
   // Minimum THOR level to import. "Notice" keeps Alert+Warning+Notice (default), "Warning"
   // drops Notice, "Alert" keeps only Alerts. Independent of dropInfo (Info is below Notice).
   minLevel?: ThorLevel;
-  // Safety cap on emitted events (most-severe kept first). Default 2000.
+  // Safety cap on emitted events. Default 2000 (overridable via DFIR_MAX_EVENTS).
   maxEvents?: number;
 }
 
@@ -138,7 +138,7 @@ const SEVERITY_RANK: Record<Severity, number> = { Critical: 0, High: 1, Medium: 
 export function parseThorReport(jsonText: string, opts: ThorImportOptions = {}): ThorParseResult {
   const dropInfo = opts.dropInfo ?? true;
   const dropLifecycle = opts.dropLifecycleModules ?? true;
-  const maxEvents = opts.maxEvents ?? 2000;
+  const maxEvents = opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000);
 
   const lines = jsonText.split(/\r\n|\r|\n/).map((l) => l.trim()).filter(Boolean);
   let total = 0;

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -45,6 +45,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 // A row from a Velociraptor artifact that shells out to Chainsaw and streams its rows back as
 // VQL (e.g. a custom "run chainsaw" artifact) carries Chainsaw's flat Sigma-mapping shape
@@ -1127,7 +1128,7 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1127,7 +1127,7 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);

--- a/companion/src/analysis/wazuhImport.ts
+++ b/companion/src/analysis/wazuhImport.ts
@@ -39,7 +39,7 @@ export interface WazuhImportOptions {
   minSeverity?: Severity;
   // Drop alerts whose rule.level is below this value. Default 3 (suppress pure noise).
   minLevel?: number;
-  // Safety cap on emitted events. Default 2000.
+  // Safety cap on emitted events. Default 2000 (overridable via DFIR_MAX_EVENTS).
   maxEvents?: number;
   // Safety cap on emitted IOCs. Default 5000.
   maxIocs?: number;
@@ -229,7 +229,7 @@ export function parseWazuhAlerts(text: string, opts: WazuhImportOptions = {}): W
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
 
   // Best-effort dominant host: most-common agent.name across ALL mapped events.

--- a/companion/src/analysis/wazuhImport.ts
+++ b/companion/src/analysis/wazuhImport.ts
@@ -28,6 +28,7 @@ import {
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
+  maxEventsDefault,
 } from "./siemImport.js";
 
 type Row = Record<string, unknown>;
@@ -229,7 +230,7 @@ export function parseWazuhAlerts(text: string, opts: WazuhImportOptions = {}): W
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
   // Best-effort dominant host: most-common agent.name across ALL mapped events.

--- a/companion/src/analysis/yaraImport.ts
+++ b/companion/src/analysis/yaraImport.ts
@@ -18,7 +18,9 @@
 // hash meta → hash IOC. Pure, no AI. Reuses siemImport's helpers.
 
 import type { Severity } from "./stateTypes.js";
-import { aggregateEvents, addIoc, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult } from "./siemImport.js";
+import { aggregateEvents, addIoc, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult,
+  maxEventsDefault,
+} from "./siemImport.js";
 
 export interface YaraImportOptions {
   aggregate?: boolean;
@@ -167,7 +169,7 @@ export function parseYaraOutput(text: string, opts: YaraImportOptions = {}): Sie
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/src/analysis/yaraImport.ts
+++ b/companion/src/analysis/yaraImport.ts
@@ -167,7 +167,7 @@ export function parseYaraOutput(text: string, opts: YaraImportOptions = {}): Sie
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,
     minSeverity: opts.minSeverity,
-    maxEvents: opts.maxEvents ?? 2000,
+    maxEvents: opts.maxEvents ?? (Number(process.env.DFIR_MAX_EVENTS) || 2000),
   });
   const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
 

--- a/companion/tests/analysis/siemImport.test.ts
+++ b/companion/tests/analysis/siemImport.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { parseSiemExport, extractRecords, isSuspiciousCmd, cleanIp, textIocs, mergeRowIocs, resolveExtractedFrom, type SiemIoc } from "../../src/analysis/siemImport.js";
+import { describe, it, expect, afterEach } from "vitest";
+import { parseSiemExport, extractRecords, isSuspiciousCmd, cleanIp, textIocs, mergeRowIocs, resolveExtractedFrom, maxEventsDefault, type SiemIoc } from "../../src/analysis/siemImport.js";
 
 // ── Representative Windows Event Log records (Elastic _source shape) ─────────────
 const LOGON_4624 = {
@@ -574,5 +574,43 @@ describe("row-scoped IOC provenance (aggKey plumbing)", () => {
     const iocs: SiemIoc[] = [{ type: "domain", value: "x.com", sourceAggKeys: ["agg-1", "agg-missing"] }];
     const eventIdByAggKey = new Map([["agg-1", "e001"]]);
     expect(resolveExtractedFrom(iocs, eventIdByAggKey)[0].extractedFrom).toEqual(["e001"]);
+  });
+});
+
+describe("maxEventsDefault", () => {
+  const ORIGINAL = process.env.DFIR_MAX_EVENTS;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.DFIR_MAX_EVENTS;
+    else process.env.DFIR_MAX_EVENTS = ORIGINAL;
+  });
+
+  it("falls back to 2000 when unset", () => {
+    delete process.env.DFIR_MAX_EVENTS;
+    expect(maxEventsDefault()).toBe(2000);
+  });
+
+  it("honors a positive override", () => {
+    process.env.DFIR_MAX_EVENTS = "50000";
+    expect(maxEventsDefault()).toBe(50000);
+  });
+
+  it("floors a fractional override", () => {
+    process.env.DFIR_MAX_EVENTS = "150.9";
+    expect(maxEventsDefault()).toBe(150);
+  });
+
+  it("falls back to 2000 for 0 instead of treating it as unlimited", () => {
+    process.env.DFIR_MAX_EVENTS = "0";
+    expect(maxEventsDefault()).toBe(2000);
+  });
+
+  it("falls back to 2000 for a negative value", () => {
+    process.env.DFIR_MAX_EVENTS = "-5";
+    expect(maxEventsDefault()).toBe(2000);
+  });
+
+  it("falls back to 2000 for an unparseable value", () => {
+    process.env.DFIR_MAX_EVENTS = "20oo";
+    expect(maxEventsDefault()).toBe(2000);
   });
 });


### PR DESCRIPTION
Replaces the hardcoded 2000-event limit across all analysis importers with a configurable "DFIR_MAX_EVENTS" environment variable, defaulting back to 2000 for safety if left unset. This allows analysts to unlock full event ingestion for datasets exceeding 2000 events by simply overriding the container's environment.