### PR TITLE
feat: starred-events review workflow (TimeSketch-style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Entity merging for duplicate assets/IOCs** — fold a duplicate asset or IOC onto a canonical node/indicator; reversible, and IOC merges preserve the alias across re-synthesis (closes #82).
+- **Starred-events review workflow (TimeSketch-style)** — event stars now live in the case (shared, tag-backed) with automatic migration of existing browser-local stars; "☆ Starred only" filters the whole super-timeline server-side; new "✨ Starred report" (savable AI forensic report over only the starred events) and "✨ Summarize view" (AI overview of the current filtered view) buttons.
 
 ## [0.32.0] - 2026-07-16
 

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -355,6 +355,8 @@ DFIR_AI_IMAGE_DETAIL=high
 # DFIR_AI_RECONCILE_PROMPT_FILE=./prompts/reconcile.txt   # second-opinion reconcile pass — judges each A-vs-B disagreement (#116)
 # DFIR_AI_IMPORTGEN_PROMPT=         # inline override for the custom-importer authoring prompt
 # DFIR_AI_IMPORTGEN_PROMPT_FILE=./prompts/importgen.txt   # the prompt analysts copy to have an LLM write a declarative importer
+# DFIR_AI_STARREDREPORT_PROMPT_FILE=./prompts/starred-report.txt   # TimeSketch-style Starred Events Report over the analyst's starred events
+# DFIR_AI_VIEWSUMMARY_PROMPT_FILE=./prompts/view-summary.txt   # quick AI overview of the current super-timeline view (filters applied)
 
 # --- Threat-intel IOC enrichment (optional) ------------------------------------
 # Add a key to enable that provider; the dashboard "Enrich IOCs" button looks up the

--- a/companion/scripts/eject-prompts.ts
+++ b/companion/scripts/eject-prompts.ts
@@ -7,7 +7,7 @@ import { join, resolve } from "node:path";
 import {
   SYSTEM_PROMPT, CSV_SYSTEM_PROMPT, LOG_SYSTEM_PROMPT, SYNTHESIS_PROMPT, ASK_PROMPT, EXEC_SUMMARY_PROMPT,
   HUNT_SUGGEST_PROMPT, PLAYBOOK_HUNT_PROMPT, GAP_HYPOTHESIS_PROMPT, MEMORY_NEXTSTEP_PROMPT, QUERY_TRANSLATE_PROMPT,
-  TAGGER_RULE_PROMPT,
+  TAGGER_RULE_PROMPT, STARRED_REPORT_PROMPT, VIEW_SUMMARY_PROMPT,
 } from "../src/analysis/pipeline.js";
 import { RECONCILE_PROMPT } from "../src/analysis/secondOpinion.js";
 
@@ -28,6 +28,8 @@ const files: Array<[string, string, string]> = [
   ["query-translate.txt", QUERY_TRANSLATE_PROMPT, "DFIR_AI_QUERYXLATE_PROMPT_FILE"],
   ["tagger-rule.txt", TAGGER_RULE_PROMPT, "DFIR_AI_TAGGERRULE_PROMPT_FILE"],
   ["reconcile.txt", RECONCILE_PROMPT, "DFIR_AI_RECONCILE_PROMPT_FILE"],
+  ["starred-report.txt", STARRED_REPORT_PROMPT, "DFIR_AI_STARREDREPORT_PROMPT_FILE"],
+  ["view-summary.txt", VIEW_SUMMARY_PROMPT, "DFIR_AI_VIEWSUMMARY_PROMPT_FILE"],
 ];
 
 for (const [name, text] of files) {

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -144,6 +144,7 @@ import {
 } from "./huntOutcomes.js";
 import type { HuntOutcomeStore } from "./huntOutcomeStore.js";
 import type { SuperTimelineStore } from "./superTimelineStore.js";
+import type { SuperQuery, SuperLabelMap } from "./superTimeline.js";
 import {
   memoryNextStepResponseSchema,
   sanitizeMemoryNextSteps,
@@ -691,7 +692,7 @@ export const SYNTHESIS_PROMPT = [
 // <NAME> is one of: SYSTEM, CSV, LOG, SYNTH. A missing/unreadable/empty file logs a warning
 // and falls back to the built-in prompt, so a typo never breaks analysis.
 // `npm run prompts:eject` writes the four defaults to ./prompts as a starting point.
-function resolvePrompt(name: "SYSTEM" | "CSV" | "LOG" | "SYNTH" | "ASK" | "EXEC" | "NARRATIVE" | "HUNTS" | "PBHUNTS" | "GAPHYP" | "MEMNEXT" | "QUERYXLATE" | "RECONCILE" | "IMPORTGEN" | "EXPLAIN" | "REMEDIATION" | "FPSIMILARITY" | "TAGGERRULE" | "HYPREVIEW", fallback: string): string {
+function resolvePrompt(name: "SYSTEM" | "CSV" | "LOG" | "SYNTH" | "ASK" | "EXEC" | "NARRATIVE" | "HUNTS" | "PBHUNTS" | "GAPHYP" | "MEMNEXT" | "QUERYXLATE" | "RECONCILE" | "IMPORTGEN" | "EXPLAIN" | "REMEDIATION" | "FPSIMILARITY" | "TAGGERRULE" | "HYPREVIEW" | "STARREDREPORT" | "VIEWSUMMARY", fallback: string): string {
   const inline = process.env[`DFIR_AI_${name}_PROMPT`];
   if (inline && inline.trim().length > 0) return inline;
   const file = process.env[`DFIR_AI_${name}_PROMPT_FILE`];
@@ -942,6 +943,54 @@ export const EXPLAIN_EVENT_PROMPT = [
     evidenceAgainst: "plausible benign explanation (or empty string if clearly malicious)",
     relatedEventIds: ["event ids from the context that support the explanation"],
   }, null, 2),
+].join("\n");
+
+// TimeSketch-style Starred Events Report: a forensic markdown report over ONLY the events the
+// investigator starred (the reserved "starred" tag) while sweeping the super timeline — the
+// TimeSketch starred-events workflow. Button-triggered only; EPHEMERAL (saving is a separate route).
+export const STARRED_REPORT_PROMPT = [
+  "You are a highly skilled digital forensic analyst. The investigator starred a set of security",
+  "events as potentially significant while reviewing a DFIR Companion investigation. Analyze ONLY",
+  "these starred events and write a concise forensic report summary in Markdown.",
+  "",
+  "Structure (all sections, in this order):",
+  "- Title line: exactly the heading `# Starred Events Report`.",
+  "- Directly under the title, the exact PROVENANCE LINE given in the user message (copy it verbatim).",
+  "- **Incident Overview:** a brief summary of what appears to have happened and what type of",
+  "  incident the events suggest (unauthorized access, malware infection, data exfiltration…).",
+  "- **Key Findings:** the most important observations and indicators. Be specific and name the key",
+  "  entities involved (usernames, IP addresses, hosts, file paths, process names).",
+  "- **Timeline of Significant Events (Chronological Order):** briefly outline the sequence of key",
+  "  actions observed in the starred events.",
+  "- **Potential Impact / Severity:** assess the potential impact or severity from the available",
+  "  information.",
+  "- **Recommended Next Steps:** 2-3 concrete next steps for the investigation.",
+  "",
+  "Use bolding (**…**) for key entities and findings. Ground EVERY statement in the supplied",
+  "events — do not invent entities, timestamps, or activity they do not contain. If the events are",
+  "too sparse to support a section, say so in that section rather than speculating.",
+  "",
+  "Return ONLY raw JSON (no markdown fences) with EXACTLY this shape:",
+  JSON.stringify({ markdown: "the full report as raw Markdown (start with the `# Starred Events Report` title line)" }, null, 2),
+].join("\n");
+
+// Quick AI overview of WHATEVER the analyst's current super-timeline filters show ("summarize this
+// view") — TimeSketch's "seen events" summary, adapted to markdown bold. Button-triggered; EPHEMERAL.
+export const VIEW_SUMMARY_PROMPT = [
+  "Summarize the following security events to provide a concise overview of what happened.",
+  "",
+  "Identify the main activity or incident described in the events. If the events suggest a",
+  "security incident, state whether the incident appears to have been successful or not, and",
+  "briefly explain why, based ONLY on the provided information.",
+  "",
+  "Highlight key observables in markdown bold (**…**): IP addresses, domain names, file paths,",
+  "usernames, hostnames, process names, search queries.",
+  "",
+  "Keep it short: a few paragraphs or tight bullets, not a full report. Do not invent entities or",
+  "activity the events do not contain.",
+  "",
+  "Return ONLY raw JSON (no markdown fences) with EXACTLY this shape:",
+  JSON.stringify({ markdown: "the concise overview as raw Markdown" }, null, 2),
 ].join("\n");
 
 // Standalone narrative-timeline generator: produces a stakeholder-friendly prose story of the
@@ -1310,6 +1359,8 @@ export const getExplainEventPrompt = (): string => resolvePrompt("EXPLAIN", EXPL
 export const getRemediationPrompt = (): string => resolvePrompt("REMEDIATION", REMEDIATION_PROMPT);
 export const getFpSimilarityPrompt = (): string => resolvePrompt("FPSIMILARITY", FP_SIMILARITY_PROMPT);
 export const getHypothesisReviewPrompt = (): string => resolvePrompt("HYPREVIEW", HYPOTHESIS_REVIEW_PROMPT);
+export const getStarredReportPrompt = (): string => resolvePrompt("STARREDREPORT", STARRED_REPORT_PROMPT);
+export const getViewSummaryPrompt = (): string => resolvePrompt("VIEWSUMMARY", VIEW_SUMMARY_PROMPT);
 
 export const IMPORTER_PROMPT = [
   "You are writing a DECLARATIVE IMPORTER DEFINITION for the DFIR Companion. Output ONLY a single",
@@ -1343,6 +1394,15 @@ export const IMPORTER_PROMPT = [
 ].join("\n");
 
 export const getImporterPrompt = (): string => resolvePrompt("IMPORTGEN", IMPORTER_PROMPT);
+
+// Result of the two view-scoped AI summaries (starred report / view summary). `eventCount` is the
+// full deduplicated match; `usedEvents` what actually fit the AI input budget.
+export interface StarredSummaryResult {
+  markdown: string;
+  eventCount: number;
+  usedEvents: number;
+  truncated: boolean;
+}
 
 export interface PipelineOptions {
   // The VISION model: screenshot analysis only (analyzeWindow). Screenshots need an image-capable
@@ -4309,6 +4369,93 @@ export class AnalysisPipeline {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getExecSummaryPrompt(), userPrompt, images: [] }, "exec-summary");
       return execSummarySchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  }
+
+  // TimeSketch-style Starred Events Report: ONE text-only AI call over ONLY the analyst-starred
+  // events (ids resolved by the route from the reserved "starred" tags — the pipeline has no tags
+  // store). Events resolve from the super-timeline store UNIONed with the forensic timeline
+  // (manual/pushed events may exist only there), deduped by id. Deliberately NO scope / false-
+  // positive filtering: the analyst hand-picked these events. EPHEMERAL — no state change.
+  async starredReport(caseId: string, starredIds: string[]): Promise<StarredSummaryResult> {
+    const provider = this.opts.synthesisProvider ?? this.requireProvider("starred report");
+    const loaded = await this.opts.stateStore.load(caseId);
+    const wanted = new Set(starredIds);
+    const byId = new Map<string, ForensicEvent>();
+    if (this.opts.superTimelineStore) {
+      for (const e of await this.opts.superTimelineStore.all(caseId)) if (wanted.has(e.id)) byId.set(e.id, e);
+    }
+    for (const e of loaded.forensicTimeline) if (wanted.has(e.id) && !byId.has(e.id)) byId.set(e.id, e);
+    const all = [...byId.values()].sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+    if (!all.length) throw new Error("no starred events");
+
+    // The provenance line is computed HERE (the model copies it verbatim, it never counts events
+    // itself) so the report's stated coverage is always accurate — including when the budget cap
+    // reduced the set.
+    const provenance = (used: number): string => used < all.length
+      ? `[*This report was generated based on the ${used} most significant of ${all.length} (deduplicated) starred events.*]`
+      : `[*This report was generated based on ${all.length} (deduplicated) starred events.*]`;
+
+    const prompt = getStarredReportPrompt();
+    const { events, render } = this.fitViewEvents(all, estimateTokens(prompt) + estimateTokens(provenance(all.length)) + 300);
+
+    const userPrompt =
+      `PROVENANCE LINE (copy verbatim directly under the title): ${provenance(events.length)}\n\n` +
+      `STARRED EVENTS (${events.length} of ${all.length}, chronological):\n` +
+      events.map(render).join("\n") +
+      `\n\nWrite the starred events report as JSON.`;
+
+    const mdSchema = z.object({ markdown: z.string() });
+    const result = await withRetry(async () => {
+      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "starred-report");
+      return mdSchema.parse(parsed);
+    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+
+    return { markdown: result.markdown, eventCount: all.length, usedEvents: events.length, truncated: events.length < all.length };
+  }
+
+  // Summarize the analyst's CURRENT super-timeline view: the route passes the exact filter set the
+  // dashboard has applied plus the tag label map (tags live outside the pipeline). EPHEMERAL.
+  async viewSummary(caseId: string, filters: SuperQuery, labelMap?: SuperLabelMap): Promise<StarredSummaryResult> {
+    const provider = this.opts.synthesisProvider ?? this.requireProvider("view summary");
+    if (!this.opts.superTimelineStore) throw new Error("super-timeline not configured");
+    const loaded = await this.opts.stateStore.load(caseId);
+    const { events: matched } = await this.opts.superTimelineStore.query(
+      caseId, { ...filters, offset: 0, limit: Number.MAX_SAFE_INTEGER }, labelMap);
+    if (!matched.length) throw new Error("no events match the current filters");
+
+    const prompt = getViewSummaryPrompt();
+    const { events, render } = this.fitViewEvents(matched, estimateTokens(prompt) + 300);
+
+    const userPrompt =
+      `EVENTS (${events.length} of ${matched.length} matching the analyst's current filters, chronological):\n` +
+      events.map(render).join("\n") +
+      `\n\nWrite the overview as JSON.`;
+
+    const mdSchema = z.object({ markdown: z.string() });
+    const result = await withRetry(async () => {
+      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "view-summary");
+      return mdSchema.parse(parsed);
+    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+
+    return { markdown: result.markdown, eventCount: matched.length, usedEvents: events.length, truncated: events.length < matched.length };
+  }
+
+  // Shared event-selection for the two view-scoped summaries: cap to the synthesis event budget
+  // (DFIR_AI_SYNTH_MAX_EVENTS, default 300), token-fit against the prompt overhead, keep the most
+  // signal-bearing subset (selectSynthesisEvents) and re-sort it chronologically for the report.
+  private fitViewEvents(all: ForensicEvent[], overheadTokens: number): { events: ForensicEvent[]; render: (e: ForensicEvent) => string } {
+    const render = (e: ForensicEvent): string =>
+      `[${e.timestamp || "(undated)"}] [${e.severity}]` +
+      (e.asset ? ` [${e.asset}]` : "") +
+      ` ${e.description.slice(0, 240)}` +
+      (e.processName ? ` | process: ${e.processName}` : "") +
+      (e.srcIp || e.dstIp ? ` | net: ${[e.srcIp, e.dstIp].filter(Boolean).join(" → ")}` : "");
+    const max = Number(process.env.DFIR_AI_SYNTH_MAX_EVENTS) || 300;
+    let events = selectSynthesisEvents(all, max);
+    const fit = fitItemsToBudget(events, render, Math.max(0, inputTokenBudget() - overheadTokens));
+    if (fit < events.length) events = selectSynthesisEvents(all, fit);
+    events = [...events].sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+    return { events, render };
   }
 
   // Incident-specific remediation plan (#178): a concrete, prioritized action list for the IR team,

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -1585,6 +1585,15 @@ export class AnalysisPipeline {
     return Boolean(this.opts.provider);
   }
 
+  // Whether a TEXT/synthesis provider is available — the gate for text-only AI features (starred
+  // report, view summary, …). Mirrors how those methods resolve their provider
+  // (`synthesisProvider ?? provider`): DFIR_AI_SYNTH_PROVIDER falls back to DFIR_AI_PROVIDER, so this
+  // is true whenever EITHER is configured. Distinct from hasAiProvider(), which reflects the VISION
+  // provider (DFIR_AI_PROVIDER only) used for screenshot/OCR analysis.
+  hasSynthesisProvider(): boolean {
+    return Boolean(this.opts.synthesisProvider ?? this.opts.provider);
+  }
+
   private requireProvider(purpose: string): AIProvider {
     if (!this.opts.provider) throw new Error(`AI provider not configured; ${purpose} requires an AI provider`);
     return this.opts.provider;

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -4380,12 +4380,16 @@ export class AnalysisPipeline {
     const provider = this.opts.synthesisProvider ?? this.requireProvider("starred report");
     const loaded = await this.opts.stateStore.load(caseId);
     const wanted = new Set(starredIds);
+    // FORENSIC copies win the union: imports dual-write the same event ids to both stores, but all
+    // later severity/MITRE re-grades (content tagger, synthesis mergeDelta) land on the forensic copy
+    // only — the super copy is frozen at import time, so it must not shadow the re-graded one.
+    // Super-only events (raw host triage never promoted) still resolve via the fill-the-gaps pass.
     const byId = new Map<string, ForensicEvent>();
+    for (const e of loaded.forensicTimeline) if (wanted.has(e.id)) byId.set(e.id, e);
     if (this.opts.superTimelineStore) {
-      for (const e of await this.opts.superTimelineStore.all(caseId)) if (wanted.has(e.id)) byId.set(e.id, e);
+      for (const e of await this.opts.superTimelineStore.all(caseId)) if (wanted.has(e.id) && !byId.has(e.id)) byId.set(e.id, e);
     }
-    for (const e of loaded.forensicTimeline) if (wanted.has(e.id) && !byId.has(e.id)) byId.set(e.id, e);
-    const all = [...byId.values()].sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+    const all = sortByEventTime([...byId.values()]);
     if (!all.length) throw new Error("no starred events");
 
     // The provenance line is computed HERE (the model copies it verbatim, it never counts events
@@ -4404,7 +4408,7 @@ export class AnalysisPipeline {
       events.map(render).join("\n") +
       `\n\nWrite the starred events report as JSON.`;
 
-    const mdSchema = z.object({ markdown: z.string() });
+    const mdSchema = z.object({ markdown: z.string().min(1) });
     const result = await withRetry(async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "starred-report");
       return mdSchema.parse(parsed);
@@ -4431,7 +4435,7 @@ export class AnalysisPipeline {
       events.map(render).join("\n") +
       `\n\nWrite the overview as JSON.`;
 
-    const mdSchema = z.object({ markdown: z.string() });
+    const mdSchema = z.object({ markdown: z.string().min(1) });
     const result = await withRetry(async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "view-summary");
       return mdSchema.parse(parsed);
@@ -4454,8 +4458,7 @@ export class AnalysisPipeline {
     let events = selectSynthesisEvents(all, max);
     const fit = fitItemsToBudget(events, render, Math.max(0, inputTokenBudget() - overheadTokens));
     if (fit < events.length) events = selectSynthesisEvents(all, fit);
-    events = [...events].sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
-    return { events, render };
+    return { events: sortByEventTime(events), render };
   }
 
   // Incident-specific remediation plan (#178): a concrete, prioritized action list for the IR team,

--- a/companion/src/analysis/starredReportStore.ts
+++ b/companion/src/analysis/starredReportStore.ts
@@ -6,6 +6,8 @@ import { atomicWrite } from "../storage/atomicWrite.js";
 // The analyst-saved Starred Events Report (the TimeSketch-style AI summary over starred events).
 // A per-case side file (state/starred-report.json) — NOT in InvestigationState, so synthesis never
 // wipes it. Single-slot: saving overwrites the previous saved report. null = nothing saved yet.
+// Deliberately NOT in SNAPSHOT_STATE_FILES — nothing mutates this file during synthesis/import,
+// so the rollback snapshot adds no protection.
 export interface SavedStarredReport {
   markdown: string;     // the report as raw Markdown
   savedAt: string;      // ISO timestamp of the save
@@ -28,9 +30,8 @@ export class StarredReportStore {
         savedAt: typeof raw.savedAt === "string" ? raw.savedAt : "",
         eventCount: Number(raw.eventCount) || 0,
       };
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
-      return null;   // malformed file: treat as nothing saved rather than break the case
+    } catch {
+      return null;   // absent or malformed: treat as nothing saved rather than break the case
     }
   }
 

--- a/companion/src/analysis/starredReportStore.ts
+++ b/companion/src/analysis/starredReportStore.ts
@@ -1,0 +1,40 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { CaseStore } from "../storage/caseStore.js";
+import { atomicWrite } from "../storage/atomicWrite.js";
+
+// The analyst-saved Starred Events Report (the TimeSketch-style AI summary over starred events).
+// A per-case side file (state/starred-report.json) — NOT in InvestigationState, so synthesis never
+// wipes it. Single-slot: saving overwrites the previous saved report. null = nothing saved yet.
+export interface SavedStarredReport {
+  markdown: string;     // the report as raw Markdown
+  savedAt: string;      // ISO timestamp of the save
+  eventCount: number;   // starred events the report was generated from (0 when unknown)
+}
+
+export class StarredReportStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "starred-report.json");
+  }
+
+  async load(caseId: string): Promise<SavedStarredReport | null> {
+    try {
+      const raw = JSON.parse(await readFile(this.path(caseId), "utf8")) as Partial<SavedStarredReport>;
+      if (typeof raw?.markdown !== "string" || !raw.markdown) return null;
+      return {
+        markdown: raw.markdown,
+        savedAt: typeof raw.savedAt === "string" ? raw.savedAt : "",
+        eventCount: Number(raw.eventCount) || 0,
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      return null;   // malformed file: treat as nothing saved rather than break the case
+    }
+  }
+
+  async save(caseId: string, report: SavedStarredReport): Promise<void> {
+    await atomicWrite(this.path(caseId), JSON.stringify(report, null, 2));
+  }
+}

--- a/companion/src/analysis/superTimeline.ts
+++ b/companion/src/analysis/superTimeline.ts
@@ -11,6 +11,11 @@ export type SuperLabelMap = Record<string, string[]>;
 // truly empties the timeline) — mirrors the forensic source filter's "(no source)".
 export const NO_HOST_FACET = "(no host)";
 
+// Reserved analyst-tag label modelling a TimeSketch-style event star. Stars are tags so they get
+// server persistence + tag filtering for free, but they are NOT triage labels: the labelsAvailable
+// facet and taggedOnly both ignore this label — the ☆ Starred button (starred=1) is its only filter UI.
+export const STARRED_LABEL = "starred";
+
 export interface SuperQuery {
   from?: string;        // ISO lower bound (inclusive)
   to?: string;          // ISO upper bound (inclusive)
@@ -19,6 +24,7 @@ export interface SuperQuery {
   excludeHosts?: string[]; // drop these hosts (the dashboard's unchecked host boxes); use NO_HOST_FACET for undated-host rows
   labels?: string[];    // keep only events carrying at least one of these labels
   taggedOnly?: boolean; // keep only events carrying at least one tag/label (any)
+  starred?: boolean;    // keep only events carrying the reserved "starred" label (ANDed with the rest)
   search?: string;      // free-text search (dashboard's main filter bar), same fields as the forensic timeline
   excludeText?: string[]; // hide events matching ANY of these terms (dashboard's main filter "Exclude" chips)
   offset?: number;
@@ -84,7 +90,7 @@ export function querySuper(events: ForensicEvent[], labelMap: SuperLabelMap, q: 
   const inWindow = events.filter(inTime);
   const origins = [...new Set(inWindow.map(superOriginOf))].sort();
   const hosts = [...new Set(inWindow.map(superHostOf))].sort();
-  const labelsAvailable = [...new Set(inWindow.flatMap((e) => labelMap[e.id] ?? []))].sort();
+  const labelsAvailable = [...new Set(inWindow.flatMap((e) => labelMap[e.id] ?? []))].filter((l) => l !== STARRED_LABEL).sort();
 
   // Results apply the origin + host + label filters on top of the time window.
   const matched = inWindow.filter((e) => {
@@ -96,8 +102,12 @@ export function querySuper(events: ForensicEvent[], labelMap: SuperLabelMap, q: 
       const evLabels = labelMap[e.id] ?? [];
       if (!evLabels.some((l) => labelSet.has(l))) return false;
     }
-    // "Tagged only": keep only events carrying at least one tag/label (any).
-    if (q.taggedOnly && !(labelMap[e.id] ?? []).length) return false;
+    // "Tagged only": keep only events carrying at least one REAL triage tag (the reserved starred
+    // pseudo-tag doesn't count — starring is not triage labelling).
+    if (q.taggedOnly && !(labelMap[e.id] ?? []).some((l) => l !== STARRED_LABEL)) return false;
+    // "Starred only" (the ☆ button): ANDed with every other filter — deliberately NOT folded into
+    // the OR-model labels= param, so "tag exfil AND starred" behaves as an analyst expects.
+    if (q.starred && !(labelMap[e.id] ?? []).includes(STARRED_LABEL)) return false;
     // Main dashboard filter bar (search + exclude terms) — same matching as the forensic timeline,
     // so scoping the case narrows the super-timeline too instead of only the forensic view.
     if (q.search && !eventMatchesSearch(e, q.search)) return false;

--- a/companion/src/analysis/superTimeline.ts
+++ b/companion/src/analysis/superTimeline.ts
@@ -95,19 +95,17 @@ export function querySuper(events: ForensicEvent[], labelMap: SuperLabelMap, q: 
   // Results apply the origin + host + label filters on top of the time window.
   const matched = inWindow.filter((e) => {
     const origin = superOriginOf(e);
+    const evLabels = labelMap[e.id] ?? [];
     if (originSet && !originSet.has(origin)) return false;
     if (excludeSet && excludeSet.has(origin)) return false;   // unchecked in the dashboard → hidden
     if (excludeHostSet && excludeHostSet.has(superHostOf(e))) return false;   // unchecked host → hidden
-    if (labelSet) {
-      const evLabels = labelMap[e.id] ?? [];
-      if (!evLabels.some((l) => labelSet.has(l))) return false;
-    }
+    if (labelSet && !evLabels.some((l) => labelSet.has(l))) return false;
     // "Tagged only": keep only events carrying at least one REAL triage tag (the reserved starred
     // pseudo-tag doesn't count — starring is not triage labelling).
-    if (q.taggedOnly && !(labelMap[e.id] ?? []).some((l) => l !== STARRED_LABEL)) return false;
+    if (q.taggedOnly && !evLabels.some((l) => l !== STARRED_LABEL)) return false;
     // "Starred only" (the ☆ button): ANDed with every other filter — deliberately NOT folded into
     // the OR-model labels= param, so "tag exfil AND starred" behaves as an analyst expects.
-    if (q.starred && !(labelMap[e.id] ?? []).includes(STARRED_LABEL)) return false;
+    if (q.starred && !evLabels.includes(STARRED_LABEL)) return false;
     // Main dashboard filter bar (search + exclude terms) — same matching as the forensic timeline,
     // so scoping the case narrows the super-timeline too instead of only the forensic view.
     if (q.search && !eventMatchesSearch(e, q.search)) return false;

--- a/companion/src/analysis/tags.ts
+++ b/companion/src/analysis/tags.ts
@@ -101,13 +101,14 @@ export class TagsStore {
     return tag;
   }
 
-  // Remove one tag by id; returns true if it existed.
-  async remove(caseId: string, tagId: string): Promise<boolean> {
+  // Remove one tag by id; returns the removed tag (so callers can inspect its label), or null if
+  // no tag with that id existed.
+  async remove(caseId: string, tagId: string): Promise<Tag | null> {
     const tags = await this.load(caseId);
-    const next = tags.filter((t) => t.id !== tagId);
-    if (next.length === tags.length) return false;
-    await this.save(caseId, next);
-    return true;
+    const removed = tags.find((t) => t.id === tagId) ?? null;
+    if (!removed) return null;
+    await this.save(caseId, tags.filter((t) => t.id !== tagId));
+    return removed;
   }
 
   // Remove every tag whose author starts with `prefix` in a single load+save; returns how many were

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -321,7 +321,10 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // events (stars = the reserved "starred" analyst tag). Button-triggered, EPHEMERAL — review,
   // copy, or persist via the PUT below. 400 when nothing is starred (the dashboard guards too).
   app.post("/cases/:id/starred-report", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for starred report" });
+    // Gate on the SYNTHESIS (text) provider, not hasAiProvider() (the VISION/OCR provider): this is a
+    // text-only call driven by synthesisProvider, so it must work whenever DFIR_AI_SYNTH_PROVIDER (or
+    // the DFIR_AI_PROVIDER it falls back to) is set — even if the vision provider alone is unconfigured.
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for starred report" });
     if (!options.tagsStore) return res.status(501).json({ error: "tags not configured" });
     try {
       const tags = await options.tagsStore.load(req.params.id);
@@ -373,7 +376,9 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // the body carries the dashboard's active filter set (same names/values as the GET
   // /super-timeline query params). Button-triggered, EPHEMERAL — nothing is stored.
   app.post("/cases/:id/view-summary", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for view summary" });
+    // Synthesis (text) provider gate — see the starred-report route above for why this is
+    // hasSynthesisProvider() rather than the vision-provider hasAiProvider().
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for view summary" });
     if (!options.superTimelineStore) return res.status(501).json({ error: "super-timeline not configured" });
     const b = req.body ?? {};
     const csv = (v: unknown): string[] => String(v ?? "").split(",").map((s) => s.trim()).filter(Boolean);

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -5,6 +5,7 @@ import { readPublicAsset } from "../serverAssets.js";
 import { defaultReportTemplate, isReportSectionEnabled, type ReportSectionKey } from "../reports/reportTemplate.js";
 import { HYPOTHESIS_STATUSES, type HypothesisStatus, type HypothesisPatch, type NewHypothesis } from "../analysis/hypothesis.js";
 import type { InvestigationQuestion, QuestionStatus } from "../analysis/stateTypes.js";
+import { STARRED_LABEL, type SuperQuery } from "../analysis/superTimeline.js";
 import type { RouteContext } from "./context.js";
 
 /**
@@ -313,6 +314,101 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
       return res.status(200).json(result);
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // TimeSketch-style Starred Events Report: ONE text-only AI call over ONLY the analyst-starred
+  // events (stars = the reserved "starred" analyst tag). Button-triggered, EPHEMERAL — review,
+  // copy, or persist via the PUT below. 400 when nothing is starred (the dashboard guards too).
+  app.post("/cases/:id/starred-report", async (req: Request, res: Response) => {
+    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for starred report" });
+    if (!options.tagsStore) return res.status(501).json({ error: "tags not configured" });
+    try {
+      const tags = await options.tagsStore.load(req.params.id);
+      const starredIds = [...new Set(tags.filter((t) => t.targetType === "event" && t.label === STARRED_LABEL).map((t) => t.targetId))];
+      if (!starredIds.length) return res.status(400).json({ error: "no starred events — star rows (☆) in the timeline first" });
+      const result = await options.pipeline.starredReport(req.params.id, starredIds);
+      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
+        category: "ai", action: "starred-report", detail: `starred events report generated (${result.usedEvents}/${result.eventCount} starred events)`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg === "no starred events") return res.status(400).json({ error: msg });
+      errLine(`[starred-report] case=${req.params.id}: ${msg}`);
+      return res.status(500).json({ error: msg });
+    }
+  });
+
+  // The saved copy of the starred report (a per-case side file; survives reload, overwritten on
+  // each save). GET → 404 when nothing is saved yet.
+  app.get("/cases/:id/starred-report", async (req: Request, res: Response) => {
+    if (!options.starredReportStore) return res.status(501).json({ error: "starred report store not configured" });
+    try {
+      const saved = await options.starredReportStore.load(req.params.id);
+      if (!saved) return res.status(404).json({ error: "no saved starred report" });
+      return res.status(200).json(saved);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.put("/cases/:id/starred-report", async (req: Request, res: Response) => {
+    if (!options.starredReportStore) return res.status(501).json({ error: "starred report store not configured" });
+    const markdown = typeof req.body?.markdown === "string" ? req.body.markdown : "";
+    if (!markdown.trim()) return res.status(400).json({ error: "markdown is required" });
+    try {
+      const saved = { markdown, savedAt: new Date().toISOString(), eventCount: Number(req.body?.eventCount) || 0 };
+      await options.starredReportStore.save(req.params.id, saved);
+      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
+        category: "ai", action: "starred-report-saved", detail: "starred events report saved to case",
+      });
+      return res.status(200).json(saved);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Summarize the analyst's CURRENT super-timeline view (TimeSketch's "seen events" summary):
+  // the body carries the dashboard's active filter set (same names/values as the GET
+  // /super-timeline query params). Button-triggered, EPHEMERAL — nothing is stored.
+  app.post("/cases/:id/view-summary", async (req: Request, res: Response) => {
+    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for view summary" });
+    const b = req.body ?? {};
+    const csv = (v: unknown): string[] => String(v ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+    const filters: SuperQuery = {
+      from: typeof b.from === "string" && b.from ? b.from : undefined,
+      to: typeof b.to === "string" && b.to ? b.to : undefined,
+      exclude: csv(b.exclude),
+      excludeHosts: csv(b.excludeHosts),
+      labels: csv(b.labels),
+      taggedOnly: b.tagged === true || b.tagged === "1",
+      starred: b.starred === true || b.starred === "1",
+      search: typeof b.q === "string" ? b.q : undefined,
+      excludeText: csv(b.excludeText),
+    };
+    try {
+      // Tag label map — same construction as the GET /super-timeline route, so labels=/starred
+      // filter by the case's analyst tags here too.
+      let tagLabelMap: Record<string, string[]> | undefined;
+      if (options.tagsStore) {
+        const tags = await options.tagsStore.load(req.params.id);
+        tagLabelMap = {};
+        for (const t of tags) {
+          if (t.targetType !== "event") continue;
+          (tagLabelMap[t.targetId] ??= []).push(t.label);
+        }
+      }
+      const result = await options.pipeline.viewSummary(req.params.id, filters, tagLabelMap);
+      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
+        category: "ai", action: "view-summary", detail: `view summary generated (${result.usedEvents}/${result.eventCount} matching events)`,
+      });
+      return res.status(200).json(result);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg === "no events match the current filters") return res.status(400).json({ error: msg });
+      errLine(`[view-summary] case=${req.params.id}: ${msg}`);
+      return res.status(500).json({ error: msg });
     }
   });
 

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -374,6 +374,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // /super-timeline query params). Button-triggered, EPHEMERAL — nothing is stored.
   app.post("/cases/:id/view-summary", async (req: Request, res: Response) => {
     if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for view summary" });
+    if (!options.superTimelineStore) return res.status(501).json({ error: "super-timeline not configured" });
     const b = req.body ?? {};
     const csv = (v: unknown): string[] => String(v ?? "").split(",").map((s) => s.trim()).filter(Boolean);
     const filters: SuperQuery = {
@@ -382,8 +383,8 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
       exclude: csv(b.exclude),
       excludeHosts: csv(b.excludeHosts),
       labels: csv(b.labels),
-      taggedOnly: b.tagged === true || b.tagged === "1",
-      starred: b.starred === true || b.starred === "1",
+      taggedOnly: b.tagged === true || b.tagged === "1" || b.tagged === "true",
+      starred: b.starred === true || b.starred === "1" || b.starred === "true",
       search: typeof b.q === "string" ? b.q : undefined,
       excludeText: csv(b.excludeText),
     };

--- a/companion/src/routes/findings.ts
+++ b/companion/src/routes/findings.ts
@@ -494,8 +494,10 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
       });
       options.onTags?.(req.params.id);
       // A star is the reserved "starred" tag — a high-frequency triage gesture; don't spam the
-      // activity log (it's hidden from every other tag surface too).
-      if (label !== STARRED_LABEL) {
+      // activity log (it's hidden from every other tag surface too). Check the STORED label
+      // (tag.label, already normalized by add()) so a differently-cased "Starred" is caught too —
+      // symmetric with the DELETE side, which reads removed.label.
+      if (tag.label !== STARRED_LABEL) {
         logActivity(options.activityLogStore, options.onActivity, req.params.id, {
           category: "collaboration", action: "tag-added", actor: tag.author,
           detail: `tagged ${targetType} ${targetId} "${label}"`, targetType, targetId,

--- a/companion/src/routes/findings.ts
+++ b/companion/src/routes/findings.ts
@@ -13,6 +13,7 @@ import { ScopeStore, type ScopeWindow } from "../analysis/scope.js";
 import { PinLimitError } from "../analysis/pinnedFindings.js";
 import { type NotebookEntryType, NOTEBOOK_ENTRY_TYPES } from "../analysis/notebookStore.js";
 import { sanitizeRuleInput } from "../analysis/iocWhitelist.js";
+import { STARRED_LABEL } from "../analysis/superTimeline.js";
 import type { ForensicEvent, Finding } from "../analysis/stateTypes.js";
 import type { RouteContext } from "./context.js";
 
@@ -492,10 +493,14 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
         author: typeof req.body?.author === "string" ? req.body.author : "",
       });
       options.onTags?.(req.params.id);
-      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
-        category: "collaboration", action: "tag-added", actor: tag.author,
-        detail: `tagged ${targetType} ${targetId} "${label}"`, targetType, targetId,
-      });
+      // A star is the reserved "starred" tag — a high-frequency triage gesture; don't spam the
+      // activity log (it's hidden from every other tag surface too).
+      if (label !== STARRED_LABEL) {
+        logActivity(options.activityLogStore, options.onActivity, req.params.id, {
+          category: "collaboration", action: "tag-added", actor: tag.author,
+          detail: `tagged ${targetType} ${targetId} "${label}"`, targetType, targetId,
+        });
+      }
       return res.status(201).json(tag);
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
@@ -508,9 +513,13 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
       const removed = await options.tagsStore.remove(req.params.id, req.params.tagId);
       if (!removed) return res.status(404).json({ error: "tag not found" });
       options.onTags?.(req.params.id);
-      logActivity(options.activityLogStore, options.onActivity, req.params.id, {
-        category: "collaboration", action: "tag-removed", detail: `tag ${req.params.tagId} removed`,
-      });
+      // A star is the reserved "starred" tag — a high-frequency triage gesture; don't spam the
+      // activity log (it's hidden from every other tag surface too).
+      if (removed.label !== STARRED_LABEL) {
+        logActivity(options.activityLogStore, options.onActivity, req.params.id, {
+          category: "collaboration", action: "tag-removed", detail: `tag ${req.params.tagId} removed`,
+        });
+      }
       return res.status(204).end();
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });

--- a/companion/src/routes/timeline.ts
+++ b/companion/src/routes/timeline.ts
@@ -152,6 +152,7 @@ export function registerTimelineRoutes(app: Express, ctx: RouteContext): void {
         excludeHosts: csv(req.query.excludeHosts),
         labels: csv(req.query.labels),
         taggedOnly: req.query.tagged === "1" || req.query.tagged === "true",
+        starred: req.query.starred === "1" || req.query.starred === "true",
         search: typeof req.query.q === "string" ? req.query.q : undefined,
         excludeText: csv(req.query.excludeText),
         offset: num(req.query.offset),

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -106,6 +106,7 @@ import { LearnedPatternStore } from "./analysis/learnedPatternStore.js";
 import { SourceTrustStore } from "./analysis/sourceTrustStore.js";
 import { DwellWindowStore } from "./analysis/dwellWindowStore.js";
 import { SuperTimelineStore } from "./analysis/superTimelineStore.js";
+import { StarredReportStore } from "./analysis/starredReportStore.js";
 import { TaggerStore } from "./analysis/taggerStore.js";
 import { autoTagNewEvents } from "./analysis/taggerAuto.js";
 import { ForensicGateControlStore } from "./analysis/forensicGateControl.js";
@@ -301,6 +302,10 @@ export interface AppOptions {
   // Super-timeline: the complete record of every imported event (a superset of the forensic timeline).
   // Every normal import dual-writes its newly-added events here; the forensic timeline stays curated.
   superTimelineStore?: SuperTimelineStore;
+  // Saved copy of the TimeSketch-style Starred Events Report (a per-case side file) — POST
+  // /starred-report generates it fresh each time (ephemeral); PUT persists the analyst's chosen
+  // copy here so it survives a reload; GET reads it back.
+  starredReportStore?: StarredReportStore;
   // Content-based event tagger (Timesketch-style tags.yaml): the rule file store. Powers manual
   // "Run tagger" + rule editing (routes/tagger.ts) and the automatic post-import run (pipeline).
   taggerStore?: TaggerStore;
@@ -2929,6 +2934,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const sourceTrustStore = new SourceTrustStore(store);
   const dwellWindowStore = new DwellWindowStore(store);
   const superTimelineStore = new SuperTimelineStore(store, Number(process.env.DFIR_SUPERTIMELINE_MAX) || undefined);
+  const starredReportStore = new StarredReportStore(store);
   const forensicGateControlStore = new ForensicGateControlStore(store);
   const confidenceControlStore = new ConfidenceControlStore(store);
   const playbookStore = new PlaybookStore(store);
@@ -3062,6 +3068,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     onDwellWindow: (caseId) => hub.broadcastTo(caseId, { type: "dwell_window_changed" }),
     superTimelineStore,
     onSuperTimeline: (caseId) => hub.broadcastTo(caseId, { type: "super_timeline_changed" }),
+    starredReportStore,
     forensicGateControlStore,
     onForensicGate: (caseId) => hub.broadcastTo(caseId, { type: "forensic_gate_changed" }),
     confidenceControlStore,

--- a/companion/tests/analysis/starredReport.test.ts
+++ b/companion/tests/analysis/starredReport.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,6 +39,10 @@ async function makePipeline(forensic: ForensicEvent[], superEvents: ForensicEven
   return { pipeline, provider };
 }
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("starredReport()", () => {
   it("reports over exactly the starred ids, with an accurate provenance count", async () => {
     const { pipeline, provider } = await makePipeline([
@@ -71,6 +75,39 @@ describe("starredReport()", () => {
     const { pipeline } = await makePipeline([ev({ id: "e1", description: "x" })]);
     await expect(pipeline.starredReport("c1", ["ghost"])).rejects.toThrow("no starred events");
   });
+
+  it("truncates to the event budget and says so in the provenance line", async () => {
+    vi.stubEnv("DFIR_AI_SYNTH_MAX_EVENTS", "2");
+    const { pipeline, provider } = await makePipeline([
+      ev({ id: "e1", description: "critical hit one", severity: "Critical", timestamp: "2026-01-01T01:00:00Z" }),
+      ev({ id: "e2", description: "high hit two", severity: "High", timestamp: "2026-01-01T02:00:00Z" }),
+      ev({ id: "e3", description: "info row three", severity: "Info", timestamp: "2026-01-01T03:00:00Z" }),
+    ]);
+    const result = await pipeline.starredReport("c1", ["e1", "e2", "e3"]);
+    expect(result.eventCount).toBe(3);
+    expect(result.usedEvents).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(provider.lastReq!.userPrompt).toContain("2 most significant of 3");
+  });
+
+  it("prefers the re-graded FORENSIC copy when the same id exists in both stores", async () => {
+    const { pipeline, provider } = await makePipeline(
+      [ev({ id: "dup1", description: "regraded suspicious logon (forensic copy)", severity: "High", asset: "DC01" })],
+      [ev({ id: "dup1", description: "raw logon row (super copy)", severity: "Info", asset: "DC01" })],
+    );
+    const result = await pipeline.starredReport("c1", ["dup1"]);
+    expect(result.eventCount).toBe(1);
+    const prompt = provider.lastReq!.userPrompt;
+    expect(prompt).toContain("regraded suspicious logon (forensic copy)");
+    expect(prompt).toContain("[High]");
+    expect(prompt).not.toContain("raw logon row (super copy)");
+  });
+
+  it("sends the starred-report system prompt", async () => {
+    const { pipeline, provider } = await makePipeline([ev({ id: "e1", description: "x" })]);
+    await pipeline.starredReport("c1", ["e1"]);
+    expect(provider.lastReq!.systemPrompt).toContain("Starred Events Report");
+  });
 });
 
 describe("viewSummary()", () => {
@@ -99,5 +136,21 @@ describe("viewSummary()", () => {
   it("throws when the filters match nothing", async () => {
     const { pipeline } = await makePipeline([], [ev({ id: "v1", description: "x" })]);
     await expect(pipeline.viewSummary("c1", { labels: ["nope"] }, {})).rejects.toThrow("no events match the current filters");
+  });
+
+  it("sends the view-summary system prompt", async () => {
+    const { pipeline, provider } = await makePipeline([], [ev({ id: "v1", description: "some row" })]);
+    await pipeline.viewSummary("c1", {}, {});
+    expect(provider.lastReq!.systemPrompt).toContain("Summarize the following security events");
+  });
+
+  it("throws when the super-timeline store is not configured", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-starredrep-"));
+    const cases = new CaseStore(root);
+    await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const stateStore = new StateStore(cases);
+    await stateStore.save(emptyState("c1"));
+    const pipeline = new AnalysisPipeline({ provider: new CapturingProvider(), stateStore, imageLoader: async () => ({ base64: "", mimeType: "image/webp" }) });
+    await expect(pipeline.viewSummary("c1", {}, {})).rejects.toThrow("super-timeline not configured");
   });
 });

--- a/companion/tests/analysis/starredReport.test.ts
+++ b/companion/tests/analysis/starredReport.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+
+class CapturingProvider implements AIProvider {
+  readonly name = "capture";
+  lastReq?: AnalyzeRequest;
+  private readonly response: object;
+  constructor(response: object = { markdown: "# Starred Events Report\n\nreport body" }) { this.response = response; }
+  async analyze(req: AnalyzeRequest): Promise<AnalyzeResult> {
+    this.lastReq = req;
+    return { rawText: JSON.stringify(this.response) };
+  }
+}
+
+function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return { timestamp: "2026-01-01T00:00:00Z", description: "", severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...p };
+}
+
+async function makePipeline(forensic: ForensicEvent[], superEvents: ForensicEvent[] = []) {
+  const root = await mkdtemp(join(tmpdir(), "dfir-starredrep-"));
+  const cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  const stateStore = new StateStore(cases);
+  const s = emptyState("c1");
+  s.forensicTimeline = forensic;
+  await stateStore.save(s);
+  const superTimelineStore = new SuperTimelineStore(cases);
+  if (superEvents.length) await superTimelineStore.append("c1", superEvents);
+  const provider = new CapturingProvider();
+  const pipeline = new AnalysisPipeline({ provider, stateStore, superTimelineStore, imageLoader: async () => ({ base64: "", mimeType: "image/webp" }) });
+  return { pipeline, provider };
+}
+
+describe("starredReport()", () => {
+  it("reports over exactly the starred ids, with an accurate provenance count", async () => {
+    const { pipeline, provider } = await makePipeline([
+      ev({ id: "e1", description: "mimikatz.exe executed", severity: "Critical", asset: "WS01", timestamp: "2026-01-01T01:00:00Z" }),
+      ev({ id: "e2", description: "benign chrome update", severity: "Info", timestamp: "2026-01-01T02:00:00Z" }),
+      ev({ id: "e3", description: "RDP logon from 10.9.9.9", severity: "High", asset: "DC01", timestamp: "2026-01-01T03:00:00Z" }),
+    ]);
+    const result = await pipeline.starredReport("c1", ["e1", "e3"]);
+    expect(result.markdown).toContain("# Starred Events Report");
+    expect(result.eventCount).toBe(2);
+    expect(result.usedEvents).toBe(2);
+    expect(result.truncated).toBe(false);
+    const prompt = provider.lastReq!.userPrompt;
+    expect(prompt).toContain("mimikatz.exe executed");
+    expect(prompt).toContain("RDP logon from 10.9.9.9");
+    expect(prompt).not.toContain("benign chrome update");     // unstarred events never leak in
+    expect(prompt).toContain("based on 2 (deduplicated) starred events");
+  });
+
+  it("resolves starred events that exist ONLY in the super-timeline store", async () => {
+    const { pipeline, provider } = await makePipeline([], [
+      ev({ id: "super1", description: "prefetch: EVIL.EXE executed", asset: "TRIAGE-HOST" }),
+    ]);
+    const result = await pipeline.starredReport("c1", ["super1"]);
+    expect(result.eventCount).toBe(1);
+    expect(provider.lastReq!.userPrompt).toContain("prefetch: EVIL.EXE executed");
+  });
+
+  it("throws when no starred id resolves to an event", async () => {
+    const { pipeline } = await makePipeline([ev({ id: "e1", description: "x" })]);
+    await expect(pipeline.starredReport("c1", ["ghost"])).rejects.toThrow("no starred events");
+  });
+});
+
+describe("viewSummary()", () => {
+  it("summarizes exactly the events matching the passed filters + label map", async () => {
+    const { pipeline, provider } = await makePipeline([], [
+      ev({ id: "v1", description: "psexec lateral hop", timestamp: "2026-01-01T01:00:00Z" }),
+      ev({ id: "v2", description: "normal dns chatter", timestamp: "2026-01-01T02:00:00Z" }),
+    ]);
+    const result = await pipeline.viewSummary("c1", { labels: ["exfil"] }, { v1: ["exfil"] });
+    expect(result.eventCount).toBe(1);
+    const prompt = provider.lastReq!.userPrompt;
+    expect(prompt).toContain("psexec lateral hop");
+    expect(prompt).not.toContain("normal dns chatter");
+  });
+
+  it("applies the starred filter through the label map", async () => {
+    const { pipeline, provider } = await makePipeline([], [
+      ev({ id: "v1", description: "starred row" }),
+      ev({ id: "v2", description: "plain row" }),
+    ]);
+    await pipeline.viewSummary("c1", { starred: true }, { v1: ["starred"] });
+    expect(provider.lastReq!.userPrompt).toContain("starred row");
+    expect(provider.lastReq!.userPrompt).not.toContain("plain row");
+  });
+
+  it("throws when the filters match nothing", async () => {
+    const { pipeline } = await makePipeline([], [ev({ id: "v1", description: "x" })]);
+    await expect(pipeline.viewSummary("c1", { labels: ["nope"] }, {})).rejects.toThrow("no events match the current filters");
+  });
+});

--- a/companion/tests/analysis/starredReportStore.test.ts
+++ b/companion/tests/analysis/starredReportStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
@@ -9,26 +9,39 @@ async function makeStore() {
   const root = await mkdtemp(join(tmpdir(), "dfir-starred-report-"));
   const cases = new CaseStore(root);
   await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
-  return new StarredReportStore(cases);
+  const path = join(cases.stateDir("c1"), "starred-report.json");
+  return { store: new StarredReportStore(cases), path };
 }
 
 describe("StarredReportStore", () => {
   it("returns null when nothing was saved", async () => {
-    const store = await makeStore();
+    const { store } = await makeStore();
     expect(await store.load("c1")).toBeNull();
   });
 
   it("round-trips a saved report", async () => {
-    const store = await makeStore();
+    const { store } = await makeStore();
     await store.save("c1", { markdown: "# Starred Events Report\n\nbody", savedAt: "2026-07-16T10:00:00Z", eventCount: 4 });
     const loaded = await store.load("c1");
     expect(loaded).toEqual({ markdown: "# Starred Events Report\n\nbody", savedAt: "2026-07-16T10:00:00Z", eventCount: 4 });
   });
 
   it("overwrites on re-save (single slot)", async () => {
-    const store = await makeStore();
+    const { store } = await makeStore();
     await store.save("c1", { markdown: "first", savedAt: "2026-07-16T10:00:00Z", eventCount: 1 });
     await store.save("c1", { markdown: "second", savedAt: "2026-07-16T11:00:00Z", eventCount: 2 });
     expect((await store.load("c1"))!.markdown).toBe("second");
+  });
+
+  it("returns null for a malformed file", async () => {
+    const { store, path } = await makeStore();
+    await writeFile(path, "{ not json", "utf8");
+    expect(await store.load("c1")).toBeNull();
+  });
+
+  it("returns null for valid JSON with no markdown", async () => {
+    const { store, path } = await makeStore();
+    await writeFile(path, "{}", "utf8");
+    expect(await store.load("c1")).toBeNull();
   });
 });

--- a/companion/tests/analysis/starredReportStore.test.ts
+++ b/companion/tests/analysis/starredReportStore.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StarredReportStore } from "../../src/analysis/starredReportStore.js";
+
+async function makeStore() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-starred-report-"));
+  const cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return new StarredReportStore(cases);
+}
+
+describe("StarredReportStore", () => {
+  it("returns null when nothing was saved", async () => {
+    const store = await makeStore();
+    expect(await store.load("c1")).toBeNull();
+  });
+
+  it("round-trips a saved report", async () => {
+    const store = await makeStore();
+    await store.save("c1", { markdown: "# Starred Events Report\n\nbody", savedAt: "2026-07-16T10:00:00Z", eventCount: 4 });
+    const loaded = await store.load("c1");
+    expect(loaded).toEqual({ markdown: "# Starred Events Report\n\nbody", savedAt: "2026-07-16T10:00:00Z", eventCount: 4 });
+  });
+
+  it("overwrites on re-save (single slot)", async () => {
+    const store = await makeStore();
+    await store.save("c1", { markdown: "first", savedAt: "2026-07-16T10:00:00Z", eventCount: 1 });
+    await store.save("c1", { markdown: "second", savedAt: "2026-07-16T11:00:00Z", eventCount: 2 });
+    expect((await store.load("c1"))!.markdown).toBe("second");
+  });
+});

--- a/companion/tests/analysis/superTimeline.test.ts
+++ b/companion/tests/analysis/superTimeline.test.ts
@@ -200,7 +200,9 @@ describe("querySuper starred filter", () => {
   });
 
   it("ANDs with the time window", () => {
-    const r = querySuper(events, labels, { starred: true, from: "2026-06-01T10:30:00Z" });
+    // from=09:30 leaves s2 (10:00, NOT starred) and s3 (11:00, starred) in-window — so s2 is
+    // excluded by the starred filter alone, proving the AND (not just the time bound) does the work.
+    const r = querySuper(events, labels, { starred: true, from: "2026-06-01T09:30:00Z" });
     expect(r.events.map((e) => e.id)).toEqual(["s3"]);
   });
 
@@ -217,5 +219,11 @@ describe("querySuper starred filter", () => {
     // s1 carries ONLY a star — that is not a triage tag, so taggedOnly must not match it.
     const r = querySuper(events, { s1: ["starred"], s2: ["exfil"] }, { taggedOnly: true });
     expect(r.events.map((e) => e.id)).toEqual(["s2"]);
+  });
+
+  it("starred + taggedOnly compose: a star-only event is still excluded (taggedOnly wins)", () => {
+    // s1 is starred but carries no real triage tag; s3 is starred AND tagged — only s3 survives both.
+    const r = querySuper(events, { s1: ["starred"], s3: ["starred", "exfil"] }, { starred: true, taggedOnly: true });
+    expect(r.events.map((e) => e.id)).toEqual(["s3"]);
   });
 });

--- a/companion/tests/analysis/superTimeline.test.ts
+++ b/companion/tests/analysis/superTimeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { superOriginOf, dedupeAppend, capEvents, querySuper } from "../../src/analysis/superTimeline.js";
+import { superOriginOf, dedupeAppend, capEvents, querySuper, STARRED_LABEL } from "../../src/analysis/superTimeline.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
 
 function ev(p: Partial<ForensicEvent> & { id: string; timestamp: string }): ForensicEvent {
@@ -173,5 +173,49 @@ describe("querySuper", () => {
     expect(r.events.map((e) => e.id)).toEqual(["in1", "in2"]);   // all fixture events share description "d"
     const none = querySuper(events, labels, { from: "2026-06-01T00:00:00Z", to: "2026-06-02T00:00:00Z", search: "nomatch" });
     expect(none.events).toEqual([]);
+  });
+});
+
+describe("querySuper starred filter", () => {
+  const events = [
+    ev({ id: "s1", timestamp: "2026-06-01T09:00:00Z", artifactName: "A" }),
+    ev({ id: "s2", timestamp: "2026-06-01T10:00:00Z", artifactName: "B" }),
+    ev({ id: "s3", timestamp: "2026-06-01T11:00:00Z", artifactName: "A" }),
+  ];
+  const labels = { s1: ["starred"], s2: ["exfil"], s3: ["starred", "exfil"] };
+
+  it("exports the reserved label constant", () => {
+    expect(STARRED_LABEL).toBe("starred");
+  });
+
+  it("starred=true keeps only events carrying the reserved starred label", () => {
+    const r = querySuper(events, labels, { starred: true });
+    expect(r.events.map((e) => e.id)).toEqual(["s1", "s3"]);
+    expect(r.total).toBe(2);
+  });
+
+  it("ANDs with the labels include-filter (starred ∩ exfil)", () => {
+    const r = querySuper(events, labels, { starred: true, labels: ["exfil"] });
+    expect(r.events.map((e) => e.id)).toEqual(["s3"]);
+  });
+
+  it("ANDs with the time window", () => {
+    const r = querySuper(events, labels, { starred: true, from: "2026-06-01T10:30:00Z" });
+    expect(r.events.map((e) => e.id)).toEqual(["s3"]);
+  });
+
+  it("yields zero when nothing is starred", () => {
+    expect(querySuper(events, { s2: ["exfil"] }, { starred: true }).total).toBe(0);
+  });
+
+  it("excludes the starred label from the labelsAvailable facet", () => {
+    const r = querySuper(events, labels, {});
+    expect(r.labelsAvailable).toEqual(["exfil"]);
+  });
+
+  it("taggedOnly ignores the starred pseudo-tag", () => {
+    // s1 carries ONLY a star — that is not a triage tag, so taggedOnly must not match it.
+    const r = querySuper(events, { s1: ["starred"], s2: ["exfil"] }, { taggedOnly: true });
+    expect(r.events.map((e) => e.id)).toEqual(["s2"]);
   });
 });

--- a/companion/tests/analysis/tags.test.ts
+++ b/companion/tests/analysis/tags.test.ts
@@ -59,10 +59,10 @@ describe("TagsStore", () => {
     await expect(store.add("c1", { targetType: "event", targetId: "e1", author: "Bob", label: "   " })).rejects.toThrow(/label/);
   });
 
-  it("removes a tag by id (true if it existed)", async () => {
+  it("removes a tag by id (returns the removed tag, or null if absent)", async () => {
     const t = await store.add("c1", { targetType: "finding", targetId: "f1", author: "Bob", label: "false-positive" });
-    expect(await store.remove("c1", t.id)).toBe(true);
+    expect(await store.remove("c1", t.id)).toMatchObject({ id: t.id, label: "false-positive" });
     expect(await store.load("c1")).toHaveLength(0);
-    expect(await store.remove("c1", "does-not-exist")).toBe(false);
+    expect(await store.remove("c1", "does-not-exist")).toBeNull();
   });
 });

--- a/companion/tests/server/starActivityLog.test.ts
+++ b/companion/tests/server/starActivityLog.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { TagsStore } from "../../src/analysis/tags.js";
+import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+
+// A star is the reserved "starred" analyst tag — a high-frequency triage gesture (starring 50
+// rows would otherwise spam 50 tag-added/tag-removed entries). The activity log must stay silent
+// for that ONE reserved label while still logging every normal tag add/remove.
+
+async function harness() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-staract-"));
+  const store = new CaseStore(root);
+  const app = createApp(store, {
+    aiConfigured: false,
+    tagsStore: new TagsStore(store),
+    activityLogStore: new ActivityLogStore(store),
+  });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app };
+}
+
+describe("activity log suppression for the reserved 'starred' tag", () => {
+  it("logs a tag-added entry for a normal label", async () => {
+    const { app } = await harness();
+    const post = await request(app).post("/cases/c1/tags").send({
+      targetType: "event", targetId: "ev1", label: "needs-review", author: "an",
+    });
+    expect(post.status).toBe(201);
+    const log = await request(app).get("/cases/c1/activity-log");
+    expect(log.status).toBe(200);
+    const added = log.body.filter((e: { action: string }) => e.action === "tag-added");
+    expect(added.length).toBe(1);
+    expect(added[0].detail).toContain("needs-review");
+  });
+
+  it("does NOT log a tag-added entry for the reserved 'starred' label", async () => {
+    const { app } = await harness();
+    const post = await request(app).post("/cases/c1/tags").send({
+      targetType: "event", targetId: "ev1", label: "starred", author: "an",
+    });
+    expect(post.status).toBe(201);
+    const log = await request(app).get("/cases/c1/activity-log");
+    expect(log.status).toBe(200);
+    const added = log.body.filter((e: { action: string }) => e.action === "tag-added");
+    expect(added.length).toBe(0);
+  });
+
+  it("does NOT log a tag-removed entry when the removed tag was 'starred'", async () => {
+    const { app } = await harness();
+    const post = await request(app).post("/cases/c1/tags").send({
+      targetType: "event", targetId: "ev1", label: "starred", author: "an",
+    });
+    const tagId = post.body.id;
+    const del = await request(app).delete(`/cases/c1/tags/${tagId}`);
+    expect(del.status).toBe(204);
+    const log = await request(app).get("/cases/c1/activity-log");
+    const removed = log.body.filter((e: { action: string }) => e.action === "tag-removed");
+    expect(removed.length).toBe(0);
+  });
+
+  it("DOES log a tag-removed entry for a normal label", async () => {
+    const { app } = await harness();
+    const post = await request(app).post("/cases/c1/tags").send({
+      targetType: "event", targetId: "ev1", label: "needs-review", author: "an",
+    });
+    const tagId = post.body.id;
+    const del = await request(app).delete(`/cases/c1/tags/${tagId}`);
+    expect(del.status).toBe(204);
+    const log = await request(app).get("/cases/c1/activity-log");
+    const removed = log.body.filter((e: { action: string }) => e.action === "tag-removed");
+    expect(removed.length).toBe(1);
+    expect(removed[0].detail).toContain(tagId);
+  });
+
+  it("404s on a repeat DELETE of the same tag id (remove() null path, no double-log)", async () => {
+    const { app } = await harness();
+    const post = await request(app).post("/cases/c1/tags").send({
+      targetType: "event", targetId: "ev1", label: "needs-review", author: "an",
+    });
+    const tagId = post.body.id;
+    await request(app).delete(`/cases/c1/tags/${tagId}`);
+    const second = await request(app).delete(`/cases/c1/tags/${tagId}`);
+    expect(second.status).toBe(404);
+    const log = await request(app).get("/cases/c1/activity-log");
+    const removed = log.body.filter((e: { action: string }) => e.action === "tag-removed");
+    expect(removed.length).toBe(1);
+  });
+});

--- a/companion/tests/server/starActivityLog.test.ts
+++ b/companion/tests/server/starActivityLog.test.ts
@@ -50,6 +50,20 @@ describe("activity log suppression for the reserved 'starred' tag", () => {
     expect(added.length).toBe(0);
   });
 
+  it("does NOT log a tag-added entry for a differently-cased 'Starred' (normalized to the reserved label)", async () => {
+    const { app } = await harness();
+    // add() normalizes "Starred" → "starred"; the suppression check reads the STORED tag.label,
+    // so a cased/spaced variant is caught too (symmetric with the DELETE side).
+    const post = await request(app).post("/cases/c1/tags").send({
+      targetType: "event", targetId: "ev1", label: "Starred", author: "an",
+    });
+    expect(post.status).toBe(201);
+    expect(post.body.label).toBe("starred");
+    const log = await request(app).get("/cases/c1/activity-log");
+    const added = log.body.filter((e: { action: string }) => e.action === "tag-added");
+    expect(added.length).toBe(0);
+  });
+
   it("does NOT log a tag-removed entry when the removed tag was 'starred'", async () => {
     const { app } = await harness();
     const post = await request(app).post("/cases/c1/tags").send({

--- a/companion/tests/server/starredReport.test.ts
+++ b/companion/tests/server/starredReport.test.ts
@@ -147,3 +147,45 @@ describe("POST /cases/:id/view-summary", () => {
     expect(r.status).toBe(400);
   });
 });
+
+// Both reports run on the SYNTHESIS (text) provider, not the vision/OCR provider (DFIR_AI_PROVIDER).
+// A synthesis-only install (DFIR_AI_SYNTH_PROVIDER set, vision provider unset → aiConfigured=false)
+// must still produce reports — the route gate is hasSynthesisProvider(), not hasAiProvider().
+describe("synthesis-provider gate (no vision provider)", () => {
+  async function synthOnlyHarness() {
+    const root = await mkdtemp(join(tmpdir(), "dfir-starred-synthonly-"));
+    const store = new CaseStore(root);
+    const stateStore = new StateStore(store);
+    const provider = new CapturingProvider();
+    const pipeline = buildRuntimePipeline({
+      provider: undefined, synthesisProvider: provider, stateStore, store,
+      imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+    });
+    const superStore = new SuperTimelineStore(store);
+    const app = createApp(store, {
+      pipeline, stateStore, aiConfigured: false,   // vision provider off — mirrors buildProvider() === undefined
+      tagsStore: new TagsStore(store),
+      superTimelineStore: superStore,
+      starredReportStore: new StarredReportStore(store),
+    });
+    await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    return { app, superStore };
+  }
+
+  it("starred-report works on synthesis alone (200, not 501)", async () => {
+    const { app, superStore } = await synthOnlyHarness();
+    await superStore.append("c1", [sev("v1", "2026-06-01T09:00:00Z", "mimikatz.exe executed")]);
+    await request(app).post("/cases/c1/tags").send({ targetType: "event", targetId: "v1", label: "starred", author: "an" });
+    const r = await request(app).post("/cases/c1/starred-report").send({});
+    expect(r.status).toBe(200);
+    expect(r.body.markdown).toContain("# Starred Events Report");
+  });
+
+  it("view-summary works on synthesis alone (200, not 501)", async () => {
+    const { app, superStore } = await synthOnlyHarness();
+    await superStore.append("c1", [sev("v1", "2026-06-01T09:00:00Z", "psexec lateral hop")]);
+    const r = await request(app).post("/cases/c1/view-summary").send({});
+    expect(r.status).toBe(200);
+    expect(r.body.eventCount).toBe(1);
+  });
+});

--- a/companion/tests/server/starredReport.test.ts
+++ b/companion/tests/server/starredReport.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, buildRuntimePipeline } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { TagsStore } from "../../src/analysis/tags.js";
+import { StarredReportStore } from "../../src/analysis/starredReportStore.js";
+import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+
+class CapturingProvider implements AIProvider {
+  readonly name = "capture";
+  lastReq?: AnalyzeRequest;
+  async analyze(req: AnalyzeRequest): Promise<AnalyzeResult> {
+    this.lastReq = req;
+    return { rawText: JSON.stringify({ markdown: "# Starred Events Report\n\nreport body" }) };
+  }
+}
+
+const sev = (id: string, ts: string, description: string) => ({
+  id, timestamp: ts, description, severity: "Info" as const,
+  mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [],
+});
+
+async function harness(opts: { ai?: boolean } = {}) {
+  const ai = opts.ai ?? true;
+  const root = await mkdtemp(join(tmpdir(), "dfir-starredrt-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const provider = ai ? new CapturingProvider() : undefined;
+  const pipeline = buildRuntimePipeline({
+    provider, synthesisProvider: provider, stateStore, store,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+  const superStore = new SuperTimelineStore(store);
+  const app = createApp(store, {
+    pipeline, stateStore, aiConfigured: ai,
+    tagsStore: new TagsStore(store),
+    superTimelineStore: superStore,
+    starredReportStore: new StarredReportStore(store),
+  });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, superStore, provider };
+}
+
+describe("POST /cases/:id/starred-report", () => {
+  it("501 when no AI provider is configured", async () => {
+    const { app } = await harness({ ai: false });
+    expect((await request(app).post("/cases/c1/starred-report").send({})).status).toBe(501);
+  });
+
+  it("400 when nothing is starred", async () => {
+    const { app } = await harness();
+    const r = await request(app).post("/cases/c1/starred-report").send({});
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/no starred events/);
+  });
+
+  it("reports over the events tagged 'starred' (and only those)", async () => {
+    const { app, superStore, provider } = await harness();
+    await superStore.append("c1", [
+      sev("sv1", "2026-06-01T09:00:00Z", "mimikatz.exe executed"),
+      sev("sv2", "2026-06-01T10:00:00Z", "benign chrome update"),
+    ]);
+    await request(app).post("/cases/c1/tags").send({ targetType: "event", targetId: "sv1", label: "starred", author: "an" });
+    const r = await request(app).post("/cases/c1/starred-report").send({});
+    expect(r.status).toBe(200);
+    expect(r.body.markdown).toContain("# Starred Events Report");
+    expect(r.body.eventCount).toBe(1);
+    expect(provider!.lastReq!.userPrompt).toContain("mimikatz.exe executed");
+    expect(provider!.lastReq!.userPrompt).not.toContain("benign chrome update");
+  });
+});
+
+describe("saved starred report (GET/PUT /cases/:id/starred-report)", () => {
+  it("404 before anything is saved; round-trips after PUT", async () => {
+    const { app } = await harness();
+    expect((await request(app).get("/cases/c1/starred-report")).status).toBe(404);
+    const put = await request(app).put("/cases/c1/starred-report").send({ markdown: "# saved", eventCount: 3 });
+    expect(put.status).toBe(200);
+    const got = await request(app).get("/cases/c1/starred-report");
+    expect(got.status).toBe(200);
+    expect(got.body.markdown).toBe("# saved");
+    expect(got.body.eventCount).toBe(3);
+    expect(typeof got.body.savedAt).toBe("string");
+  });
+
+  it("400 on an empty markdown body", async () => {
+    const { app } = await harness();
+    expect((await request(app).put("/cases/c1/starred-report").send({ markdown: "" })).status).toBe(400);
+  });
+});
+
+describe("POST /cases/:id/view-summary", () => {
+  it("summarizes only the events matching the posted filter set", async () => {
+    const { app, superStore, provider } = await harness();
+    await superStore.append("c1", [
+      sev("v1", "2026-06-01T09:00:00Z", "psexec lateral hop"),
+      sev("v2", "2026-06-01T10:00:00Z", "normal dns chatter"),
+    ]);
+    await request(app).post("/cases/c1/tags").send({ targetType: "event", targetId: "v1", label: "exfil", author: "an" });
+    const r = await request(app).post("/cases/c1/view-summary").send({ labels: "exfil" });
+    expect(r.status).toBe(200);
+    expect(r.body.eventCount).toBe(1);
+    expect(provider!.lastReq!.userPrompt).toContain("psexec lateral hop");
+    expect(provider!.lastReq!.userPrompt).not.toContain("normal dns chatter");
+  });
+
+  it("applies the starred filter", async () => {
+    const { app, superStore, provider } = await harness();
+    await superStore.append("c1", [
+      sev("v1", "2026-06-01T09:00:00Z", "starred row"),
+      sev("v2", "2026-06-01T10:00:00Z", "plain row"),
+    ]);
+    await request(app).post("/cases/c1/tags").send({ targetType: "event", targetId: "v1", label: "starred", author: "an" });
+    const r = await request(app).post("/cases/c1/view-summary").send({ starred: "1" });
+    expect(r.status).toBe(200);
+    expect(provider!.lastReq!.userPrompt).toContain("starred row");
+    expect(provider!.lastReq!.userPrompt).not.toContain("plain row");
+  });
+
+  it("400 when the filters match nothing", async () => {
+    const { app } = await harness();
+    const r = await request(app).post("/cases/c1/view-summary").send({ labels: "nope" });
+    expect(r.status).toBe(400);
+  });
+});

--- a/companion/tests/server/starredReport.test.ts
+++ b/companion/tests/server/starredReport.test.ts
@@ -92,9 +92,28 @@ describe("saved starred report (GET/PUT /cases/:id/starred-report)", () => {
     const { app } = await harness();
     expect((await request(app).put("/cases/c1/starred-report").send({ markdown: "" })).status).toBe(400);
   });
+
+  it("400 on a whitespace-only markdown body (trims to empty)", async () => {
+    const { app } = await harness();
+    expect((await request(app).put("/cases/c1/starred-report").send({ markdown: "   " })).status).toBe(400);
+  });
 });
 
 describe("POST /cases/:id/view-summary", () => {
+  it("501 when no AI provider is configured", async () => {
+    const { app } = await harness({ ai: false });
+    expect((await request(app).post("/cases/c1/view-summary").send({})).status).toBe(501);
+  });
+
+  // Pins the Express body-absent seam: a POST with NO body at all must not crash the route —
+  // the empty filter set matches the (empty) store, so the pipeline's empty-match 400 comes back.
+  it("400 (not a crash) when posted with no body and nothing in the store", async () => {
+    const { app } = await harness();
+    const r = await request(app).post("/cases/c1/view-summary");
+    expect(r.status).toBe(400);
+    expect(r.body.error).toMatch(/no events match/);
+  });
+
   it("summarizes only the events matching the posted filter set", async () => {
     const { app, superStore, provider } = await harness();
     await superStore.append("c1", [

--- a/companion/tests/server/superTimeline.test.ts
+++ b/companion/tests/server/superTimeline.test.ts
@@ -28,12 +28,13 @@ async function harness(opts: { withStore?: boolean } = {}) {
     provider: undefined, synthesisProvider: undefined, stateStore, store,
     imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
   });
+  const superStore = opts.withStore === false ? undefined : new SuperTimelineStore(store);
   const app = createApp(store, {
-    pipeline, stateStore, importerStore,
-    ...(opts.withStore === false ? {} : { superTimelineStore: new SuperTimelineStore(store) }),
+    pipeline, stateStore, importerStore, tagsStore: new TagsStore(store),
+    ...(superStore ? { superTimelineStore: superStore } : {}),
   });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
-  return { app };
+  return { app, superStore };
 }
 
 const MDE_CSV =
@@ -527,5 +528,34 @@ describe("run-bundle validates artifacts against the server catalog", () => {
     expect(run.status).toBe(400);
     expect(run.body.error).toContain("Windows.Bogus.One");
     expect(launchCalls).toEqual([]);   // hunt never launched
+  });
+});
+
+// ── starred=1 server-side filter (stars = the reserved "starred" analyst tag) ────────────────────
+describe("super-timeline starred filter (server-side)", () => {
+  const sev = (id: string, ts: string, description: string) => ({
+    id, timestamp: ts, description, severity: "Info" as const,
+    mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [],
+  });
+
+  it("keeps only events tagged 'starred' and hides the label from the facet", async () => {
+    const { app, superStore } = await harness();
+    await superStore!.append("c1", [
+      sev("sv1", "2026-06-01T09:00:00Z", "benign row"),
+      sev("sv2", "2026-06-01T10:00:00Z", "suspicious row"),
+    ]);
+    const t = await request(app).post("/cases/c1/tags")
+      .send({ targetType: "event", targetId: "sv2", label: "starred", author: "an" });
+    expect(t.status).toBe(201);
+
+    const r = await request(app).get("/cases/c1/super-timeline?starred=1");
+    expect(r.status).toBe(200);
+    expect(r.body.events.map((e: { id: string }) => e.id)).toEqual(["sv2"]);
+    expect(r.body.total).toBe(1);
+    expect(r.body.labelsAvailable).not.toContain("starred");
+
+    // Without the param both rows return (the filter is opt-in).
+    const all = await request(app).get("/cases/c1/super-timeline");
+    expect(all.body.total).toBe(2);
   });
 });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -6813,14 +6813,14 @@
       const btn = document.getElementById("stStarredReport");
       btn.disabled = true; btn.textContent = "✨ generating…";
       fetch(`/cases/${caseId}/starred-report`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
-        .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw new Error(d.error || ("HTTP " + r.status)); return d; })
+        .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw Object.assign(new Error(d.error || ("HTTP " + r.status)), { status: r.status }); return d; })
         .then(d => {
           lastStarredReport = d;
           stRenderAiPanel("✨ Starred events report", d.markdown || "(empty report)",
             d.truncated ? `${d.usedEvents} of ${d.eventCount} starred events (AI input budget)` : `${d.eventCount} starred event${d.eventCount !== 1 ? "s" : ""}`,
             saveStarredReport);
         })
-        .catch(e => stRenderNote(/501/.test(e.message) ? "AI provider not configured (Settings → AI)." : "starred report failed: " + e.message, true))
+        .catch(e => stRenderNote(e.status === 501 ? "AI provider not configured (Settings → AI)." : "starred report failed: " + e.message, true))
         .finally(() => { btn.disabled = false; btn.textContent = "✨ Starred report"; });
     }
 
@@ -6836,11 +6836,11 @@
       p.delete("offset"); p.delete("limit");
       const body = Object.fromEntries(p.entries());
       fetch(`/cases/${caseId}/view-summary`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) })
-        .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw new Error(d.error || ("HTTP " + r.status)); return d; })
+        .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw Object.assign(new Error(d.error || ("HTTP " + r.status)), { status: r.status }); return d; })
         .then(d => stRenderAiPanel("✨ View summary", d.markdown || "(empty summary)",
           d.truncated ? `${d.usedEvents} of ${d.eventCount} matching events (AI input budget)` : `${d.eventCount} matching event${d.eventCount !== 1 ? "s" : ""}`,
           null))
-        .catch(e => stRenderNote(/501/.test(e.message) ? "AI provider not configured (Settings → AI)." : "view summary failed: " + e.message, true))
+        .catch(e => stRenderNote(e.status === 501 ? "AI provider not configured (Settings → AI)." : "view summary failed: " + e.message, true))
         .finally(() => { btn.disabled = false; btn.textContent = "✨ Summarize view"; });
     }
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4237,7 +4237,7 @@
         <span class="src-legend st-dd" id="stHostWrap" style="display:none;margin-left:0" title="Show or hide events by affected host"><button type="button" class="src-filter-btn" id="stHostBtn">🖥 Hosts</button><div class="src-filter-menu" id="stHostMenu" hidden></div></span>
         <span class="src-legend st-dd" id="stTagWrap" style="display:none;margin-left:0" title="Filter to events carrying specific tag(s)"><button type="button" class="src-filter-btn" id="stTagBtn">🏷 Tags</button><div class="src-filter-menu" id="stTagMenu" hidden></div></span>
         <button id="stTaggedOnly" class="ev-bulk-btn" title="Show only events carrying at least one tag">☐ Tagged only</button>
-        <button id="stStarredOnly" class="ev-bulk-btn" title="Show only starred events (this page)">☆ Starred only</button>
+        <button id="stStarredOnly" class="ev-bulk-btn" title="Show only starred events (whole timeline)">☆ Starred only</button>
       </div>
       <div id="superTimelineMsg" style="font-size:12px;color:var(--c-ff6b6b);margin:4px 0"></div>
       <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:6px;padding:6px;border:1px solid var(--c-2b3242);border-radius:6px">
@@ -5524,7 +5524,7 @@
       return "#9aa4b2";
     }
     function tagPills(type, id) {
-      const list = tagsByTarget.get(targetKey(type, id)) || [];
+      const list = (tagsByTarget.get(targetKey(type, id)) || []).filter(t => t.label !== "starred");
       return list.map(t => {
         const c = tagColor(t.label);
         return `<span class="tag-pill" style="color:${c};border-color:${c}" title="tag by ${escAttr(t.author)}">${esc(t.label)}</span>`;
@@ -5545,6 +5545,8 @@
           let arr = tagsByTarget.get(k); if (!arr) { arr = []; tagsByTarget.set(k, arr); }
           arr.push(t);
         });
+        deriveStarred();               // stars are tags — rebuild the star lookup with every tag load
+        migrateLocalStars(caseId);     // one-time: push legacy localStorage stars up as tags
         if (lastState) render(lastState);     // refresh inline pills
         // A tag change alters the super-timeline's Tags filter facet + tag-filtered results (both now
         // server-driven by tags), so reload it rather than a cache re-render — but only when its section
@@ -6201,7 +6203,7 @@
                                     // (bulk star/tag/promote all act on it), keyed by ("event", id) so it
                                     // unifies with the forensic timeline's tag/star machinery.
     let superTaggedOnly = false;    // filter: only events carrying ≥1 tag (server-side, tagged=1)
-    let superStarredOnly = false;   // filter: only starred events (client-side, current page only)
+    let superStarredOnly = false;   // filter: only starred events (server-side, starred=1)
     let superSavedTimeframes = [];  // dwell-windows (saved timeframes)
     let lastSuperData = null;       // last super-timeline query response (for client-side re-render on tag/comment/star change)
     const superCaseId = () => document.getElementById("caseId").value.trim();
@@ -6469,6 +6471,7 @@
       // (empty = no tag filter = all).
       if (superSelectedLabels.size) p.set("labels", [...superSelectedLabels].join(","));
       if (superTaggedOnly) p.set("tagged", "1");
+      if (superStarredOnly) p.set("starred", "1");
       p.set("offset", String(superOffset));
       p.set("limit", String(ST_PAGE));
       return p.toString();
@@ -6568,12 +6571,11 @@
       if (next) next.disabled = superOffset + ST_PAGE >= superTotal;
       const el = document.getElementById("superTimelineList");
       if (!el) return;
-      // "Starred only" is a CLIENT-side, page-local filter: keep only starred rows of the loaded page
-      // (server-side pagination means we can only see the current page here).
-      const rows = superStarredOnly ? events.filter(e => starredEvents.has(e.id)) : events;
+      // Starred-only is now a SERVER-side filter (starred=1) — the rows here are already filtered.
+      const rows = events;
       if (!rows.length) {
-        el.innerHTML = superStarredOnly && events.length
-          ? "<div style='color:var(--c-9aa4b2);font-size:12px'>No starred events on this page. (Starred-only filters the current page only.)</div>"
+        el.innerHTML = superStarredOnly
+          ? "<div style='color:var(--c-9aa4b2);font-size:12px'>No starred events match the current filters — star rows (☆) to build the review set.</div>"
           : "<div style='color:var(--c-9aa4b2);font-size:12px'>No events yet — import evidence (or run the Super-Timeline Triage bundle) and they'll appear here.</div>";
         updateSuperSelBar(rows);
         return;
@@ -6642,7 +6644,7 @@
     // Tag pills for a super row, each clickable to filter the super-timeline to that single tag (sets the
     // Tags box and reloads). Mirrors tagPills() but adds the st-tag-filter affordance.
     function superTagPills(type, id) {
-      const list = tagsByTarget.get(targetKey(type, id)) || [];
+      const list = (tagsByTarget.get(targetKey(type, id)) || []).filter(t => t.label !== "starred");
       return list.map(t => {
         const c = tagColor(t.label);
         return `<span class="tag-pill st-tag-filter" data-label="${escAttr(t.label)}" style="color:${c};border-color:${c};cursor:pointer" title="Filter the super-timeline to this tag">${esc(t.label)}</span>`;
@@ -6694,11 +6696,9 @@
       if (lastSuperData) updateSuperSelBar(currentSuperRows());
     }
 
-    // The rows currently on screen (honoring the client-side starred-only page filter), used by
-    // select-all + the selection bar so they stay in sync with what's actually rendered.
+    // The rows currently on screen (starred-only is server-side now, so this is just the page).
     function currentSuperRows() {
-      const events = (lastSuperData && Array.isArray(lastSuperData.events)) ? lastSuperData.events : [];
-      return superStarredOnly ? events.filter(e => starredEvents.has(e.id)) : events;
+      return (lastSuperData && Array.isArray(lastSuperData.events)) ? lastSuperData.events : [];
     }
 
     // Select-all: tick/untick every row currently shown on this page.
@@ -6708,16 +6708,13 @@
       refreshSuperRows();
     }
 
-    // Bulk star: star all selected if any is unstarred, else unstar all (mirrors bulkToggleStar).
+    // Bulk star: star all selected if any is unstarred, else unstar all (shared serialized helper).
     function superBulkStar() {
       const caseId = superCaseId();
       const ids = [...superPromote];
-      if (!caseId || !ids.length) { const m = document.getElementById("superTimelineMsg"); if (m) { m.style.color = "var(--c-9aa4b2)"; m.textContent = "tick some events first"; } return; }
-      const anyUnstarred = ids.some(id => !starredEvents.has(id));
-      ids.forEach(id => { if (anyUnstarred) starredEvents.add(id); else starredEvents.delete(id); });
-      saveStarred(caseId);
-      renderTimelineEvents(lastFt);   // the star key is shared with the forensic timeline
-      refreshSuperRows();
+      const m = document.getElementById("superTimelineMsg");
+      if (!caseId || !ids.length) { if (m) { m.style.color = "var(--c-9aa4b2)"; m.textContent = "tick some events first"; } return; }
+      bulkStarIds(caseId, ids, m);
     }
 
     // Bulk tag: reuse the forensic bulk-tag modal (it applies a tag to every id in the list, keyed by
@@ -6736,12 +6733,12 @@
       superPage(0);
     }
 
-    // Toggle "Starred only" (client-side, current page) and re-render the loaded page.
+    // Toggle "Starred only" (server-side starred=1 — filters the WHOLE super-timeline) and reload.
     function toggleSuperStarredOnly() {
       superStarredOnly = !superStarredOnly;
       const b = document.getElementById("stStarredOnly");
       if (b) { b.textContent = superStarredOnly ? "★ Starred only" : "☆ Starred only"; b.classList.toggle("active", superStarredOnly); }
-      refreshSuperRows();
+      superPage(0);
     }
 
     // Inline ±window menu anchored to a ⌖ button. Only one is open at a time.
@@ -7303,8 +7300,13 @@
     // (IP/domain/URL-gated). Deterministic templating from the entity's structured fields — no AI, no
     // server round-trip, no cost. The Companion stays a post-detection layer: these PIVOT off a
     // confirmed indicator, they don't author detections for it.
-    // --- Starred events (per case, localStorage) ---------------------------------
+    // --- Starred events (per case, tag-backed) ---------------------------------
+    // A star IS the reserved analyst tag "starred" on ("event", id) — server-side, shared across
+    // browsers/analysts (TimeSketch's model: its star is the __ts_star label). starredEvents /
+    // starredTagIds are DERIVED from tagsByTarget in loadTags(); legacy localStorage stars are
+    // migrated up once per case, then the key is deleted.
     let starredEvents = new Set();
+    let starredTagIds = new Map();   // eventId -> tag id (needed for DELETE /cases/:id/tags/:tagId)
     let showStarredOnly = false;
     // Transient "show only this set of event ids" filter — set by the Timeline Anomalies
     // "view N events" link (and reusable by any panel that points at a group of events) so the
@@ -7331,18 +7333,59 @@
     function isSystemPathIoc(i) { return i.type === "file" && SYSTEM_PATH_RE.test(String(i.value || "").trim()); }
     let hideSystemPaths = _boolPref("hideSysPaths", true);
     const starredKey = caseId => `dfir_starred_${caseId}`;
-    function loadStarred(caseId) {
-      try { starredEvents = new Set(JSON.parse(localStorage.getItem(starredKey(caseId)) || "[]")); }
-      catch { starredEvents = new Set(); }
+    const starMigrationDone = new Set();   // caseIds migrated this session (guards re-entry)
+
+    // Rebuild the star lookup from the freshly-loaded tags (called by loadTags()).
+    function deriveStarred() {
+      starredEvents = new Set();
+      starredTagIds = new Map();
+      tagsByTarget.forEach(list => list.forEach(t => {
+        if (t.targetType === "event" && t.label === "starred") {
+          starredEvents.add(t.targetId);
+          starredTagIds.set(t.targetId, t.id);
+        }
+      }));
     }
-    function saveStarred(caseId) {
-      try { localStorage.setItem(starredKey(caseId), JSON.stringify([...starredEvents])); } catch {}
+
+    // One-time migration: pre-server-side stars lived in localStorage — push any not already
+    // starred up as "starred" tags (SERIALIZED — TagsStore.add() is read-modify-write, concurrent
+    // POSTs clobber each other), then delete the key so this never runs again.
+    async function migrateLocalStars(caseId) {
+      if (starMigrationDone.has(caseId)) return;
+      starMigrationDone.add(caseId);
+      let legacy = [];
+      try { legacy = JSON.parse(localStorage.getItem(starredKey(caseId)) || "[]"); } catch {}
+      if (!legacy.length) return;
+      const toMigrate = legacy.filter(id => !starredEvents.has(id));
+      try {
+        for (const id of toMigrate) {
+          const r = await fetch(`/cases/${caseId}/tags`, { method: "POST", headers: { "content-type": "application/json" },
+            body: JSON.stringify({ targetType: "event", targetId: id, author: investigatorName(), label: "starred" }) });
+          if (!r.ok) throw new Error("HTTP " + r.status);
+        }
+        localStorage.removeItem(starredKey(caseId));   // only after every star landed
+        if (toMigrate.length) loadTags(caseId);
+      } catch { starMigrationDone.delete(caseId); }    // retry on the next loadTags
     }
+
     function toggleStar(caseId, id) {
-      if (starredEvents.has(id)) starredEvents.delete(id); else starredEvents.add(id);
-      saveStarred(caseId);
+      const wasStarred = starredEvents.has(id);
+      // Optimistic flip for instant feedback; loadTags() re-derives the truth after the server call.
+      if (wasStarred) starredEvents.delete(id); else starredEvents.add(id);
       renderTimelineEvents(lastFt);
       refreshSuperRows();   // the star may belong to a super-timeline row (shared ("event", id) key)
+      const revert = () => {
+        if (wasStarred) starredEvents.add(id); else starredEvents.delete(id);
+        renderTimelineEvents(lastFt); refreshSuperRows();
+      };
+      const req = wasStarred
+        ? fetch(`/cases/${caseId}/tags/${encodeURIComponent(starredTagIds.get(id) || "")}`, { method: "DELETE" })
+        : fetch(`/cases/${caseId}/tags`, { method: "POST", headers: { "content-type": "application/json" },
+            body: JSON.stringify({ targetType: "event", targetId: id, author: investigatorName(), label: "starred" }) });
+      req.then(r => {
+        if (!r.ok && r.status !== 404) throw new Error("HTTP " + r.status);   // 404 delete = already gone
+        loadTags(caseId);
+      }).catch(revert);
     }
 
     // --- Multi-select (session-only, cleared on re-render) ----------------------
@@ -7371,12 +7414,35 @@
       }
     }
     function clearIocSelection() { selectedIocs.clear(); if (lastState) renderIocs(lastState.iocs || []); }
+    // Bulk star/unstar N events: any unstarred → star all, else unstar all. SERIALIZED requests —
+    // TagsStore.add() is read-modify-write on tags.json (same reason addTag()'s bulk mode awaits
+    // each call). Optimistic set updates keep the UI live; loadTags() reconciles at the end.
+    async function bulkStarIds(caseId, ids, msgEl) {
+      if (!caseId || !ids.length) return;
+      const anyUnstarred = ids.some(id => !starredEvents.has(id));
+      try {
+        for (let i = 0; i < ids.length; i++) {
+          const id = ids[i];
+          if (msgEl) { msgEl.style.color = "var(--c-9aa4b2)"; msgEl.textContent = `${anyUnstarred ? "starring" : "unstarring"}… (${i + 1}/${ids.length})`; }
+          if (anyUnstarred && !starredEvents.has(id)) {
+            const r = await fetch(`/cases/${caseId}/tags`, { method: "POST", headers: { "content-type": "application/json" },
+              body: JSON.stringify({ targetType: "event", targetId: id, author: investigatorName(), label: "starred" }) });
+            if (!r.ok) throw new Error("HTTP " + r.status);
+            starredEvents.add(id);
+          } else if (!anyUnstarred && starredTagIds.has(id)) {
+            await fetch(`/cases/${caseId}/tags/${encodeURIComponent(starredTagIds.get(id))}`, { method: "DELETE" });
+            starredEvents.delete(id);
+          }
+        }
+        if (msgEl) msgEl.textContent = "";
+      } catch (e) {
+        if (msgEl) { msgEl.style.color = "var(--c-ff6b6b)"; msgEl.textContent = "star failed: " + e.message; }
+      }
+      loadTags(caseId);   // reconcile + refresh both timelines (loadTags reloads the super view)
+    }
     function bulkToggleStar() {
       const caseId = document.getElementById("caseId").value.trim();
-      const anyUnstarred = [...selectedEvents].some(id => !starredEvents.has(id));
-      selectedEvents.forEach(id => { if (anyUnstarred) starredEvents.add(id); else starredEvents.delete(id); });
-      saveStarred(caseId);
-      renderTimelineEvents(lastFt);
+      bulkStarIds(caseId, [...selectedEvents], null);
     }
     function openBulkTagModal(ids, targetType) {
       tagTarget = { bulk: true, ids, targetType: targetType || "event" };
@@ -14228,7 +14294,6 @@
       loadSavedTimeframes(caseId);
       loadSuperTimeline(caseId);
       loadPlaybook(caseId);
-      loadStarred(caseId);
       selectedEvents.clear();
       selectedIocs.clear();
       selectedFindings.clear();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -6771,8 +6771,8 @@
         + `<div>${mdToHtml(markdown)}</div></div>`;
       document.getElementById("stAiCopy").onclick = () => {
         navigator.clipboard.writeText(markdown).then(
-          () => { document.getElementById("stAiMsg").textContent = "copied ✓"; },
-          () => { document.getElementById("stAiMsg").textContent = "copy failed"; });
+          () => { const m = document.getElementById("stAiMsg"); if (m) m.textContent = "copied ✓"; },
+          () => { const m = document.getElementById("stAiMsg"); if (m) m.textContent = "copy failed"; });
       };
       document.getElementById("stAiClose").onclick = () => { panel.hidden = true; panel.innerHTML = ""; };
       const save = document.getElementById("stAiSave");
@@ -6781,11 +6781,11 @@
 
     function saveStarredReport() {
       const caseId = superCaseId();
-      if (!caseId || !lastStarredReport) return;
+      if (!caseId || !lastStarredReport || lastStarredReport.caseId !== caseId) return;
       fetch(`/cases/${caseId}/starred-report`, { method: "PUT", headers: { "content-type": "application/json" },
         body: JSON.stringify({ markdown: lastStarredReport.markdown, eventCount: lastStarredReport.eventCount }) })
-        .then(r => { if (!r.ok) throw new Error("HTTP " + r.status); document.getElementById("stAiMsg").textContent = "saved to case ✓"; })
-        .catch(e => { document.getElementById("stAiMsg").textContent = "save failed: " + e.message; });
+        .then(r => { if (!r.ok) throw new Error("HTTP " + r.status); const m = document.getElementById("stAiMsg"); if (m) m.textContent = "saved to case ✓"; })
+        .catch(e => { const m = document.getElementById("stAiMsg"); if (m) m.textContent = "save failed: " + e.message; });
     }
 
     // On case load: a previously-saved report reappears in the panel (read-only; no Save button).
@@ -6815,7 +6815,8 @@
       fetch(`/cases/${caseId}/starred-report`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
         .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw Object.assign(new Error(d.error || ("HTTP " + r.status)), { status: r.status }); return d; })
         .then(d => {
-          lastStarredReport = d;
+          if (caseId !== superCaseId()) return;   // case switched mid-flight — drop the stale result
+          lastStarredReport = { ...d, caseId };
           stRenderAiPanel("✨ Starred events report", d.markdown || "(empty report)",
             d.truncated ? `${d.usedEvents} of ${d.eventCount} starred events (AI input budget)` : `${d.eventCount} starred event${d.eventCount !== 1 ? "s" : ""}`,
             saveStarredReport);
@@ -6837,9 +6838,12 @@
       const body = Object.fromEntries(p.entries());
       fetch(`/cases/${caseId}/view-summary`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) })
         .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw Object.assign(new Error(d.error || ("HTTP " + r.status)), { status: r.status }); return d; })
-        .then(d => stRenderAiPanel("✨ View summary", d.markdown || "(empty summary)",
-          d.truncated ? `${d.usedEvents} of ${d.eventCount} matching events (AI input budget)` : `${d.eventCount} matching event${d.eventCount !== 1 ? "s" : ""}`,
-          null))
+        .then(d => {
+          if (caseId !== superCaseId()) return;   // case switched mid-flight — drop the stale result
+          stRenderAiPanel("✨ View summary", d.markdown || "(empty summary)",
+            d.truncated ? `${d.usedEvents} of ${d.eventCount} matching events (AI input budget)` : `${d.eventCount} matching event${d.eventCount !== 1 ? "s" : ""}`,
+            null);
+        })
         .catch(e => stRenderNote(e.status === 501 ? "AI provider not configured (Settings → AI)." : "view summary failed: " + e.message, true))
         .finally(() => { btn.disabled = false; btn.textContent = "✨ Summarize view"; });
     }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4238,8 +4238,11 @@
         <span class="src-legend st-dd" id="stTagWrap" style="display:none;margin-left:0" title="Filter to events carrying specific tag(s)"><button type="button" class="src-filter-btn" id="stTagBtn">🏷 Tags</button><div class="src-filter-menu" id="stTagMenu" hidden></div></span>
         <button id="stTaggedOnly" class="ev-bulk-btn" title="Show only events carrying at least one tag">☐ Tagged only</button>
         <button id="stStarredOnly" class="ev-bulk-btn" title="Show only starred events (whole timeline)">☆ Starred only</button>
+        <button id="stStarredReport" class="ev-bulk-btn" title="AI report over ONLY the starred events (one AI call) — the TimeSketch starred-events review workflow">✨ Starred report</button>
+        <button id="stViewSummary" class="ev-bulk-btn" title="AI summary of whatever the current filters show (one AI call). Ephemeral — copy it to keep it.">✨ Summarize view</button>
       </div>
       <div id="superTimelineMsg" style="font-size:12px;color:var(--c-ff6b6b);margin:4px 0"></div>
+      <div id="stAiPanel" hidden style="margin:6px 0"></div>
       <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:6px;padding:6px;border:1px solid var(--c-2b3242);border-radius:6px">
         <strong style="font-size:12px;color:var(--c-9aa4b2)">🏷 Content tagger</strong>
         <button class="ev-bulk-btn" onclick="runTagger()" title="Run the content-based rules over this case and tag matching events (like Timesketch's tagger analyzer)">Run tagger</button>
@@ -6739,6 +6742,106 @@
       const b = document.getElementById("stStarredOnly");
       if (b) { b.textContent = superStarredOnly ? "★ Starred only" : "☆ Starred only"; b.classList.toggle("active", superStarredOnly); }
       superPage(0);
+    }
+
+    // --- Starred report + view summary (TimeSketch-style; button-triggered ONLY, never automatic) --
+    let lastStarredReport = null;   // last generated (unsaved) report — what "Save to case" persists
+
+    function stRenderNote(text, isError) {
+      const panel = document.getElementById("stAiPanel");
+      if (!panel) return;
+      panel.hidden = false;
+      panel.innerHTML = `<div style="font-size:12px;color:${isError ? "var(--c-ff9f43)" : "var(--c-9aa4b2)"}">${esc(text)}</div>`;
+    }
+
+    // Render an AI markdown result with Copy (+ Save to case when onSave is provided).
+    function stRenderAiPanel(title, markdown, meta, onSave) {
+      const panel = document.getElementById("stAiPanel");
+      if (!panel) return;
+      panel.hidden = false;
+      panel.innerHTML = `<div class="info-card" style="border-left:3px solid var(--c-6aa9ff)">`
+        + `<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:6px">`
+        + `<strong style="font-size:12px">${esc(title)}</strong>`
+        + `<span style="font-size:11px;color:var(--c-9aa4b2)">${esc(meta || "")}</span>`
+        + `<span style="flex:1"></span>`
+        + `<button id="stAiCopy" class="ev-bulk-btn" title="Copy the raw markdown">Copy</button>`
+        + (onSave ? `<button id="stAiSave" class="ev-bulk-btn" title="Save to the case (survives reload; overwrites the previous saved report)">Save to case</button>` : "")
+        + `<button id="stAiClose" class="ev-bulk-btn" title="Close">✕</button>`
+        + `<span id="stAiMsg" style="font-size:11px;color:var(--c-9aa4b2)"></span></div>`
+        + `<div>${mdToHtml(markdown)}</div></div>`;
+      document.getElementById("stAiCopy").onclick = () => {
+        navigator.clipboard.writeText(markdown).then(
+          () => { document.getElementById("stAiMsg").textContent = "copied ✓"; },
+          () => { document.getElementById("stAiMsg").textContent = "copy failed"; });
+      };
+      document.getElementById("stAiClose").onclick = () => { panel.hidden = true; panel.innerHTML = ""; };
+      const save = document.getElementById("stAiSave");
+      if (save) save.onclick = onSave;
+    }
+
+    function saveStarredReport() {
+      const caseId = superCaseId();
+      if (!caseId || !lastStarredReport) return;
+      fetch(`/cases/${caseId}/starred-report`, { method: "PUT", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ markdown: lastStarredReport.markdown, eventCount: lastStarredReport.eventCount }) })
+        .then(r => { if (!r.ok) throw new Error("HTTP " + r.status); document.getElementById("stAiMsg").textContent = "saved to case ✓"; })
+        .catch(e => { document.getElementById("stAiMsg").textContent = "save failed: " + e.message; });
+    }
+
+    // On case load: a previously-saved report reappears in the panel (read-only; no Save button).
+    function loadSavedStarredReport(caseId) {
+      const panel = document.getElementById("stAiPanel");
+      if (panel) { panel.hidden = true; panel.innerHTML = ""; }   // clear the previous case's panel
+      lastStarredReport = null;
+      fetch(`/cases/${caseId}/starred-report`)
+        .then(r => r.ok ? r.json() : null)
+        .then(d => {
+          if (!d || !d.markdown) return;
+          const when = d.savedAt ? new Date(d.savedAt).toLocaleString() : "";
+          stRenderAiPanel("✨ Starred events report", d.markdown, `saved${when ? " " + when : ""}${d.eventCount ? ` — ${d.eventCount} starred events` : ""}`, null);
+        })
+        .catch(() => {});
+    }
+
+    function genStarredReport() {
+      const caseId = superCaseId();
+      if (!caseId) return;
+      if (!starredEvents.size) {
+        stRenderNote("No starred events yet — star rows (☆) in the timeline first; the report runs over only the starred set.");
+        return;
+      }
+      const btn = document.getElementById("stStarredReport");
+      btn.disabled = true; btn.textContent = "✨ generating…";
+      fetch(`/cases/${caseId}/starred-report`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
+        .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw new Error(d.error || ("HTTP " + r.status)); return d; })
+        .then(d => {
+          lastStarredReport = d;
+          stRenderAiPanel("✨ Starred events report", d.markdown || "(empty report)",
+            d.truncated ? `${d.usedEvents} of ${d.eventCount} starred events (AI input budget)` : `${d.eventCount} starred event${d.eventCount !== 1 ? "s" : ""}`,
+            saveStarredReport);
+        })
+        .catch(e => stRenderNote(/501/.test(e.message) ? "AI provider not configured (Settings → AI)." : "starred report failed: " + e.message, true))
+        .finally(() => { btn.disabled = false; btn.textContent = "✨ Starred report"; });
+    }
+
+    function genViewSummary() {
+      const caseId = superCaseId();
+      if (!caseId) return;
+      if (lastSuperData && !superTotal) { stRenderNote("Nothing to summarize — the current filters match no events."); return; }
+      const btn = document.getElementById("stViewSummary");
+      btn.disabled = true; btn.textContent = "✨ summarizing…";
+      // Exactly the filter set the timeline query uses, minus pagination (the summary covers the
+      // WHOLE match, not the visible page).
+      const p = new URLSearchParams(superQueryString());
+      p.delete("offset"); p.delete("limit");
+      const body = Object.fromEntries(p.entries());
+      fetch(`/cases/${caseId}/view-summary`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) })
+        .then(async r => { const d = await r.json().catch(() => ({})); if (!r.ok) throw new Error(d.error || ("HTTP " + r.status)); return d; })
+        .then(d => stRenderAiPanel("✨ View summary", d.markdown || "(empty summary)",
+          d.truncated ? `${d.usedEvents} of ${d.eventCount} matching events (AI input budget)` : `${d.eventCount} matching event${d.eventCount !== 1 ? "s" : ""}`,
+          null))
+        .catch(e => stRenderNote(/501/.test(e.message) ? "AI provider not configured (Settings → AI)." : "view summary failed: " + e.message, true))
+        .finally(() => { btn.disabled = false; btn.textContent = "✨ Summarize view"; });
     }
 
     // Inline ±window menu anchored to a ⌖ button. Only one is open at a time.
@@ -14294,6 +14397,7 @@
       loadHypotheses(caseId);
       loadSavedTimeframes(caseId);
       loadSuperTimeline(caseId);
+      loadSavedStarredReport(caseId);
       loadPlaybook(caseId);
       starredEvents = new Set(); starredTagIds = new Map();   // reset synchronously; loadTags re-derives for the new case
       selectedEvents.clear();
@@ -14973,6 +15077,8 @@
       if (e.target.id === "stBulkTag") { superBulkTag(); return; }
       if (e.target.id === "stTaggedOnly") { toggleSuperTaggedOnly(); return; }
       if (e.target.id === "stStarredOnly") { toggleSuperStarredOnly(); return; }
+      if (e.target.id === "stStarredReport") { genStarredReport(); return; }
+      if (e.target.id === "stViewSummary") { genViewSummary(); return; }
       // Super-timeline: click a tag pill to filter the timeline to that tag.
       const stTag = e.target.closest && e.target.closest(".st-tag-filter");
       if (stTag) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5524,7 +5524,7 @@
       return "#9aa4b2";
     }
     function tagPills(type, id) {
-      const list = (tagsByTarget.get(targetKey(type, id)) || []).filter(t => t.label !== "starred");
+      const list = (tagsByTarget.get(targetKey(type, id)) || []).filter(t => !(t.label === "starred" && t.targetType === "event"));
       return list.map(t => {
         const c = tagColor(t.label);
         return `<span class="tag-pill" style="color:${c};border-color:${c}" title="tag by ${escAttr(t.author)}">${esc(t.label)}</span>`;
@@ -6644,7 +6644,7 @@
     // Tag pills for a super row, each clickable to filter the super-timeline to that single tag (sets the
     // Tags box and reloads). Mirrors tagPills() but adds the st-tag-filter affordance.
     function superTagPills(type, id) {
-      const list = (tagsByTarget.get(targetKey(type, id)) || []).filter(t => t.label !== "starred");
+      const list = (tagsByTarget.get(targetKey(type, id)) || []).filter(t => !(t.label === "starred" && t.targetType === "event"));
       return list.map(t => {
         const c = tagColor(t.label);
         return `<span class="tag-pill st-tag-filter" data-label="${escAttr(t.label)}" style="color:${c};border-color:${c};cursor:pointer" title="Filter the super-timeline to this tag">${esc(t.label)}</span>`;
@@ -7416,7 +7416,7 @@
     function clearIocSelection() { selectedIocs.clear(); if (lastState) renderIocs(lastState.iocs || []); }
     // Bulk star/unstar N events: any unstarred → star all, else unstar all. SERIALIZED requests —
     // TagsStore.add() is read-modify-write on tags.json (same reason addTag()'s bulk mode awaits
-    // each call). Optimistic set updates keep the UI live; loadTags() reconciles at the end.
+    // each call). Set updates are reconciled into the UI by the per-tag ws broadcasts and the final loadTags().
     async function bulkStarIds(caseId, ids, msgEl) {
       if (!caseId || !ids.length) return;
       const anyUnstarred = ids.some(id => !starredEvents.has(id));
@@ -7430,7 +7430,8 @@
             if (!r.ok) throw new Error("HTTP " + r.status);
             starredEvents.add(id);
           } else if (!anyUnstarred && starredTagIds.has(id)) {
-            await fetch(`/cases/${caseId}/tags/${encodeURIComponent(starredTagIds.get(id))}`, { method: "DELETE" });
+            const r = await fetch(`/cases/${caseId}/tags/${encodeURIComponent(starredTagIds.get(id))}`, { method: "DELETE" });
+            if (!r.ok && r.status !== 404) throw new Error("HTTP " + r.status);   // 404 = already gone
             starredEvents.delete(id);
           }
         }
@@ -7442,7 +7443,7 @@
     }
     function bulkToggleStar() {
       const caseId = document.getElementById("caseId").value.trim();
-      bulkStarIds(caseId, [...selectedEvents], null);
+      bulkStarIds(caseId, [...selectedEvents], document.getElementById("evBulkCount"));
     }
     function openBulkTagModal(ids, targetType) {
       tagTarget = { bulk: true, ids, targetType: targetType || "event" };
@@ -14294,6 +14295,7 @@
       loadSavedTimeframes(caseId);
       loadSuperTimeline(caseId);
       loadPlaybook(caseId);
+      starredEvents = new Set(); starredTagIds = new Map();   // reset synchronously; loadTags re-derives for the new case
       selectedEvents.clear();
       selectedIocs.clear();
       selectedFindings.clear();


### PR DESCRIPTION
## Summary

Reproduces TimeSketch's starred-events review workflow in the Super-Timeline:

- **Server-side stars** — event stars move from browser localStorage to the case, modeled as the reserved analyst tag `starred` on `("event", id)`. Stars are shared across browsers/analysts and survive synthesis. Existing browser-local stars migrate up automatically (once per case, idempotent), then the localStorage key is retired. The reserved label is hidden from every triage surface (tag chips, palette, filter dropdown, `taggedOnly`, `labelsAvailable` facet, and the collaboration activity log).
- **Whole-timeline "☆ Starred only"** — the filter is now server-side (`starred=1`), ANDed with all other filters, across every page (previously page-local).
- **✨ Starred report** — one text-only AI call over *only* the starred events → a TimeSketch-style Markdown forensic report (incident overview, key findings, chronological timeline, impact, next steps). Server-computed provenance line with honest truncation when the starred set exceeds the AI input budget. Copy + **Save to case** (persisted side file, survives reload).
- **✨ Summarize view** — ephemeral AI overview of whatever the current filters show.
- Nothing runs automatically; both actions are button-triggered, logged to the AI cost card, and their prompts are env-overridable (`DFIR_AI_STARREDREPORT_PROMPT` / `DFIR_AI_VIEWSUMMARY_PROMPT`).

Both AI actions correctly gate on and run against the **synthesis** provider (text), not the vision/OCR provider — so they work in a synthesis-only install.

## Implementation notes

- Pure query logic (`querySuper` `starred` filter), a `StarredReportStore` side file, two pipeline methods (`starredReport` / `viewSummary`) following the existing `executiveSummary`/`generateNarrative` pattern (JSON `{markdown}` envelope through `analyzeRestored`), routes in `aiSynthesis.ts`, and the dashboard wiring in `public/dashboard.html`.
- Starred-report event resolution unions the super-timeline with the forensic timeline, with the **forensic copy winning** on id conflict (it carries later severity/MITRE re-grades; the super copy is frozen at import time).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Feature test surface green: `superTimeline`, `starredReport` (analysis + server), `starredReportStore`, `starActivityLog` (75+ tests, incl. synthesis-only-provider regression, truncation/priority, migration idempotency, activity-log suppression)
- [x] Full suite green (one unrelated `aiReload` EBUSY = known Windows `.env`-lock flake, passes in isolation)
- [ ] Live smoke: star rows → persist across reload; ☆ Starred only spans all pages; ✨ Starred report renders + Save/reload; ✨ Summarize view; empty + AI-off paths; no activity-log spam

## Follow-up (separate PR)

A systemic gate mismatch exists beyond this feature: ~21 other text-AI routes (and the auto-synth scheduler) still gate on the vision provider (`hasAiProvider()`) instead of synthesis. Tracked separately; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)