### PR TITLE
feat: KEV / verdict-first / hunt-artifact confidence signals for findings (#61)

### DIFF
--- a/companion/src/analysis/findingGrounding.ts
+++ b/companion/src/analysis/findingGrounding.ts
@@ -254,7 +254,8 @@ export function corroborationLabel(f: Finding): string {
   if (c.intelSources > 0) parts.push("intel ✓");
   if (c.graphLinked) parts.push("graph-linked");
   if (c.kevLinked) parts.push("KEV ✓");
+  if (c.verdictFirst) parts.push("tool-confirmed");
   const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked || !!c.kevLinked;
-  const huntCaution = c.huntArtifactOnly && c.intelSources === 0 && !c.kevLinked ? " — hunt-artifact only" : "";
+  const huntCaution = c.huntArtifactOnly && c.intelSources === 0 && !c.kevLinked ? " — unconfirmed lead" : "";
   return `${parts.join(" / ")}${corroborated ? "" : " — uncorroborated"}${huntCaution}`;
 }

--- a/companion/src/analysis/findingGrounding.ts
+++ b/companion/src/analysis/findingGrounding.ts
@@ -13,12 +13,21 @@
 
 import type { Finding, ForensicEvent, IOC, FindingCorroboration, Severity, NextStep } from "./stateTypes.js";
 import { classifyVerdict, iocHasBehavioralEvent } from "./iocAnchors.js";
+import { SEVERITY_RANK } from "./forensicGate.js";
+import { extractCveIds } from "./kev.js";
 
 // A finding with no cited in-scope evidence is a hypothesis — cap hard so it can't outrank grounded work.
 export const UNGROUNDED_CONFIDENCE_CAP = 45;
 // A grounded but single-source (one tool, one host, no corroborating IOC/graph) finding is capped here —
 // it may be real, but it can't claim high confidence on one uncorroborated observation.
 export const SINGLE_SOURCE_CONFIDENCE_CAP = 65;
+// A finding that rests ONLY on raw hunt-collection artifacts (every supporting event is Info telemetry —
+// no tool adjudicated it, no intel/KEV lift) is capped here (issue #61): it's a lead someone still has to
+// triage, not a confirmed detection. Lower than the single-source cap because nothing has verdicted it.
+export const HUNT_ARTIFACT_CONFIDENCE_CAP = 55;
+// Rank at/above which a supporting event counts as an adjudicated "detection" (verdict-first) rather than
+// raw telemetry — the same Low+ cut iocProvenance.ts uses for detection-vs-telemetry.
+const DETECTION_RANK = SEVERITY_RANK.Low;
 
 function appendReason(existing: string | undefined, note: string): string {
   const base = (existing ?? "").trim();
@@ -30,6 +39,9 @@ export interface GroundingInput {
   scopedEvents: readonly ForensicEvent[];      // in-scope events, carrying relatedFindingIds (reverse links)
   iocs: readonly IOC[];
   graphLinkedEventIds: ReadonlySet<string>;     // event ids that participate in an evidence-graph edge
+  // CVE ids (upper-cased) present in the case that MATCH the CISA KEV catalog (issue #61). A finding is
+  // `kevLinked` when it references one of these. Optional — omit/empty when no KEV catalog is loaded.
+  kevCveIds?: ReadonlySet<string>;
 }
 
 // The IOC ids that carry at least one malicious/suspicious intel verdict — the finding-level "intel
@@ -42,9 +54,29 @@ function intelFlaggedIocIds(iocs: readonly IOC[]): Set<string> {
   return out;
 }
 
+// A finding is KEV-linked when any CVE it references — in its own title/description, its supporting
+// events' text, or its related IOC values — is in the case's KEV-matched set. Empty set ⇒ never linked.
+function findingIsKevLinked(
+  f: Finding,
+  supporting: readonly ForensicEvent[],
+  iocById: ReadonlyMap<string, IOC>,
+  kevCveIds: ReadonlySet<string>,
+): boolean {
+  if (!kevCveIds.size) return false;
+  const texts: string[] = [f.title, f.description];
+  for (const e of supporting) { texts.push(e.description); if (e.message) texts.push(e.message); }
+  for (const id of f.relatedIocs ?? []) { const i = iocById.get(id); if (i) texts.push(i.value); }
+  for (const t of texts) {
+    for (const cve of extractCveIds(t)) if (kevCveIds.has(cve)) return true;
+  }
+  return false;
+}
+
 export function groundAndScoreFindings(input: GroundingInput): Finding[] {
   const { findings, scopedEvents, iocs, graphLinkedEventIds } = input;
+  const kevCveIds = input.kevCveIds ?? new Set<string>();
   const scopedById = new Map(scopedEvents.map((e) => [e.id, e] as const));
+  const iocById = new Map(iocs.map((i) => [i.id, i] as const));
   const intelIocs = intelFlaggedIocIds(iocs);
 
   return findings.map((f) => {
@@ -65,7 +97,13 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
     const distinctHosts = new Set(supporting.map((e) => e.asset).filter((a): a is string => !!a)).size;
     const graphLinked = supporting.some((e) => graphLinkedEventIds.has(e.id));
     const intelSources = (f.relatedIocs ?? []).filter((id) => intelIocs.has(id)).length;
-    const corroboration: FindingCorroboration = { distinctTools, distinctHosts, intelSources, graphLinked };
+    // Issue #61 signals: verdict-first = any supporting event is a graded (Low+) detection a tool
+    // adjudicated; hunt-artifact-only = grounded but EVERY supporting event is raw Info telemetry;
+    // KEV-linked = references an actively-exploited CVE.
+    const verdictFirst = supporting.some((e) => (SEVERITY_RANK[e.severity] ?? 0) >= DETECTION_RANK);
+    const huntArtifactOnly = supporting.length > 0 && !verdictFirst;
+    const kevLinked = findingIsKevLinked(f, supporting, iocById, kevCveIds);
+    const corroboration: FindingCorroboration = { distinctTools, distinctHosts, intelSources, graphLinked, verdictFirst, huntArtifactOnly, kevLinked };
 
     // Rewrite relatedEventIds to the resolved supporting set so the forward link is consistent and
     // auditable (adds the reverse-linked backfill events; drops hallucinated ids).
@@ -75,14 +113,29 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
     let confidenceReason = f.confidenceReason;
     let ungrounded = false;
 
+    // KEV is an independent corroboration signal (an external catalog confirms active exploitation),
+    // so it exempts a finding from the single-source cap alongside 2+ tools / intel / graph linkage.
+    const corroborated = distinctTools >= 2 || intelSources > 0 || graphLinked || kevLinked;
+
     if (supporting.length === 0) {
       ungrounded = true;
       confidence = Math.min(confidence ?? UNGROUNDED_CONFIDENCE_CAP, UNGROUNDED_CONFIDENCE_CAP);
       confidenceReason = appendReason(confidenceReason, "capped: no cited evidence in scope — treat as a hypothesis, not a fact");
-    } else if (distinctTools <= 1 && distinctHosts <= 1 && intelSources === 0 && !graphLinked) {
-      if ((confidence ?? 100) > SINGLE_SOURCE_CONFIDENCE_CAP) {
-        confidence = SINGLE_SOURCE_CONFIDENCE_CAP;
-        confidenceReason = appendReason(confidenceReason, "capped: single-source, uncorroborated");
+    } else {
+      if (!corroborated && distinctHosts <= 1) {
+        if ((confidence ?? 100) > SINGLE_SOURCE_CONFIDENCE_CAP) {
+          confidence = SINGLE_SOURCE_CONFIDENCE_CAP;
+          confidenceReason = appendReason(confidenceReason, "capped: single-source, uncorroborated");
+        }
+      }
+      // Hunt-artifact penalty (#61): rests only on raw collection artifacts with no detection verdict,
+      // no intel, and no KEV lift — a triage lead, not a confirmed detection. Applied independently so
+      // it can lower a finding even when 2+ raw-telemetry tools "corroborate" the same unadjudicated data.
+      if (huntArtifactOnly && intelSources === 0 && !kevLinked) {
+        if ((confidence ?? 100) > HUNT_ARTIFACT_CONFIDENCE_CAP) {
+          confidence = HUNT_ARTIFACT_CONFIDENCE_CAP;
+          confidenceReason = appendReason(confidenceReason, "capped: rests only on raw hunt-collection artifacts — no detection verdict; triage before acting");
+        }
       }
     }
 
@@ -200,6 +253,8 @@ export function corroborationLabel(f: Finding): string {
   const parts = [`${c.distinctTools} tool${c.distinctTools === 1 ? "" : "s"}`, `${c.distinctHosts} host${c.distinctHosts === 1 ? "" : "s"}`];
   if (c.intelSources > 0) parts.push("intel ✓");
   if (c.graphLinked) parts.push("graph-linked");
-  const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked;
-  return `${parts.join(" / ")}${corroborated ? "" : " — uncorroborated"}`;
+  if (c.kevLinked) parts.push("KEV ✓");
+  const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked || !!c.kevLinked;
+  const huntCaution = c.huntArtifactOnly && c.intelSources === 0 && !c.kevLinked ? " — hunt-artifact only" : "";
+  return `${parts.join(" / ")}${corroborated ? "" : " — uncorroborated"}${huntCaution}`;
 }

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -107,7 +107,7 @@ import { selectSynthesisEvents, selectSynthesisEventsAnnotated, buildSynthesisCo
 import { unionEventTechniques } from "./reconTechniques.js";
 import { buildGraphContext, DEFAULT_MAX_GRAPH_EDGES } from "./graphContext.js";
 import type { KevStore } from "./kevStore.js";
-import type { KevCatalog } from "./kev.js";
+import { extractCveIds, matchKevEntries, type KevCatalog } from "./kev.js";
 import {
   huntSuggestionsResponseSchema,
   sanitizeHuntSuggestions,
@@ -4646,7 +4646,17 @@ export class AnalysisPipeline {
       const evidenceGraph = buildEvidenceGraph(next);
       const graphLinkedEventIds = new Set(evidenceGraph.edges.flatMap((e) => e.eventIds));
       const inScope = next.forensicTimeline.filter((e) => eligibleIds.has(e.id));
-      const grounded = groundAndScoreFindings({ findings: next.findings, scopedEvents: inScope, iocs: next.iocs, graphLinkedEventIds });
+      // KEV-linked confidence signal (issue #61): the CVEs mentioned in-scope (events + IOCs) that match
+      // the CISA KEV catalog. Empty when no catalog is loaded, so the signal is simply never set then.
+      const kevCatalog = await this.getKevCatalog();
+      let kevCveIds: Set<string> | undefined;
+      if (kevCatalog && kevCatalog.size > 0) {
+        const cveIds = new Set<string>();
+        for (const e of inScope) { extractCveIds(e.description).forEach((id) => cveIds.add(id)); if (e.message) extractCveIds(e.message).forEach((id) => cveIds.add(id)); }
+        for (const i of next.iocs) extractCveIds(i.value).forEach((id) => cveIds.add(id));
+        kevCveIds = new Set(matchKevEntries([...cveIds], kevCatalog).map((m) => m.cveID));
+      }
+      const grounded = groundAndScoreFindings({ findings: next.findings, scopedEvents: inScope, iocs: next.iocs, graphLinkedEventIds, kevCveIds });
       // Intel-verdict gate (investigation-guidance #7): floor an intel-ONLY High/Critical finding (no
       // behavioral corroboration, all its verdict IOCs lone-intel/conflicted) to Medium/≤60 — the
       // northpeak stale-CTI-on-own-server class. Runs after grounding so it sees the corroboration rollup.

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -45,6 +45,11 @@ export interface FindingCorroboration {
   distinctHosts: number;   // distinct event.asset across them
   intelSources: number;    // this finding's related IOCs carrying a malicious/suspicious intel verdict
   graphLinked: boolean;    // any supporting event participates in an evidence-graph causal edge
+  // Issue #61 — three additional deterministic confidence signals, all computed in
+  // groundAndScoreFindings and optional so findings persisted before they existed still validate:
+  verdictFirst?: boolean;      // ≥1 supporting event is a graded (Low+) detection — a tool adjudicated it
+  huntArtifactOnly?: boolean;  // grounded, but EVERY supporting event is Info telemetry (raw collection) — penalised
+  kevLinked?: boolean;         // a CISA-KEV (actively-exploited) CVE appears in the finding, its events, or its IOCs
 }
 
 export interface Finding {

--- a/companion/tests/analysis/findingGrounding.test.ts
+++ b/companion/tests/analysis/findingGrounding.test.ts
@@ -111,9 +111,9 @@ describe("corroborationLabel", () => {
   it("marks a single-tool finding uncorroborated", () => {
     expect(corroborationLabel(f({ corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 0, graphLinked: false } }))).toMatch(/uncorroborated/);
   });
-  it("surfaces a KEV badge and a hunt-artifact caution", () => {
+  it("surfaces a KEV badge and an unconfirmed-lead caution", () => {
     expect(corroborationLabel(f({ corroboration: { distinctTools: 2, distinctHosts: 1, intelSources: 0, graphLinked: false, kevLinked: true } }))).toMatch(/KEV/);
-    expect(corroborationLabel(f({ corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 0, graphLinked: false, huntArtifactOnly: true } }))).toMatch(/hunt-artifact/i);
+    expect(corroborationLabel(f({ corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 0, graphLinked: false, huntArtifactOnly: true } }))).toMatch(/unconfirmed lead/i);
   });
 });
 

--- a/companion/tests/analysis/findingGrounding.test.ts
+++ b/companion/tests/analysis/findingGrounding.test.ts
@@ -4,6 +4,7 @@ import {
   corroborationLabel,
   UNGROUNDED_CONFIDENCE_CAP,
   SINGLE_SOURCE_CONFIDENCE_CAP,
+  HUNT_ARTIFACT_CONFIDENCE_CAP,
 } from "../../src/analysis/findingGrounding.js";
 import type { Finding, ForensicEvent, IOC, Severity } from "../../src/analysis/stateTypes.js";
 
@@ -48,7 +49,7 @@ describe("groundAndScoreFindings", () => {
     });
     expect(out[0].ungrounded).toBeUndefined();
     expect(out[0].relatedEventIds).toEqual(["e1"]);
-    expect(out[0].corroboration).toEqual({ distinctTools: 2, distinctHosts: 1, intelSources: 0, graphLinked: false });
+    expect(out[0].corroboration).toEqual({ distinctTools: 2, distinctHosts: 1, intelSources: 0, graphLinked: false, verdictFirst: true, huntArtifactOnly: false, kevLinked: false });
     expect(out[0].confidence).toBe(100); // corroborated by 2 tools → not capped
   });
 
@@ -109,5 +110,70 @@ describe("corroborationLabel", () => {
   });
   it("marks a single-tool finding uncorroborated", () => {
     expect(corroborationLabel(f({ corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 0, graphLinked: false } }))).toMatch(/uncorroborated/);
+  });
+  it("surfaces a KEV badge and a hunt-artifact caution", () => {
+    expect(corroborationLabel(f({ corroboration: { distinctTools: 2, distinctHosts: 1, intelSources: 0, graphLinked: false, kevLinked: true } }))).toMatch(/KEV/);
+    expect(corroborationLabel(f({ corroboration: { distinctTools: 1, distinctHosts: 1, intelSources: 0, graphLinked: false, huntArtifactOnly: true } }))).toMatch(/hunt-artifact/i);
+  });
+});
+
+describe("groundAndScoreFindings — verdict-first / hunt-artifact / KEV signals (issue #61)", () => {
+  it("marks verdictFirst when a supporting event is graded (Low+), not hunt-artifact-only", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 90, relatedEventIds: ["e1"] })],
+      scopedEvents: [ev({ id: "e1", severity: "High", sources: ["EDR"], asset: "H1" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].corroboration?.verdictFirst).toBe(true);
+    expect(out[0].corroboration?.huntArtifactOnly).toBe(false);
+  });
+
+  it("marks huntArtifactOnly and caps at 55 when every supporting event is Info telemetry", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 90, relatedEventIds: ["e1"] })],
+      scopedEvents: [ev({ id: "e1", severity: "Info", sources: ["Velociraptor"], asset: "H1", artifactName: "Windows.NTFS.MFT" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].corroboration?.huntArtifactOnly).toBe(true);
+    expect(out[0].corroboration?.verdictFirst).toBe(false);
+    expect(out[0].confidence).toBe(HUNT_ARTIFACT_CONFIDENCE_CAP);
+    expect(out[0].confidenceReason).toMatch(/hunt-collection artifacts/i);
+  });
+
+  it("does NOT apply the hunt-artifact cap when intel or KEV backs it", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 90, relatedEventIds: ["e1"], relatedIocs: ["i1"] })],
+      scopedEvents: [ev({ id: "e1", severity: "Info", sources: ["Velociraptor"], asset: "H1" })],
+      iocs: [ioc({ id: "i1", enrichments: [{ source: "VT", verdict: "malicious", fetchedAt: "" }] })],
+      graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].corroboration?.huntArtifactOnly).toBe(true);
+    expect(out[0].confidence).toBe(90); // intel lifts it above the hunt-artifact cap
+  });
+
+  it("marks kevLinked and exempts a single-source finding from the 65 cap", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({ id: "f1", confidence: 90, relatedEventIds: ["e1"], description: "exploitation of CVE-2024-38094" })],
+      scopedEvents: [ev({ id: "e1", severity: "High", sources: ["OneTool"], asset: "H1" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+      kevCveIds: new Set(["CVE-2024-38094"]),
+    });
+    expect(out[0].corroboration?.kevLinked).toBe(true);
+    expect(out[0].confidence).toBe(90); // KEV is independent corroboration → not single-source-capped
+  });
+
+  it("kevLinked reads CVEs from a supporting event's message and related IOC values", () => {
+    const viaEvent = groundAndScoreFindings({
+      findings: [f({ id: "f1", relatedEventIds: ["e1"] })],
+      scopedEvents: [ev({ id: "e1", severity: "High", message: "Suspected CVE-2023-1234 exploit", sources: ["T"], asset: "H" })],
+      iocs: [], graphLinkedEventIds: new Set(), kevCveIds: new Set(["CVE-2023-1234"]),
+    });
+    expect(viaEvent[0].corroboration?.kevLinked).toBe(true);
+    const notInKev = groundAndScoreFindings({
+      findings: [f({ id: "f1", relatedEventIds: ["e1"], description: "CVE-2000-9999" })],
+      scopedEvents: [ev({ id: "e1", severity: "High", sources: ["T"], asset: "H" })],
+      iocs: [], graphLinkedEventIds: new Set(), kevCveIds: new Set(["CVE-2024-38094"]),
+    });
+    expect(notInKev[0].corroboration?.kevLinked).toBe(false);
   });
 });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -9969,15 +9969,19 @@
         const parts = [`${c.distinctTools} tool${c.distinctTools === 1 ? "" : "s"}`, `${c.distinctHosts} host${c.distinctHosts === 1 ? "" : "s"}`];
         if (c.intelSources > 0) parts.push("intel ✓");
         if (c.graphLinked) parts.push("graph-linked");
