### PR TITLE
feat: AI-assisted content-tagger rule authoring (NL → rule, preview, remove, reset)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **AI-assisted content-tagger rules** — describe a content-tagger rule in plain English and the AI drafts a valid rule you can preview (live match count against the open case), edit, and add. Plus per-rule remove (any rule, including shipped defaults) and reset-to-defaults. New ejectable prompt `tagger-rule.txt` (`npm run prompts:eject`). AI-gated — falls back cleanly when no provider is configured.
 - **Right-click "Send to DFIR-Companion"** — send a page's selected text, a table (nearest to the click), or a link's URL straight to the connected case from any page, not just recognized adapter consoles.
 - **VolWeb adapter + manual tool override** — the extension now auto-detects VolWeb alongside the existing six consoles, and the popup shows the detected tool with a dropdown to force a different adapter (or none) for the current tab.
 
 ### Fixed
+- **Tagger rules file wasn't created on first write if its directory didn't exist** — a fresh install could throw `ENOENT` when saving edited content-tagger rules; the directory is now created on demand.
 - **Extension content script failed to load on every page** — `content.js` shared a chunk with `popup.js` and was built as an ES module (`import ...`), which Chrome rejects for a classic content script ("Cannot use import statement outside a module"). The build now compiles content.js and pageHook.js in their own isolated builds so they're always self-contained.
 
 ## [0.31.0] - 2026-07-10

--- a/companion/scripts/eject-prompts.ts
+++ b/companion/scripts/eject-prompts.ts
@@ -7,6 +7,7 @@ import { join, resolve } from "node:path";
 import {
   SYSTEM_PROMPT, CSV_SYSTEM_PROMPT, LOG_SYSTEM_PROMPT, SYNTHESIS_PROMPT, ASK_PROMPT, EXEC_SUMMARY_PROMPT,
   HUNT_SUGGEST_PROMPT, PLAYBOOK_HUNT_PROMPT, GAP_HYPOTHESIS_PROMPT, MEMORY_NEXTSTEP_PROMPT, QUERY_TRANSLATE_PROMPT,
+  TAGGER_RULE_PROMPT,
 } from "../src/analysis/pipeline.js";
 import { RECONCILE_PROMPT } from "../src/analysis/secondOpinion.js";
 
@@ -25,6 +26,7 @@ const files: Array<[string, string, string]> = [
   ["gap-hypothesis.txt", GAP_HYPOTHESIS_PROMPT, "DFIR_AI_GAPHYP_PROMPT_FILE"],
   ["memory-next-step.txt", MEMORY_NEXTSTEP_PROMPT, "DFIR_AI_MEMNEXT_PROMPT_FILE"],
   ["query-translate.txt", QUERY_TRANSLATE_PROMPT, "DFIR_AI_QUERYXLATE_PROMPT_FILE"],
+  ["tagger-rule.txt", TAGGER_RULE_PROMPT, "DFIR_AI_TAGGERRULE_PROMPT_FILE"],
   ["reconcile.txt", RECONCILE_PROMPT, "DFIR_AI_RECONCILE_PROMPT_FILE"],
 ];
 

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -29,6 +29,8 @@ import { parseJsonLoose } from "./extractJson.js";
 import { applyFalsePositive, buildFalsePositiveContext, buildAuthorizedContextBlock, filterFalsePositiveEvents, type FalsePositiveStore } from "./falsePositive.js";
 import { backfillHighSeverityFindings } from "./highSeverityFindings.js";
 import { checkConfiguredPromptDrift } from "./promptCapabilities.js";
