### PR TITLE
fix(ai): gate text AI on synthesis provider + rename vision env vars to DFIR_VISION_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Screenshot/vision AI vars renamed `DFIR_AI_*` → `DFIR_VISION_*`** — the vision-model config (`DFIR_VISION_PROVIDER` / `_MODEL` / `_KEY` / `_BASE_URL` / `_IMAGE_DETAIL`) now has a name that reflects its screenshots-only role, distinct from the text-work family (`DFIR_AI_SYNTH_*`). The legacy `DFIR_AI_*` names still work as a deprecated fallback (the new name wins when both are set), so existing `.env` files keep working with no change required.
+
 ### Fixed
-- **Text AI features no longer require the screenshot/vision provider** — synthesis, ask, event explain, executive summary/remediation/narrative, hunt suggestions, CSV/log import triage, query translation, tagger-rule drafting, gap hypotheses, and auto/re-synthesis now run whenever a synthesis provider is configured (`DFIR_AI_SYNTH_PROVIDER`), instead of returning 501 in OCR-less installs where `DFIR_AI_PROVIDER` is unset.
+- **Text AI features no longer require the screenshot/vision provider** — synthesis, ask, event explain, executive summary/remediation/narrative, hunt suggestions, CSV/log import triage, query translation, tagger-rule drafting, gap hypotheses, and auto/re-synthesis now run whenever a synthesis provider is configured (`DFIR_AI_SYNTH_PROVIDER`), instead of returning 501 in OCR-less installs where the vision provider (`DFIR_VISION_PROVIDER`) is unset.
 
 ### Added
 - **Login Graph** — new dashboard section: an interactive, Timesketch-style directed graph of Windows logon activity (accounts → hosts from super-timeline 4624/4625 rows). Draggable nodes, five layouts (spread/dagre/circle/concentric/breadthfirst), bezier/taxi edges, selection transparency, live filter, PNG export, fullscreen. Failed logons render as dashed red edges, risky logon shapes (external RDP, cleartext, `runas /netonly`) as orange, and a one-click filter hides machine/system-session account noise. Click an edge for the underlying events; click a node to pivot into the super-timeline. Fully offline (vendored cytoscape.js).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Text AI features no longer require the screenshot/vision provider** — synthesis, ask, event explain, executive summary/remediation/narrative, hunt suggestions, CSV/log import triage, query translation, tagger-rule drafting, gap hypotheses, and auto/re-synthesis now run whenever a synthesis provider is configured (`DFIR_AI_SYNTH_PROVIDER`), instead of returning 501 in OCR-less installs where `DFIR_AI_PROVIDER` is unset.
+
 ### Added
 - **Login Graph** — new dashboard section: an interactive, Timesketch-style directed graph of Windows logon activity (accounts → hosts from super-timeline 4624/4625 rows). Draggable nodes, five layouts (spread/dagre/circle/concentric/breadthfirst), bezier/taxi edges, selection transparency, live filter, PNG export, fullscreen. Failed logons render as dashed red edges, risky logon shapes (external RDP, cleartext, `runas /netonly`) as orange, and a one-click filter hides machine/system-session account noise. Click an edge for the underlying events; click a node to pivot into the super-timeline. Fully offline (vendored cytoscape.js).
 - **Entity merging for duplicate assets/IOCs** — fold a duplicate asset or IOC onto a canonical node/indicator; reversible, and IOC merges preserve the alias across re-synthesis (closes #82).

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ attacker path, questions). Configure both via `.env` — see `companion/README.m
    git clone https://github.com/hasamba/DFIR-Companion.git
    cd DFIR-Companion/companion
    npm install
-   cp .env.example .env      # set DFIR_AI_PROVIDER / MODEL / KEY (or leave AI off)
+   cp .env.example .env      # set DFIR_VISION_PROVIDER / MODEL / KEY (or leave AI off)
    npm run dev               # serves http://127.0.0.1:4773  (dashboard at /dashboard)
    ```
 
@@ -572,33 +572,35 @@ All companion behavior is configured via env vars (`companion/.env` or shell). C
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `DFIR_AI_PROVIDER` | — | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` \| `anthropic`; unset = capture-only |
-| `DFIR_AI_MODEL` | — | Model id (e.g. `gpt-4o-mini`, `gemini-2.5-flash`); **must support vision** for screenshot extraction |
-| `DFIR_AI_KEY` | — | Provider API key; leave blank for an auth-less local proxy |
-| `DFIR_AI_BASE_URL` | provider default | Override base URL — for a local LiteLLM proxy or any OpenAI-compatible endpoint |
+| `DFIR_VISION_PROVIDER` | — | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` \| `anthropic`; unset = capture-only |
+| `DFIR_VISION_MODEL` | — | Model id (e.g. `gpt-4o-mini`, `gemini-2.5-flash`); **must support vision** for screenshot extraction |
+| `DFIR_VISION_KEY` | — | Provider API key; leave blank for an auth-less local proxy |
+| `DFIR_VISION_BASE_URL` | provider default | Override base URL — for a local LiteLLM proxy or any OpenAI-compatible endpoint |
 | `DFIR_AI_TIMEOUT_MS` | `180000` | Per-request timeout (ms); raise for strong models on large timelines |
 | `DFIR_AI_MAX_TOKENS` | `16000` | Max completion tokens; too low truncates synthesis, prevents OpenRouter 402 on low balance |
 | `DFIR_AI_SYNTH_MAX_EVENTS` | `300` | Cap on forensic events sent to synthesis; Critical/High always get a finding regardless |
 | `DFIR_REPORT_SYNTH_COVERAGE` | _(off)_ | Set truthy to add a **§3.4 Synthesis coverage** footnote to the report — "considered N of M in-window events (K omitted: budget/filtered)", the token estimate, and how many high-severity omissions the safety-net backfill recovered. The dashboard synth-meta card always shows this line; this flag only controls whether it also appears in the exported report |
 | `DFIR_AI_CONTEXT_TOKENS` | `128000` | Model context window; raise for Claude/Gemini (200k/1M) to send more per call |
-| `DFIR_AI_IMAGE_DETAIL` | `high` | `high` \| `low` \| `auto` (OpenAI/OpenRouter); `high` tiles at full res for small-text OCR |
+| `DFIR_VISION_IMAGE_DETAIL` | `high` | `high` \| `low` \| `auto` (OpenAI/OpenRouter); `high` tiles at full res for small-text OCR |
 | `DFIR_AI_AUTO_SYNTHESIZE` | `on` | Re-synthesize during capture: `on` \| `off` |
 | `DFIR_AI_AUTO_SYNTHESIZE_MS` | `8000` | Debounce window before auto-synthesis fires (ms) |
 | `DFIR_FLUSH_INTERVAL_MS` | `300000` | Safety-net flush of leftover capture buffers (ms); `0` disables |
 | `DFIR_ANONYMIZE` | `on` | Tokenize victim IPs/hosts/users/paths before AI calls: `on` \| `off` |
 
+> The screenshot/vision vars above (`DFIR_VISION_PROVIDER` / `DFIR_VISION_MODEL` / `DFIR_VISION_KEY` / `DFIR_VISION_BASE_URL` / `DFIR_VISION_IMAGE_DETAIL`) were renamed from the `DFIR_AI_*` prefix; the legacy `DFIR_AI_PROVIDER` / `DFIR_AI_MODEL` / `DFIR_AI_KEY` / `DFIR_AI_BASE_URL` / `DFIR_AI_IMAGE_DETAIL` names still work as a deprecated fallback (the new name wins when both are set).
+
 ### AI — text model (two-tier, optional)
 
-The split is **vision vs text**: `DFIR_AI_MODEL` reads screenshots (must be multimodal); the `DFIR_AI_SYNTH_*` model does **all text work** — CSV extraction, log triage, synthesis, ask/explain. If unset, text work reuses `DFIR_AI_MODEL`.
+The split is **vision vs text**: `DFIR_VISION_MODEL` reads screenshots (must be multimodal); the `DFIR_AI_SYNTH_*` model does **all text work** — CSV extraction, log triage, synthesis, ask/explain. If unset, text work reuses `DFIR_VISION_MODEL`.
 
 Recommended: cheap vision model for screenshots, strong reasoning model for text. Don't economise on the text model — a weak one fails log triage *silently*, returning no events rather than wrong ones (`npm run eval:real` measures exactly this).
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `DFIR_AI_SYNTH_PROVIDER` | = `DFIR_AI_PROVIDER` | Provider for text work (CSV/log/synthesis) |
-| `DFIR_AI_SYNTH_MODEL` | = `DFIR_AI_MODEL` | Text model id — CSV/log extraction + synthesis (e.g. `gpt-4o`, `gemini-2.5-pro`, `claude-sonnet-4-6`) |
-| `DFIR_AI_SYNTH_KEY` | = `DFIR_AI_KEY` | Text-model API key |
-| `DFIR_AI_SYNTH_BASE_URL` | = `DFIR_AI_BASE_URL` | Synthesis base URL |
+| `DFIR_AI_SYNTH_PROVIDER` | = `DFIR_VISION_PROVIDER` | Provider for text work (CSV/log/synthesis) |
+| `DFIR_AI_SYNTH_MODEL` | = `DFIR_VISION_MODEL` | Text model id — CSV/log extraction + synthesis (e.g. `gpt-4o`, `gemini-2.5-pro`, `claude-sonnet-4-6`) |
+| `DFIR_AI_SYNTH_KEY` | = `DFIR_VISION_KEY` | Text-model API key |
+| `DFIR_AI_SYNTH_BASE_URL` | = `DFIR_VISION_BASE_URL` | Synthesis base URL |
 
 ### AI — Velociraptor hunt model (optional)
 
