### PR TITLE
test(eval): screenshot golden for the analyzeWindow vision path (#64)

### DIFF
--- a/companion/tests/eval/README.md
+++ b/companion/tests/eval/README.md
@@ -9,7 +9,7 @@ The original issue asked for a single harness with "CI-friendly exit codes" that
 - **Phase 1 — mock (CI-gating):** every fixture is driven by a `MockProvider` built from its canned response. Deterministic, zero-cost, runs in normal CI. Gates the *plumbing and the scoring math*.
 - **Phase 2 — `--real` (non-blocking):** the env-configured provider (`realProviderOrNull()` → `buildProvider()`) scores the **current prompt's actual output** against the golden expectations — the real regression signal. Gated on `DFIR_AI_*`: if no provider is configured it **skips (exit 0)**, so it never breaks CI. Uses `REAL_THRESHOLDS` (recall-gated — see *Why `--real` gates on recall* below) because a real model won't reproduce a golden set exactly. Run it manually or on a nightly/labeled workflow; it is **not** in `npm test`.
 
-Screenshot goldens (`analyzeWindow`) are deliberately not committed — real case screenshots are sensitive. The committed golden set is synthetic CSV/log/synthesis, which exercises prompt quality without shipping evidence. A future step can point `--real` at a local screenshot directory via env.
+Screenshots (`analyzeWindow`, the vision path) are covered **mock-only**: a synthetic capture + canned delta drives the plumbing through a stub image, so it gates the analyzeWindow→scorer path without committing any evidence. **Real** vision grading stays deferred — real case screenshots are sensitive, so `--real` skips the screenshot fixtures; a future step can point them at a local screenshot directory via env. The committed golden set (CSV, log, screenshot, synthesis) is entirely synthetic.
 
 ## Files
 
@@ -17,7 +17,7 @@ Screenshot goldens (`analyzeWindow`) are deliberately not committed — real cas
 |------|------|
 | `scorer.ts` | Pure scoring core — no I/O, no clock, no AI. Fuzzy extraction match → precision/recall; synthesis coverage/hallucination/rubric checks. |
 | `scorer.test.ts` | Unit tests for every scorer path. |
-| `harness.ts` | Drives the real pipeline (`analyzeCsv` / `analyzeLog` / `synthesize`) via a MockProvider, maps output to the scorer's shapes. |
+| `harness.ts` | Drives the real pipeline (`analyzeCsv` / `analyzeLog` / `analyzeWindow` / `synthesize`) via a MockProvider, maps output to the scorer's shapes. |
 | `fixtures.ts` | Golden dataset: input + canned model response + expected `GoldenEvent[]` / synthesis seed. |
 | `harness.test.ts` | Integration: fixtures through the pipeline → scorer, asserting thresholds + a deliberate regression. |
 | `run.ts` | CLI runner with a summary report + CI exit codes. |
@@ -68,4 +68,4 @@ Point `--real` at a strong model via `DFIR_AI_MODEL` (it need not be the model u
 
 ## Adding a golden case
 
-Append to `EXTRACTION_FIXTURES` (input + canned delta + `golden`) or `SYNTHESIS_FIXTURES` (seed timeline + canned synthesis delta) in `fixtures.ts`. Keep golden data **synthetic or sanitized** — never snapshot real case evidence.
+Append to `EXTRACTION_FIXTURES` (input + canned delta + `golden`), `SCREENSHOT_FIXTURES` (synthetic captures + canned delta + `golden`, mock-only), or `SYNTHESIS_FIXTURES` (seed timeline + canned synthesis delta) in `fixtures.ts`. Keep golden data **synthetic or sanitized** — never snapshot real case evidence.

--- a/companion/tests/eval/fixtures.ts
+++ b/companion/tests/eval/fixtures.ts
@@ -18,6 +18,7 @@
 // nothing at all, and "no events" scores recall 0 for reasons that have nothing to do with the prompt.
 
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+import type { CaptureMetadata } from "../../src/types.js";
 import type { GoldenEvent, Thresholds } from "./scorer.js";
 
 // A delta the MockProvider returns verbatim for an extraction call. Kept as a builder so fixtures read as data.
@@ -41,6 +42,29 @@ export interface SynthesisFixture {
   name: string;
   seedEvents: ForensicEvent[];
   canned: string;
+}
+
+export interface ScreenshotFixture {
+  name: string;
+  captures: CaptureMetadata[]; // synthetic capture metadata; no real image bytes are shipped
+  canned: string;              // MockProvider response — MOCK-ONLY (see SCREENSHOT_FIXTURES note)
+  golden: GoldenEvent[];
+  thresholds?: Thresholds;
+}
+
+// A synthetic browser capture, sized like the real thing. Defaults are the boring path; a fixture overrides
+// only what it asserts on. contentHash is a stand-in string — dedup never runs on a single eval capture.
+function cap(partial: Partial<CaptureMetadata> & { sequenceNumber: number; screenshotFile: string }): CaptureMetadata {
+  return {
+    caseId: "eval",
+    timestamp: "2026-06-01T14:05:00Z",
+    url: "https://velociraptor.local/app/index.html",
+    tabTitle: "Velociraptor",
+    triggerType: "timer",
+    contentHash: `evalhash-${partial.sequenceNumber}`,
+    isDuplicate: false,
+    ...partial,
+  };
 }
 
 function ev(partial: Partial<ForensicEvent> & { id: string; timestamp: string; description: string }): ForensicEvent {
@@ -186,5 +210,33 @@ export const SYNTHESIS_FIXTURES: SynthesisFixture[] = [
       iocs: [], mitreTechniques: [{ id: "T1021.002", name: "SMB/Windows Admin Shares" }],
       threadsOpened: [], threadsClosed: [], timelineNote: "", summary: "lateral movement case",
     }),
+  },
+];
+
+// Screenshot goldens exercise the VISION path (`analyzeWindow`) — the one modality CSV/log fixtures can't
+// reach. MOCK-ONLY BY DESIGN: the MockProvider returns the canned delta and the harness's stub imageLoader
+// supplies placeholder bytes, so this gates the analyzeWindow plumbing + scorer WITHOUT committing any real
+// screenshot. Real vision grading needs committed evidence (sensitive) and stays deferred — the runner
+// skips these in `--real` mode (see README). Note the golden timestamp is the ARTIFACT's OWN time, hours
+// off the capture time, which is exactly the behavior analyzeWindow's prompt exists to enforce.
+export const SCREENSHOT_FIXTURES: ScreenshotFixture[] = [
+  {
+    name: "velociraptor-scheduled-task",
+    captures: [
+      cap({
+        sequenceNumber: 42,
+        screenshotFile: "000042_velociraptor-scheduled-tasks.webp",
+        tabTitle: "Velociraptor — Windows.System.TaskScheduler on WS02",
+        url: "https://velociraptor.local/app/index.html#/collected/C.eval/WS02",
+      }),
+    ],
+    canned: delta([
+      { id: "e1", timestamp: "2026-06-01T02:13:00Z", description: "Scheduled task 'UpdateOrchestratorBackdoor' launches hidden powershell on WS02 (persistence)", severity: "High", mitreTechniques: ["T1053.005"], asset: "WS02" },
+    ]),
+    golden: [
+      // Timestamp is the artifact's own 02:13, NOT the 14:05 capture — keyword + technique + host are the
+      // checkable facts; severity is left unpinned (a defensible judgment call), per the golden discipline above.
+      { timestamp: "2026-06-01T02:13:00Z", keywords: ["powershell"], mitreTechniques: ["T1053.005"], asset: "WS02" },
+    ],
   },
 ];

