### PR TITLE
feat(second-opinion): stable delta keys via semanticKey (#69)

### DIFF
--- a/companion/src/analysis/findingGrounding.ts
+++ b/companion/src/analysis/findingGrounding.ts
@@ -16,6 +16,7 @@ import { classifyVerdict, iocHasBehavioralEvent } from "./iocAnchors.js";
 import { SEVERITY_RANK } from "./forensicGate.js";
 import { extractCveIds } from "./kev.js";
 import { trustForSources, type SourceTrustMap } from "./sourceTrust.js";
+import { deriveSemanticKey } from "./semanticKey.js";
 
 // A finding with no cited in-scope evidence is a hypothesis — cap hard so it can't outrank grounded work.
 export const UNGROUNDED_CONFIDENCE_CAP = 45;
@@ -164,6 +165,9 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
       ...rest,
       relatedEventIds,
       corroboration,
+      // Stable cross-run identity (issue #69) — recomputed every synthesis so second-opinion deltas
+      // key on it instead of the raw title. Deterministic from the (idempotent-safe) title + techniques.
+      semanticKey: deriveSemanticKey(f),
       ...(ungrounded ? { ungrounded: true } : {}),
       ...(confidence !== undefined ? { confidence } : {}),
       ...(confidenceReason !== undefined ? { confidenceReason } : {}),

--- a/companion/src/analysis/secondOpinion.ts
+++ b/companion/src/analysis/secondOpinion.ts
@@ -70,18 +70,21 @@ function indexFindings(findings: readonly Finding[]): FindingIndex {
   const bySem = new Map<string, Finding>();
   const byTitle = new Map<string, Finding>();
   for (const f of findings) {
+    // Key on the DERIVED matchKey, not the stored `semanticKey` field: model B's second-opinion
+    // findings are a dry-run synthesis that never persisted through grounding, so they carry no
+    // stored key. Deriving it here is what lets B's differently-worded findings match A's by
+    // semanticKey at all (#69) — indexing on the stored field silently disabled that.
     const key = matchKey(f);
     if (!key || seen.has(key)) continue;
     seen.add(key);
     all.push(f);
-    const sem = f.semanticKey?.trim();
-    if (sem && !bySem.has(sem)) bySem.set(sem, f);
+    if (!bySem.has(key)) bySem.set(key, f);
     const t = norm(f.title);
     if (t && !byTitle.has(t)) byTitle.set(t, f);
   }
   const match = (f: Finding): Finding | undefined => {
-    const sem = f.semanticKey?.trim();
-    if (sem) { const hit = bySem.get(sem); if (hit) return hit; }
+    const hit = bySem.get(matchKey(f));
+    if (hit) return hit;
     const t = norm(f.title);
     return t ? byTitle.get(t) : undefined;
   };

--- a/companion/src/analysis/secondOpinion.ts
+++ b/companion/src/analysis/secondOpinion.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { Finding, InvestigationState, Severity, Technique } from "./stateTypes.js";
+import { deriveSemanticKey } from "./semanticKey.js";
 
 // Second LLM opinion (issue #116). A QA control: a DIFFERENT model independently re-synthesizes
 // the same case, and we surface where it disagrees with the primary synthesis so the analyst can
@@ -16,7 +17,7 @@ export type DeltaStatus = "pending" | "accepted" | "rejected";
 export type DeltaRecommendation = "accept_b" | "keep_a" | "review";
 
 export interface SecondOpinionDelta {
-  id: string;                         // stable: `${kind}:${slug(title)}`
+  id: string;                         // stable across runs: `${kind}:${slug(semanticKey|title|techniqueId)}` (#69)
   kind: SecondOpinionDeltaKind;
   title: string;                      // finding title, or the ATT&CK technique id for mitre_* deltas
   aSeverity?: Severity;               // severity/ a_only: model A's severity
@@ -33,63 +34,102 @@ export interface SecondOpinion {
   modelA: string;                     // primary synthesis model label
   modelB: string;                     // second-opinion model label
   summary: string;                    // reconcile-AI overall assessment (default "")
-  agreementCount: number;             // findings BOTH models share (by normalized title)
+  agreementCount: number;             // findings BOTH models share (by matchKey — semanticKey or title)
   deltas: SecondOpinionDelta[];
 }
 
 const norm = (title: string): string => String(title).trim().toLowerCase().replace(/\s+/g, " ");
+
+// The STABLE cross-run identity of a finding (issue #69). Keying deltas by the raw normalized title
+// made a trivial rewording between runs ("Encoded PowerShell execution" vs "PowerShell encoded
+// command") register as a brand-new delta, so second-opinion tracking filled with noise. The
+// semanticKey (dominant technique + order-independent noun phrase) collapses those to one key. Falls
+// back to DERIVING it from the finding (so it works even on the second-opinion dry-run findings,
+// which aren't persisted through grounding and so carry no stored semanticKey). deriveSemanticKey
+// never returns empty (it slugs the title when no salient tokens survive), so this is always defined.
+const matchKey = (f: Finding): string => f.semanticKey?.trim() || deriveSemanticKey(f);
 
 // URL/id-safe slug for a stable delta id. Collapses runs of non-alphanumerics to single dashes.
 function slug(text: string): string {
   return String(text).trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "x";
 }
 
-// First occurrence of each normalized title wins (mirrors findingsDiff.byTitle), keeping the
-// displayed finding object so we can carry/merge it.
-function byTitle(findings: readonly Finding[]): Map<string, Finding> {
-  const map = new Map<string, Finding>();
+// A cross-run finding index. A counterpart is matched by semanticKey FIRST (so a reworded title with
+// the same technique+phrase collapses to one finding — the #69 fix) and by normalized title as a
+// fallback (so a same-title finding stays matched even when the two runs mapped it to different
+// dominant techniques — that divergence surfaces separately as mitre deltas, not as finding noise).
+// The side's own list is de-duped by matchKey (first wins), mirroring the previous byTitle behavior.
+interface FindingIndex {
+  all: readonly Finding[];                          // de-duped findings (first per matchKey)
+  match: (f: Finding) => Finding | undefined;       // this side's counterpart to `f`, by semanticKey then title
+}
+
+function indexFindings(findings: readonly Finding[]): FindingIndex {
+  const all: Finding[] = [];
+  const seen = new Set<string>();
+  const bySem = new Map<string, Finding>();
+  const byTitle = new Map<string, Finding>();
   for (const f of findings) {
-    const key = norm(f.title);
-    if (!key || map.has(key)) continue;
-    map.set(key, f);
+    const key = matchKey(f);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    all.push(f);
+    const sem = f.semanticKey?.trim();
+    if (sem && !bySem.has(sem)) bySem.set(sem, f);
+    const t = norm(f.title);
+    if (t && !byTitle.has(t)) byTitle.set(t, f);
   }
-  return map;
+  const match = (f: Finding): Finding | undefined => {
+    const sem = f.semanticKey?.trim();
+    if (sem) { const hit = bySem.get(sem); if (hit) return hit; }
+    const t = norm(f.title);
+    return t ? byTitle.get(t) : undefined;
+  };
+  return { all, match };
 }
 
 // Compute the deterministic delta set between model A (primary, saved) and model B (second opinion).
-// b_only: B raised a finding A missed; a_only: A has a finding B dropped; severity: shared title,
+// b_only: B raised a finding A missed; a_only: A has a finding B dropped; severity: matched finding,
 // different severity; mitre_added/removed: ATT&CK techniques present on one side only (by id).
 export function buildSecondOpinionDeltas(a: InvestigationState, b: InvestigationState): SecondOpinionDelta[] {
-  const aF = byTitle(a.findings);
-  const bF = byTitle(b.findings);
+  const aIdx = indexFindings(a.findings);
+  const bIdx = indexFindings(b.findings);
   const deltas: SecondOpinionDelta[] = [];
+  const matchedA = new Set<Finding>();
 
-  for (const [key, bf] of bF) {
-    const af = aF.get(key);
+  for (const bf of bIdx.all) {
+    const af = aIdx.match(bf);
     if (!af) {
-      deltas.push(delta("b_only", bf.title, { finding: bf, bSeverity: bf.severity }));
-    } else if (af.severity !== bf.severity) {
-      deltas.push(delta("severity", af.title, { finding: af, aSeverity: af.severity, bSeverity: bf.severity }));
+      deltas.push(delta("b_only", matchKey(bf), bf.title, { finding: bf, bSeverity: bf.severity }));
+    } else if (!matchedA.has(af)) {
+      matchedA.add(af); // one delta per A finding — a second B finding mapping to it agrees, no delta
+      if (af.severity !== bf.severity) {
+        deltas.push(delta("severity", matchKey(af), af.title, { finding: af, aSeverity: af.severity, bSeverity: bf.severity }));
+      }
     }
   }
-  for (const [key, af] of aF) {
-    if (!bF.has(key)) deltas.push(delta("a_only", af.title, { finding: af, aSeverity: af.severity }));
+  for (const af of aIdx.all) {
+    if (!matchedA.has(af)) deltas.push(delta("a_only", matchKey(af), af.title, { finding: af, aSeverity: af.severity }));
   }
 
   const aTech = new Map(a.mitreTechniques.map((t) => [t.id, t]));
   const bTech = new Map(b.mitreTechniques.map((t) => [t.id, t]));
   for (const [id, t] of bTech) {
-    if (!aTech.has(id)) deltas.push(delta("mitre_added", id, { techniqueName: t.name }));
+    if (!aTech.has(id)) deltas.push(delta("mitre_added", id, id, { techniqueName: t.name }));
   }
   for (const [id, t] of aTech) {
-    if (!bTech.has(id)) deltas.push(delta("mitre_removed", id, { techniqueName: t.name }));
+    if (!bTech.has(id)) deltas.push(delta("mitre_removed", id, id, { techniqueName: t.name }));
   }
   return deltas;
 }
 
-function delta(kind: SecondOpinionDeltaKind, title: string, extra: Partial<SecondOpinionDelta>): SecondOpinionDelta {
+// `keyBasis` is the STABLE identity the delta id is slugged from — a finding's matchKey (semanticKey
+// or normalized title) or, for mitre deltas, the technique id. Keying the id off semanticKey rather
+// than the raw title is what keeps the delta stable across a reworded re-run (issue #69). `title`
+// remains the human-readable label rendered to the analyst.
+function delta(kind: SecondOpinionDeltaKind, keyBasis: string, title: string, extra: Partial<SecondOpinionDelta>): SecondOpinionDelta {
   return {
-    id: `${kind}:${slug(title)}`,
+    id: `${kind}:${slug(keyBasis)}`,
     kind,
     title,
     rationale: "",
@@ -99,12 +139,17 @@ function delta(kind: SecondOpinionDeltaKind, title: string, extra: Partial<Secon
   };
 }
 
-// Findings BOTH models produced (intersection of normalized titles) — a simple agreement signal.
+// Findings BOTH models produced — a simple agreement signal. Matched by the same union rule as the
+// deltas (semanticKey then title), counting each A finding at most once.
 function agreementCount(a: InvestigationState, b: InvestigationState): number {
-  const aT = byTitle(a.findings);
-  let n = 0;
-  for (const key of byTitle(b.findings).keys()) if (aT.has(key)) n++;
-  return n;
+  const aIdx = indexFindings(a.findings);
+  const bIdx = indexFindings(b.findings);
+  const matchedA = new Set<Finding>();
+  for (const bf of bIdx.all) {
+    const af = aIdx.match(bf);
+    if (af && !matchedA.has(af)) matchedA.add(af);
+  }
+  return matchedA.size;
 }
 
 export interface BuildSecondOpinionInput {
@@ -225,8 +270,10 @@ export function setAllPendingStatus(so: SecondOpinion, status: DeltaStatus): Sec
 }
 
 // Apply EVERY accepted delta onto a case state. Pure, immutable, IDEMPOTENT (safe to run on every
-// read/synthesis): b_only adds B's finding if absent by title; a_only dismisses A's finding in
+// read/synthesis): b_only adds B's finding if absent by matchKey; a_only dismisses A's finding in
 // place; severity rewrites A's finding severity; mitre_added/removed add/remove the technique.
+// Findings are matched by matchKey (semanticKey, falling back to title — issue #69) so an accepted
+// delta re-applies to the same finding even after a reworded re-synthesis.
 // Used by both the apply route (on the live state) and synthesize() post-processing (durability).
 export function applyAcceptedSecondOpinion(state: InvestigationState, so: SecondOpinion | null): InvestigationState {
   if (!so) return state;
@@ -236,17 +283,21 @@ export function applyAcceptedSecondOpinion(state: InvestigationState, so: Second
   let findings = state.findings;
   let techniques = state.mitreTechniques;
 
+  // The stable key a finding-bearing delta targets: its carried finding's matchKey, falling back to
+  // the delta's normalized title for a (defensive) delta with no finding attached.
+  const deltaKey = (d: SecondOpinionDelta): string => (d.finding ? matchKey(d.finding) : norm(d.title));
+
   for (const d of accepted) {
     if (d.kind === "b_only" && d.finding) {
-      const key = norm(d.title);
-      if (!findings.some((f) => norm(f.title) === key)) {
+      const key = deltaKey(d);
+      if (!findings.some((f) => matchKey(f) === key)) {
         findings = [...findings, { ...d.finding, id: `so:${slug(d.title)}`, status: "open" }];
       }
     } else if (d.kind === "a_only") {
-      findings = mapByTitle(findings, d.title, (f) => ({ ...f, status: "dismissed" as const }));
+      findings = mapByKey(findings, deltaKey(d), (f) => ({ ...f, status: "dismissed" as const }));
     } else if (d.kind === "severity" && d.bSeverity) {
       const sev = d.bSeverity;
-      findings = mapByTitle(findings, d.title, (f) => ({ ...f, severity: sev }));
+      findings = mapByKey(findings, deltaKey(d), (f) => ({ ...f, severity: sev }));
     } else if (d.kind === "mitre_added") {
       if (!techniques.some((t) => t.id === d.title)) {
         techniques = [...techniques, { id: d.title, name: d.techniqueName || d.title, findingIds: [] } satisfies Technique];
@@ -260,7 +311,6 @@ export function applyAcceptedSecondOpinion(state: InvestigationState, so: Second
   return { ...state, findings, mitreTechniques: techniques };
 }
 
-function mapByTitle(findings: readonly Finding[], title: string, fn: (f: Finding) => Finding): Finding[] {
-  const key = norm(title);
-  return findings.map((f) => (norm(f.title) === key ? fn(f) : f));
+function mapByKey(findings: readonly Finding[], key: string, fn: (f: Finding) => Finding): Finding[] {
+  return findings.map((f) => (matchKey(f) === key ? fn(f) : f));
 }

--- a/companion/src/analysis/semanticKey.ts
+++ b/companion/src/analysis/semanticKey.ts
@@ -1,0 +1,65 @@
+import type { Finding } from "./stateTypes.js";
+
+// Stable, wording-resilient identity for a finding (issue #69). The second-opinion pass matches
+// findings across two independent synthesis runs; keying by the raw title made a trivial rewording
+// ("Encoded PowerShell execution" vs "PowerShell encoded command") register as a brand-new delta,
+// so the disagreement list filled with noise. A semanticKey anchors the identity on the dominant
+// ATT&CK technique plus an ORDER-INDEPENDENT noun phrase from the title, so reworded-but-equivalent
+// findings collapse to one key, e.g. `T1059.001:encoded_powershell`.
+//
+// PURE + deterministic (no I/O, no AI). Populated post-synthesis by groundAndScoreFindings and used
+// as the primary delta key in secondOpinion.ts, falling back to the normalized title.
+
+// Stopwords + generic DFIR filler dropped when deriving the noun phrase. These carry no
+// discriminating meaning, so removing them lets equivalent titles converge on the same phrase.
+const STOPWORDS = new Set<string>([
+  // grammatical
+  "a", "an", "the", "of", "to", "in", "on", "for", "and", "or", "with", "via", "by", "from", "at",
+  "as", "is", "was", "were", "be", "into", "over", "this", "that", "these", "those",
+  // generic security / DFIR filler
+  "detected", "detection", "suspicious", "possible", "potential", "likely", "observed", "activity",
+  "attempt", "attempted", "execution", "executed", "command", "commands", "behavior", "behaviour",
+  "event", "events", "alert", "alerts", "indicator", "indicators", "evidence", "use", "usage",
+  "using", "seen", "found", "multiple", "unusual", "anomalous", "malicious", "unknown",
+]);
+
+// Max salient tokens kept in the phrase — bounds key length and, combined with sorting, keeps the
+// key stable when a longer wording adds trailing qualifiers.
+const MAX_TOKENS = 4;
+
+const TECHNIQUE_RE = /^T\d{4}(?:\.\d{3})?$/;
+
+const lower = (s: string): string => String(s ?? "").trim().toLowerCase();
+
+// The dominant technique = the first well-formed ATT&CK id on the finding (synthesis lists the
+// primary technique first). "" when the finding maps none.
+function dominantTechnique(mitreTechniques: readonly string[] | undefined): string {
+  for (const raw of mitreTechniques ?? []) {
+    const id = String(raw ?? "").trim().toUpperCase();
+    if (TECHNIQUE_RE.test(id)) return id;
+  }
+  return "";
+}
+
+// An order-independent noun phrase: split the title into tokens, drop stopwords/filler, de-dupe,
+// sort alphabetically (so reordered wording produces the SAME phrase), cap, and join with "_".
+// Falls back to a slug of the whole normalized title when nothing salient survives, so it's never
+// empty. Exported for direct testing.
+export function nounPhrase(title: string): string {
+  const tokens = lower(title)
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .filter((t) => !STOPWORDS.has(t));
+  const salient = [...new Set(tokens)].sort().slice(0, MAX_TOKENS);
+  const phrase = salient.join("_");
+  if (phrase) return phrase;
+  return lower(title).replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+// Derive the stable semanticKey for a finding: `${dominantTechnique}:${nounPhrase}` when a technique
+// is mapped, else just the noun phrase. Deterministic and idempotent.
+export function deriveSemanticKey(finding: Pick<Finding, "title" | "mitreTechniques">): string {
+  const tech = dominantTechnique(finding.mitreTechniques);
+  const phrase = nounPhrase(finding.title ?? "");
+  return tech ? `${tech}:${phrase}` : phrase;
+}

--- a/companion/src/analysis/semanticKey.ts
+++ b/companion/src/analysis/semanticKey.ts
@@ -41,15 +41,29 @@ function dominantTechnique(mitreTechniques: readonly string[] | undefined): stri
   return "";
 }
 
-// An order-independent noun phrase: split the title into tokens, drop stopwords/filler, de-dupe,
-// sort alphabetically (so reordered wording produces the SAME phrase), cap, and join with "_".
-// Falls back to a slug of the whole normalized title when nothing salient survives, so it's never
-// empty. Exported for direct testing.
+// A token is "descriptive" — a word that anchors identity — only if it carries a letter and isn't a
+// hash/blob. VOLATILE, non-descriptive tokens are dropped so they can't dominate the phrase:
+//   - pure-numeric (no letter): IP octets, event IDs, PIDs, CVE numbers, counts, timestamps
+//   - long hex strings (≥16 all-hex chars): SHA/MD5 hashes, GUIDs
+// Without this, IP-heavy or hash-heavy titles produced keys like "256_a1b2c3…" or "101_185_220_47",
+// which erase the real subject and collapse genuinely-different findings that share an IP (#69 live).
+// Short tokens like "dc01"/"web01"/"c2"/"svchost32" keep their letters and survive.
+function isDescriptive(token: string): boolean {
+  if (!/[a-z]/.test(token)) return false;             // pure-numeric → drop
+  if (token.length >= 16 && /^[0-9a-f]+$/.test(token)) return false; // hash/hex blob → drop
+  return true;
+}
+
+// An order-independent noun phrase: split the title into tokens, drop stopwords/filler and volatile
+// non-descriptive tokens (numbers/hashes), de-dupe, sort alphabetically (so reordered wording
+// produces the SAME phrase), cap, and join with "_". Falls back to a slug of the whole normalized
+// title when nothing salient survives, so it's never empty. Exported for direct testing.
 export function nounPhrase(title: string): string {
   const tokens = lower(title)
     .split(/[^a-z0-9]+/)
     .filter(Boolean)
-    .filter((t) => !STOPWORDS.has(t));
+    .filter((t) => !STOPWORDS.has(t))
+    .filter(isDescriptive);
   const salient = [...new Set(tokens)].sort().slice(0, MAX_TOKENS);
   const phrase = salient.join("_");
   if (phrase) return phrase;

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -73,6 +73,12 @@ export interface Finding {
   connectedness?: number;
   relevanceDiscriminator?: string;
   title: string;
+  // Stable, wording-resilient identity for cross-run matching (issue #69): dominant ATT&CK technique
+  // + an order-independent noun phrase from the title, e.g. "T1059.001:encoded_powershell". Set
+  // post-synthesis by groundAndScoreFindings (deriveSemanticKey); used as the primary second-opinion
+  // delta key so a trivial rewording no longer registers as a new finding. Optional — findings
+  // synthesized before this field existed fall back to the normalized title.
+  semanticKey?: string;
   description: string;
   relatedIocs: string[];        // IOC ids
   sourceScreenshots: string[];  // screenshot filenames

--- a/companion/tests/analysis/secondOpinion.test.ts
+++ b/companion/tests/analysis/secondOpinion.test.ts
@@ -274,4 +274,31 @@ describe("second-opinion delta keys are stable across wording changes (issue #69
     const out = applyAcceptedSecondOpinion(aRun, so); // aRun already has the same semanticKey
     expect(out.findings.filter((f) => f.semanticKey === KEY)).toHaveLength(1);
   });
+
+  // Regression for the LIVE bug: model B's second-opinion findings are a dry-run synthesis and carry
+  // NO stored semanticKey. The matcher must DERIVE the key for them (not read the absent field), or a
+  // differently-worded B finding never matches A and the whole feature is inert in the real flow.
+  it("matches a B finding with NO stored semanticKey to A by the DERIVED key", () => {
+    const a = stateWith({
+      // A went through grounding → has the stored key
+      findings: [finding({ id: "f1", title: "Encoded PowerShell execution", severity: "High", semanticKey: "T1059.001:encoded_powershell", mitreTechniques: ["T1059.001"] })],
+    });
+    const b = stateWith({
+      // B is a dry-run: differently worded, SAME technique, and crucially NO semanticKey field
+      findings: [finding({ id: "g1", title: "PowerShell encoded command", severity: "High", mitreTechniques: ["T1059.001"] })],
+    });
+    const deltas = buildSecondOpinionDeltas(a, b);
+    expect(deltas.filter((d) => d.kind === "a_only" || d.kind === "b_only")).toHaveLength(0);
+    expect(buildSecondOpinion({ a, b, modelA: "a", modelB: "b", now: () => "t" }).agreementCount).toBe(1);
+  });
+
+  // Guard against OVER-collapse: two genuinely different findings that merely share an IP must stay
+  // distinct — the derivation drops the numeric octets so the descriptive words decide identity.
+  it("keeps two different findings that share an IP as separate deltas", () => {
+    const a = stateWith({ findings: [finding({ id: "f1", title: "DNS query resolved to 185.220.101.47", severity: "Medium", mitreTechniques: ["T1071.001"] })] });
+    const b = stateWith({ findings: [finding({ id: "g1", title: "Inbound connection from 185.220.101.47 to beacon", severity: "Medium", mitreTechniques: ["T1071.001"] })] });
+    const deltas = buildSecondOpinionDeltas(a, b);
+    expect(deltas.filter((d) => d.kind === "a_only")).toHaveLength(1);
+    expect(deltas.filter((d) => d.kind === "b_only")).toHaveLength(1);
+  });
 });

--- a/companion/tests/analysis/secondOpinion.test.ts
+++ b/companion/tests/analysis/secondOpinion.test.ts
@@ -215,3 +215,63 @@ describe("applyAcceptedSecondOpinion", () => {
     expect(next.deltas.slice(1)).toEqual(so.deltas.slice(1));
   });
 });
+
+// Issue #69 — deltas key on semanticKey (dominant technique + order-independent noun phrase) rather
+// than the raw title, so a trivial rewording between runs no longer registers as a new delta.
+describe("second-opinion delta keys are stable across wording changes (issue #69)", () => {
+  const KEY = "T1059.001:encoded_powershell";
+  // Same finding, reworded between runs, same semanticKey + severity.
+  const aRun = stateWith({
+    findings: [finding({ id: "f1", title: "Encoded PowerShell execution", severity: "High", semanticKey: KEY })],
+  });
+  const bRun = stateWith({
+    findings: [finding({ id: "g1", title: "PowerShell encoded command", severity: "High", semanticKey: KEY })],
+  });
+
+  it("treats reworded-but-equivalent findings as the SAME finding (no a_only/b_only noise)", () => {
+    const deltas = buildSecondOpinionDeltas(aRun, bRun);
+    expect(deltas.filter((d) => d.kind === "b_only" || d.kind === "a_only")).toHaveLength(0);
+    const so = buildSecondOpinion({ a: aRun, b: bRun, modelA: "a", modelB: "b", now: () => "t" });
+    expect(so.agreementCount).toBe(1); // counted as agreement despite different titles
+  });
+
+  it("still flags a real severity disagreement on the shared semanticKey", () => {
+    const bHi = stateWith({
+      findings: [finding({ id: "g1", title: "PowerShell encoded command", severity: "Critical", semanticKey: KEY })],
+    });
+    const sev = buildSecondOpinionDeltas(aRun, bHi).filter((d) => d.kind === "severity");
+    expect(sev).toHaveLength(1);
+    expect(sev[0].aSeverity).toBe("High");
+    expect(sev[0].bSeverity).toBe("Critical");
+  });
+
+  it("gives the delta a stable id derived from semanticKey, unchanged when the title is reworded", () => {
+    const bReworded = stateWith({
+      findings: [finding({ id: "g1", title: "PS enc command observed", severity: "Critical", semanticKey: KEY })],
+    });
+    const bOriginal = stateWith({
+      findings: [finding({ id: "g1", title: "PowerShell encoded command", severity: "Critical", semanticKey: KEY })],
+    });
+    const id1 = buildSecondOpinionDeltas(aRun, bOriginal).find((d) => d.kind === "severity")!.id;
+    const id2 = buildSecondOpinionDeltas(aRun, bReworded).find((d) => d.kind === "severity")!.id;
+    expect(id1).toBe(id2);
+    expect(id1).toBe("severity:t1059-001-encoded-powershell");
+  });
+
+  it("falls back to the normalized title when a finding lacks a semanticKey (backward compatible)", () => {
+    const aNoKey = stateWith({ findings: [finding({ id: "f1", title: "Legacy finding", severity: "Medium" })] });
+    const bNoKey = stateWith({ findings: [finding({ id: "g1", title: "legacy finding", severity: "Medium" })] });
+    // same normalized title, no semanticKey → matched as the same finding
+    expect(buildSecondOpinionDeltas(aNoKey, bNoKey).filter((d) => d.kind === "b_only" || d.kind === "a_only")).toHaveLength(0);
+  });
+
+  it("dedups an accepted b_only by semanticKey — does not add a duplicate of an existing A finding", () => {
+    // A already has the finding under a different title but the SAME semanticKey; B raised it too.
+    // (Constructed directly so the b_only delta exists to accept.)
+    const bOnly = buildSecondOpinion({ a: stateWith({ findings: [] }), b: bRun, modelA: "a", modelB: "b", now: () => "t" });
+    let so = bOnly;
+    so = setDeltaStatus(so, so.deltas.find((d) => d.kind === "b_only")!.id, "accepted");
+    const out = applyAcceptedSecondOpinion(aRun, so); // aRun already has the same semanticKey
+    expect(out.findings.filter((f) => f.semanticKey === KEY)).toHaveLength(1);
+  });
+});

--- a/companion/tests/analysis/semanticKey.test.ts
+++ b/companion/tests/analysis/semanticKey.test.ts
@@ -29,6 +29,24 @@ describe("nounPhrase", () => {
   it("is case- and punctuation-insensitive", () => {
     expect(nounPhrase("Mimikatz: credential DUMPING!")).toBe(nounPhrase("mimikatz credential dumping"));
   });
+
+  // Volatile-token dropping (#69 live finding): numbers/hashes must not dominate the phrase, else
+  // IP-heavy or hash-heavy titles key on the IP/hash and collapse genuinely-different findings.
+  it("drops pure-numeric tokens (IP octets, event IDs, counts) — descriptive words win", () => {
+    // 185/220/101/47/4698 all dropped; only the words anchor the key
+    expect(nounPhrase("Beacon callback to 185.220.101.47, EventID 4698")).toBe("beacon_callback_eventid");
+  });
+
+  it("drops long hex hash/blob tokens but keeps short letter+digit tokens (dc01, svchost32)", () => {
+    // 32-hex hash dropped; "dc01" (len 4) kept
+    expect(nounPhrase("update.dll on DC01 sha a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")).toBe("dc01_dll_sha_update");
+  });
+
+  it("keeps two different findings that share an IP distinct (no IP-domination collapse)", () => {
+    const dns = nounPhrase("DNS query resolved to 185.220.101.47");
+    const conn = nounPhrase("Inbound connection from 185.220.101.47 to beacon");
+    expect(dns).not.toBe(conn);
+  });
 });
 
 describe("deriveSemanticKey", () => {

--- a/companion/tests/analysis/semanticKey.test.ts
+++ b/companion/tests/analysis/semanticKey.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { deriveSemanticKey, nounPhrase } from "../../src/analysis/semanticKey.js";
+
+describe("nounPhrase", () => {
+  it("is order-independent — reordered wording produces the same phrase", () => {
+    expect(nounPhrase("Encoded PowerShell execution")).toBe(nounPhrase("PowerShell encoded command"));
+  });
+
+  it("drops generic DFIR filler and sorts the salient tokens", () => {
+    // "execution"/"command"/"suspicious" are filler → dropped; remaining sorted alphabetically
+    expect(nounPhrase("Suspicious encoded PowerShell command")).toBe("encoded_powershell");
+  });
+
+  it("de-dupes repeated tokens", () => {
+    expect(nounPhrase("PowerShell PowerShell encoded")).toBe("encoded_powershell");
+  });
+
+  it("caps the number of tokens to keep the key bounded", () => {
+    const phrase = nounPhrase("alpha bravo charlie delta echo foxtrot golf");
+    expect(phrase.split("_")).toHaveLength(4);
+    expect(phrase).toBe("alpha_bravo_charlie_delta"); // first 4 after sort
+  });
+
+  it("falls back to a slug of the whole title when only filler survives", () => {
+    // every token is a stopword/filler → phrase would be empty, so slug the title instead
+    expect(nounPhrase("suspicious activity detected")).toBe("suspicious_activity_detected");
+  });
+
+  it("is case- and punctuation-insensitive", () => {
+    expect(nounPhrase("Mimikatz: credential DUMPING!")).toBe(nounPhrase("mimikatz credential dumping"));
+  });
+});
+
+describe("deriveSemanticKey", () => {
+  it("prefixes the dominant (first) ATT&CK technique", () => {
+    expect(deriveSemanticKey({ title: "Encoded PowerShell execution", mitreTechniques: ["T1059.001", "T1027"] }))
+      .toBe("T1059.001:encoded_powershell");
+  });
+
+  it("collapses reworded-but-equivalent findings with the same technique to one key", () => {
+    const a = deriveSemanticKey({ title: "Encoded PowerShell execution", mitreTechniques: ["T1059.001"] });
+    const b = deriveSemanticKey({ title: "PowerShell encoded command", mitreTechniques: ["T1059.001"] });
+    expect(a).toBe(b);
+  });
+
+  it("skips malformed technique ids and uses the first well-formed one", () => {
+    expect(deriveSemanticKey({ title: "Credential dumping", mitreTechniques: ["bogus", "T1003.001"] }))
+      .toBe("T1003.001:credential_dumping");
+  });
+
+  it("omits the technique prefix when the finding maps none", () => {
+    expect(deriveSemanticKey({ title: "Cobalt Strike beacon", mitreTechniques: [] }))
+      .toBe("beacon_cobalt_strike");
+  });
+
+  it("is deterministic / idempotent", () => {
+    const f = { title: "Mimikatz credential dumping", mitreTechniques: ["T1003.001"] };
+    expect(deriveSemanticKey(f)).toBe(deriveSemanticKey(f));
+  });
+});

--- a/companion/tests/server/secondOpinion.test.ts
+++ b/companion/tests/server/secondOpinion.test.ts
@@ -47,7 +47,7 @@ const SYNTH_B = JSON.stringify({
 
 const RECONCILE = JSON.stringify({
   summary: "Model B surfaces a C2 finding A missed.",
-  verdicts: [{ id: "b_only:b-only-finding", rationale: "Supported by event e1.", recommendation: "accept_b" }],
+  verdicts: [{ id: "b_only:b-finding-only", rationale: "Supported by event e1.", recommendation: "accept_b" }],
 });
 
 // Only the timeline is seeded; model A's findings/MITRE come from the Pass-0 primary re-synthesis.
@@ -118,9 +118,9 @@ describe("Second opinion routes (#116)", () => {
   it("accepting a b_only delta adds the finding to the case (durably) and records the decision", async () => {
     const { app, stateStore } = await makeApp({ enabled: true });
     await request(app).post("/cases/c1/second-opinion").send({});
-    const res = await request(app).post("/cases/c1/second-opinion/apply").send({ deltaId: "b_only:b-only-finding", accept: true });
+    const res = await request(app).post("/cases/c1/second-opinion/apply").send({ deltaId: "b_only:b-finding-only", accept: true });
     expect(res.status).toBe(200);
-    expect(res.body.deltas.find((d: { id: string }) => d.id === "b_only:b-only-finding").status).toBe("accepted");
+    expect(res.body.deltas.find((d: { id: string }) => d.id === "b_only:b-finding-only").status).toBe("accepted");
     const state = await stateStore.load("c1");
     expect(state.findings.find((f) => f.title === "B only finding")?.id).toBe("so:b-only-finding");
   });
@@ -129,9 +129,9 @@ describe("Second opinion routes (#116)", () => {
     const { app, stateStore } = await makeApp({ enabled: true });
     await request(app).post("/cases/c1/second-opinion").send({});
     const before = (await stateStore.load("c1")).findings.length;
-    const res = await request(app).post("/cases/c1/second-opinion/apply").send({ deltaId: "b_only:b-only-finding", accept: false });
+    const res = await request(app).post("/cases/c1/second-opinion/apply").send({ deltaId: "b_only:b-finding-only", accept: false });
     expect(res.status).toBe(200);
-    expect(res.body.deltas.find((d: { id: string }) => d.id === "b_only:b-only-finding").status).toBe("rejected");
+    expect(res.body.deltas.find((d: { id: string }) => d.id === "b_only:b-finding-only").status).toBe("rejected");
     expect((await stateStore.load("c1")).findings).toHaveLength(before);
   });
 
@@ -157,11 +157,11 @@ describe("Second opinion routes (#116)", () => {
   it("apply-all leaves an already-decided delta untouched", async () => {
     const { app } = await makeApp({ enabled: true });
     await request(app).post("/cases/c1/second-opinion").send({});
-    await request(app).post("/cases/c1/second-opinion/apply").send({ deltaId: "a_only:a-only-finding", accept: false });
+    await request(app).post("/cases/c1/second-opinion/apply").send({ deltaId: "a_only:finding-only", accept: false });
     const res = await request(app).post("/cases/c1/second-opinion/apply-all").send({ accept: true });
     const byId = (id: string) => res.body.deltas.find((d: { id: string }) => d.id === id).status;
-    expect(byId("a_only:a-only-finding")).toBe("rejected");
-    expect(res.body.deltas.filter((d: { id: string }) => d.id !== "a_only:a-only-finding").every((d: { status: string }) => d.status === "accepted")).toBe(true);
+    expect(byId("a_only:finding-only")).toBe("rejected");
+    expect(res.body.deltas.filter((d: { id: string }) => d.id !== "a_only:finding-only").every((d: { status: string }) => d.status === "accepted")).toBe(true);
   });
 
   it("GET returns the stored record after a run", async () => {


### PR DESCRIPTION
Closes #69

## Problem
`buildSecondOpinionDeltas` keyed second-opinion deltas by normalized finding **title**. A small wording change between the primary and second-opinion runs created a spurious "new" delta and reset the analyst's accept/reject decision — noisy second-opinion tracking.

## Change
Add a stable, wording-resilient `semanticKey` to `Finding`, derived from the **dominant ATT&CK technique + an order-independent noun phrase** from the title (e.g. `T1059.001:encoded_powershell`), and key the deltas (and their ids) on it instead of the raw title.

- New `semanticKey.ts`: pure, tested `deriveSemanticKey` / `nounPhrase`.
- `groundAndScoreFindings` stamps `semanticKey` post-synthesis (idempotent).
- Second-opinion matching keys on the semanticKey (derived on the fly for model B's dry-run findings), UNION with the normalized title so a same-title finding whose technique differs stays matched (that divergence still surfaces as separate MITRE deltas).
- Delta ids slug the semanticKey, so an analyst decision survives a reworded rerun.
- Backward-compatible: findings without the field derive/fall back to title.

## Two fixes found by live end-to-end testing (not caught by unit tests)
1. **Matching never engaged.** The index/lookup keyed on the *stored* `semanticKey` field, but model B's dry-run findings never persist it — they silently fell back to title-only matching, so differently-worded B findings never matched A. Fixed to key on the *derived* key.
2. **Numeric/hash tokens dominated the key** (IP octets, event IDs, hashes crowded out the subject, e.g. `...:101_185_220_47`), collapsing genuinely-different findings that share an IP. Fixed by dropping pure-numeric and long-hex tokens so descriptive words anchor identity.

## Acceptance criteria (#69)
- [x] `semanticKey` field on `Finding`
- [x] Stable key derivation function with tests
- [x] Second-opinion deltas use `semanticKey`
- [x] Backward-compatible with findings that lack the key

## Test plan
- `tsc --noEmit` clean; full unit suite **3954 passing** (+ regression tests reproducing the live conditions: B with no stored key + same derived key must match; two findings sharing an IP must stay distinct).
- **Live end-to-end** on the seeded demo case, same two models, before vs after: agreements 16 → **28**, total deltas 31 → **7**, phantom `a_only`/`b_only` pairs sharing a key basis: many → **0**. The 7 remaining are genuine disagreements (a severity split, model-unique findings, one MITRE difference), rendered correctly in the dashboard 2nd-opinion panel.