-        // Issue #61 provenance signals: KEV-linked (actively exploited) and verdict-first (a tool
-        // adjudicated it) are positive; hunt-artifact-only (raw collection, no verdict) is a caution.
-        if (c.kevLinked) parts.push("🎯 KEV");
-        if (c.verdictFirst) parts.push("⚑ verdict-first");
+        // Issue #61 provenance signals, shown as badges with plain-English tooltips: KEV-linked
+        // (actively exploited) and tool-confirmed (a tool adjudicated it) are positive; unconfirmed-lead
+        // (raw collection, no verdict) is a caution. Titles are static, safe HTML — not user data.
         const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked || c.kevLinked;
         const huntCaution = c.huntArtifactOnly && c.intelSources === 0 && !c.kevLinked;
-        const suffix = huntCaution ? " — 🐇 hunt-artifact only (triage before acting)" : (corroborated ? "" : " — uncorroborated");
+        const badges = [];
+        if (c.kevLinked) badges.push(`<span title="A CVE in this finding is on CISA's Known Exploited Vulnerabilities (KEV) list — confirmed exploited in the wild. Counts as independent corroboration.">🎯 KEV</span>`);
+        if (c.verdictFirst) badges.push(`<span title="Backed by at least one tool-adjudicated detection (a graded alert), not just raw collected data.">⚑ tool-confirmed</span>`);
+        if (huntCaution) badges.push(`<span title="Rests only on raw collected artifacts that no tool flagged — an unconfirmed lead to triage, not a confirmed detection. Confidence capped at 55.">🐇 unconfirmed lead</span>`);
+        const suffix = (!huntCaution && !corroborated) ? " — uncorroborated" : "";
         const warn = huntCaution || !corroborated;
