### PR TITLE
feat: redesign Forensic Timeline as bordered cards matching Findings/IOCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Right-click "Send to DFIR-Companion"** — send a page's selected text, a table (nearest to the click), or a link's URL straight to the connected case from any page, not just recognized adapter consoles.
 - **VolWeb adapter + manual tool override** — the extension now auto-detects VolWeb alongside the existing six consoles, and the popup shows the detected tool with a dropdown to force a different adapter (or none) for the current tab.
 
+### Changed
+- **Forensic Timeline redesign** — timeline events now use the same bordered-card row language as Findings and IOCs: each event is its own rounded card with a severity-coloured left rail, a dedicated Severity column (coloured square + label), and a calm monospace timestamp, under an uppercase column header. The super-timeline is unchanged.
+
 ### Fixed
 - **Extension content script failed to load on every page** — `content.js` shared a chunk with `popup.js` and was built as an ES module (`import ...`), which Chrome rejects for a classic content script ("Cannot use import statement outside a module"). The build now compiles content.js and pageHook.js in their own isolated builds so they're always self-contained.
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -809,12 +809,33 @@
     .hunt-run-res { padding: 8px 10px; border-top: 1px solid var(--c-2a2f3a); }
     .hunt-refresh { background: var(--c-2a2f3a); border: 0; color: var(--c-cbd3df); border-radius: 5px; padding: 1px 8px; font-size: 11px; cursor: pointer; }
     .hunt-refresh:hover { color: #fff; }
-    /* Timeline table layout — checkbox · star · icons | timestamp | tags+message */
+    /* Timeline table layout — checkbox · star · icons | severity | timestamp | tags+message.
+       The forensic timeline uses the same bordered-card row language as Findings / IOCs: each event
+       is its own rounded card with a severity-coloured left rail, a dedicated severity column
+       (coloured square + label), and a calm monospace timestamp. Scoped to #forensicTimeline so the
+       super-timeline (which reuses .ev-row) keeps its own flat layout. */
     #forensicTimeline { container-type: inline-size; }
     .ev-row { display: flex; align-items: flex-start; border-bottom: 1px solid var(--c-1a1f28); padding: 3px 0; }
+    #forensicTimeline .ev-row {
+      border: 1px solid var(--c-2a2f3a); border-left: 3px solid var(--c-2a2f3a); border-radius: 6px;
+      background: var(--c-11151c); padding: 4px 10px; margin-bottom: 4px;
+    }
+    #forensicTimeline .ev-row:hover { background: var(--c-11151c); border-color: var(--c-3a4050); }
     .ev-row:hover { background: var(--c-0d1117); }
     .ev-row.ev-selected { background: var(--c-142038); }
+    #forensicTimeline .ev-row.ev-selected { background: var(--c-142038); }
     .ev-row.ev-focused { outline: 2px solid var(--c-6aa9ff); outline-offset: -2px; border-radius: 3px; }
