### PR TITLE
fix(ci): add required projection=DRAFT param to CWS item lookup

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -262,8 +262,11 @@ jobs:
             exit 1
           fi
 
+          # The Chrome Web Store API requires a projection param on items.get, even though
+          # "DRAFT" is a historical name — it's the only supported value, not an indication
+          # this returns unpublished-draft data instead of the live listing.
           ITEM_RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer $ACCESS_TOKEN" -H "x-goog-api-version: 2" \
-            "https://www.googleapis.com/chromewebstore/v1.1/items/$EXTENSION_ID")
+            "https://www.googleapis.com/chromewebstore/v1.1/items/$EXTENSION_ID?projection=DRAFT")
           ITEM_HTTP_CODE=$(echo "$ITEM_RESPONSE" | tail -n1)
           ITEM_BODY=$(echo "$ITEM_RESPONSE" | sed '$d')
 


### PR DESCRIPTION
## Summary
- Follow-up to #142. With the token-exchange urlencoding fixed, the verify step's item lookup call now fails with a clear API error instead of a silent 400: `"Please append ?projection=DRAFT to your request."`
- The Chrome Web Store API's `items.get` requires a `projection` param; `DRAFT` is the only supported value (a historical naming quirk in the API, not an indication it returns unpublished data instead of the live listing).
- Fix: append `?projection=DRAFT` to the item lookup URL.

## Test plan
- [ ] Merge, then dispatch `release-artifacts.yml` against master with `tag=v0.32.0` and confirm the chrome-webstore job's verify step passes end-to-end, reporting the matching live version.