### PR TITLE
feat: paginate the IOC list like the timelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **IOC list pagination** — the IOCs section now pages client-side like the timelines (default 100 per page, selectable 50/100/250/500/All) with Prev/Next controls and a "page X of Y" badge, so cases with thousands of IOCs stay responsive. Filters and imports reset to the first page; select-all is page-scoped while selections persist across pages.
 - **AI-assisted content-tagger rules** — describe a content-tagger rule in plain English and the AI drafts a valid rule you can preview (live match count against the open case), edit, and add. Plus per-rule remove (any rule, including shipped defaults) and reset-to-defaults. New ejectable prompt `tagger-rule.txt` (`npm run prompts:eject`). AI-gated — falls back cleanly when no provider is configured.
 - **Right-click "Send to DFIR-Companion"** — send a page's selected text, a table (nearest to the click), or a link's URL straight to the connected case from any page, not just recognized adapter consoles.
 - **VolWeb adapter + manual tool override** — the extension now auto-detects VolWeb alongside the existing six consoles, and the popup shows the detected tool with a dropdown to force a different adapter (or none) for the current tab.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4409,6 +4409,10 @@
     let tlPage = 0;                           // current timeline page (0-based)
     let tlPageSize = 50;                      // rows per page; user-selectable
     let _tlKeepPage = false;                  // pagination buttons set this to avoid resetting to page 0
+    let iocPage = 0;                          // current IOC page (0-based) — client-side paging, mirrors the timeline
+    let iocPageSize = 100;                     // IOCs per page; user-selectable (0 = All)
+    let _iocKeepPage = false;                 // pagination buttons set this to avoid resetting to page 0
+    let _lastRenderedIocs = [];               // exact array last passed to renderIocs, so pagination can re-render the same data
 
     // --- Search/filter helpers (mirror companion/src/analysis/searchFilter.ts) ---------
     function _evMatchesSearch(e, q) {
@@ -12616,9 +12620,24 @@
       return [...iocs].sort((a, b) =>
         (a.type || "").localeCompare(b.type || "") || (a.value || "").localeCompare(b.value || "", undefined, { sensitivity: "base" }));
     }
