### PR TITLE
Unify graphs on shared Cytoscape view (Assets & IoC + Evidence Chain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Assets & IoC Graph and Evidence Chain now share the Login Graph's interactive Cytoscape view** — both moved off static SVG onto a shared graph-view module, so all three graphs offer the same five layouts (spread/dagre/circle/concentric/breadthfirst), bezier/taxi edges, selection transparency, live filter, fit, fullscreen, and PNG export. Custom node glyphs (host/account/service/process/file/network) are preserved, and the Evidence Chain keeps its typed, colored, directional edges. The old bespoke asset layouts (horizontal/vertical/radial) and manual node-position saving were replaced by the shared generic layouts.
 - **Screenshot/vision AI vars renamed `DFIR_AI_*` → `DFIR_VISION_*`** — the vision-model config (`DFIR_VISION_PROVIDER` / `_MODEL` / `_KEY` / `_BASE_URL` / `_IMAGE_DETAIL`) now has a name that reflects its screenshots-only role, distinct from the text-work family (`DFIR_AI_SYNTH_*`). The legacy `DFIR_AI_*` names still work as a deprecated fallback (the new name wins when both are set), so existing `.env` files keep working with no change required.
 
 ### Fixed

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2390,6 +2390,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     "/vendor/cytoscape/cytoscape.min.js": "application/javascript; charset=utf-8",
     "/vendor/cytoscape/dagre.min.js": "application/javascript; charset=utf-8",
     "/vendor/cytoscape/cytoscape-dagre.js": "application/javascript; charset=utf-8",
+    "/js/graph-view.js": "application/javascript; charset=utf-8",
   };
   for (const [route, type] of Object.entries(vendorFiles)) {
     app.get(route, async (_req, res) => {

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2381,8 +2381,9 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // (startServer), so createApp-only unit tests never start a filesystem poller.
   if (dropWatchEnabled && options.dropStatusStore) startDropWatcher();
 
-  // Vendored client libraries (Leaflet for the Geographic map, #133; cytoscape+dagre for the
-  // Login Graph). Whitelisted filenames only.
+  // Whitelisted static client assets: vendored libraries (Leaflet for the Geographic map, #133;
+  // cytoscape+dagre for the graphs) plus first-party browser modules (the shared graph-view module
+  // used by the Login/Assets/Evidence graphs). Whitelisted paths only.
   // Registered inside createApp so the routes are available in tests (startServer calls createApp).
   const vendorFiles: Record<string, string> = {
     "/vendor/leaflet/leaflet.js": "application/javascript; charset=utf-8",

--- a/companion/tests/analysis/graphView.test.ts
+++ b/companion/tests/analysis/graphView.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+// The shared browser module lives outside companion/. It guards its window assignment,
+// so importing its pure named exports in node works.
+import { layoutOptions, dimOpacity, filterMatch } from "../../../public/js/graph-view.js";
+
+describe("layoutOptions", () => {
+  it("maps 'spread' to the cose layout", () => {
+    expect(layoutOptions({ layout: "spread" }).name).toBe("cose");
+  });
+  it("passes other layout names through unchanged", () => {
+    expect(layoutOptions({ layout: "dagre" }).name).toBe("dagre");
+    expect(layoutOptions({ layout: "circle" }).name).toBe("circle");
+  });
+  it("always disables animation and fits with padding 30", () => {
+    const o = layoutOptions({ layout: "circle" });
+    expect(o.animate).toBe(false);
+    expect(o.fit).toBe(true);
+    expect(o.padding).toBe(30);
+  });
+  it("adds concentric + levelWidth callbacks for the concentric layout", () => {
+    const o = layoutOptions({ layout: "concentric" });
+    expect(typeof o.concentric).toBe("function");
+    expect(typeof o.levelWidth).toBe("function");
+    expect(o.levelWidth()).toBe(1);
+  });
+  it("marks breadthfirst as directed", () => {
+    expect(layoutOptions({ layout: "breadthfirst" }).directed).toBe(true);
+  });
+});
+
+describe("dimOpacity", () => {
+  it("returns full opacity at 0", () => { expect(dimOpacity(0)).toBe(1); });
+  it("returns ~0.1 at 90", () => { expect(dimOpacity(90)).toBeCloseTo(0.1, 5); });
+  it("clamps to a 0.05 floor at 100", () => { expect(dimOpacity(100)).toBe(0.05); });
+});
+
+describe("filterMatch", () => {
+  it("matches node name case-insensitively (query already lowercased)", () => {
+    expect(filterMatch("WIN-DC01", undefined, "dc01")).toBe(true);
+  });
+  it("falls back to the edge label when there is no name", () => {
+    expect(filterMatch(undefined, "RemoteInteractive (12)", "remote")).toBe(true);
+  });
+  it("returns false when neither field matches", () => {
+    expect(filterMatch("host-a", "type 3", "zzz")).toBe(false);
+  });
+  it("treats missing name and label as an empty string (no throw)", () => {
+    expect(filterMatch(undefined, undefined, "x")).toBe(false);
+  });
+});

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -115,6 +115,13 @@ describe("dashboard.html", () => {
     expect(html).toMatch(/\.asset-graph-wrap\s*\{[^}]*position:\s*relative/);
   });
 
+  it("toggles the graph View panel closed on a second click (no re-open regression)", async () => {
+    const mod = await readFile(new URL("../../../public/js/graph-view.js", import.meta.url), "utf8");
+    // The options-panel toggle must read purely off display==="none"; an `|| !p.style.display`
+    // fallback misread the open ("") state as hidden and re-opened instead of closing.
+    expect(mod).toContain('const show = p.style.display === "none";');
+  });
+
   it("wires the Ask-the-AI panel (ask + add-to-open-questions)", async () => {
     const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
     expect(html).toContain('id="askInput"');

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -110,6 +110,9 @@ describe("dashboard.html", () => {
     // .asset-graph-wrap and their canvas div is .login-graph, so the sizing rule must target that
     // (a regression guard — the old rule targeted the now-removed .asset-graph class).
     expect(html).toContain(".asset-graph-wrap:fullscreen .login-graph");
+    // The absolutely-positioned View/side panels must anchor to their own graph wrap — otherwise
+    // they escape to the page and stay floating over other sections when you scroll away.
+    expect(html).toMatch(/\.asset-graph-wrap\s*\{[^}]*position:\s*relative/);
   });
 
   it("wires the Ask-the-AI panel (ask + add-to-open-questions)", async () => {

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -106,6 +106,10 @@ describe("dashboard.html", () => {
     expect(html).toContain('value="dagre"');
     expect(html).toContain('value="circle"');
     expect(mod).toContain("requestFullscreen");
+    // Fullscreen must actually grow the cytoscape canvas: the asset/evidence wraps are
+    // .asset-graph-wrap and their canvas div is .login-graph, so the sizing rule must target that
+    // (a regression guard — the old rule targeted the now-removed .asset-graph class).
+    expect(html).toContain(".asset-graph-wrap:fullscreen .login-graph");
   });
 
   it("wires the Ask-the-AI panel (ask + add-to-open-questions)", async () => {

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -94,13 +94,18 @@ describe("dashboard.html", () => {
     expect(html).toContain("/asset-graph");
   });
 
-  it("offers fullscreen and layout (horizontal/vertical/radial) controls for the graph", async () => {
+  it("offers fullscreen and layout controls for the asset graph (shared cytoscape toolbar)", async () => {
     const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
-    expect(html).toContain('id="assetFullscreen"');
-    expect(html).toContain('id="assetLayout"');
-    expect(html).toContain('value="vertical"');
-    expect(html).toContain('value="radial"');
-    expect(html).toContain("requestFullscreen");
+    const mod = await readFile(new URL("../../../public/js/graph-view.js", import.meta.url), "utf8");
+    // The asset graph now uses the shared graph-view module: the fullscreen button lives in the
+    // toolbar; requestFullscreen is handled once in the module. Layout is chosen via the generic
+    // layout radios (spread/dagre/circle/concentric/breadthfirst) — the old bespoke
+    // horizontal/vertical/radial SVG layouts were replaced by the shared set.
+    expect(html).toContain('id="assetFullscreenBtn"');
+    expect(html).toContain('name="assetLayoutRadio"');
+    expect(html).toContain('value="dagre"');
+    expect(html).toContain('value="circle"');
+    expect(mod).toContain("requestFullscreen");
   });
 
   it("wires the Ask-the-AI panel (ask + add-to-open-questions)", async () => {
@@ -219,12 +224,13 @@ describe("dashboard.html", () => {
     expect(html).toContain("regenVeloHunt");
   });
 
-  it("offers zoom in/out/fit buttons and mouse-wheel zoom for the graph", async () => {
+  it("offers fit and mouse-wheel zoom for the asset graph (shared cytoscape toolbar)", async () => {
     const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
-    expect(html).toContain('id="assetZoomIn"');
-    expect(html).toContain('id="assetZoomOut"');
-    expect(html).toContain('id="assetZoomReset"');
-    expect(html).toContain('addEventListener("wheel"');
+    const mod = await readFile(new URL("../../../public/js/graph-view.js", import.meta.url), "utf8");
+    // The bespoke zoom in/out/reset buttons were replaced by the toolbar's Fit button plus
+    // cytoscape's built-in mouse-wheel zoom (configured via wheelSensitivity in the module).
+    expect(html).toContain('id="assetFit"');
+    expect(mod).toContain("wheelSensitivity");
   });
 
   it("has the hypotheses panel (#140) with CRUD wiring and the notebook→hypothesis bridge", async () => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -547,13 +547,6 @@
     input { background: var(--c-0f1115); color: var(--c-e6e6e6); border: 1px solid var(--c-2a2f3a); padding: 6px; border-radius: 6px; }
     #status { font-size: 12px; color: var(--c-9aa4b2); }
     /* Compromised assets + asset↔IoC graph */
-    .asset-controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; font-size: 12px; color: var(--c-9aa4b2); margin-bottom: 8px; }
-    .asset-controls label { display: flex; align-items: center; gap: 4px; }
-    .asset-controls button { padding: 3px 9px; font-size: 12px; }
-    .asset-controls select { background: var(--c-0f1115); color: var(--c-e6e6e6); border: 1px solid var(--c-2a2f3a); border-radius: 6px; padding: 3px; font-size: 12px; }
-    .asset-ctrl-sep { width: 1px; align-self: stretch; background: var(--c-2a2f3a); margin: 0 4px; }
-    #assetZoomLevel { min-width: 40px; text-align: center; }
-    .asset-hint { margin-left: auto; color: var(--c-ffd93b); }
     .asset-graph { overflow: auto; max-height: 460px; border: 1px solid var(--c-2a2f3a); border-radius: 6px; background: var(--c-0f1115); }
     .asset-graph svg text { fill: var(--c-cbd3df); font-size: 11px; }
     .asset-node { cursor: grab; }
@@ -562,7 +555,6 @@
     .ev-node { cursor: grab; }
     .ev-node:active { cursor: grabbing; }
     .ev-node.moved text { fill: var(--c-ffd93b); }                /* a repositioned node's label is tinted */
-    .ev-drag-hint { color: var(--c-6b7585); font-size: 11px; font-style: italic; }
     .ev-node text { paint-order: stroke; stroke: var(--c-0f1115); stroke-width: 2.5px; }   /* legible over edges */
     .ev-sub { font-size: 12px; color: var(--c-9aa4b2); font-weight: normal; margin-left: 8px; }
     .ev-legend { display: inline-flex; align-items: center; gap: 6px; color: var(--c-9aa4b2); font-size: 12px; }
@@ -5015,9 +5007,7 @@
 
     // ── Login Graph (cytoscape) ─────────────────────────────────────────────
     let lgData = null;               // last /login-graph payload
-    let lgCy = null;                 // cytoscape instance
     let lgTimer = null;              // debounced reload
-    let lgPendingRender = false;     // section was collapsed at render time
     function loadLoginGraph(caseId) {
       const gv = lgEnsureGV();
       if (gv) gv.loadView();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -557,6 +557,9 @@
     .ev-leg-file { border-top: 2px solid var(--c-4ade80); }
     .ev-leg-net { border-top: 2px solid var(--c-38bdf8); }
     .legend-ico { vertical-align: middle; margin-right: 2px; }
+    /* Anchor the absolutely-positioned View/side panels (.lg-options/.lg-side-panel) to their own
+       graph wrap — without this they escape to the page and stay floating when you scroll away. */
+    .asset-graph-wrap { position: relative; }
     /* Fullscreen: the wrapper fills the screen and the graph grows to fit. */
     .asset-graph-wrap:fullscreen { background: var(--c-11161d); padding: 12px; }
     .asset-graph-wrap:fullscreen .login-graph { height: calc(100vh - 90px); }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5039,18 +5039,10 @@
     let lgCy = null;                 // cytoscape instance
     let lgTimer = null;              // debounced reload
     let lgPendingRender = false;     // section was collapsed at render time
-    const LG_VIEW_DEFAULTS = { layout: "spread", edgeStyle: "bezier", dim: 85, showFailed: true, hideNoise: false };
-    let lgView = { ...LG_VIEW_DEFAULTS };
-    const lgViewKey = () => "dfir.loginGraphView." + (document.getElementById("caseId").value.trim() || "");
-    function loadLgView() {
-      try { lgView = { ...LG_VIEW_DEFAULTS, ...JSON.parse(localStorage.getItem(lgViewKey()) || "{}") }; }
-      catch (e) { lgView = { ...LG_VIEW_DEFAULTS }; }
-    }
-    function saveLgView() { try { localStorage.setItem(lgViewKey(), JSON.stringify(lgView)); } catch (e) { /* quota — non-fatal */ } }
-
     function loadLoginGraph(caseId) {
-      loadLgView();
-      fetch(`/cases/${encodeURIComponent(caseId)}/login-graph`).then(r => r.json()).then(g => {
+      const gv = lgEnsureGV();
+      if (gv) gv.loadView();
+      fetch(`/cases/${encodeURIComponent(caseId)}/login-graph`).then((r) => r.json()).then((g) => {
         lgData = g; renderLoginGraph();
       }).catch(() => {});
     }
@@ -5069,19 +5061,21 @@
       return `${Math.round(s / 3600)} h ago`;
     }
 
-    function lgElements() {
-      // Apply the data toggles (failed / noise) BEFORE handing elements to cytoscape.
-      const edges = (lgData.edges || []).filter(e => lgView.showFailed || e.outcome !== "failed");
-      const nodeById = new Map((lgData.nodes || []).map(n => [n.id, n]));
-      const keptEdges = lgView.hideNoise
-        ? edges.filter(e => !(nodeById.get(e.source) || {}).isNoise && !(nodeById.get(e.target) || {}).isNoise)
+    // The shared-module instance for the Login Graph (created once, lazily, after DOM is ready).
+    let lgGV = null;
+
+    // Build cytoscape elements from lgData + the module's view (data toggles live in view).
+    function lgBuildElements(view) {
+      const edges = (lgData.edges || []).filter((e) => view.showFailed || e.outcome !== "failed");
+      const nodeById = new Map((lgData.nodes || []).map((n) => [n.id, n]));
+      const keptEdges = view.hideNoise
+        ? edges.filter((e) => !(nodeById.get(e.source) || {}).isNoise && !(nodeById.get(e.target) || {}).isNoise)
         : edges;
-      const refd = new Set(keptEdges.flatMap(e => [e.source, e.target]));
-      const nodes = (lgData.nodes || []).filter(n => refd.has(n.id));
+      const refd = new Set(keptEdges.flatMap((e) => [e.source, e.target]));
+      const nodes = (lgData.nodes || []).filter((n) => refd.has(n.id));
       return [
-        ...nodes.map(n => ({ data: { id: n.id, name: n.name, type: n.type } })),
+        ...nodes.map((n) => ({ data: { id: n.id, name: n.name, type: n.type } })),
         ...keptEdges.map((e) => ({ data: {
-          // Semantic key (not a positional index) so edge identity is stable across re-renders/toggles.
           id: `lge:${e.source}|${e.target}|${e.logonType}|${e.outcome}`, source: e.source, target: e.target,
           label: `${e.logonType} (${e.count})`,
           outcome: e.outcome, risk: e.risk,
@@ -5107,75 +5101,61 @@
       } },
       { selector: 'edge[outcome = "failed"]', style: { "line-style": "dashed", "line-color": "#e05c5c", "target-arrow-color": "#e05c5c" } },
       { selector: 'edge[risk = "medium"]', style: { "line-color": "#e0a15c", "target-arrow-color": "#e0a15c", width: 2 } },
-      { selector: ".lg-dim", style: { opacity: 0.15 } },
+      { selector: ".gv-dim", style: { opacity: 0.15 } },
     ];
 
-    function lgLayoutOpts() {
-      const name = lgView.layout === "spread" ? "cose" : lgView.layout;
-      // animate:false — animated layouts advance on requestAnimationFrame, which browsers pause in
-      // background/occluded tabs, stalling the layout forever and leaving the initial grid. Synchronous
-      // positioning always applies, even when the dashboard loads in a backgrounded tab.
-      const base = { name, animate: false, fit: true, padding: 30 };
-      if (name === "concentric") return { ...base, concentric: (n) => n.degree(), levelWidth: () => 1 };
-      if (name === "breadthfirst") return { ...base, directed: true };
-      return base;
+    function lgEnsureGV() {
+      if (lgGV) return lgGV;
+      if (!window.DfirGraphView) return null;   // module not loaded yet (should not happen post-load)
+      lgGV = window.DfirGraphView.createGraphView({
+        graphId: "login",
+        container: document.getElementById("loginGraph"),
+        wrap: document.getElementById("loginGraphWrap"),
+        caseIdEl: document.getElementById("caseId"),
+        exportName: "login-graph.png",
+        defaults: { layout: "spread", edgeStyle: "bezier", dim: 85, showFailed: true, hideNoise: false },
+        style: LG_STYLE,
+        buildElements: lgBuildElements,
+        onNodeTap: (node) => lgShowNodePanel(node),
+        onEdgeTap: (edge) => lgShowEdgePanel(edge),
+        onBackgroundTap: () => lgHideSidePanel(),
+        onRefresh: () => { const cId = document.getElementById("caseId").value.trim(); if (cId) { clearTimeout(lgTimer); loadLoginGraph(cId); } },
+        controls: {
+          layoutRadios: document.querySelectorAll('input[name="lgLayout"]'),
+          edgeStyleRadios: document.querySelectorAll('input[name="lgEdgeStyle"]'),
+          dimSlider: document.getElementById("lgDim"),
+          filterInput: document.getElementById("lgFilter"),
+          fitBtn: document.getElementById("lgFit"),
+          fullscreenBtn: document.getElementById("lgFullscreen"),
+          exportBtn: document.getElementById("lgExport"),
+          refreshBtn: document.getElementById("lgRefresh"),
+          optionsBtn: document.getElementById("lgOptions"),
+          optionsPanel: document.getElementById("lgOptionsPanel"),
+          toggles: [
+            { input: document.getElementById("lgShowFailed"), key: "showFailed" },
+            { input: document.getElementById("lgHideNoise"), key: "hideNoise" },
+          ],
+        },
+      });
+      return lgGV;
     }
 
     function renderLoginGraph() {
-      const el = document.getElementById("loginGraph");
       const stats = document.getElementById("loginGraphStats");
       if (!lgData) { stats.textContent = "—"; return; }
-      // Route errors (501 super-timeline not configured / 500) come back as {error} JSON — surface
-      // them instead of masquerading as the empty state. textContent: the message is server-derived.
-      if (lgData.error) { stats.textContent = "Login graph unavailable: " + lgData.error; if (lgCy) { lgCy.destroy(); lgCy = null; } return; }
+      if (lgData.error) { stats.textContent = "Login graph unavailable: " + lgData.error; if (lgGV) lgGV.destroy(); return; }
       if (!lgData.edges || !lgData.edges.length) {
         stats.textContent = "No Windows logon events (4624/4625) found in this case's super-timeline.";
-        if (lgCy) { lgCy.destroy(); lgCy = null; }
+        if (lgGV) lgGV.destroy();
         return;
       }
-      // Collapsed section → zero-size container → cytoscape can't layout. Defer; the section's h2
-      // click hook re-renders on expand (see the Login Graph control wiring).
-      if (!el.offsetWidth) { lgPendingRender = true; return; }
-      lgPendingRender = false;
-      if (typeof cytoscape === "undefined") { stats.textContent = "Graph library not loaded — restart the companion server."; return; }
-      const elements = lgElements();
-      const shown = elements.filter(x => x.data.source).length;
+      const gv = lgEnsureGV();
+      if (!gv) { stats.textContent = "Graph library not loaded — restart the companion server."; return; }
+      const elements = lgBuildElements(gv.view);
+      const shown = elements.filter((x) => x.data.source).length;
       stats.innerHTML = `${elements.length - shown} nodes and ${shown} edges · generated ${lgAgo(lgData.generatedAt)}` +
         (lgData.truncated ? ` · <span class="lg-truncated">showing busiest ${lgData.edges.length} of ${lgData.totalEdges} relationships — refine with the filter</span>` : "");
-      if (lgCy) { lgCy.destroy(); lgCy = null; }
-      lgCy = cytoscape({ container: el, elements, style: LG_STYLE, wheelSensitivity: 0.2 });
-      lgApplyEdgeStyle();
-      lgApplyDim();
-      lgCy.layout(lgLayoutOpts()).run();
-      lgWireGraphEvents();
-    }
-
-    function lgApplyEdgeStyle() {
-      if (!lgCy) return;
-      lgCy.style().selector("edge").style("curve-style", lgView.edgeStyle === "taxi" ? "taxi" : "bezier").update();
-    }
-    function lgApplyDim() {
-      if (!lgCy) return;
-      // Slider 0..90 → unselected-element opacity 1..0.1, linear (higher = more transparent).
-      lgCy.style().selector(".lg-dim").style("opacity", Math.max(0.05, 1 - lgView.dim / 100)).update();
-    }
-    function lgWireGraphEvents() {
-      // Instance-scoped only — lgCy is recreated per render and destroy() unbinds these.
-      // Document/element-level listeners live in the one-time control wiring block instead.
-      lgCy.on("tap", "node", (evt) => { lgDimExcept(evt.target); lgShowNodePanel(evt.target); });
-      lgCy.on("tap", "edge", (evt) => { lgDimExcept(evt.target); lgShowEdgePanel(evt.target); });
-      lgCy.on("tap", (evt) => {   // background tap clears selection + panel
-        if (evt.target === lgCy) { lgDimExcept(null); lgHideSidePanel(); }
-      });
-    }
-
-    // Dim everything except `eles` and their neighborhood; null/empty → undim all.
-    function lgDimExcept(eles) {
-      if (!lgCy) return;
-      lgCy.elements().removeClass("lg-dim");
-      if (!eles || eles.empty()) return;
-      const keep = eles.union(eles.neighborhood());
-      lgCy.elements().difference(keep).addClass("lg-dim");
+      gv.render();
     }
 
     function lgHideSidePanel() {
@@ -5214,7 +5194,7 @@
       open.onclick = () => lgPivotToTimeline(name);
       const close = lgEl("button", "lg-close", "✕ Close");
       close.type = "button";
-      close.onclick = () => { lgHideSidePanel(); lgDimExcept(null); };
+      close.onclick = () => { lgHideSidePanel(); if (lgGV) lgGV.dimExcept(null); };
       wrap.append(open, close);
       return wrap;
     }
@@ -15323,80 +15303,9 @@
       }
     });
 
-    // ── Login Graph controls (one-time wiring; graph-instance events live in lgWireGraphEvents) ──
-    document.getElementById("lgFit").addEventListener("click", () => { if (lgCy) lgCy.fit(undefined, 30); });
-    // Fullscreen toggle on the wrap (mirrors #assetFullscreen); the floating ⚙/side panels are
-    // position:absolute INSIDE the wrap, so they stay usable while fullscreen.
-    document.getElementById("lgFullscreen").addEventListener("click", () => {
-      const wrap = document.getElementById("loginGraphWrap");
-      if (document.fullscreenElement === wrap) document.exitFullscreen();
-      else if (wrap.requestFullscreen) wrap.requestFullscreen();
-    });
-    // Resize + refit when OUR wrap enters/exits fullscreen. lgFsWas distinguishes our exit from
-    // another section's fullscreenchange (on exit fullscreenElement is null for everyone).
-    let lgFsWas = false;
-    document.addEventListener("fullscreenchange", () => {
-      const isNow = document.fullscreenElement === document.getElementById("loginGraphWrap");
-      if (!isNow && !lgFsWas) return;   // unrelated section's fullscreen event
-      lgFsWas = isNow;
-      if (lgCy) setTimeout(() => { if (lgCy) { lgCy.resize(); lgCy.fit(undefined, 30); } }, 60);   // wait for the relayout before measuring
-    });
-    document.getElementById("lgRefresh").addEventListener("click", () => {
-      const c = document.getElementById("caseId").value.trim();
-      if (!c) return;
-      clearTimeout(lgTimer);             // don't double-fetch against the WS debounce
-      loadLoginGraph(c);
-    });
-    document.getElementById("lgExport").addEventListener("click", () => {
-      if (!lgCy) return;
-      const a = document.createElement("a");
-      a.href = lgCy.png({ full: true, scale: 2, bg: "#0f1115" });
-      a.download = "login-graph.png";
-      a.click();
-    });
-    document.getElementById("lgOptions").addEventListener("click", () => {
-      const p = document.getElementById("lgOptionsPanel");
-      const show = p.style.display === "none";
-      if (show) {   // sync controls from lgView before showing
-        document.querySelectorAll('input[name="lgLayout"]').forEach(r => { r.checked = r.value === lgView.layout; });
-        document.querySelectorAll('input[name="lgEdgeStyle"]').forEach(r => { r.checked = r.value === lgView.edgeStyle; });
-        document.getElementById("lgDim").value = lgView.dim;
-        document.getElementById("lgShowFailed").checked = lgView.showFailed;
-        document.getElementById("lgHideNoise").checked = lgView.hideNoise;
-      }
-      p.style.display = show ? "" : "none";
-    });
-    document.querySelectorAll('input[name="lgLayout"]').forEach(r => r.addEventListener("change", () => {
-      lgView.layout = r.value; saveLgView();
-      if (lgCy) lgCy.layout(lgLayoutOpts()).run();       // re-layout live
-    }));
-    document.querySelectorAll('input[name="lgEdgeStyle"]').forEach(r => r.addEventListener("change", () => {
-      lgView.edgeStyle = r.value; saveLgView(); lgApplyEdgeStyle();
-    }));
-    document.getElementById("lgDim").addEventListener("input", () => {
-      lgView.dim = Number(document.getElementById("lgDim").value); saveLgView(); lgApplyDim();
-    });
-    document.getElementById("lgShowFailed").addEventListener("change", (e) => {
-      lgView.showFailed = e.target.checked; saveLgView(); renderLoginGraph();   // element-set change → rebuild
-    });
-    document.getElementById("lgHideNoise").addEventListener("change", (e) => {
-      lgView.hideNoise = e.target.checked; saveLgView(); renderLoginGraph();
-    });
-    // Live filter: dim everything that doesn't match (nodes by name, edges by label).
-    document.getElementById("lgFilter").addEventListener("input", (e) => {
-      if (!lgCy) return;
-      const q = e.target.value.trim().toLowerCase();
-      if (!q) { lgDimExcept(null); return; }
-      const hits = lgCy.elements().filter(el =>
-        String(el.data("name") || el.data("label") || "").toLowerCase().includes(q));
-      // Zero matches must read as "nothing matches" (dim ALL) — lgDimExcept(empty) would UNdim all.
-      if (hits.empty()) { lgCy.elements().addClass("lg-dim"); return; }
-      lgDimExcept(hits);
-    });
     // Deferred render for a section that was collapsed at data-arrival time (zero-size container).
-    // setTimeout(0) runs after setupCollapsible's own h2 click handler has toggled .collapsed.
     document.querySelector("#sec-login-graph h2").addEventListener("click", () => {
-      setTimeout(() => { if (lgPendingRender) renderLoginGraph(); else if (lgCy) lgCy.resize(); }, 0);
+      setTimeout(() => { if (lgGV) lgGV.onExpand(); }, 0);
     });
 
     // Evidence Chain graph controls (mirror the asset-graph chrome).

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -546,16 +546,8 @@
     button { background: var(--c-2d6cdf); color: white; border: 0; padding: 8px 12px; border-radius: 6px; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; }
     input { background: var(--c-0f1115); color: var(--c-e6e6e6); border: 1px solid var(--c-2a2f3a); padding: 6px; border-radius: 6px; }
     #status { font-size: 12px; color: var(--c-9aa4b2); }
-    /* Compromised assets + asset↔IoC graph */
-    .asset-graph { overflow: auto; max-height: 460px; border: 1px solid var(--c-2a2f3a); border-radius: 6px; background: var(--c-0f1115); }
-    .asset-graph svg text { fill: var(--c-cbd3df); font-size: 11px; }
-    .asset-node { cursor: grab; }
-    .asset-node:active { cursor: grabbing; }
-    .asset-node.moved text { fill: var(--c-ffd93b); }            /* a repositioned (pinned) node's label is tinted */
-    .ev-node { cursor: grab; }
-    .ev-node:active { cursor: grabbing; }
-    .ev-node.moved text { fill: var(--c-ffd93b); }                /* a repositioned node's label is tinted */
-    .ev-node text { paint-order: stroke; stroke: var(--c-0f1115); stroke-width: 2.5px; }   /* legible over edges */
+    /* Compromised-assets + Evidence-Chain graphs render via cytoscape (see .login-graph); only their
+       side-panel text styling remains here. */
     .ev-sub { font-size: 12px; color: var(--c-9aa4b2); font-weight: normal; margin-left: 8px; }
     .ev-legend { display: inline-flex; align-items: center; gap: 6px; color: var(--c-9aa4b2); font-size: 12px; }
     .ev-leg-line { display: inline-block; width: 18px; height: 0; vertical-align: middle; }
@@ -566,8 +558,8 @@
     .ev-leg-net { border-top: 2px solid var(--c-38bdf8); }
     .legend-ico { vertical-align: middle; margin-right: 2px; }
     /* Fullscreen: the wrapper fills the screen and the graph grows to fit. */
-    .asset-graph-wrap:fullscreen { background: var(--c-11161d); padding: 12px; display: flex; flex-direction: column; }
-    .asset-graph-wrap:fullscreen .asset-graph { flex: 1; max-height: none; }
+    .asset-graph-wrap:fullscreen { background: var(--c-11161d); padding: 12px; }
+    .asset-graph-wrap:fullscreen .login-graph { height: calc(100vh - 90px); }
     /* ── Login Graph (cytoscape) ─────────────────────────── */
     .login-graph-wrap { position: relative; }
     .login-graph { height: 480px; border: 1px solid var(--c-2a2f3a); border-radius: 6px; background: var(--c-0f1115); }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3878,33 +3878,48 @@
       <h2>Evidence Chain<span class="ev-sub">causal links — process trees, lateral movement, file lineage &amp; network flows (derived, no AI)</span></h2>
       <div id="evPanel">
         <div id="evGraphWrap" class="asset-graph-wrap">
-          <div class="asset-controls">
-            <span>Show:</span>
-            <label title="Parent → child process spawn chains (processName / parentName fields). Shows how an initial process (e.g. Word) spawned a shell, which spawned further tools."><input type="checkbox" class="ev-type-toggle" value="spawned" checked> Process trees</label>
-            <label title="Same binary hash or account seen on ≥ 2 hosts — indicates the attacker moved laterally between machines."><input type="checkbox" class="ev-type-toggle" value="lateral_move"> Lateral movement</label>
-            <label title="A file written (action=write) then executed (action=execute) with the same hash — shows dropper → payload chains."><input type="checkbox" class="ev-type-toggle" value="file_lineage"> File lineage</label>
-            <label title="Directed network connections from Suricata alerts / Zeek notices (srcIp → dstIp:port). Shows C2 call-outs and lateral network movement."><input type="checkbox" class="ev-type-toggle" value="network_flow"> Network flows</label>
-            <span class="asset-ctrl-sep"></span>
-            <span class="ev-legend"><span class="ev-leg-line ev-leg-high"></span>high
-              <span class="ev-leg-line ev-leg-med"></span>medium
-              <span class="ev-leg-line ev-leg-ran"></span>ran on
-              <span class="ev-leg-line ev-leg-file"></span>file lineage
-              <span class="ev-leg-line ev-leg-net"></span>network flow</span>
-            <span class="asset-ctrl-sep"></span>
-            <label title="Hide nodes below this severity to reduce clutter on large graphs">Sev <select id="evMinSev"><option value="Info">All</option><option value="Medium">≥ Med</option><option value="High">≥ High</option><option value="Critical">Crit only</option></select></label>
-            <span class="asset-ctrl-sep"></span>
-            <button id="evZoomOut" type="button" title="Zoom out">−</button>
-            <span id="evZoomLevel" title="Zoom level (scroll the mouse wheel over the graph to zoom)">100%</span>
-            <button id="evZoomIn" type="button" title="Zoom in">+</button>
-            <button id="evZoomReset" type="button" title="Reset / fit zoom">Fit</button>
-            <span class="asset-ctrl-sep"></span>
-            <button id="evFullscreen" type="button" title="Enlarge the graph to full screen">⤢ Fullscreen</button>
-            <button id="evResetLayout" type="button" title="Clear manual node positions — back to the auto layout">↺ Reset layout</button>
-            <button id="evExportSvg" type="button" title="Download the evidence graph as an SVG file">⬇ SVG</button>
-            <span class="ev-drag-hint">drag nodes to rearrange</span>
-            <span id="evFocusHint" class="asset-hint"></span>
+          <div class="lg-toolbar">
+            <input id="evFilter" type="text" placeholder="Filter nodes and edges" autocomplete="off" />
+            <button type="button" id="evFit" title="Fit to screen">⤢ Fit</button>
+            <button type="button" id="evFullscreenBtn" title="Enlarge the graph to full screen">⛶ Fullscreen</button>
+            <button type="button" id="evExport" title="Export as PNG">⬇ PNG</button>
+            <button type="button" id="evRefresh" title="Rebuild the evidence graph">↻ Refresh</button>
+            <button type="button" id="evOptions" title="View options">⚙ View</button>
           </div>
-          <div id="evGraph" class="asset-graph">—</div>
+          <div id="evOptionsPanel" class="lg-options" style="display:none">
+            <div class="lg-opt-group"><span class="lg-opt-label">Layout type</span>
+              <label><input type="radio" name="evLayoutRadio" value="spread" /> spread</label>
+              <label><input type="radio" name="evLayoutRadio" value="dagre" /> dagre</label>
+              <label><input type="radio" name="evLayoutRadio" value="circle" /> circle</label>
+              <label><input type="radio" name="evLayoutRadio" value="concentric" /> concentric</label>
+              <label><input type="radio" name="evLayoutRadio" value="breadthfirst" /> breadthfirst</label>
+            </div>
+            <div class="lg-opt-group"><span class="lg-opt-label">Edge style</span>
+              <label><input type="radio" name="evEdgeStyle" value="bezier" /> bezier</label>
+              <label><input type="radio" name="evEdgeStyle" value="taxi" /> taxi</label>
+            </div>
+            <div class="lg-opt-group"><span class="lg-opt-label">Transparency for unselected elements</span>
+              <input type="range" id="evDim" min="0" max="90" step="5" />
+            </div>
+            <div class="lg-opt-group"><span class="lg-opt-label">Show</span>
+              <label title="Parent → child process spawn chains."><input type="checkbox" class="ev-type-toggle" value="spawned" checked> Process trees</label>
+              <label title="Same binary hash or account seen on ≥ 2 hosts."><input type="checkbox" class="ev-type-toggle" value="lateral_move"> Lateral movement</label>
+              <label title="A file written then executed with the same hash."><input type="checkbox" class="ev-type-toggle" value="file_lineage"> File lineage</label>
+              <label title="Directed network connections from Suricata/Zeek."><input type="checkbox" class="ev-type-toggle" value="network_flow"> Network flows</label>
+            </div>
+            <div class="lg-opt-group"><span class="lg-opt-label">Min severity</span>
+              <label><select id="evMinSev"><option value="Info">All</option><option value="Medium">≥ Med</option><option value="High">≥ High</option><option value="Critical">Crit only</option></select></label>
+            </div>
+            <div class="lg-opt-group">
+              <span class="ev-legend"><span class="ev-leg-line ev-leg-high"></span>high
+                <span class="ev-leg-line ev-leg-med"></span>medium
+                <span class="ev-leg-line ev-leg-ran"></span>ran on
+                <span class="ev-leg-line ev-leg-file"></span>file lineage
+                <span class="ev-leg-line ev-leg-net"></span>network flow</span>
+            </div>
+          </div>
+          <div id="evGraph" class="login-graph"></div>
+          <div id="evSidePanel" class="lg-side-panel" style="display:none"></div>
         </div>
       </div>
     </section>
@@ -4903,9 +4918,6 @@
     let assetGraphTimer = null;
     const assetTypesEnabled = new Set(["host", "account", "service"]);
 
-    // Shared by the Evidence Chain graph's zoom controls.
-    function clampZoom(z) { return Math.min(5, Math.max(0.25, z)); }
-
     function truncate(s, n) { s = String(s); return s.length > n ? s.slice(0, n - 1) + "…" : s; }
 
     // The compact, always-visible row title: a plain-weight (not bold — a whole sentence in bold reads
@@ -5402,54 +5414,18 @@
 
     // --- Evidence Chain graph (causal: process trees + lateral movement) ----------
     let evGraphData = null;                                 // { nodes, edges }
-    let evFocus = null;                                     // focused node id, or null
     let evGraphTimer = null;
-    let evZoom = 1;
-    let evDims = { W: 0, H: 0 };
     const evTypesEnabled = new Set(
       [...document.querySelectorAll(".ev-type-toggle")].filter(cb => cb.checked).map(cb => cb.value)
     );
     const evMinSevRank = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4 };
     let evMinSev = "Info";  // show nodes at this severity or above; "Info" = show all
-    // Drag-to-reposition state. evPos = effective id→{x,y} for the current draw (auto layout
-    // with any manual overrides applied); evPosOverride = the persisted manual positions.
-    let evPos = new Map(), evNodes = [], evEdges = [];
-    let evPosOverride = new Map();                          // id -> {x,y}, persisted per case
-    let evDrag = null;                                      // { id, startX, startY, origX, origY, scale, moved }
-
-    const evPosKey = () => "dfir.evpos." + (document.getElementById("caseId").value.trim() || "");
-    function loadEvPosOverride() {
-      evPosOverride = new Map();
-      try {
-        const o = JSON.parse(localStorage.getItem(evPosKey()) || "{}");
-        for (const [k, v] of Object.entries(o)) if (Array.isArray(v)) evPosOverride.set(k, { x: v[0], y: v[1] });
-      } catch (e) { /* ignore corrupt state */ }
-    }
-    function saveEvPosOverride() {
-      const o = {}; evPosOverride.forEach((v, k) => { o[k] = [Math.round(v.x), Math.round(v.y)]; });
-      try { localStorage.setItem(evPosKey(), JSON.stringify(o)); } catch (e) { /* quota — non-fatal */ }
-    }
-
-    function updateEvZoomLabel() { const el = document.getElementById("evZoomLevel"); if (el) el.textContent = Math.round(evZoom * 100) + "%"; }
-    function applyEvZoom() {
-      const svg = document.querySelector("#evGraph svg");
-      if (svg && evDims.W) { svg.setAttribute("width", Math.round(evDims.W * evZoom)); svg.setAttribute("height", Math.round(evDims.H * evZoom)); }
-      updateEvZoomLabel();
-    }
-    function setEvZoom(z) { evZoom = clampZoom(z); applyEvZoom(); }
-    function fitEvZoom() {
-      const g = document.getElementById("evGraph");
-      if (evDims.W && g && g.clientWidth && g.clientHeight) {
-        const z = Math.min((g.clientWidth - 10) / evDims.W, (g.clientHeight - 10) / evDims.H);
-        setEvZoom(z > 0 && isFinite(z) ? z : 1);
-      } else setEvZoom(1);
-    }
-    function isEvFullscreen() { return document.fullscreenElement === document.getElementById("evGraphWrap"); }
 
     function loadEvidenceGraph(caseId) {
-      loadEvPosOverride();   // restore this case's manual node positions
+      const gv = evEnsureGV();
+      if (gv) gv.loadView();   // restore this case's persisted view state (layout/dim/edge-style)
       fetch(`/cases/${caseId}/evidence-graph`).then(r => r.json()).then(g => {
-        evGraphData = g; evFocus = null; renderEvidenceGraph();
+        evGraphData = g; renderEvidenceGraph();
       }).catch(() => {});
     }
     // State changes (imports / synthesis) re-derive the graph — debounced.
@@ -5458,41 +5434,6 @@
       if (!caseId) return;
       clearTimeout(evGraphTimer);
       evGraphTimer = setTimeout(() => loadEvidenceGraph(caseId), 800);
-    }
-
-    // Layered left→right layout: longest-path layering over the directed edges. Process trees
-    // fall into natural columns (excel→powershell→cmd); lateral edges span hosts/accounts.
-    // Cycle-safe (leftover nodes get layer 0), so a rare A→B/B→A pair can't loop.
-    function evLayout(nodes, edges) {
-      const byId = new Map(nodes.map(n => [n.id, n]));
-      const out = new Map(), indeg = new Map();
-      nodes.forEach(n => { out.set(n.id, []); indeg.set(n.id, 0); });
-      edges.forEach(e => { if (out.has(e.source) && byId.has(e.target)) { out.get(e.source).push(e.target); indeg.set(e.target, indeg.get(e.target) + 1); } });
-      const layer = new Map(), deg = new Map(indeg);
-      const q = nodes.filter(n => deg.get(n.id) === 0).map(n => n.id);
-      q.forEach(id => layer.set(id, 0));
-      for (let head = 0; head < q.length; head++) {
-        const u = q[head];
-        for (const v of out.get(u) || []) {
-          layer.set(v, Math.max(layer.get(v) ?? 0, (layer.get(u) ?? 0) + 1));
-          deg.set(v, deg.get(v) - 1);
-          if (deg.get(v) === 0) q.push(v);
-        }
-      }
-      let maxLayer = 0;
-      nodes.forEach(n => { if (!layer.has(n.id)) layer.set(n.id, 0); maxLayer = Math.max(maxLayer, layer.get(n.id)); });
-      const buckets = Array.from({ length: maxLayer + 1 }, () => []);
-      [...nodes].sort((a, b) => a.id.localeCompare(b.id)).forEach(n => buckets[layer.get(n.id)].push(n));
-      const colW = 200, rowH = 64, padX = 110, padY = 44;
-      const rows = Math.max(1, ...buckets.map(b => b.length));
-      const W = padX * 2 + maxLayer * colW + 40;
-      const H = padY * 2 + (rows - 1) * rowH + 40;
-      const pos = new Map();
-      buckets.forEach((b, li) => {
-        const colH = (b.length - 1) * rowH, y0 = (H - colH) / 2;
-        b.forEach((n, i) => pos.set(n.id, { x: padX + li * colW, y: b.length === 1 ? H / 2 : y0 + i * rowH }));
-      });
-      return { pos, W, H };
     }
 
     function evSevColor(sev) { return (sev === "Critical" || sev === "High") ? "#ff5c5c" : sev === "Medium" ? "#ff9f43" : "#6aa9ff"; }
@@ -5514,109 +5455,129 @@
         + `<rect x="${f(x - 9)}" y="${f(y - 6)}" width="18" height="12" rx="2.5" fill="${c}" stroke="#0f1115" stroke-width="1"/>`;
     }
 
-    // Filter + lay out, applying any saved manual positions, then draw. Split from drawEv so a
-    // drag can redraw cheaply without recomputing the layering.
+    let evGV = null;
+
+    function evBuildElements(view) {
+      // ran_on rides with the Process-trees toggle — it hangs each tree off its host.
+      const edges0 = evGraphData.edges.filter((e) =>
+        evTypesEnabled.has(e.type) || (e.type === "ran_on" && evTypesEnabled.has("spawned")));
+      const keep = new Set(edges0.flatMap((e) => [e.source, e.target]));
+      const minRank = evMinSevRank[evMinSev] ?? 4;
+      const nodes = evGraphData.nodes.filter((n) =>
+        keep.has(n.id) && (evMinSevRank[n.maxSeverity] ?? 4) <= minRank);
+      const visibleIds = new Set(nodes.map((n) => n.id));
+      const edges = edges0.filter((e) => visibleIds.has(e.source) && visibleIds.has(e.target));
+      const els = [];
+      for (const n of nodes) {
+        const titleSuffix = n.asset ? " on " + n.asset : n.ip ? " (" + n.ip + ")" : "";
+        els.push({ data: {
+          id: n.id, name: truncate(n.label, 22), full: n.label + titleSuffix, kind: n.kind, sev: n.maxSeverity,
+          glyph: glyphDataUri(evNodeGlyph(n, 11, 11)),
+        } });
+      }
+      for (const e of edges) {
+        els.push({ data: {
+          id: `ev:${e.source}|${e.target}|${e.type}`, source: e.source, target: e.target,
+          etype: e.type, conf: e.confidence, basis: e.basis,
+        } });
+      }
+      return els;
+    }
+
+    const EV_STYLE = [
+      { selector: "node", style: {
+        "background-image": "data(glyph)", "background-color": "#0f1115", "background-opacity": 0,
+        "background-fit": "none", "background-clip": "none", width: 26, height: 26,
+        label: "data(name)", color: "#cbd3df", "font-size": "10px",
+        "text-valign": "bottom", "text-halign": "center", "text-margin-y": 3,
+      } },
+      { selector: "edge", style: {
+        width: 1.6, "line-color": "#7f8aa0", "curve-style": "bezier",
+        "target-arrow-shape": "triangle", "target-arrow-color": "#7f8aa0", "arrow-scale": 0.9,
+        "line-style": "dashed",
+      } },
+      // causal high-confidence: solid orange
+      { selector: 'edge[etype = "causal"][conf = "high"]', style: { "line-style": "solid", "line-color": "#ff8a5c", "target-arrow-color": "#ff8a5c" } },
+      { selector: 'edge[etype = "ran_on"]', style: { "line-style": "solid", "line-color": "#52617a", "target-arrow-color": "#52617a", width: 1.1, opacity: 0.7 } },
+      { selector: 'edge[etype = "file_lineage"]', style: { "line-style": "solid", "line-color": "#4ade80", "target-arrow-color": "#4ade80" } },
+      { selector: 'edge[etype = "network_flow"]', style: { "line-style": "solid", "line-color": "#38bdf8", "target-arrow-color": "#38bdf8" } },
+      { selector: ".gv-dim", style: { opacity: 0.1 } },
+    ];
+
+    function evShowNodePanel(node) {
+      const p = document.getElementById("evSidePanel");
+      p.replaceChildren();
+      const title = lgEl("div");
+      title.append(lgEl("b", null, node.data("full")), lgEl("span", "ev-sub", " " + node.data("sev")));
+      const close = lgEl("button", "lg-close", "✕ Close");
+      close.type = "button";
+      close.onclick = () => { p.style.display = "none"; if (evGV) evGV.dimExcept(null); };
+      p.append(title, close);
+      p.style.display = "block";
+    }
+    function evShowEdgePanel(edge) {
+      const p = document.getElementById("evSidePanel");
+      const d = edge.data();
+      p.replaceChildren();
+      const title = lgEl("div");
+      title.append(lgEl("b", null, d.etype));
+      const sub = lgEl("div", "ev-sub", d.basis + (d.etype === "ran_on" ? "" : " — " + d.conf + " confidence"));
+      const close = lgEl("button", "lg-close", "✕ Close");
+      close.type = "button";
+      close.onclick = () => { p.style.display = "none"; if (evGV) evGV.dimExcept(null); };
+      p.append(title, sub, close);
+      p.style.display = "block";
+    }
+
+    function evEnsureGV() {
+      if (evGV) return evGV;
+      if (!window.DfirGraphView) return null;
+      evGV = window.DfirGraphView.createGraphView({
+        graphId: "evidence",
+        container: document.getElementById("evGraph"),
+        wrap: document.getElementById("evGraphWrap"),
+        caseIdEl: document.getElementById("caseId"),
+        exportName: "evidence-graph.png",
+        defaults: { layout: "dagre", edgeStyle: "bezier", dim: 85 },
+        style: EV_STYLE,
+        buildElements: evBuildElements,
+        onNodeTap: (node) => evShowNodePanel(node),
+        onEdgeTap: (edge) => evShowEdgePanel(edge),
+        onBackgroundTap: () => { document.getElementById("evSidePanel").style.display = "none"; },
+        onRefresh: () => { const cId = document.getElementById("caseId").value.trim(); if (cId) loadEvidenceGraph(cId); },
+        controls: {
+          layoutRadios: document.querySelectorAll('input[name="evLayoutRadio"]'),
+          edgeStyleRadios: document.querySelectorAll('input[name="evEdgeStyle"]'),
+          dimSlider: document.getElementById("evDim"),
+          filterInput: document.getElementById("evFilter"),
+          fitBtn: document.getElementById("evFit"),
+          fullscreenBtn: document.getElementById("evFullscreenBtn"),
+          exportBtn: document.getElementById("evExport"),
+          refreshBtn: document.getElementById("evRefresh"),
+          optionsBtn: document.getElementById("evOptions"),
+          optionsPanel: document.getElementById("evOptionsPanel"),
+          toggles: [],   // ev-type toggles + min-sev are wired separately (Set / select, not a view flag)
+        },
+      });
+      return evGV;
+    }
+
     function renderEvidenceGraph() {
       const el = document.getElementById("evGraph");
       if (!evGraphData || !evGraphData.edges || !evGraphData.edges.length) {
         el.innerHTML = "<div style='padding:16px;color:var(--c-9aa4b2)'>No causal chains yet — import process-creation events (Sysmon EID 1, THOR, Velociraptor, Cyber Triage, Volatility/Rekall memory) or evidence spanning multiple hosts, then Synthesize.</div>";
-        evNodes = []; evEdges = []; evDims = { W: 0, H: 0 }; updateEvZoomLabel();
+        if (evGV) evGV.destroy();
         return;
       }
-      // ran_on (host→process-tree anchor) rides with the Process-trees toggle — it's the
-      // connective tissue that hangs each tree off its host so lateral movement bridges them.
-      evEdges = evGraphData.edges.filter(e =>
-        evTypesEnabled.has(e.type) || (e.type === "ran_on" && evTypesEnabled.has("spawned")));
-      const keep = new Set(evEdges.flatMap(e => [e.source, e.target]));
-      // Severity filter: hide low-severity nodes then drop orphaned edges.
-      const minRank = evMinSevRank[evMinSev] ?? 4;
-      evNodes = evGraphData.nodes.filter(n =>
-        keep.has(n.id) &&
-        (evMinSevRank[n.maxSeverity] ?? 4) <= minRank);
-      const visibleIds = new Set(evNodes.map(n => n.id));
-      evEdges = evEdges.filter(e => visibleIds.has(e.source) && visibleIds.has(e.target));
-      if (!evEdges.length) { el.innerHTML = "<div style='padding:16px;color:var(--c-9aa4b2)'>No links match the current type / severity filters.</div>"; evNodes = []; evDims = { W: 0, H: 0 }; updateEvZoomLabel(); return; }
-
-      const { pos } = evLayout(evNodes, evEdges);
-      // Effective position = auto layout, with a saved manual override taking precedence.
-      evPos = new Map();
-      for (const n of evNodes) evPos.set(n.id, evPosOverride.get(n.id) || pos.get(n.id));
-      drawEv();
-    }
-
-    // Render the SVG from evPos/evNodes/evEdges and wire drag + focus. The canvas grows to fit
-    // dragged-out nodes so nothing clips. Called on every drag-move (no relayout).
-    function drawEv() {
-      const el = document.getElementById("evGraph");
-      if (!evNodes.length) return;
-      const neighbors = new Map();
-      const addN = (a, b) => { let s = neighbors.get(a); if (!s) { s = new Set(); neighbors.set(a, s); } s.add(b); };
-      evEdges.forEach(e => { addN(e.source, e.target); addN(e.target, e.source); });
-      const related = (id) => !evFocus || id === evFocus || (neighbors.get(evFocus) && neighbors.get(evFocus).has(id));
-
-      let W = 200, H = 160;                                  // fit the canvas to current positions
-      for (const p of evPos.values()) { W = Math.max(W, p.x + 90); H = Math.max(H, p.y + 60); }
-      evDims = { W, H };
-      const zw = Math.round(W * evZoom), zh = Math.round(H * evZoom);
-      let svg = `<svg width="${zw}" height="${zh}" viewBox="0 0 ${W} ${H}">`;
-      svg += `<defs>`
-        + `<marker id="evArrowHigh" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#ff8a5c"/></marker>`
-        + `<marker id="evArrowMed" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#7f8aa0"/></marker>`
-        + `<marker id="evArrowRan" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#52617a"/></marker>`
-        + `<marker id="evArrowFile" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#4ade80"/></marker>`
-        + `<marker id="evArrowNet" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#38bdf8"/></marker>`
-        + `</defs>`;
-      for (const e of evEdges) {
-        const p = evPos.get(e.source), q = evPos.get(e.target);
-        if (!p || !q) continue;
-        const vis = related(e.source) && related(e.target);
-        // ran_on = muted anchor; file_lineage = green; network_flow = cyan; causal = orange/gray.
-        const isRan = e.type === "ran_on", isFile = e.type === "file_lineage", isNet = e.type === "network_flow";
-        const high = e.confidence === "high";
-        const stroke = isRan ? "#52617a" : isFile ? "#4ade80" : isNet ? "#38bdf8" : high ? "#ff8a5c" : "#7f8aa0";
-        const dash = (isRan || isFile || isNet || high) ? "" : ` stroke-dasharray="5 4"`;
-        const marker = isRan ? "url(#evArrowRan)" : isFile ? "url(#evArrowFile)" : isNet ? "url(#evArrowNet)" : high ? "url(#evArrowHigh)" : "url(#evArrowMed)";
-        const sw = isRan ? "1.1" : "1.6";
-        // Trim the segment to the node radius so the arrowhead lands at the glyph edge, not its center.
-        const ang = Math.atan2(q.y - p.y, q.x - p.x), r = 13;
-        const x1 = (p.x + r * Math.cos(ang)).toFixed(1), y1 = (p.y + r * Math.sin(ang)).toFixed(1);
-        const x2 = (q.x - r * Math.cos(ang)).toFixed(1), y2 = (q.y - r * Math.sin(ang)).toFixed(1);
-        svg += `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${stroke}" stroke-width="${sw}"${dash} marker-end="${marker}" opacity="${vis ? (isRan ? 0.6 : 0.9) : 0.06}">`
-          + `<title>${esc(e.basis + (isRan ? "" : " — " + e.confidence + " confidence"))}</title></line>`;
+      const gv = evEnsureGV();
+      if (!gv) { el.textContent = "Graph library not loaded — restart the companion server."; return; }
+      const els = evBuildElements(gv.view);
+      if (!els.some((x) => x.data.source)) {
+        el.innerHTML = "<div style='padding:16px;color:var(--c-9aa4b2)'>No links match the current type / severity filters.</div>";
+        if (evGV) evGV.destroy();
+        return;
       }
-      for (const n of evNodes) {
-        const p = evPos.get(n.id);
-        const moved = evPosOverride.has(n.id) ? " moved" : "";
-        const titleSuffix = n.asset ? " on " + n.asset : n.ip ? " (" + n.ip + ")" : "";
-        svg += `<g class="ev-node${moved}" data-id="${escAttr(n.id)}" opacity="${related(n.id) ? 1 : 0.12}">`
-          + `<text x="${p.x.toFixed(1)}" y="${(p.y + 22).toFixed(1)}" text-anchor="middle">${esc(truncate(n.label, 22))}</text>`
-          + evNodeGlyph(n, p.x, p.y)
-          + `<title>${esc(n.label + titleSuffix + " — " + n.maxSeverity + " · drag to reposition")}</title></g>`;
-      }
-      svg += `</svg>`;
-      el.innerHTML = svg;
-      updateEvZoomLabel();
-      // Press starts a potential drag; the document mousemove/mouseup (wired once) carry it. A
-      // press with no movement is a focus toggle, so click-to-focus still works.
-      el.querySelectorAll(".ev-node").forEach(node => node.addEventListener("mousedown", (ev) => {
-        ev.preventDefault();
-        const id = node.getAttribute("data-id");
-        const s = el.querySelector("svg"); if (!s) return;
-        const rect = s.getBoundingClientRect();
-        const scale = rect.width ? evDims.W / rect.width : 1;   // viewBox units per screen pixel
-        const cur = evPos.get(id);
-        evDrag = { id, startX: ev.clientX, startY: ev.clientY, origX: cur.x, origY: cur.y, scale, moved: false };
-      }));
-    }
-
-    function evExportSvg() {
-      const svg = document.querySelector("#evGraph svg");
-      if (!svg) return;
-      const svgStr = '<?xml version="1.0" encoding="utf-8"?>\n' + new XMLSerializer().serializeToString(svg);
-      const blob = new Blob([svgStr], { type: "image/svg+xml" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a"); a.href = url; a.download = "evidence-graph.svg"; a.click();
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
+      gv.render();
     }
 
     // --- Investigator comments (collaboration) -----------------------------------
@@ -15172,52 +15133,15 @@
     });
 
     // Evidence Chain graph controls (mirror the asset-graph chrome).
-    document.querySelectorAll(".ev-type-toggle").forEach(cb => cb.onchange = () => {
+    document.querySelectorAll(".ev-type-toggle").forEach((cb) => cb.addEventListener("change", () => {
       if (cb.checked) evTypesEnabled.add(cb.value); else evTypesEnabled.delete(cb.value);
-      evFocus = null; renderEvidenceGraph();
-    });
-    document.getElementById("evMinSev").onchange = function() { evMinSev = this.value; evFocus = null; renderEvidenceGraph(); };
-    document.getElementById("evExportSvg").onclick = evExportSvg;
-    document.getElementById("evZoomIn").onclick = () => setEvZoom(evZoom * 1.25);
-    document.getElementById("evZoomOut").onclick = () => setEvZoom(evZoom / 1.25);
-    document.getElementById("evZoomReset").onclick = () => fitEvZoom();
-    document.getElementById("evGraph").addEventListener("wheel", (e) => {
-      if (!evGraphData) return;
-      e.preventDefault();
-      setEvZoom(evZoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
-    }, { passive: false });
-    document.getElementById("evFullscreen").onclick = () => {
-      const wrap = document.getElementById("evGraphWrap");
-      if (isEvFullscreen()) document.exitFullscreen();
-      else if (wrap.requestFullscreen) wrap.requestFullscreen();
-    };
-    document.addEventListener("fullscreenchange", () => {
-      if (!evGraphData) return;
       renderEvidenceGraph();
-      setTimeout(fitEvZoom, 60);
+    }));
+    document.getElementById("evMinSev").addEventListener("change", (e) => {
+      evMinSev = e.target.value; renderEvidenceGraph();
     });
-    // Drag a node to reposition it (positions persist per case); ↺ clears overrides.
-    document.getElementById("evResetLayout").onclick = () => {
-      evPosOverride = new Map(); saveEvPosOverride(); renderEvidenceGraph();
-    };
-    // Drag carry, wired once. evDrag is set on a node mousedown; here we move it and redraw,
-    // committing the position on release. A release with no real movement is a focus toggle.
-    document.addEventListener("mousemove", (ev) => {
-      if (!evDrag) return;
-      if (Math.abs(ev.clientX - evDrag.startX) > 3 || Math.abs(ev.clientY - evDrag.startY) > 3) evDrag.moved = true;
-      evPos.set(evDrag.id, { x: evDrag.origX + (ev.clientX - evDrag.startX) * evDrag.scale,
-                             y: evDrag.origY + (ev.clientY - evDrag.startY) * evDrag.scale });
-      drawEv();
-    });
-    document.addEventListener("mouseup", () => {
-      if (!evDrag) return;
-      const d = evDrag; evDrag = null;
-      if (d.moved) { evPosOverride.set(d.id, evPos.get(d.id)); saveEvPosOverride(); drawEv(); }
-      else {
-        evFocus = (evFocus === d.id) ? null : d.id;
-        document.getElementById("evFocusHint").textContent = evFocus ? "showing related only — click the node again to reset" : "";
-        drawEv();
-      }
+    document.querySelector("#sec-evidence h2").addEventListener("click", () => {
+      setTimeout(() => { if (evGV) evGV.onExpand(); }, 0);
     });
     document.getElementById("saveReportMeta").onclick = saveReportMeta;
     document.getElementById("rm-companyLogoFile").addEventListener("change", (e) => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -11,6 +11,7 @@
   <script defer src="/vendor/cytoscape/cytoscape.min.js"></script>
   <script defer src="/vendor/cytoscape/dagre.min.js"></script>
   <script defer src="/vendor/cytoscape/cytoscape-dagre.js"></script>
+  <script type="module" src="/js/graph-view.js"></script>
   <script>
     /* Theme bootstrap (issue #53) — runs before paint so there is no flash. Effective theme =
        explicit localStorage choice, else the OS preference. */

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3838,32 +3838,37 @@
       </div>
       <div id="assetPanel">
         <div id="assetGraphWrap" class="asset-graph-wrap">
-          <div class="asset-controls">
-            <span>Show:</span>
-            <label><input type="checkbox" class="asset-type-toggle" value="host" checked> <span class="legend-slot" data-ltype="host"></span>Hosts</label>
-            <label><input type="checkbox" class="asset-type-toggle" value="account" checked> <span class="legend-slot" data-ltype="account"></span>Accounts</label>
-            <label><input type="checkbox" class="asset-type-toggle" value="service" checked> <span class="legend-slot" data-ltype="service"></span>Services</label>
-            <button id="assetTypeAll" type="button" title="Show all asset types">All</button>
-            <span class="asset-ctrl-sep"></span>
-            <label>Layout
-              <select id="assetLayout" title="Graph layout">
-                <option value="horizontal">Horizontal</option>
-                <option value="vertical">Vertical</option>
-                <option value="radial">Radial</option>
-              </select>
-            </label>
-            <span class="asset-ctrl-sep"></span>
-            <button id="assetZoomOut" type="button" title="Zoom out">−</button>
-            <span id="assetZoomLevel" title="Zoom level (scroll the mouse wheel over the graph to zoom)">100%</span>
-            <button id="assetZoomIn" type="button" title="Zoom in">+</button>
-            <button id="assetZoomReset" type="button" title="Reset / fit zoom">Fit</button>
-            <span class="asset-ctrl-sep"></span>
-            <button id="assetFullscreen" type="button" title="Enlarge the graph to full screen">⤢ Fullscreen</button>
-            <button id="assetResetLayout" type="button" title="Clear manual node positions — back to the chosen layout">↺ Reset layout</button>
-            <span class="ev-drag-hint">drag nodes to rearrange</span>
-            <span id="assetFocusHint" class="asset-hint"></span>
+          <div class="lg-toolbar">
+            <input id="assetFilter" type="text" placeholder="Filter nodes and edges" autocomplete="off" />
+            <button type="button" id="assetFit" title="Fit to screen">⤢ Fit</button>
+            <button type="button" id="assetFullscreenBtn" title="Enlarge the graph to full screen">⛶ Fullscreen</button>
+            <button type="button" id="assetExport" title="Export as PNG">⬇ PNG</button>
+            <button type="button" id="assetRefresh" title="Rebuild the asset graph">↻ Refresh</button>
+            <button type="button" id="assetOptions" title="View options">⚙ View</button>
           </div>
-          <div id="assetGraph" class="asset-graph">—</div>
+          <div id="assetOptionsPanel" class="lg-options" style="display:none">
+            <div class="lg-opt-group"><span class="lg-opt-label">Layout type</span>
+              <label><input type="radio" name="assetLayoutRadio" value="spread" /> spread</label>
+              <label><input type="radio" name="assetLayoutRadio" value="dagre" /> dagre</label>
+              <label><input type="radio" name="assetLayoutRadio" value="circle" /> circle</label>
+              <label><input type="radio" name="assetLayoutRadio" value="concentric" /> concentric</label>
+              <label><input type="radio" name="assetLayoutRadio" value="breadthfirst" /> breadthfirst</label>
+            </div>
+            <div class="lg-opt-group"><span class="lg-opt-label">Edge style</span>
+              <label><input type="radio" name="assetEdgeStyle" value="bezier" /> bezier</label>
+              <label><input type="radio" name="assetEdgeStyle" value="taxi" /> taxi</label>
+            </div>
+            <div class="lg-opt-group"><span class="lg-opt-label">Transparency for unselected elements</span>
+              <input type="range" id="assetDim" min="0" max="90" step="5" />
+            </div>
+            <div class="lg-opt-group"><span class="lg-opt-label">Show</span>
+              <label><input type="checkbox" class="asset-type-toggle" value="host" checked> <span class="legend-slot" data-ltype="host"></span>Hosts</label>
+              <label><input type="checkbox" class="asset-type-toggle" value="account" checked> <span class="legend-slot" data-ltype="account"></span>Accounts</label>
+              <label><input type="checkbox" class="asset-type-toggle" value="service" checked> <span class="legend-slot" data-ltype="service"></span>Services</label>
+            </div>
+          </div>
+          <div id="assetGraph" class="login-graph"></div>
+          <div id="assetSidePanel" class="lg-side-panel" style="display:none"></div>
         </div>
         <h3 class="asset-subhead">Known compromised assets</h3>
         <div id="assetList">—</div>
@@ -4895,50 +4900,11 @@
     // --- Compromised assets + asset↔IoC graph -------------------------------------
     let assetGraphData = null;                              // { assets, iocs, edges }
     let assetOverridesData = null;                          // { renames, added, removed, addedLinks, removedLinks }
-    let assetFocus = null;                                  // focused node id, or null
     let assetGraphTimer = null;
-    let assetLayout = "horizontal";                         // "horizontal" | "vertical" | "radial"
-    let assetZoom = 1;                                       // graph zoom factor
-    let assetDims = { W: 0, H: 0 };                          // intrinsic graph size of the last render
     const assetTypesEnabled = new Set(["host", "account", "service"]);
-    // Drag-to-reposition (same model as the Evidence Chain graph). assetPos = effective id→{x,y}
-    // for the current draw; assetLabOffset = each label's offset from its node (so the label
-    // follows when the node moves); assetPosOverride = the persisted manual positions ("pins").
-    let assetPos = new Map(), assetLabOffset = new Map(), assetBaseDims = { W: 0, H: 0 };
-    let assetDrawAssets = [], assetDrawIocs = [], assetDrawEdges = [];
-    let assetPosOverride = new Map();                        // id -> {x,y}, persisted per case
-    let assetDrag = null;                                    // { id, startX, startY, origX, origY, scale, moved }
 
-    const assetPosKey = () => "dfir.assetpos." + (document.getElementById("caseId").value.trim() || "");
-    function loadAssetPosOverride() {
-      assetPosOverride = new Map();
-      try {
-        const o = JSON.parse(localStorage.getItem(assetPosKey()) || "{}");
-        for (const [k, v] of Object.entries(o)) if (Array.isArray(v)) assetPosOverride.set(k, { x: v[0], y: v[1] });
-      } catch (e) { /* ignore corrupt state */ }
-    }
-    function saveAssetPosOverride() {
-      const o = {}; assetPosOverride.forEach((v, k) => { o[k] = [Math.round(v.x), Math.round(v.y)]; });
-      try { localStorage.setItem(assetPosKey(), JSON.stringify(o)); } catch (e) { /* quota — non-fatal */ }
-    }
-
+    // Shared by the Evidence Chain graph's zoom controls.
     function clampZoom(z) { return Math.min(5, Math.max(0.25, z)); }
-    function updateZoomLabel() { const el = document.getElementById("assetZoomLevel"); if (el) el.textContent = Math.round(assetZoom * 100) + "%"; }
-    // Resize the existing SVG to the zoom factor (cheap — no re-render); the container scrolls to pan.
-    function applyAssetZoom() {
-      const svg = document.querySelector("#assetGraph svg");
-      if (svg && assetDims.W) { svg.setAttribute("width", Math.round(assetDims.W * assetZoom)); svg.setAttribute("height", Math.round(assetDims.H * assetZoom)); }
-      updateZoomLabel();
-    }
-    function setAssetZoom(z) { assetZoom = clampZoom(z); applyAssetZoom(); }
-    // Fit the whole graph into the visible area (used by the Fit button and on entering fullscreen).
-    function fitAssetZoom() {
-      const ag = document.getElementById("assetGraph");
-      if (assetDims.W && ag && ag.clientWidth && ag.clientHeight) {
-        const z = Math.min((ag.clientWidth - 10) / assetDims.W, (ag.clientHeight - 10) / assetDims.H);
-        setAssetZoom(z > 0 && isFinite(z) ? z : 1);
-      } else setAssetZoom(1);
-    }
 
     function truncate(s, n) { s = String(s); return s.length > n ? s.slice(0, n - 1) + "…" : s; }
 
@@ -5016,9 +4982,10 @@
     }
 
     function loadAssetGraph(caseId) {
-      loadAssetPosOverride();   // restore this case's manual node positions
+      const gv = assetEnsureGV();
+      if (gv) gv.loadView();   // restore this case's persisted view state (layout/dim/edge-style/positions)
       fetch(`/cases/${caseId}/asset-graph`).then(r => r.json()).then(g => {
-        assetGraphData = g; assetFocus = null; renderAssetGraph();
+        assetGraphData = g; renderAssetGraph();
       }).catch(() => {});
     }
     function loadAssetOverrides(caseId) {
@@ -5280,44 +5247,87 @@
       el.innerHTML = html;
     }
 
-    function isAssetFullscreen() { return document.fullscreenElement === document.getElementById("assetGraphWrap"); }
+    let assetGV = null;
 
-    // Compute node positions for the chosen layout. Returns intrinsic canvas size +
-    // per-node position and label placement, so drawing is layout-agnostic.
-    function assetLayoutPositions(assets, iocs, layout) {
-      const pos = new Map(), lab = new Map();
-      const n = Math.max(assets.length, iocs.length, 1);
-      let W, H;
-      if (layout === "vertical") {
-        W = Math.max(640, 60 + n * 72); H = 360;
-        const topY = 70, botY = H - 60;
-        const spread = (arr, y, up) => arr.forEach((it, i) => {
-          const x = arr.length === 1 ? W / 2 : 40 + i * ((W - 80) / (arr.length - 1));
-          pos.set(it.id, { x, y });
-          lab.set(it.id, { x, y: up ? y - 12 : y + 14, anchor: "end", rotate: -40 });
-        });
-        spread(assets, topY, true); spread(iocs, botY, false);
-      } else if (layout === "radial") {
-        const d = Math.max(440, 140 + n * 26); W = d; H = d;
-        const cx = W / 2, cy = H / 2, r = d / 2 - 90;
-        const arc = (arr, a0, a1) => arr.forEach((it, i) => {
-          const t = (arr.length === 1 ? (a0 + a1) / 2 : a0 + i * ((a1 - a0) / (arr.length - 1))) * Math.PI / 180;
-          pos.set(it.id, { x: cx + r * Math.cos(t), y: cy + r * Math.sin(t) });
-          lab.set(it.id, { x: cx + (r + 10) * Math.cos(t), y: cy + (r + 10) * Math.sin(t) + 4, anchor: Math.cos(t) < 0 ? "end" : "start", rotate: 0 });
-        });
-        arc(assets, 100, 260);   // assets on the left arc
-        arc(iocs, -80, 80);      // IoCs on the right arc
-      } else {                   // horizontal (two columns)
-        W = 660; H = 40 + Math.max(1, n - 1) * 26 + 40;
-        const aX = 150, bX = W - 230;
-        const col = (arr, x, isAsset) => arr.forEach((it, i) => {
-          const y = arr.length === 1 ? H / 2 : 20 + i * ((H - 40) / (arr.length - 1));
-          pos.set(it.id, { x, y });
-          lab.set(it.id, { x: isAsset ? x - 12 : x + 12, y: y + 4, anchor: isAsset ? "end" : "start", rotate: 0 });
-        });
-        col(assets, aX, true); col(iocs, bX, false);
+    function assetBuildElements(view) {
+      const assets = assetGraphData.assets.filter((a) => assetTypesEnabled.has(a.type));
+      const assetIds = new Set(assets.map((a) => a.id));
+      const iocs = assetGraphData.iocs.filter((i) => i.assetIds.some((id) => assetIds.has(id)));
+      const iocIds = new Set(iocs.map((i) => i.id));
+      const edges = assetGraphData.edges.filter((e) => assetIds.has(e.asset) && iocIds.has(e.ioc));
+      const iocColor = (v) => v === "malicious" ? "#ff5c5c" : v === "suspicious" ? "#ff9f43" : "#6aa9ff";
+      const els = [];
+      for (const a of assets) {
+        els.push({ data: {
+          id: a.id, name: truncate(a.name, 40), full: a.name, kind: "asset",
+          glyph: glyphDataUri(assetIcon(a.type, 11, 11, a.compromised ? "#ff5c5c" : "#6aa9ff")),
+        } });
       }
-      return { pos, lab, W, H };
+      for (const i of iocs) {
+        els.push({ data: {
+          id: i.id, name: truncate(i.value, 40), full: `${i.value} (${i.type})`, kind: "ioc",
+          glyph: glyphDataUri(`<circle cx="11" cy="11" r="6" fill="${iocColor(i.verdict)}" stroke="#0f1115" stroke-width="1.5"/>`),
+        } });
+      }
+      for (const e of edges) els.push({ data: { id: `ae:${e.asset}|${e.ioc}`, source: e.asset, target: e.ioc } });
+      return els;
+    }
+
+    const ASSET_STYLE = [
+      { selector: "node", style: {
+        "background-image": "data(glyph)", "background-color": "#0f1115", "background-opacity": 0,
+        "background-fit": "none", "background-clip": "none", width: 26, height: 26,
+        label: "data(name)", color: "#cbd3df", "font-size": "10px",
+        "text-valign": "bottom", "text-halign": "center", "text-margin-y": 3,
+      } },
+      { selector: "edge", style: {
+        width: 1, "line-color": "#3a4456", "curve-style": "bezier", "target-arrow-shape": "none",
+      } },
+      { selector: ".gv-dim", style: { opacity: 0.1 } },
+    ];
+
+    function assetShowNodePanel(node) {
+      const p = document.getElementById("assetSidePanel");
+      p.replaceChildren();
+      const title = lgEl("div");
+      title.append(lgEl("b", null, node.data("full")), lgEl("span", "ev-sub", " " + node.data("kind")));
+      const close = lgEl("button", "lg-close", "✕ Close");
+      close.type = "button";
+      close.onclick = () => { p.style.display = "none"; if (assetGV) assetGV.dimExcept(null); };
+      p.append(title, close);
+      p.style.display = "block";
+    }
+
+    function assetEnsureGV() {
+      if (assetGV) return assetGV;
+      if (!window.DfirGraphView) return null;
+      assetGV = window.DfirGraphView.createGraphView({
+        graphId: "assets",
+        container: document.getElementById("assetGraph"),
+        wrap: document.getElementById("assetGraphWrap"),
+        caseIdEl: document.getElementById("caseId"),
+        exportName: "asset-graph.png",
+        defaults: { layout: "spread", edgeStyle: "bezier", dim: 85 },
+        style: ASSET_STYLE,
+        buildElements: assetBuildElements,
+        onNodeTap: (node) => assetShowNodePanel(node),
+        onBackgroundTap: () => { document.getElementById("assetSidePanel").style.display = "none"; },
+        onRefresh: () => { const cId = document.getElementById("caseId").value.trim(); if (cId) loadAssetGraph(cId); },
+        controls: {
+          layoutRadios: document.querySelectorAll('input[name="assetLayoutRadio"]'),
+          edgeStyleRadios: document.querySelectorAll('input[name="assetEdgeStyle"]'),
+          dimSlider: document.getElementById("assetDim"),
+          filterInput: document.getElementById("assetFilter"),
+          fitBtn: document.getElementById("assetFit"),
+          fullscreenBtn: document.getElementById("assetFullscreenBtn"),
+          exportBtn: document.getElementById("assetExport"),
+          refreshBtn: document.getElementById("assetRefresh"),
+          optionsBtn: document.getElementById("assetOptions"),
+          optionsPanel: document.getElementById("assetOptionsPanel"),
+          toggles: [],   // asset-type toggles are wired separately below (they mutate a Set, not a view flag)
+        },
+      });
+      return assetGV;
     }
 
     // A gear/cog outline with flat-topped (trapezoidal) teeth for the "service" asset icon —
@@ -5380,126 +5390,14 @@
       const el = document.getElementById("assetGraph");
       if (!assetGraphData || !assetGraphData.assets.length) {
         el.innerHTML = "<div style='padding:16px;color:var(--c-9aa4b2)'>No assets yet — import evidence (THOR / CSV / SIEM-EDR JSON) or run Synthesize. Hosts come from each event's affected asset.</div>";
+        if (assetGV) assetGV.destroy();
         return;
       }
-      const assets = assetGraphData.assets.filter(a => assetTypesEnabled.has(a.type));
-      const assetIds = new Set(assets.map(a => a.id));
-      const iocs = assetGraphData.iocs.filter(i => i.assetIds.some(id => assetIds.has(id)));
-      const iocIds = new Set(iocs.map(i => i.id));
-      const edges = assetGraphData.edges.filter(e => assetIds.has(e.asset) && iocIds.has(e.ioc));
-      if (!assets.length) { el.innerHTML = "<div style='padding:16px;color:var(--c-9aa4b2)'>No assets of the selected type(s).</div>"; return; }
-
-      let { pos, lab, W, H } = assetLayoutPositions(assets, iocs, assetLayout);
-      // Keep labels inside the canvas: estimate each label's horizontal extent and, if any
-      // overflows the left/right edge, shift every node+label right and widen the canvas.
-      // This only pads the canvas (node spacing and radius are untouched), so it cannot
-      // introduce overlap — it fixes labels clipping on the far-left arc of the radial
-      // layout (and the top corners of the vertical layout) without a geometry change.
-      // The horizontal layout puts each label on its own row with nothing above/below it, so a
-      // long label can't overlap a neighbor — only the canvas width grows to fit it (handled
-      // below). Vertical/radial labels sit close together at an angle, so they keep a tighter
-      // cap to avoid overlapping the next node's label.
-      const nameLimit = assetLayout === "horizontal" ? 60 : 20;
-      const iocLimit = assetLayout === "horizontal" ? 70 : 26;
-      const labelText = (it, isIoc) => isIoc
-        ? `${truncate(it.value, iocLimit)} (${it.type})`
-        : truncate(it.name, nameLimit);
-      const labelWidth = (s) => s.length * 6.5 + 6;   // ~6.5px/char at the 11px label font
-      let minX = 0, maxX = W;
-      const fitLabel = (it, isIoc) => {
-        const l = lab.get(it.id); if (!l) return;
-        const w = labelWidth(labelText(it, isIoc));
-        const lo = l.anchor === "end" ? l.x - w : l.anchor === "start" ? l.x : l.x - w / 2;
-        const hi = l.anchor === "end" ? l.x : l.anchor === "start" ? l.x + w : l.x + w / 2;
-        if (lo < minX) minX = lo;
-        if (hi > maxX) maxX = hi;
-      };
-      assets.forEach(a => fitLabel(a, false));
-      iocs.forEach(i => fitLabel(i, true));
-      const dx = minX < 0 ? Math.ceil(-minX) : 0;
-      if (dx > 0) { for (const m of [pos, lab]) for (const v of m.values()) v.x += dx; }
-      W = Math.max(W, Math.ceil(maxX) + dx);
-
-      // Record each label's offset from its node so the label follows when the node is dragged,
-      // then apply any saved manual positions ("pins"). Non-pinned nodes keep the auto layout —
-      // so you can re-arrange a few nodes for clarity and still re-flow the rest by switching layout.
-      assetLabOffset = new Map();
-      for (const it of [...assets, ...iocs]) {
-        const p = pos.get(it.id), l = lab.get(it.id);
-        if (p && l) assetLabOffset.set(it.id, { dx: l.x - p.x, dy: l.y - p.y, anchor: l.anchor, rotate: l.rotate });
-      }
-      assetPos = new Map();
-      for (const it of [...assets, ...iocs]) assetPos.set(it.id, assetPosOverride.get(it.id) || pos.get(it.id));
-      assetDrawAssets = assets; assetDrawIocs = iocs; assetDrawEdges = edges;
-      assetBaseDims = { W, H };
-      drawAssetGraph();
-    }
-
-    // Render the asset↔IoC SVG from assetPos/assetLabOffset (+ focus) and wire drag + focus. Split
-    // from renderAssetGraph so a drag redraws without recomputing the layout; the canvas grows to
-    // fit dragged-out nodes. Mirrors the Evidence Chain graph's draw/drag.
-    function drawAssetGraph() {
-      const el = document.getElementById("assetGraph");
-      if (!assetDrawAssets.length) return;
-      const neighbors = new Map();
-      const addN = (a, b) => { let s = neighbors.get(a); if (!s) { s = new Set(); neighbors.set(a, s); } s.add(b); };
-      assetDrawEdges.forEach(e => { addN(e.asset, e.ioc); addN(e.ioc, e.asset); });
-      const related = (id) => !assetFocus || id === assetFocus || (neighbors.get(assetFocus) && neighbors.get(assetFocus).has(id));
-
-      let W = assetBaseDims.W, H = assetBaseDims.H;            // grow to fit any dragged-out node
-      for (const [id, p] of assetPos) {
-        const o = assetLabOffset.get(id) || { dx: 0, dy: 0 };
-        W = Math.max(W, p.x + 30, p.x + o.dx + 90); H = Math.max(H, p.y + 30, p.y + o.dy + 16);
-      }
-      assetDims = { W, H };
-      const iocColor = (v) => v === "malicious" ? "#ff5c5c" : v === "suspicious" ? "#ff9f43" : "#6aa9ff";
-      const zw = Math.round(W * assetZoom), zh = Math.round(H * assetZoom);
-
-      let svg = `<svg width="${zw}" height="${zh}" viewBox="0 0 ${W} ${H}">`;
-      for (const e of assetDrawEdges) {
-        const p = assetPos.get(e.asset), q = assetPos.get(e.ioc);
-        if (!p || !q) continue;
-        const vis = related(e.asset) && related(e.ioc) && (!assetFocus || e.asset === assetFocus || e.ioc === assetFocus);
-        svg += `<line x1="${p.x.toFixed(1)}" y1="${p.y.toFixed(1)}" x2="${q.x.toFixed(1)}" y2="${q.y.toFixed(1)}" stroke="#3a4456" stroke-width="1" opacity="${vis ? 0.85 : 0.05}"/>`;
-      }
-      // Wrap a node's body (icon/circle) with its label + drag/focus group. The label sits at the
-      // node position plus its recorded offset, so it tracks the node when dragged.
-      const nameLimit = assetLayout === "horizontal" ? 60 : 20;
-      const iocLimit = assetLayout === "horizontal" ? 70 : 26;
-      const wrapNode = (it, isIoc, body) => {
-        const p = assetPos.get(it.id), o = assetLabOffset.get(it.id) || { dx: 0, dy: 0, anchor: "middle", rotate: 0 };
-        const lx = p.x + o.dx, ly = p.y + o.dy;
-        const label = isIoc ? `${esc(truncate(it.value, iocLimit))} <tspan fill="#6b7585">(${esc(it.type)})</tspan>` : esc(truncate(it.name, nameLimit));
-        const full = isIoc ? `${it.value} (${it.type})` : it.name;
-        const rot = o.rotate ? ` transform="rotate(${o.rotate} ${lx.toFixed(1)} ${ly.toFixed(1)})"` : "";
-        const pinned = assetPosOverride.has(it.id) ? " moved" : "";
-        return `<g class="asset-node${pinned}" data-id="${escAttr(it.id)}" opacity="${related(it.id) ? 1 : 0.1}">`
-          + `<title>${esc(full)}</title>`
-          + `<text x="${lx.toFixed(1)}" y="${ly.toFixed(1)}" text-anchor="${o.anchor}"${rot}>${label}</text>`
-          + body + `</g>`;
-      };
-      for (const a of assetDrawAssets) {
-        const p = assetPos.get(a.id);
-        svg += wrapNode(a, false, assetIcon(a.type, p.x, p.y, a.compromised ? "#ff5c5c" : "#6aa9ff"));
-      }
-      for (const i of assetDrawIocs) {
-        const p = assetPos.get(i.id);
-        svg += wrapNode(i, true, `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="5" fill="${iocColor(i.verdict)}" stroke="#0f1115" stroke-width="1.5"/>`);
-      }
-      svg += `</svg>`;
-      el.innerHTML = svg;
-      updateZoomLabel();
-      // Press starts a potential drag (document mousemove/mouseup carry it); a press with no
-      // movement is a focus toggle, preserving click-to-focus.
-      el.querySelectorAll(".asset-node").forEach(node => node.addEventListener("mousedown", (ev) => {
-        ev.preventDefault();
-        const id = node.getAttribute("data-id");
-        const s = el.querySelector("svg"); if (!s) return;
-        const rect = s.getBoundingClientRect();
-        const scale = rect.width ? assetDims.W / rect.width : 1;   // viewBox units per screen pixel
-        const cur = assetPos.get(id);
-        assetDrag = { id, startX: ev.clientX, startY: ev.clientY, origX: cur.x, origY: cur.y, scale, moved: false };
-      }));
+      const assets = assetGraphData.assets.filter((a) => assetTypesEnabled.has(a.type));
+      if (!assets.length) { el.innerHTML = "<div style='padding:16px;color:var(--c-9aa4b2)'>No assets of the selected type(s).</div>"; if (assetGV) assetGV.destroy(); return; }
+      const gv = assetEnsureGV();
+      if (!gv) { el.textContent = "Graph library not loaded — restart the companion server."; return; }
+      gv.render();
     }
 
     // --- Evidence Chain graph (causal: process trees + lateral movement) ----------
@@ -15258,58 +15156,14 @@
       }
     }
 
-    document.querySelectorAll(".asset-type-toggle").forEach(cb => cb.onchange = () => {
+    // Asset-type toggles mutate the enabled Set, then rebuild through the module.
+    document.querySelectorAll(".asset-type-toggle").forEach((cb) => cb.addEventListener("change", () => {
       if (cb.checked) assetTypesEnabled.add(cb.value); else assetTypesEnabled.delete(cb.value);
-      assetFocus = null; renderAssetGraph();
-    });
-    document.getElementById("assetTypeAll").onclick = () => {
-      document.querySelectorAll(".asset-type-toggle").forEach(cb => cb.checked = true);
-      assetTypesEnabled.clear(); ["host", "account", "service"].forEach(t => assetTypesEnabled.add(t));
-      assetFocus = null; renderAssetGraph();
-    };
-    document.getElementById("assetLayout").onchange = (e) => { assetLayout = e.target.value; renderAssetGraph(); };
-    document.getElementById("assetZoomIn").onclick = () => setAssetZoom(assetZoom * 1.25);
-    document.getElementById("assetZoomOut").onclick = () => setAssetZoom(assetZoom / 1.25);
-    document.getElementById("assetZoomReset").onclick = () => fitAssetZoom();
-    // Mouse-wheel over the graph zooms (in = up). preventDefault stops the page from scrolling.
-    document.getElementById("assetGraph").addEventListener("wheel", (e) => {
-      if (!assetGraphData) return;
-      e.preventDefault();
-      setAssetZoom(assetZoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
-    }, { passive: false });
-    document.getElementById("assetFullscreen").onclick = () => {
-      const wrap = document.getElementById("assetGraphWrap");
-      if (isAssetFullscreen()) document.exitFullscreen();
-      else if (wrap.requestFullscreen) wrap.requestFullscreen();
-    };
-    // On enter/exit fullscreen, re-render then fit the graph to the (new) viewport.
-    document.addEventListener("fullscreenchange", () => {
-      if (!assetGraphData) return;
       renderAssetGraph();
-      setTimeout(fitAssetZoom, 60);   // wait for the fullscreen relayout before measuring
-    });
-    // Drag a node to reposition it (positions persist per case as "pins"); ↺ clears them.
-    document.getElementById("assetResetLayout").onclick = () => {
-      assetPosOverride = new Map(); saveAssetPosOverride(); renderAssetGraph();
-    };
-    // Drag carry, wired once. assetDrag is set on a node mousedown; move + redraw, commit on
-    // release. A release with no real movement is a focus toggle (preserves click-to-focus).
-    document.addEventListener("mousemove", (ev) => {
-      if (!assetDrag) return;
-      if (Math.abs(ev.clientX - assetDrag.startX) > 3 || Math.abs(ev.clientY - assetDrag.startY) > 3) assetDrag.moved = true;
-      assetPos.set(assetDrag.id, { x: assetDrag.origX + (ev.clientX - assetDrag.startX) * assetDrag.scale,
-                                   y: assetDrag.origY + (ev.clientY - assetDrag.startY) * assetDrag.scale });
-      drawAssetGraph();
-    });
-    document.addEventListener("mouseup", () => {
-      if (!assetDrag) return;
-      const d = assetDrag; assetDrag = null;
-      if (d.moved) { assetPosOverride.set(d.id, assetPos.get(d.id)); saveAssetPosOverride(); drawAssetGraph(); }
-      else {
-        assetFocus = (assetFocus === d.id) ? null : d.id;
-        document.getElementById("assetFocusHint").textContent = assetFocus ? "showing related only — click the node again to reset" : "";
-        drawAssetGraph();
-      }
+    }));
+    // Deferred render when the collapsed section expands.
+    document.querySelector("#sec-assets h2").addEventListener("click", () => {
+      setTimeout(() => { if (assetGV) assetGV.onExpand(); }, 0);
     });
 
     // Deferred render for a section that was collapsed at data-arrival time (zero-size container).

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5366,6 +5366,15 @@
     // Paint the legend glyph into each Show-toggle (doubles as the graph's icon key).
     document.querySelectorAll(".legend-slot").forEach((s) => { s.innerHTML = legendIcon(s.dataset.ltype); });
 
+    // Wrap centered glyph markup (as produced by assetIcon(type,11,11,color) / evNodeGlyph(n,11,11))
+    // into a standalone SVG data URI usable as a cytoscape node background-image. The 22×22 viewBox
+    // matches the icon coordinates (center 11,11); size is the rendered pixel box.
+    function glyphDataUri(innerSvg, size) {
+      const px = size || 26;
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${px}" height="${px}" viewBox="0 0 22 22">${innerSvg}</svg>`;
+      return "data:image/svg+xml;utf8," + encodeURIComponent(svg);
+    }
+
     function renderAssetGraph() {
       renderAssetList();
       const el = document.getElementById("assetGraph");

--- a/public/js/graph-view.js
+++ b/public/js/graph-view.js
@@ -1,0 +1,39 @@
+// Shared Cytoscape graph-view module. Loaded in the browser as an ES module
+// (<script type="module" src="/js/graph-view.js">) which sets window.DfirGraphView;
+// its pure helpers are also named exports so Vitest (node env) can unit-test them.
+//
+// LOAD ORDER: module scripts run after classic inline scripts, so window.DfirGraphView is
+// NOT set while the inline dashboard script's top level executes. That is fine — the inline
+// code only *calls* DfirGraphView inside fetch handlers / event listeners / DOMContentLoaded,
+// all of which fire after this module has run.
+
+// Build cytoscape layout options from a view. 'spread' is our label for the cose force layout.
+// animate:false — animated layouts advance on requestAnimationFrame, which browsers pause in
+// background/occluded tabs, stalling the layout forever; synchronous positioning always applies.
+export function layoutOptions(view) {
+  const name = view.layout === "spread" ? "cose" : view.layout;
+  const base = { name, animate: false, fit: true, padding: 30 };
+  if (name === "concentric") return { ...base, concentric: (n) => n.degree(), levelWidth: () => 1 };
+  if (name === "breadthfirst") return { ...base, directed: true };
+  return base;
+}
+
+// Dim slider 0..90 → unselected-element opacity 1..0.1 (higher = more transparent), 0.05 floor.
+export function dimOpacity(dim) {
+  return Math.max(0.05, 1 - dim / 100);
+}
+
+// Search predicate: does a node's name (or, failing that, an edge's label) contain the query?
+// `query` is expected already trimmed + lowercased by the caller.
+export function filterMatch(name, label, query) {
+  return String(name || label || "").toLowerCase().includes(query);
+}
+
+// createGraphView is implemented in Phase 2. Stub keeps the module importable meanwhile.
+export function createGraphView() {
+  throw new Error("createGraphView not implemented yet");
+}
+
+if (typeof window !== "undefined") {
+  window.DfirGraphView = { createGraphView, layoutOptions, dimOpacity, filterMatch };
+}

--- a/public/js/graph-view.js
+++ b/public/js/graph-view.js
@@ -29,9 +29,157 @@ export function filterMatch(name, label, query) {
   return String(name || label || "").toLowerCase().includes(query);
 }
 
-// createGraphView is implemented in Phase 2. Stub keeps the module importable meanwhile.
-export function createGraphView() {
-  throw new Error("createGraphView not implemented yet");
+// Factory for one Cytoscape graph instance + its shared chrome. The adapter supplies data,
+// style, and click behavior; this owns everything generic.
+//
+// opts:
+//   graphId       string   — persistence namespace + logical id ("login"|"assets"|"evidence")
+//   container     Element  — the graph canvas div
+//   wrap          Element  — the element that goes fullscreen (may equal container's parent)
+//   caseIdEl      Element  — the #caseId input, for per-case persistence keys
+//   exportName    string   — PNG download filename
+//   defaults      object   — { layout, edgeStyle, dim, ...toggleKeys }
+//   style         array    — cytoscape stylesheet (MUST include a ".gv-dim" selector rule)
+//   buildElements (view)=>array — build cytoscape elements from live data + view/toggle state
+//   onNodeTap     (node, api)=>void   — adapter side-panel for a node (optional)
+//   onEdgeTap     (edge, api)=>void   — adapter side-panel for an edge (optional)
+//   onBackgroundTap (api)=>void       — background click, e.g. hide side panel (optional)
+//   onRefresh     ()=>void            — refetch data (optional; wired to the refresh button)
+//   controls      object   — DOM handles: { layoutRadios(NodeList), edgeStyleRadios(NodeList),
+//                              dimSlider, filterInput, fitBtn, fullscreenBtn, exportBtn,
+//                              refreshBtn, optionsBtn, optionsPanel, toggles:[{input,key}] }
+// returns api: { cy, view, render, fit, resize, exportPng, dimExcept, applyFilter, onExpand, destroy }
+export function createGraphView(opts) {
+  const {
+    graphId, container, wrap, caseIdEl, exportName,
+    defaults, style, buildElements,
+    onNodeTap, onEdgeTap, onBackgroundTap, onRefresh,
+    controls = {},
+  } = opts;
+
+  const DIM_CLASS = "gv-dim";
+  let cy = null;
+  let pendingRender = false;      // container was zero-size (collapsed) at render time
+  let view = { ...defaults };
+
+  const viewKey = () => `dfir.graphView.${graphId}.` + ((caseIdEl && caseIdEl.value.trim()) || "");
+  function loadView() {
+    try { view = { ...defaults, ...JSON.parse(localStorage.getItem(viewKey()) || "{}") }; }
+    catch (e) { view = { ...defaults }; }
+  }
+  function saveView() { try { localStorage.setItem(viewKey(), JSON.stringify(view)); } catch (e) { /* quota — non-fatal */ } }
+
+  function applyEdgeStyle() {
+    if (!cy) return;
+    cy.style().selector("edge").style("curve-style", view.edgeStyle === "taxi" ? "taxi" : "bezier").update();
+  }
+  function applyDim() {
+    if (!cy) return;
+    cy.style().selector("." + DIM_CLASS).style("opacity", dimOpacity(view.dim)).update();
+  }
+  // Dim everything except `eles` and their neighborhood; null/empty → undim all.
+  function dimExcept(eles) {
+    if (!cy) return;
+    cy.elements().removeClass(DIM_CLASS);
+    if (!eles || eles.empty()) return;
+    const keep = eles.union(eles.neighborhood());
+    cy.elements().difference(keep).addClass(DIM_CLASS);
+  }
+  function wireInstanceEvents() {
+    // Instance-scoped — cy is recreated per render and destroy() unbinds these.
+    cy.on("tap", "node", (evt) => { dimExcept(evt.target); if (onNodeTap) onNodeTap(evt.target, api); });
+    cy.on("tap", "edge", (evt) => { dimExcept(evt.target); if (onEdgeTap) onEdgeTap(evt.target, api); });
+    cy.on("tap", (evt) => { if (evt.target === cy) { dimExcept(null); if (onBackgroundTap) onBackgroundTap(api); } });
+  }
+
+  function render() {
+    // Collapsed section → zero-size container → cytoscape can't lay out. Defer; onExpand() re-renders.
+    if (!container.offsetWidth) { pendingRender = true; return; }
+    pendingRender = false;
+    if (typeof cytoscape === "undefined") return;   // vendor script failed to load
+    const elements = buildElements(view);
+    if (cy) { cy.destroy(); cy = null; }
+    cy = cytoscape({ container, elements, style, wheelSensitivity: 0.2 });
+    applyEdgeStyle();
+    applyDim();
+    cy.layout(layoutOptions(view)).run();
+    wireInstanceEvents();
+  }
+
+  function fit() { if (cy) cy.fit(undefined, 30); }
+  function resize() { if (cy) cy.resize(); }
+  function exportPng() {
+    if (!cy) return;
+    const a = document.createElement("a");
+    a.href = cy.png({ full: true, scale: 2, bg: "#0f1115" });
+    a.download = exportName;
+    a.click();
+  }
+  function applyFilter(raw) {
+    if (!cy) return;
+    const q = String(raw || "").trim().toLowerCase();
+    if (!q) { dimExcept(null); return; }
+    const hits = cy.elements().filter((el) => filterMatch(el.data("name"), el.data("label"), q));
+    // Zero matches must read as "nothing matches" (dim ALL) — dimExcept(empty) would UNdim all.
+    if (hits.empty()) { cy.elements().addClass(DIM_CLASS); return; }
+    dimExcept(hits);
+  }
+
+  // ---- one-time control wiring (document/element listeners; instance events are in wireInstanceEvents) ----
+  const c = controls;
+  if (c.fitBtn) c.fitBtn.addEventListener("click", fit);
+  if (c.exportBtn) c.exportBtn.addEventListener("click", exportPng);
+  if (c.refreshBtn && onRefresh) c.refreshBtn.addEventListener("click", () => onRefresh());
+  if (c.filterInput) c.filterInput.addEventListener("input", (e) => applyFilter(e.target.value));
+  if (c.dimSlider) c.dimSlider.addEventListener("input", () => { view.dim = Number(c.dimSlider.value); saveView(); applyDim(); });
+  if (c.layoutRadios) c.layoutRadios.forEach((r) => r.addEventListener("change", () => {
+    if (!r.checked) return;
+    view.layout = r.value; saveView();
+    if (cy) cy.layout(layoutOptions(view)).run();   // re-layout live
+  }));
+  if (c.edgeStyleRadios) c.edgeStyleRadios.forEach((r) => r.addEventListener("change", () => {
+    if (!r.checked) return;
+    view.edgeStyle = r.value; saveView(); applyEdgeStyle();
+  }));
+  (c.toggles || []).forEach((t) => t.input.addEventListener("change", () => {
+    view[t.key] = t.input.checked; saveView(); render();   // element-set change → rebuild
+  }));
+  if (c.optionsBtn && c.optionsPanel) c.optionsBtn.addEventListener("click", () => {
+    const p = c.optionsPanel;
+    const show = p.style.display === "none" || !p.style.display;
+    if (show) {   // sync controls from view before showing
+      if (c.layoutRadios) c.layoutRadios.forEach((r) => { r.checked = r.value === view.layout; });
+      if (c.edgeStyleRadios) c.edgeStyleRadios.forEach((r) => { r.checked = r.value === view.edgeStyle; });
+      if (c.dimSlider) c.dimSlider.value = view.dim;
+      (c.toggles || []).forEach((t) => { t.input.checked = !!view[t.key]; });
+    }
+    p.style.display = show ? "" : "none";
+  });
+  if (c.fullscreenBtn && wrap) {
+    c.fullscreenBtn.addEventListener("click", () => {
+      if (document.fullscreenElement === wrap) document.exitFullscreen();
+      else if (wrap.requestFullscreen) wrap.requestFullscreen();
+    });
+    // Resize + refit when OUR wrap enters/exits fullscreen. fsWas distinguishes our exit from
+    // another section's fullscreenchange (on exit fullscreenElement is null for everyone).
+    let fsWas = false;
+    document.addEventListener("fullscreenchange", () => {
+      const isNow = document.fullscreenElement === wrap;
+      if (!isNow && !fsWas) return;
+      fsWas = isNow;
+      if (cy) setTimeout(() => { if (cy) { cy.resize(); cy.fit(undefined, 30); } }, 60);
+    });
+  }
+
+  const api = {
+    get cy() { return cy; },
+    get view() { return view; },
+    loadView, saveView, render, fit, resize, exportPng, dimExcept, applyFilter,
+    // Called by the section's h2 click hook after setupCollapsible toggles .collapsed.
+    onExpand() { if (pendingRender) render(); else if (cy) cy.resize(); },
+    destroy() { if (cy) { cy.destroy(); cy = null; } },
+  };
+  return api;
 }
 
 if (typeof window !== "undefined") {

--- a/public/js/graph-view.js
+++ b/public/js/graph-view.js
@@ -146,7 +146,10 @@ export function createGraphView(opts) {
   }));
   if (c.optionsBtn && c.optionsPanel) c.optionsBtn.addEventListener("click", () => {
     const p = c.optionsPanel;
-    const show = p.style.display === "none" || !p.style.display;
+    // The panel starts hidden via inline style="display:none". Toggle purely on that: clicking
+    // View while it's open ("") must CLOSE it. (An `|| !p.style.display` fallback would read the
+    // open "" state as "hidden" and re-open instead of closing.)
+    const show = p.style.display === "none";
     if (show) {   // sync controls from view before showing
       if (c.layoutRadios) c.layoutRadios.forEach((r) => { r.checked = r.value === view.layout; });
       if (c.edgeStyleRadios) c.edgeStyleRadios.forEach((r) => { r.checked = r.value === view.edgeStyle; });


### PR DESCRIPTION
## Summary

Extracts the Login Graph's Cytoscape interaction chrome into one reusable module (`public/js/graph-view.js`) and migrates the **Compromised Assets & IoC Graph** and the **Evidence Chain** off their hand-rolled SVG onto it. All three graphs now share the same behavior: five layouts (spread/dagre/circle/concentric/breadthfirst), bezier/taxi edges, selection transparency, live filter, fit, fullscreen, PNG export, and per-case view persistence.

Each graph stays a thin adapter that supplies its own data, style, and click handlers:
- Custom node glyphs are preserved (host/account/service/process/file/network) by reusing the existing SVG generators as Cytoscape `background-image` data URIs.
- The Evidence Chain keeps its typed, colored, directional edges (ran_on / file_lineage / network_flow / causal).
- Backend is untouched — this is a pure frontend rendering swap; the node/edge payloads and their tests are unchanged.

The old bespoke asset layouts (horizontal/vertical/radial) and manual node-position saving were replaced by the shared generic layouts, per design.

## Changes
- New `public/js/graph-view.js` (pure helpers unit-tested + `createGraphView` factory), served via the static whitelist and loaded as an ES module.
- Login Graph refactored onto the module; Assets & IoC Graph and Evidence Chain migrated from SVG.
- Dead SVG code + CSS swept; CHANGELOG updated.
- Fixes found during review/testing: fullscreen now grows the asset/evidence canvas; View/side panels anchor to their own graph wrap (no longer float over the page); the View button closes its panel on a second click.

## Test plan
- [x] `npm test` — full suite green (359 files / 4072 tests)
- [x] `npx tsc --noEmit` — clean
- [x] New unit tests for the module's pure helpers (`tests/analysis/graphView.test.ts`)
- [x] Updated + added markup-contract/regression guards (`tests/reports/dashboardHtml.test.ts`)
- [x] Live browser verification of all three graphs on the seeded `demo` case: rendering, glyphs, all five layouts, edge-style toggle, dim, data toggles, filter, fit, fullscreen, PNG export, tap-to-select side panels, and the View-panel toggle/anchoring fixes