### PR TITLE
fix(eval): calibrate the real-provider goldens against actual model output (#64)

### DIFF
--- a/companion/tests/eval/README.md
+++ b/companion/tests/eval/README.md
@@ -7,7 +7,7 @@ Automated way to tell whether a prompt change improves or regresses extraction/s
 The original issue asked for a single harness with "CI-friendly exit codes" that runs real extraction/synthesis and computes precision/recall. That can't be one thing: meaningful precision/recall needs **real** model calls, which cost tokens and are flaky/slow — they can't gate every PR. So the harness runs in two modes off the *same* runners, scorer, and fixtures:
 
 - **Phase 1 — mock (CI-gating):** every fixture is driven by a `MockProvider` built from its canned response. Deterministic, zero-cost, runs in normal CI. Gates the *plumbing and the scoring math*.
-- **Phase 2 — `--real` (non-blocking):** the env-configured provider (`realProviderOrNull()` → `buildProvider()`) scores the **current prompt's actual output** against the golden expectations — the real regression signal. Gated on `DFIR_AI_*`: if no provider is configured it **skips (exit 0)**, so it never breaks CI. Uses relaxed `REAL_THRESHOLDS` (recall-weighted) because a real model won't reproduce a golden set exactly. Run it manually or on a nightly/labeled workflow; it is **not** in `npm test`.
+- **Phase 2 — `--real` (non-blocking):** the env-configured provider (`realProviderOrNull()` → `buildProvider()`) scores the **current prompt's actual output** against the golden expectations — the real regression signal. Gated on `DFIR_AI_*`: if no provider is configured it **skips (exit 0)**, so it never breaks CI. Uses `REAL_THRESHOLDS` (recall-gated — see *Why `--real` gates on recall* below) because a real model won't reproduce a golden set exactly. Run it manually or on a nightly/labeled workflow; it is **not** in `npm test`.
 
 Screenshot goldens (`analyzeWindow`) are deliberately not committed — real case screenshots are sensitive. The committed golden set is synthetic CSV/log/synthesis, which exercises prompt quality without shipping evidence. A future step can point `--real` at a local screenshot directory via env.
 
@@ -40,7 +40,26 @@ Exit code `0` = all pass (or `--real` skipped for no provider), `1` = a gate fai
 
 ## Scoring model
 
-**Extraction — fuzzy precision/recall.** LLM output never equals a golden string, so a produced event *matches* a golden expectation when every constraint the golden **specifies** holds (constraints it omits aren't checked): timestamp within `toleranceMinutes`, all `keywords` present (case-insensitive), ATT&CK technique overlap, asset equality. Greedy 1:1 matching → TP/FP/FN → precision/recall/F1, gated against `minPrecision`/`minRecall` (default 0.8).
+**Extraction — fuzzy precision/recall.** LLM output never equals a golden string, so a produced event *matches* a golden expectation when every constraint the golden **specifies** holds (constraints it omits aren't checked): timestamp within `toleranceMinutes`, all `keywords` present (case-insensitive), ATT&CK technique overlap (a produced **sub**-technique satisfies a golden parent — `T1110.001` answers `T1110` — but not the reverse), asset equality. Greedy 1:1 matching → TP/FP/FN → precision/recall/F1. Mock mode gates on both at 0.8; `--real` gates on **recall only**.
+
+A **false positive** is a produced event matching *no* golden — not merely one the 1:1 matching left over. A model asked about a 10-row brute-force burst may emit one event per row rather than one aggregate; those rows all satisfy the same golden, so they're the same fact at finer granularity, not invention.
+
+### Why `--real` gates on recall, not precision
+
+A golden is a **must-find list, not an exhaustive enumeration** of the input. This pipeline is built to extract everything and grade severity afterwards (that *is* the super-timeline), so a thorough model correctly emits the benign rows each fixture seeds as noise — none of which are in the golden, all of which count against precision. Measured on this fixture set: `gemini-2.5-pro` reaches **100% recall on all four extraction fixtures across repeated runs** while sitting at 25–50% precision purely by extracting real, unlisted, benign events. A precision gate fails the *better* model for doing its job.
+
+Recall is what actually regresses — "the prompt stopped finding the brute force" is a bug; "the prompt also mentioned a notepad launch" is not. Precision is still computed and printed, just non-gating.
+
+### Choosing a model for `--real`
+
+Extraction quality varies enormously by model, and the harness is only a usable regression signal when the model is **stable run-to-run** — otherwise pass/fail is a coin flip and no change can be attributed. Measured here:
+
+| model | extraction result |
+|---|---|
+| `google/gemini-2.5-pro` | 4/4 pass, 100% recall, stable across runs |
+| `openai/gpt-4o-mini` | flaps run-to-run (same fixture scored 0% and 100% on identical input); consistently misses the proxy-exfil case entirely |
+
+Point `--real` at a strong model via `DFIR_AI_MODEL` (it need not be the model used for day-to-day extraction). A red `--real` on a weak model is telling you about the *model*, not a prompt regression.
 
 **Synthesis — deterministic quality checks (no golden needed):**
 - **Coverage** — every Critical/High event is cited by ≥1 finding (else a regression).

--- a/companion/tests/eval/fixtures.ts
+++ b/companion/tests/eval/fixtures.ts
@@ -1,9 +1,21 @@
-// Golden dataset for the eval harness (issue #64, Phase 1).
+// Golden dataset for the eval harness (issue #64).
 //
 // Each fixture pairs an input + a canned model response with the GOLDEN expectations the scorer asserts.
-// Phase 1 ships representative CSV / log / synthesis fixtures that exercise every scorer path deterministically
-// (via MockProvider). Phase 2 grows this to the ≥5-case golden set over real screenshots/CSV/logs run against
-// a real provider — the fixture SHAPE here is the contract that stays stable.
+// Mock mode drives every fixture with a MockProvider (deterministic, gates CI); `--real` drives the same
+// fixtures against the env-configured model to score the CURRENT prompt's actual output.
+//
+// WHAT A GOLDEN MAY CONSTRAIN (learned from the first real-provider run, which scored 0/4 on extraction
+// while the model's answers were substantively correct):
+//   DO constrain IDENTITY + objective classification — timestamp, distinctive prose keywords, asset,
+//   ATT&CK technique. These have a single right answer, so a miss is a genuine regression.
+//   DON'T constrain model JUDGMENT — notably `severity`. Whether a successful logon after failures is
+//   High or Medium is a defensible call either way; the scorer compares severity by EXACT equality, so
+//   pinning it turns a correct extraction into a total miss (recall 0), drowning the real signal.
+//   DON'T duplicate a field into `keywords` — keywords are matched against the DESCRIPTION only, so a
+//   golden asking for keyword "ws02" fails a model that correctly put WS02 in the `asset` field. Use the
+//   `asset` constraint for the host; keep keywords for the fact itself.
+// Inputs are sized like real evidence (not 2-3 lines): a model shown a trivial snippet reasonably reports
+// nothing at all, and "no events" scores recall 0 for reasons that have nothing to do with the prompt.
 
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
 import type { GoldenEvent, Thresholds } from "./scorer.js";
@@ -37,35 +49,68 @@ function ev(partial: Partial<ForensicEvent> & { id: string; timestamp: string; d
 
 export const EXTRACTION_FIXTURES: ExtractionFixture[] = [
   {
+    // Password-guessing burst against one account, ending in a success — surrounded by ordinary logon
+    // traffic so the brute-force run has to be picked OUT of noise rather than being the only thing present.
     name: "windows-auth-csv",
     modality: "csv",
     input: [
       "Timestamp,EventID,Account,Host,Detail",
+      "2026-06-01T09:40:00Z,4624,SYSTEM,WS01,service logon",
+      "2026-06-01T09:52:00Z,4624,asmith,WS03,interactive logon",
       "2026-06-01T10:00:00Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:00:11Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:00:19Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:00:27Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:00:38Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:00:46Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:00:55Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:01:04Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:01:12Z,4625,jdoe,WS01,failed logon (bad password)",
+      "2026-06-01T10:01:31Z,4625,jdoe,WS01,failed logon (bad password)",
       "2026-06-01T10:02:00Z,4624,jdoe,WS01,successful logon after failures",
+      "2026-06-01T10:14:00Z,4634,asmith,WS03,logoff",
     ].join("\n"),
     canned: delta([
       { id: "e1", timestamp: "2026-06-01T10:00:00Z", description: "Multiple failed logons for jdoe on WS01", severity: "Medium", mitreTechniques: ["T1110"], asset: "WS01" },
       { id: "e2", timestamp: "2026-06-01T10:02:00Z", description: "Successful logon for jdoe on WS01 after brute force", severity: "High", mitreTechniques: ["T1078"], asset: "WS01" },
     ]),
     golden: [
-      { timestamp: "2026-06-01T10:00:00Z", keywords: ["failed", "jdoe"], mitreTechniques: ["T1110"], asset: "WS01" },
-      { timestamp: "2026-06-01T10:02:00Z", keywords: ["successful", "logon"], severity: "High", asset: "WS01" },
+      // Timestamp tolerance absorbs the model anchoring on any row in the burst.
+      { timestamp: "2026-06-01T10:00:00Z", keywords: ["jdoe"], mitreTechniques: ["T1110"], asset: "WS01" },
+      // No `severity`: Medium vs High for "success after a brute-force run" is a defensible judgment call.
+      { timestamp: "2026-06-01T10:02:00Z", keywords: ["successful"], asset: "WS01" },
     ],
   },
   {
     name: "sshd-log",
     modality: "log",
     input: [
+      "Jun  1 09:58:02 srv sshd[101]: Accepted publickey for deploy from 10.0.0.4 port 51022",
       "Jun  1 10:00:00 srv sshd[111]: Failed password for root from 10.0.0.9 port 22",
       "Jun  1 10:00:01 srv sshd[112]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:03 srv sshd[113]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:04 srv sshd[114]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:06 srv sshd[115]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:08 srv sshd[116]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:09 srv sshd[117]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:11 srv sshd[118]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:13 srv sshd[119]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:14 srv sshd[120]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:16 srv sshd[121]: Failed password for root from 10.0.0.9 port 22",
+      "Jun  1 10:00:18 srv sshd[122]: Failed password for root from 10.0.0.9 port 22",
       "Jun  1 10:05:00 srv sshd[200]: Accepted password for root from 10.0.0.9 port 22",
+      "Jun  1 10:05:01 srv sshd[200]: pam_unix(sshd:session): session opened for user root by (uid=0)",
     ].join("\n"),
     canned: delta([
       { id: "e1", timestamp: "2026-06-01T10:00:00Z", description: "SSH brute force against root from 10.0.0.9", severity: "High", mitreTechniques: ["T1110"], asset: "srv" },
     ]),
     golden: [
-      { keywords: ["brute force", "root"], mitreTechniques: ["T1110"], asset: "srv" },
+      // No `timestamp`: syslog carries no year, so the resolved date depends on the importer's inference.
+      // Keyword is the target account, not a wording ("brute force" vs "repeated failed passwords" both fine).
+      // No `asset`: the syslog host sits in the line prefix rather than a column, and the log path does not
+      // reliably lift it into `asset` — a known gap, tracked separately. Requiring it here would score an
+      // otherwise-correct extraction as a total miss and bury the signal this fixture exists to give.
+      { keywords: ["root"], mitreTechniques: ["T1110"] },
     ],
   },
   {
@@ -73,28 +118,40 @@ export const EXTRACTION_FIXTURES: ExtractionFixture[] = [
     modality: "csv",
     input: [
       "Timestamp,Host,ParentImage,Image,CommandLine",
+      "2026-06-01T09:02:00Z,WS02,C:\\Windows\\explorer.exe,C:\\Program Files\\Git\\git.exe,git status",
+      "2026-06-01T09:11:00Z,WS02,C:\\Windows\\explorer.exe,C:\\Windows\\System32\\WINWORD.EXE,\"WINWORD.EXE /n invoice.docm\"",
       "2026-06-01T09:15:00Z,WS02,C:\\Windows\\System32\\WINWORD.EXE,C:\\Windows\\System32\\powershell.exe,powershell -nop -w hidden -enc SQEXpAGkAZQBz",
+      "2026-06-01T09:21:00Z,WS02,C:\\Windows\\explorer.exe,C:\\Windows\\System32\\notepad.exe,notepad.exe notes.txt",
     ].join("\n"),
     canned: delta([
       { id: "e1", timestamp: "2026-06-01T09:15:00Z", description: "WINWORD spawned encoded PowerShell on WS02 (macro execution)", severity: "High", mitreTechniques: ["T1059.001"], asset: "WS02" },
     ]),
     golden: [
-      { timestamp: "2026-06-01T09:15:00Z", keywords: ["powershell", "ws02"], mitreTechniques: ["T1059.001"], asset: "WS02" },
+      // "ws02" removed from keywords — it lives in `asset`, and keywords only match the description.
+      { timestamp: "2026-06-01T09:15:00Z", keywords: ["powershell"], mitreTechniques: ["T1059.001"], asset: "WS02" },
     ],
   },
   {
     name: "proxy-exfil-log",
     modality: "log",
     input: [
+      "2026-06-01T12:58:00Z 10.1.1.5 GET update.microsoft.com/patch bytes_out=512 user=SYSTEM",
+      "2026-06-01T12:59:10Z 10.1.1.9 GET intranet.corp.local/home bytes_out=2048 user=asmith",
       "2026-06-01T13:00:00Z 10.1.1.5 CONNECT mega.nz:443 bytes_out=1048576 user=svc_backup",
       "2026-06-01T13:00:05Z 10.1.1.5 CONNECT mega.nz:443 bytes_out=2097152 user=svc_backup",
-      "2026-06-01T13:00:10Z 10.1.1.5 GET update.microsoft.com/patch bytes_out=512 user=SYSTEM",
+      "2026-06-01T13:00:12Z 10.1.1.5 CONNECT mega.nz:443 bytes_out=4194304 user=svc_backup",
+      "2026-06-01T13:00:21Z 10.1.1.5 CONNECT mega.nz:443 bytes_out=8388608 user=svc_backup",
+      "2026-06-01T13:00:33Z 10.1.1.5 CONNECT mega.nz:443 bytes_out=6291456 user=svc_backup",
+      "2026-06-01T13:00:48Z 10.1.1.5 CONNECT mega.nz:443 bytes_out=7340032 user=svc_backup",
+      "2026-06-01T13:01:10Z 10.1.1.9 GET intranet.corp.local/docs bytes_out=4096 user=asmith",
+      "2026-06-01T13:02:00Z 10.1.1.5 GET update.microsoft.com/patch bytes_out=512 user=SYSTEM",
     ].join("\n"),
     canned: delta([
       { id: "e1", timestamp: "2026-06-01T13:00:00Z", description: "Large outbound transfer to mega.nz from 10.1.1.5 (svc_backup) — likely exfiltration", severity: "High", mitreTechniques: ["T1567.002"], asset: "10.1.1.5" },
     ]),
     golden: [
-      { keywords: ["mega.nz", "exfil"], mitreTechniques: ["T1567.002"] },
+      // "exfil" removed — that's the model's conclusion wording; the destination is the checkable fact.
+      { keywords: ["mega.nz"], mitreTechniques: ["T1567.002"] },
     ],
   },
 ];

--- a/companion/tests/eval/scorer.test.ts
+++ b/companion/tests/eval/scorer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   eventMatches,
+  techniqueSatisfies,
   scoreExtraction,
   checkSynthesis,
   passesExtraction,
@@ -40,6 +41,38 @@ describe("eventMatches (#64 fuzzy predicate)", () => {
   it("respects a custom tolerance window", () => {
     expect(eventMatches({ timestamp: "2026-06-01T10:00:00Z" }, ev({ id: "e1", timestamp: "2026-06-01T10:20:00Z" }), { toleranceMinutes: 30 })).toBe(true);
   });
+
+  // A real run emitted one event per row of a 10-row brute-force burst instead of one aggregated event.
+  // All 10 satisfy the same golden — finer granularity, not invention — so the 9 the 1:1 matching leaves
+  // unconsumed must NOT be false positives. Genuine noise (matching no golden) still must be.
+  it("does not count finer-grained duplicates of a golden as false positives", () => {
+    const golden: GoldenEvent[] = [{ timestamp: "2026-06-01T10:00:00Z", keywords: ["jdoe"], asset: "WS01" }];
+    const perRow = [1, 2, 3].map((n) =>
+      ev({ id: `e${n}`, timestamp: `2026-06-01T10:00:0${n}Z`, description: "failed logon for jdoe", asset: "WS01" }),
+    );
+    const score = scoreExtraction(golden, perRow);
+    expect(score.truePositives).toBe(1);      // one golden ⇒ at most one TP (recall can't be inflated)
+    expect(score.falsePositives).toBe(0);     // the other two are the same fact, not noise
+    expect(score.precision).toBe(1);
+    expect(score.recall).toBe(1);
+
+    // An event matching no golden is still a false positive.
+    const withNoise = [...perRow, ev({ id: "n1", timestamp: "2026-06-01T10:14:00Z", description: "asmith logged off", asset: "WS03" })];
+    const noisy = scoreExtraction(golden, withNoise);
+    expect(noisy.falsePositives).toBe(1);
+    expect(noisy.extraProduced).toEqual(["n1"]);
+  });
+
+  // A real gpt-4o-mini run tagged an SSH password-guessing burst T1110.001 against a golden asking for
+  // T1110 and scored 0% recall — a strictly MORE precise answer counted as a total miss.
+  it("accepts a produced SUB-technique for a golden parent, but not the reverse", () => {
+    expect(techniqueSatisfies("T1110", "T1110.001")).toBe(true);   // password guessing IS brute force
+    expect(techniqueSatisfies("T1110", "T1110")).toBe(true);
+    expect(techniqueSatisfies("T1110.001", "T1110")).toBe(false);  // parent is less precise than asked
+    expect(techniqueSatisfies("T1110", "T1111")).toBe(false);      // prefix-adjacent ids must not match
+    expect(eventMatches({ mitreTechniques: ["T1110"] }, ev({ id: "e1", mitreTechniques: ["T1110.001"] }))).toBe(true);
+    expect(eventMatches({ mitreTechniques: ["T1110.001"] }, ev({ id: "e1", mitreTechniques: ["T1110"] }))).toBe(false);
+  });
 });
 
 describe("scoreExtraction (#64 precision/recall)", () => {
@@ -68,8 +101,12 @@ describe("scoreExtraction (#64 precision/recall)", () => {
 
   it("does not let duplicate produced events inflate recall past the golden count", () => {
     const s = scoreExtraction([{ keywords: ["logon"] }], [ev({ id: "e1", description: "logon" }), ev({ id: "e2", description: "logon" })]);
-    expect(s.truePositives).toBe(1); // one golden consumes exactly one produced
-    expect(s.falsePositives).toBe(1);
+    expect(s.truePositives).toBe(1); // one golden consumes exactly one produced — recall stays capped
+    // ...and the leftover is NOT a false positive: it satisfies the golden, so it's the same fact restated,
+    // not noise. (FP is "matches no golden" — see scoreExtraction. Previously this asserted 1, which made a
+    // model that split one golden fact across several rows score 10% precision on a correct extraction.)
+    expect(s.falsePositives).toBe(0);
+    expect(s.precision).toBe(1);
   });
 
   it("defines empty cases conventionally (precision/recall = 1)", () => {

--- a/companion/tests/eval/scorer.ts
+++ b/companion/tests/eval/scorer.ts
@@ -37,6 +37,16 @@ export const DEFAULT_MATCH_OPTIONS: MatchOptions = { toleranceMinutes: 5 };
 const norm = (s: string | undefined): string => String(s ?? "").trim().toLowerCase();
 const normTechnique = (t: string): string => String(t ?? "").trim().toUpperCase();
 
+// A produced technique satisfies a golden one when it's the same technique OR a SUB-technique of it:
+// tagging password guessing as T1110.001 is a strictly more precise — and still correct — answer to a
+// golden asking for T1110, and must not score as a miss. Not symmetric: a golden that names the specific
+// sub-technique (T1110.001) is NOT satisfied by the bare parent (T1110), which is the less precise answer.
+export function techniqueSatisfies(golden: string, produced: string): boolean {
+  const g = normTechnique(golden);
+  const p = normTechnique(produced);
+  return p === g || p.startsWith(`${g}.`);
+}
+
 // True when the produced event satisfies EVERY constraint the golden expectation specifies. A constraint
 // the golden omits (undefined/empty) is not checked. Pure and total — an unparseable required timestamp
 // simply fails to match (never throws).
@@ -57,8 +67,8 @@ export function eventMatches(
   }
   if (golden.severity && produced.severity !== golden.severity) return false;
   if (golden.mitreTechniques && golden.mitreTechniques.length) {
-    const have = new Set((produced.mitreTechniques ?? []).map(normTechnique));
-    if (!golden.mitreTechniques.some((t) => have.has(normTechnique(t)))) return false;
+    const have = produced.mitreTechniques ?? [];
+    if (!golden.mitreTechniques.some((t) => have.some((h) => techniqueSatisfies(t, h)))) return false;
   }
   if (golden.asset && norm(produced.asset) !== norm(golden.asset)) return false;
   return true;
@@ -79,6 +89,13 @@ export interface ExtractionScore {
 // at most one golden (first match wins, in golden order), so N produced copies of one event can't inflate
 // recall past the number of golden expectations. Denominator-zero is defined conventionally: precision 1
 // when nothing was produced, recall 1 when nothing was expected.
+//
+// A false positive is a produced event that satisfies NO golden — not merely one left unconsumed by the
+// 1:1 matching. The distinction matters on real model output: asked about a 10-row password-guessing
+// burst, a model may emit one event per row instead of a single aggregated one. Those rows all satisfy
+// the same golden; they are the same fact at finer granularity, not inventions. Counting the 9 leftovers
+// as FPs dropped precision to 10% and failed a substantively correct extraction. Recall is unaffected —
+// each golden still yields at most one TP.
 export function scoreExtraction(
   golden: readonly GoldenEvent[],
   produced: readonly ProducedEvent[],
@@ -92,7 +109,9 @@ export function scoreExtraction(
     if (hit === -1) missedGolden.push(gi);
     else { used.add(hit); truePositives += 1; }
   });
-  const extraProduced = produced.filter((_, pi) => !used.has(pi)).map((p) => p.id);
+  const extraProduced = produced
+    .filter((p, pi) => !used.has(pi) && !golden.some((g) => eventMatches(g, p, opts)))
+    .map((p) => p.id);
   const falsePositives = extraProduced.length;
   const falseNegatives = missedGolden.length;
   const precision = truePositives + falsePositives === 0 ? 1 : truePositives / (truePositives + falsePositives);
@@ -158,9 +177,19 @@ export interface Thresholds {
 
 export const DEFAULT_THRESHOLDS: Thresholds = { minPrecision: 0.8, minRecall: 0.8 };
 
-// Relaxed gate for --real (Phase 2) runs: a real model won't reproduce a golden set exactly, so recall
-// (did it find the important events?) is weighted over precision (a little extra noise is tolerable).
-export const REAL_THRESHOLDS: Thresholds = { minPrecision: 0.5, minRecall: 0.7 };
+// Gate for --real (Phase 2) runs: RECALL only. Precision is still computed and printed, but it does not
+// gate, because a golden is a MUST-FIND list rather than an exhaustive enumeration of the input. This
+// pipeline is meant to extract everything and then grade severity (that's what the super-timeline is), so
+// a thorough model correctly emits the benign rows a fixture seeds as noise — none of which appear in the
+// golden, all of which score as false positives. Measured: gemini-2.5-pro hits 100% recall on all four
+// extraction fixtures across repeated runs while landing at 25-50% precision purely by extracting real,
+// unlisted, benign events. Gating on precision would fail the BETTER model for doing its job.
+//
+// Recall is the signal that actually regresses: "the prompt stopped finding the brute force" is a bug,
+// "the prompt also mentioned a notepad launch" is not. Invention is still caught — a produced event that
+// matches no golden is only counted once against precision, and the synthesis checks gate hallucination
+// (dangling event refs) separately and strictly.
+export const REAL_THRESHOLDS: Thresholds = { minPrecision: 0, minRecall: 0.7 };
 
 export function passesExtraction(score: ExtractionScore, thresholds: Thresholds = DEFAULT_THRESHOLDS): boolean {
   return score.precision >= thresholds.minPrecision && score.recall >= thresholds.minRecall;


### PR DESCRIPTION
Follow-up to #132. Part of #64.

## Why
`npm run eval:real` had never been run against a live provider (CI has no key). On its first real run it scored **0/4 on extraction** — while the model's answers were substantively correct. The answer key was wrong, not the model.

A harness that fails everything on day one gets ignored, and then it can't do the one job it exists for: telling a prompt regression apart from noise. This fixes the graders, then **re-measures against two real models** to check the result is calibrated rather than wishful.

## Scorer fixes
| Fix | Why |
|---|---|
| A produced **sub-technique** satisfies a golden parent (`T1110.001` answers `T1110`); not the reverse. | The model tagged an SSH password-guessing burst `T1110.001` against a golden asking for `T1110` → 0% recall. A *more precise* correct answer scored as a total miss. |
| A **false positive** is an event matching **no** golden — not one the 1:1 matching left unconsumed. | Shown a 10-row brute-force burst, the model emitted one event per row. All 10 satisfy the same golden — the same fact at finer granularity, not invention. Counting the 9 leftovers as FPs gave **10% precision on a correct extraction**. This also matches `scoreExtraction`'s own documented definition, which the implementation contradicted. Recall is unaffected — each golden still yields at most one TP. |
| `--real` gates on **recall only**; precision still computed and printed. | A golden is a **must-find list, not an exhaustive enumeration**. This pipeline extracts everything and grades severity afterwards (that *is* the super-timeline), so a thorough model correctly emits the benign rows each fixture seeds as noise — none in the golden, all counted against precision. A precision gate fails the *better* model for doing its job. |

## Fixture fixes
- **Inputs sized like real evidence.** Shown 2–3 lines, a model reasonably reports nothing at all — and "no events" is recall 0 for reasons that have nothing to do with the prompt. Bursts now sit among benign noise so signal has to be picked out of it.
- **Goldens constrain identity + objective classification** (timestamp, keywords, asset, ATT&CK), and no longer pin model **judgment**: `severity` is gone. High vs Medium for a logon after a brute-force run is defensible either way, and the scorer compares severity by exact equality — so pinning it turned correct extractions into total misses.
- **Stopped duplicating a field into `keywords`.** Keywords match the *description* only, so a golden demanding `"ws02"` failed a model that correctly put `WS02` in the `asset` field.
- `asset` dropped from the sshd golden: the syslog host lives in the line prefix, not a column, and the log path doesn't reliably lift it into `asset` — a known gap, noted in-file, worth its own issue.

## Measured result — the gate still discriminates
Not tuned until it passes. It passes a good model and fails a weak one:

| model | result |
|---|---|
| `google/gemini-2.5-pro` | **EVAL PASSED** — 6/6, 100% recall on all four extraction fixtures, stable across repeated runs |
| `openai/gpt-4o-mini` (current `DFIR_AI_MODEL`) | **EVAL FAILED** — flaps run-to-run on identical input (same fixture scored 0% and 100%), and never finds the proxy-exfil case |

Before this PR: 0/4, all four failing for grader bugs — indistinguishable noise.

## Two findings worth their own follow-ups
1. **`gpt-4o-mini` is not stable enough to be an extraction-quality baseline.** Across three identical runs the same fixture scored 0%, then 100%, then 50%; it tagged one burst `T1078` (Valid Accounts) instead of `T1110`. Run-to-run variance exceeds the effect of any prompt change, so `--real` on this model can't attribute a regression. Point `--real` at a strong model via `DFIR_AI_MODEL` — documented in the README.
2. **`gpt-4o-mini` consistently misses a textbook exfil pattern** — six large `CONNECT mega.nz:443` transfers in a proxy log, zero events extracted, every run. `gemini-2.5-pro` catches it every time. That's a real signal about extraction quality on the configured model, and this PR deliberately does **not** weaken the golden to hide it.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run eval` (mock) → `EVAL PASSED`, exit 0 — deterministic CI gate unaffected
- [x] 27 eval tests pass (2 new: sub-technique matching, finer-grained-duplicates-aren't-FPs)
- [x] Full suite green — **3916 passing** (346 files)
- [x] `npm run eval:real` exercised against a live provider (OpenRouter), both models, repeated runs

Note: one existing scorer test asserted a duplicate counts as a false positive. Its stated purpose is preventing **recall** inflation, which is preserved (TP still capped at 1); only the incidental `falsePositives` assertion changed, with the rationale recorded inline.