+    // Client-side IOC pagination controls (mirror the forensic-timeline pager). Step keeps the current
+    // page across the re-render (_iocKeepPage); a page-size change jumps back to the first page.
+    function iocPageStep(delta) {
+      iocPage = Math.max(0, iocPage + delta);
+      _iocKeepPage = true;
+      renderIocs(_lastRenderedIocs);
+    }
+    function iocSetPageSize(n) {
+      iocPageSize = n;
+      iocPage = 0;
+      renderIocs(_lastRenderedIocs);
+    }
     function renderIocs(iocsRaw) {
       const el = document.getElementById("iocs");
       if (!el) return;
+      _lastRenderedIocs = iocsRaw || [];        // cache exact data so pagination can re-render the same list
+      if (!_iocKeepPage) iocPage = 0;           // any non-pagination re-render (import, filter, state push) resets to page 1
+      _iocKeepPage = false;
       const iocs = sortIocsForDisplay(dedupeIocsById(iocsRaw));
       renderIocTypeFilter(iocs);
       renderIocExcludeRules((lastState && lastState.iocExcludeRules) || []);
@@ -12649,12 +12668,21 @@
       // wants to catch, so this stays its own opt-out rather than being folded into "signal only".
       if (hideSystemPaths) visible = visible.filter(i => !isSystemPathIoc(i));
       const noiseFiltersActive = hideFpNoIntel || showSignalIocsOnly || hideSystemPaths;
+      // Client-side pagination (mirrors the forensic timeline) — slice the filtered set into pages.
+      const totalFiltered = visible.length;
+      const iocTotalPages = iocPageSize > 0 ? Math.max(1, Math.ceil(totalFiltered / iocPageSize)) : 1;
+      if (iocPage >= iocTotalPages) iocPage = iocTotalPages - 1;
+      if (iocPage < 0) iocPage = 0;
+      const iocStart = iocPageSize > 0 ? iocPage * iocPageSize : 0;
+      const iocEnd = iocPageSize > 0 ? Math.min(iocStart + iocPageSize, totalFiltered) : totalFiltered;
+      const pageVisible = iocPageSize > 0 ? visible.slice(iocStart, iocEnd) : visible;
       // Mirror the forensic/super timeline badges: "(N of M IOCs)" when a filter narrows the list,
       // else just the total — plus the flagged count, which always reflects the FULL unfiltered set.
       const cnt = document.getElementById("iocFlaggedCount");
       if (cnt) {
         const scope = visible.length === iocs.length ? `${iocs.length} IOC${iocs.length !== 1 ? "s" : ""}` : `${visible.length} of ${iocs.length} IOCs`;
-        cnt.textContent = ` (${scope}${flaggedTotal ? ` · ${flaggedTotal} flagged` : ""})`;
+        const pageSuffix = (iocPageSize > 0 && totalFiltered > iocPageSize) ? ` — page ${iocPage + 1} of ${iocTotalPages}` : "";
+        cnt.textContent = ` (${scope}${flaggedTotal ? ` · ${flaggedTotal} flagged` : ""}${pageSuffix})`;
       }
       if (!visible.length) {
         el.innerHTML = showFlaggedIocsOnly
@@ -12665,17 +12693,29 @@
         updateIocBulkBar();
         return;
       }
-      const allIds = visible.map(i => i.id);
+      // Select-all is page-scoped (matches the forensic timeline): the header checkbox reflects only the
+      // rows actually rendered on this page, since the select-all click handler acts on the rendered rows.
+      const allIds = pageVisible.map(i => i.id);
       const allSel = allIds.length > 0 && allIds.every(id => selectedIocs.has(id));
       const someSel = allIds.some(id => selectedIocs.has(id));
       const countLabel = visible.length === iocs.length
         ? `${visible.length} IOC${visible.length !== 1 ? "s" : ""}`
         : `${visible.length} of ${iocs.length} IOC${iocs.length !== 1 ? "s" : ""} shown`;
+      // Page-size selector (right column of the header) + Prev/Next bar — reuse the timeline pager styles.
+      const iocPageSizes = [50, 100, 250, 500, 0];
+      const iocPageSizeOpts = iocPageSizes.map(n =>
+        `<option value="${n}"${iocPageSize === n ? " selected" : ""}>${n === 0 ? "All" : n}</option>`).join("");
+      const iocPaginationBar = (iocPageSize > 0 && totalFiltered > iocPageSize) ? `<div class="tl-page-bar">`
+        + `<button class="tl-page-btn" onclick="iocPageStep(-1)" ${iocPage === 0 ? "disabled" : ""}>‹ Prev</button>`
+        + `<span class="tl-page-info">${iocStart + 1}–${iocEnd} of ${totalFiltered}</span>`
+        + `<button class="tl-page-btn" onclick="iocPageStep(1)" ${iocPage >= iocTotalPages - 1 ? "disabled" : ""}>Next ›</button>`
+        + `</div>` : "";
       const headerRow = `<div class="ioc-header-row">`
         + `<input type="checkbox" class="ioc-cb" id="iocSelectAll" ${allSel ? "checked" : ""} title="Select / deselect all visible IOCs" />`
-        + `<span>Type</span><span>${countLabel}</span><span></span>`
+        + `<span>Type</span><span>${countLabel}</span>`
+        + `<span class="tl-pagesize-wrap" title="IOCs per page"><select class="tl-pagesize-sel" onchange="iocSetPageSize(+this.value)">${iocPageSizeOpts}</select></span>`
         + `</div>`;
-      const rows = visible.map(i => {
+      const rows = pageVisible.map(i => {
         const isNew = newIocKeys.has(i.value);
         const isSel = selectedIocs.has(i.id);
         const isFp = fpVals.has(String(i.value).trim().toLowerCase());
@@ -12698,7 +12738,7 @@
           + `<span class="ioc-actions-cell">${commentChip("ioc", i.id)} ${tagAddBtn("ioc", i.id)} ${huntChip("ioc", i.id)} ${iocChainChip(i.id)} ${fpAction}</span>`
           + `</div>`;
       }).join("");
-      el.innerHTML = headerRow + rows;
+      el.innerHTML = headerRow + iocPaginationBar + rows;
       const selAll = document.getElementById("iocSelectAll");
       if (selAll && someSel && !allSel) selAll.indeterminate = true;
       updateIocBulkBar();


### PR DESCRIPTION
## What
The IOCs section now paginates client-side, mirroring the forensic-timeline pager, so cases with thousands of IOCs stay responsive instead of rendering every row into the DOM at once.

- Default **100 per page**, selectable **50 / 100 / 250 / 500 / All** via a selector in the list header
- **‹ Prev / Next ›** controls with a `101–200 of N` range readout (reuses the existing `.tl-page-bar` styles)
- Section-header badge shows **"page X of Y"**
- Filters and imports **reset to page 1**; paging keeps the current page (same `_iocKeepPage` pattern as the timeline's `_tlKeepPage`)
- **Select-all is page-scoped** (matches the timeline); selections still persist across pages for bulk actions

Only `public/dashboard.html` changed (+ a CHANGELOG line).

## Test plan
- [x] 15k-IOC case (INC-2026-005): 100 rows/page, "page 1 of 103", Prev/Next + page-size selector render
- [x] Next/Prev navigate; page-size change resets to page 1; "All" shows one page with no pager
- [x] Filter change from a deep page snaps back to page 1
- [x] Page-scoped select-all; selection persists across pages