### PR TITLE
fix: show a background job for evidence drop-folder auto-imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Forensic Timeline redesign** — timeline events now use the same bordered-card row language as Findings and IOCs: each event is its own rounded card with a severity-coloured left rail, a dedicated Severity column (coloured square + label), and a calm monospace timestamp, under an uppercase column header. The super-timeline is unchanged.
 
 ### Fixed
+- **Evidence drop-folder auto-imports were invisible in the Jobs panel** — files imported from a case's `drop/` folder ran through the same pipeline as the Import button but never registered a background job, so the dashboard showed no activity while they processed. Each sweep now registers an `import` job (`drop import (N files)`) with live progress, exactly like a manual import.
 - **Tagger rules file wasn't created on first write if its directory didn't exist** — a fresh install could throw `ENOENT` when saving edited content-tagger rules; the directory is now created on demand.
 - **Extension content script failed to load on every page** — `content.js` shared a chunk with `popup.js` and was built as an ES module (`import ...`), which Chrome rejects for a classic content script ("Cannot use import statement outside a module"). The build now compiles content.js and pageHook.js in their own isolated builds so they're always self-contained.
 

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -34,7 +34,7 @@ import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
 import { AiControlStore, type AiControl } from "./analysis/aiControl.js";
-import { JobManager } from "./analysis/jobManager.js";
+import { JobManager, type RegisteredJob } from "./analysis/jobManager.js";
 import { AnonControlStore } from "./analysis/anonControl.js";
 import { CustomEntitiesStore } from "./analysis/anonEntities.js";
 import { DiscoveredEntitiesStore } from "./analysis/anonDiscovered.js";