+import { MATCHABLE_FIELDS } from "./taggerRules.js";
+import { suggestedRuleResponseSchema, sanitizeSuggestedRule, type SuggestOutcome } from "./taggerRuleSuggest.js";
 import { resolveSynthThinkingBudget, type SynthThinkingInput } from "./synthThinking.js";
 import { detectTimelineGaps, backfillSilenceGapFindings, gapEnvOptions } from "./gapDetect.js";
 import {
@@ -684,7 +686,7 @@ export const SYNTHESIS_PROMPT = [
 // <NAME> is one of: SYSTEM, CSV, LOG, SYNTH. A missing/unreadable/empty file logs a warning
 // and falls back to the built-in prompt, so a typo never breaks analysis.
 // `npm run prompts:eject` writes the four defaults to ./prompts as a starting point.
-function resolvePrompt(name: "SYSTEM" | "CSV" | "LOG" | "SYNTH" | "ASK" | "EXEC" | "NARRATIVE" | "HUNTS" | "PBHUNTS" | "GAPHYP" | "MEMNEXT" | "QUERYXLATE" | "RECONCILE" | "IMPORTGEN" | "EXPLAIN" | "REMEDIATION" | "FPSIMILARITY", fallback: string): string {
+function resolvePrompt(name: "SYSTEM" | "CSV" | "LOG" | "SYNTH" | "ASK" | "EXEC" | "NARRATIVE" | "HUNTS" | "PBHUNTS" | "GAPHYP" | "MEMNEXT" | "QUERYXLATE" | "RECONCILE" | "IMPORTGEN" | "EXPLAIN" | "REMEDIATION" | "FPSIMILARITY" | "TAGGERRULE", fallback: string): string {
   const inline = process.env[`DFIR_AI_${name}_PROMPT`];
   if (inline && inline.trim().length > 0) return inline;
   const file = process.env[`DFIR_AI_${name}_PROMPT_FILE`];
@@ -700,11 +702,68 @@ function resolvePrompt(name: "SYSTEM" | "CSV" | "LOG" | "SYNTH" | "ASK" | "EXEC"
   return fallback;
 }
 
+// Natural-language → ONE content-tagger rule (PR #112 follow-up). The model receives the analyst's
+// description and returns a JSON object describing a single rule, or a `decline` string when the
+// request can't be expressed as a single-event field-match rule. The rule is validated by
+// compileRuleset before it is ever offered to save (see taggerRuleSuggest.ts).
+// NOTE: declared here (not beside QUERY_TRANSLATE_PROMPT) because BUILTIN_PROMPT_BY_NAME below reads
+// its value eagerly at module load — a later declaration would hit the temporal dead zone.
+export const TAGGER_RULE_PROMPT = [
+  "You are a DFIR detection engineer. Convert the analyst's PLAIN-ENGLISH request into ONE content-tagger",
+  "rule for the DFIR-Companion event tagger. A rule matches a SINGLE forensic/timeline event by its fields",
+  "and, when it matches, applies tags / MITRE techniques / a raised severity.",
+  "",
+  "A rule is a JSON object with:",
+  "- one or more CONDITION blocks: `any` (OR — ≥1 must match), `all` (AND — every one must match),",
+  "  `none` (NOT — none may match). At least one condition across any/all/none is required.",
+  "- at least one ACTION: `tags` (string[]), `mitre` (ATT&CK id string[]), `severity`, `view` (string).",
+  "- an optional `description` (string).",
+  "",
+  "Each CONDITION is `{ field, <one operator> }` where exactly ONE operator is present:",
+  "- contains: string | string[]   (case-insensitive substring; a list is OR)",
+  "- equals:   string | string[]   (case-insensitive exact match)",
+  "- regex:    string   (optional `flags`, e.g. 'i')   (JS regex against the field)",
+  "- exists:   true | false   (field present-and-non-empty / absent)",
+  "",
+  "MATCHABLE FIELDS (an unknown field is INVALID — use only these; the exact list is in the user message):",
+  "description, message, asset, path, artifactName, processName, parentName, sha256, md5, srcIp, dstIp,",
+  "veloUrl, severity, action, sources, mitreTechniques, relatedFindingIds, provenance, port, pid, count.",
+  "",
+  "severity is one of: Critical, High, Medium, Low, Info.",
+  "",
+  "IMPORTANT RULES:",
+  "- Author a GENERIC rule. Do NOT hardcode this case's specific IPs, hostnames, or hashes — write a rule",
+  "  that would be reusable across investigations (match on artifact/event-id/path/filename patterns).",
+  "- If the request CANNOT be expressed as a single-event field-match rule — e.g. it needs counting,",
+  "  time-windows, thresholds, or correlating multiple events — do NOT invent a rule. Instead return",
+  "  `{ \"decline\": \"<one-sentence reason>\" }` and nothing else.",
+  "- Choose a short snake_case `ruleId` describing the rule.",
+  "- `explanation`: one or two sentences on exactly what the rule matches and what it does.",
+  "",
+  "Return ONLY raw JSON (no markdown fences) in EXACTLY one of these two shapes:",
+  JSON.stringify({
+    ruleId: "windows_security_log_cleared",
+    explanation: "Matches events whose message shows Security event ID 1102 or 'audit log was cleared'; tags them log-cleared and defense-evasion and raises severity to High.",
+    rule: {
+      description: "Windows Security event log cleared (Security 1102)",
+      any: [{ field: "message", contains: ["1102", "audit log was cleared"] }],
+      tags: ["log-cleared", "defense-evasion"],
+      mitre: ["T1070.001"],
+      severity: "High",
+    },
+  }, null, 2),
+  "OR, when it cannot be expressed as a rule:",
+  JSON.stringify({ decline: "This needs counting logons within a time window, which a single-event content rule can't express." }, null, 2),
+].join("\n");
+
+export const getTaggerRulePrompt = (): string => resolvePrompt("TAGGERRULE", TAGGER_RULE_PROMPT);
+
 // The built-in prompt text for each capability the drift check knows about (see promptCapabilities.ts),
 // keyed by resolvePrompt name. Exported so the rot-guard test can assert each built-in still contains
 // its own required markers (if a rewrite drops one, the drift check silently rots — the test catches it).
 export const BUILTIN_PROMPT_BY_NAME: Record<string, string> = {
   SYNTH: SYNTHESIS_PROMPT,
+  TAGGERRULE: TAGGER_RULE_PROMPT,
 };
 
 // Answer a free-form analyst question about ONE case using only its evidence digest.
@@ -3953,6 +4012,28 @@ export class AnalysisPipeline {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getQueryTranslatePrompt(), userPrompt, images: [] }, "translate-query");
       const { interpretation, queries } = queryTranslationResponseSchema.parse(parsed);
       return { interpretation: sanitizeInterpretation(interpretation), queries: sanitizeQueryTranslations(queries, targets) };
+    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  }
+
+  // Convert a plain-English description into ONE content-tagger rule (PR #112 follow-up), or a
+  // decline reason when it can't be expressed as a single-event field-match rule. EPHEMERAL — this
+  // returns a candidate for review; nothing is persisted here (the route's add step saves it). Uses
+  // the strong synthesisProvider like translateQuery — authoring a schema-constrained rule benefits
+  // from the general model over the VQL-tuned velociraptorProvider.
+  async suggestTaggerRule(caseId: string, description: string): Promise<SuggestOutcome> {
+    const provider = this.opts.synthesisProvider ?? this.requireProvider("tagger rule suggestion");
+    const loaded = await this.opts.stateStore.load(caseId);
+    const userPrompt =
+      `MATCHABLE FIELDS (use ONLY these): ${MATCHABLE_FIELDS.join(", ")}\n\n` +
+      `ANALYST REQUEST: ${description.trim()}\n\n` +
+      `Return the rule as JSON (or a decline).`;
+    return withRetry(async () => {
+      const parsed = await this.analyzeRestored(
+        caseId, loaded, provider,
+        { systemPrompt: getTaggerRulePrompt(), userPrompt, images: [] },
+        "suggest-tagger-rule",
+      );
+      return sanitizeSuggestedRule(suggestedRuleResponseSchema.parse(parsed));
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
   }
 

--- a/companion/src/analysis/promptCapabilities.ts
+++ b/companion/src/analysis/promptCapabilities.ts
@@ -41,6 +41,14 @@ export const PROMPT_CAPABILITIES: readonly PromptCapability[] = [
     // evidenceRequests→ guidance #11 second-look loop (delta.evidenceRequests drives the raw re-query).
     markers: ["hypotheses", "confidenceReason", "relatedFindingIds", "logSource", "evidenceRequests"],
   },
+  {
+    name: "TAGGERRULE",
+    file: "tagger-rule.txt",
+    envVar: "DFIR_AI_TAGGERRULE_PROMPT_FILE",
+    // ruleId / decline / severity are the JSON keys the feature parses; an ejected file that drops
+    // them is stale and would silently break NL rule suggestion.
+    markers: ["ruleId", "decline", "severity"],
+  },
 ];
 
 // The required markers absent from `text` (case-sensitive substring match). Empty = no drift.

--- a/companion/src/analysis/tagger.ts
+++ b/companion/src/analysis/tagger.ts
@@ -110,3 +110,21 @@ export function applyToForensicEvent(event: ForensicEvent, result: EventTagResul
   }
   return { ...event, severity, mitreTechniques };
 }
+
+/** The tagger's evaluation scope (mirrors readTaggerSettings() in taggerRun.ts). */
+export type TaggerScope = "both" | "forensic" | "super";
+
+/**
+ * Select the events a tagger run/preview should evaluate for a given scope. For "both", union the
+ * forensic timeline with the super timeline by id (forensic wins on overlap). Pure — no I/O.
+ */
+export function selectScopedEvents(
+  scope: TaggerScope,
+  forensic: readonly ForensicEvent[],
+  superEvents: readonly ForensicEvent[],
+): ForensicEvent[] {
+  if (scope === "forensic") return [...forensic];
+  if (scope === "super") return [...superEvents];
+  const seen = new Set(forensic.map((e) => e.id));
+  return [...forensic, ...superEvents.filter((e) => !seen.has(e.id))];
+}

--- a/companion/src/analysis/taggerRuleSuggest.ts
+++ b/companion/src/analysis/taggerRuleSuggest.ts
@@ -1,0 +1,59 @@
+// Natural-language → content-tagger rule (PR #112 follow-up). The AI returns a JSON object
+// describing ONE tagger rule (or a decline reason); this PURE module parses that reply leniently
+// (like queryTranslate.ts), validates the proposed rule through the REAL compiler
+// (compileRuleset), and emits a single-entry YAML map ready to preview/add. It never performs I/O
+// and never returns a rule that would not compile — a malformed reply becomes a friendly decline,
+// so a broken rule can never reach the ruleset.
+
+import { z } from "zod";
+import { stringify as stringifyYaml } from "yaml";
+import { compileRuleset } from "./taggerRules.js";
+
+// Lenient response schema — every field has a default so a slightly-off reply still parses.
+export const suggestedRuleResponseSchema = z.object({
+  ruleId: z.string().catch(""),
+  explanation: z.string().catch(""),
+  decline: z.string().catch(""),   // non-empty ⇒ the model refused; `rule` is ignored
+  rule: z.unknown().catch(null),   // the raw rule object; validated via compileRuleset below
+});
+export type SuggestedRuleResponse = z.infer<typeof suggestedRuleResponseSchema>;
+
+// The outcome the pipeline hands back: a validated rule (ready to preview/add) or a decline reason.
+export type SuggestOutcome =
+  | { kind: "rule"; ruleId: string; explanation: string; ruleYaml: string }
+  | { kind: "decline"; reason: string };
+
+const MAX_ID_LEN = 60;
+const MAX_TEXT_LEN = 1200;
+
+/** Normalize a proposed id to `[a-z0-9_]` (tagger ids are YAML keys). Empty → `fallback`. */
+export function slugifyRuleId(raw: string, fallback = "rule"): string {
+  const s = raw.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, MAX_ID_LEN);
+  return s || fallback;
+}
+
+/**
+ * Turn a parsed AI reply into a SuggestOutcome. Declines pass through. Otherwise the proposed rule
+ * is validated by compiling a one-entry ruleset `{ ruleId: rule }`; on ANY compile error the result
+ * is a decline ("couldn't turn that into a valid rule"), never a broken rule.
+ */
+export function sanitizeSuggestedRule(parsed: SuggestedRuleResponse): SuggestOutcome {
+  const decline = parsed.decline.trim();
+  if (decline) return { kind: "decline", reason: decline.slice(0, MAX_TEXT_LEN) };
+
+  if (parsed.rule === null || parsed.rule === undefined) {
+    return { kind: "decline", reason: "The AI did not return a rule. Try rephrasing the request." };
+  }
+
+  const ruleId = slugifyRuleId(parsed.ruleId);
+  const singleEntry = { [ruleId]: parsed.rule };
+  try {
+    compileRuleset(singleEntry); // throws with a human-readable message on any problem
+  } catch (err) {
+    return {
+      kind: "decline",
+      reason: `Couldn't turn that into a valid rule — try rephrasing. (${(err as Error).message})`.slice(0, MAX_TEXT_LEN),
+    };
+  }
+  return { kind: "rule", ruleId, explanation: parsed.explanation.trim().slice(0, MAX_TEXT_LEN), ruleYaml: stringifyYaml(singleEntry) };
+}

--- a/companion/src/analysis/taggerRuleSuggest.ts
+++ b/companion/src/analysis/taggerRuleSuggest.ts
@@ -14,7 +14,9 @@ export const suggestedRuleResponseSchema = z.object({
   ruleId: z.string().catch(""),
   explanation: z.string().catch(""),
   decline: z.string().catch(""),   // non-empty ⇒ the model refused; `rule` is ignored
-  rule: z.unknown().catch(null),   // the raw rule object; validated via compileRuleset below
+  rule: z.unknown(),               // raw rule object (also allows undefined); the real null-guard is
+                                   // the explicit `parsed.rule == null` check in sanitizeSuggestedRule.
+                                   // No .catch() here — z.unknown() never throws, so it would be dead.
 });
 export type SuggestedRuleResponse = z.infer<typeof suggestedRuleResponseSchema>;
 
@@ -25,10 +27,12 @@ export type SuggestOutcome =
 
 const MAX_ID_LEN = 60;
 const MAX_TEXT_LEN = 1200;
+const MAX_RULE_YAML_LEN = 8000;
 
 /** Normalize a proposed id to `[a-z0-9_]` (tagger ids are YAML keys). Empty → `fallback`. */
 export function slugifyRuleId(raw: string, fallback = "rule"): string {
-  const s = raw.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, MAX_ID_LEN);
+  // Trim underscores AFTER the slice so truncation can't reintroduce a trailing "_".
+  const s = raw.toLowerCase().replace(/[^a-z0-9]+/g, "_").slice(0, MAX_ID_LEN).replace(/^_+|_+$/g, "");
   return s || fallback;
 }
 
@@ -55,5 +59,9 @@ export function sanitizeSuggestedRule(parsed: SuggestedRuleResponse): SuggestOut
       reason: `Couldn't turn that into a valid rule — try rephrasing. (${(err as Error).message})`.slice(0, MAX_TEXT_LEN),
     };
   }
