### PR TITLE
feat(analysis): entity merging for duplicate assets/IOCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Entity merging for duplicate assets/IOCs** — fold a duplicate asset or IOC onto a canonical node/indicator; reversible, and IOC merges preserve the alias across re-synthesis (closes #82).
+
 ## [0.32.0] - 2026-07-16
 
 ### Added

--- a/companion/src/analysis/assetGraph.ts
+++ b/companion/src/analysis/assetGraph.ts
@@ -56,13 +56,16 @@ interface DescMatcher { ioc: IOC; test: (descLower: string) => boolean; }
 function buildDescMatchers(iocs: readonly IOC[]): DescMatcher[] {
   const out: DescMatcher[] = [];
   for (const i of iocs) {
-    const v = i.value.toLowerCase();
-    if (v.length < 4) continue;
-    if (IPV4_SHAPE.test(v)) {
-      const re = new RegExp(`(?<![\\d.])${escapeRegExp(v)}(?![\\d.])`);
-      out.push({ ioc: i, test: (d) => re.test(d) });
-    } else {
-      out.push({ ioc: i, test: (d) => d.includes(v) });
+    // Match the IOC's own value plus any analyst-merged alias values (#82) — an event mentioning
+    // the pre-merge duplicate value should still link to the canonical IOC.
+    for (const v of [i.value, ...(i.aliasValues ?? [])].map((s) => s.toLowerCase())) {
+      if (v.length < 4) continue;
+      if (IPV4_SHAPE.test(v)) {
+        const re = new RegExp(`(?<![\\d.])${escapeRegExp(v)}(?![\\d.])`);
+        out.push({ ioc: i, test: (d) => re.test(d) });
+      } else {
+        out.push({ ioc: i, test: (d) => d.includes(v) });
+      }
     }
   }
   return out;
@@ -108,7 +111,11 @@ export function buildAssetGraph(state: InvestigationState): AssetGraph {
   const iocs = state.iocs;
   const byId = new Map(iocs.map((i) => [i.id, i] as const));
   const byValue = new Map<string, IOC>();
-  for (const i of iocs) byValue.set(i.value.toLowerCase(), i);
+  for (const i of iocs) {
+    byValue.set(i.value.toLowerCase(), i);
+    // Analyst-merged duplicate values (#82, iocMerge.ts) still resolve onto this canonical IOC.
+    for (const alias of i.aliasValues ?? []) byValue.set(alias.toLowerCase(), i);
+  }
   const findingById = new Map(state.findings.map((f) => [f.id, f] as const));
   const descMatchers = buildDescMatchers(iocs);
 

--- a/companion/src/analysis/assetOverrides.ts
+++ b/companion/src/analysis/assetOverrides.ts
@@ -25,15 +25,34 @@ export const assetOverridesSchema = z.object({
   removed: z.array(z.string()).default([]),          // suppressed auto-derived asset ids
   addedLinks: z.array(z.object({ asset: z.string(), ioc: z.string() })).default([]),
   removedLinks: z.array(z.object({ asset: z.string(), ioc: z.string() })).default([]),
-}).catch({ renames: {}, added: [], removed: [], addedLinks: [], removedLinks: [] });
+  // Entity merging (#82): duplicate asset id -> canonical asset id it was folded into
+  // (e.g. "HOST01" merged into "host01.corp"). Applied after renames/suppressions, before the
+  // edge set is built, so the duplicate's IOC/finding/event links land on the canonical node.
+  merges: z.record(z.string(), z.string()).default({}),
+}).catch({ renames: {}, added: [], removed: [], addedLinks: [], removedLinks: [], merges: {} });
 
 export type AssetOverrides = z.infer<typeof assetOverridesSchema>;
 
 export function emptyOverrides(): AssetOverrides {
-  return { renames: {}, added: [], removed: [], addedLinks: [], removedLinks: [] };
+  return { renames: {}, added: [], removed: [], addedLinks: [], removedLinks: [], merges: {} };
+}
+
+// Resolve a merge chain (A->B->C) to its final canonical id. Breaks on a cycle (returns the
+// original id unresolved) so a bad edit can never infinite-loop the graph build.
+function resolveCanonical(id: string, merges: Record<string, string>): string {
+  let cur = id;
+  const seen = new Set<string>([cur]);
+  while (merges[cur] !== undefined) {
+    cur = merges[cur];
+    if (seen.has(cur)) return id; // cycle — bail out to the original id
+    seen.add(cur);
+  }
+  return cur;
 }
 
 const SEV_RANK: Record<Severity, number> = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4 };
+function worseSeverity(a: Severity, b: Severity): Severity { return SEV_RANK[b] < SEV_RANK[a] ? b : a; }
+function uniqStrings(values: string[]): string[] { return [...new Set(values)]; }
 
 // Apply manual overrides to an auto-derived asset graph. Pure — mutates neither argument.
 export function applyAssetOverrides(graph: AssetGraph, overrides: AssetOverrides): AssetGraph {
@@ -57,24 +76,47 @@ export function applyAssetOverrides(graph: AssetGraph, overrides: AssetOverrides
     }
   }
 
-  // 3. Build final edge set: suppress removedLinks, append addedLinks.
+  // 2b. Entity merging (#82): fold each duplicate node onto its resolved canonical node — union
+  // findingIds/eventCount/maxSeverity, then drop the duplicate. A merge target that doesn't exist
+  // (already suppressed, or a stale id) is skipped, leaving the duplicate as its own node.
+  for (const [dupId] of Object.entries(overrides.merges)) {
+    const dup = assetMap.get(dupId);
+    if (!dup) continue;
+    const canonicalId = resolveCanonical(dupId, overrides.merges);
+    if (canonicalId === dupId) continue;
+    const canonical = assetMap.get(canonicalId);
+    if (!canonical) continue;
+    canonical.findingIds = uniqStrings([...canonical.findingIds, ...dup.findingIds]);
+    canonical.eventCount += dup.eventCount;
+    canonical.maxSeverity = worseSeverity(canonical.maxSeverity, dup.maxSeverity);
+    assetMap.delete(dupId);
+  }
+  const redirect = (assetId: string): string => {
+    const canonical = resolveCanonical(assetId, overrides.merges);
+    return assetMap.has(canonical) ? canonical : assetId;
+  };
+
+  // 3. Build final edge set: suppress removedLinks, append addedLinks, redirecting merged
+  // duplicates' edges onto their canonical asset.
   const iocById = new Map<string, GraphIoc>(graph.iocs.map((i) => [i.id, i]));
   const removedSet = new Set(overrides.removedLinks.map((r) => `${r.asset}|${r.ioc}`));
   const edgeSet = new Set<string>();
   const edges: AssetGraphEdge[] = [];
 
   for (const e of graph.edges) {
+    const asset = redirect(e.asset);
     const key = `${e.asset}|${e.ioc}`;
-    if (!removedSet.has(key) && assetMap.has(e.asset) && !edgeSet.has(key)) {
-      edgeSet.add(key);
-      edges.push(e);
+    if (!removedSet.has(key) && assetMap.has(asset) && !edgeSet.has(`${asset}|${e.ioc}`)) {
+      edgeSet.add(`${asset}|${e.ioc}`);
+      edges.push({ asset, ioc: e.ioc });
     }
   }
   for (const link of overrides.addedLinks) {
-    const key = `${link.asset}|${link.ioc}`;
-    if (!edgeSet.has(key) && assetMap.has(link.asset) && iocById.has(link.ioc)) {
+    const asset = redirect(link.asset);
+    const key = `${asset}|${link.ioc}`;
+    if (!edgeSet.has(key) && assetMap.has(asset) && iocById.has(link.ioc)) {
       edgeSet.add(key);
-      edges.push(link);
+      edges.push({ asset, ioc: link.ioc });
     }
   }
 
@@ -210,6 +252,29 @@ export class AssetOverridesStore {
   async restoreLink(caseId: string, asset: string, ioc: string): Promise<AssetOverrides> {
     const ov = await this.load(caseId);
     const next = { ...ov, removedLinks: ov.removedLinks.filter((l) => !(l.asset === asset && l.ioc === ioc)) };
+    await this.save(caseId, next);
+    return next;
+  }
+
+  // Merge a duplicate asset onto a canonical one (#82): folds its IOC/finding/event links onto
+  // `intoId` on the next graph build (applyAssetOverrides). Rejects merging an asset into itself
+  // or creating a cycle (A merged into B, then B merged into A) — both would leave the graph
+  // undefined, so the store refuses rather than silently corrupting it.
+  async mergeAsset(caseId: string, fromId: string, intoId: string): Promise<AssetOverrides> {
+    if (fromId === intoId) throw new Error("cannot merge an asset into itself");
+    const ov = await this.load(caseId);
+    if (resolveCanonical(intoId, ov.merges) === fromId) throw new Error("merge would create a cycle");
+    const next = { ...ov, merges: { ...ov.merges, [fromId]: intoId } };
+    await this.save(caseId, next);
+    return next;
+  }
+
+  // Un-merge: remove a duplicate id from the merge map so it reappears as its own node.
+  async unmergeAsset(caseId: string, fromId: string): Promise<AssetOverrides> {
+    const ov = await this.load(caseId);
+    const merges = { ...ov.merges };
+    delete merges[fromId];
+    const next = { ...ov, merges };
     await this.save(caseId, next);
     return next;
   }

--- a/companion/src/analysis/iocAlias.ts
+++ b/companion/src/analysis/iocAlias.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import type { CaseStore } from "../storage/caseStore.js";
+import { atomicWrite } from "../storage/atomicWrite.js";
+
+// Per-case IOC alias map (#82): duplicate IOC value (lowercased) -> canonical IOC id it was
+// merged into. Kept in `state/ioc-aliases.json`, NOT in InvestigationState, so re-synthesis never
+// wipes it (same pattern as asset-overrides.json). stateMerge.ts's mergeDelta consults this map
+// BEFORE its own exact-value dedup so that if the AI re-extracts the same near-duplicate value
+// from new source text later, it's routed straight onto the canonical IOC instead of recreating
+// the duplicate — "synthesis re-merge preserves the alias".
+
+export const iocAliasSchema = z.object({
+  aliases: z.record(z.string(), z.string()).default({}),
+}).catch({ aliases: {} });
+
+export type IocAliasMap = z.infer<typeof iocAliasSchema>;
+
+export function emptyIocAliasMap(): IocAliasMap {
+  return { aliases: {} };
+}
+
+// Canonical IOC id for a value the analyst previously merged away, or undefined if none.
+export function resolveIocAlias(value: string, map: IocAliasMap): string | undefined {
+  return map.aliases[value.trim().toLowerCase()];
+}
+
+export class IocAliasStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "ioc-aliases.json");
+  }
+
+  async load(caseId: string): Promise<IocAliasMap> {
+    try {
+      return iocAliasSchema.parse(JSON.parse(await readFile(this.path(caseId), "utf8")));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return emptyIocAliasMap();
+      throw err;
+    }
+  }
+
+  private async save(caseId: string, map: IocAliasMap): Promise<void> {
+    await atomicWrite(this.path(caseId), JSON.stringify(map, null, 2));
+  }
+
+  // Record that `value` (the merged-away duplicate's value) should route onto `intoId` going
+  // forward. Idempotent.
+  async add(caseId: string, value: string, intoId: string): Promise<IocAliasMap> {
+    const map = await this.load(caseId);
+    const next = { aliases: { ...map.aliases, [value.trim().toLowerCase()]: intoId } };
+    await this.save(caseId, next);
+    return next;
+  }
+
+  // Un-merge: stop auto-routing this value onto its former canonical IOC.
+  async remove(caseId: string, value: string): Promise<IocAliasMap> {
+    const map = await this.load(caseId);
+    const aliases = { ...map.aliases };
+    delete aliases[value.trim().toLowerCase()];
+    const next = { aliases };
+    await this.save(caseId, next);
+    return next;
+  }
+}

--- a/companion/src/analysis/iocMerge.ts
+++ b/companion/src/analysis/iocMerge.ts
@@ -1,0 +1,58 @@
+import type { InvestigationState, IOC } from "./stateTypes.js";
+
+// Entity merging for duplicate IOCs (#82): folds a near-duplicate IOC (a value the automatic
+// case-insensitive exact-match dedup in stateMerge.ts didn't catch, e.g. "evil.com" vs
+// "www.evil.com") onto a canonical one. Unlike the asset graph (purely derived on every read),
+// IOCs live directly in InvestigationState, so this is a real, one-time edit — every consumer
+// (report, CSV, exports, dashboard) sees the merged result without extra plumbing. Reversibility
+// comes from the caller pushing an import-undo checkpoint before applying it (see server.ts's
+// pushImportCheckpoint); going-forward prevention comes from iocAlias.ts + stateMerge.ts.
+
+function uniq<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+export interface IocMergeResult {
+  state: InvestigationState;
+  from: IOC;
+  into: IOC;
+}
+
+// Fold `fromId` onto `intoId`: unions extractedFrom/enrichments/enrichedBy onto the canonical
+// IOC, records the duplicate's value as an alias (so value-keyed lookups like assetGraph's
+// byValue still resolve it), rewrites every finding's relatedIocs reference, and drops the
+// duplicate row. Pure — returns a new state, throws on a missing id or self-merge.
+export function mergeIocs(state: InvestigationState, fromId: string, intoId: string): IocMergeResult {
+  if (fromId === intoId) throw new Error("cannot merge an IOC into itself");
+  const from = state.iocs.find((i) => i.id === fromId);
+  const into = state.iocs.find((i) => i.id === intoId);
+  if (!from) throw new Error(`IOC not found: ${fromId}`);
+  if (!into) throw new Error(`IOC not found: ${intoId}`);
+
+  const extractedFrom = uniq([...(into.extractedFrom ?? []), ...(from.extractedFrom ?? [])]);
+  const enrichments = [...(into.enrichments ?? []), ...(from.enrichments ?? [])];
+  const enrichedBy = uniq([...(into.enrichedBy ?? []), ...(from.enrichedBy ?? [])]);
+  const aliasValues = uniq([...(into.aliasValues ?? []), from.value, ...(from.aliasValues ?? [])]);
+
+  const merged: IOC = {
+    ...into,
+    ...(extractedFrom.length ? { extractedFrom } : {}),
+    ...(enrichments.length ? { enrichments } : {}),
+    ...(enrichedBy.length ? { enrichedBy } : {}),
+    aliasValues,
+    firstSeen: from.firstSeen < into.firstSeen ? from.firstSeen : into.firstSeen,
+  };
+
+  const iocs = state.iocs.filter((i) => i.id !== fromId).map((i) => (i.id === intoId ? merged : i));
+  const findings = state.findings.map((f) =>
+    f.relatedIocs.includes(fromId)
+      ? { ...f, relatedIocs: uniq(f.relatedIocs.map((id) => (id === fromId ? intoId : id))) }
+      : f,
+  );
+
+  return {
+    state: { ...state, iocs, findings, updatedAt: new Date().toISOString() },
+    from,
+    into: merged,
+  };
+}

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -19,7 +19,8 @@ import { loadMitigationsDataset } from "./attackMitigationsData.js";
 import { buildD3fendResult } from "./d3fendMap.js";
 import { loadD3fendDataset, d3fendEnvOptions } from "./d3fendData.js";
 import { buildStateSummary } from "./summary.js";
-import { mergeDelta } from "./stateMerge.js";
+import { mergeDelta, type WindowContext } from "./stateMerge.js";
+import type { IocAliasStore } from "./iocAlias.js";
 import type { StateLock } from "./stateLock.js";
 import { sortByEventTime } from "./forensicSort.js";
 import { applySeverityFloor } from "./severityFloor.js";
@@ -1379,6 +1380,10 @@ export interface PipelineOptions {
   // Per-source trust overrides (issue #66): steers cross-source merge description choice + caps confidence
   // for low-trust-only findings. Absent → built-in DEFAULT_SOURCE_TRUST only (no per-case override).
   sourceTrustStore?: SourceTrustStore;
+  // Analyst IOC merges (#82): duplicate value -> canonical IOC id. When set, every mergeDelta call
+  // resolves it first, so a later import/synthesis re-extracting the merged-away duplicate routes
+  // onto the canonical IOC instead of recreating it. Absent → no alias resolution (pre-#82 behavior).
+  iocAliasStore?: IocAliasStore;
   // Optional investigation time-window — events outside it are excluded.
   scopeStore?: ScopeStore;
   // Per-case anonymization control. When a case has it enabled, the userPrompt is tokenized
@@ -1480,6 +1485,19 @@ export class AnalysisPipeline {
 
   constructor(private readonly opts: PipelineOptions) {
     this.log = opts.logger ?? createConsoleLogger(normalizeLogLevel(process.env.DFIR_LOG_LEVEL));
+  }
+
+  // Wraps mergeDelta with the case's analyst IOC-merge aliases (#82), if any store is configured.
+  // Every import/synthesis call site uses this instead of calling mergeDelta directly, so a merged
+  // duplicate value stays folded onto its canonical IOC across every future window/re-synthesis.
+  private async mergeWithAliases(
+    state: InvestigationState,
+    delta: Parameters<typeof mergeDelta>[1],
+    ctx: WindowContext,
+  ): Promise<InvestigationState> {
+    if (!this.opts.iocAliasStore) return mergeDelta(state, delta, ctx);
+    const { aliases } = await this.opts.iocAliasStore.load(state.caseId);
+    return mergeDelta(state, delta, { ...ctx, iocAliases: aliases });
   }
 
   // Serializes the load->merge->save critical section of every import/analyze method per
@@ -1701,7 +1719,7 @@ export class AnalysisPipeline {
       // captured tab titles (e.g. "Velociraptor", "CrowdStrike Falcon"), else generic "screenshot".
       const winSource = detectTool(analyzable.map((c) => c.tabTitle).join(" ")) ?? "screenshot";
       const tagged = { ...delta, forensicEvents: (delta.forensicEvents ?? []).map((e) => ({ ...e, sources: e.sources?.length ? e.sources : [winSource] })) };
-      const next = mergeDelta(state, tagged, {
+      const next = await this.mergeWithAliases(state, tagged, {
         windowSequence,
         timestamp: analyzable[analyzable.length - 1].timestamp,
         sourceScreenshots: analyzable.map((c) => c.screenshotFile),
@@ -1769,7 +1787,7 @@ export class AnalysisPipeline {
           forensicEvents: applySeverityFloor(delta.forensicEvents ?? [], opts.minSeverity).map((e) => ({ ...e, id: `${opts.idPrefix}e${++evSeq}`, sources: e.sources?.length ? e.sources : [detectTool(opts.label) ?? "CSV import"] })),
         };
 
-        state = mergeDelta(state, renumbered, {
+        state = await this.mergeWithAliases(state, renumbered, {
           windowSequence: -(b + 1), // negative: distinguishes import batches from capture windows
           timestamp: opts.importedAt,
           sourceScreenshots: [opts.label], // evidence traceability: the CSV file
@@ -1857,7 +1875,7 @@ export class AnalysisPipeline {
           forensicEvents: applySeverityFloor(delta.forensicEvents ?? [], opts.minSeverity).map((e) => ({ ...e, id: `${opts.idPrefix}e${++evSeq}`, sources: e.sources?.length ? e.sources : [detectTool(opts.label) ?? "Log import"] })),
         };
 
-        state = mergeDelta(state, renumbered, {
+        state = await this.mergeWithAliases(state, renumbered, {
           windowSequence: -(b + 1),
           timestamp: opts.importedAt,
           sourceScreenshots: [opts.label],
@@ -1908,7 +1926,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -1968,7 +1986,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2019,7 +2037,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2068,7 +2086,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2117,7 +2135,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, { windowSequence: -1, timestamp: opts.importedAt, sourceScreenshots: [opts.label] });
+      state = await this.mergeWithAliases(state, delta, { windowSequence: -1, timestamp: opts.importedAt, sourceScreenshots: [opts.label] });
       await this.opts.stateStore.save(state);
       this.opts.onState?.(state);
       opts.onProgress?.(1, 1);
@@ -2143,7 +2161,7 @@ export class AnalysisPipeline {
         timelineNote: opts.note ?? `Promoted ${events.length} event(s) from the super-timeline`, summary: "",
         forensicEvents: events.map((e) => ({ ...e })),
       });
-      state = mergeDelta(state, delta, { windowSequence: -1, timestamp: opts.importedAt, sourceScreenshots: [] });
+      state = await this.mergeWithAliases(state, delta, { windowSequence: -1, timestamp: opts.importedAt, sourceScreenshots: [] });
       // Stamp provenance markers on the promoted rows (second-look #11) — mergeDelta carries no
       // provenance through the delta schema, so apply them here by id (union with any existing). Lets the
       // forensic timeline show WHY a raw row was pulled up ("[second-look: h2]").
@@ -2205,7 +2223,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2255,7 +2273,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2327,7 +2345,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2378,7 +2396,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2434,7 +2452,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2482,7 +2500,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2530,7 +2548,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2580,7 +2598,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2629,7 +2647,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2690,7 +2708,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2738,7 +2756,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2797,7 +2815,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2846,7 +2864,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2899,7 +2917,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2949,7 +2967,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -2998,7 +3016,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3047,7 +3065,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3097,7 +3115,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3146,7 +3164,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3236,7 +3254,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3287,7 +3305,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3338,7 +3356,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3390,7 +3408,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3440,7 +3458,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3490,7 +3508,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3545,7 +3563,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3595,7 +3613,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3644,7 +3662,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -3694,7 +3712,7 @@ export class AnalysisPipeline {
 
     return this.withStateLock(caseId, async () => {
       let state = await this.opts.stateStore.load(caseId);
-      state = mergeDelta(state, delta, {
+      state = await this.mergeWithAliases(state, delta, {
         windowSequence: -1,
         timestamp: opts.importedAt,
         sourceScreenshots: [opts.label],
@@ -4773,7 +4791,7 @@ export class AnalysisPipeline {
     // and merged (deduped by value); scope/legitimate still filter them at projection.
     // Threads and the forensic timeline are also preserved.
     const base = { ...state, findings: [], mitreTechniques: [] };
-    const merged = mergeDelta(base, delta, { windowSequence: 0, timestamp: ts, sourceScreenshots: [] });
+    const merged = await this.mergeWithAliases(base, delta, { windowSequence: 0, timestamp: ts, sourceScreenshots: [] });
     // Safety net: drop anything confirmed false-positive even if the model re-introduced it.
     const filtered = applyFalsePositive(merged, markers);
 

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -29,6 +29,10 @@ export interface WindowContext {
   windowSequence: number;
   timestamp: string;
   sourceScreenshots: string[];
+  // Analyst IOC merges (#82): duplicate value (lowercased) -> canonical IOC id it was folded
+  // into. Consulted before the exact-value dedup below so a later window re-extracting the same
+  // near-duplicate routes straight onto the canonical IOC instead of recreating the duplicate.
+  iocAliases?: Record<string, string>;
 }
 
 function uniq(values: string[]): string[] {
@@ -72,14 +76,23 @@ export function mergeDelta(
     // comparison let those through as separate rows instead of collapsing into one (matches
     // applyDeobfuscation.ts's dedup, which was already case-insensitive).
     const incomingLower = incoming.value.toLowerCase();
-    const dup = iocs.find((i) => i.value.toLowerCase() === incomingLower);
-    const canonical = dup ? dup.id : padIocId(nextSeq++);
+    // An analyst-recorded alias (#82) takes precedence: a near-duplicate value that doesn't
+    // exact-match anything currently in state.iocs (the merge already dropped the duplicate row)
+    // still routes onto the canonical IOC it was merged into, rather than recreating it.
+    const aliasTarget = ctx.iocAliases?.[incomingLower];
+    const dup = iocs.find((i) => i.value.toLowerCase() === incomingLower || (aliasTarget !== undefined && i.id === aliasTarget));
+    const canonical = dup ? dup.id : (aliasTarget ?? padIocId(nextSeq++));
     if (dup) {
       // Union (not overwrite): the same value can legitimately be extracted from
       // different source events across separate import runs — preserve every link.
       if (incoming.extractedFrom?.length) {
         const existingRefs = dup.extractedFrom ?? [];
         dup.extractedFrom = uniq([...existingRefs, ...incoming.extractedFrom]);
+      }
+      // Routed here via an alias, not an exact-value match: record the incoming value too, so
+      // value-keyed lookups (assetGraph's byValue) resolve it without a second manual merge.
+      if (dup.value.toLowerCase() !== incomingLower && !(dup.aliasValues ?? []).some((a) => a.toLowerCase() === incomingLower)) {
+        dup.aliasValues = [...(dup.aliasValues ?? []), incoming.value];
       }
     } else {
       iocs.push({

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -34,6 +34,10 @@ export interface IOC {
   // priority importers via pipeline.ts). Absent/empty ⇒ iocProvenanceChain.ts falls back to
   // matching by value, same as before this field existed.
   extractedFrom?: string[];
+  // Near-duplicate values folded onto this IOC by an analyst merge (#82, iocMerge.ts) — e.g.
+  // "evil.com" merged into "www.evil.com". Kept so value-keyed lookups (assetGraph's byValue,
+  // event sha256/md5/path matching) still resolve the old value onto this canonical IOC.
+  aliasValues?: string[];
 }
 
 // Deterministic corroboration rollup for a finding (investigation-guidance #6), computed post-synthesis

--- a/companion/src/routes/analysisGraph.ts
+++ b/companion/src/routes/analysisGraph.ts
@@ -1,5 +1,6 @@
 import type { Express, Request, Response } from "express";
 import type { AssetType } from "../analysis/assetGraph.js";
+import { mergeIocs } from "../analysis/iocMerge.js";
 import type { RouteContext } from "./context.js";
 
 /**
@@ -26,8 +27,15 @@ import type { RouteContext } from "./context.js";
  *   - POST   /cases/:id/asset-overrides/assets                     — create a manual asset.
  *   - DELETE /cases/:id/asset-overrides/assets/:assetId            — suppress / delete an asset.
  *   - POST   /cases/:id/asset-overrides/assets/:assetId/restore    — restore a suppressed asset.
+ *   - POST   /cases/:id/asset-overrides/assets/:assetId/merge      — merge a duplicate asset (#82).
+ *   - POST   /cases/:id/asset-overrides/assets/:assetId/unmerge    — un-merge a duplicate asset.
  *   - POST   /cases/:id/asset-overrides/links                      — add a manual asset↔IoC link.
  *   - DELETE /cases/:id/asset-overrides/links                      — suppress / delete a link.
+ *
+ *   IOC merging (options.stateStore + options.iocAliasStore, #82 — a REAL edit to InvestigationState,
+ *   not an overlay, since IOCs are read directly by many consumers; see iocMerge.ts's header):
+ *   - POST   /cases/:id/ioc-overrides/merge   — fold a duplicate IOC onto a canonical one.
+ *   - DELETE /cases/:id/ioc-overrides/merge   — stop auto-routing a merged-away value (?value=...).
  *
  *   Saved timeframes / dwell-windows (options.dwellWindowStore, analyst-defined presence ranges):
  *   - GET    /cases/:id/dwell-windows                — list saved timeframes.
@@ -247,6 +255,33 @@ export function registerAnalysisGraphRoutes(app: Express, ctx: RouteContext): vo
     }
   });
 
+  // Merge a duplicate asset onto a canonical one (#82). Body: { into }. Folds the duplicate's
+  // IOC/finding/event links onto the canonical node on the next graph build.
+  app.post("/cases/:id/asset-overrides/assets/:assetId/merge", async (req: Request, res: Response) => {
+    if (!options.assetOverridesStore) return res.status(501).json({ error: "asset overrides not configured" });
+    const into = typeof req.body?.into === "string" ? req.body.into.trim() : "";
+    if (!into) return res.status(400).json({ error: "into is required" });
+    try {
+      const ov = await options.assetOverridesStore.mergeAsset(req.params.id, req.params.assetId, into);
+      options.onAssetOverrides?.(req.params.id);
+      return res.status(200).json(ov);
+    } catch (err) {
+      return res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  // Un-merge a duplicate asset (remove it from the merge map).
+  app.post("/cases/:id/asset-overrides/assets/:assetId/unmerge", async (req: Request, res: Response) => {
+    if (!options.assetOverridesStore) return res.status(501).json({ error: "asset overrides not configured" });
+    try {
+      const ov = await options.assetOverridesStore.unmergeAsset(req.params.id, req.params.assetId);
+      options.onAssetOverrides?.(req.params.id);
+      return res.status(200).json(ov);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
   // Add a manual link between an asset and an IoC. Body: { asset, ioc }.
   app.post("/cases/:id/asset-overrides/links", async (req: Request, res: Response) => {
     if (!options.assetOverridesStore) return res.status(501).json({ error: "asset overrides not configured" });
@@ -272,6 +307,50 @@ export function registerAnalysisGraphRoutes(app: Express, ctx: RouteContext): vo
       const ov = await options.assetOverridesStore.removeLink(req.params.id, asset, ioc);
       options.onAssetOverrides?.(req.params.id);
       return res.status(200).json(ov);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Merge a duplicate IOC onto a canonical one (#82). Body: { from, into }. Unlike the asset
+  // overrides above, this is a REAL edit to InvestigationState (IOCs are read directly by many
+  // consumers, not just the graph) — reversible via the existing import-undo checkpoint, and the
+  // merge is recorded as an alias so a future re-synthesis re-extracting the same near-duplicate
+  // value routes onto the canonical IOC instead of recreating it (see iocMerge.ts, iocAlias.ts).
+  app.post("/cases/:id/ioc-overrides/merge", async (req: Request, res: Response) => {
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    const caseId = req.params.id;
+    const from = typeof req.body?.from === "string" ? req.body.from.trim() : "";
+    const into = typeof req.body?.into === "string" ? req.body.into.trim() : "";
+    if (!from || !into) return res.status(400).json({ error: "from and into are required" });
+    try {
+      const stateStore = options.stateStore;
+      let result: Awaited<ReturnType<typeof mergeIocs>> | undefined;
+      await ctx.runStateExclusive(caseId, async () => {
+        const state = await stateStore.load(caseId);
+        result = mergeIocs(state, from, into);
+        await ctx.pushImportCheckpoint(caseId, state, `merge IOC ${result.from.value} -> ${result.into.value}`);
+        await stateStore.save(result.state);
+        options.onState?.(result.state);
+      });
+      if (options.iocAliasStore && result) await options.iocAliasStore.add(caseId, result.from.value, result.into.id);
+      options.onIocMerge?.(caseId);
+      return res.status(200).json({ from: result!.from, into: result!.into });
+    } catch (err) {
+      return res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  // Stop auto-routing a merged-away value onto its former canonical IOC (#82). The historical
+  // fold itself is only reversible via the import-undo "Undo" button. Query param: ?value=...
+  app.delete("/cases/:id/ioc-overrides/merge", async (req: Request, res: Response) => {
+    if (!options.iocAliasStore) return res.status(501).json({ error: "IOC alias store not configured" });
+    const value = typeof req.query?.value === "string" ? req.query.value : "";
+    if (!value) return res.status(400).json({ error: "value query param is required" });
+    try {
+      const map = await options.iocAliasStore.remove(req.params.id, value);
+      options.onIocMerge?.(req.params.id);
+      return res.status(200).json(map);
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -118,6 +118,7 @@ import { HuntOutcomeStore } from "./analysis/huntOutcomeStore.js";
 import { recordDeploy, fillOutcome, HUNT_OUTCOME_MAX_DEFAULT, type HuntDeployInput } from "./analysis/huntOutcomes.js";
 import { PlaybookControlStore, DEFAULT_PLAYBOOK_CONTROL, type PlaybookControl } from "./analysis/playbookControl.js";
 import { AssetOverridesStore } from "./analysis/assetOverrides.js";
+import { IocAliasStore } from "./analysis/iocAlias.js";
 import { SynthMetaStore } from "./analysis/synthMeta.js";
 import { AiCostStore } from "./analysis/aiCost.js";
 import { SecondOpinionStore } from "./analysis/secondOpinionStore.js";
@@ -331,6 +332,12 @@ export interface AppOptions {
   // pings dashboard clients over the WS to re-fetch the graph when overrides change.
   assetOverridesStore?: AssetOverridesStore;
   onAssetOverrides?: (caseId: string) => void;
+  // Entity merging for duplicate IOCs (#82). iocAliasStore persists per-case merge aliases (state/
+  // ioc-aliases.json) so a future re-synthesis routes the merged-away value onto its canonical IOC
+  // instead of recreating it (see pipeline.ts's mergeWithAliases). onIocMerge pings dashboard
+  // clients over the WS to re-fetch when a merge/unmerge happens.
+  iocAliasStore?: IocAliasStore;
+  onIocMerge?: (caseId: string) => void;
   // Confirmed false-positive markers. onFalsePositive pings dashboard
   // clients over the WS so other investigators see the change immediately, before synthesis.
   onFalsePositive?: (caseId: string) => void;
@@ -2783,6 +2790,7 @@ export function buildRuntimePipeline(params: RuntimePipelineParams): AnalysisPip
     ocrRunner: params.ocrRunner,
     logger: params.logger,
     kevStore: params.kevStore,
+    iocAliasStore: new IocAliasStore(params.store),  // #82: keep analyst IOC merges applied across re-synthesis
   });
 }
 
@@ -2927,6 +2935,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const playbookHuntStore = new PlaybookHuntStore(store);
   const playbookControlStore = new PlaybookControlStore(store);
   const assetOverridesStore = new AssetOverridesStore(store);
+  const iocAliasStore = new IocAliasStore(store);   // #82: analyst IOC merges (survive re-synthesis)
   const synthMetaStore = new SynthMetaStore(store);
   const aiCostStore = new AiCostStore(store);
   const correlationProfileStore = new CorrelationProfileStore(store);
@@ -3063,6 +3072,8 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     onPlaybook: (caseId) => hub.broadcastTo(caseId, { type: "playbook_changed" }),
     assetOverridesStore,
     onAssetOverrides: (caseId) => hub.broadcastTo(caseId, { type: "asset_overrides_changed" }),
+    iocAliasStore,
+    onIocMerge: (caseId) => hub.broadcastTo(caseId, { type: "ioc_merge_changed" }),
     onFalsePositive: (caseId) => hub.broadcastTo(caseId, { type: "false_positive_changed" }),
     onScope: (caseId, scope) => hub.broadcastTo(caseId, { type: "scope_changed", ...scope }),
     synthMetaStore,

--- a/companion/tests/analysis/assetOverrides.test.ts
+++ b/companion/tests/analysis/assetOverrides.test.ts
@@ -134,6 +134,60 @@ describe("applyAssetOverrides", () => {
     expect(node?.name).not.toBe("OVERRIDE");
   });
 
+  it("merges a duplicate asset onto its canonical node, folding IOC/finding/event links", () => {
+    const g = baseGraph();
+    const win01 = g.assets.find((a) => a.name === "WIN-01")!;
+    const win02 = g.assets.find((a) => a.name === "WIN-02")!;
+    const result = applyAssetOverrides(g, { ...emptyOverrides(), merges: { [win01.id]: win02.id } });
+    // Duplicate node is gone
+    expect(result.assets.some((a) => a.id === win01.id)).toBe(false);
+    // Canonical node now carries the duplicate's IOC link (i1, via sha256) plus its own (i2)
+    const canonical = result.assets.find((a) => a.id === win02.id)!;
+    expect(canonical.iocIds.sort()).toEqual(["i1", "i2"]);
+    // Canonical severity is the worse of the two (Critical from WIN-01's malware finding)
+    expect(canonical.maxSeverity).toBe("Critical");
+    // Edges reflect the redirect: i1 is now linked to win02.id, not win01.id
+    expect(result.edges.some((e) => e.asset === win01.id)).toBe(false);
+    expect(result.edges.some((e) => e.asset === win02.id && e.ioc === "i1")).toBe(true);
+  });
+
+  it("resolves a merge chain (A -> B -> C) to the final canonical node", () => {
+    const g = baseGraph();
+    const win01 = g.assets.find((a) => a.name === "WIN-01")!;
+    const win02 = g.assets.find((a) => a.name === "WIN-02")!;
+    const result = applyAssetOverrides(g, {
+      ...emptyOverrides(),
+      added: [{ id: "manual:c", name: "FINAL", type: "host" }],
+      merges: { [win01.id]: win02.id, [win02.id]: "manual:c" },
+    });
+    expect(result.assets.some((a) => a.id === win01.id)).toBe(false);
+    expect(result.assets.some((a) => a.id === win02.id)).toBe(false);
+    const final = result.assets.find((a) => a.id === "manual:c")!;
+    expect(final.iocIds.sort()).toEqual(["i1", "i2"]);
+  });
+
+  it("ignores a merge that would create a cycle instead of hanging", () => {
+    const g = baseGraph();
+    const win01 = g.assets.find((a) => a.name === "WIN-01")!;
+    const win02 = g.assets.find((a) => a.name === "WIN-02")!;
+    // A -> B -> A: resolveCanonical must bail out rather than loop forever.
+    const result = applyAssetOverrides(g, {
+      ...emptyOverrides(),
+      merges: { [win01.id]: win02.id, [win02.id]: win01.id },
+    });
+    expect(result.assets.length).toBeGreaterThan(0); // did not hang / throw
+  });
+
+  it("un-merging (removing the entry) restores the duplicate as its own node", () => {
+    const g = baseGraph();
+    const win01 = g.assets.find((a) => a.name === "WIN-01")!;
+    const win02 = g.assets.find((a) => a.name === "WIN-02")!;
+    const merged = applyAssetOverrides(g, { ...emptyOverrides(), merges: { [win01.id]: win02.id } });
+    expect(merged.assets.some((a) => a.id === win01.id)).toBe(false);
+    const restored = applyAssetOverrides(g, emptyOverrides());
+    expect(restored.assets.some((a) => a.id === win01.id)).toBe(true);
+  });
+
   it("combined: rename + add manual asset + suppress link", () => {
     const g = baseGraph();
     const win01 = g.assets.find((a) => a.name === "WIN-01")!;
@@ -142,6 +196,7 @@ describe("applyAssetOverrides", () => {
       renames: { [win01.id]: "CORP-WS-01" },
       added: [{ id: "manual:pivot", name: "JUMP-SERVER", type: "host" }],
       removed: [],
+      merges: {},
       addedLinks: [],
       removedLinks: [{ asset: win02.id, ioc: "i2" }],
     });

--- a/companion/tests/analysis/iocMerge.test.ts
+++ b/companion/tests/analysis/iocMerge.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { mergeIocs } from "../../src/analysis/iocMerge.js";
+import { buildAssetGraph } from "../../src/analysis/assetGraph.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+
+function baseState() {
+  const s = emptyState("c1");
+  s.iocs.push(
+    { id: "i1", type: "domain", value: "evil.com", firstSeen: "2026-01-02T00:00:00Z", extractedFrom: ["e1"] },
+    { id: "i2", type: "domain", value: "www.evil.com", firstSeen: "2026-01-01T00:00:00Z", extractedFrom: ["e2"],
+      enrichments: [{ source: "VirusTotal", verdict: "malicious", fetchedAt: "2026-01-01T00:00:00Z" }],
+      enrichedBy: ["VirusTotal"] },
+  );
+  s.findings.push({
+    id: "f1", severity: "High", title: "C2 beacon", description: "beacon to evil.com",
+    relatedIocs: ["i1"], mitreTechniques: [], sourceScreenshots: [], firstSeen: "", lastUpdated: "", status: "open",
+  });
+  s.forensicTimeline.push(
+    { id: "e1", timestamp: "2026-01-01T00:00:00Z", description: "connection to evil.com", severity: "High",
+      mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], asset: "WIN-01" },
+  );
+  return s;
+}
+
+describe("mergeIocs", () => {
+  it("throws on self-merge or a missing id", () => {
+    const s = baseState();
+    expect(() => mergeIocs(s, "i1", "i1")).toThrow(/itself/);
+    expect(() => mergeIocs(s, "i1", "nope")).toThrow(/not found/);
+    expect(() => mergeIocs(s, "nope", "i1")).toThrow(/not found/);
+  });
+
+  it("folds the duplicate's data onto the canonical IOC and drops the duplicate row", () => {
+    const s = baseState();
+    const { state, into } = mergeIocs(s, "i1", "i2");
+    expect(state.iocs.map((i) => i.id)).toEqual(["i2"]);
+    expect(into.aliasValues).toContain("evil.com");
+    expect(into.extractedFrom?.sort()).toEqual(["e1", "e2"]);
+    expect(into.enrichments?.length).toBe(1); // union preserved from the canonical side
+    // Earlier firstSeen wins
+    expect(into.firstSeen).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("rewrites finding.relatedIocs from the duplicate id to the canonical id", () => {
+    const s = baseState();
+    const { state } = mergeIocs(s, "i1", "i2");
+    expect(state.findings[0].relatedIocs).toEqual(["i2"]);
+  });
+
+  it("keeps the merged IOC's alias value discoverable in the asset graph", () => {
+    const s = baseState();
+    const { state } = mergeIocs(s, "i1", "i2");
+    const graph = buildAssetGraph(state);
+    // e1's description mentions "evil.com" (the pre-merge duplicate value) — it should still
+    // resolve onto the canonical IOC i2 via the alias, linking WIN-01 to i2.
+    const win01 = graph.assets.find((a) => a.name === "WIN-01");
+    expect(win01?.iocIds).toContain("i2");
+  });
+});

--- a/companion/tests/analysis/stateMerge.test.ts
+++ b/companion/tests/analysis/stateMerge.test.ts
@@ -131,6 +131,24 @@ describe("mergeDelta", () => {
     expect(state.iocs[0].value).toBe("DESKTOP-MNNUHHU.localdomain"); // first-seen casing wins
   });
 
+  it("routes an incoming IOC value onto its analyst-merged canonical id (#82) instead of recreating the duplicate", () => {
+    let state = emptyState("c1");
+    // Simulate a prior merge: only the canonical IOC exists; "evil.com" was folded into it.
+    state.iocs.push({ id: "i002", type: "domain", value: "www.evil.com", firstSeen: "2026-05-28T10:00:00.000Z", aliasValues: ["evil.com"] });
+    state = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [{ id: "i1", type: "domain", value: "evil.com" }],
+      findings: [{ id: "f1", severity: "High", title: "C2", description: "beacon",
+        relatedIocs: ["i1"], mitreTechniques: [], status: "open" }],
+    }, {
+      windowSequence: 2, timestamp: "2026-05-28T10:05:00.000Z", sourceScreenshots: [],
+      iocAliases: { "evil.com": "i002" },
+    });
+    expect(state.iocs).toHaveLength(1); // no duplicate "evil.com" row created
+    expect(state.iocs[0].id).toBe("i002");
+    expect(state.findings[0].relatedIocs).toEqual(["i002"]); // remapped onto the canonical id
+  });
+
   it("drops an incoming IOC that matches a per-case exclude rule — never created, so it can't be enriched", () => {
     const state = {
       ...emptyState("c1"),

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1706,6 +1706,18 @@
       </div>
     </div>
   </div>
+  <div id="mergeOverlay" class="comment-overlay">
+    <div class="comment-modal">
+      <h3 id="mergeTitle">Merge duplicate</h3>
+      <input id="mergeSearch" type="text" placeholder="Filter…" style="width:100%; box-sizing:border-box; margin:6px 0; padding:5px; background:var(--c-0f1115); color:var(--c-e6e6e6); border:1px solid var(--c-2a2f3a); border-radius:6px;" />
+      <div id="mergeCandidates" style="max-height:260px; overflow-y:auto; display:flex; flex-direction:column; gap:2px; margin-top:4px;"></div>
+      <div style="margin-top:8px; display:flex; gap:8px; align-items:center;">
+        <button id="mergeConfirmBtn" type="button" disabled>Merge</button>
+        <button id="mergeCancelBtn" type="button" style="background:var(--c-2a2f3a);">Cancel</button>
+        <span id="mergeMsg" style="color:var(--c-9aa4b2); font-size:12px;"></span>
+      </div>
+    </div>
+  </div>
   <div id="importSevOverlay" class="comment-overlay">
     <div class="comment-modal">
       <h3>Minimum severity to import</h3>
@@ -4947,7 +4959,7 @@
         a.compromised && (a.type === "host" || a.type === "account") && assetTypesEnabled.has(a.type));
       const editBtns = (a) =>
         `<button class="asset-rename-btn" data-assetid="${escAttr(a.id)}" data-name="${escAttr(a.name)}" title="Rename asset" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">✏</button>`
-        + `<button class="asset-merge-btn" data-assetid="${escAttr(a.id)}" data-name="${escAttr(a.name)}" title="Merge into another asset (duplicate entity)" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">⇄</button>`
+        + `<button class="asset-merge-btn" data-assetid="${escAttr(a.id)}" data-name="${escAttr(a.name)}" data-assettype="${escAttr(a.type)}" title="Merge into another asset (duplicate entity)" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">⇄</button>`
         + `<button class="asset-del-btn" data-assetid="${escAttr(a.id)}" title="Suppress asset from graph" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">×</button>`;
       const chip = (a) => `<span class="asset-chip" style="padding-right:2px">${esc(a.name)}${editBtns(a)}</span>`;
       const group = (label, assets) => assets.length
@@ -12805,13 +12817,15 @@
       if (iocMerge) {
         const id = iocMerge.dataset.iocid;
         const cur = iocMerge.dataset.value;
-        const into = prompt(`Merge IOC "${cur}" into which IOC id? (duplicate indicator — folds its enrichments/links onto the target, and future imports re-extracting "${cur}" will route onto it too)`, "");
-        if (!into || !into.trim()) return;
-        fetch(`/cases/${caseId}/ioc-overrides/merge`, {
-          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ from: id, into: into.trim() }),
-        }).then(r => r.ok ? null : r.json().then(err => Promise.reject(err.error)))
-          .then(() => { if (lastState) renderIocs(lastState.iocs || []); })
-          .catch(err => alert("Merge failed: " + err));
+        const type = iocMerge.dataset.ioctype;
+        const candidates = dedupeIocsById(_lastRenderedIocs || [])
+          .filter(i => i.id !== id && i.type === type)
+          .map(i => ({ id: i.id, label: i.value }));
+        openMergeModal(`Merge IOC "${cur}" into which ${type}?`, candidates, (into) =>
+          fetch(`/cases/${caseId}/ioc-overrides/merge`, {
+            method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ from: id, into }),
+          }).then(r => r.ok ? null : r.json().then(err => Promise.reject(err.error)))
+            .then(() => { if (lastState) renderIocs(lastState.iocs || []); }));
         return;
       }
       const un = e.target.closest(".unfp-btn");
@@ -12978,7 +12992,7 @@
           +   `<span class="ioc-value-line"><span class="qa-val" data-vtype="${escAttr(i.type)}" data-val="${escAttr(i.value)}" data-iocid="${escAttr(i.id)}">${valueHtml}</span>${newBadge}${iocRiskBadge(i.id)}${iocCorroBadge(i.id)}${iocProvenanceBadge(i.id)}${enrichHtml}${tagsHtml}</span>`
           + `</span>`
           + `<span class="ioc-actions-cell">${commentChip("ioc", i.id)} ${tagAddBtn("ioc", i.id)} ${huntChip("ioc", i.id)} ${iocChainChip(i.id)} ${fpAction} `
-          +   `<button class="ioc-merge-btn" data-iocid="${escAttr(i.id)}" data-value="${escAttr(i.value)}" title="Merge into another IOC (duplicate indicator)" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">⇄</button>`
+          +   `<button class="ioc-merge-btn" data-iocid="${escAttr(i.id)}" data-value="${escAttr(i.value)}" data-ioctype="${escAttr(i.type)}" title="Merge into another IOC (duplicate indicator)" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">⇄</button>`
           + (i.aliasValues && i.aliasValues.length ? ` <span class="asset-chip" style="opacity:0.7;font-size:10px" title="Values merged onto this IOC">= ${i.aliasValues.map(esc).join(", ")}</span>` : "")
           + `</span>`
           + `</div>`;
@@ -15918,6 +15932,52 @@
     document.getElementById("ceDomainChips").addEventListener("click", e => { const x = e.target.closest(".x"); if (x) ceRemoveTarget(x.dataset.kind, x.dataset.val); });
     document.getElementById("ceEmailChips").addEventListener("click", e => { const x = e.target.closest(".x"); if (x) ceRemoveTarget(x.dataset.kind, x.dataset.val); });
     document.getElementById("ceProviders").addEventListener("change", e => { if (e.target.classList && e.target.classList.contains("ce-prov")) ceAutosaveTargets(); });
+    // ── Generic merge-target picker modal (#82) — used for both asset merge and IOC merge. Shows
+    // a filterable, click-to-select list of same-type candidates instead of asking the analyst to
+    // type an id/value by hand.
+    let mergeTarget = null;   // { candidates: [{id, label}], selectedId, onConfirm(selectedId) }
+    function renderMergeCandidates() {
+      const term = document.getElementById("mergeSearch").value.trim().toLowerCase();
+      const list = mergeTarget.candidates.filter(c => !term || c.label.toLowerCase().includes(term));
+      const el = document.getElementById("mergeCandidates");
+      if (!list.length) { el.innerHTML = "<div style='color:var(--c-9aa4b2);font-size:12px;padding:4px'>No matching candidates.</div>"; return; }
+      el.innerHTML = list.map(c => {
+        const selected = c.id === mergeTarget.selectedId;
+        return `<div class="merge-candidate-row" data-id="${escAttr(c.id)}" style="cursor:pointer;padding:5px 8px;border-radius:6px;border:1px solid ${selected ? "var(--c-6bcb77)" : "var(--c-2a2f3a)"};background:${selected ? "rgba(107,203,119,0.12)" : "transparent"}">${esc(c.label)}</div>`;
+      }).join("");
+    }
+    function openMergeModal(title, candidates, onConfirm) {
+      mergeTarget = { candidates, selectedId: null, onConfirm };
+      document.getElementById("mergeTitle").textContent = title;
+      document.getElementById("mergeSearch").value = "";
+      document.getElementById("mergeMsg").textContent = "";
+      document.getElementById("mergeConfirmBtn").disabled = true;
+      renderMergeCandidates();
+      document.getElementById("mergeOverlay").classList.add("open");
+      document.getElementById("mergeSearch").focus();
+    }
+    function closeMergeModal() {
+      mergeTarget = null;
+      document.getElementById("mergeOverlay").classList.remove("open");
+    }
+    document.getElementById("mergeSearch").addEventListener("input", () => { if (mergeTarget) renderMergeCandidates(); });
+    document.getElementById("mergeCandidates").addEventListener("click", (e) => {
+      const row = e.target.closest(".merge-candidate-row");
+      if (!row || !mergeTarget) return;
+      mergeTarget.selectedId = row.dataset.id;
+      document.getElementById("mergeConfirmBtn").disabled = false;
+      renderMergeCandidates();
+    });
+    document.getElementById("mergeCancelBtn").onclick = closeMergeModal;
+    document.getElementById("mergeConfirmBtn").onclick = () => {
+      if (!mergeTarget || !mergeTarget.selectedId) return;
+      const { selectedId, onConfirm } = mergeTarget;
+      document.getElementById("mergeMsg").textContent = "merging…";
+      Promise.resolve(onConfirm(selectedId))
+        .then(() => closeMergeModal())
+        .catch(err => { document.getElementById("mergeMsg").textContent = "failed: " + err; });
+    };
+
     // ── Asset overrides (rename / add / suppress / link) ───────────────────────────
     document.getElementById("addAssetBtn").onclick = () => {
       const caseId = document.getElementById("caseId").value.trim();
@@ -15980,14 +16040,15 @@
       } else if (mergeBtn) {
         const id = mergeBtn.dataset.assetid;
         const cur = mergeBtn.dataset.name;
-        const others = (assetGraphData?.assets || []).filter(a => a.id !== id).map(a => `${a.name} (${a.id})`).join("\n");
-        const into = prompt(`Merge "${cur}" into which asset id? (duplicate entity — folds its IOCs/findings onto the target)\n\nOther assets:\n${others}`, "");
-        if (!into || !into.trim()) return;
-        fetch(`/cases/${encodeURIComponent(caseId)}/asset-overrides/assets/${encodeURIComponent(id)}/merge`, {
-          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ into: into.trim() }),
-        }).then(r => r.ok ? null : r.json().then(e => Promise.reject(e.error)))
-          .then(() => { loadAssetGraph(caseId); loadAssetOverrides(caseId); })
-          .catch(e => alert("Merge failed: " + e));
+        const type = mergeBtn.dataset.assettype;
+        const candidates = (assetGraphData?.assets || [])
+          .filter(a => a.id !== id && a.type === type)
+          .map(a => ({ id: a.id, label: a.name }));
+        openMergeModal(`Merge "${cur}" into which ${type}?`, candidates, (into) =>
+          fetch(`/cases/${encodeURIComponent(caseId)}/asset-overrides/assets/${encodeURIComponent(id)}/merge`, {
+            method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ into }),
+          }).then(r => r.ok ? null : r.json().then(e => Promise.reject(e.error)))
+            .then(() => { loadAssetGraph(caseId); loadAssetOverrides(caseId); }));
       } else if (unmergeBtn) {
         const id = unmergeBtn.dataset.assetid;
         fetch(`/cases/${encodeURIComponent(caseId)}/asset-overrides/assets/${encodeURIComponent(id)}/unmerge`, { method: "POST" })

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4947,6 +4947,7 @@
         a.compromised && (a.type === "host" || a.type === "account") && assetTypesEnabled.has(a.type));
       const editBtns = (a) =>
         `<button class="asset-rename-btn" data-assetid="${escAttr(a.id)}" data-name="${escAttr(a.name)}" title="Rename asset" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">✏</button>`
+        + `<button class="asset-merge-btn" data-assetid="${escAttr(a.id)}" data-name="${escAttr(a.name)}" title="Merge into another asset (duplicate entity)" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">⇄</button>`
         + `<button class="asset-del-btn" data-assetid="${escAttr(a.id)}" title="Suppress asset from graph" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">×</button>`;
       const chip = (a) => `<span class="asset-chip" style="padding-right:2px">${esc(a.name)}${editBtns(a)}</span>`;
       const group = (label, assets) => assets.length
@@ -4957,6 +4958,14 @@
       // Manual additions (not necessarily compromised — show them so analysts can confirm/remove).
       const manual = (assetGraphData.assets || []).filter(a => a.id.startsWith("manual:"));
       if (manual.length) html += group("Manual additions", manual);
+      // Merged (duplicate) assets (#82) — shown with what they were folded into, click ↺ to unmerge.
+      if (assetOverridesData && Object.keys(assetOverridesData.merges || {}).length) {
+        html += `<div style="margin-top:8px"><div class="asset-subhead" style="margin:0 0 4px">Merged (click ↺ to un-merge)</div>`
+          + Object.entries(assetOverridesData.merges).map(([fromId, intoId]) =>
+            `<span class="asset-chip" style="opacity:0.5">${esc(fromId)} → ${esc(intoId)}`
+            + ` <button class="asset-unmerge-btn" data-assetid="${escAttr(fromId)}" title="Un-merge asset" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">↺</button></span>`
+          ).join(" ") + `</div>`;
+      }
       // Suppressed assets (from overrides) — shown for easy restoration.
       if (assetOverridesData && (assetOverridesData.removed || []).length) {
         html += `<div style="margin-top:8px"><div class="asset-subhead" style="margin:0 0 4px">Suppressed (click ↺ to restore)</div>`
@@ -12792,6 +12801,19 @@
         openFalsePositiveModal(kind, ref, label != null ? label : ref, []);
         return;
       }
+      const iocMerge = e.target.closest(".ioc-merge-btn");
+      if (iocMerge) {
+        const id = iocMerge.dataset.iocid;
+        const cur = iocMerge.dataset.value;
+        const into = prompt(`Merge IOC "${cur}" into which IOC id? (duplicate indicator — folds its enrichments/links onto the target, and future imports re-extracting "${cur}" will route onto it too)`, "");
+        if (!into || !into.trim()) return;
+        fetch(`/cases/${caseId}/ioc-overrides/merge`, {
+          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ from: id, into: into.trim() }),
+        }).then(r => r.ok ? null : r.json().then(err => Promise.reject(err.error)))
+          .then(() => { if (lastState) renderIocs(lastState.iocs || []); })
+          .catch(err => alert("Merge failed: " + err));
+        return;
+      }
       const un = e.target.closest(".unfp-btn");
       if (un) {
         // Parse the marker id (`<kind>:<ref>`) so the reversal can be recorded in the Investigation
@@ -12955,7 +12977,10 @@
           + `<span class="ioc-main-cell">`
           +   `<span class="ioc-value-line"><span class="qa-val" data-vtype="${escAttr(i.type)}" data-val="${escAttr(i.value)}" data-iocid="${escAttr(i.id)}">${valueHtml}</span>${newBadge}${iocRiskBadge(i.id)}${iocCorroBadge(i.id)}${iocProvenanceBadge(i.id)}${enrichHtml}${tagsHtml}</span>`
           + `</span>`
-          + `<span class="ioc-actions-cell">${commentChip("ioc", i.id)} ${tagAddBtn("ioc", i.id)} ${huntChip("ioc", i.id)} ${iocChainChip(i.id)} ${fpAction}</span>`
+          + `<span class="ioc-actions-cell">${commentChip("ioc", i.id)} ${tagAddBtn("ioc", i.id)} ${huntChip("ioc", i.id)} ${iocChainChip(i.id)} ${fpAction} `
+          +   `<button class="ioc-merge-btn" data-iocid="${escAttr(i.id)}" data-value="${escAttr(i.value)}" title="Merge into another IOC (duplicate indicator)" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">⇄</button>`
+          + (i.aliasValues && i.aliasValues.length ? ` <span class="asset-chip" style="opacity:0.7;font-size:10px" title="Values merged onto this IOC">= ${i.aliasValues.map(esc).join(", ")}</span>` : "")
+          + `</span>`
           + `</div>`;
       }).join("");
       el.innerHTML = headerRow + iocPaginationBar + rows;
@@ -15940,6 +15965,8 @@
       const caseId = document.getElementById("caseId").value.trim();
       if (!caseId) return;
       const renameBtn = e.target.closest(".asset-rename-btn");
+      const mergeBtn = e.target.closest(".asset-merge-btn");
+      const unmergeBtn = e.target.closest(".asset-unmerge-btn");
       const delBtn = e.target.closest(".asset-del-btn");
       const restoreBtn = e.target.closest(".asset-restore-btn");
       if (renameBtn) {
@@ -15950,6 +15977,21 @@
         fetch(`/cases/${encodeURIComponent(caseId)}/asset-overrides/assets/${encodeURIComponent(id)}`, {
           method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: newName }),
         }).then(() => { loadAssetGraph(caseId); loadAssetOverrides(caseId); }).catch(() => {});
+      } else if (mergeBtn) {
+        const id = mergeBtn.dataset.assetid;
+        const cur = mergeBtn.dataset.name;
+        const others = (assetGraphData?.assets || []).filter(a => a.id !== id).map(a => `${a.name} (${a.id})`).join("\n");
+        const into = prompt(`Merge "${cur}" into which asset id? (duplicate entity — folds its IOCs/findings onto the target)\n\nOther assets:\n${others}`, "");
+        if (!into || !into.trim()) return;
+        fetch(`/cases/${encodeURIComponent(caseId)}/asset-overrides/assets/${encodeURIComponent(id)}/merge`, {
+          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ into: into.trim() }),
+        }).then(r => r.ok ? null : r.json().then(e => Promise.reject(e.error)))
+          .then(() => { loadAssetGraph(caseId); loadAssetOverrides(caseId); })
+          .catch(e => alert("Merge failed: " + e));
+      } else if (unmergeBtn) {
+        const id = unmergeBtn.dataset.assetid;
+        fetch(`/cases/${encodeURIComponent(caseId)}/asset-overrides/assets/${encodeURIComponent(id)}/unmerge`, { method: "POST" })
+          .then(() => { loadAssetGraph(caseId); loadAssetOverrides(caseId); }).catch(() => {});
       } else if (delBtn) {
         const id = delBtn.dataset.assetid;
         fetch(`/cases/${encodeURIComponent(caseId)}/asset-overrides/assets/${encodeURIComponent(id)}`, { method: "DELETE" })


### PR DESCRIPTION
## Summary
- Adds a "merge into" action for near-duplicate entities (e.g. `HOST01` vs `host01.corp`, `evil.com` vs `www.evil.com`), closing #82.
- Assets: overlay-based (`merges` map in `assetOverrides.ts`), resolved on every graph build — reversible via un-merge, survives re-synthesis automatically since assets are always re-derived.
- IOCs: a real one-time edit to `InvestigationState` (`iocMerge.ts`), since IOCs are read directly by many consumers. Reversible via the existing import-undo checkpoint. A per-case alias store (`iocAlias.ts`) makes a future re-synthesis route a re-extracted near-duplicate onto the canonical IOC instead of recreating it.
- New routes: `POST/DELETE .../asset-overrides/assets/:id/merge|unmerge`, `POST/DELETE .../ioc-overrides/merge`.
- Dashboard: merge buttons (⇄) on asset chips and IOC rows open a filtered picker modal (same-type candidates only, click to select) instead of a free-text prompt.

## Test plan
- [x] `npx vitest run` — full suite passes (3963 tests; one unrelated timing flake reproduced clean in isolation)
- [x] `npx tsc --noEmit` — clean
- [x] Live-verified via `/browse`: asset merge/unmerge, IOC merge/unmerge, import-undo reversibility, and the picker modal filtering by type for both assets and IOCs

🤖 Generated with [Claude Code](https://claude.com/claude-code)