@@ -608,8 +610,8 @@ A dedicated model used **only** to generate Velociraptor VQL hunts (the *Suggest
 |---|---|---|
 | `DFIR_AI_VELO_PROVIDER` | `openrouter` | Provider for VQL-hunt generation |
 | `DFIR_AI_VELO_MODEL` | `anthropic/claude-haiku-4.5` | Model id for VQL-hunt generation |
-| `DFIR_AI_VELO_KEY` | = `DFIR_AI_KEY` | API key (reuses the main key when blank) |
-| `DFIR_AI_VELO_BASE_URL` | = `DFIR_AI_BASE_URL` | Base URL override |
+| `DFIR_AI_VELO_KEY` | = `DFIR_VISION_KEY` | API key (reuses the main key when blank) |
+| `DFIR_AI_VELO_BASE_URL` | = `DFIR_VISION_BASE_URL` | Base URL override |
 
 ### AI — custom prompts (optional)
 
@@ -838,11 +840,11 @@ The token is stored in `notifications/config.json` (beside `cases/`) and is **ne
 Example `.env` (two-tier OpenRouter setup):
 
 ```
-DFIR_AI_PROVIDER=openrouter
-DFIR_AI_MODEL=openai/gpt-4o-mini          # cheap extraction (per screenshot)
-DFIR_AI_KEY=sk-or-...
+DFIR_VISION_PROVIDER=openrouter
+DFIR_VISION_MODEL=openai/gpt-4o-mini          # cheap extraction (per screenshot)
+DFIR_VISION_KEY=sk-or-...
 DFIR_AI_SYNTH_MODEL=google/gemini-2.5-pro # strong synthesis (one call)
-DFIR_AI_IMAGE_DETAIL=high
+DFIR_VISION_IMAGE_DETAIL=high
 ```
 
 ## npm scripts — full CLI reference
@@ -882,9 +884,9 @@ events, and attacker-path preview.
 | Arg / flag | Default | Effect |
 | --- | --- | --- |
 | `caseId` (positional) | `test1` | Case to sample screenshots from. |
-| `--provider NAME` | from `.env` | Override `DFIR_AI_PROVIDER` for this run. |
-| `--model ID` | from `.env` | Override `DFIR_AI_MODEL` for this run. |
-| `--key KEY` | from `.env` | Override `DFIR_AI_KEY` for this run. |
+| `--provider NAME` | from `.env` | Override `DFIR_VISION_PROVIDER` for this run. |
+| `--model ID` | from `.env` | Override `DFIR_VISION_MODEL` for this run. |
+| `--key KEY` | from `.env` | Override `DFIR_VISION_KEY` for this run. |
 
 ```
 npm run verify:ai
@@ -918,10 +920,10 @@ Uses your API quota (~1 call per `--window` screenshots, plus 1 synthesis call).
 | `--reset` | off | Empty the state before analyzing. Otherwise merges into existing. |
 | `--all` | off | Include duplicate screenshots too (most thorough, more API calls). |
 | `--window N` | `4` | Screenshots per AI extraction call. |
-| `--provider NAME` | from `.env` | Override `DFIR_AI_PROVIDER` (extraction). |
-| `--model ID` | from `.env` | Override `DFIR_AI_MODEL` (extraction). |
-| `--key KEY` | from `.env` | Override `DFIR_AI_KEY` (extraction). |
-| `--base-url URL` | from `.env` | Override `DFIR_AI_BASE_URL` (extraction) — e.g. a local LiteLLM proxy. |
+| `--provider NAME` | from `.env` | Override `DFIR_VISION_PROVIDER` (extraction). |
+| `--model ID` | from `.env` | Override `DFIR_VISION_MODEL` (extraction). |
+| `--key KEY` | from `.env` | Override `DFIR_VISION_KEY` (extraction). |
+| `--base-url URL` | from `.env` | Override `DFIR_VISION_BASE_URL` (extraction) — e.g. a local LiteLLM proxy. |
 | `--synth-provider NAME` | = extraction / `DFIR_AI_SYNTH_PROVIDER` | Provider for the synthesis pass. |
 | `--synth-model ID` | = extraction / `DFIR_AI_SYNTH_MODEL` | Stronger model for synthesis (findings / MITRE / attacker path). |
 | `--synth-key KEY` | = extraction / `DFIR_AI_SYNTH_KEY` | API key for the synthesis provider. |
@@ -970,10 +972,10 @@ back to the extraction model.
 | Arg / flag | Default | Effect |
 | --- | --- | --- |
 | `caseId` (positional) | `test1` | Case to synthesize. |
-| `--provider NAME` | `DFIR_AI_SYNTH_PROVIDER` ?? `DFIR_AI_PROVIDER` | Override the synthesis provider. |
-| `--model ID` | `DFIR_AI_SYNTH_MODEL` ?? `DFIR_AI_MODEL` | Override the synthesis model. |
-| `--key KEY` | `DFIR_AI_SYNTH_KEY` ?? `DFIR_AI_KEY` | Override the synthesis API key. |
-| `--base-url URL` | `DFIR_AI_SYNTH_BASE_URL` ?? `DFIR_AI_BASE_URL` | Override the synthesis base URL (e.g. a local LiteLLM proxy). |
+| `--provider NAME` | `DFIR_AI_SYNTH_PROVIDER` ?? `DFIR_VISION_PROVIDER` | Override the synthesis provider. |
+| `--model ID` | `DFIR_AI_SYNTH_MODEL` ?? `DFIR_VISION_MODEL` | Override the synthesis model. |
+| `--key KEY` | `DFIR_AI_SYNTH_KEY` ?? `DFIR_VISION_KEY` | Override the synthesis API key. |
+| `--base-url URL` | `DFIR_AI_SYNTH_BASE_URL` ?? `DFIR_VISION_BASE_URL` | Override the synthesis base URL (e.g. a local LiteLLM proxy). |
 
 ```
 # Use whatever .env says

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -399,16 +399,16 @@ DFIR Companion supports multiple AI backends:
 
 | Provider | Setting |
 |----------|---------|
-| **OpenAI** | `DFIR_AI_PROVIDER=openai` |
-| **Anthropic (Claude)** | `DFIR_AI_PROVIDER=openai` with `DFIR_AI_BASE_URL=https://api.anthropic.com/v1` |
-| **OpenRouter** | `DFIR_AI_PROVIDER=openrouter` |
-| **Google Gemini** | `DFIR_AI_PROVIDER=gemini` |
-| **Ollama** (local) | `DFIR_AI_PROVIDER=ollama`, `DFIR_AI_BASE_URL=http://localhost:11434/v1` |
-| **LiteLLM** (local proxy) | `DFIR_AI_PROVIDER=litellm` |
+| **OpenAI** | `DFIR_VISION_PROVIDER=openai` |
+| **Anthropic (Claude)** | `DFIR_VISION_PROVIDER=openai` with `DFIR_VISION_BASE_URL=https://api.anthropic.com/v1` |
+| **OpenRouter** | `DFIR_VISION_PROVIDER=openrouter` |
+| **Google Gemini** | `DFIR_VISION_PROVIDER=gemini` |
+| **Ollama** (local) | `DFIR_VISION_PROVIDER=ollama`, `DFIR_VISION_BASE_URL=http://localhost:11434/v1` |
+| **LiteLLM** (local proxy) | `DFIR_VISION_PROVIDER=litellm` |
 
-Configure via the Setup Wizard or in `.env`. All AI calls are made server-side — API keys never go to the browser.
+Configure via the Setup Wizard or in `.env`. All AI calls are made server-side — API keys never go to the browser. (The screenshot/vision vars were renamed from `DFIR_AI_*` to `DFIR_VISION_*`; the legacy `DFIR_AI_*` names still work as a deprecated fallback.)
 
-> **Using a local model?** Only screenshot reading needs a **multimodal** (vision) model — that's `DFIR_AI_MODEL`. Everything else (CSV/log import, synthesis, and all other text-only AI features) runs on `DFIR_AI_SYNTH_MODEL`, so a text-only model is fine there. Use the two-tier setup (`DFIR_AI_MODEL` = cheap vision for screenshots, `DFIR_AI_SYNTH_MODEL` = strong reasoning for everything else) — a weak text model fails log triage silently, returning no events at all rather than wrong ones.
+> **Using a local model?** Only screenshot reading needs a **multimodal** (vision) model — that's `DFIR_VISION_MODEL`. Everything else (CSV/log import, synthesis, and all other text-only AI features) runs on `DFIR_AI_SYNTH_MODEL`, so a text-only model is fine there. Use the two-tier setup (`DFIR_VISION_MODEL` = cheap vision for screenshots, `DFIR_AI_SYNTH_MODEL` = strong reasoning for everything else) — a weak text model fails log triage silently, returning no events at all rather than wrong ones.
 
 ### What the AI sees (anonymization)
 

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -99,40 +99,45 @@ DFIR_MAX_BODY_MB=256
 # for the separate (much higher) cap used by Velociraptor super-timeline artifacts.
 # DFIR_MAX_EVENTS=2000
 
-# --- AI analysis (optional). Leave DFIR_AI_PROVIDER unset to run capture-only. ---
+# --- AI analysis (optional). Leave DFIR_VISION_PROVIDER unset to run capture-only. ---
+#
+# NAMING: the SCREENSHOT (vision) config uses the DFIR_VISION_* prefix. The old DFIR_AI_*
+# names (DFIR_AI_PROVIDER/MODEL/KEY/BASE_URL/IMAGE_DETAIL) are still honored as a DEPRECATED
+# fallback, so an existing .env keeps working — the new DFIR_VISION_* name wins when both are
+# set. The text-work family (DFIR_AI_SYNTH_*) and the tuning vars below are unchanged.
 
 # One of: openai | openrouter | ollama | litellm | gemini | anthropic
-DFIR_AI_PROVIDER=openai
+DFIR_VISION_PROVIDER=openai
 
 # Model id understood by your provider. This is the SCREENSHOT model and it MUST support
 # vision. It is also the fallback for all text work (CSV/log/synthesis) when
 # DFIR_AI_SYNTH_MODEL is unset — set that one too; see the two-tier section below.
-DFIR_AI_MODEL=gpt-4o-mini
+DFIR_VISION_MODEL=gpt-4o-mini
 
 # Your provider API key.
-DFIR_AI_KEY=sk-replace-me
+DFIR_VISION_KEY=sk-replace-me
 
 # Override the provider's API base URL. Needed for a self-hosted LiteLLM proxy or any
 # OpenAI-compatible local endpoint; leave unset to use the provider's own default.
 # --- Local Ollama (no proxy — simplest fully-offline setup) -------------------------
 # Ollama serves a native OpenAI-compatible API at http://localhost:11434/v1. Pull a model
 # (`ollama pull llama3.2-vision`), make sure `ollama serve` is running, then point here:
-#   DFIR_AI_PROVIDER=ollama
-#   DFIR_AI_MODEL=llama3.2-vision   # screenshot EXTRACTION needs a VISION model
-#   DFIR_AI_KEY=                    # Ollama ignores the key — leave blank
-#   DFIR_AI_BASE_URL=http://localhost:11434/v1
-# Without DFIR_AI_BASE_URL the ollama provider targets the hosted Ollama Cloud
+#   DFIR_VISION_PROVIDER=ollama
+#   DFIR_VISION_MODEL=llama3.2-vision   # screenshot EXTRACTION needs a VISION model
+#   DFIR_VISION_KEY=                    # Ollama ignores the key — leave blank
+#   DFIR_VISION_BASE_URL=http://localhost:11434/v1
+# Without DFIR_VISION_BASE_URL the ollama provider targets the hosted Ollama Cloud
 # (https://ollama.com/v1) instead, which DOES need a key. A text-only local model still
 # handles CSV/log/synthesis; only per-screenshot extraction requires vision.
 # --- Local LiteLLM proxy (run your own gateway over Ollama / vLLM / 100+ backends) ---
 # Start the proxy (`litellm --model ollama/llama3.1`, default port 4000), then point here:
-#   DFIR_AI_PROVIDER=litellm
-#   DFIR_AI_MODEL=ollama/llama3.1   # whatever model name your proxy config exposes
-#   DFIR_AI_KEY=                    # blank if the proxy has no master/virtual key
-# The litellm provider defaults DFIR_AI_BASE_URL to http://localhost:4000/v1 — set this
+#   DFIR_VISION_PROVIDER=litellm
+#   DFIR_VISION_MODEL=ollama/llama3.1   # whatever model name your proxy config exposes
+#   DFIR_VISION_KEY=                    # blank if the proxy has no master/virtual key
+# The litellm provider defaults DFIR_VISION_BASE_URL to http://localhost:4000/v1 — set this
 # only to change the host/port (e.g. a proxy on another machine). For vision extraction,
-# point DFIR_AI_MODEL at a multimodal model; text-only models still handle CSV/log/synthesis.
-# DFIR_AI_BASE_URL=http://localhost:4000/v1
+# point DFIR_VISION_MODEL at a multimodal model; text-only models still handle CSV/log/synthesis.
+# DFIR_VISION_BASE_URL=http://localhost:4000/v1
 
 # Per-request timeout in ms (default 180000). Strong models over a large timeline
 # can take >60s — raise this if you see "request timed out" during synthesis.
@@ -223,16 +228,16 @@ DFIR_AI_CONTEXT_TOKENS=128000
 # Image detail for OpenAI/OpenRouter vision models: high | low | auto (default high).
 # "high" tiles screenshots at full resolution so small text (usernames, hostnames,
 # domains in Velociraptor tables) is read accurately. Use "low" only to cut cost.
-DFIR_AI_IMAGE_DETAIL=high
+DFIR_VISION_IMAGE_DETAIL=high
 
 # --- Two-tier models (optional) ------------------------------------------------
 # The split is VISION vs TEXT:
 #
-#   DFIR_AI_MODEL       (above) — SCREENSHOTS ONLY. Reads each screenshot batch, so it
+#   DFIR_VISION_MODEL   (above) — SCREENSHOTS ONLY. Reads each screenshot batch, so it
 #                                 MUST be multimodal. High volume — keep it cheap.
 #   DFIR_AI_SYNTH_MODEL (here)  — ALL TEXT WORK: CSV extraction, log triage, synthesis,
 #                                 ask/explain. Point a strong reasoning model here.
-#                                 If unset, text work falls back to DFIR_AI_MODEL.
+#                                 If unset, text work falls back to DFIR_VISION_MODEL.
 #
 # CSV/log extraction runs on the TEXT model because it is text reasoning, not OCR — and a
 # weak model fails it silently, returning NO events rather than wrong ones. Measured with
@@ -242,30 +247,30 @@ DFIR_AI_IMAGE_DETAIL=high
 #
 # Recommended models by provider:
 #
-#   OpenAI  (DFIR_AI_PROVIDER=openai)
+#   OpenAI  (DFIR_VISION_PROVIDER=openai)
 #     Screenshots (vision, high-volume):  gpt-4o-mini        — multimodal, accurate OCR, 3× cheaper than gpt-4o
 #     Text (CSV/log/synthesis):           gpt-4o             — strong reasoning; or o3 for deeper analysis
 #
-#   Gemini  (DFIR_AI_PROVIDER=gemini)
+#   Gemini  (DFIR_VISION_PROVIDER=gemini)
 #     Screenshots (vision, high-volume):  gemini-2.5-flash   — fast, cheap, multimodal, 1M-token context
 #     Text (CSV/log/synthesis):           gemini-2.5-pro     — best reasoning + 1M context fits large timelines
 #
-#   Anthropic  (DFIR_AI_PROVIDER=anthropic)
+#   Anthropic  (DFIR_VISION_PROVIDER=anthropic)
 #     Screenshots (vision, high-volume):  claude-haiku-4-5-20251001  — cheapest Claude with vision; set DFIR_AI_CONTEXT_TOKENS=200000
 #     Text (CSV/log/synthesis):           claude-sonnet-4-6          — best speed/reasoning balance; 200K context
 #                                         claude-opus-4-8            — deepest reasoning for complex cases
 #
 # Example — OpenAI two-tier setup:
-# DFIR_AI_MODEL=gpt-4o-mini            # screenshots (set above)
+# DFIR_VISION_MODEL=gpt-4o-mini        # screenshots (set above)
 # DFIR_AI_SYNTH_MODEL=gpt-4o           # CSV/log/synthesis (set here)
 #
 # Example — Gemini two-tier setup:
-# DFIR_AI_MODEL=gemini-2.5-flash       # screenshots (set above)
+# DFIR_VISION_MODEL=gemini-2.5-flash   # screenshots (set above)
 # DFIR_AI_SYNTH_MODEL=gemini-2.5-pro   # CSV/log/synthesis (set here)
 #
 # Example — Anthropic two-tier setup:
-# DFIR_AI_PROVIDER=anthropic
-# DFIR_AI_MODEL=claude-haiku-4-5-20251001  # extraction (set above)
+# DFIR_VISION_PROVIDER=anthropic
+# DFIR_VISION_MODEL=claude-haiku-4-5-20251001  # screenshots (set above)
 # DFIR_AI_CONTEXT_TOKENS=200000            # Claude's 200K window — send more per call
 # DFIR_AI_SYNTH_PROVIDER=anthropic
 # DFIR_AI_SYNTH_MODEL=claude-sonnet-4-6    # synthesis (set here)
@@ -273,19 +278,19 @@ DFIR_AI_IMAGE_DETAIL=high
 # DFIR_AI_SYNTH_PROVIDER=openrouter
 # DFIR_AI_SYNTH_MODEL=google/gemini-2.5-pro
 # DFIR_AI_SYNTH_KEY=
-# DFIR_AI_SYNTH_BASE_URL=         # synthesis base URL override (falls back to DFIR_AI_BASE_URL)
+# DFIR_AI_SYNTH_BASE_URL=         # synthesis base URL override (falls back to DFIR_VISION_BASE_URL)
 
 # --- Velociraptor hunt model (#70) ---------------------------------------------
 # A DEDICATED model used ONLY to generate Velociraptor VQL hunts (the "✨ Suggest
 # Velociraptor hunts" / "Suggested Fleet Hunts" features) — separate from the
 # extraction, synthesis, and OCR models. Many LLMs botch VQL; pin a known-good one here.
 # DEFAULT (when unset): provider=openrouter, model=anthropic/claude-haiku-4.5.
-# The key falls back to DFIR_AI_KEY, so this works out of the box when your main
+# The key falls back to DFIR_VISION_KEY, so this works out of the box when your main
 # provider is openrouter. Also settable in the dashboard: Settings → AI.
 # DFIR_AI_VELO_PROVIDER=openrouter
 # DFIR_AI_VELO_MODEL=anthropic/claude-haiku-4.5
-# DFIR_AI_VELO_KEY=               # falls back to DFIR_AI_KEY when blank
-# DFIR_AI_VELO_BASE_URL=          # falls back to DFIR_AI_BASE_URL when blank
+# DFIR_AI_VELO_KEY=               # falls back to DFIR_VISION_KEY when blank
+# DFIR_AI_VELO_BASE_URL=          # falls back to DFIR_VISION_BASE_URL when blank
 
 # --- Second LLM opinion (#116) -------------------------------------------------
 # An on-demand QA cross-check: a DIFFERENT model independently re-synthesizes the case,
@@ -294,12 +299,12 @@ DFIR_AI_IMAGE_DETAIL=high
 # DFIR_AI_SECOND_OPINION_MODEL is set (that var IS the opt-in; the dashboard "2nd opinion"
 # button stays hidden otherwise). Pick a model from a DIFFERENT provider than your synthesis
 # model so the opinion is genuinely independent — same-provider models share blind spots. The
-# provider/key/base-url fall back to the main DFIR_AI_* config so it works on one account.
+# provider/key/base-url fall back to the vision config (DFIR_VISION_*) so it works on one account.
 # Two text-only AI calls per run; same caching + anonymization invariants as synthesis.
 # DFIR_AI_SECOND_OPINION_MODEL=gpt-4o            # e.g. primary synth = Anthropic, second opinion = OpenAI
-# DFIR_AI_SECOND_OPINION_PROVIDER=openai         # falls back to DFIR_AI_PROVIDER when blank
-# DFIR_AI_SECOND_OPINION_KEY=                    # falls back to DFIR_AI_KEY when blank
-# DFIR_AI_SECOND_OPINION_BASE_URL=               # falls back to DFIR_AI_BASE_URL when blank
+# DFIR_AI_SECOND_OPINION_PROVIDER=openai         # falls back to DFIR_VISION_PROVIDER when blank
+# DFIR_AI_SECOND_OPINION_KEY=                    # falls back to DFIR_VISION_KEY when blank
+# DFIR_AI_SECOND_OPINION_BASE_URL=               # falls back to DFIR_VISION_BASE_URL when blank
 
 # Log-text extraction (#10): raw log lines are collapsed into distinct, counted templates
 # (most-frequent first) before being sent to the AI so a huge log doesn't blow the prompt
@@ -815,7 +820,7 @@ DFIR_FLUSH_INTERVAL_MS=300000
 # disabled.
 # Note: with an EXTERNAL vision model, screenshots are OCR-redacted IN-MEMORY before they are sent —
 # local Tesseract.js (on-box, no cloud OCR) blacks out words matching the case entity set. It's
-# best-effort (the dashboard still warns). A local Ollama vision model (DFIR_AI_MODEL) keeps
+# best-effort (the dashboard still warns). A local Ollama vision model (DFIR_VISION_MODEL) keeps
 # screenshots on-box and skips OCR entirely. The original screenshot files on disk are never modified.
 DFIR_ANONYMIZE=on
 

--- a/companion/README.md
+++ b/companion/README.md
@@ -58,13 +58,13 @@ http://127.0.0.1:4773/dashboard. On startup it logs the resolved cases root, e.g
 | `DFIR_LOG_LEVEL` | `debug`/`info`/`warn`/`error` (default `info`); live toggle via Settings |
 | `DFIR_LOG_DIR` | Global session log folder (beside cases root) |
 | **AI — extraction** | — |
-| `DFIR_AI_PROVIDER` | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` (unset = capture-only) |
-| `DFIR_AI_MODEL` | Model id (must support vision for screenshot extraction) |
-| `DFIR_AI_KEY` | Provider API key (blank for auth-less local proxy) |
-| `DFIR_AI_BASE_URL` | Override API base URL (for LiteLLM or OpenAI-compatible endpoints) |
-| `DFIR_AI_IMAGE_DETAIL` | `high` \| `low` \| `auto` (default `high` for OCR) |
+| `DFIR_VISION_PROVIDER` | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` (unset = capture-only) |
+| `DFIR_VISION_MODEL` | Model id (must support vision for screenshot extraction) |
+| `DFIR_VISION_KEY` | Provider API key (blank for auth-less local proxy) |
+| `DFIR_VISION_BASE_URL` | Override API base URL (for LiteLLM or OpenAI-compatible endpoints) |
+| `DFIR_VISION_IMAGE_DETAIL` | `high` \| `low` \| `auto` (default `high` for OCR) |
 | **AI — text model (optional two-tier)** | — |
-| `DFIR_AI_SYNTH_PROVIDER` / `_MODEL` / `_KEY` | Stronger model for ALL text work — CSV extraction, log triage, findings/MITRE/attacker path (unset = reuses `DFIR_AI_MODEL`). `DFIR_AI_MODEL` itself is the vision model: screenshots only. |
+| `DFIR_AI_SYNTH_PROVIDER` / `_MODEL` / `_KEY` | Stronger model for ALL text work — CSV extraction, log triage, findings/MITRE/attacker path (unset = reuses `DFIR_VISION_MODEL`). `DFIR_VISION_MODEL` itself is the vision model: screenshots only. |
 | **AI — Velociraptor VQL generation** | — |
 | `DFIR_AI_VELO_PROVIDER` / `_MODEL` / `_KEY` | Dedicated model for VQL hunts (many models botch VQL) |
 | **AI — second LLM opinion** | — |
@@ -76,20 +76,22 @@ http://127.0.0.1:4773/dashboard. On startup it logs the resolved cases root, e.g
 | `DFIR_AI_SYNTH_THINKING_TOKENS` | **Chain-of-Thought** budget for synthesis (#121); off by default, set ≥1024 to let the model reason step-by-step before findings (Anthropic extended thinking / OpenRouter `reasoning`). Per-run alternative: the dashboard **🧠 deep** checkbox (no restart; covers AI Re-synthesize + 2nd opinion) |
 | `DFIR_AI_CONTEXT_TOKENS` | Model context window; default 128000 (raise for Claude 200k/Gemini 1M) |
 
+> The five screenshot/vision vars (`DFIR_VISION_PROVIDER` / `DFIR_VISION_MODEL` / `DFIR_VISION_KEY` / `DFIR_VISION_BASE_URL` / `DFIR_VISION_IMAGE_DETAIL`) were renamed from the `DFIR_AI_*` prefix; the legacy `DFIR_AI_PROVIDER` / `DFIR_AI_MODEL` / `DFIR_AI_KEY` / `DFIR_AI_BASE_URL` / `DFIR_AI_IMAGE_DETAIL` names still work as a deprecated fallback (the new name wins when both are set).
+
 Local models via **LiteLLM**: run [LiteLLM](https://docs.litellm.ai/) as a local gateway
 in front of Ollama / vLLM / any of its 100+ backends — it speaks the OpenAI chat-completions
 API, so the companion talks to it natively. Start the proxy (`litellm --model ollama/llama3.1`,
-default port `4000`), then set `DFIR_AI_PROVIDER=litellm` and `DFIR_AI_MODEL=<your proxy model>`.
-The `litellm` provider defaults `DFIR_AI_BASE_URL` to `http://localhost:4000/v1`; set that var
-only to change the host/port (e.g. a proxy on another box). Leave `DFIR_AI_KEY` blank for an
+default port `4000`), then set `DFIR_VISION_PROVIDER=litellm` and `DFIR_VISION_MODEL=<your proxy model>`.
+The `litellm` provider defaults `DFIR_VISION_BASE_URL` to `http://localhost:4000/v1`; set that var
+only to change the host/port (e.g. a proxy on another box). Leave `DFIR_VISION_KEY` blank for an
 auth-less proxy, or set it to the proxy's master/virtual key. Screenshot extraction needs a
 **multimodal** model; text-only models still drive CSV/log/synthesis (pair them via the two-tier
 `DFIR_AI_SYNTH_*` vars). Keeping everything on-box means evidence never leaves your network.
 
 Direct local **Ollama** (no proxy): Ollama already serves a native OpenAI-compatible API, so you
-can skip LiteLLM entirely — set `DFIR_AI_PROVIDER=ollama`, `DFIR_AI_BASE_URL=http://localhost:11434/v1`,
-and `DFIR_AI_MODEL` to a pulled model (a **vision** model such as `llama3.2-vision` for screenshot
-extraction). Leave `DFIR_AI_KEY` blank — Ollama ignores it. *Without* `DFIR_AI_BASE_URL` the `ollama`
+can skip LiteLLM entirely — set `DFIR_VISION_PROVIDER=ollama`, `DFIR_VISION_BASE_URL=http://localhost:11434/v1`,
+and `DFIR_VISION_MODEL` to a pulled model (a **vision** model such as `llama3.2-vision` for screenshot
+extraction). Leave `DFIR_VISION_KEY` blank — Ollama ignores it. *Without* `DFIR_VISION_BASE_URL` the `ollama`
 provider targets hosted Ollama Cloud (`https://ollama.com/v1`), which does need a key.
 
 Self-hosted enrichment TLS: if your **MISP**, **YETI**, or **OpenCTI** instance presents an internal-CA
@@ -127,10 +129,10 @@ via an injected undici dispatcher; VirusTotal/AbuseIPDB and the AI calls keep th
 | `--reset` | Start from an empty state before analyzing (otherwise merges into existing). | off |
 | `--all` | Include duplicate screenshots too (most thorough; more API calls). Otherwise only non-duplicates. | off |
 | `--window N` | Screenshots per AI call. | `4` |
-| `--provider NAME` | Override `DFIR_AI_PROVIDER` (extraction model) for this run. | from `.env` |
-| `--model ID` | Override `DFIR_AI_MODEL` (extraction model) for this run. | from `.env` |
-| `--key KEY` | Override `DFIR_AI_KEY` for this run. | from `.env` |
-| `--base-url URL` | Override `DFIR_AI_BASE_URL` (e.g. a local LiteLLM proxy) for this run. | from `.env` |
+| `--provider NAME` | Override `DFIR_VISION_PROVIDER` (extraction model) for this run. | from `.env` |
+| `--model ID` | Override `DFIR_VISION_MODEL` (extraction model) for this run. | from `.env` |
+| `--key KEY` | Override `DFIR_VISION_KEY` for this run. | from `.env` |
+| `--base-url URL` | Override `DFIR_VISION_BASE_URL` (e.g. a local LiteLLM proxy) for this run. | from `.env` |
 | `--synth-model ID` | Use a **different (stronger) model for the synthesis pass** — findings / MITRE / attacker path. Per-screenshot extraction still uses `--model`. | = extraction model |
 | `--synth-provider NAME` / `--synth-key KEY` / `--synth-base-url URL` | Provider/key/base-URL for the synthesis model (if different). | = extraction provider/key/base-URL |
 | `--no-synthesis` | Skip the final synthesis pass (raw forensic timeline only, no findings/attacker path). | off |
@@ -656,7 +658,7 @@ always contain the real data ("tokenize-in-transit").
   it is sent: words matching the case entity set are covered with opaque black rectangles in
   an **in-memory** copy. The original screenshot files on disk are never modified. OCR is
   best-effort, so the dashboard still warns when anon is on and the vision model is external.
-  Pointing `DFIR_AI_MODEL` at a local Ollama vision model keeps screenshots on-box and skips
+  Pointing `DFIR_VISION_MODEL` at a local Ollama vision model keeps screenshots on-box and skips
   OCR entirely.
   - **Visibility:** a one-line `[OCR] case=… redaction ran on N screenshot(s) — scrubbed M
     word(s)…` is logged whenever the pre-pass runs (so you can tell the redacted path ran vs.
@@ -688,7 +690,7 @@ high-volume part (one AI call per few screenshots) — use a cheap vision model 
 Synthesis is a single text-only call over the whole timeline — point a stronger model
 at just that. Configure it once in `.env`:
 
-    DFIR_AI_MODEL=openai/gpt-4o-mini          # extraction (cheap, reads every screenshot)
+    DFIR_VISION_MODEL=openai/gpt-4o-mini          # extraction (cheap, reads every screenshot)
     DFIR_AI_SYNTH_MODEL=google/gemini-2.5-pro # synthesis (strong, one text-only call)
 
 …then just `npm run reanalyze -- <caseId> --reset`. Or set it ad-hoc on the CLI
@@ -725,7 +727,7 @@ Screenshots are captured **lossless** (PNG) at the browser's full viewport resol
 hostnames and domains usually come from (1) the vision model downscaling large images,
 and (2) model OCR strength. Mitigations:
 
-- `DFIR_AI_IMAGE_DETAIL=high` (default) tiles images at full resolution for OpenAI/
+- `DFIR_VISION_IMAGE_DETAIL=high` (default) tiles images at full resolution for OpenAI/
   OpenRouter models instead of downscaling — the biggest single accuracy win.
 - Use a stronger vision model for text-heavy forensic screenshots, e.g.
   `openai/gpt-4o` or `google/gemini-2.5-pro` rather than a fast/cheap flash model.

--- a/companion/scripts/reanalyze.ts
+++ b/companion/scripts/reanalyze.ts
@@ -31,6 +31,7 @@ import { DiscoveredEntitiesStore } from "../src/analysis/anonDiscovered.js";
 import { SynthMetaStore } from "../src/analysis/synthMeta.js";
 import { HypothesisStore } from "../src/analysis/hypothesisStore.js";
 import { buildProviderFrom } from "../src/server.js";
+import { visionEnv } from "../src/config/aiEnv.js";
 import type { CaptureMetadata } from "../src/types.js";
 
 function flag(name: string): boolean {
@@ -51,16 +52,16 @@ async function main(): Promise<void> {
   const reset = flag("reset");
   const windowSize = Math.max(1, opt("window", 4));
 
-  const imageDetail = process.env.DFIR_AI_IMAGE_DETAIL as "high" | "low" | "auto" | undefined;
+  const imageDetail = visionEnv(process.env, "IMAGE_DETAIL") as "high" | "low" | "auto" | undefined;
 
-  // Extraction model (per screenshot) — CLI overrides fall back to .env.
-  const provName = strOpt("provider") ?? process.env.DFIR_AI_PROVIDER;
-  const model = strOpt("model") ?? process.env.DFIR_AI_MODEL;
-  const apiKey = strOpt("key") ?? process.env.DFIR_AI_KEY;
-  const baseUrl = strOpt("base-url") ?? process.env.DFIR_AI_BASE_URL;
+  // Screenshot (vision) model — CLI overrides fall back to .env (DFIR_VISION_*, legacy DFIR_AI_*).
+  const provName = strOpt("provider") ?? visionEnv(process.env, "PROVIDER");
+  const model = strOpt("model") ?? visionEnv(process.env, "MODEL");
+  const apiKey = strOpt("key") ?? visionEnv(process.env, "KEY");
+  const baseUrl = strOpt("base-url") ?? visionEnv(process.env, "BASE_URL");
   const provider = buildProviderFrom({ provider: provName, model, apiKey, baseUrl, imageDetail });
   if (!provider) {
-    console.error("No AI provider configured (DFIR_AI_PROVIDER / --provider). Aborting.");
+    console.error("No AI provider configured (DFIR_VISION_PROVIDER / --provider). Aborting.");
     process.exit(1);
   }
 

--- a/companion/scripts/synthesize.ts
+++ b/companion/scripts/synthesize.ts
@@ -22,6 +22,7 @@ import { DiscoveredEntitiesStore } from "../src/analysis/anonDiscovered.js";
 import { SynthMetaStore } from "../src/analysis/synthMeta.js";
 import { HypothesisStore } from "../src/analysis/hypothesisStore.js";
 import { buildProviderFrom } from "../src/server.js";
+import { visionEnv } from "../src/config/aiEnv.js";
 
 function strOpt(name: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`);
@@ -33,17 +34,16 @@ async function main(): Promise<void> {
 
   // Synthesis prefers the dedicated synth model. Precedence: CLI flag >
   // DFIR_AI_SYNTH_* > the main extraction model in .env.
-  const provName = strOpt("provider") ?? process.env.DFIR_AI_SYNTH_PROVIDER ?? process.env.DFIR_AI_PROVIDER;
-  const model = strOpt("model") ?? process.env.DFIR_AI_SYNTH_MODEL ?? process.env.DFIR_AI_MODEL;
-  const apiKey = strOpt("key") ?? process.env.DFIR_AI_SYNTH_KEY ?? process.env.DFIR_AI_KEY;
-  const baseUrl = strOpt("base-url") ?? process.env.DFIR_AI_SYNTH_BASE_URL ?? process.env.DFIR_AI_BASE_URL;
-  const imageDetail = process.env.DFIR_AI_IMAGE_DETAIL as "high" | "low" | "auto" | undefined;
+  const provName = strOpt("provider") ?? process.env.DFIR_AI_SYNTH_PROVIDER ?? visionEnv(process.env, "PROVIDER");
+  const model = strOpt("model") ?? process.env.DFIR_AI_SYNTH_MODEL ?? visionEnv(process.env, "MODEL");
+  const apiKey = strOpt("key") ?? process.env.DFIR_AI_SYNTH_KEY ?? visionEnv(process.env, "KEY");
+  const baseUrl = strOpt("base-url") ?? process.env.DFIR_AI_SYNTH_BASE_URL ?? visionEnv(process.env, "BASE_URL");
+  const imageDetail = visionEnv(process.env, "IMAGE_DETAIL") as "high" | "low" | "auto" | undefined;
   const provider = buildProviderFrom({ provider: provName, model, apiKey, baseUrl, imageDetail });
   if (!provider) {
-    console.error("No AI provider configured (DFIR_AI_PROVIDER / --provider). Aborting.");
+    console.error("No AI provider configured (DFIR_AI_SYNTH_PROVIDER / DFIR_VISION_PROVIDER / --provider). Aborting.");
     process.exit(1);
   }
-  process.env.DFIR_AI_MODEL = model; // for the log line below
   const raw = process.env.DFIR_CASES_ROOT ?? "cases";
   const companionDir = fileURLToPath(new URL("../", import.meta.url));
   const casesRoot = isAbsolute(raw) ? raw : resolve(companionDir, raw);
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
   const pipeline = new AnalysisPipeline({ provider, stateStore, falsePositiveStore: new FalsePositiveStore(store), scopeStore: new ScopeStore(store), imageLoader: makeImageLoader(store), anonStore: new AnonControlStore(store), customEntitiesStore: new CustomEntitiesStore(store), discoveredStore: new DiscoveredEntitiesStore(store), synthMetaStore: new SynthMetaStore(store), hypothesisStore: new HypothesisStore(store) });
 
   const before = await stateStore.load(caseId);
-  console.log(`Synthesizing "${caseId}" from ${before.forensicTimeline.length} forensic events (provider=${provider.name} model=${process.env.DFIR_AI_MODEL})…`);
+  console.log(`Synthesizing "${caseId}" from ${before.forensicTimeline.length} forensic events (provider=${provider.name} model=${model})…`);
   if (before.forensicTimeline.length === 0) {
     console.log("No forensic timeline yet — run `npm run reanalyze -- " + caseId + "` first.");
     return;

--- a/companion/scripts/verify-ai.ts
+++ b/companion/scripts/verify-ai.ts
@@ -9,6 +9,7 @@ import { readFile, readdir } from "node:fs/promises";
 import { join, isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildProvider } from "../src/server.js";
+import { visionEnv } from "../src/config/aiEnv.js";
 import { extractJsonText } from "../src/analysis/extractJson.js";
 import { deltaSchema } from "../src/analysis/responseSchema.js";
 import { getSystemPrompt } from "../src/analysis/pipeline.js";
@@ -19,16 +20,16 @@ function strOpt(name: string): string | undefined {
 }
 
 async function main(): Promise<void> {
-  if (strOpt("provider")) process.env.DFIR_AI_PROVIDER = strOpt("provider");
-  if (strOpt("model")) process.env.DFIR_AI_MODEL = strOpt("model");
-  if (strOpt("key")) process.env.DFIR_AI_KEY = strOpt("key");
+  if (strOpt("provider")) process.env.DFIR_VISION_PROVIDER = strOpt("provider");
+  if (strOpt("model")) process.env.DFIR_VISION_MODEL = strOpt("model");
+  if (strOpt("key")) process.env.DFIR_VISION_KEY = strOpt("key");
 
   const provider = buildProvider();
   if (!provider) {
-    console.log("No provider configured (DFIR_AI_PROVIDER unset).");
+    console.log("No provider configured (DFIR_VISION_PROVIDER unset).");
     return;
   }
-  console.log(`Provider: ${provider.name}, model: ${process.env.DFIR_AI_MODEL}`);
+  console.log(`Provider: ${provider.name}, model: ${visionEnv(process.env, "MODEL")}`);
 
   const raw = process.env.DFIR_AI_CASES_ROOT ?? process.env.DFIR_CASES_ROOT ?? "cases";
   const companionDir = fileURLToPath(new URL("../", import.meta.url));

--- a/companion/src/analysis/diagnostics.ts
+++ b/companion/src/analysis/diagnostics.ts
@@ -4,6 +4,7 @@
 // classify, and REDACT them into a shareable report. Keeping the transforms pure makes the
 // whole surface unit-testable without spinning up a server or touching the filesystem.
 import { isLocalAiProvider } from "./anonymize.js";
+import { visionEnv } from "../config/aiEnv.js";
 import type { DiskStats, DiskWarningLevel, DiskWarnThresholds } from "./diskWarn.js";
 
 /** Human-readable byte size (binary units, 1 decimal place under 100). */
@@ -34,7 +35,7 @@ export function formatAge(ms: number): string {
 
 // ── AI config sanity (REDACTED — never carries an API key) ──────────────────────────────
 // All fields here are non-secret config: provider names, model ids, base URLs, numeric
-// bounds. API keys (DFIR_AI_KEY etc.) are deliberately NOT read so they can never leak into
+// bounds. API keys (DFIR_VISION_KEY etc.) are deliberately NOT read so they can never leak into
 // the diagnostics payload or the copy-to-clipboard blob.
 export interface AiDiagnostics {
   configured: boolean;
@@ -73,9 +74,10 @@ function orNull(v: string | undefined): string | null {
  * AND a model are the minimum (a key may legitimately be absent for a local Ollama).
  */
 export function buildAiDiagnostics(env: EnvLike): AiDiagnostics {
-  const provider = orNull(env.DFIR_AI_PROVIDER);
-  const model = orNull(env.DFIR_AI_MODEL);
-  const baseUrl = orNull(env.DFIR_AI_BASE_URL);
+  // Vision/screenshot config: DFIR_VISION_* (legacy DFIR_AI_* honored as a fallback via visionEnv).
+  const provider = orNull(visionEnv(env, "PROVIDER"));
+  const model = orNull(visionEnv(env, "MODEL"));
+  const baseUrl = orNull(visionEnv(env, "BASE_URL"));
   return {
     configured: Boolean(provider && model),
     provider,
@@ -84,7 +86,7 @@ export function buildAiDiagnostics(env: EnvLike): AiDiagnostics {
     secondOpinionModel: orNull(env.DFIR_AI_SECOND_OPINION_MODEL),
     velociraptorModel: orNull(env.DFIR_AI_VELO_MODEL),
     baseUrl,
-    imageDetail: orNull(env.DFIR_AI_IMAGE_DETAIL) ?? "high",
+    imageDetail: orNull(visionEnv(env, "IMAGE_DETAIL")) ?? "high",
     timeoutMs: num(env.DFIR_AI_TIMEOUT_MS, 180_000),
     maxTokens: num(env.DFIR_AI_MAX_TOKENS, 16_000),
     contextTokens: num(env.DFIR_AI_CONTEXT_TOKENS, 128_000),

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -1525,6 +1525,14 @@ export class AnalysisPipeline {
     return Boolean(this.opts.provider);
   }
 
+  // True when TEXT work (synthesis, ask/explain, summaries, hunts, CSV/log triage, …) can run:
+  // the dedicated synthesis provider, or the vision provider it falls back to. Route gates for
+  // text-only AI features must use this — NOT hasAiProvider(), which reflects only the
+  // screenshot/vision provider and is false in an OCR-less install (DFIR_AI_SYNTH_PROVIDER only).
+  hasSynthesisProvider(): boolean {
+    return Boolean(this.opts.synthesisProvider ?? this.opts.provider);
+  }
+
   private requireProvider(purpose: string): AIProvider {
     if (!this.opts.provider) throw new Error(`AI provider not configured; ${purpose} requires an AI provider`);
     return this.opts.provider;

--- a/companion/src/config/aiEnv.ts
+++ b/companion/src/config/aiEnv.ts
@@ -1,0 +1,39 @@
+// The screenshot/vision provider config was renamed DFIR_AI_* → DFIR_VISION_* (2026-07). This model
+// reads SCREENSHOTS ONLY (it must be multimodal); the DFIR_AI_SYNTH_* family does ALL text work
+// (CSV/log extraction, synthesis, ask/explain, summaries, hunts, …).
+//
+// The legacy DFIR_AI_* names are still honored as a DEPRECATED fallback so existing .env files keep
+// working after an upgrade — the new DFIR_VISION_* name WINS when both are set. Only the five vision
+// vars below moved; the shared tuning vars (DFIR_AI_TIMEOUT_MS / _MAX_TOKENS / _CONTEXT_TOKENS) and
+// the whole DFIR_AI_SYNTH_* family are intentionally NOT renamed.
+
+export type VisionEnvSuffix = "PROVIDER" | "MODEL" | "KEY" | "BASE_URL" | "IMAGE_DETAIL";
+
+/** A subset of process.env — any string-keyed env-like map. */
+export type EnvSource = Record<string, string | undefined>;
+
+/** The five vision-config suffixes, in .env declaration order. */
+export const VISION_ENV_SUFFIXES: readonly VisionEnvSuffix[] = [
+  "PROVIDER", "MODEL", "KEY", "BASE_URL", "IMAGE_DETAIL",
+];
+
+/** New DFIR_VISION_<suffix> wins; legacy DFIR_AI_<suffix> is the deprecated fallback. */
+export function visionEnv(env: EnvSource, suffix: VisionEnvSuffix): string | undefined {
+  return env[`DFIR_VISION_${suffix}`] ?? env[`DFIR_AI_${suffix}`];
+}
+
+/**
+ * For the Settings form: surface each legacy DFIR_AI_<suffix> value under its new DFIR_VISION_<suffix>
+ * key when the new key isn't set in the file, so an existing install's value still populates the
+ * renamed field (and a Save then writes the canonical new name). Returns a shallow copy — never
+ * mutates the input. The legacy keys are left in place so nothing is hidden.
+ */
+export function withVisionEnvAliases(env: EnvSource): EnvSource {
+  const out: EnvSource = { ...env };
+  for (const suffix of VISION_ENV_SUFFIXES) {
+    const newKey = `DFIR_VISION_${suffix}`;
+    const oldKey = `DFIR_AI_${suffix}`;
+    if (out[newKey] === undefined && out[oldKey] !== undefined) out[newKey] = out[oldKey];
+  }
+  return out;
+}

--- a/companion/src/providers/litellm.ts
+++ b/companion/src/providers/litellm.ts
@@ -3,8 +3,10 @@ import { OpenAIProvider, type OpenAIOptions } from "./openai.js";
 // LiteLLM exposes an OpenAI-compatible /chat/completions endpoint (it proxies 100+
 // model backends behind one OpenAI shape), so a local — or self-hosted — LiteLLM proxy
 // is just the OpenAI provider pointed at the proxy's base URL. The default targets a
-// `litellm` proxy on its standard local port; override the host/port with DFIR_AI_BASE_URL.
-// The proxy may require a virtual/master key (set DFIR_AI_KEY) or none at all when run
+// `litellm` proxy on its standard local port; override the host/port with the base-URL var for
+// whichever role uses it (DFIR_VISION_BASE_URL for screenshots, DFIR_AI_SYNTH_BASE_URL for text).
+// The proxy may require a virtual/master key (set the matching DFIR_VISION_KEY / DFIR_AI_SYNTH_KEY)
+// or none at all when run
 // fully local with no auth — an empty key sends a harmless `Bearer` the proxy ignores.
 export class LiteLlmProvider extends OpenAIProvider {
   override readonly name = "litellm";

--- a/companion/src/providers/provider.ts
+++ b/companion/src/providers/provider.ts
@@ -64,10 +64,10 @@ export function httpErrorMessage(provider: string, status: number, body?: string
   switch (status) {
     case 402:
       return `${provider} HTTP 402 (payment required): the ${provider} account is out of credits or has no active billing. ` +
-        `Add credits/billing on the provider, or switch DFIR_AI_PROVIDER / DFIR_AI_MODEL (e.g. a cheaper model, OpenRouter, or local Ollama).${snippet}`;
+        `Add credits/billing on the provider, or switch the AI model (DFIR_VISION_* for screenshots, DFIR_AI_SYNTH_* for text — e.g. a cheaper model, OpenRouter, or local Ollama).${snippet}`;
     case 401:
     case 403:
-      return `${provider} HTTP ${status} (auth): the API key is missing, invalid, or lacks access to the model. Check DFIR_AI_KEY and DFIR_AI_MODEL.${snippet}`;
+      return `${provider} HTTP ${status} (auth): the API key is missing, invalid, or lacks access to the model. Check the AI key/model config (DFIR_VISION_* for screenshots, DFIR_AI_SYNTH_* for text).${snippet}`;
     case 429:
       return `${provider} HTTP 429 (rate limit / quota): too many requests or quota exhausted. Wait and retry, slow imports, or switch model/provider.${snippet}`;
     default:

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -36,7 +36,9 @@ import type { RouteContext } from "./context.js";
  *
  * Shared surface — reuses already-graduated ctx members; nothing new was invented beyond the two
  * graduated below:
- *   - store, options, hasAiProvider — stable ctx surface.
+ *   - store, options — stable ctx surface. (Text-AI gates ask the pipeline directly via
+ *     options.pipeline.hasSynthesisProvider(), NOT ctx.hasAiProvider — that reflects only the
+ *     screenshot/vision provider and would 501 every text feature in an OCR-less install.)
  *   - getControl / loadPlaybookControl — already-graduated stable methods, reused as-is.
  *   - captureBuffers() — the live accessor for the per-case capture buffer Map; the ai-control POST
  *     handler drops the pending buffer through it when pausing (the ONE non-verbatim rebind: the
@@ -64,7 +66,7 @@ import type { RouteContext } from "./context.js";
  *     the moved handler bodies keep their original log calls verbatim.
  */
 export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options, hasAiProvider, getControl, setControl, backfill, loadPlaybookControl } = ctx;
+  const { store, options, getControl, setControl, backfill, loadPlaybookControl } = ctx;
 
   // Module-private wrappers mirroring createApp's logLine/errLine (serverLogger.info/error), so the
   // moved handler bodies keep their original `logLine(...)` / `errLine(...)` calls verbatim.
@@ -122,7 +124,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // forensic timeline. (Per-window capture builds the timeline; this writes the
   // conclusions.) Broadcasts the updated state to dashboard clients via onState.
   app.post("/cases/:id/synthesize", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for synthesis" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for synthesis" });
     const caseId = req.params.id;
     const caseMeta = await store.getCaseMeta(caseId).catch(() => null);
     if (caseMeta?.status === "closed" || caseMeta?.status === "archived") {
@@ -268,7 +270,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // Ask the LLM a free-form question about the case ("was data exfiltrated?"). Single-shot,
   // no state change — returns a grounded answer + status + collection guidance (`pointer`).
   app.post("/cases/:id/ask", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for case questions" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for case questions" });
     const question = typeof req.body?.question === "string" ? req.body.question.trim() : "";
     if (!question) return res.status(400).json({ error: "question is required" });
     try {
@@ -286,7 +288,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // Returns structured analysis: what happened, why it matters, ATT&CK mapping, pivot queries,
   // and evidence for/against maliciousness. Useful for junior analysts and training.
   app.post("/cases/:id/events/:eid/explain", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for event explanation" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for event explanation" });
     try {
       const result = await options.pipeline.explainEvent(req.params.id, req.params.eid);
       return res.status(200).json(result);
@@ -302,7 +304,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // call). The dashboard shows it and can save it into report-meta.executiveSummary, which then
   // overrides the auto-derived summary in the generated report.
   app.post("/cases/:id/executive-summary", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for executive summary" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for executive summary" });
     if (!(await reportSectionEnabled(req.params.id, "executiveSummary")))
       return res.status(409).json({ error: "The Executive summary section is disabled in this case's report template — enable it in Settings → Report template to generate (skipped to save tokens).", sectionDisabled: true, section: "executiveSummary" });
     try {
@@ -320,7 +322,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // case's findings + the deterministic ATT&CK mitigations. Ephemeral (no state change); the
   // dashboard renders it under the Mitigation & Defensive Countermeasures panel.
   app.post("/cases/:id/remediation-plan", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for remediation plan" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for remediation plan" });
     try {
       const result = await options.pipeline.remediationPlan(req.params.id);
       logActivity(options.activityLogStore, options.onActivity, req.params.id, {
@@ -336,7 +338,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // hypothesis's supporting vs. refuting evidence and returns an ADVISORY recommended status. Ephemeral:
   // it NEVER mutates a hypothesis (the analyst applies any recommendation via the existing PATCH route).
   app.post("/cases/:id/hypothesis-review", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for hypothesis review" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for hypothesis review" });
     if (!options.hypothesisStore) return res.status(501).json({ error: "hypotheses not configured" });
     try {
       const result = await options.pipeline.hypothesisReview(req.params.id);
@@ -352,7 +354,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // Generate (or regenerate) a prose narrative timeline for the case (one text-only AI call).
   // Saves the result to state.narrativeTimeline so it persists and appears in the report/dashboard.
   app.post("/cases/:id/narrative", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for narrative generation" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for narrative generation" });
     // The narrative timeline renders under report section 3.2, inside the "Timeline of events"
     // major section — so a disabled `timeline` section means the narrative won't appear; skip its
     // AI call to save tokens (issue #168). The analyst's already-saved narrative is left intact.
@@ -560,7 +562,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // wide hunt to proactively detect it. Single text-only AI call, EPHEMERAL (no state change) — the
   // dashboard shows the VQL + rationale for review, then deploys via POST /velociraptor/hunt.
   app.post("/cases/:id/adversary-hints/hunt-technique", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
     const techniqueId = String((req.body as { techniqueId?: unknown })?.techniqueId ?? "").trim();
     const techniqueName = String((req.body as { techniqueName?: unknown })?.techniqueName ?? "").trim() || undefined;
     if (!/^T\d{4}(?:\.\d{3})?$/i.test(techniqueId)) return res.status(400).json({ error: "valid ATT&CK techniqueId required" });
@@ -579,7 +581,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
   // run. EPHEMERAL (no state change). Needs an AI provider; returns [] when the case has no memory
   // evidence (the dashboard hides the panel in that case).
   app.post("/cases/:id/memory/next-steps", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for memory next-step suggestions" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for memory next-step suggestions" });
     try {
       const suggestions = await options.pipeline.suggestMemoryNextSteps(req.params.id);
       logLine(`[memory] suggested ${suggestions.length} next step(s) for ${req.params.id}`);

--- a/companion/src/routes/anonymization.ts
+++ b/companion/src/routes/anonymization.ts
@@ -10,6 +10,7 @@ import { buildRedactedExport } from "../reports/redactedExportBuilder.js";
 import { CustomerStore } from "../analysis/customerStore.js";
 import { isValidCaseId } from "../storage/caseStore.js";
 import { normalizeHuntPlatform, HUNT_PLATFORMS, type HuntPlatform } from "../analysis/huntPlatforms.js";
+import { visionEnv } from "../config/aiEnv.js";
 import type { RouteContext } from "./context.js";
 
 /**
@@ -49,7 +50,7 @@ export function registerAnonymizationRoutes(app: Express, ctx: RouteContext): vo
   const anonControl = new AnonControlStore(store);
   const customEntities = new CustomEntitiesStore(store);
   const discoveredEntities = new DiscoveredEntitiesStore(store);
-  const visionIsLocal = isLocalAiProvider(process.env.DFIR_AI_PROVIDER, process.env.DFIR_AI_BASE_URL);
+  const visionIsLocal = isLocalAiProvider(visionEnv(process.env, "PROVIDER"), visionEnv(process.env, "BASE_URL"));
 
   // Anonymization control: GET reports the control + whether screenshots are exposed (anon on +
   // external vision). POST updates it and, when `enabled` flips, forces a re-synth so conclusions

--- a/companion/src/routes/anonymization.ts
+++ b/companion/src/routes/anonymization.ts
@@ -23,7 +23,7 @@ import type { RouteContext } from "./context.js";
  *   - applyDeobfuscationToCase — the shared deobfuscation sweep (owned by createApp; also fired by
  *     the push-ingest seam), graduated for the import domain and reused by POST /deobfuscate here.
  *   - resynthesizeInBackground — the shared post-mutation re-synthesis kick, likewise graduated.
- * Plus the stable ctx surface (store, options, hasAiProvider, serverLogger).
+ * Plus the stable ctx surface (store, options, serverLogger).
  *
  * Domain-local state is rebuilt in-module from ctx.store: the three stateless disk-backed stores
  * (anonControl, customEntities, discoveredEntities) each just wrap ctx.store, so a fresh instance
@@ -38,7 +38,7 @@ import type { RouteContext } from "./context.js";
  * were intentionally left in place.
  */
 export function registerAnonymizationRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options, hasAiProvider } = ctx;
+  const { store, options } = ctx;
   // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved handler
   // bodies keep their original `logLine(...)` calls verbatim.
   const logLine = (msg: string): void => ctx.serverLogger.info(msg);
@@ -79,7 +79,7 @@ export function registerAnonymizationRoutes(app: Express, ctx: RouteContext): vo
         redactSecrets: typeof req.body?.redactSecrets === "boolean" ? req.body.redactSecrets : cur.redactSecrets,
       };
       await anonControl.save(req.params.id, next);
-      if (next.enabled !== cur.enabled && options.pipeline && hasAiProvider()) {
+      if (next.enabled !== cur.enabled && options.pipeline && options.pipeline.hasSynthesisProvider()) {
         void options.pipeline.synthesize(req.params.id, { force: true }).catch(() => {});
       }
       if (next.enabled !== cur.enabled) {
@@ -225,7 +225,7 @@ export function registerAnonymizationRoutes(app: Express, ctx: RouteContext): vo
   // `platforms` is an optional analyst-chosen subset; both it and the result are bounded by the
   // server's DFIR_HUNT_PLATFORMS allowlist so a disabled platform is never generated.
   app.post("/cases/:id/translate-query", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for query translation" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for query translation" });
     const request = typeof req.body?.request === "string" ? req.body.request.trim() : "";
     if (!request) return res.status(400).json({ error: "request is required" });
     const enabled = options.huntPlatforms ?? [...HUNT_PLATFORMS];

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -903,7 +903,10 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
   // IRIS/Velociraptor reconnect routes' reloadEnvPrefix pattern.
   app.post("/settings/ai-reload", async (_req: Request, res: Response) => {
     try {
-      const applied = await reloadEnvPrefix("DFIR_AI_");
+      // Reload BOTH the vision family (renamed DFIR_VISION_*) and the legacy DFIR_AI_* prefix (still
+      // honored as a fallback, and covers DFIR_AI_SYNTH_*/VELO/SECOND_OPINION), so the wizard's
+      // save → reload → ai-test flow sees new config under either naming without a restart.
+      const applied = [...await reloadEnvPrefix("DFIR_VISION_"), ...await reloadEnvPrefix("DFIR_AI_")];
       return res.json({ ok: true, applied });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
@@ -915,7 +918,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
   // step sees the new config. ALLOWLISTED — the prefix must be a known integration group, so a request
   // can't reload arbitrary env (and the route never reads/returns secret VALUES, only the applied keys).
   const RELOADABLE_PREFIXES = new Set([
-    "DFIR_AI_", "DFIR_IRIS_", "DFIR_VELOCIRAPTOR_", "DFIR_TIMESKETCH_", "DFIR_NOTION_", "DFIR_CLICKUP_",
+    "DFIR_VISION_", "DFIR_AI_", "DFIR_IRIS_", "DFIR_VELOCIRAPTOR_", "DFIR_TIMESKETCH_", "DFIR_NOTION_", "DFIR_CLICKUP_",
     "DFIR_VT_", "DFIR_ABUSEIPDB_", "DFIR_HUNTINGCH_", "DFIR_MB_", "DFIR_CROWDSTRIKE_", "DFIR_SHODAN_",
     "DFIR_MISP_", "DFIR_YETI_", "DFIR_OPENCTI_", "DFIR_ROCKYRACCOON_", "DFIR_GEOIP_",
     "DFIR_LEAKCHECK_", "DFIR_HIBP_", "DFIR_DEHASHED_", "DFIR_PUSH_TOKEN", "DFIR_NSRL_", "DFIR_TOOL_",
@@ -941,7 +944,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
   app.get("/setup/status", (_req: Request, res: Response) => {
     const has = (k: string): boolean => !!(process.env[k] && process.env[k]!.trim());
     res.status(200).json({
-      ai: !!hasAiProvider() || has("DFIR_AI_PROVIDER"),
+      ai: !!hasAiProvider() || has("DFIR_VISION_PROVIDER") || has("DFIR_AI_PROVIDER"),
       velociraptor: !!options.velociraptorClient || has("DFIR_VELOCIRAPTOR_API_CONFIG"),
       iris: !!ctx.irisClient() || (has("DFIR_IRIS_URL") && has("DFIR_IRIS_KEY")),
       timesketch: !!options.timesketchClient || (has("DFIR_TIMESKETCH_URL") && has("DFIR_TIMESKETCH_USER") && has("DFIR_TIMESKETCH_PASSWORD")),

--- a/companion/src/routes/findings.ts
+++ b/companion/src/routes/findings.ts
@@ -33,7 +33,7 @@ import type { RouteContext } from "./context.js";
  * shared back with createApp beyond one already-graduated member reused via ctx:
  *   - resynthesizeInBackground — the shared post-mutation re-synthesis kick (owned by createApp,
  *     graduated for the import domain); the false-positive + scope mutations reuse it.
- * Plus the stable ctx surface (store, options, hasAiProvider).
+ * Plus the stable ctx surface (store, options).
  *
  * Domain-local state is rebuilt in-module from ctx.store:
  *   - falsePositives (FalsePositiveStore) — a stateless disk-backed store that just wraps ctx.store,
@@ -55,7 +55,7 @@ import type { RouteContext } from "./context.js";
  * floor, which belongs to the aiSynthesis domain, not analyst annotations).
  */
 export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options, hasAiProvider, resynthesizeInBackground } = ctx;
+  const { store, options, resynthesizeInBackground } = ctx;
 
   // Domain-local stateless disk-backed stores, rebuilt from ctx.store (see module header).
   const falsePositives = new FalsePositiveStore(store);
@@ -298,7 +298,7 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
         : findSimilarFindings(anchor as Finding, state.findings);
 
       if (!req.body?.ai) return res.status(200).json({ candidates: deterministic });
-      if (!options.pipeline || !hasAiProvider()) {
+      if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) {
         return res.status(200).json({ candidates: deterministic, aiUnavailable: true });
       }
 

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -55,12 +55,14 @@ import type { RouteContext } from "./context.js";
  *   and the drop-watcher state maps dropSeen / dropScanning / dropPendingLogged (live accessors —
  *   the poller mutates the SAME maps, so they must be read live, never captured at registration).
  * Pre-existing ctx members reused: store, options, serverLogger, recordImportFailure, recordAiError,
- * hasAiProvider, getControl, runToolAndIngest, resolveImportKind + liveToolConfigs + customTools +
- * dropWatchEnabled (live accessors).
+ * getControl, runToolAndIngest, resolveImportKind + liveToolConfigs + customTools +
+ * dropWatchEnabled (live accessors). (The AI CSV/log gates ask the pipeline directly via
+ * options.pipeline.hasSynthesisProvider() — text work runs on the synthesis provider, so the
+ * vision-only ctx.hasAiProvider would wrongly 501 an OCR-less install.)
  */
 export function registerImportRoutes(app: Express, ctx: RouteContext): void {
   const {
-    store, options, recordImportFailure, recordAiError, hasAiProvider, getControl,
+    store, options, recordImportFailure, recordAiError, getControl,
     runToolAndIngest, pushImportCheckpoint, moveDropFile,
     dispatchImport, demoteForensicForCase, resynthesizeInBackground,
     applyWhitelistToCase, applyNsrlToCase, applyDeobfuscationToCase,
@@ -191,7 +193,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
     if (kind === "unknown") {
       return res.status(400).json({ error: "could not detect the file type — not recognized as any supported import (THOR / SIEM-EDR / Chainsaw-EVTX / Hayabusa / Velociraptor / Suricata-Zeek / KAPE / Cyber Triage / M365-Entra / AWS / GCP-Azure / Plaso / Sandbox / Volatility-Rekall memory / Email-eml-msg / auditd / journald / sysdig-Falco / syslog / CSV / log)" });
     }
-    if ((kind === "csv" || kind === "log") && !hasAiProvider()) {
+    if ((kind === "csv" || kind === "log") && !options.pipeline?.hasSynthesisProvider()) {
       return res.status(501).json({ error: "AI provider not configured for CSV/log analysis" });
     }
 
@@ -376,7 +378,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
     if (kind === "unknown") {
       return res.status(400).json({ error: "could not detect the file type — not recognized as any supported import format" });
     }
-    if ((kind === "csv" || kind === "log") && !hasAiProvider()) {
+    if ((kind === "csv" || kind === "log") && !options.pipeline?.hasSynthesisProvider()) {
       return res.status(501).json({ error: "AI provider not configured for CSV/log analysis" });
     }
 
@@ -515,7 +517,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
   // timeline, then synthesize findings/TTPs/attacker-path. Evidence-first: the raw
   // CSV is persisted + audit-logged BEFORE any analysis; analysis runs in background.
   app.post("/cases/:id/import-csv", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for CSV analysis" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for CSV analysis" });
     const caseId = req.params.id;
     const csv = typeof req.body?.csv === "string" ? req.body.csv : "";
     const originalName = String(req.body?.filename ?? "import.csv");
@@ -563,7 +565,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
   // Same evidence-first pattern as import-csv: persist + audit, then analyze in the
   // background (line-batched). The CSV path stays specialized for tabular exports.
   app.post("/cases/:id/import-log", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for log analysis" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for log analysis" });
     const caseId = req.params.id;
     const text = typeof req.body?.text === "string" ? req.body.text : "";
     const originalName = String(req.body?.filename ?? "import.log");

--- a/companion/src/routes/playbookHunts.ts
+++ b/companion/src/routes/playbookHunts.ts
@@ -36,7 +36,7 @@ import type { RouteContext } from "./context.js";
  *   - refreshVeloClients — the client-inventory refresh (already graduated for routes/velociraptor.ts);
  *                          the suggest-hunts route reuses it so a host enrolled mid-investigation is
  *                          resolvable at deploy time.
- * Plus the stable ctx surface (options, hasAiProvider).
+ * Plus the stable ctx surface (options).
  *
  * Domain-local helpers moved verbatim into the module (used only by these routes):
  *   - loadFreshHunts — load persisted #70 hunt suggestions, dropping any whose task was reworded/deleted.
@@ -46,7 +46,7 @@ import type { RouteContext } from "./context.js";
  *     state, so rebuilding them here is behaviour-identical (same singleton notifier).
  */
 export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): void {
-  const { options, hasAiProvider, refreshVeloClients, syncPlaybook, loadPlaybookControl } = ctx;
+  const { options, refreshVeloClients, syncPlaybook, loadPlaybookControl } = ctx;
 
   // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved handler
   // bodies keep their original `logLine(...)` calls verbatim.
@@ -151,7 +151,7 @@ export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): vo
   // the playbook store; does NOT need the Velociraptor API (the VQL is useful to copy even when off).
   // Registered BEFORE /:taskId so "suggest-hunts" is not captured as a task id.
   app.post("/cases/:id/playbook/suggest-hunts", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
     if (!options.playbookStore || !options.stateStore) return res.status(501).json({ error: "playbook not configured" });
     try {
       const tasks = await syncPlaybook(req.params.id);

--- a/companion/src/routes/pushNotify.ts
+++ b/companion/src/routes/pushNotify.ts
@@ -18,7 +18,7 @@ import type { RouteContext } from "./context.js";
  * integration domains and stay in createApp.
  */
 export function registerPushNotifyRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options, serverLogger, hasAiProvider, ingestStreamed } = ctx;
+  const { store, options, serverLogger, ingestStreamed } = ctx;
 
   // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved call
   // sites stay verbatim.
@@ -46,7 +46,7 @@ export function registerPushNotifyRoutes(app: Express, ctx: RouteContext): void 
     if (!text.trim()) return res.status(400).json({ error: "empty push payload" });
     const kind = ctx.resolveImportKind()(filename, text);
     if (kind === "unknown") return res.status(400).json({ error: "could not detect the payload type — not recognized as any supported import shape" });
-    if ((kind === "csv" || kind === "log") && !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for CSV/log analysis" });
+    if ((kind === "csv" || kind === "log") && !options.pipeline?.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for CSV/log analysis" });
 
     const minSeverity = parseMinSeverity(req.body?.minSeverity);
     logLine(`[push] case ${caseId}: received "${source}" → ${kind}`);

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -289,7 +289,7 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
   app.post("/diagnostics/ai-test", async (_req: Request, res: Response) => {
     const provider = options.aiTestProvider?.();
     if (!provider) {
-      return res.status(501).json({ ok: false, error: "AI provider not configured — set DFIR_AI_PROVIDER / DFIR_AI_MODEL / DFIR_AI_KEY in Settings → AI, then restart the server" });
+      return res.status(501).json({ ok: false, error: "AI provider not configured — set DFIR_VISION_PROVIDER / DFIR_VISION_MODEL / DFIR_VISION_KEY in Settings → AI, then restart the server" });
     }
     const startedAt = Date.now();
     try {
@@ -352,7 +352,7 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
     // 1. AI provider — CRITICAL: without it, analysis and synthesis don't work.
     const aiProvider = options.aiTestProvider?.();
     if (!aiProvider) {
-      items.push({ name: "AI provider", ok: false, critical: true, detail: "not configured — set DFIR_AI_PROVIDER / DFIR_AI_MODEL / DFIR_AI_KEY in .env, then restart" });
+      items.push({ name: "AI provider", ok: false, critical: true, detail: "not configured — set DFIR_VISION_PROVIDER / DFIR_VISION_MODEL / DFIR_VISION_KEY in .env, then restart" });
     } else {
       try {
         await aiProvider.analyze({

--- a/companion/src/routes/tagger.ts
+++ b/companion/src/routes/tagger.ts
@@ -23,7 +23,7 @@ import type { RouteContext } from "./context.js";
  *   - POST   /cases/:id/tagger/preview   — dry-run a candidate rule; report its match count (no writes).
  */
 export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
-  const { options, hasAiProvider } = ctx;
+  const { options } = ctx;
   const logLine = (msg: string): void => ctx.serverLogger.info(msg);
 
   // The active ruleset: raw YAML for the editor + a compact per-rule summary + where it came from
@@ -131,7 +131,7 @@ export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
   // Suggest ONE tagger rule from a plain-English description (PR #112 follow-up). AI-gated. Returns
   // a candidate for review — nothing is persisted here. Body: { description }.
   app.post("/cases/:id/tagger/suggest-rule", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for tagger rule suggestion" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for tagger rule suggestion" });
     const description = typeof req.body?.description === "string" ? req.body.description.trim() : "";
     if (!description) return res.status(400).json({ error: "description is required" });
     try {

--- a/companion/src/routes/timeline.ts
+++ b/companion/src/routes/timeline.ts
@@ -17,7 +17,7 @@ import type { RouteContext } from "./context.js";
  *   - POST /cases/:id/super-timeline/promote      — pull raw events up into the analyzed timeline.
  *
  * Pure structural move out of createApp (see routes/system.ts for the conventions). Nothing here is
- * shared back with createApp beyond the stable ctx surface (options, hasAiProvider, serverLogger) and
+ * shared back with createApp beyond the stable ctx surface (options, serverLogger) and
  * one already-graduated member reused via ctx:
  *   - resynthesizeInBackground — the shared post-mutation re-synthesis kick (owned by createApp; fired
  *     here after /super-timeline/promote merges events into the forensic timeline). No new graduations.
@@ -29,7 +29,7 @@ import type { RouteContext } from "./context.js";
  * in createApp; only the timeline/super-timeline views + exports move here.
  */
 export function registerTimelineRoutes(app: Express, ctx: RouteContext): void {
-  const { options, hasAiProvider, resynthesizeInBackground } = ctx;
+  const { options, resynthesizeInBackground } = ctx;
   // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved handler
   // bodies keep their original `logLine(...)` calls verbatim.
   const logLine = (msg: string): void => ctx.serverLogger.info(msg);
@@ -67,7 +67,7 @@ export function registerTimelineRoutes(app: Express, ctx: RouteContext): void {
   // collections for review, then deploys a chosen shadow-artifact collection via POST /velociraptor/hunt.
   // Needs an AI provider; does NOT need the Velociraptor API (the VQL is useful to copy even when off).
   app.post("/cases/:id/timeline-gaps/hypothesize", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for gap hypotheses" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for gap hypotheses" });
     try {
       const result = await options.pipeline.hypothesizeGaps(req.params.id);
       logLine(`[gaps] hypothesised ${result.hypotheses.length} timeline gap(s) for ${req.params.id}`);

--- a/companion/src/routes/velociraptor.ts
+++ b/companion/src/routes/velociraptor.ts
@@ -31,7 +31,7 @@ import type { RouteContext } from "./context.js";
  * /velociraptor/* and /cases/:id/velociraptor/* endpoints moved.
  */
 export function registerVelociraptorRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options, hasAiProvider } = ctx;
+  const { store, options } = ctx;
   // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved handler
   // bodies keep their original `logLine(...)` calls verbatim.
   const logLine = (msg: string): void => ctx.serverLogger.info(msg);
@@ -245,7 +245,7 @@ export function registerVelociraptorRoutes(app: Express, ctx: RouteContext): voi
   // for review, then deploys the chosen one through POST /velociraptor/hunt (launchHunt). Needs an AI
   // provider; does NOT need the Velociraptor API (the VQL is useful to copy even when deploy is off).
   app.post("/cases/:id/velociraptor/suggest-hunts", async (req: Request, res: Response) => {
-    if (!options.pipeline || !hasAiProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
+    if (!options.pipeline || !options.pipeline.hasSynthesisProvider()) return res.status(501).json({ error: "AI provider not configured for hunt suggestions" });
     try {
       // Optional excludeVql → regenerate a DIFFERENT take (the per-card ↻ Regenerate button), mirroring
       // the playbook-hunt regen. Absent → a normal full suggestion pass.

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -862,7 +862,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   const synthInFlight = new Set<string>();
 
   function scheduleSynthesis(caseId: string): void {
-    if (!autoSynth || !options.pipeline || !hasAiProvider()) return;
+    // synthesize() is TEXT work — it runs on the synthesis provider (falling back to the vision
+    // provider), so gate on that, not hasAiProvider(): an OCR-less install (only
+    // DFIR_AI_SYNTH_PROVIDER set) must still auto-synthesize after imports.
+    if (!autoSynth || !options.pipeline || !options.pipeline.hasSynthesisProvider()) return;
     const existing = synthTimers.get(caseId);
     if (existing) clearTimeout(existing);
     synthTimers.set(caseId, setTimeout(() => {
@@ -2211,7 +2214,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   function resynthesizeInBackground(caseId: string): void {
     const pipeline = options.pipeline;
     if (!pipeline) return;
-    if (!hasAiProvider()) { autoEnrichIfEnabled(caseId); return; }
+    // synthesize() is TEXT work — gate on the synthesis provider (which falls back to the vision
+    // provider), not hasAiProvider(): an OCR-less install (only DFIR_AI_SYNTH_PROVIDER set) must
+    // still re-synthesize after imports/mutations.
+    if (!pipeline.hasSynthesisProvider()) { autoEnrichIfEnabled(caseId); return; }
     void (async () => {
       // Synthesis is an LLM call — respect the per-case AI toggle, exactly like the /captures
       // path (AI analysis only runs when enabled for the case). With AI off, a deterministic

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2423,6 +2423,7 @@ import { AnalysisPipeline as AnalysisPipelineImpl } from "./analysis/pipeline.js
 import { makeImageLoader } from "./analysis/imageLoader.js";
 import { ProviderRegistry, ProviderError } from "./providers/provider.js";
 import type { AIProvider as AnalyzeProvider } from "./providers/provider.js";
+import { visionEnv } from "./config/aiEnv.js";
 import { OpenAIProvider } from "./providers/openai.js";
 import { OpenRouterProvider } from "./providers/openrouter.js";
 import { OllamaCloudProvider } from "./providers/ollama.js";
@@ -2479,23 +2480,26 @@ export function buildProviderFrom(params: ProviderParams): AnalyzeProvider | und
 }
 
 export function buildProvider(): AnalyzeProvider | undefined {
+  // Vision/screenshot model — DFIR_VISION_* (legacy DFIR_AI_* still honored via visionEnv).
   return buildProviderFrom({
-    provider: process.env.DFIR_AI_PROVIDER,
-    model: process.env.DFIR_AI_MODEL,
-    apiKey: process.env.DFIR_AI_KEY,
-    baseUrl: process.env.DFIR_AI_BASE_URL,
-    imageDetail: process.env.DFIR_AI_IMAGE_DETAIL as "high" | "low" | "auto" | undefined,
+    provider: visionEnv(process.env, "PROVIDER"),
+    model: visionEnv(process.env, "MODEL"),
+    apiKey: visionEnv(process.env, "KEY"),
+    baseUrl: visionEnv(process.env, "BASE_URL"),
+    imageDetail: visionEnv(process.env, "IMAGE_DETAIL") as "high" | "low" | "auto" | undefined,
   });
 }
 
 // Synthesis model: dedicated DFIR_AI_SYNTH_* vars, falling back to the main model.
 export function buildSynthesisProvider(): AnalyzeProvider | undefined {
+  // Text model — DFIR_AI_SYNTH_*, falling back to the vision model's config (DFIR_VISION_*, legacy
+  // DFIR_AI_* via visionEnv) when a dedicated synth var is unset.
   return buildProviderFrom({
-    provider: process.env.DFIR_AI_SYNTH_PROVIDER ?? process.env.DFIR_AI_PROVIDER,
-    model: process.env.DFIR_AI_SYNTH_MODEL ?? process.env.DFIR_AI_MODEL,
-    apiKey: process.env.DFIR_AI_SYNTH_KEY ?? process.env.DFIR_AI_KEY,
-    baseUrl: process.env.DFIR_AI_SYNTH_BASE_URL ?? process.env.DFIR_AI_BASE_URL,
-    imageDetail: process.env.DFIR_AI_IMAGE_DETAIL as "high" | "low" | "auto" | undefined,
+    provider: process.env.DFIR_AI_SYNTH_PROVIDER ?? visionEnv(process.env, "PROVIDER"),
+    model: process.env.DFIR_AI_SYNTH_MODEL ?? visionEnv(process.env, "MODEL"),
+    apiKey: process.env.DFIR_AI_SYNTH_KEY ?? visionEnv(process.env, "KEY"),
+    baseUrl: process.env.DFIR_AI_SYNTH_BASE_URL ?? visionEnv(process.env, "BASE_URL"),
+    imageDetail: visionEnv(process.env, "IMAGE_DETAIL") as "high" | "low" | "auto" | undefined,
   });
 }
 
@@ -2508,10 +2512,10 @@ export function buildSecondOpinionProvider(): AnalyzeProvider | undefined {
   const model = process.env.DFIR_AI_SECOND_OPINION_MODEL?.trim();
   if (!model) return undefined;
   return buildProviderFrom({
-    provider: process.env.DFIR_AI_SECOND_OPINION_PROVIDER ?? process.env.DFIR_AI_PROVIDER,
+    provider: process.env.DFIR_AI_SECOND_OPINION_PROVIDER ?? visionEnv(process.env, "PROVIDER"),
     model,
-    apiKey: process.env.DFIR_AI_SECOND_OPINION_KEY ?? process.env.DFIR_AI_KEY,
-    baseUrl: process.env.DFIR_AI_SECOND_OPINION_BASE_URL ?? process.env.DFIR_AI_BASE_URL,
+    apiKey: process.env.DFIR_AI_SECOND_OPINION_KEY ?? visionEnv(process.env, "KEY"),
+    baseUrl: process.env.DFIR_AI_SECOND_OPINION_BASE_URL ?? visionEnv(process.env, "BASE_URL"),
   });
 }
 
@@ -2526,8 +2530,8 @@ export function buildVelociraptorProvider(): AnalyzeProvider | undefined {
   return buildProviderFrom({
     provider: process.env.DFIR_AI_VELO_PROVIDER?.trim() || DEFAULT_VELO_PROVIDER,
     model: process.env.DFIR_AI_VELO_MODEL?.trim() || DEFAULT_VELO_MODEL,
-    apiKey: process.env.DFIR_AI_VELO_KEY ?? process.env.DFIR_AI_KEY,
-    baseUrl: process.env.DFIR_AI_VELO_BASE_URL ?? process.env.DFIR_AI_BASE_URL,
+    apiKey: process.env.DFIR_AI_VELO_KEY ?? visionEnv(process.env, "KEY"),
+    baseUrl: process.env.DFIR_AI_VELO_BASE_URL ?? visionEnv(process.env, "BASE_URL"),
   });
 }
 
@@ -2996,13 +3000,13 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const velociraptorProvider = buildVelociraptorProvider();   // dedicated VQL-hunt model (#70)
   const secondOpinionProvider = buildSecondOpinionProvider(); // dedicated second-opinion model (#116)
   // Model labels for the second-opinion comparison header (fall back to provider name in the pipeline).
-  const synthesisModelLabel = process.env.DFIR_AI_SYNTH_MODEL ?? process.env.DFIR_AI_MODEL ?? undefined;
+  const synthesisModelLabel = process.env.DFIR_AI_SYNTH_MODEL ?? visionEnv(process.env, "MODEL") ?? undefined;
   const secondOpinionModelLabel = process.env.DFIR_AI_SECOND_OPINION_MODEL?.trim() || undefined;
   if (secondOpinionProvider) logLine(`[second-opinion] enabled — model "${secondOpinionModelLabel}" (${secondOpinionProvider.name})`);
   // Provide the Tesseract OCR runner only when the vision model is on an external (cloud)
   // provider — if the model is local, screenshots never leave the machine so redaction is
   // optional. Evidence-first: the runner only redacts the in-memory copy sent to the model.
-  const visionIsLocalForPipeline = isLocalAiProvider(process.env.DFIR_AI_PROVIDER, process.env.DFIR_AI_BASE_URL);
+  const visionIsLocalForPipeline = isLocalAiProvider(visionEnv(process.env, "PROVIDER"), visionEnv(process.env, "BASE_URL"));
   const ocrRunner = !visionIsLocalForPipeline ? new TesseractOcrRunner() : undefined;
   const wiredPipeline = buildRuntimePipeline({
     provider, synthesisProvider, velociraptorProvider, stateStore, store, stateLock, onState: (s) => hub.broadcast(s), ocrRunner, logger, kevStore,

--- a/companion/src/settings/envManager.ts
+++ b/companion/src/settings/envManager.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { isSeaRuntime } from "../serverAssets.js";
+import { withVisionEnvAliases } from "../config/aiEnv.js";
 
 const SECRET_SUFFIXES = ["_KEY", "_SECRET", "_PASSWORD", "_TOKEN"];
 
@@ -78,7 +79,9 @@ export async function reloadEnvPrefix(prefix: string): Promise<string[]> {
 
 /** Return all .env values; secrets are replaced with the sentinel string. */
 export async function getEnvForSettings(): Promise<Record<string, string>> {
-  const raw = parseLines(await readRaw());
+  // Surface legacy DFIR_AI_* vision values under the renamed DFIR_VISION_* keys so an existing
+  // install's values still populate the renamed Settings fields (a Save then writes the new names).
+  const raw = withVisionEnvAliases(parseLines(await readRaw())) as Record<string, string>;
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(raw)) {
     out[k] = isSecretKey(k) && v ? "••••••••" : v;

--- a/companion/tests/config/aiEnv.test.ts
+++ b/companion/tests/config/aiEnv.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { visionEnv, withVisionEnvAliases, VISION_ENV_SUFFIXES } from "../../src/config/aiEnv.js";
+import { buildAiDiagnostics } from "../../src/analysis/diagnostics.js";
+
+// The screenshot/vision provider config was renamed DFIR_AI_* → DFIR_VISION_* with the legacy names
+// kept as a deprecated fallback (new name wins). These guard that contract end-to-end.
+
+describe("visionEnv (DFIR_VISION_* with legacy DFIR_AI_* fallback)", () => {
+  it("prefers the new DFIR_VISION_* name when both are set", () => {
+    const env = { DFIR_VISION_MODEL: "new", DFIR_AI_MODEL: "old" };
+    expect(visionEnv(env, "MODEL")).toBe("new");
+  });
+
+  it("falls back to the legacy DFIR_AI_* name when the new one is unset", () => {
+    expect(visionEnv({ DFIR_AI_PROVIDER: "openai" }, "PROVIDER")).toBe("openai");
+    expect(visionEnv({ DFIR_AI_BASE_URL: "http://x" }, "BASE_URL")).toBe("http://x");
+  });
+
+  it("is undefined when neither name is set", () => {
+    expect(visionEnv({}, "KEY")).toBeUndefined();
+  });
+
+  it("covers the whole vision family", () => {
+    expect(VISION_ENV_SUFFIXES).toEqual(["PROVIDER", "MODEL", "KEY", "BASE_URL", "IMAGE_DETAIL"]);
+  });
+});
+
+describe("withVisionEnvAliases (Settings-form migration display)", () => {
+  it("surfaces a legacy value under the new key when the new key is absent", () => {
+    const out = withVisionEnvAliases({ DFIR_AI_MODEL: "gpt-4o-mini" });
+    expect(out.DFIR_VISION_MODEL).toBe("gpt-4o-mini");
+    expect(out.DFIR_AI_MODEL).toBe("gpt-4o-mini"); // legacy key left in place, nothing hidden
+  });
+
+  it("keeps the new value when both are present (new wins)", () => {
+    const out = withVisionEnvAliases({ DFIR_VISION_MODEL: "new", DFIR_AI_MODEL: "old" });
+    expect(out.DFIR_VISION_MODEL).toBe("new");
+  });
+
+  it("does not invent keys when neither is set", () => {
+    expect("DFIR_VISION_KEY" in withVisionEnvAliases({})).toBe(false);
+  });
+});
+
+describe("buildAiDiagnostics honors the rename", () => {
+  it("reads the new DFIR_VISION_* names", () => {
+    const d = buildAiDiagnostics({ DFIR_VISION_PROVIDER: "openai", DFIR_VISION_MODEL: "gpt-4o-mini" });
+    expect(d.configured).toBe(true);
+    expect(d.provider).toBe("openai");
+    expect(d.model).toBe("gpt-4o-mini");
+  });
+
+  it("still reads legacy DFIR_AI_* names (fallback)", () => {
+    const d = buildAiDiagnostics({ DFIR_AI_PROVIDER: "anthropic", DFIR_AI_MODEL: "claude" });
+    expect(d.configured).toBe(true);
+    expect(d.provider).toBe("anthropic");
+    expect(d.model).toBe("claude");
+  });
+
+  it("prefers the new name when both are set", () => {
+    const d = buildAiDiagnostics({ DFIR_VISION_MODEL: "new", DFIR_AI_MODEL: "old", DFIR_VISION_PROVIDER: "openai" });
+    expect(d.model).toBe("new");
+  });
+});

--- a/companion/tests/eval/README.md
+++ b/companion/tests/eval/README.md
@@ -30,13 +30,15 @@ npm run eval             # both extraction + synthesis
 npm run eval:extraction  # precision/recall per fixture
 npm run eval:synthesis   # coverage / hallucination per fixture
 
-# Phase 2 — real provider (needs DFIR_AI_PROVIDER / DFIR_AI_KEY in env or .env); non-blocking
+# Phase 2 — real provider (needs DFIR_VISION_PROVIDER / DFIR_VISION_KEY in env or .env); non-blocking
 npm run eval:real
 npm run eval:real:extraction
 npm run eval:real:synthesis
 ```
 
 Exit code `0` = all pass (or `--real` skipped for no provider), `1` = a gate failed, `2` = a runner error.
+
+> `DFIR_VISION_PROVIDER` / `DFIR_VISION_MODEL` / `DFIR_VISION_KEY` were formerly `DFIR_AI_PROVIDER` / `DFIR_AI_MODEL` / `DFIR_AI_KEY`; the legacy names still work as a deprecated fallback.
 
 ## Scoring model
 
@@ -59,7 +61,7 @@ Extraction quality varies enormously by model, and the harness is only a usable 
 | `google/gemini-2.5-pro` | 4/4 pass, 100% recall, stable across runs |
 | `openai/gpt-4o-mini` | flaps run-to-run (same fixture scored 0% and 100% on identical input); consistently misses the proxy-exfil case entirely |
 
-Point `--real` at a strong model via `DFIR_AI_MODEL` (it need not be the model used for day-to-day extraction). A red `--real` on a weak model is telling you about the *model*, not a prompt regression.
+Point `--real` at a strong model via `DFIR_VISION_MODEL` (it need not be the model used for day-to-day extraction). A red `--real` on a weak model is telling you about the *model*, not a prompt regression.
 
 **Synthesis — deterministic quality checks (no golden needed):**
 - **Coverage** — every Critical/High event is cited by ≥1 finding (else a regression).

--- a/companion/tests/eval/harness.ts
+++ b/companion/tests/eval/harness.ts
@@ -33,7 +33,7 @@ export function mockProvider(canned: string): MockProvider {
 // gracefully so a missing key never fails CI. dotenv is loaded by the runner.
 //
 // Deliberately the TEXT model (`buildSynthesisProvider()`, i.e. DFIR_AI_SYNTH_MODEL falling back to
-// DFIR_AI_MODEL), not `buildProvider()`: every path these fixtures exercise — analyzeCsv, analyzeLog,
+// the vision model DFIR_VISION_MODEL), not `buildProvider()`: every path these fixtures exercise — analyzeCsv, analyzeLog,
 // synthesize — runs on the text model in production. Grading the vision model here would score a model
 // production never uses for this work.
 export function realProviderOrNull(): AIProvider | undefined {

--- a/companion/tests/eval/run.ts
+++ b/companion/tests/eval/run.ts
@@ -11,6 +11,7 @@
 // Exit codes: 0 = all pass (or real-mode skipped), 1 = a gate failed, 2 = a runner error.
 
 import { config as loadDotenv } from "dotenv";
+import { visionEnv } from "../../src/config/aiEnv.js";
 import { runExtractionFixture, runScreenshotFixture, runSynthesisFixture, mockProvider, realProviderOrNull } from "./harness.js";
 import {
   scoreExtraction, checkSynthesis, passesExtraction, passesSynthesis,
@@ -76,11 +77,11 @@ async function main(): Promise<void> {
     loadDotenv({ quiet: true });
     const provider = realProviderOrNull();
     if (!provider) {
-      console.log("eval --real: no AI provider configured (set DFIR_AI_PROVIDER / DFIR_AI_KEY) — skipped.");
+      console.log("eval --real: no AI provider configured (set DFIR_AI_SYNTH_* or DFIR_VISION_*) — skipped.");
       process.exit(0);
     }
     // Report the TEXT model — that's what realProviderOrNull() resolves and what these fixtures grade.
-    const model = process.env.DFIR_AI_SYNTH_MODEL ?? process.env.DFIR_AI_MODEL ?? "(default)";
+    const model = process.env.DFIR_AI_SYNTH_MODEL ?? visionEnv(process.env, "MODEL") ?? "(default)";
     console.log(`eval --real: provider ${provider.name}, model ${model}\n`);
     extractionProvider = synthesisProvider = () => provider;
     override = REAL_THRESHOLDS;

--- a/companion/tests/server/aiReload.test.ts
+++ b/companion/tests/server/aiReload.test.ts
@@ -31,6 +31,8 @@ beforeEach(async () => {
   }
   delete process.env.DFIR_AI_PROVIDER;
   delete process.env.DFIR_AI_MODEL;
+  delete process.env.DFIR_VISION_PROVIDER;
+  delete process.env.DFIR_VISION_MODEL;
 });
 
 afterEach(async () => {
@@ -52,6 +54,17 @@ describe("/settings/ai-reload", () => {
     // The values are now live in process.env (what buildProvider() reads).
     expect(process.env.DFIR_AI_PROVIDER).toBe("openai");
     expect(process.env.DFIR_AI_MODEL).toBe("gpt-4o-mini");
+  });
+
+  it("also applies the renamed DFIR_VISION_* vision family (screenshot provider)", async () => {
+    await writeFile(ENV_PATH, "DFIR_VISION_PROVIDER=openai\nDFIR_VISION_MODEL=gpt-4o-mini\n", "utf8");
+
+    const res = await request(app).post("/settings/ai-reload");
+    expect(res.status).toBe(200);
+    expect(res.body.applied).toContain("DFIR_VISION_PROVIDER");
+    expect(res.body.applied).toContain("DFIR_VISION_MODEL");
+    expect(process.env.DFIR_VISION_PROVIDER).toBe("openai");
+    expect(process.env.DFIR_VISION_MODEL).toBe("gpt-4o-mini");
   });
 
   it("succeeds with an empty applied list when no DFIR_AI_* keys are present", async () => {

--- a/companion/tests/server/caseLifecycleRoutes.test.ts
+++ b/companion/tests/server/caseLifecycleRoutes.test.ts
@@ -7,6 +7,7 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { CommentsStore } from "../../src/analysis/comments.js";
+import { MockProvider } from "../../src/providers/provider.js";
 
 const PASSWORD = "correct horse battery staple";
 
@@ -22,18 +23,18 @@ async function harness() {
 // /import, /import-file and /synthesize each 501 with "not configured" before they ever look at
 // caseMeta.status when options.pipeline is absent — harness() deliberately has no pipeline, so
 // those routes' own precondition gate is unreachable-proof against the archived-status guard.
-// This variant wires a real (no-AI) pipeline via buildRuntimePipeline, same as
+// This variant wires a real pipeline via buildRuntimePipeline, same as
 // tests/server/importMissingCase.test.ts, so requests clear that gate and actually reach the
-// closed/archived check under test. aiConfigured forces /synthesize's hasAiProvider() gate true
-// too, without needing a working AI provider — the archived check short-circuits before any
-// AI call would happen.
+// closed/archived check under test. A mock synthesisProvider forces /synthesize's
+// hasSynthesisProvider() gate true too, without needing a working AI provider — the archived
+// check short-circuits before any AI call would happen (the mock is never invoked).
 async function harnessWithPipeline() {
   const root = await mkdtemp(join(tmpdir(), "dfir-lifecycle-pipeline-"));
   const store = new CaseStore(root);
   const stateStore = new StateStore(store);
   const commentsStore = new CommentsStore(store);
   const pipeline = buildRuntimePipeline({
-    provider: undefined, synthesisProvider: undefined, stateStore, store,
+    provider: undefined, synthesisProvider: new MockProvider("stub", "{}"), stateStore, store,
     imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
   });
   const app = createApp(store, { stateStore, commentsStore, pipeline, aiConfigured: true });

--- a/companion/tests/server/synthesisOnlyGate.test.ts
+++ b/companion/tests/server/synthesisOnlyGate.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, buildRuntimePipeline } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { MockProvider } from "../../src/providers/provider.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+
+// Regression tests for the provider-gate mismatch: DFIR_AI_PROVIDER is the SCREENSHOT (vision)
+// model, DFIR_AI_SYNTH_PROVIDER is ALL TEXT WORK. An OCR-less install sets ONLY the synthesis
+// provider — so every text-AI route must gate on pipeline.hasSynthesisProvider(), NOT on the
+// vision provider (hasAiProvider / aiConfigured). These apps are built exactly like that install:
+// provider: undefined, synthesisProvider: <mock>, aiConfigured: false — and must get 200, not 501.
+async function makeSynthOnlyApp(canned: string) {
+  const root = await mkdtemp(join(tmpdir(), "dfir-synthonly-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const pipeline = buildRuntimePipeline({
+    provider: undefined,
+    synthesisProvider: new MockProvider("synth-only", canned),
+    stateStore, store,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+  const app = createApp(store, { pipeline, stateStore, aiConfigured: false });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, store, stateStore };
+}
+
+describe("synthesis-provider gate (no vision provider)", () => {
+  it("POST /cases/:id/synthesize runs on the synthesis provider alone", async () => {
+    const { app, stateStore } = await makeSynthOnlyApp(JSON.stringify({
+      findings: [{ id: "f1", severity: "High", title: "synth finding", description: "d",
+        relatedIocs: [], mitreTechniques: [], status: "open", relatedEventIds: ["e1"] }],
+      iocs: [], mitreTechniques: [], attackerPath: "path", summary: "s",
+      forensicEvents: [], threadsOpened: [], threadsClosed: [], timelineNote: "",
+    }));
+    // synthesize() early-returns on an empty timeline (nothing to synthesize), so seed one event.
+    const s = emptyState("c1");
+    s.forensicTimeline.push({
+      id: "e1", timestamp: "2026-05-20T09:00:00Z", description: "phish opened",
+      severity: "High", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [],
+    });
+    await stateStore.save(s);
+    const res = await request(app).post("/cases/c1/synthesize").send({});
+    expect(res.status).toBe(200);
+    expect(res.body.findings).toBe(1);
+  });
+
+  it("POST /cases/:id/ask answers on the synthesis provider alone", async () => {
+    const { app } = await makeSynthOnlyApp(JSON.stringify({
+      answer: "No evidence of exfiltration.", status: "unknown",
+      pointer: "Check egress proxy/firewall logs.", relatedEventIds: [],
+    }));
+    const res = await request(app).post("/cases/c1/ask").send({ question: "was data exfiltrated?" });
+    expect(res.status).toBe(200);
+    expect(res.body.answer).toBeTruthy();
+  });
+
+  it("POST /cases/:id/events/:eid/explain explains on the synthesis provider alone", async () => {
+    const { app, stateStore } = await makeSynthOnlyApp(JSON.stringify({
+      summary: "PowerShell spawned by Word",
+      whyItMatters: "Classic macro initial access",
+      normalContext: "Unusual in office environments",
+      suspiciousIndicators: "WINWORD.EXE parent process",
+      attackMapping: "T1059.001",
+      pivotQueries: [{ platform: "velociraptor", query: "SELECT * FROM pslist()", rationale: "check process tree" }],
+      evidenceFor: "Macro execution chain",
+      evidenceAgainst: "Could be legitimate automation",
+      relatedEventIds: [],
+    }));
+    const s = emptyState("c1");
+    s.forensicTimeline.push({
+      id: "ev1", timestamp: "2026-06-01T10:00:00Z", description: "powershell.exe spawned",
+      severity: "High", mitreTechniques: ["T1059.001"], relatedFindingIds: [], sourceScreenshots: [],
+    });
+    await stateStore.save(s);
+    const res = await request(app).post("/cases/c1/events/ev1/explain");
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toBeTruthy();
+  });
+
+  it("POST /cases/:id/executive-summary generates on the synthesis provider alone", async () => {
+    const { app } = await makeSynthOnlyApp(JSON.stringify({ summary: "Management summary." }));
+    const res = await request(app).post("/cases/c1/executive-summary").send({});
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toBeTruthy();
+  });
+
+  it("POST /cases/:id/import-csv accepts CSV analysis on the synthesis provider alone", async () => {
+    const { app } = await makeSynthOnlyApp(JSON.stringify({
+      findings: [], iocs: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [],
+      timelineNote: "", summary: "", forensicEvents: [],
+    }));
+    const res = await request(app).post("/cases/c1/import-csv")
+      .send({ filename: "results.csv", csv: "ts,event\n2026-06-01T10:00:00Z,logon\n" });
+    expect(res.status).toBe(202);
+    expect(res.body.accepted).toBe(true);
+  });
+
+  it("still 501s when NEITHER provider is configured", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-noai-"));
+    const store = new CaseStore(root);
+    const stateStore = new StateStore(store);
+    const pipeline = buildRuntimePipeline({
+      provider: undefined, synthesisProvider: undefined, stateStore, store,
+      imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+    });
+    const app = createApp(store, { pipeline, stateStore, aiConfigured: false });
+    await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const synth = await request(app).post("/cases/c1/synthesize").send({});
+    expect(synth.status).toBe(501);
+    const ask = await request(app).post("/cases/c1/ask").send({ question: "q" });
+    expect(ask.status).toBe(501);
+    const csv = await request(app).post("/cases/c1/import-csv").send({ filename: "x.csv", csv: "a,b\n1,2\n" });
+    expect(csv.status).toBe(501);
+  });
+});

--- a/companion/tests/server/synthesisOnlyGate.test.ts
+++ b/companion/tests/server/synthesisOnlyGate.test.ts
@@ -9,7 +9,7 @@ import { StateStore } from "../../src/analysis/stateStore.js";
 import { MockProvider } from "../../src/providers/provider.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
 
-// Regression tests for the provider-gate mismatch: DFIR_AI_PROVIDER is the SCREENSHOT (vision)
+// Regression tests for the provider-gate mismatch: DFIR_VISION_PROVIDER is the SCREENSHOT (vision)
 // model, DFIR_AI_SYNTH_PROVIDER is ALL TEXT WORK. An OCR-less install sets ONLY the synthesis
 // provider — so every text-AI route must gate on pipeline.hasSynthesisProvider(), NOT on the
 // vision provider (hasAiProvider / aiConfigured). These apps are built exactly like that install:

--- a/companion/tests/server/taggerRoutes.test.ts
+++ b/companion/tests/server/taggerRoutes.test.ts
@@ -163,6 +163,7 @@ describe("POST /cases/:id/tagger/clear", () => {
 function appAi(suggest: (caseId: string, desc: string) => Promise<SuggestOutcome>) {
   const fakePipeline = {
     hasAiProvider: () => true,
+    hasSynthesisProvider: () => true,   // suggest-rule is TEXT work — gated on the synthesis provider
     suggestTaggerRule: suggest,
   } as unknown as import("../../src/analysis/pipeline.js").AnalysisPipeline;
   return createApp(store, {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,15 @@ services:
       DFIR_PORT: "4773"
       DFIR_CASES_ROOT: "/data/cases"
       DFIR_MAX_BODY_MB: "256"
-      # --- AI analysis (optional). Leave DFIR_AI_PROVIDER unset for capture/import-only. ---
-      # DFIR_AI_PROVIDER: "openai"
-      # DFIR_AI_MODEL: "gpt-4o"
-      # DFIR_AI_KEY: "sk-replace-me"
+      # --- AI analysis (optional). Leave DFIR_VISION_PROVIDER unset for capture/import-only. ---
+      # DFIR_VISION_* is the SCREENSHOT (vision) model; DFIR_AI_SYNTH_* does all text work.
+      # (Legacy DFIR_AI_PROVIDER/MODEL/KEY/BASE_URL still work as a deprecated fallback.)
+      # DFIR_VISION_PROVIDER: "openai"
+      # DFIR_VISION_MODEL: "gpt-4o"
+      # DFIR_VISION_KEY: "sk-replace-me"
       # Reach an AI endpoint on the host (Docker Desktop): http://host.docker.internal:PORT/v1
-      # e.g. a local Ollama:  DFIR_AI_PROVIDER=ollama  DFIR_AI_BASE_URL=http://host.docker.internal:11434/v1
-      # DFIR_AI_BASE_URL: "http://host.docker.internal:11434/v1"
+      # e.g. a local Ollama:  DFIR_VISION_PROVIDER=ollama  DFIR_VISION_BASE_URL=http://host.docker.internal:11434/v1
+      # DFIR_VISION_BASE_URL: "http://host.docker.internal:11434/v1"
     # Prefer a file for config? Copy companion/.env.example to .env and uncomment:
     # env_file:
     #   - .env

--- a/mkdocs-docs/reference/ai-analysis.md
+++ b/mkdocs-docs/reference/ai-analysis.md
@@ -30,17 +30,17 @@ DFIR Companion supports multiple AI backends:
 
 | Provider | Setting |
 |----------|---------|
-| **OpenAI** | `DFIR_AI_PROVIDER=openai` |
-| **Anthropic (Claude)** | `DFIR_AI_PROVIDER=openai` with `DFIR_AI_BASE_URL=https://api.anthropic.com/v1` |
-| **OpenRouter** | `DFIR_AI_PROVIDER=openrouter` |
-| **Google Gemini** | `DFIR_AI_PROVIDER=gemini` |
-| **Ollama** (local) | `DFIR_AI_PROVIDER=ollama`, `DFIR_AI_BASE_URL=http://localhost:11434/v1` |
-| **LiteLLM** (local proxy) | `DFIR_AI_PROVIDER=litellm` |
+| **OpenAI** | `DFIR_VISION_PROVIDER=openai` |
+| **Anthropic (Claude)** | `DFIR_VISION_PROVIDER=openai` with `DFIR_VISION_BASE_URL=https://api.anthropic.com/v1` |
+| **OpenRouter** | `DFIR_VISION_PROVIDER=openrouter` |
+| **Google Gemini** | `DFIR_VISION_PROVIDER=gemini` |
+| **Ollama** (local) | `DFIR_VISION_PROVIDER=ollama`, `DFIR_VISION_BASE_URL=http://localhost:11434/v1` |
+| **LiteLLM** (local proxy) | `DFIR_VISION_PROVIDER=litellm` |
 
-Configure via the Setup Wizard or in `.env`. All AI calls are made server-side — API keys never go to the browser.
+Configure via the Setup Wizard or in `.env`. All AI calls are made server-side — API keys never go to the browser. (The screenshot/vision vars were renamed from `DFIR_AI_*` to `DFIR_VISION_*`; the legacy `DFIR_AI_*` names still work as a deprecated fallback.)
 
 !!! tip "Using a local model?"
-    Only screenshot reading needs a **multimodal** (vision) model — that's `DFIR_AI_MODEL`. Everything else (CSV/log import, synthesis, and all other text-only AI features) runs on `DFIR_AI_SYNTH_MODEL`, so a text-only model is fine there. Use the two-tier setup (`DFIR_AI_MODEL` = cheap vision for screenshots, `DFIR_AI_SYNTH_MODEL` = strong reasoning for everything else) — a weak text model fails log triage silently, returning no events at all rather than wrong ones.
+    Only screenshot reading needs a **multimodal** (vision) model — that's `DFIR_VISION_MODEL`. Everything else (CSV/log import, synthesis, and all other text-only AI features) runs on `DFIR_AI_SYNTH_MODEL`, so a text-only model is fine there. Use the two-tier setup (`DFIR_VISION_MODEL` = cheap vision for screenshots, `DFIR_AI_SYNTH_MODEL` = strong reasoning for everything else) — a weak text model fails log triage silently, returning no events at all rather than wrong ones.
 
 ---
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2354,8 +2354,8 @@
         <p class="rm-hint" style="font-size:11px;color:var(--c-9aa4b2);margin:2px 0 8px">New here? <a href="#" id="rerunAiWizard" style="color:var(--c-2d6cdf)">Re-run the setup wizard</a> for a guided provider/model/key flow with a built-in connection test (#181).</p>
         <div class="sfield-row">
           <div class="sfield">
-            <label>Provider<span class="sfield-hint">DFIR_AI_PROVIDER</span></label>
-            <select id="env-DFIR_AI_PROVIDER">
+            <label>Provider (screenshots)<span class="sfield-hint">DFIR_VISION_PROVIDER</span></label>
+            <select id="env-DFIR_VISION_PROVIDER">
               <option value="">— not set —</option>
               <option value="openai">openai</option>
               <option value="openrouter">openrouter</option>
@@ -2365,11 +2365,11 @@
               <option value="anthropic">anthropic</option>
             </select>
           </div>
-          <div class="sfield"><label>Model (extraction, must support vision)<span class="sfield-hint">DFIR_AI_MODEL</span></label><input id="env-DFIR_AI_MODEL" placeholder="gpt-4o-mini" /></div>
+          <div class="sfield"><label>Model (screenshots, must support vision)<span class="sfield-hint">DFIR_VISION_MODEL</span></label><input id="env-DFIR_VISION_MODEL" placeholder="gpt-4o-mini" /></div>
         </div>
         <div class="sfield-row">
-          <div class="sfield"><label>API key<span class="sfield-hint">DFIR_AI_KEY</span></label><input id="env-DFIR_AI_KEY" type="password" placeholder="(not set)" autocomplete="new-password" /></div>
-          <div class="sfield"><label>Base URL override<span class="sfield-hint">DFIR_AI_BASE_URL — leave blank for provider default</span></label><input id="env-DFIR_AI_BASE_URL" placeholder="e.g. http://localhost:11434/v1" /></div>
+          <div class="sfield"><label>API key<span class="sfield-hint">DFIR_VISION_KEY</span></label><input id="env-DFIR_VISION_KEY" type="password" placeholder="(not set)" autocomplete="new-password" /></div>
+          <div class="sfield"><label>Base URL override<span class="sfield-hint">DFIR_VISION_BASE_URL — leave blank for provider default</span></label><input id="env-DFIR_VISION_BASE_URL" placeholder="e.g. http://localhost:11434/v1" /></div>
         </div>
         <div class="sfield-row3">
           <div class="sfield"><label>Timeout (ms)<span class="sfield-hint">DFIR_AI_TIMEOUT_MS</span></label><input id="env-DFIR_AI_TIMEOUT_MS" placeholder="180000" /></div>
@@ -2379,8 +2379,8 @@
         <div class="sfield-row">
           <div class="sfield"><label>Synth max events<span class="sfield-hint">DFIR_AI_SYNTH_MAX_EVENTS</span></label><input id="env-DFIR_AI_SYNTH_MAX_EVENTS" placeholder="300" /></div>
           <div class="sfield">
-            <label>Image detail<span class="sfield-hint">DFIR_AI_IMAGE_DETAIL</span></label>
-            <select id="env-DFIR_AI_IMAGE_DETAIL">
+            <label>Image detail<span class="sfield-hint">DFIR_VISION_IMAGE_DETAIL</span></label>
+            <select id="env-DFIR_VISION_IMAGE_DETAIL">
               <option value="">— default (high) —</option>
               <option value="high">high</option>
               <option value="low">low</option>
@@ -10019,7 +10019,7 @@
       ).join("");
       document.getElementById("anonCustCat").innerHTML = ANON_ENTITY_CATEGORIES.map(c => `<option value="${escAttr(c)}">${esc(c)}</option>`).join("");
       const warn = document.getElementById("anonWarning");
-      if (anonControl.screenshotWarning) { warn.style.display = "block"; warn.textContent = "⚠ Screenshots are OCR-redacted (best-effort) before being sent to the external vision model — text matching the entities below is blacked out on an in-memory copy; the original on disk is untouched. OCR can miss text, so don't rely on it for highly sensitive screens. Point DFIR_AI_MODEL at a local Ollama vision model to keep screenshots fully on-box. Imported CSV/log text and synthesis are anonymized."; }
+      if (anonControl.screenshotWarning) { warn.style.display = "block"; warn.textContent = "⚠ Screenshots are OCR-redacted (best-effort) before being sent to the external vision model — text matching the entities below is blacked out on an in-memory copy; the original on disk is untouched. OCR can miss text, so don't rely on it for highly sensitive screens. Point DFIR_VISION_MODEL at a local Ollama vision model to keep screenshots fully on-box. Imported CSV/log text and synthesis are anonymized."; }
       else { warn.style.display = "none"; }
       document.getElementById("anonMsg").textContent = "loading entities…";
       loadAnonEntities(caseId)
@@ -17443,9 +17443,9 @@
       if (!key && !local) { result.style.color = "#ffb05a"; result.textContent = "Enter an API key (or pick a local provider)."; return; }
       const btn = wizEl("wizTestSaveBtn"); btn.disabled = true;
       result.style.color = "#9aa4b2"; result.textContent = "Saving configuration…";
-      const updates = { DFIR_AI_PROVIDER: provider, DFIR_AI_MODEL: model };
-      if (key) updates.DFIR_AI_KEY = key;
-      if (baseUrl) updates.DFIR_AI_BASE_URL = baseUrl;
+      const updates = { DFIR_VISION_PROVIDER: provider, DFIR_VISION_MODEL: model };
+      if (key) updates.DFIR_VISION_KEY = key;
+      if (baseUrl) updates.DFIR_VISION_BASE_URL = baseUrl;
       try {
         const save = await fetch("/settings/env", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ updates }) });
         if (!save.ok) { const j = await save.json().catch(() => ({})); result.style.color = "#ff9f9f"; result.textContent = "Could not save: " + esc(j.error || ("HTTP " + save.status)) + " — restart the companion server if this 404s."; btn.disabled = false; return; }


### PR DESCRIPTION
## Summary

Two related changes that clarify and correct the **vision (screenshots) vs. text (synthesis)** split in DFIR Companion's AI config.

### 1. Gate text-AI features on the synthesis provider, not the vision provider
Route-level availability gates used `hasAiProvider()` = `Boolean(vision provider)`, so **every text-AI feature was gated on the screenshot/vision model**. In an OCR-less install (synthesis provider set, vision provider unset) they all returned **501** even though `pipeline.ts` model routing already sends everything except `analyzeWindow` (screenshots) to the synthesis provider.

- Added `AnalysisPipeline.hasSynthesisProvider()` → `Boolean(synthesisProvider ?? provider)`.
- Switched every text-feature gate to it: `/synthesize`, `/ask`, event `/explain`, `/executive-summary`, `/remediation-plan`, `/hypothesis-review`, `/narrative`, hunt suggestions (adversary-hints, velociraptor, playbook), `/memory/next-steps`, CSV/log import (+ `/import`, `/import-file` pre-checks, push ingest), tagger-rule suggest, `/timeline-gaps/hypothesize`, `/translate-query`, FP-similarity, anon re-synth-on-toggle, and the `scheduleSynthesis` / `resynthesizeInBackground` schedulers.
- **Left vision-gated (correct):** live screenshot analysis (`captures.ts` `willAnalyze`, `flush()`), the screenshot-anonymization warning, `/setup/status` capability flag.

### 2. Rename the screenshot/vision env vars `DFIR_AI_*` → `DFIR_VISION_*`
The vision-model config now has a name that reflects its screenshots-only role, distinct from the text-work family `DFIR_AI_SYNTH_*`. Five vars moved: `DFIR_AI_{PROVIDER,MODEL,KEY,BASE_URL,IMAGE_DETAIL}` → `DFIR_VISION_*`.

- **Backward compatible:** legacy `DFIR_AI_*` names still work as a deprecated fallback (new name wins when both set) via a new `config/aiEnv.ts` (`visionEnv`). Existing `.env` files keep working with no change.
- Unchanged: shared tuning (`DFIR_AI_TIMEOUT_MS`/`_MAX_TOKENS`/`_CONTEXT_TOKENS`) and `DFIR_AI_SYNTH_*` / `_VELO_*` / `_SECOND_OPINION_*`.
- Wired through the four provider builders, diagnostics, the anon vision-local check, provider error hints, the three CLI scripts, and the dashboard Settings form + first-run wizard. `/settings/ai-reload` reloads both prefixes; `getEnvForSettings` aliases legacy→new so existing installs' values still populate the renamed fields. `.env.example`, `docker-compose.yml`, README ×2, USER_MANUAL, and mkdocs lead with the new names and document the fallback.

## Verification
- New `tests/config/aiEnv.test.ts` (precedence + aliases + diagnostics) and `tests/server/synthesisOnlyGate.test.ts` (a synthesis-only app returns 200 for the switched routes; neither-provider still 501s). `aiReload.test.ts` extended for the new prefix. The existing `DFIR_AI_*` diagnostics/ollama tests now double as fallback-regression coverage.
- `npx tsc --noEmit` clean; full suite green (**4003 passed / 353 files**).

## Test plan
From `companion/`:
```
git fetch && git switch feat/text-ai-synthesis-gate
npx tsc --noEmit
npx vitest run tests/server/synthesisOnlyGate.test.ts tests/config/aiEnv.test.ts tests/server/aiReload.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