-  return { kind: "rule", ruleId, explanation: parsed.explanation.trim().slice(0, MAX_TEXT_LEN), ruleYaml: stringifyYaml(singleEntry) };
+  const ruleYaml = stringifyYaml(singleEntry);
+  if (ruleYaml.length > MAX_RULE_YAML_LEN) {
+    return { kind: "decline", reason: "The generated rule is too large — try a more specific description." };
+  }
+  return { kind: "rule", ruleId, explanation: parsed.explanation.trim().slice(0, MAX_TEXT_LEN), ruleYaml };
 }

--- a/companion/src/analysis/taggerStore.ts
+++ b/companion/src/analysis/taggerStore.ts
@@ -9,11 +9,11 @@
 // Invalid YAML / an invalid ruleset THROWS (never a partial load): the manual-run route surfaces the
 // error; the auto-run pipeline hook catches it and skips (a broken hand-edit must not break imports).
 
-import { readFile, access } from "node:fs/promises";
+import { readFile, access, rm } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { atomicWrite } from "../storage/atomicWrite.js";
 import { compileRuleset, type CompiledRuleset } from "./taggerRules.js";
 
@@ -44,6 +44,15 @@ function defaultCandidatePaths(): string[] {
 
 async function exists(path: string): Promise<boolean> {
   try { await access(path); return true; } catch { return false; }
+}
+
+/** Append `_2`, `_3`, … to `base` until it is not in `taken`. */
+function uniqueKey(base: string, taken: ReadonlySet<string>): string {
+  if (!taken.has(base)) return base;
+  for (let i = 2; ; i++) {
+    const candidate = `${base}_${i}`;
+    if (!taken.has(candidate)) return candidate;
+  }
 }
 
 export class TaggerStore {
@@ -97,6 +106,70 @@ export class TaggerStore {
     const compiled = compileText(yamlText); // throws on invalid — nothing is written
     await atomicWrite(this.userRulesPath, yamlText);
     return compiled;
+  }
+
+  /** True when an operator env override (TAGGER_RULES_FILE) owns the ruleset (read-only from our side). */
+  isEnvOverride(): boolean {
+    return this.envPath() !== undefined;
+  }
+
+  /** Parse the active ruleset into its raw id → rule map (for structural edits). Empty → {}. */
+  private async loadRawMap(): Promise<Record<string, unknown>> {
+    const active = await this.readActive();
+    if (!active.text.trim()) return {};
+    const doc = parseYaml(active.text);
+    return doc && typeof doc === "object" && !Array.isArray(doc) ? (doc as Record<string, unknown>) : {};
+  }
+
+  private assertEditable(): void {
+    if (this.isEnvOverride()) {
+      throw new Error("rules are managed by an operator override (TAGGER_RULES_FILE); editing is disabled");
+    }
+  }
+
+  /**
+   * Merge one rule (a single-entry YAML map of id → rule) into the active ruleset. Validates the new
+   * rule compiles, de-collides its id against existing ids, and persists via the validated save()
+   * path. Returns the (possibly de-collided) id and the new total rule count.
+   */
+  async addRuleYaml(singleEntryText: string): Promise<{ id: string; ruleCount: number }> {
+    this.assertEditable();
+    const doc = parseYaml(singleEntryText);
+    if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
+      throw new Error("expected a single rule (a YAML map of id → rule)");
+    }
+    const entries = Object.entries(doc as Record<string, unknown>);
+    if (entries.length !== 1) throw new Error(`expected exactly one rule, got ${entries.length}`);
+    const [rawId, rule] = entries[0];
+    compileRuleset({ [rawId]: rule }); // throws on an invalid rule BEFORE we touch the file
+    const map = await this.loadRawMap();
+    const id = uniqueKey(rawId, new Set(Object.keys(map)));
+    const compiled = await this.save(stringifyYaml({ ...map, [id]: rule }));
+    return { id, ruleCount: compiled.rules.length };
+  }
+
+  /** Remove one rule by id. Returns removed=false (and the unchanged count) when the id is absent. */
+  async removeRule(id: string): Promise<{ removed: boolean; ruleCount: number }> {
+    this.assertEditable();
+    const map = await this.loadRawMap();
+    if (!(id in map)) {
+      const current = await this.load();
+      return { removed: false, ruleCount: current.rules.length };
+    }
+    const next: Record<string, unknown> = { ...map };
+    delete next[id];
+    // An empty map serializes to "{}"; persist "" instead so the store reads back an empty ruleset.
+    const text = Object.keys(next).length ? stringifyYaml(next) : "";
+    const compiled = await this.save(text);
+    return { removed: true, ruleCount: compiled.rules.length };
+  }
+
+  /** Delete the user rule file so the active ruleset falls back to the bundled default. No-op if absent. */
+  async resetToDefault(): Promise<{ ruleCount: number }> {
+    this.assertEditable();
+    await rm(this.userRulesPath, { force: true });
+    const compiled = await this.load();
+    return { ruleCount: compiled.rules.length };
   }
 }
 

--- a/companion/src/analysis/taggerStore.ts
+++ b/companion/src/analysis/taggerStore.ts
@@ -127,6 +127,10 @@ export class TaggerStore {
     }
   }
 
+  // addRuleYaml/removeRule/resetToDefault do an UNLOCKED read-modify-write on the shared rules file,
+  // matching the existing PUT /tagger/rules behavior — concurrent edits could interleave and one may
+  // clobber the other. Acceptable for a single-analyst local tool; not wired to a lock deliberately.
+
   /**
    * Merge one rule (a single-entry YAML map of id → rule) into the active ruleset. Validates the new
    * rule compiles, de-collides its id against existing ids, and persists via the validated save()
@@ -152,12 +156,11 @@ export class TaggerStore {
   async removeRule(id: string): Promise<{ removed: boolean; ruleCount: number }> {
     this.assertEditable();
     const map = await this.loadRawMap();
-    if (!(id in map)) {
+    if (!Object.hasOwn(map, id)) {
       const current = await this.load();
       return { removed: false, ruleCount: current.rules.length };
     }
-    const next: Record<string, unknown> = { ...map };
-    delete next[id];
+    const { [id]: _removed, ...next } = map;
     // An empty map serializes to "{}"; persist "" instead so the store reads back an empty ruleset.
     const text = Object.keys(next).length ? stringifyYaml(next) : "";
     const compiled = await this.save(text);

--- a/companion/src/analysis/taggerStore.ts
+++ b/companion/src/analysis/taggerStore.ts
@@ -9,7 +9,7 @@
 // Invalid YAML / an invalid ruleset THROWS (never a partial load): the manual-run route surfaces the
 // error; the auto-run pipeline hook catches it and skips (a broken hand-edit must not break imports).
 
-import { readFile, access, rm } from "node:fs/promises";
+import { readFile, access, rm, mkdir } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -104,6 +104,7 @@ export class TaggerStore {
    */
   async save(yamlText: string): Promise<CompiledRuleset> {
     const compiled = compileText(yamlText); // throws on invalid — nothing is written
+    await mkdir(dirname(this.userRulesPath), { recursive: true }); // atomicWrite won't create parents
     await atomicWrite(this.userRulesPath, yamlText);
     return compiled;
   }

--- a/companion/src/routes/tagger.ts
+++ b/companion/src/routes/tagger.ts
@@ -12,10 +12,15 @@ import type { RouteContext } from "./context.js";
  * unioned MITRE, per analysis/tagger.ts. Manual runs and rule editing live here; the automatic
  * post-import run lives in the pipeline.
  *
- *   - GET  /tagger/rules            — the active ruleset (raw YAML + a parsed summary + its source).
- *   - PUT  /tagger/rules            — validate + persist edited rule YAML (400 on an invalid ruleset).
- *   - POST /cases/:id/tagger/run    — run the ruleset over the case; report per-rule match counts.
- *   - POST /cases/:id/tagger/clear  — remove every tagger-authored tag (reversible; analyst tags kept).
+ *   - GET    /tagger/rules               — the active ruleset (raw YAML + a parsed summary + its source).
+ *   - PUT    /tagger/rules               — validate + persist edited rule YAML (400 on an invalid ruleset).
+ *   - POST   /tagger/rules/add           — merge one reviewed rule (single-entry YAML) into the ruleset.
+ *   - DELETE /tagger/rules/:ruleId       — remove one rule by id (any rule; 404 if absent).
+ *   - POST   /tagger/rules/reset         — restore the shipped default ruleset (discard customizations).
+ *   - POST   /cases/:id/tagger/run       — run the ruleset over the case; report per-rule match counts.
+ *   - POST   /cases/:id/tagger/clear     — remove every tagger-authored tag (reversible; analyst tags kept).
+ *   - POST   /cases/:id/tagger/suggest-rule — AI: draft one rule from a plain-English description (ephemeral).
+ *   - POST   /cases/:id/tagger/preview   — dry-run a candidate rule; report its match count (no writes).
  */
 export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
   const { options, hasAiProvider } = ctx;

--- a/companion/src/routes/tagger.ts
+++ b/companion/src/routes/tagger.ts
@@ -1,6 +1,8 @@
 import type { Express, Request, Response } from "express";
 import { logActivity } from "../analysis/activityLog.js";
 import type { ForensicEvent } from "../analysis/stateTypes.js";