@@ -1394,6 +1394,9 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   async function scanCaseDrops(caseId: string): Promise<void> {
     if (dropScanning.has(caseId)) return;   // a previous sweep of this case is still running
     dropScanning.add(caseId);
+    // Surface the auto-import sweep as a background job (registered below once we know files are
+    // ready) so the dashboard Jobs panel shows drop-folder activity, exactly like a manual /import (#225).
+    let job: RegisteredJob | undefined;
     try {
       const meta = await store.getCaseMeta(caseId).catch(() => null);
       if (meta?.status === "closed" || meta?.status === "archived") return; // don't auto-import into a closed or archived case (parity with /import)
@@ -1404,26 +1407,39 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       dropSeen.set(caseId, nextSeen);
       if (ready.length === 0) return;
 
+      // One job per sweep, kind "import" (same panel row as the Import button). Non-cancellable: the
+      // sweep runs mixed importers that don't thread an abort signal, and a file already imported and
+      // moved to _processed/ can't be un-imported — so there's nothing safe to cancel mid-flight.
+      job = options.jobManager?.register({
+        caseId, kind: "import", label: `drop import (${ready.length} file${ready.length === 1 ? "" : "s"})`,
+      });
+
       const imported: string[] = [];
       const failed: DropFailure[] = [];
       const pendingRawInputs: PendingRawInput[] = [];
+      let processed = 0;
       for (let i = 0; i < ready.length; i += DROP_CONCURRENCY) {
         const batch = ready.slice(i, i + DROP_CONCURRENCY);
         await Promise.all(batch.map(async (file) => {
-          const res = await processDropFile(caseId, dropDir, file);
-          if (res.pending) {
-            // Raw input awaiting a tool: keep it in place (don't move, keep tracked) so the banner's
-            // "Run <tool>" can act on it and a later config/auto-run picks it up next sweep.
-            pendingRawInputs.push(res.pending);
-            return;
+          try {
+            const res = await processDropFile(caseId, dropDir, file);
+            if (res.pending) {
+              // Raw input awaiting a tool: keep it in place (don't move, keep tracked) so the banner's
+              // "Run <tool>" can act on it and a later config/auto-run picks it up next sweep.
+              pendingRawInputs.push(res.pending);
+              return;
+            }
+            if (res.ok) imported.push(file.relpath);
+            else failed.push({ relpath: file.relpath, reason: res.reason ?? "import failed" });
+            await moveDropFile(dropDir, file.relpath, res.ok).catch((e) => logLine(`[drop] move failed for ${file.relpath}: ${(e as Error).message}`));
+            nextSeen.delete(file.relpath); // moved out of the watched area — forget it
+            dropPendingLogged.get(caseId)?.delete(file.relpath); // resolved — no longer pending
+          } finally {
+            if (job) options.jobManager?.progress(job.jobId, ++processed, ready.length, basename(file.relpath));
           }
-          if (res.ok) imported.push(file.relpath);
-          else failed.push({ relpath: file.relpath, reason: res.reason ?? "import failed" });
-          await moveDropFile(dropDir, file.relpath, res.ok).catch((e) => logLine(`[drop] move failed for ${file.relpath}: ${(e as Error).message}`));
-          nextSeen.delete(file.relpath); // moved out of the watched area — forget it
-          dropPendingLogged.get(caseId)?.delete(file.relpath); // resolved — no longer pending
         }));
       }
+      if (job) options.jobManager?.finish(job.jobId);
       if (imported.length === 0 && failed.length === 0 && pendingRawInputs.length === 0) return;
 
       if (options.dropStatusStore) {
@@ -1451,6 +1467,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
         const lines = failed.slice(0, 20).map((x) => `• ${x.relpath} — ${x.reason}`);
         dispatchNotify(milestoneEvent(caseId, `Drop import: ${imported.length} imported, ${failed.length} failed`, lines, new Date().toISOString()));
       }
+    } catch (err) {
+      // A sweep-level failure (listing/meta/store I/O) must terminate the job — a job stuck "running"
+      // forever is a worse UI bug than the original invisibility. No-op if it already finished.
+      if (job) options.jobManager?.fail(job.jobId, err);
+      throw err;
     } finally {
       dropScanning.delete(caseId);
     }

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import request from "supertest";
@@ -19,6 +19,7 @@ import { IocWhitelistStore } from "../src/analysis/iocWhitelistStore.js";
 import { emptyState, type InvestigationState } from "../src/analysis/stateTypes.js";
 import type { CustomerExposureProvider } from "../src/analysis/customerExposure.js";
 import { JobManager } from "../src/analysis/jobManager.js";
+import { DropStatusStore } from "../src/analysis/dropStatus.js";
 
 let app: ReturnType<typeof createApp>;
 
@@ -1831,6 +1832,40 @@ describe("AI on/off control", () => {
     }
     expect(jobs.some((j) => j.kind === "synthesis")).toBe(true);
   });
+
+  it("tracks a drop-folder auto-import as a job so the Jobs panel shows it (parity with /import)", async () => {
+    // Bug: the evidence drop-folder poller (scanCaseDrops) imported files through the SAME chain as
+    // the Import button, but never registered with the jobManager — so an auto-import ran invisibly,
+    // with nothing in the dashboard Jobs panel, unlike a manual /import. The sweep must register a job.
+    const prevPoll = process.env.DFIR_DROP_POLL_S;
+    process.env.DFIR_DROP_POLL_S = "2"; // minimum settle: seen at poll 1, imported at poll 2 (~4s)
+    try {
+      const root = await mkdtemp(join(tmpdir(), "dfir-dropjob-"));
+      const store = new CaseStore(root);
+      const stateStore = new StateStore(store);
+      const jobManager = new JobManager();
+      const app = createApp(store, {
+        pipeline: findingPipeline(stateStore), stateStore, jobManager,
+        dropStatusStore: new DropStatusStore(store), // presence ARMS the drop-folder poller
+      });
+      await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+      // Drop a deterministic Velociraptor JSON into the case drop folder (imports without AI).
+      const dropDir = join(store.caseDir("c1"), "drop");
+      await mkdir(dropDir, { recursive: true });
+      const velo = JSON.stringify([{ _Source: "Windows.Detection.X", Detection: { Name: "Bad" }, EventTime: "2026-01-01T00:00:00Z", EntryPath: "c:\\x.exe" }]);
+      await writeFile(join(dropDir, "evidence.json"), velo, "utf8");
+
+      let jobs: { kind: string; label?: string }[] = [];
+      for (let i = 0; i < 200 && !jobs.some((j) => j.kind === "import"); i++) {
+        await new Promise((r) => setTimeout(r, 50));
+        jobs = jobManager.list("c1");
+      }
+      expect(jobs.some((j) => j.kind === "import" && /drop/i.test(j.label ?? ""))).toBe(true);
+    } finally {
+      if (prevPoll === undefined) delete process.env.DFIR_DROP_POLL_S;
+      else process.env.DFIR_DROP_POLL_S = prevPoll;
+    }
+  }, 15000);
 
   it("POST /import fires onImport(caseId) so dashboards can warn cross-case (parity with captures)", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-onimport-"));


### PR DESCRIPTION
## Problem
The evidence drop-folder poller (`scanCaseDrops`) imports files through the exact same pipeline as the Import button, but — unlike the manual `/import` route, synthesis, and enrichment — it never registered a job with the `JobManager`. So a drop-folder auto-import ran completely invisibly: no row in the dashboard Jobs panel, no progress, no completion.

## Fix
`scanCaseDrops` now registers one `import` job per sweep, labelled `drop import (N files)`:
- **Progress** updates as each file settles (`done/total`).
- **Finish** when the sweep completes; **fail** on a sweep-level I/O error so a job can never get stuck "running".
- **Non-cancellable** — the sweep runs mixed importers that don't thread an abort signal, and a file already imported and moved to `_processed/` can't be un-imported.

Because it reuses the existing `import` job kind and lifecycle, the **UI needs no changes** — the Jobs panel already renders import jobs and re-fetches on the `job_changed` WebSocket broadcast. A drop-import now behaves identically to a manual import in the panel.

## Test plan
- Added a TDD integration test that drives the real poller: drops a file into a case's `drop/`, lets it settle across two polls, imports it, and asserts an `import` job with a `drop` label appears in the `JobManager`. Confirmed RED before the fix, GREEN after.
- `tsc --noEmit` clean.
- Full `server.test.ts` (86) + all job/drop suites (66) pass.

Part of #225 (background-job registry).