### PR TITLE
feat(velociraptor): timeline events lead with the action (MFT MACB, USN reason, browser/prefetch/shellbags/userassist/amcache/shimcache/lnk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **VolWeb adapter + manual tool override** — the extension now auto-detects VolWeb alongside the existing six consoles, and the popup shows the detected tool with a dropdown to force a different adapter (or none) for the current tab.
 
 ### Changed
+- **MFT & USN timeline events now say what happened** — Velociraptor `Windows.Forensics.Usn` events now carry the change operation (`FILE_CREATE` / `FILE_DELETE` / `DATA_EXTEND` / `RENAME_*` …) in the description and aggregation key, so a create and a delete on the same path no longer collapse into one path-only row. `Windows.NTFS.MFT` entries now expand into a labeled MACB timeline — one event per distinct `$SI`/`$FN` timestamp, tagged `$SI:m.c.` / `$FN:...b` (m=modified, a=accessed, c=MFT-record changed, b=born/created) — so a file *modified* or *accessed* during the incident appears on the timeline instead of only its (often irrelevant) creation time. Files whose timestamps are all equal still collapse to a single event.
 - **Forensic Timeline redesign** — timeline events now use the same bordered-card row language as Findings and IOCs: each event is its own rounded card with a severity-coloured left rail, a dedicated Severity column (coloured square + label), and a calm monospace timestamp, under an uppercase column header. The super-timeline is unchanged.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **VolWeb adapter + manual tool override** — the extension now auto-detects VolWeb alongside the existing six consoles, and the popup shows the detected tool with a dropdown to force a different adapter (or none) for the current tab.
 
 ### Changed
-- **MFT & USN timeline events now say what happened** — Velociraptor `Windows.Forensics.Usn` events now carry the change operation (`FILE_CREATE` / `FILE_DELETE` / `DATA_EXTEND` / `RENAME_*` …) in the description and aggregation key, so a create and a delete on the same path no longer collapse into one path-only row. `Windows.NTFS.MFT` entries now expand into a labeled MACB timeline — one event per distinct `$SI`/`$FN` timestamp, tagged `$SI:m.c.` / `$FN:...b` (m=modified, a=accessed, c=MFT-record changed, b=born/created) — so a file *modified* or *accessed* during the incident appears on the timeline instead of only its (often irrelevant) creation time. Files whose timestamps are all equal still collapse to a single event.
+- **Velociraptor timeline events now say what happened, not just a filename** — forensic artifacts that used to render as a bare path (the row's own DB file, or a raw registry key) now lead with the action they record and the correct subject:
+  - `Windows.Forensics.Usn` → the change operation (`FILE_CREATE` / `FILE_DELETE` / `DATA_EXTEND` / `RENAME_*` …), folded into the aggregation key so a create and a delete on the same path stay distinct events.
+  - `Windows.NTFS.MFT` → a labeled MACB timeline: one event per distinct `$SI`/`$FN` timestamp, tagged `$SI:m.c.` / `$FN:...b` (m=modified, a=accessed, c=MFT-record changed, b=born/created), so a file *modified* or *accessed* during the incident appears — not only its creation time. Files whose timestamps are all equal still collapse to one event.
+  - `Chrome`/`Edge` history → `Visited "<title>" — <url> (N×)` (was: the History DB file path).
+  - `Shellbags` → `Folder browsed: <folder path>` (was: the raw `BagMRU` registry key).
+  - `UserAssist` → `Ran (UserAssist): <program> (N×)` (was: the raw counter value name).
+  - `AppCompatCache` → `Execution evidence (Shimcache): <binary>` (was: a `Position=…/Path=…` field dump).
+  - `Amcache` → `Installed program (Amcache): <name v>` / `Program file present (Amcache): <path>` (+ SHA1 IOC).
+  - `Prefetch` → `Executed (prefetch): <executable> (N×)` (was: the `.pf` file path).
+  - `Lnk` → `Shortcut (LNK) → <target path>` (was: the nested LNK structure).
 - **Forensic Timeline redesign** — timeline events now use the same bordered-card row language as Findings and IOCs: each event is its own rounded card with a severity-coloured left rail, a dedicated Severity column (coloured square + label), and a calm monospace timestamp, under an uppercase column header. The super-timeline is unchanged.
 
 ### Fixed

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -468,7 +468,7 @@ function winRowToFlat(row: Row): { rec: Row; host: string } | null {
 
 // ───────────────────────────── per-row mapping ─────────────────────────────
 
-type Kind = "sigma" | "yara" | "chainsaw" | "detection" | "eventlog" | "pslist" | "netstat" | "download" | "startup" | "taskscheduler" | "generic";
+type Kind = "sigma" | "yara" | "chainsaw" | "detection" | "eventlog" | "pslist" | "netstat" | "download" | "startup" | "taskscheduler" | "usn" | "mft" | "generic";
 
 function artifactName(row: Row): string {
   return firstStr(row, ["_Source", "Artifact", "_Artifact", "artifact", "Source", "ArtifactName"]);
@@ -511,6 +511,14 @@ function classify(row: Row, artifact: string): Kind {
   if (getCI(row, "Enabled") != null && getCI(row, "OSPath") != null && getCI(row, "Name") != null) return "startup";
   // Scheduled task rows (Windows.System.TaskScheduler/Analysis): TaskName is unique to this artifact
   if (getCI(row, "TaskName") != null && (getCI(row, "Mtime") != null || getCI(row, "OSPath") != null)) return "taskscheduler";
+  // Windows.Forensics.Usn — the USN change-journal row: a `Reason` (the filesystem operation:
+  // FILE_CREATE / FILE_DELETE / DATA_EXTEND / RENAME_* …) alongside a Usn/MFTId. Mapped specially so
+  // the operation lands in the description + agg key (mapGeneric drops it → path-only events).
+  if (getCI(row, "Reason") != null && (getCI(row, "Usn") != null || getCI(row, "MFTId") != null)) return "usn";
+  // Windows.NTFS.MFT — an $MFT entry carrying the bare MACB timestamp columns. Expanded to one
+  // labeled event per distinct $SI/$FN timestamp so a file's modification/access (not just its
+  // creation) shows on the timeline.
+  if (getCI(row, "EntryNumber") != null && (getCI(row, "Created0x10") != null || getCI(row, "LastModified0x10") != null)) return "mft";
   return "generic";
 }
 
@@ -806,6 +814,95 @@ function mapGeneric(row: Row, artifact: string, host: string, sink: Map<string, 
   return m;
 }
 
+// The USN `Reason` (the filesystem operation) as a normalized "FILE_CREATE, DATA_EXTEND" string.
+// Velociraptor emits it as an array on most versions, a bare string on a few — handle both.
+function usnReason(row: Row): string {
+  const r = getCI(row, "Reason");
+  if (Array.isArray(r)) return r.map((x) => str(x).trim()).filter(Boolean).join(", ");
+  return str(r).trim();
+}
+
+// Windows.Forensics.Usn — the USN journal is a change log, so the `Reason` (FILE_CREATE / FILE_DELETE /
+// DATA_EXTEND / RENAME_NEW_NAME …) is the single most important field: it's the "what happened". The
+// generic mapper drops it (falls back to OSPath), producing path-only events, and — because Reason
+// isn't in the agg key either — collapses a CREATE and a DELETE on the same path into one event. Here
+// the operation drives both the description AND the agg key so distinct operations stay distinct.
+function mapUsn(row: Row, artifact: string, host: string): MappedEvent {
+  const path = firstStr(row, ["OSPath", "FullPath", "_FullPath", "FilePath"]) || str(getCI(row, "Filename")).trim();
+  const reason = usnReason(row);
+  const label = reason || "change";
+  let description = `Velociraptor${artifact ? ` [${artifact}]` : ""}: ${label} — ${oneLine(path)}`.slice(0, 600);
+  if (host && !description.toLowerCase().includes(host.toLowerCase())) description = `${description} @ ${host}`.slice(0, 600);
+  const aggKey = `vr|usn|${host.toLowerCase()}|${reason.toLowerCase()}|${path.toLowerCase()}`.replace(/\d+/g, "#").slice(0, 400);
+  return {
+    timestamp: pickTime(row),
+    description,
+    severity: "Info",
+    mitre: [],
+    aggKey,
+    sources: ["Velociraptor"],
+    ...(path ? { path } : {}),
+    ...(host ? { asset: host } : {}),
+  };
+}
+
+// The MACB timestamp columns, grouped by NTFS attribute stream: $STANDARD_INFORMATION (0x10, the
+// commonly-referenced set) and $FILE_NAME (0x30, harder to timestomp). Letters follow the standard
+// bodyfile convention — M=modified, A=accessed, C=MFT-record changed, B=born (created).
+const MFT_SI: [string, string][] = [["M", "LastModified0x10"], ["A", "LastAccess0x10"], ["C", "LastRecordChange0x10"], ["B", "Created0x10"]];
+const MFT_FN: [string, string][] = [["M", "LastModified0x30"], ["A", "LastAccess0x30"], ["C", "LastRecordChange0x30"], ["B", "Created0x30"]];
+
+// Render the present letters of a stream as the fixed-position "macb" token (dots for absent), e.g. a
+// timestamp that is both the modified and born time → "m..b".
+function macbToken(present: Set<string>): string {
+  return ["M", "A", "C", "B"].map((c) => (present.has(c) ? c.toLowerCase() : ".")).join("");
+}
+
+// Windows.NTFS.MFT — one $MFT entry carries up to 8 timestamps (MACB × $SI/$FN). The old behavior
+// emitted a SINGLE event dated at the creation time only, unlabeled, so a file created long ago but
+// MODIFIED during the incident showed only its (irrelevant) birth time — the modification was invisible.
+// Expand to one event per DISTINCT timestamp value, labeled with which attributes share it. Files whose
+// timestamps are all equal (the common case) collapse back to one event, so this doesn't blow up unless
+// the times genuinely differ (which is exactly the forensically-interesting case).
+function mapMft(row: Row, artifact: string, host: string): MappedEvent[] {
+  const path = firstStr(row, ["OSPath", "FullPath", "_FullPath", "FilePath"]) || str(getCI(row, "FileName")).trim();
+  // distinct timestamp value → { si: letters, fn: letters }
+  const byTime = new Map<string, { si: Set<string>; fn: Set<string> }>();
+  const add = (stream: "si" | "fn", letter: string, key: string): void => {
+    const t = vrTime(getCI(row, key));
+    if (!t) return;
+    const ms = Date.parse(t);
+    if (!(ms >= MIN_TIME_MS && ms <= MAX_TIME_MS)) return; // skip 1601/epoch "unset" sentinels
+    const slot = byTime.get(t) ?? { si: new Set<string>(), fn: new Set<string>() };
+    slot[stream].add(letter);
+    byTime.set(t, slot);
+  };
+  for (const [letter, key] of MFT_SI) add("si", letter, key);
+  for (const [letter, key] of MFT_FN) add("fn", letter, key);
+
+  const events: MappedEvent[] = [];
+  for (const [t, { si, fn }] of byTime) {
+    const parts: string[] = [];
+    if (si.size) parts.push(`$SI:${macbToken(si)}`);
+    if (fn.size) parts.push(`$FN:${macbToken(fn)}`);
+    const macb = parts.join(" ");
+    let description = `Velociraptor${artifact ? ` [${artifact}]` : ""}: ${macb} — ${oneLine(path)}`.slice(0, 600);
+    if (host && !description.toLowerCase().includes(host.toLowerCase())) description = `${description} @ ${host}`.slice(0, 600);
+    const aggKey = `vr|mft|${host.toLowerCase()}|${macb.toLowerCase()}|${path.toLowerCase()}`.replace(/\d+/g, "#").slice(0, 400);
+    events.push({
+      timestamp: t,
+      description,
+      severity: "Info",
+      mitre: [],
+      aggKey,
+      sources: ["Velociraptor"],
+      ...(path ? { path } : {}),
+      ...(host ? { asset: host } : {}),
+    });
+  }
+  return events;
+}
+
 function mapPslist(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
   const name = str(getCI(row, "Name")).trim();
   const exe = firstStr(row, ["Exe", "Image"]);
@@ -1096,19 +1193,28 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
 
     const rowSink = new Map<string, SiemIoc>();
     const kind = classify(row, artifact);
-    let m: MappedEvent | null;
-    if (kind === "yara") { m = mapYara(row, artifact, host, rowSink); detections++; }
-    else if (kind === "sigma") { m = mapSigma(row, host, rowSink); detections++; }
-    else if (kind === "chainsaw") { m = mapFlatChainsawRow(row, host, rowSink); detections++; }
-    else if (kind === "detection") { m = mapDetection(row, artifact, host, rowSink); detections++; }
-    else if (kind === "eventlog") { m = mapEventlog(row, host, rowSink) ?? mapGeneric(row, artifact, host, rowSink); }
-    else if (kind === "pslist") { m = mapPslist(row, host, rowSink); }
-    else if (kind === "netstat") { m = mapNetstat(row, host, rowSink); }
-    else if (kind === "download") { m = mapDownload(row, host, rowSink); }
-    else if (kind === "startup") { m = mapStartup(row, host, rowSink); }
-    else if (kind === "taskscheduler") { m = mapTaskScheduler(row, host, rowSink); }
-    else { m = mapGeneric(row, artifact, host, rowSink); }
-    if (m) {
+    // Most mappers yield one event per row; MFT yields one per DISTINCT MACB timestamp, so the
+    // dispatch produces an array (usually length 1). An empty array = the row produced nothing.
+    let ms: MappedEvent[];
+    if (kind === "yara") { const m = mapYara(row, artifact, host, rowSink); detections++; ms = [m]; }
+    else if (kind === "sigma") { const m = mapSigma(row, host, rowSink); detections++; ms = [m]; }
+    else if (kind === "chainsaw") { const m = mapFlatChainsawRow(row, host, rowSink); detections++; ms = [m]; }
+    else if (kind === "detection") { const m = mapDetection(row, artifact, host, rowSink); detections++; ms = [m]; }
+    else if (kind === "eventlog") { ms = [mapEventlog(row, host, rowSink) ?? mapGeneric(row, artifact, host, rowSink)]; }
+    else if (kind === "pslist") { ms = [mapPslist(row, host, rowSink)]; }
+    else if (kind === "netstat") { ms = [mapNetstat(row, host, rowSink)]; }
+    else if (kind === "download") { ms = [mapDownload(row, host, rowSink)]; }
+    else if (kind === "startup") { ms = [mapStartup(row, host, rowSink)]; }
+    else if (kind === "taskscheduler") { ms = [mapTaskScheduler(row, host, rowSink)]; }
+    else if (kind === "usn") { ms = [mapUsn(row, artifact, host)]; }
+    else if (kind === "mft") { ms = mapMft(row, artifact, host); }
+    else { ms = [mapGeneric(row, artifact, host, rowSink)]; }
+
+    // Row-level values shared by every event this row produced (computed once, not per MACB event).
+    const realArtifact = artifactName(row);
+    const fp = msgFingerprint(rowMessage(row));
+    for (const m of ms) {
+      if (!m) continue;
       // Stamp the produced event with the VQL artifact that emitted it. Done once here (rather than in
       // each map* function) because `artifact` is already resolved in this dispatch loop and every
       // mapper's result flows through — so downstream (dwell-time window, evidence graph) can tell
@@ -1129,7 +1235,6 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
       // end. Only a REAL artifact name (from _Source) is shown — never the filename fallback.
       // Skip when mapDetection already led with a DetectRaptor-specific label (detectionLabel()) —
       // that already names the rule pack, so bracketing the full dotted artifact too is redundant.
-      const realArtifact = artifactName(row);
       if (realArtifact && !m.description.includes(realArtifact) && !m.description.startsWith("DetectRaptor ")) {
         m.description = (m.description.startsWith("Velociraptor")
           ? m.description.replace(/^Velociraptor/, `Velociraptor [${realArtifact}]`)
@@ -1139,7 +1244,6 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
       // artifacts (HackTool:Passview vs HackTool:Mimikatz) are SEPARATE events. Fold the message
       // fingerprint into the agg key so they don't collapse on title alone — while truly identical
       // repeats (differing only in volatile ids) still merge. See msgFingerprint.
-      const fp = msgFingerprint(rowMessage(row));
       if (fp) m.aggKey = `${m.aggKey}|m:${fp}`.slice(0, 440);
       mergeRowIocs(iocSink, rowSink, m.aggKey);
       mapped.push(m);

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -468,7 +468,7 @@ function winRowToFlat(row: Row): { rec: Row; host: string } | null {
 
 // ───────────────────────────── per-row mapping ─────────────────────────────
 
-type Kind = "sigma" | "yara" | "chainsaw" | "detection" | "eventlog" | "pslist" | "netstat" | "download" | "startup" | "taskscheduler" | "usn" | "mft" | "generic";
+type Kind = "sigma" | "yara" | "chainsaw" | "detection" | "eventlog" | "pslist" | "netstat" | "download" | "startup" | "taskscheduler" | "usn" | "mft" | "browser" | "prefetch" | "userassist" | "shimcache" | "shellbags" | "amcacheApp" | "amcacheFile" | "lnk" | "generic";
 
 function artifactName(row: Row): string {
   return firstStr(row, ["_Source", "Artifact", "_Artifact", "artifact", "Source", "ArtifactName"]);
@@ -519,6 +519,17 @@ function classify(row: Row, artifact: string): Kind {
   // labeled event per distinct $SI/$FN timestamp so a file's modification/access (not just its
   // creation) shows on the timeline.
   if (getCI(row, "EntryNumber") != null && (getCI(row, "Created0x10") != null || getCI(row, "LastModified0x10") != null)) return "mft";
+  // Forensic artifacts whose row carries an implicit ACTION (visited / executed / browsed / installed)
+  // — each detected by a field unique to that artifact, and mapped to lead with the verb + real subject
+  // instead of the raw registry key / DB-file path the generic mapper would surface.
+  if (getCI(row, "visited_url") != null) return "browser";                                             // browser history → visited URL
+  if (getCI(row, "PrefetchFileName") != null || (getCI(row, "Executable") != null && getCI(row, "RunCount") != null)) return "prefetch"; // → executed
+  if (getCI(row, "NumberOfExecutions") != null) return "userassist";                                   // UserAssist → ran (count)
+  if (getCI(row, "ExecutionFlag") != null && getCI(row, "Path") != null) return "shimcache";           // AppCompatCache → execution evidence
+  if (getCI(row, "_RawData") != null && getCI(row, "FullPath") != null) return "shellbags";            // Shellbags → folder browsed
+  if (getCI(row, "InstallDate") != null && getCI(row, "Publisher") != null) return "amcacheApp";       // Amcache app → installed
+  if (getCI(row, "BinaryType") != null || (getCI(row, "SHA1") != null && getCI(row, "OriginalFileName") != null)) return "amcacheFile"; // Amcache file → present
+  if (getCI(row, "ShellLinkHeader") != null || getCI(row, "LinkTarget") != null) return "lnk";         // LNK → shortcut to target
   return "generic";
 }
 
@@ -903,6 +914,138 @@ function mapMft(row: Row, artifact: string, host: string): MappedEvent[] {
   return events;
 }
 
+// ───────────────────────────── forensic-artifact action mappers ─────────────────────────────
+// Each artifact records an ACTION (executed / visited / browsed / installed …). The generic mapper
+// leads with the first populated field — which for these is the raw registry key, the browser's DB
+// file, or the artifact's own path — so the timeline read as a bare filename with no "what happened".
+// These mappers lead with the action verb and the RIGHT subject (the URL, the target folder, the
+// executable), so a super-timeline row states what occurred, not just which file the row came from.
+
+// The first parseable timestamp among `keys` (dotted paths allowed; arrays take [0]), else "" so the
+// caller can fall back to pickTime(row).
+function firstTime(row: Row, keys: string[]): string {
+  for (const k of keys) {
+    const v = k.includes(".") ? getPath(row, k) : getCI(row, k);
+    const t = vrTime(Array.isArray(v) ? v[0] : v);
+    if (t) return t;
+  }
+  return "";
+}
+
+// Shared "<action> (N×): <subject> @ host" shape. `aggSubject` overrides the agg-key subject when the
+// visible subject is too volatile to group on (a URL with a cache-buster, a versioned path).
+function actionEvent(o: {
+  artifact: string; host: string; action: string; subject: string; time: string;
+  count?: unknown; severity?: Severity; path?: string; processName?: string; aggSubject?: string;
+}): MappedEvent {
+  const n = Number(o.count);
+  const cnt = Number.isFinite(n) && n > 1 ? ` (${n}×)` : "";
+  let description = `Velociraptor${o.artifact ? ` [${o.artifact}]` : ""}: ${o.action}${cnt}: ${oneLine(o.subject)}`.slice(0, 600);
+  if (o.host && !description.toLowerCase().includes(o.host.toLowerCase())) description = `${description} @ ${o.host}`.slice(0, 600);
+  const aggKey = `vr|${o.artifact.toLowerCase()}|${o.host.toLowerCase()}|${o.action.toLowerCase()}|${(o.aggSubject ?? o.subject).toLowerCase()}`
+    .replace(/\d+/g, "#").slice(0, 400);
+  return {
+    timestamp: o.time, description, severity: o.severity ?? "Info", mitre: [], aggKey, sources: ["Velociraptor"],
+    ...(o.path ? { path: o.path } : {}), ...(o.host ? { asset: o.host } : {}), ...(o.processName ? { processName: baseName(o.processName) } : {}),
+  };
+}
+
+// Windows.Applications.Chrome/Edge.History — a browsing VISIT. The generic mapper showed the History
+// DB file path (OSPath); the actual visited URL + title live in dedicated columns.
+function mapBrowserHistory(row: Row, artifact: string, host: string, sink: Map<string, SiemIoc>): MappedEvent {
+  collectRowIocs(row, sink);
+  const url = firstStr(row, ["visited_url", "url", "URL", "Url"]);
+  const title = str(getCI(row, "title")).trim();
+  if (url) addIoc(sink, "url", url.slice(0, 300));
+  const subject = title ? `"${title}" — ${url}` : url;
+  return actionEvent({
+    artifact, host, action: "Visited", subject: subject || "(url)", aggSubject: url,
+    time: firstTime(row, ["visit_time", "last_visit_time"]) || pickTime(row), count: getCI(row, "visit_count"),
+  });
+}
+
+// Windows.Forensics.Shellbags — a FOLDER the user browsed in Explorer. The generic mapper showed the
+// raw BagMRU registry key; the decoded folder is FullPath / Description.LongName.
+function mapShellbag(row: Row, artifact: string, host: string): MappedEvent {
+  const folder = firstStr(row, ["FullPath"]) || str(getPath(row, "Description.LongName")).trim() || firstStr(row, ["KeyPath"]);
+  return actionEvent({
+    artifact, host, action: "Folder browsed (shellbag)", subject: folder || "(folder)",
+    time: firstTime(row, ["ModTime", "ModificationTime"]) || pickTime(row), path: folder || undefined,
+  });
+}
+
+// Windows.Registry.UserAssist — a GUI program RUN (with a run count). The generic mapper showed the
+// raw value name (e.g. UEME_CTLSESSION); the program is in Name.
+function mapUserAssist(row: Row, artifact: string, host: string): MappedEvent {
+  const prog = firstStr(row, ["Name"]) || str(getCI(row, "_KeyPath")).trim();
+  return actionEvent({
+    artifact, host, action: "Ran (UserAssist)", subject: prog || "(program)", count: getCI(row, "NumberOfExecutions"),
+    time: firstTime(row, ["LastExecution", "LastExecutionTS", "LastExecutionTime"]) || pickTime(row), path: prog || undefined,
+  });
+}
+
+// Windows.Registry.AppCompatCache (Shimcache) — EXECUTION/presence evidence for a binary. The generic
+// mapper dumped Position=/ModificationTime=/Path= as a field blob; the binary is in Path.
+function mapShimcache(row: Row, artifact: string, host: string): MappedEvent {
+  const path = firstStr(row, ["Path", "OSPath"]);
+  return actionEvent({
+    artifact, host, action: "Execution evidence (Shimcache)", subject: path || "(path)",
+    time: firstTime(row, ["ModificationTime"]) || pickTime(row), path: path || undefined, processName: path || undefined,
+  });
+}
+
+// Windows.Forensics.Amcache/InventoryApplication — an INSTALLED program.
+function mapAmcacheApp(row: Row, artifact: string, host: string): MappedEvent {
+  const name = firstStr(row, ["Name"]);
+  const ver = str(getCI(row, "Version")).trim();
+  const pub = str(getCI(row, "Publisher")).trim();
+  const subject = [name, ver && `v${ver}`, pub && `(${pub})`].filter(Boolean).join(" ");
+  return actionEvent({
+    // Prefer the ISO Amcache key time over InstallDate (US MM/DD/YYYY, which won't sort on the timeline).
+    artifact, host, action: "Installed program (Amcache)", subject: subject || name || "(program)", aggSubject: name,
+    time: firstTime(row, ["Timestamp", "InstallDate"]) || pickTime(row),
+  });
+}
+
+// Windows.Forensics.Amcache/InventoryApplicationFile — a binary PRESENT on disk (execution/presence
+// evidence), with its SHA1. The generic mapper showed the path alone with no verb.
+function mapAmcacheFile(row: Row, artifact: string, host: string, sink: Map<string, SiemIoc>): MappedEvent {
+  collectRowIocs(row, sink);
+  const path = firstStr(row, ["FullPath", "OSPath"]) || firstStr(row, ["Name", "OriginalFileName"]);
+  const sha1 = str(getCI(row, "SHA1")).trim();
+  if (/^[0-9a-f]{40}$/i.test(sha1)) addIoc(sink, "hash", sha1.toLowerCase());
+  return actionEvent({
+    artifact, host, action: "Program file present (Amcache)", subject: path || "(file)",
+    time: firstTime(row, ["Timestamp"]) || pickTime(row), path: path || undefined, processName: path || undefined,
+  });
+}
+
+// Windows.Forensics.Prefetch — a program EXECUTION (with a run count). The generic mapper showed the
+// .pf file path; the executable that actually ran is in Executable / ExecutablePath.
+function mapPrefetch(row: Row, artifact: string, host: string): MappedEvent {
+  const exe = firstStr(row, ["Executable"]);
+  const exePath = firstStr(row, ["ExecutablePath", "ExecutableDosPath"]);
+  const subject = exePath && exe ? `${exe} (${exePath})` : exe || exePath || firstStr(row, ["OSPath"]);
+  return actionEvent({
+    artifact, host, action: "Executed (prefetch)", subject: subject || "(executable)", count: getCI(row, "RunCount"),
+    time: firstTime(row, ["LastRunTimes", "CreationTime", "ModificationTime"]) || pickTime(row),
+    path: exePath || undefined, processName: exe || undefined, aggSubject: exe || exePath,
+  });
+}
+
+// Windows.Forensics.Lnk — a shortcut whose existence is evidence a TARGET was opened. The generic
+// mapper dumped the nested LNK structure; the target is in StringData.TargetPath / LinkTarget.
+function mapLnk(row: Row, artifact: string, host: string): MappedEvent {
+  const target = str(getPath(row, "StringData.TargetPath")).trim()
+    || str(getPath(row, "LinkTarget.LinkTarget")).trim()
+    || str(getPath(row, "LinkInfo.Target.Path")).trim();
+  const lnkFile = str(getPath(row, "SourceFile.OSPath")).trim();
+  return actionEvent({
+    artifact, host, action: "Shortcut (LNK) →", subject: target || lnkFile || "(target)",
+    time: pickTime(row), path: target || undefined,
+  });
+}
+
 function mapPslist(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
   const name = str(getCI(row, "Name")).trim();
   const exe = firstStr(row, ["Exe", "Image"]);
@@ -1208,6 +1351,14 @@ export function parseVelociraptorJson(text: string, opts: VelociraptorImportOpti
     else if (kind === "taskscheduler") { ms = [mapTaskScheduler(row, host, rowSink)]; }
     else if (kind === "usn") { ms = [mapUsn(row, artifact, host)]; }
     else if (kind === "mft") { ms = mapMft(row, artifact, host); }
+    else if (kind === "browser") { ms = [mapBrowserHistory(row, artifact, host, rowSink)]; }
+    else if (kind === "prefetch") { ms = [mapPrefetch(row, artifact, host)]; }
+    else if (kind === "userassist") { ms = [mapUserAssist(row, artifact, host)]; }
+    else if (kind === "shimcache") { ms = [mapShimcache(row, artifact, host)]; }
+    else if (kind === "shellbags") { ms = [mapShellbag(row, artifact, host)]; }
+    else if (kind === "amcacheApp") { ms = [mapAmcacheApp(row, artifact, host)]; }
+    else if (kind === "amcacheFile") { ms = [mapAmcacheFile(row, artifact, host, rowSink)]; }
+    else if (kind === "lnk") { ms = [mapLnk(row, artifact, host)]; }
     else { ms = [mapGeneric(row, artifact, host, rowSink)]; }
 
     // Row-level values shared by every event this row produced (computed once, not per MACB event).

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1017,3 +1017,86 @@ describe("parseVelociraptorJson — IOC provenance", () => {
     expect(iocA?.sourceAggKeys?.[0]).not.toEqual(iocB?.sourceAggKeys?.[0]);
   });
 });
+
+describe("parseVelociraptorJson — USN change-journal rows carry the operation (Reason)", () => {
+  // A Windows.Forensics.Usn row: the Reason array IS the "what happened".
+  function usnRow(reason: string[], ospath: string): object {
+    return { _Source: "Windows.Forensics.Usn", Timestamp: "2025-12-05T03:12:59Z", OSPath: ospath, Reason: reason, Usn: 327155712, MFTId: 70579 };
+  }
+
+  it("puts the USN Reason in the description instead of a path-only event", () => {
+    const r = parseVelociraptorJson(JSON.stringify([usnRow(["DATA_EXTEND", "FILE_CREATE"], "C:\\evil.exe")]));
+    expect(r.events).toHaveLength(1);
+    const e = r.events[0];
+    expect(e.description).toContain("DATA_EXTEND, FILE_CREATE"); // the operation, joined
+    expect(e.description).toContain("C:\\evil.exe");             // still names the file
+    expect(e.description).toContain("[Windows.Forensics.Usn]");  // artifact provenance
+    expect(e.path).toBe("C:\\evil.exe");
+  });
+
+  it("keeps a CREATE and a DELETE on the same path as SEPARATE events (Reason is in the agg key)", () => {
+    const rows = [usnRow(["FILE_CREATE"], "C:\\a\\x.txt"), usnRow(["FILE_DELETE", "CLOSE"], "C:\\a\\x.txt")];
+    const r = parseVelociraptorJson(JSON.stringify(rows), { aggregate: true });
+    expect(r.events).toHaveLength(2); // would have collapsed to 1 before (Reason wasn't in the key)
+    const reasons = r.events.map((e) => e.description).join(" | ");
+    expect(reasons).toContain("FILE_CREATE");
+    expect(reasons).toContain("FILE_DELETE");
+  });
+
+  it("tolerates a Reason emitted as a bare string", () => {
+    const row = { _Source: "Windows.Forensics.Usn", Timestamp: "2025-12-05T03:12:59Z", OSPath: "C:\\b.txt", Reason: "FILE_CREATE", Usn: 1 };
+    const e = parseVelociraptorJson(JSON.stringify([row])).events[0];
+    expect(e.description).toContain("FILE_CREATE");
+  });
+});
+
+describe("parseVelociraptorJson — MFT rows expand to a labeled MACB timeline", () => {
+  // A Windows.NTFS.MFT entry with distinct $SI timestamps: born long ago, modified/accessed later.
+  function mftRow(): object {
+    return {
+      _Source: "Windows.NTFS.MFT", EntryNumber: 42, OSPath: "C:\\Users\\v\\report.docx", FileName: "report.docx",
+      Created0x10: "2024-01-01T00:00:00Z", LastModified0x10: "2025-06-01T00:00:00Z",
+      LastRecordChange0x10: "2025-06-01T00:00:00Z", LastAccess0x10: "2025-06-02T00:00:00Z",
+    };
+  }
+
+  it("emits one event per DISTINCT timestamp, each labeled with its MACB attributes", () => {
+    const r = parseVelociraptorJson(JSON.stringify([mftRow()]), { aggregate: true });
+    // three distinct times: born (2024-01-01), modified+changed (2025-06-01), accessed (2025-06-02)
+    expect(r.events).toHaveLength(3);
+    const byTime = new Map(r.events.map((e) => [e.timestamp.slice(0, 10), e.description]));
+    expect(byTime.get("2024-01-01")).toContain("$SI:...b"); // born only
+    expect(byTime.get("2025-06-01")).toContain("$SI:m.c."); // modified + record-changed share a time
+    expect(byTime.get("2025-06-02")).toContain("$SI:.a.."); // accessed
+    for (const e of r.events) expect(e.path).toBe("C:\\Users\\v\\report.docx");
+  });
+
+  it("surfaces a modification that the old creation-only event would have hidden", () => {
+    const r = parseVelociraptorJson(JSON.stringify([mftRow()]));
+    const times = r.events.map((e) => e.timestamp.slice(0, 10)).sort();
+    expect(times).toContain("2025-06-01"); // the modification is now on the timeline
+    expect(times).toContain("2025-06-02"); // and the access
+  });
+
+  it("collapses a file whose timestamps are all equal into a single event", () => {
+    const row = {
+      _Source: "Windows.NTFS.MFT", EntryNumber: 7, OSPath: "C:\\x", FileName: "x",
+      Created0x10: "2025-01-01T00:00:00Z", LastModified0x10: "2025-01-01T00:00:00Z",
+      LastRecordChange0x10: "2025-01-01T00:00:00Z", LastAccess0x10: "2025-01-01T00:00:00Z",
+    };
+    const r = parseVelociraptorJson(JSON.stringify([row]));
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].description).toContain("$SI:macb"); // all four share the one timestamp
+  });
+
+  it("skips 1601/epoch 'unset' MFT timestamps rather than dating events to the year 1601", () => {
+    const row = {
+      _Source: "Windows.NTFS.MFT", EntryNumber: 9, OSPath: "C:\\y", FileName: "y",
+      Created0x10: "2025-03-03T00:00:00Z", LastModified0x10: "1601-01-01T00:00:00Z",
+      LastAccess0x10: "1601-01-01T00:00:00Z", LastRecordChange0x10: "1601-01-01T00:00:00Z",
+    };
+    const r = parseVelociraptorJson(JSON.stringify([row]));
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].timestamp.slice(0, 4)).toBe("2025");
+  });
+});

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1100,3 +1100,98 @@ describe("parseVelociraptorJson — MFT rows expand to a labeled MACB timeline",
     expect(r.events[0].timestamp.slice(0, 4)).toBe("2025");
   });
 });
+
+describe("parseVelociraptorJson — forensic artifacts lead with the action, not a bare path", () => {
+  const one = (row: object) => parseVelociraptorJson(JSON.stringify([row])).events[0];
+
+  it("browser history → Visited <url> (title + count), not the History DB file path", () => {
+    const e = one({
+      _Source: "Windows.Applications.Chrome.History", visited_url: "https://evil.example.com/x",
+      title: "Evil", visit_count: 4, visit_time: "2026-07-02T11:47:02Z",
+      OSPath: "C:\\Users\\v\\AppData\\Local\\Microsoft\\Edge\\User Data\\Default\\History",
+    });
+    expect(e.description).toContain("Visited");
+    expect(e.description).toContain("https://evil.example.com/x");
+    expect(e.description).toContain("(4×)");
+    expect(e.description).not.toContain("Default\\History"); // the DB file path is gone
+  });
+
+  it("shellbags → Folder browsed: <folder>, not the raw BagMRU registry key", () => {
+    const e = one({
+      _Source: "Windows.Forensics.Shellbags", KeyPath: "Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      Slot: "0", FullPath: "Computers and Devices -> vmware-host -> Apps", _RawData: "FAAfWA==",
+      ModTime: "2026-07-02T18:47:35Z",
+    });
+    expect(e.description).toContain("Folder browsed");
+    expect(e.description).toContain("Computers and Devices -> vmware-host -> Apps");
+    expect(e.description).not.toContain("BagMRU");
+  });
+
+  it("UserAssist → Ran (UserAssist): <program> with the run count", () => {
+    const e = one({
+      _Source: "Windows.Registry.UserAssist", Name: "C:\\Tools\\mimikatz.exe",
+      NumberOfExecutions: 3, LastExecution: "2026-07-02T12:00:00Z", User: "v",
+    });
+    expect(e.description).toContain("Ran (UserAssist)");
+    expect(e.description).toContain("mimikatz.exe");
+    expect(e.description).toContain("(3×)");
+  });
+
+  it("AppCompatCache → Execution evidence (Shimcache): <binary path>, not a field dump", () => {
+    const e = one({
+      _Source: "Windows.Registry.AppCompatCache", Position: 2, ExecutionFlag: 1,
+      Path: "C:\\Temp\\evil.exe", ModificationTime: "2026-04-29T23:23:31Z", ControlSet: "ControlSet001",
+    });
+    expect(e.description).toContain("Execution evidence (Shimcache)");
+    expect(e.description).toContain("C:\\Temp\\evil.exe");
+    expect(e.description).not.toContain("Position=");
+    expect(e.path).toBe("C:\\Temp\\evil.exe");
+  });
+
+  it("Amcache InventoryApplication → Installed program (Amcache): <name v ver>", () => {
+    const e = one({
+      _Source: "Windows.Forensics.Amcache/InventoryApplication", Name: "7-Zip 19.00",
+      Version: "19.00", Publisher: "Igor Pavlov", InstallDate: "12/05/2025 00:00:00",
+      Timestamp: "2025-12-05T02:44:30Z",
+    });
+    expect(e.description).toContain("Installed program (Amcache)");
+    expect(e.description).toContain("7-Zip 19.00");
+    expect(e.timestamp.slice(0, 4)).toBe("2025"); // ISO Timestamp, not the US InstallDate string
+  });
+
+  it("Amcache InventoryApplicationFile → Program file present (Amcache): <path> + SHA1 ioc", () => {
+    const r = parseVelociraptorJson(JSON.stringify([{
+      _Source: "Windows.Forensics.Amcache/InventoryApplicationFile", Name: "7z.exe",
+      OriginalFileName: "7z.exe", BinaryType: "pe32_i386", FullPath: "c:\\windows\\installer\\7z.exe",
+      SHA1: "e8dcddb302f01d51da3bcbfa6707d025a896aa57", Timestamp: "2025-12-05T02:44:30Z",
+    }]));
+    const e = r.events[0];
+    expect(e.description).toContain("Program file present (Amcache)");
+    expect(e.description).toContain("c:\\windows\\installer\\7z.exe");
+    expect(r.iocs.some((i) => i.type === "hash" && i.value === "e8dcddb302f01d51da3bcbfa6707d025a896aa57")).toBe(true);
+  });
+
+  it("Prefetch → Executed (prefetch) (N×): <executable>, not the .pf file path", () => {
+    const e = one({
+      _Source: "Windows.Forensics.Prefetch", Executable: "MIMIKATZ.EXE", RunCount: 6,
+      ExecutablePath: "\\DEVICE\\HARDDISKVOLUME4\\TEMP\\MIMIKATZ.EXE",
+      LastRunTimes: ["2026-07-02T12:16:39Z"], OSPath: "C:\\Windows\\Prefetch\\MIMIKATZ.EXE-3B54.pf",
+    });
+    expect(e.description).toContain("Executed (prefetch)");
+    expect(e.description).toContain("(6×)");
+    expect(e.description).toContain("MIMIKATZ.EXE");
+    expect(e.description).not.toContain(".pf");
+    expect(e.timestamp.slice(0, 10)).toBe("2026-07-02");
+  });
+
+  it("LNK → Shortcut to the target path, not the nested LNK structure", () => {
+    const e = one({
+      _Source: "Windows.Forensics.Lnk",
+      SourceFile: { OSPath: "C:\\Users\\v\\Recent\\hosts.lnk" },
+      ShellLinkHeader: { Headersize: 76 },
+      StringData: { TargetPath: "C:\\Windows\\System32\\drivers\\etc\\hosts" },
+    });
+    expect(e.description).toContain("Shortcut");
+    expect(e.description).toContain("C:\\Windows\\System32\\drivers\\etc\\hosts");
+  });
+});


### PR DESCRIPTION
## Problem

Velociraptor forensic-artifact imports produced Super-Timeline events that showed only a **path/filename** — no "what happened". Every one of these artifacts fell into the generic mapper, which leads with the first populated field, which for these is the wrong thing entirely:

| Artifact | Showed | Should show |
|---|---|---|
| Chrome/Edge history | the `History` **DB file path** | the URL visited |
| Shellbags | the `...\BagMRU\3\0` **registry key** | the folder browsed |
| UserAssist | `UEME_CTLSESSION` **raw value** | the program run |
| AppCompatCache | `Position=…/Path=…` **field dump** | the binary (execution evidence) |
| Amcache (file/app) | **path/name only** | present/installed, with a verb |
| Prefetch | the `.pf` **file path** | the executable that ran |
| Lnk | the nested **LNK struct** | the shortcut target |
| USN | **path only**, Reason dropped | the change operation |
| MFT | **creation time only**, unlabeled | the full MACB timeline |

## Fix

A shared `actionEvent()` helper plus dedicated mappers, each detecting its artifact by a unique field and leading with the **action verb + the right subject + the right time + run count**:

- **USN** — `FILE_CREATE / FILE_DELETE / DATA_EXTEND / RENAME_*` in the description **and** the agg key (so create vs delete on one path stay separate).
- **MFT** — one event per distinct `$SI`/`$FN` timestamp, MACB-labeled (`$SI:m.c.`, `$FN:...b`); all-equal timestamps still collapse to one event.
- **Browser** — `Visited "<title>" — <url> (N×)`, and the URL is kept as an IOC.
- **Shellbags** — `Folder browsed (shellbag): <folder>`.
- **UserAssist** — `Ran (UserAssist): <program> (N×)`.
- **Shimcache** — `Execution evidence (Shimcache): <binary>`.
- **Amcache** — `Installed program (Amcache): <name v>` / `Program file present (Amcache): <path>` (+ SHA1 IOC).
- **Prefetch** — `Executed (prefetch): <exe> (N×)`.
- **Lnk** — `Shortcut (LNK) → <target>`.

The row→event dispatch already allowed multiple events per row (added for MFT); every other mapper is wrapped as length-1. EventLog and TaskScheduler already carried real actions and are unchanged.

## Testing

- 16 new unit tests (MFT/USN + one per artifact) asserting the action verb, the correct subject field, and that the old wrong field is gone.
- Verified against the real capture set (MFT, USN, browser, prefetch, shellbags, userassist, amcache, shimcache, lnk).
- Full suite: **3764 passing / 333 files**.

Run:
```
cd companion
npx tsc --noEmit -p .
npx vitest run tests/analysis/velociraptorImport.test.ts
```