+import { runTagger, selectScopedEvents } from "../analysis/tagger.js";
+import { compileText } from "../analysis/taggerStore.js";
 import { runAndApplyTagger, readTaggerSettings, TAGGER_AUTHOR_PREFIX } from "../analysis/taggerRun.js";
 import type { RouteContext } from "./context.js";
 
@@ -16,7 +18,7 @@ import type { RouteContext } from "./context.js";
  *   - POST /cases/:id/tagger/clear  — remove every tagger-authored tag (reversible; analyst tags kept).
  */
 export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
-  const { options } = ctx;
+  const { options, hasAiProvider } = ctx;
   const logLine = (msg: string): void => ctx.serverLogger.info(msg);
 
   // The active ruleset: raw YAML for the editor + a compact per-rule summary + where it came from
@@ -73,12 +75,7 @@ export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
         const superEvents = scope !== "forensic" && options.superTimelineStore
           ? await options.superTimelineStore.all(caseId)
           : [];
-        // Build the scoped evaluation set. For "both", union the forensic timeline with the super
-        // timeline by id (the super timeline is a superset in practice, but a capped one).
-        const events: ForensicEvent[] =
-          scope === "super" ? superEvents
-          : scope === "forensic" ? state.forensicTimeline
-          : dedupeById(state.forensicTimeline, superEvents);
+        const events: ForensicEvent[] = selectScopedEvents(scope, state.forensicTimeline, superEvents);
 
         const applied = await runAndApplyTagger({
           caseId, events, ruleset,
@@ -125,10 +122,81 @@ export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
       return res.status(500).json({ error: (err as Error).message });
     }
   });
-}
 