+    /* Severity left-rail (border-left colour) — distinct from .ev-new's green inset box-shadow, so a
+       newly-imported high-severity row shows both cues without conflict. */
+    #forensicTimeline .ev-row.sevr-Critical { border-left-color: var(--c-ff5c5c); }
+    #forensicTimeline .ev-row.sevr-High     { border-left-color: var(--c-ff9f43); }
+    #forensicTimeline .ev-row.sevr-Medium   { border-left-color: var(--c-ffd93b); }
+    #forensicTimeline .ev-row.sevr-Low      { border-left-color: var(--c-6bcb77); }
+    #forensicTimeline .ev-row.sevr-Info     { border-left-color: var(--c-6aa9ff); }
+    /* Severity column: coloured square + label, colour driven by the .sev-<level> class. */
+    .ev-col-sev { flex-shrink: 0; width: 92px; margin-right: 6px; display: flex; align-items: center; gap: 7px; font-weight: 650; font-size: 12px; align-self: center; }
+    .ev-col-sev .ev-sq { width: 9px; height: 9px; border-radius: 2px; background: currentColor; flex-shrink: 0; }
+    .ev-header-sev { width: 92px; margin-right: 6px; flex-shrink: 0; }
     .ev-col-ctrl { display: flex; align-items: center; gap: 2px; flex-shrink: 0; width: 178px; margin-right: 6px; padding-top: 1px; }
     /* Buttons default to flex-shrink:1, which silently compresses (and can visually clip) their
        icon/count once the row's icon set (star/comment/tag/hunt/explain/geo) nears the column's
@@ -833,7 +854,7 @@
     .ev-geo { background: none; border: none; cursor: pointer; padding: 0 4px; color: var(--c-6b7280); display: inline-flex; align-items: center; }
     .ev-geo:hover { color: var(--c-6aa9ff); }
     .ev-geo svg { width: 12px; height: 12px; }
-    .ev-col-time { flex-shrink: 0; width: 192px; font-size: 11px; font-family: ui-monospace, Menlo, Consolas, monospace; align-self: center; }
+    .ev-col-time { flex-shrink: 0; width: 192px; font-size: 11px; font-family: ui-monospace, Menlo, Consolas, monospace; align-self: center; color: var(--c-9aa4b2); }
     .ev-col-content { flex: 1; min-width: 0; padding-top: 1px; }
     .ev-origin { color: var(--c-7e8aa0); white-space: nowrap; font-size: 11px; }
     .ev-more-btn { background: none; border: none; color: var(--c-6aa9ff); cursor: pointer; font-size: 0.78em; padding: 0 3px; margin-left: 2px; vertical-align: middle; }
@@ -843,7 +864,7 @@
     .ev-details-toggle { background: none; border: 1px solid var(--c-2a4a6b); border-radius: 3px; color: var(--c-6aa9ff); font-size: 11px; padding: 1px 5px; cursor: pointer; margin-top: 3px; }
     .ev-details-panel { margin-top: 4px; padding: 6px 8px; background: var(--c-0d1117, #0d1117); border-left: 2px solid var(--c-2a4a6b); border-radius: 2px; font-size: 11px; color: var(--c-c9d1d9); }
     .ev-details-panel > * + * { margin-top: 4px; }
-    .ev-header-row { display: flex; align-items: center; padding: 2px 0 5px; border-bottom: 1px solid var(--c-2a2f3a); margin-bottom: 1px; font-size: 11px; color: var(--c-6b7280); }
+    .ev-header-row { display: flex; align-items: center; padding: 0 11px 6px 13px; margin-bottom: 1px; font-size: 10px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--c-9aa4b2); }
     .ev-header-ctrl { width: 178px; margin-right: 6px; flex-shrink: 0; display: flex; align-items: center; gap: 4px; }
     .ev-header-time { width: 192px; flex-shrink: 0; }
     .tl-pagesize-wrap { margin-left: auto; flex-shrink: 0; }
@@ -12871,8 +12892,9 @@
 
       const headerRow = `<div class="ev-header-row">`
         + `<div class="ev-header-ctrl"><input type="checkbox" class="ev-checkbox" id="evSelectAll" ${allSelected ? "checked" : ""} title="Select / deselect all visible events" /></div>`
+        + `<div class="ev-header-sev">Severity${sortArrows("severity")}</div>`
         + `<div class="ev-header-time">Timestamp (UTC)${sortArrows("date")}</div>`
-        + `<div style="flex:1">Message<span class="tl-sevsort-label">severity</span>${sortArrows("severity")}</div>`
+        + `<div style="flex:1">Message</div>`
         + `<div class="tl-pagesize-wrap" title="Rows per page"><select class="tl-pagesize-sel" onchange="tlPageSize=+this.value;renderTimelineEvents(lastFt)">${pageSizeOpts}</select></div>`
         + `</div>`;
 
@@ -12918,7 +12940,7 @@
           mitre: tlShow("mitre", tld), findings: tlShow("findings", tld), evidence: tlShow("evidence", tld),
         });
 
-        return `<div class="ev-row${isSelected ? " ev-selected" : ""}${isNew ? " ev-new" : ""}" data-evid="${escAttr(id)}">`
+        return `<div class="ev-row sevr-${esc(e.severity)}${isSelected ? " ev-selected" : ""}${isNew ? " ev-new" : ""}" data-evid="${escAttr(id)}">`
           + `<div class="ev-col-ctrl">`
           + `<input type="checkbox" class="ev-checkbox ev-row-cb" data-evid="${escAttr(id)}" ${isSelected ? "checked" : ""} title="Select event" />`
           + (tlShow("icons", tld)
@@ -12927,7 +12949,8 @@
                 + ((e.srcIp || e.dstIp) ? `<button type="button" class="ev-geo" title="Show this event's IP on the map" onclick="geoFocusIp('${escAttr(e.dstIp || e.srcIp)}')">${ICON_GEO}</button>` : "")
               : "")
           + `</div>`
-          + `<div class="ev-col-time"><span class="sev-${esc(e.severity)}">${span}</span></div>`
+          + `<div class="ev-col-sev sev-${esc(e.severity)}" title="Severity: ${escAttr(e.severity || "unrated")}"><span class="ev-sq"></span>${esc(e.severity || "")}</div>`
+          + `<div class="ev-col-time">${span}</div>`
           + `<div class="ev-col-content">`
           + (tlShow("tags", tld) ? tagPills("event", e.id) : "")
           + (tlShow("badges", tld) ? `${newBadge}${badge}${corro}${chain}` : "")


### PR DESCRIPTION
## Summary
Redesigns the Forensic Timeline so its rows use the same **bordered-card row language** already used by the Findings and IOC lists — addressing the "flat / messy" look where severity was conveyed only by the timestamp's text colour.

Each event is now:
- A **rounded bordered card** with a **severity-coloured left rail** (`border-left`), for at-a-glance severity scanning down the column.
- Given a dedicated **Severity column** — a coloured square + label (e.g. `■ Critical`), mirroring the finding severity cell.
- Shown with a **calm muted-grey monospace timestamp** (severity no longer shouts in red text).
- Placed under an **uppercase column header** (Controls · Severity · Timestamp · Message), matching the Findings/IOC header. The severity-sort arrows moved onto the new Severity header.

## Scope / safety
- All new styling is scoped to `#forensicTimeline`, so the **super-timeline** (which reuses `.ev-row`) keeps its existing flat layout.
- The severity rail uses `border-left-color`, distinct from `.ev-new`'s green inset box-shadow, so a newly-imported high-severity row shows both cues without conflict.
- Purely presentational — checkboxes, star/tag/comment/hunt icons, badges, `[details]`, host chips, sorting and pagination are unchanged.

## Test plan
- [ ] Load a case with a populated Forensic Timeline; confirm rows render as cards with a coloured left rail + Severity column, and the header shows Controls · Severity · Timestamp · Message.
- [ ] Severity sort (arrows on the Severity header) and timestamp sort still work.
- [ ] Row selection, star/tag/comment, `[details]` expand, pagination, and the "NEW" import highlight all still work.
- [ ] Super-Timeline is visually unchanged.