--- a/companion/tests/eval/harness.test.ts
+++ b/companion/tests/eval/harness.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { runExtractionFixture, runSynthesisFixture, mockProvider } from "./harness.js";
+import { runExtractionFixture, runScreenshotFixture, runSynthesisFixture, mockProvider } from "./harness.js";
 import { scoreExtraction, checkSynthesis, passesExtraction, passesSynthesis } from "./scorer.js";
-import { EXTRACTION_FIXTURES, SYNTHESIS_FIXTURES } from "./fixtures.js";
+import { EXTRACTION_FIXTURES, SCREENSHOT_FIXTURES, SYNTHESIS_FIXTURES } from "./fixtures.js";
 
 // Phase-1 integration: a MockProvider (built from each fixture's canned response) makes every run
 // deterministic, so these assertions gate the pipeline→scorer PLUMBING and the fixtures — not model
@@ -25,6 +25,19 @@ describe("eval harness — extraction fixtures (#64)", () => {
     expect(score.falseNegatives).toBe(1);
     expect(passesExtraction(score)).toBe(false);
   });
+});
+
+// The vision path (analyzeWindow) driven MOCK-ONLY: a canned delta + stub image, so this gates the
+// analyzeWindow→scorer plumbing without any committed screenshot. Real vision grading stays deferred.
+describe("eval harness — screenshot fixtures (#64)", () => {
+  for (const fx of SCREENSHOT_FIXTURES) {
+    it(`screenshot: ${fx.name} meets its golden precision/recall`, async () => {
+      const produced = await runScreenshotFixture(fx, mockProvider(fx.canned));
+      expect(produced.length).toBeGreaterThan(0);       // analyzeWindow actually emitted events
+      const score = scoreExtraction(fx.golden, produced, { toleranceMinutes: 5 });
+      expect(passesExtraction(score, fx.thresholds)).toBe(true);
+    });
+  }
 });
 
 describe("eval harness — synthesis fixtures (#64)", () => {

--- a/companion/tests/eval/harness.ts
+++ b/companion/tests/eval/harness.ts
@@ -14,7 +14,7 @@ import { buildRuntimePipeline, buildProvider, buildSynthesisProvider } from "../
 import { MockProvider, type AIProvider } from "../../src/providers/provider.js";
 import { emptyState, type InvestigationState } from "../../src/analysis/stateTypes.js";
 import type { ProducedEvent, ProducedFinding } from "./scorer.js";
-import type { ExtractionFixture, SynthesisFixture } from "./fixtures.js";
+import type { ExtractionFixture, ScreenshotFixture, SynthesisFixture } from "./fixtures.js";
 
 const IMPORTED_AT = "2026-06-01T00:00:00Z"; // fixed clock input — keeps runs reproducible
 
@@ -74,6 +74,17 @@ export async function runExtractionFixture(fx: ExtractionFixture, provider: AIPr
   const state = fx.modality === "csv"
     ? await pipeline.analyzeCsv(caseId, fx.input, { label: `${fx.name}.csv`, idPrefix: "m1", importedAt: IMPORTED_AT })
     : await pipeline.analyzeLog(caseId, fx.input, { label: `${fx.name}.log`, idPrefix: "l1", importedAt: IMPORTED_AT });
+  return producedEvents(state);
+}
+
+// Run one screenshot fixture through the VISION path (`analyzeWindow`) and return the produced events.
+// MOCK-ONLY in practice: the provider returns the fixture's canned delta and makeEvalPipeline's stub
+// imageLoader supplies placeholder bytes, so no real screenshot is decoded or shipped. This exercises the
+// analyzeWindow plumbing + scorer — the one modality the CSV/log runners can't reach.
+export async function runScreenshotFixture(fx: ScreenshotFixture, provider: AIProvider): Promise<ProducedEvent[]> {
+  const { pipeline, caseId } = await makeEvalPipeline(provider);
+  const captures = fx.captures.map((c) => ({ ...c, caseId })); // bind synthetic captures to the temp case
+  const state = await pipeline.analyzeWindow(caseId, captures);
   return producedEvents(state);
 }
 

--- a/companion/tests/eval/run.ts
+++ b/companion/tests/eval/run.ts
@@ -11,13 +11,13 @@
 // Exit codes: 0 = all pass (or real-mode skipped), 1 = a gate failed, 2 = a runner error.
 
 import { config as loadDotenv } from "dotenv";
-import { runExtractionFixture, runSynthesisFixture, mockProvider, realProviderOrNull } from "./harness.js";
+import { runExtractionFixture, runScreenshotFixture, runSynthesisFixture, mockProvider, realProviderOrNull } from "./harness.js";
 import {
   scoreExtraction, checkSynthesis, passesExtraction, passesSynthesis,
   formatExtractionReport, formatSynthesisReport, REAL_THRESHOLDS,
   type Thresholds,
 } from "./scorer.js";
-import { EXTRACTION_FIXTURES, SYNTHESIS_FIXTURES } from "./fixtures.js";
+import { EXTRACTION_FIXTURES, SCREENSHOT_FIXTURES, SYNTHESIS_FIXTURES } from "./fixtures.js";
 import type { AIProvider } from "../../src/providers/provider.js";
 
 // In mock mode each fixture is driven by its OWN canned response, so the provider is chosen per fixture; in
@@ -32,6 +32,20 @@ async function runExtraction(providerFor: ProviderFor<(typeof EXTRACTION_FIXTURE
     const thresholds = fx.thresholds ?? override;
     console.log(formatExtractionReport(fx.name, score, thresholds));
     allPass = passesExtraction(score, thresholds) && allPass;
+  }
+  return allPass;
+}
+
+// Screenshot fixtures drive the vision path (analyzeWindow). MOCK-ONLY: each is driven by its own canned
+// delta against a stub image, so it gates the plumbing + scorer without shipping evidence. Real vision
+// grading is deferred (see README), so the runner never invokes this in --real mode.
+async function runScreenshots(): Promise<boolean> {
+  let allPass = true;
+  for (const fx of SCREENSHOT_FIXTURES) {
+    const produced = await runScreenshotFixture(fx, mockProvider(fx.canned));
+    const score = scoreExtraction(fx.golden, produced, { toleranceMinutes: 5 });
+    console.log(formatExtractionReport(`${fx.name} (screenshot)`, score, fx.thresholds));
+    allPass = passesExtraction(score, fx.thresholds) && allPass;
   }
   return allPass;
 }
@@ -75,7 +89,13 @@ async function main(): Promise<void> {
   }
 
   let ok = true;
-  if (mode === "extraction" || mode === "all") ok = (await runExtraction(extractionProvider, override)) && ok;
+  if (mode === "extraction" || mode === "all") {
+    ok = (await runExtraction(extractionProvider, override)) && ok;
+    // Screenshot fixtures are mock-only. In --real mode there's no committed evidence to grade the vision
+    // model against, so skip them (deliberate — see README) rather than run them against a stub image.
+    if (real) console.log("\nscreenshot fixtures: mock-only — skipped in --real mode (see README)");
+    else ok = (await runScreenshots()) && ok;
+  }
   if (mode === "synthesis" || mode === "all") ok = (await runSynthesis(synthesisProvider)) && ok;
   console.log(ok ? "\nEVAL PASSED" : "\nEVAL FAILED");
   process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary
Adds the screenshot golden that was the last unmet item in #64's acceptance criterion #1 ("covering screenshot"). The committed eval golden set was CSV/log/synthesis only, leaving the vision extraction path (`analyzeWindow`) untested.

This adds a **synthetic, mock-only** screenshot fixture that drives `analyzeWindow` through a `MockProvider` + stub image — gating the vision plumbing and the scorer **without committing any real (sensitive) screenshot**. The golden's timestamp is the artifact's own time, hours off the capture time, which is exactly the behavior `analyzeWindow`'s prompt exists to enforce (read the artifact's timestamp, not the capture/current time).

Real vision-model grading stays deferred by design (needs the vision provider + real images) — `run.ts` skips screenshot fixtures in `--real` mode, and that follow-up is tracked in #135.

## Changes
All under `companion/tests/eval/`:
- **fixtures.ts** — `ScreenshotFixture` type, `cap()` capture builder, `SCREENSHOT_FIXTURES` (a Velociraptor scheduled-task persistence case)
- **harness.ts** — `runScreenshotFixture`, driving the real `analyzeWindow`
- **run.ts** — `runScreenshots` (mock-only; skipped under `--real`)
- **harness.test.ts** — integration test for the screenshot fixture (7 → 8 tests)
- **README.md** — document screenshot coverage + the mock-only rationale

## Test plan
- [x] `npm run eval` → 5/5 extraction (incl. `velociraptor-scheduled-task (screenshot)`) + 2/2 synthesis pass, `EVAL PASSED`
- [x] `npx vitest run tests/eval` → 28 passed (scorer 20, harness 8)
- [x] `npx tsc --noEmit` → clean
- [x] Secret-scan pre-push hook → passed; all fixture data synthetic (`velociraptor.local`, `WS02`, synthetic timestamps)

Completes the final gap in #64 (now closed). Real vision grading follow-up: #135.