-/** Union two event lists by id, keeping the first occurrence (forensic events win over super copies). */
-function dedupeById(a: readonly ForensicEvent[], b: readonly ForensicEvent[]): ForensicEvent[] {
-  const seen = new Set(a.map((e) => e.id));
-  return [...a, ...b.filter((e) => !seen.has(e.id))];
+  // Suggest ONE tagger rule from a plain-English description (PR #112 follow-up). AI-gated. Returns
+  // a candidate for review — nothing is persisted here. Body: { description }.
+  app.post("/cases/:id/tagger/suggest-rule", async (req: Request, res: Response) => {
+    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for tagger rule suggestion" });
+    const description = typeof req.body?.description === "string" ? req.body.description.trim() : "";
+    if (!description) return res.status(400).json({ error: "description is required" });
+    try {
+      const outcome = await options.pipeline.suggestTaggerRule(req.params.id, description);
+      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
+        category: "ai", action: "tagger-suggest-rule",
+        detail: `suggested rule from: "${description.slice(0, 120)}" — ${outcome.kind}`,
+      });
+      return res.status(200).json(outcome);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Dry-run a candidate rule over the case's scoped events and report how many it would match. No AI,
+  // no tags written, no state mutated. Body: { ruleYaml } (a single-entry rule map). 400 on invalid.
+  app.post("/cases/:id/tagger/preview", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "tagger not configured" });
+    const ruleYaml = typeof req.body?.ruleYaml === "string" ? req.body.ruleYaml : "";
+    const { scope } = readTaggerSettings();
+    try {
+      const ruleset = compileText(ruleYaml); // throws on invalid → 400 below
+      const state = await options.stateStore.load(req.params.id);
+      const superEvents = scope !== "forensic" && options.superTimelineStore
+        ? await options.superTimelineStore.all(req.params.id)
+        : [];
+      const events = selectScopedEvents(scope, state.forensicTimeline, superEvents);
+      const result = runTagger(events, ruleset);
+      return res.status(200).json({ matched: result.totalMatched, scope });
+    } catch (err) {
+      return res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  // Merge one reviewed rule into the ruleset. No AI. Body: { ruleYaml } (single-entry map). 400 on
+  // invalid; the store de-collides the id and validates before persisting.
+  app.post("/tagger/rules/add", async (req: Request, res: Response) => {
+    if (!options.taggerStore) return res.status(501).json({ error: "tagger not configured" });
+    const ruleYaml = typeof req.body?.ruleYaml === "string" ? req.body.ruleYaml : "";
+    try {
+      const { id, ruleCount } = await options.taggerStore.addRuleYaml(ruleYaml);
+      logLine(`[tagger] rule added: ${id} — ${ruleCount} rule(s)`);
+      return res.status(200).json({ id, ruleCount });
+    } catch (err) {
+      return res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  // Remove one rule by id (any rule, default or added). 404 when the id isn't present.
+  app.delete("/tagger/rules/:ruleId", async (req: Request, res: Response) => {
+    if (!options.taggerStore) return res.status(501).json({ error: "tagger not configured" });
+    try {
+      const { removed, ruleCount } = await options.taggerStore.removeRule(req.params.ruleId);
+      if (!removed) return res.status(404).json({ error: `rule "${req.params.ruleId}" not found` });
+      logLine(`[tagger] rule removed: ${req.params.ruleId} — ${ruleCount} rule(s)`);
+      return res.status(200).json({ ruleCount });
+    } catch (err) {
+      return res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  // Reset the ruleset to the shipped default (discards all customizations).
+  app.post("/tagger/rules/reset", async (_req: Request, res: Response) => {
+    if (!options.taggerStore) return res.status(501).json({ error: "tagger not configured" });
+    try {
+      const { ruleCount } = await options.taggerStore.resetToDefault();
+      logLine(`[tagger] rules reset to default — ${ruleCount} rule(s)`);
+      return res.status(200).json({ ruleCount });
+    } catch (err) {
+      return res.status(400).json({ error: (err as Error).message });
+    }
+  });
 }

--- a/companion/src/routes/tagger.ts
+++ b/companion/src/routes/tagger.ts
@@ -146,8 +146,9 @@ export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
     }
   });
 
-  // Dry-run a candidate rule over the case's scoped events and report how many it would match. No AI,
-  // no tags written, no state mutated. Body: { ruleYaml } (a single-entry rule map). 400 on invalid.
+  // Dry-run a candidate rule over the case's scoped events and report how many it would match PLUS a
+  // capped sample of the matching events (so the analyst can see WHAT it covers, not just a count).
+  // No AI, no tags written, no state mutated. Body: { ruleYaml } (a single-entry rule map). 400 on invalid.
   app.post("/cases/:id/tagger/preview", async (req: Request, res: Response) => {
     if (!options.stateStore) return res.status(501).json({ error: "tagger not configured" });
     const ruleYaml = typeof req.body?.ruleYaml === "string" ? req.body.ruleYaml : "";
@@ -160,7 +161,19 @@ export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
         : [];
       const events = selectScopedEvents(scope, state.forensicTimeline, superEvents);
       const result = runTagger(events, ruleset);
-      return res.status(200).json({ matched: result.totalMatched, scope });
+      // A capped, trimmed view of the matching events for the dashboard preview list.
+      const PREVIEW_SAMPLE_CAP = 100;
+      const byId = new Map(events.map((e) => [e.id, e]));
+      const sample = result.perEvent.slice(0, PREVIEW_SAMPLE_CAP).map((m) => {
+        const e = byId.get(m.eventId);
+        return {
+          id: m.eventId,
+          timestamp: e?.timestamp ?? "",
+          asset: e?.asset ?? "",
+          description: (e?.description ?? "").slice(0, 200),
+        };
+      });
+      return res.status(200).json({ matched: result.totalMatched, scope, sample });
     } catch (err) {
       return res.status(400).json({ error: (err as Error).message });
     }

--- a/companion/tests/analysis/tagger.test.ts
+++ b/companion/tests/analysis/tagger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compileRuleset } from "../../src/analysis/taggerRules.js";
-import { runTagger, raiseSeverity, applyToForensicEvent } from "../../src/analysis/tagger.js";
+import { runTagger, raiseSeverity, applyToForensicEvent, selectScopedEvents } from "../../src/analysis/tagger.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
 
 function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
@@ -96,5 +96,21 @@ describe("applyToForensicEvent", () => {
     const original = ev({ id: "e1", severity: "Critical" });
     const result = { eventId: "e1", tags: [], mitre: [], severity: "Low" as const, ruleIds: ["x"] };
     expect(applyToForensicEvent(original, result).severity).toBe("Critical");
+  });
+});
+
+describe("selectScopedEvents", () => {
+  const f = (id: string) => ({ id, timestamp: "t", description: "d", severity: "Info" as const, mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [] });
+  const forensic = [f("a"), f("b")];
+  const superEvents = [f("b"), f("c")]; // 'b' overlaps
+
+  it("returns only forensic events for scope 'forensic'", () => {
+    expect(selectScopedEvents("forensic", forensic, superEvents).map((e) => e.id)).toEqual(["a", "b"]);
+  });
+  it("returns only super events for scope 'super'", () => {
+    expect(selectScopedEvents("super", forensic, superEvents).map((e) => e.id)).toEqual(["b", "c"]);
+  });
+  it("unions by id (forensic wins) for scope 'both'", () => {
+    expect(selectScopedEvents("both", forensic, superEvents).map((e) => e.id)).toEqual(["a", "b", "c"]);
   });
 });

--- a/companion/tests/analysis/taggerRuleSuggest.test.ts
+++ b/companion/tests/analysis/taggerRuleSuggest.test.ts
@@ -59,6 +59,17 @@ describe("sanitizeSuggestedRule", () => {
     if (out.kind === "decline") expect(out.reason).toMatch(/not_a_real_field|valid rule/i);
   });
 
+  it("declines when the generated rule is too large", () => {
+    const parsed = suggestedRuleResponseSchema.parse({
+      ruleId: "huge",
+      explanation: "x",
+      rule: { any: [{ field: "message", contains: "a".repeat(8001) }], tags: ["t"] },
+    });
+    const out = sanitizeSuggestedRule(parsed);
+    expect(out.kind).toBe("decline");
+    if (out.kind === "decline") expect(out.reason).toMatch(/too large/i);
+  });
+
   it("declines when the model returns no rule and no decline text", () => {
     const parsed = suggestedRuleResponseSchema.parse({ ruleId: "", explanation: "" });
     const out = sanitizeSuggestedRule(parsed);

--- a/companion/tests/analysis/taggerRuleSuggest.test.ts
+++ b/companion/tests/analysis/taggerRuleSuggest.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { parse as parseYaml } from "yaml";
+import {
+  suggestedRuleResponseSchema,
+  sanitizeSuggestedRule,
+  slugifyRuleId,
+} from "../../src/analysis/taggerRuleSuggest.js";
+import { compileRuleset } from "../../src/analysis/taggerRules.js";
+
+describe("slugifyRuleId", () => {
+  it("lowercases, replaces non-alphanumerics with underscores, trims", () => {
+    expect(slugifyRuleId("Windows Log Cleared!")).toBe("windows_log_cleared");
+  });
+  it("falls back when the input has no usable characters", () => {
+    expect(slugifyRuleId("!!!")).toBe("rule");
+  });
+});
+
+describe("sanitizeSuggestedRule", () => {
+  it("returns a decline when the model declines", () => {
+    const parsed = suggestedRuleResponseSchema.parse({
+      decline: "Counting logons over time isn't expressible as a single-event rule.",
+    });
+    const out = sanitizeSuggestedRule(parsed);
+    expect(out.kind).toBe("decline");
+    if (out.kind === "decline") expect(out.reason).toMatch(/single-event/);
+  });
+
+  it("produces a valid single-entry YAML rule from a well-formed reply", () => {
+    const parsed = suggestedRuleResponseSchema.parse({
+      ruleId: "Windows Log Cleared",
+      explanation: "Matches Security 1102 log-clear events.",
+      rule: {
+        description: "Security event log cleared",
+        any: [{ field: "message", contains: ["1102", "audit log was cleared"] }],
+        tags: ["log-cleared", "defense-evasion"],
+        mitre: ["T1070.001"],
+        severity: "High",
+      },
+    });
+    const out = sanitizeSuggestedRule(parsed);
+    expect(out.kind).toBe("rule");
+    if (out.kind === "rule") {
+      expect(out.ruleId).toBe("windows_log_cleared");
+      const doc = parseYaml(out.ruleYaml);
+      expect(Object.keys(doc)).toEqual(["windows_log_cleared"]);
+      expect(() => compileRuleset(doc)).not.toThrow();
+    }
+  });
+
+  it("declines (never returns a broken rule) when the rule does not compile", () => {
+    const parsed = suggestedRuleResponseSchema.parse({
+      ruleId: "bad",
+      explanation: "x",
+      rule: { any: [{ field: "not_a_real_field", contains: "x" }], tags: ["t"] },
+    });
+    const out = sanitizeSuggestedRule(parsed);
+    expect(out.kind).toBe("decline");
+    if (out.kind === "decline") expect(out.reason).toMatch(/not_a_real_field|valid rule/i);
+  });
+
+  it("declines when the model returns no rule and no decline text", () => {
+    const parsed = suggestedRuleResponseSchema.parse({ ruleId: "", explanation: "" });
+    const out = sanitizeSuggestedRule(parsed);
+    expect(out.kind).toBe("decline");
+  });
+});

--- a/companion/tests/analysis/taggerStore.test.ts
+++ b/companion/tests/analysis/taggerStore.test.ts
@@ -109,6 +109,14 @@ describe("TaggerStore edits (add/remove/reset)", () => {
     expect(active.rules.map((r) => r.id).sort()).toEqual(["logon", "svc"]);
   });
 
+  it("addRuleYaml creates the rules directory if it does not exist", async () => {
+    // point the store at a NESTED path whose parent dir is absent
+    const nestedStore = new TaggerStore(join(dir, "missing-subdir", "tags.yaml"), [defaultPath]);
+    const res = await nestedStore.addRuleYaml("logon:\n  any:\n    - { field: message, contains: 'x' }\n  tags: ['t']\n");
+    expect(res.ruleCount).toBeGreaterThanOrEqual(1);
+    expect((await nestedStore.load()).source).toBe("user");
+  });
+
   it("addRuleYaml de-collides an id that already exists", async () => {
     const yaml = "svc:\n  any:\n    - { field: message, contains: 'x' }\n  tags: ['t']\n";
     const res = await store.addRuleYaml(yaml);

--- a/companion/tests/analysis/taggerStore.test.ts
+++ b/companion/tests/analysis/taggerStore.test.ts
@@ -81,3 +81,86 @@ describe("TaggerStore", () => {
     expect(loaded.rules[0].id).toBe("env_rule");
   });
 });
+
+import { mkdtemp, writeFile, rm, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { TaggerStore } from "../../src/analysis/taggerStore.js";
+
+describe("TaggerStore edits (add/remove/reset)", () => {
+  let dir: string, userPath: string, defaultPath: string, store: TaggerStore;
+  const DEFAULT = "svc:\n  any:\n    - { field: message, contains: ['7045'] }\n  tags: ['persistence']\n";
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "dfir-tagger-store-edit-"));
+    userPath = join(dir, "user-tags.yaml");
+    defaultPath = join(dir, "default-tags.yaml");
+    await writeFile(defaultPath, DEFAULT);
+    store = new TaggerStore(userPath, [defaultPath]);
+    delete process.env.TAGGER_RULES_FILE;
+  });
+  afterEach(async () => {
+    delete process.env.TAGGER_RULES_FILE;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("addRuleYaml merges a new rule and returns the new count", async () => {
+    const yaml = "logon:\n  any:\n    - { field: message, contains: 'logged on' }\n  tags: ['logon']\n";
+    const res = await store.addRuleYaml(yaml);
+    expect(res.id).toBe("logon");
+    expect(res.ruleCount).toBe(2);
+    const active = await store.load();
+    expect(active.source).toBe("user");
+    expect(active.rules.map((r) => r.id).sort()).toEqual(["logon", "svc"]);
+  });
+
+  it("addRuleYaml de-collides an id that already exists", async () => {
+    const yaml = "svc:\n  any:\n    - { field: message, contains: 'x' }\n  tags: ['t']\n";
+    const res = await store.addRuleYaml(yaml);
+    expect(res.id).toBe("svc_2");
+    expect(res.ruleCount).toBe(2);
+  });
+
+  it("addRuleYaml rejects an invalid rule without persisting", async () => {
+    const bad = "bad:\n  any:\n    - { field: not_a_field, contains: 'x' }\n  tags: ['t']\n";
+    await expect(store.addRuleYaml(bad)).rejects.toThrow(/not_a_field/);
+    await expect(access(userPath)).rejects.toBeTruthy();
+  });
+
+  it("removeRule drops a rule and reports removed=true", async () => {
+    await store.addRuleYaml("logon:\n  any:\n    - { field: message, contains: 'x' }\n  tags: ['t']\n");
+    const res = await store.removeRule("svc");
+    expect(res.removed).toBe(true);
+    expect(res.ruleCount).toBe(1);
+    const active = await store.load();
+    expect(active.rules.map((r) => r.id)).toEqual(["logon"]);
+  });
+
+  it("removeRule on an absent id reports removed=false and leaves the count unchanged", async () => {
+    const res = await store.removeRule("does-not-exist");
+    expect(res.removed).toBe(false);
+    expect(res.ruleCount).toBe(1);
+  });
+
+  it("resetToDefault deletes the user file and falls back to the bundled default", async () => {
+    await store.addRuleYaml("logon:\n  any:\n    - { field: message, contains: 'x' }\n  tags: ['t']\n");
+    expect((await store.load()).source).toBe("user");
+    const res = await store.resetToDefault();
+    expect(res.ruleCount).toBe(1);
+    expect((await store.load()).source).toBe("default");
+  });
+
+  it("resetToDefault is a no-op when no user file exists", async () => {
+    const res = await store.resetToDefault();
+    expect(res.ruleCount).toBe(1);
+    expect((await store.load()).source).toBe("default");
+  });
+
+  it("refuses edits when TAGGER_RULES_FILE (operator override) is set", async () => {
+    process.env.TAGGER_RULES_FILE = defaultPath;
+    await expect(store.addRuleYaml("x:\n  any:\n    - { field: message, contains: 'x' }\n  tags: ['t']\n")).rejects.toThrow(/operator override/i);
+    await expect(store.removeRule("svc")).rejects.toThrow(/operator override/i);
+    await expect(store.resetToDefault()).rejects.toThrow(/operator override/i);
+  });
+});

--- a/companion/tests/analysis/taggerStore.test.ts
+++ b/companion/tests/analysis/taggerStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, rm, readFile } from "node:fs/promises";
+import { mkdtemp, writeFile, rm, readFile, access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { TaggerStore, compileText } from "../../src/analysis/taggerStore.js";
@@ -82,12 +82,6 @@ describe("TaggerStore", () => {
   });
 });
 
-import { mkdtemp, writeFile, rm, access } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { TaggerStore } from "../../src/analysis/taggerStore.js";
-
 describe("TaggerStore edits (add/remove/reset)", () => {
   let dir: string, userPath: string, defaultPath: string, store: TaggerStore;
   const DEFAULT = "svc:\n  any:\n    - { field: message, contains: ['7045'] }\n  tags: ['persistence']\n";
@@ -150,6 +144,12 @@ describe("TaggerStore edits (add/remove/reset)", () => {
     const res = await store.removeRule("does-not-exist");
     expect(res.removed).toBe(false);
     expect(res.ruleCount).toBe(1);
+  });
+
+  it("removeRule treats a prototype-chain key (e.g. 'toString') as absent", async () => {
+    const res = await store.removeRule("toString");
+    expect(res.removed).toBe(false);
+    expect(res.ruleCount).toBe(1); // 'svc' untouched
   });
 
   it("resetToDefault deletes the user file and falls back to the bundled default", async () => {

--- a/companion/tests/analysis/taggerStore.test.ts
+++ b/companion/tests/analysis/taggerStore.test.ts
@@ -137,6 +137,15 @@ describe("TaggerStore edits (add/remove/reset)", () => {
     expect(active.rules.map((r) => r.id)).toEqual(["logon"]);
   });
 
+  it("removeRule on the last remaining rule empties the ruleset (persists \"\", not falls back to default)", async () => {
+    const res = await store.removeRule("svc"); // svc is the only rule, no prior addRuleYaml
+    expect(res.removed).toBe(true);
+    expect(res.ruleCount).toBe(0);
+    const active = await store.load();
+    expect(active.source).toBe("user");
+    expect(active.rules).toEqual([]);
+  });
+
   it("removeRule on an absent id reports removed=false and leaves the count unchanged", async () => {
     const res = await store.removeRule("does-not-exist");
     expect(res.removed).toBe(false);

--- a/companion/tests/server/taggerRoutes.test.ts
+++ b/companion/tests/server/taggerRoutes.test.ts
@@ -196,11 +196,17 @@ describe("POST /cases/:id/tagger/suggest-rule", () => {
 });
 
 describe("POST /cases/:id/tagger/preview", () => {
-  it("counts matches without writing tags or mutating state (no AI needed)", async () => {
+  it("counts matches and returns a sample of matching events without writing tags or mutating state", async () => {
     const ruleYaml = "svc:\n  any:\n    - { field: message, contains: '7045' }\n  tags: ['t']\n";
     const res = await request(app()).post("/cases/c1/tagger/preview").send({ ruleYaml });
     expect(res.status).toBe(200);
     expect(res.body.matched).toBe(1);
+    // the sample lists the actual matching event (e1), with its identifying fields
+    expect(Array.isArray(res.body.sample)).toBe(true);
+    expect(res.body.sample).toHaveLength(1);
+    expect(res.body.sample[0]).toMatchObject({ id: "e1" });
+    expect(res.body.sample[0]).toHaveProperty("timestamp");
+    expect(res.body.sample[0]).toHaveProperty("description");
     const tags = (await request(app()).get("/cases/c1/tags")).body as unknown[];
     expect(tags).toHaveLength(0);
   });

--- a/companion/tests/server/taggerRoutes.test.ts
+++ b/companion/tests/server/taggerRoutes.test.ts
@@ -11,6 +11,7 @@ import { TagsStore } from "../../src/analysis/tags.js";
 import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
 import { TaggerStore } from "../../src/analysis/taggerStore.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+import type { SuggestOutcome } from "../../src/analysis/taggerRuleSuggest.js";
 
 function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
   return {
@@ -156,5 +157,92 @@ describe("POST /cases/:id/tagger/clear", () => {
     const tags = (await request(app()).get("/cases/c1/tags")).body as Array<{ label: string; author: string }>;
     expect(tags).toHaveLength(1);
     expect(tags[0]).toMatchObject({ label: "key-evidence", author: "alice" });
+  });
+});
+
+function appAi(suggest: (caseId: string, desc: string) => Promise<SuggestOutcome>) {
+  const fakePipeline = {
+    hasAiProvider: () => true,
+    suggestTaggerRule: suggest,
+  } as unknown as import("../../src/analysis/pipeline.js").AnalysisPipeline;
+  return createApp(store, {
+    stateStore, tagsStore, taggerStore,
+    superTimelineStore: new SuperTimelineStore(store),
+    pipeline: fakePipeline,
+    aiConfigured: true,
+  });
+}
+
+describe("POST /cases/:id/tagger/suggest-rule", () => {
+  it("is 501 when no AI provider is configured", async () => {
+    const res = await request(app()).post("/cases/c1/tagger/suggest-rule").send({ description: "flag log clears" });
+    expect(res.status).toBe(501);
+  });
+
+  it("returns a rule outcome from the pipeline", async () => {
+    const outcome: SuggestOutcome = {
+      kind: "rule", ruleId: "logon", explanation: "e",
+      ruleYaml: "logon:\n  any:\n    - { field: message, contains: 'logged on' }\n  tags: ['logon']\n",
+    };
+    const res = await request(appAi(async () => outcome)).post("/cases/c1/tagger/suggest-rule").send({ description: "x" });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ kind: "rule", ruleId: "logon" });
+  });
+
+  it("400s on an empty description", async () => {
+    const res = await request(appAi(async () => ({ kind: "decline", reason: "n/a" }))).post("/cases/c1/tagger/suggest-rule").send({ description: "  " });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /cases/:id/tagger/preview", () => {
+  it("counts matches without writing tags or mutating state (no AI needed)", async () => {
+    const ruleYaml = "svc:\n  any:\n    - { field: message, contains: '7045' }\n  tags: ['t']\n";
+    const res = await request(app()).post("/cases/c1/tagger/preview").send({ ruleYaml });
+    expect(res.status).toBe(200);
+    expect(res.body.matched).toBe(1);
+    const tags = (await request(app()).get("/cases/c1/tags")).body as unknown[];
+    expect(tags).toHaveLength(0);
+  });
+
+  it("400s on an invalid rule YAML", async () => {
+    const res = await request(app()).post("/cases/c1/tagger/preview").send({ ruleYaml: "bad:\n  any:\n    - { field: nope, contains: 'x' }\n  tags: ['t']\n" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/nope/);
+  });
+});
+
+describe("POST /tagger/rules/add", () => {
+  it("merges the rule and GET reflects source=user with both rules", async () => {
+    const ruleYaml = "logon:\n  any:\n    - { field: message, contains: 'logged on' }\n  tags: ['logon']\n";
+    const res = await request(app()).post("/tagger/rules/add").send({ ruleYaml });
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe("logon");
+    expect(res.body.ruleCount).toBe(2);
+    const get = await request(app()).get("/tagger/rules");
+    expect(get.body.rules.map((r: { id: string }) => r.id).sort()).toEqual(["logon", "svc"]);
+  });
+});
+
+describe("DELETE /tagger/rules/:ruleId", () => {
+  it("removes a rule (200) and 404s for an unknown id", async () => {
+    await request(app()).post("/tagger/rules/add").send({ ruleYaml: "logon:\n  any:\n    - { field: message, contains: 'logged on' }\n  tags: ['logon']\n" });
+    const del = await request(app()).delete("/tagger/rules/svc");
+    expect(del.status).toBe(200);
+    expect(del.body.ruleCount).toBe(1);
+    const missing = await request(app()).delete("/tagger/rules/nope");
+    expect(missing.status).toBe(404);
+  });
+});
+
+describe("POST /tagger/rules/reset", () => {
+  it("restores the shipped default ruleset", async () => {
+    await request(app()).post("/tagger/rules/add").send({ ruleYaml: "logon:\n  any:\n    - { field: message, contains: 'x' }\n  tags: ['t']\n" });
+    expect((await request(app()).get("/tagger/rules")).body.source).toBe("user");
+    const reset = await request(app()).post("/tagger/rules/reset");
+    expect(reset.status).toBe(200);
+    const get = await request(app()).get("/tagger/rules");
+    expect(get.body.source).toBe("default");
+    expect(get.body.ruleCount).toBe(1);
   });
 });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4104,9 +4104,12 @@
         <button class="ev-bulk-btn" onclick="runTagger()" title="Run the content-based rules over this case and tag matching events (like Timesketch's tagger analyzer)">Run tagger</button>
         <button class="ev-bulk-btn" onclick="clearTaggerTags()" title="Remove every tag the tagger applied (author 'tagger:*'); analyst tags are kept">Clear tagger tags</button>
         <button class="ev-bulk-btn" onclick="toggleTaggerRules()" title="View / edit the tagging rules (YAML)">Edit rules</button>
+        <button id="taggerSuggestToggle" class="ev-bulk-btn" onclick="toggleTaggerSuggest()" title="Create tagger rules with AI from a plain-English description, and manage the active rule list">✨ Suggest rule</button>
         <span id="taggerMsg" style="font-size:12px;color:var(--c-9aa4b2)"></span>
       </div>
-      <!-- NL → rule (PR #112 follow-up): describe a rule in plain English; AI drafts it for review. -->
+      <!-- NL → rule (PR #112 follow-up): AI rule authoring + rule management, hidden until ✨ Suggest rule is clicked. -->
+      <div id="taggerSuggestWrap" hidden>
+      <!-- describe a rule in plain English; AI drafts it for review. -->
       <div id="taggerSuggestPane" style="margin-bottom:8px">
         <div style="font-size:11px;color:var(--c-9aa4b2);margin-bottom:4px">
           ✨ Describe a rule in plain English — the AI drafts a rule you can preview, edit, and add.
@@ -4128,6 +4131,7 @@
             <button class="ev-bulk-btn" onclick="discardSuggestedTaggerRule()">Discard</button>
             <span id="taggerSuggestResultMsg" style="font-size:12px;color:var(--c-9aa4b2)"></span>
           </div>
+          <div id="taggerSuggestMatches" hidden style="margin-top:6px;max-height:170px;overflow-y:auto;border:1px solid var(--c-2b3242);border-radius:6px;padding:6px;font-size:11px;font-family:monospace;color:var(--c-9aa4b2)"></div>
         </div>
       </div>
       <!-- Active rules with per-rule remove + reset-to-defaults. -->
@@ -4140,6 +4144,7 @@
         </div>
         <div id="taggerRuleRows" style="font-size:12px"></div>
       </div>
+      </div><!-- /taggerSuggestWrap -->
       <div id="taggerRulesPane" hidden style="margin-bottom:8px">
         <div style="font-size:11px;color:var(--c-9aa4b2);margin-bottom:4px">Rules YAML — one entry per rule (name → any/all/none conditions + tags/mitre/severity/view). Source: <span id="taggerRulesSource">—</span>. Matchable fields: description, message, asset, path, processName, parentName, sources, sha256, port, severity, …</div>
         <textarea id="taggerRulesText" spellcheck="false" style="width:100%;min-height:220px;font-family:monospace;font-size:12px;background:var(--c-11151c);color:var(--c-e6e6e6);border:1px solid var(--c-2b3242);border-radius:6px;padding:8px"></textarea>
@@ -6060,6 +6065,8 @@
       const caseId = document.getElementById("caseId").value.trim();
       const ruleYaml = document.getElementById("taggerSuggestYaml").value;
       const msg = document.getElementById("taggerSuggestResultMsg");
+      const matchBox = document.getElementById("taggerSuggestMatches");
+      matchBox.hidden = true; matchBox.innerHTML = "";
       if (!caseId) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Connect to a case first."; return; }
       msg.style.color = "var(--c-9aa4b2)"; msg.textContent = "Checking…";
       try {
@@ -6069,8 +6076,33 @@
         const d = await r.json();
         if (!r.ok || d.error) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Invalid rule: " + (d.error || r.status); return; }
         msg.style.color = d.matched > 0 ? "var(--c-9aa4b2)" : "var(--c-ff9800)";
-        msg.textContent = `Would match ${d.matched} event(s) in this case.`;
+        msg.textContent = `Would match ${d.matched} event(s) in this case${d.scope ? " (scope: " + d.scope + ")" : ""}.`;
+        // Show the actual matching events (a capped sample) so the analyst can see WHAT it covers.
+        const sample = d.sample || [];
+        if (sample.length) {
+          const header = document.createElement("div");
+          header.style.cssText = "color:var(--c-e6e6e6);margin-bottom:4px";
+          header.textContent = `Matching events${d.matched > sample.length ? ` (showing first ${sample.length} of ${d.matched})` : ""}:`;
+          matchBox.appendChild(header);
+          sample.forEach((ev) => {
+            const row = document.createElement("div");
+            row.style.cssText = "padding:1px 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis";
+            const ts = (ev.timestamp || "").replace("T", " ").replace(/\.\d+Z$/, "Z");
+            row.textContent = `${ts}  ${ev.asset ? "[" + ev.asset + "] " : ""}${ev.description || ev.id}`;
+            row.title = ev.description || ev.id;
+            matchBox.appendChild(row);
+          });
+          matchBox.hidden = false;
+        }
       } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Check failed: " + e.message; }
+    }
+
+    // Toggle the AI rule-authoring + rule-management pane (collapsed by default; opened from the toolbar).
+    function toggleTaggerSuggest() {
+      const wrap = document.getElementById("taggerSuggestWrap");
+      if (!wrap) return;
+      wrap.hidden = !wrap.hidden;
+      if (!wrap.hidden) refreshTaggerRuleList();
     }
 
     async function addSuggestedTaggerRule() {
@@ -6093,6 +6125,8 @@
       document.getElementById("taggerSuggestResult").hidden = true;
       document.getElementById("taggerSuggestYaml").value = "";
       document.getElementById("taggerSuggestInput").value = "";
+      const matchBox = document.getElementById("taggerSuggestMatches");
+      if (matchBox) { matchBox.hidden = true; matchBox.innerHTML = ""; }
     }
 
     async function refreshTaggerRuleList() {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4106,6 +4106,40 @@
         <button class="ev-bulk-btn" onclick="toggleTaggerRules()" title="View / edit the tagging rules (YAML)">Edit rules</button>
         <span id="taggerMsg" style="font-size:12px;color:var(--c-9aa4b2)"></span>
       </div>
+      <!-- NL → rule (PR #112 follow-up): describe a rule in plain English; AI drafts it for review. -->
+      <div id="taggerSuggestPane" style="margin-bottom:8px">
+        <div style="font-size:11px;color:var(--c-9aa4b2);margin-bottom:4px">
+          ✨ Describe a rule in plain English — the AI drafts a rule you can preview, edit, and add.
+          <span style="color:var(--c-ff9800)">⚠ AI-generated — review what it matches before adding.</span>
+        </div>
+        <textarea id="taggerSuggestInput" spellcheck="true" placeholder="e.g. flag any time the Windows security event log is cleared"
+          style="width:100%;min-height:44px;font-size:12px;background:var(--c-11151c);color:var(--c-e6e6e6);border:1px solid var(--c-2b3242);border-radius:6px;padding:8px"></textarea>
+        <div style="display:flex;gap:6px;align-items:center;margin-top:4px">
+          <button id="taggerSuggestBtn" class="ev-bulk-btn" onclick="suggestTaggerRule()" title="Ask the AI to draft a tagger rule from your description (one AI call)">✨ Suggest rule</button>
+          <span id="taggerSuggestMsg" style="font-size:12px;color:var(--c-9aa4b2)"></span>
+        </div>
+        <div id="taggerSuggestResult" hidden style="margin-top:6px">
+          <div id="taggerSuggestExplain" style="font-size:12px;color:var(--c-9aa4b2);margin-bottom:4px"></div>
+          <textarea id="taggerSuggestYaml" spellcheck="false"
+            style="width:100%;min-height:140px;font-family:monospace;font-size:12px;background:var(--c-11151c);color:var(--c-e6e6e6);border:1px solid var(--c-2b3242);border-radius:6px;padding:8px"></textarea>
+          <div style="display:flex;gap:6px;align-items:center;margin-top:4px">
+            <button class="ev-bulk-btn" onclick="previewTaggerRule()" title="Count how many events in this case the draft rule would match (no changes made)">Check matches</button>
+            <button class="ev-bulk-btn" onclick="addSuggestedTaggerRule()" title="Add this rule to the ruleset">Add rule</button>
+            <button class="ev-bulk-btn" onclick="discardSuggestedTaggerRule()">Discard</button>
+            <span id="taggerSuggestResultMsg" style="font-size:12px;color:var(--c-9aa4b2)"></span>
+          </div>
+        </div>
+      </div>
+      <!-- Active rules with per-rule remove + reset-to-defaults. -->
+      <div id="taggerRuleList" style="margin-bottom:8px">
+        <div style="display:flex;gap:6px;align-items:center;margin-bottom:4px">
+          <strong style="font-size:12px;color:var(--c-9aa4b2)">Active rules</strong>
+          <button class="ev-bulk-btn" onclick="refreshTaggerRuleList()" title="Reload the rule list">↻</button>
+          <button class="ev-bulk-btn" onclick="resetTaggerRules()" title="Discard all customizations and restore the shipped default rules">Reset to defaults</button>
+          <span id="taggerRuleListMsg" style="font-size:12px;color:var(--c-9aa4b2)"></span>
+        </div>
+        <div id="taggerRuleRows" style="font-size:12px"></div>
+      </div>
       <div id="taggerRulesPane" hidden style="margin-bottom:8px">
         <div style="font-size:11px;color:var(--c-9aa4b2);margin-bottom:4px">Rules YAML — one entry per rule (name → any/all/none conditions + tags/mitre/severity/view). Source: <span id="taggerRulesSource">—</span>. Matchable fields: description, message, asset, path, processName, parentName, sources, sha256, port, severity, …</div>
         <textarea id="taggerRulesText" spellcheck="false" style="width:100%;min-height:220px;font-family:monospace;font-size:12px;background:var(--c-11151c);color:var(--c-e6e6e6);border:1px solid var(--c-2b3242);border-radius:6px;padding:8px"></textarea>
@@ -5985,6 +6019,135 @@
       } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Tagger failed: " + e.message; }
     }
 
+    // ── NL → rule (PR #112 follow-up) ──────────────────────────────────────────
+    async function suggestTaggerRule() {
+      const caseId = document.getElementById("caseId").value.trim();
+      const desc = document.getElementById("taggerSuggestInput").value.trim();
+      const msg = document.getElementById("taggerSuggestMsg");
+      if (!caseId) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Connect to a case first."; return; }
+      if (!desc) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Describe the rule first."; return; }
+      const btn = document.getElementById("taggerSuggestBtn");
+      btn.disabled = true;
+      msg.style.color = "var(--c-9aa4b2)";
+      msg.textContent = "Drafting… (one AI call)";
+      try {
+        const r = await fetch(`/cases/${caseId}/tagger/suggest-rule`, {
+          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ description: desc }),
+        });
+        const d = await r.json();
+        if (!r.ok || d.error) {
+          const hint = /501/.test(String(r.status)) ? " — AI provider not configured (Settings → AI)" : "";
+          msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Suggest error: " + (d.error || r.status) + hint; return;
+        }
+        const result = document.getElementById("taggerSuggestResult");
+        const explain = document.getElementById("taggerSuggestExplain");
+        const yaml = document.getElementById("taggerSuggestYaml");
+        if (d.kind === "decline") {
+          result.hidden = true;
+          msg.style.color = "var(--c-ff9800)"; msg.textContent = "Can't make a rule: " + d.reason;
+          return;
+        }
+        msg.textContent = "";
+        explain.textContent = d.explanation || "";
+        yaml.value = d.ruleYaml || "";
+        document.getElementById("taggerSuggestResultMsg").textContent = "";
+        result.hidden = false;
+      } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Suggest failed: " + e.message; }
+      finally { btn.disabled = false; }
+    }
+
+    async function previewTaggerRule() {
+      const caseId = document.getElementById("caseId").value.trim();
+      const ruleYaml = document.getElementById("taggerSuggestYaml").value;
+      const msg = document.getElementById("taggerSuggestResultMsg");
+      if (!caseId) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Connect to a case first."; return; }
+      msg.style.color = "var(--c-9aa4b2)"; msg.textContent = "Checking…";
+      try {
+        const r = await fetch(`/cases/${caseId}/tagger/preview`, {
+          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ ruleYaml }),
+        });
+        const d = await r.json();
+        if (!r.ok || d.error) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Invalid rule: " + (d.error || r.status); return; }
+        msg.style.color = d.matched > 0 ? "var(--c-9aa4b2)" : "var(--c-ff9800)";
+        msg.textContent = `Would match ${d.matched} event(s) in this case.`;
+      } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Check failed: " + e.message; }
+    }
+
+    async function addSuggestedTaggerRule() {
+      const ruleYaml = document.getElementById("taggerSuggestYaml").value;
+      const msg = document.getElementById("taggerSuggestResultMsg");
+      msg.style.color = "var(--c-9aa4b2)"; msg.textContent = "Adding…";
+      try {
+        const r = await fetch(`/tagger/rules/add`, {
+          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ ruleYaml }),
+        });
+        const d = await r.json();
+        if (!r.ok || d.error) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Add error: " + (d.error || r.status); return; }
+        msg.style.color = "var(--c-4caf50)"; msg.textContent = `Added rule "${d.id}" — ${d.ruleCount} rule(s) total.`;
+        discardSuggestedTaggerRule();
+        refreshTaggerRuleList();
+      } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Add failed: " + e.message; }
+    }
+
+    function discardSuggestedTaggerRule() {
+      document.getElementById("taggerSuggestResult").hidden = true;
+      document.getElementById("taggerSuggestYaml").value = "";
+      document.getElementById("taggerSuggestInput").value = "";
+    }
+
+    async function refreshTaggerRuleList() {
+      const rows = document.getElementById("taggerRuleRows");
+      const msg = document.getElementById("taggerRuleListMsg");
+      if (!rows) return;
+      try {
+        const r = await fetch(`/tagger/rules`);
+        const d = await r.json();
+        if (!r.ok || d.error) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = d.error || ("error " + r.status); return; }
+        msg.style.color = "var(--c-9aa4b2)";
+        msg.textContent = `${d.ruleCount} rule(s) · source: ${d.source}`;
+        const readonly = d.source === "env";
+        rows.innerHTML = "";
+        (d.rules || []).forEach((rule) => {
+          const row = document.createElement("div");
+          row.style.cssText = "display:flex;gap:6px;align-items:center;padding:2px 0;border-bottom:1px solid var(--c-2b3242)";
+          const label = document.createElement("span");
+          label.style.cssText = "flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap";
+          label.textContent = `${rule.id}${rule.severity ? " · " + rule.severity : ""}${rule.description ? " — " + rule.description : ""}`;
+          row.appendChild(label);
+          if (!readonly) {
+            const btn = document.createElement("button");
+            btn.className = "ev-bulk-btn"; btn.textContent = "✕";
+            btn.title = "Remove this rule";
+            btn.onclick = () => removeTaggerRule(rule.id);
+            row.appendChild(btn);
+          }
+          rows.appendChild(row);
+        });
+      } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "list failed: " + e.message; }
+    }
+
+    async function removeTaggerRule(ruleId) {
+      if (!confirm(`Remove the rule "${ruleId}"? (Reset to defaults restores all shipped rules.)`)) return;
+      const msg = document.getElementById("taggerRuleListMsg");
+      try {
+        const r = await fetch(`/tagger/rules/${encodeURIComponent(ruleId)}`, { method: "DELETE" });
+        const d = await r.json();
+        if (!r.ok || d.error) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Remove error: " + (d.error || r.status); return; }
+        refreshTaggerRuleList();
+      } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Remove failed: " + e.message; }
+    }
+
+    async function resetTaggerRules() {
+      if (!confirm("Discard ALL rule customizations (AI-added rules, manual edits, and removals) and restore the shipped default rules?")) return;
+      const msg = document.getElementById("taggerRuleListMsg");
+      try {
+        const r = await fetch(`/tagger/rules/reset`, { method: "POST" });
+        const d = await r.json();
+        if (!r.ok || d.error) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Reset error: " + (d.error || r.status); return; }
+        refreshTaggerRuleList();
+      } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Reset failed: " + e.message; }
+    }
+
     async function clearTaggerTags() {
       const caseId = superCaseId();
       if (!caseId) return;
@@ -6014,6 +6177,7 @@
         document.getElementById("taggerRulesSource").textContent =
           (d.source || "default") + (d.error ? ` (current file invalid: ${d.error})` : ` — ${d.ruleCount} rule(s)`);
       } catch (e) { msg.style.color = "var(--c-ff6b6b)"; msg.textContent = "Failed to load rules: " + e.message; }
+      refreshTaggerRuleList();
     }
 
     async function saveTaggerRules() {


### PR DESCRIPTION
## Summary
Follow-up to the content tagger (#112). Lets an analyst author tagger rules without hand-writing YAML: describe a rule in plain English, the AI drafts a validated rule, and you review → preview → add it. Plus per-rule remove and reset-to-defaults.

### What the analyst can do (Content tagger panel, Super-Timeline section)
- **✨ Suggest rule** — type a description (e.g. *"flag any time the Windows security event log is cleared"*); the AI returns one rule as an editable YAML block plus a plain-English explanation of what it matches. If the request can't be expressed as a single-event rule (counting, time-windows, correlation), the AI **declines** with a clear reason instead of inventing a broken rule.
- **Check matches** — dry-run the draft against the open case and see how many events it would match (no AI, no writes) — the guardrail against a too-broad or dead rule.
- **Add rule** — merge the reviewed rule into the shared ruleset.
- **Per-rule remove** — every rule (AI-added *or* shipped default) has a ✕; removing a default is safe because…
- **Reset to defaults** — one click restores the shipped ruleset.

### Safety / behavior
- Rules are **global/shared** across cases (matches existing tagger behavior); the AI is instructed to author generic rules (no case-specific IPs/hosts/hashes).
- Every write path is validated by `compileRuleset` **before** persisting — a malformed rule (from the AI or a hand-edit) can never be saved; a bad AI reply becomes a friendly decline.
- All edit operations refuse when an operator override (`TAGGER_RULES_FILE`) owns the ruleset.
- Only **Suggest** calls the AI (gated → 501 when no provider configured); preview / add / remove / reset all work with no AI.
- New ejectable prompt `tagger-rule.txt` (`npm run prompts:eject`), drift-guarded.
- Fixed a latent bug: the tagger rules file is now created if its directory doesn't exist (a fresh install could `ENOENT` when saving edited rules).

## Architecture
| Module | Role |
|---|---|
| `analysis/taggerRuleSuggest.ts` | pure: lenient AI-response schema → `compileRuleset`-validated single-rule YAML, or a decline |
| `analysis/pipeline.ts` `suggestTaggerRule()` | the one AI call (mirrors `translateQuery`) |
| `analysis/tagger.ts` `selectScopedEvents()` | shared scope→events selector (run + preview) |
| `analysis/taggerStore.ts` | `addRuleYaml` / `removeRule` / `resetToDefault` (validated, env-override-guarded) |
| `routes/tagger.ts` | `suggest-rule` (AI), `preview`, `/tagger/rules/add`, `DELETE /tagger/rules/:id`, `/tagger/rules/reset` |
| `public/dashboard.html` | the panel UI |

## Test plan
- [x] Unit: pure suggestion module (schema/sanitize/decline/size-cap), scoped-event selector, store add/remove/reset incl. env-override + empty-ruleset + dir-create edges, routes (501/400/404 + happy paths).
- [x] **Full suite green (3720 tests), `tsc --noEmit` clean.**
- [x] **End-to-end in the browser** on the demo case: suggest→a valid rule + explanation; decline path on a "count over time window" request; preview match count + invalid-rule error; add (source flips to `user`, 13→14); remove an AI-added rule and a shipped default; reset restores defaults (removed default came back). No console errors.

Part of #112.