-        rows.push(`<div class="fev-row"><span class="fev-k">Corroboration</span><span class="fev-v"${warn ? ' style="color:var(--c-e0a458,#e0a458)"' : ""}>${esc(parts.join(" / "))}${esc(suffix)}</span></div>`);
+        const badgeHtml = badges.length ? " / " + badges.join(" / ") : "";
+        rows.push(`<div class="fev-row"><span class="fev-k">Corroboration</span><span class="fev-v"${warn ? ' style="color:var(--c-e0a458,#e0a458)"' : ""}>${esc(parts.join(" / "))}${badgeHtml}${esc(suffix)}</span></div>`);
       }
       const byVal = new Map((iocs || []).map(i => [String(i.value).trim().toLowerCase(), i.value]));
       const vals = new Set();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -9969,8 +9969,15 @@
         const parts = [`${c.distinctTools} tool${c.distinctTools === 1 ? "" : "s"}`, `${c.distinctHosts} host${c.distinctHosts === 1 ? "" : "s"}`];
         if (c.intelSources > 0) parts.push("intel ✓");
         if (c.graphLinked) parts.push("graph-linked");
-        const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked;
-        rows.push(`<div class="fev-row"><span class="fev-k">Corroboration</span><span class="fev-v"${corroborated ? "" : ' style="color:var(--c-e0a458,#e0a458)"'}>${esc(parts.join(" / "))}${corroborated ? "" : " — uncorroborated"}</span></div>`);
+        // Issue #61 provenance signals: KEV-linked (actively exploited) and verdict-first (a tool
+        // adjudicated it) are positive; hunt-artifact-only (raw collection, no verdict) is a caution.
+        if (c.kevLinked) parts.push("🎯 KEV");
+        if (c.verdictFirst) parts.push("⚑ verdict-first");
+        const corroborated = c.distinctTools >= 2 || c.intelSources > 0 || c.graphLinked || c.kevLinked;
+        const huntCaution = c.huntArtifactOnly && c.intelSources === 0 && !c.kevLinked;
+        const suffix = huntCaution ? " — 🐇 hunt-artifact only (triage before acting)" : (corroborated ? "" : " — uncorroborated");
+        const warn = huntCaution || !corroborated;
+        rows.push(`<div class="fev-row"><span class="fev-k">Corroboration</span><span class="fev-v"${warn ? ' style="color:var(--c-e0a458,#e0a458)"' : ""}>${esc(parts.join(" / "))}${esc(suffix)}</span></div>`);
       }
       const byVal = new Map((iocs || []).map(i => [String(i.value).trim().toLowerCase(), i.value]));
       const vals = new Set();


### PR DESCRIPTION
Closes the genuinely-missing part of #61. As noted in [the review comment](https://github.com/hasamba/DFIR-Companion/issues/61#issuecomment-4962588004), the corroboration/grounding rubric #61 proposed already shipped in guidance #6 (`c196d78`) as `groundAndScoreFindings` → `FindingCorroboration`. This PR adds the **three signals that were actually absent**.

## What's added

All three are computed deterministically in `groundAndScoreFindings` (`findingGrounding.ts`) and surfaced in the dashboard + report. The pass still only ever **lowers** confidence — no signal raises a score.

| Signal | Meaning | Effect |
|---|---|---|
| `kevLinked` | a CISA-KEV (actively-exploited) CVE appears in the finding, its supporting events, or its related IOCs | independent corroboration → **exempts the single-source cap**; badge `🎯 KEV` |
| `verdictFirst` | ≥1 supporting event is a graded (Low+) detection a tool adjudicated | positive display signal; badge `⚑ verdict-first` |
| `huntArtifactOnly` | grounded, but **every** supporting event is raw Info telemetry — no verdict, no intel, no KEV | **new `HUNT_ARTIFACT_CONFIDENCE_CAP` (55)**; badge `🐇 hunt-artifact only` |

### Reused, not reinvented
- **KEV**: `extractCveIds` / `matchKevEntries` (`kev.ts`) — wired at the synthesis grounding call site (`pipeline.ts`) to compute the case's KEV-matched CVE set, passed as `kevCveIds`.
- **verdict-first / hunt-artifact classification**: `SEVERITY_RANK` (`forensicGate.ts`) — the same Low+ "detection vs telemetry" cut `iocProvenance.ts` already uses. No fragile source-name list.

### Design notes
- `FindingCorroboration` gains three **optional** fields, so findings persisted before this change still validate.
- `huntArtifactOnly` and `verdictFirst` are mutually exclusive by construction.
- The hunt-artifact cap fires independently of tool/host corroboration (two raw-telemetry tools still haven't *adjudicated* anything), but is lifted by intel or KEV.
- No synthesis-prompt change: these are post-synthesis deterministic caps/badges the model doesn't emit.

## Test plan
- [x] 6 new unit tests in `findingGrounding.test.ts` (each signal + cap + exemptions + KEV text/IOC extraction)
- [x] Full suite green (**3697 tests**, +6), \`tsc --noEmit\` clean
- [x] End-to-end glue check: simulated the pipeline's \`kevCveIds\` computation → a single-source finding referencing \`CVE-2024-38094\` stayed at 90 with \`KEV ✓\`; a finding grounded only on a \`Windows.NTFS.MFT\` Info artifact capped to 55 with \`hunt-artifact only\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6dmWkoTut3QWf2G1wxweJ