### PR TITLE
Add jitter + 429-aware retry/backoff to TI enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,9 @@ Add a key to enable that provider. All external providers are opt-in per case fr
 | `DFIR_SHODAN_KEY` | — | Shodan API key — also powers the Shodan host-lookup IP enricher (shared with customer exposure) |
 | `DFIR_HASHLOOKUP_URL` | `https://hashlookup.circl.lu` | CIRCL hashlookup base (keyless known-file lookup for hash IOCs); override for a self-hosted / air-gapped mirror |
 | `DFIR_ENRICH_DELAY_MS` | `1500` | Throttle between lookups (ms) |
+| `DFIR_ENRICH_JITTER_MS` | `0` | ± random jitter added to the inter-call wait (ms); spreads out aligned/parallel runs so they don't all hit a provider's rate-limit window together |
+| `DFIR_ENRICH_RETRIES` | `2` | Retry attempts for a provider call that hits a 429, honouring `Retry-After` when the provider sends one, before it's counted as an error |
+| `DFIR_ENRICH_RETRY_BACKOFF_MS` | `1000` | Base backoff before the first 429 retry (doubles each attempt, capped at 30s) when the provider gave no `Retry-After` |
 | `DFIR_ENRICH_MAX` | `100` | Max IOCs per enrich run |
 | `DFIR_ENRICH_HEALTH_TTL_MS` | `60000` | Cache up/down verdict for self-hosted providers (ms) |
 | `DFIR_ENRICH_HEALTH_POLL_MS` | `60000` | Re-probe interval for down providers; `0` disables background poller |

--- a/companion/src/enrichment/abuseipdb.ts
+++ b/companion/src/enrichment/abuseipdb.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind, Verdict } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind, type Verdict } from "./provider.js";
 
 export interface AbuseIpdbOptions {
   apiKey: string;
@@ -27,7 +27,7 @@ export class AbuseIpdbProvider implements EnrichmentProvider {
       signal: AbortSignal.timeout(this.opts.timeoutMs ?? 20_000),
     });
     if (res.status === 401 || res.status === 403) throw new Error("AbuseIPDB auth failed (check DFIR_ABUSEIPDB_KEY)");
-    if (res.status === 429) throw new Error("AbuseIPDB rate limit");
+    if (res.status === 429) throw new RateLimitError("AbuseIPDB rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`AbuseIPDB HTTP ${res.status}`);
 
     const json = (await res.json()) as { data?: { abuseConfidenceScore?: number; totalReports?: number; countryCode?: string; isp?: string; domain?: string } };

--- a/companion/src/enrichment/chainValidate.ts
+++ b/companion/src/enrichment/chainValidate.ts
@@ -6,10 +6,14 @@
 
 import type { ForensicEvent, ProcessChainCheck } from "../analysis/stateTypes.js";
 import type { ParentChildResult } from "./rockyraccoon.js";
+import { withRateLimitRetry, type RetryPolicy } from "./provider.js";
 
 export interface ChainValidateOptions {
   check: (parent: string, child: string) => Promise<ParentChildResult | null>;
   delayMs?: number;
+  jitterMs?: number;         // ± random jitter added to the inter-call wait (default 0 = none)
+  random?: () => number;     // injected jitter source (default Math.random), returns [0, 1)
+  retry?: RetryPolicy;       // retry policy for a check() that throws RateLimitError (HTTP 429)
   maxChecks?: number;        // cap on distinct (parent,child) pairs queried per run
   force?: boolean;           // re-check events that already have a chainCheck
   now?: () => string;
@@ -41,6 +45,8 @@ export async function validateProcessChains(
   const now = opts.now ?? (() => new Date().toISOString());
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const delayMs = opts.delayMs ?? 1500;
+  const jitterMs = opts.jitterMs ?? 0;
+  const random = opts.random ?? Math.random;
   const maxChecks = opts.maxChecks ?? 100;
 
   const candidates = events.filter((e) => e.parentName && e.processName && (opts.force || !e.chainCheck));
@@ -58,10 +64,13 @@ export async function validateProcessChains(
   const results = new Map<string, ProcessChainCheck>();
   let calls = 0;
   for (const { parent, child, key } of order.slice(0, maxChecks)) {
-    if (calls > 0) await sleep(delayMs);
+    if (calls > 0) {
+      const jitter = jitterMs > 0 ? Math.round((random() * 2 - 1) * jitterMs) : 0;
+      await sleep(Math.max(0, delayMs + jitter));
+    }
     calls += 1;
     try {
-      const r = await opts.check(parent, child);
+      const r = await withRateLimitRetry(() => opts.check(parent, child), { ...opts.retry, sleep, random });
       if (r) {
         results.set(key, { observed: r.observed, note: r.note, link: r.link, checkedAt: now() });
         if (!r.observed) summary.anomalies += 1;

--- a/companion/src/enrichment/crowdstrike.ts
+++ b/companion/src/enrichment/crowdstrike.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind, Verdict } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind, type Verdict } from "./provider.js";
 
 export interface CrowdStrikeOptions {
   clientId: string;
@@ -94,7 +94,7 @@ export class CrowdStrikeProvider implements EnrichmentProvider {
     let res = await call(await this.ensureToken());
     if (res.status === 401) res = await call(await this.ensureToken(true));   // token expired → refresh once
     if (res.status === 403) throw new CsAuthError(`CrowdStrike 403 — API client is missing scope: ${scopeHint}`);
-    if (res.status === 429) throw new Error("CrowdStrike rate limit");
+    if (res.status === 429) throw new RateLimitError("CrowdStrike rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (res.status === 404) return {};
     if (!res.ok) throw new Error(`CrowdStrike HTTP ${res.status}`);
     return (await res.json()) as Record<string, unknown>;

--- a/companion/src/enrichment/enrichService.ts
+++ b/companion/src/enrichment/enrichService.ts
@@ -3,7 +3,7 @@
 // the normalized results to the IOC. Pure-ish and testable — sleep + now are injectable.
 
 import type { IOC, IocEnrichment } from "../analysis/stateTypes.js";
-import { iocKind, type EnrichmentProvider, type IocKind } from "./provider.js";
+import { iocKind, withRateLimitRetry, type EnrichmentProvider, type IocKind, type RetryPolicy } from "./provider.js";
 import type { ProviderHealthCache } from "./providerHealth.js";
 
 // Emitted once per outbound provider call so callers can log exactly which threat-intel
@@ -22,6 +22,15 @@ export interface EnrichOptions {
   providers: EnrichmentProvider[];
   delayMs?: number;                       // throttle between external lookups (default 1500)
   perProviderDelayMs?: Record<string, number>;  // per-provider throttle; overrides delayMs for named providers
+  // ± random jitter added to every inter-call wait (default 0 = none), so aligned/parallel runs
+  // against the same provider don't all land on the same rate-limit window. E.g. jitterMs: 300
+  // on a 1500ms delay waits somewhere in [1200, 1800].
+  jitterMs?: number;
+  random?: () => number;                  // injected jitter source (default Math.random), returns [0, 1)
+  // Retry policy for a provider call that throws RateLimitError (HTTP 429): retried with
+  // exponential backoff honouring the server's Retry-After when it sent one, instead of
+  // aborting the lookup on the first rate-limit hit. Other errors are not retried here.
+  retry?: RetryPolicy;
   maxIocs?: number;                       // cap IOCs queried per run (default 100)
   force?: boolean;                        // re-query IOCs already enriched
   now?: () => string;                     // injected timestamp
@@ -77,6 +86,8 @@ export async function enrichIocs(
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const monotonic = opts.monotonic ?? (() => Date.now());
   const delayMs = opts.delayMs ?? 1500;
+  const jitterMs = opts.jitterMs ?? 0;
+  const random = opts.random ?? Math.random;
   const maxIocs = opts.maxIocs ?? 100;
 
   // For each enrichable IOC, work out which of the given providers still need to query it:
@@ -135,13 +146,18 @@ export async function enrichIocs(
       const provDelay = opts.perProviderDelayMs?.[provider.name] ?? delayMs;
       const lastAt = lastCallAt.get(provider.name);
       if (lastAt !== undefined) {
-        const wait = provDelay - (monotonic() - lastAt);
+        // ± jitterMs so a fixed delay doesn't have every parallel/scheduled run land in the
+        // exact same rate-limit window on the provider's side.
+        const jitter = jitterMs > 0 ? Math.round((random() * 2 - 1) * jitterMs) : 0;
+        const wait = provDelay + jitter - (monotonic() - lastAt);
         if (wait > 0) await sleep(wait);
       }
       const startedAt = monotonic();
       lastCallAt.set(provider.name, startedAt);
       try {
-        const r = await provider.lookup(kind, ioc.value);
+        // A single 429 doesn't abort the lookup: retry with backoff (honouring Retry-After)
+        // before giving up and counting it as an error.
+        const r = await withRateLimitRetry(() => provider.lookup(kind, ioc.value), { ...opts.retry, sleep, random });
         // A provider may return a single result, several (a fan-out source like Hunting.ch),
         // or null/[] for a miss. When a result's displayed `source` differs from the provider
         // (a fan-out emits sub-sources like "MalwareBazaar"), stamp the OWNING provider so

--- a/companion/src/enrichment/geoip.ts
+++ b/companion/src/enrichment/geoip.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind } from "./provider.js";
 
 // Geo-IP lookup for an IP IOC — "what country (and city / ASN / hosting org) did this address
 // come from?". Answers the analyst's first question about any external IP. Pure geo/network
@@ -106,7 +106,7 @@ export class GeoIpProvider implements EnrichmentProvider {
       signal: AbortSignal.timeout(this.opts.timeoutMs ?? 20_000),
     });
     if (res.status === 401 || res.status === 403) throw new Error("GeoIP auth failed / blocked (set DFIR_GEOIP_URL or DFIR_GEOIP_KEY)");
-    if (res.status === 429) throw new Error("GeoIP rate limit");
+    if (res.status === 429) throw new RateLimitError("GeoIP rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`GeoIP HTTP ${res.status}`);
 
     const json = (await res.json()) as GeoResponse;

--- a/companion/src/enrichment/hashlookup.ts
+++ b/companion/src/enrichment/hashlookup.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind, Verdict } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind, type Verdict } from "./provider.js";
 
 // CIRCL hashlookup (https://www.circl.lu/services/hashlookup/) — a large, free, keyless
 // KNOWN-FILE database (NSRL-derived corpus + Linux distro packages + more). For DFIR this is
@@ -72,7 +72,7 @@ export class HashlookupProvider implements EnrichmentProvider {
     });
     // Unknown hash (404) or malformed (400) → a clean miss, cached as "checked, nothing".
     if (res.status === 404 || res.status === 400) return null;
-    if (res.status === 429) throw new Error("Hashlookup rate limit");
+    if (res.status === 429) throw new RateLimitError("Hashlookup rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`Hashlookup HTTP ${res.status}`);
 
     const json = (await res.json()) as Record<string, unknown>;

--- a/companion/src/enrichment/provider.ts
+++ b/companion/src/enrichment/provider.ts
@@ -60,3 +60,61 @@ export function iocKind(type: string): IocKind | undefined {
     default: return undefined;
   }
 }
+
+// Thrown by a provider on HTTP 429 instead of a plain Error, so callers can distinguish
+// "back off and retry" from a hard failure (auth, network) that should surface immediately.
+// Carries the server's Retry-After (parsed to ms) when it sent one.
+export class RateLimitError extends Error {
+  readonly retryAfterMs?: number;
+  constructor(message: string, retryAfterMs?: number) {
+    super(message);
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+// Retry-After is either a whole number of seconds, or an HTTP-date. Returns ms, or undefined
+// when absent/unparseable (caller falls back to its own backoff schedule).
+export function parseRetryAfterMs(header: string | null | undefined, nowMs = Date.now()): number | undefined {
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const at = Date.parse(header);
+  return Number.isNaN(at) ? undefined : Math.max(0, at - nowMs);
+}
+
+export interface RetryPolicy {
+  retries?: number;       // additional attempts after the first (default 2)
+  backoffMs?: number;     // base backoff before the first retry (default 1000, doubles each attempt)
+  maxBackoffMs?: number;  // cap on the computed backoff, before jitter (default 30_000)
+}
+
+export interface RetryRunOptions extends RetryPolicy {
+  sleep?: (ms: number) => Promise<void>;  // injectable delay (tests pass a no-op)
+  random?: () => number;                  // injectable jitter source (default Math.random), returns [0, 1)
+}
+
+// Retries `fn` when it throws a RateLimitError, waiting the server's Retry-After if it gave
+// one, else an exponential backoff — with a bit of jitter either way so parallel callers
+// hitting the same limit don't all retry in lockstep. Any other error (auth, network, a
+// provider's plain "not found") is NOT retried — it should surface to the caller immediately.
+export async function withRateLimitRetry<T>(fn: () => Promise<T>, opts: RetryRunOptions = {}): Promise<T> {
+  const retries = opts.retries ?? 2;
+  const backoffMs = opts.backoffMs ?? 1000;
+  const maxBackoffMs = opts.maxBackoffMs ?? 30_000;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const random = opts.random ?? Math.random;
+
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!(err instanceof RateLimitError) || attempt >= retries) throw err;
+      const base = err.retryAfterMs ?? Math.min(maxBackoffMs, backoffMs * 2 ** attempt);
+      const jitter = base * 0.2 * random();   // 0–20% extra, never below the requested wait
+      await sleep(Math.round(base + jitter));
+      attempt++;
+    }
+  }
+}

--- a/companion/src/enrichment/rdap.ts
+++ b/companion/src/enrichment/rdap.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind } from "./provider.js";
 
 // WHOIS-equivalent registration lookup for an IP IOC, over RDAP (the modern, JSON-over-HTTPS
 // replacement for port-43 WHOIS). Resolves which network block owns the address: net name,
@@ -94,7 +94,7 @@ export class RdapProvider implements EnrichmentProvider {
       signal: AbortSignal.timeout(this.opts.timeoutMs ?? 20_000),
     });
     if (res.status === 404) return null;                          // no allocation found for this IP
-    if (res.status === 429) throw new Error("RDAP/WHOIS rate limit");
+    if (res.status === 429) throw new RateLimitError("RDAP/WHOIS rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`RDAP/WHOIS HTTP ${res.status}`);
 
     const json = (await res.json()) as RdapIpResponse;

--- a/companion/src/enrichment/rockyraccoon.ts
+++ b/companion/src/enrichment/rockyraccoon.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind, Verdict } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind, type Verdict } from "./provider.js";
 
 export interface RockyRaccoonOptions {
   apiKey: string;    // et_live_… (Authorization: Bearer)
@@ -61,7 +61,7 @@ export class RockyRaccoonProvider implements EnrichmentProvider {
       return { source: this.name, verdict: "unknown", score: "not seen in ~346M events (uncommon process)" };
     }
     if (res.status === 401 || res.status === 403) throw new Error("RockyRaccoon auth/tier error (check DFIR_ROCKYRACCOON_KEY / plan)");
-    if (res.status === 429) throw new Error("RockyRaccoon rate/quota limit");
+    if (res.status === 429) throw new RateLimitError("RockyRaccoon rate/quota limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`RockyRaccoon HTTP ${res.status}`);
 
     const p = (await res.json()) as ProcessProfile;
@@ -100,7 +100,7 @@ export class RockyRaccoonProvider implements EnrichmentProvider {
     const res = await this.fetchFn(url, { headers: this.headers(), signal: AbortSignal.timeout(this.opts.timeoutMs ?? 20_000) });
     if (res.status === 404) return { observed: false, note: `${p} → ${c} not seen; child '${c}' is unknown to the dataset` };
     if (res.status === 401 || res.status === 403) throw new Error("RockyRaccoon auth/tier error");
-    if (res.status === 429) throw new Error("RockyRaccoon rate/quota limit");
+    if (res.status === 429) throw new RateLimitError("RockyRaccoon rate/quota limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`RockyRaccoon HTTP ${res.status}`);
 
     const j = (await res.json()) as { observed?: boolean; percentage?: number; common_parents?: Array<{ parent?: string; percentage?: number }> };

--- a/companion/src/enrichment/shodan.ts
+++ b/companion/src/enrichment/shodan.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind } from "./provider.js";
 
 // Shodan host lookup for an IP IOC — "what is hosted on this address?". Surfaces the web
 // properties / services Shodan has seen: hostnames + domains, open ports, the running
@@ -54,7 +54,7 @@ export class ShodanProvider implements EnrichmentProvider {
     });
     if (res.status === 404) return null;                          // "No information available for that IP"
     if (res.status === 401 || res.status === 403) throw new Error("Shodan auth failed (check DFIR_SHODAN_KEY)");
-    if (res.status === 429) throw new Error("Shodan rate limit");
+    if (res.status === 429) throw new RateLimitError("Shodan rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`Shodan HTTP ${res.status}`);
 
     const h = (await res.json()) as ShodanHost;

--- a/companion/src/enrichment/virustotal.ts
+++ b/companion/src/enrichment/virustotal.ts
@@ -1,4 +1,4 @@
-import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind, Verdict } from "./provider.js";
+import { RateLimitError, parseRetryAfterMs, type EnrichmentProvider, type EnrichmentResult, type FetchFn, type IocKind, type Verdict } from "./provider.js";
 
 export interface VirusTotalOptions {
   apiKey: string;
@@ -50,7 +50,7 @@ export class VirusTotalProvider implements EnrichmentProvider {
     });
     if (res.status === 404) return null;                       // unknown to VT
     if (res.status === 401 || res.status === 403) throw new Error("VirusTotal auth failed (check DFIR_VT_KEY)");
-    if (res.status === 429) throw new Error("VirusTotal rate limit (free tier is ~4/min)");
+    if (res.status === 429) throw new RateLimitError("VirusTotal rate limit (free tier is ~4/min)", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`VirusTotal HTTP ${res.status}`);
 
     const json = (await res.json()) as { data?: { id?: string; attributes?: Record<string, unknown> } };

--- a/companion/src/routes/threatIntel.ts
+++ b/companion/src/routes/threatIntel.ts
@@ -281,6 +281,8 @@ export function registerThreatIntelRoutes(app: Express, ctx: RouteContext): void
           providers: enabledProviders,
           delayMs: options.enrichDelayMs,
           perProviderDelayMs: options.enrichProviderDelayMs,
+          jitterMs: options.enrichJitterMs,
+          retry: { retries: options.enrichRetries, backoffMs: options.enrichRetryBackoffMs },
           maxIocs: options.enrichMaxIocs,
           force,
           health: ctx.enrichHealth(),

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -396,6 +396,9 @@ export interface AppOptions {
   enrichmentProviders?: EnrichmentProvider[];
   enrichDelayMs?: number;
   enrichProviderDelayMs?: Record<string, number>;  // per-provider throttle overrides (keyed by provider.name)
+  enrichJitterMs?: number;          // ± random jitter added to the inter-call wait (#78)
+  enrichRetries?: number;           // retry attempts for a provider call that hits a 429 (#78)
+  enrichRetryBackoffMs?: number;    // base backoff before the first 429 retry, doubles each attempt (#78)
   enrichMaxIocs?: number;
   // Customer Exposure is separate from IOC enrichment: only customer-owned domains/emails are
   // sent to breach-data providers. IOC domains are never queried here.
@@ -2125,6 +2128,8 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
         providers,
         delayMs: options.enrichDelayMs,
         perProviderDelayMs: options.enrichProviderDelayMs,
+        jitterMs: options.enrichJitterMs,
+        retry: { retries: options.enrichRetries, backoffMs: options.enrichRetryBackoffMs },
         maxIocs: options.enrichMaxIocs,
         force,
         signal: job?.signal,    // #225: analyst cancel — stop between IOCs (partial enrichment is additive/safe)
@@ -2160,6 +2165,8 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
         const { events, summary: cs } = await validateProcessChains(merged.forensicTimeline, {
           check: (p, c) => rocky.checkParentChild(p, c),
           delayMs: options.enrichProviderDelayMs?.["RockyRaccoon"] ?? options.enrichDelayMs,
+          jitterMs: options.enrichJitterMs,
+          retry: { retries: options.enrichRetries, backoffMs: options.enrichRetryBackoffMs },
           maxChecks: options.enrichMaxIocs,
           force,
         });
@@ -3127,6 +3134,11 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     enrichmentProviders: buildEnrichmentProviders(),
     enrichDelayMs: Number(process.env.DFIR_ENRICH_DELAY_MS) || undefined,
     enrichProviderDelayMs: buildEnrichProviderDelayMap(),
+    // #78: ± jitter on the inter-call wait, and bounded retry-with-backoff on a 429 (honouring
+    // Retry-After) instead of a single rate-limit hit aborting the lookup.
+    enrichJitterMs: Number(process.env.DFIR_ENRICH_JITTER_MS) || undefined,
+    enrichRetries: Number(process.env.DFIR_ENRICH_RETRIES) || undefined,
+    enrichRetryBackoffMs: Number(process.env.DFIR_ENRICH_RETRY_BACKOFF_MS) || undefined,
     enrichMaxIocs: Number(process.env.DFIR_ENRICH_MAX) || undefined,
     customerExposureProviders: buildCustomerExposureProviders(),
     customerExposureDelayMs: Number(process.env.DFIR_EXPOSURE_DELAY_MS) || undefined,

--- a/companion/tests/enrichment/chainValidate.test.ts
+++ b/companion/tests/enrichment/chainValidate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { validateProcessChains, hasChainWork } from "../../src/enrichment/chainValidate.js";
+import { RateLimitError } from "../../src/enrichment/provider.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
 import type { ParentChildResult } from "../../src/enrichment/rockyraccoon.js";
 
@@ -55,6 +56,33 @@ describe("validateProcessChains", () => {
     const many = [ev({ id: "1", parentName: "a", processName: "x" }), ev({ id: "2", parentName: "b", processName: "y" })];
     const capped = await validateProcessChains(many, { check, sleep: noSleep, now, maxChecks: 1 });
     expect(capped.summary.checked).toBe(1);
+  });
+
+  it("applies ± jitterMs on top of delayMs between checks", async () => {
+    const slept: number[] = [];
+    const check = async (): Promise<ParentChildResult> => ({ observed: true, note: "ok" });
+    const events = [
+      ev({ id: "a", parentName: "p1.exe", processName: "c1.exe" }),
+      ev({ id: "b", parentName: "p2.exe", processName: "c2.exe" }),
+    ];
+    await validateProcessChains(events, {
+      check, now, sleep: async (ms) => { slept.push(ms); }, delayMs: 1000, jitterMs: 200, random: () => 1,
+    });
+    expect(slept).toEqual([1200]);   // random()=1 → +jitterMs edge
+  });
+
+  it("retries a check() that throws RateLimitError instead of counting it as an immediate error", async () => {
+    let attempts = 0;
+    const check = async (): Promise<ParentChildResult> => {
+      attempts++;
+      if (attempts < 3) throw new RateLimitError("rate limited");
+      return { observed: true, note: "ok" };
+    };
+    const events = [ev({ id: "a", parentName: "p.exe", processName: "c.exe" })];
+    const { summary } = await validateProcessChains(events, { check, now, sleep: noSleep, retry: { retries: 3, backoffMs: 1 } });
+    expect(attempts).toBe(3);
+    expect(summary.checked).toBe(1);
+    expect(summary.errors).toBe(0);
   });
 });
 

--- a/companion/tests/enrichment/enrichService.test.ts
+++ b/companion/tests/enrichment/enrichService.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { enrichIocs, hasEnrichableWork, type EnrichLookupEvent } from "../../src/enrichment/enrichService.js";
 import { ProviderHealthCache } from "../../src/enrichment/providerHealth.js";
-import type { EnrichmentProvider, EnrichmentResult, IocKind } from "../../src/enrichment/provider.js";
+import { RateLimitError, type EnrichmentProvider, type EnrichmentResult, type IocKind } from "../../src/enrichment/provider.js";
 import type { IOC } from "../../src/analysis/stateTypes.js";
 
 function ioc(over: Partial<IOC> & { value: string; type: IOC["type"] }): IOC {
@@ -321,6 +321,30 @@ describe("enrichIocs", () => {
       expect(slept).toEqual([999]);   // Unknown not in map → falls back to global 999
     });
 
+    it("applies ± jitterMs on top of the delay when configured", async () => {
+      const slept: number[] = [];
+      const calls: string[] = [];
+      const vt = fakeProvider("VirusTotal", ["hash"], { source: "VirusTotal", verdict: "harmless" }, calls);
+      // random() → 1 picks the +jitterMs edge: 1500 + (1*2-1)*300 = 1800
+      await enrichIocs(
+        [ioc({ value: "h1", type: "hash" }), ioc({ value: "h2", type: "hash" })],
+        { providers: [vt], now, monotonic: () => 0, sleep: async (ms) => { slept.push(ms); }, delayMs: 1500, jitterMs: 300, random: () => 1 },
+      );
+      expect(slept).toEqual([1800]);
+    });
+
+    it("defaults jitterMs to 0 (no jitter) when not configured", async () => {
+      const slept: number[] = [];
+      const calls: string[] = [];
+      const vt = fakeProvider("VirusTotal", ["hash"], { source: "VirusTotal", verdict: "harmless" }, calls);
+      await enrichIocs(
+        [ioc({ value: "h1", type: "hash" }), ioc({ value: "h2", type: "hash" })],
+        // random() would throw if ever called with jitterMs unset — proves jitter math is skipped
+        { providers: [vt], now, monotonic: () => 0, sleep: async (ms) => { slept.push(ms); }, delayMs: 1500, random: () => { throw new Error("should not be called"); } },
+      );
+      expect(slept).toEqual([1500]);
+    });
+
     it("skips the sleep when elapsed time already exceeds the provider delay", async () => {
       const slept: number[] = [];
       let t = 0;
@@ -334,6 +358,53 @@ describe("enrichIocs", () => {
         { providers: [vtFast], now, monotonic: () => t, sleep: async (ms) => { slept.push(ms); }, perProviderDelayMs: { VirusTotal: 500 } },
       );
       expect(slept).toHaveLength(0);   // 600ms elapsed > 500ms delay → no sleep needed
+    });
+  });
+
+  describe("429 retry", () => {
+    it("retries a provider that throws RateLimitError instead of counting it as an immediate error", async () => {
+      let attempts = 0;
+      const flaky: EnrichmentProvider = {
+        name: "Flaky", scope: "external", supports: () => true,
+        lookup: async () => {
+          attempts++;
+          if (attempts < 3) throw new RateLimitError("rate limited");
+          return { source: "Flaky", verdict: "malicious" };
+        },
+      };
+      const { iocs: out, summary } = await enrichIocs([ioc({ value: "h1", type: "hash" })], {
+        providers: [flaky], sleep: noSleep, now, retry: { retries: 3, backoffMs: 1 },
+      });
+      expect(attempts).toBe(3);
+      expect(summary.errors).toBe(0);
+      expect(out[0].enrichments!.map((e) => e.source)).toEqual(["Flaky"]);
+    });
+
+    it("counts it as an error once the retry budget is exhausted", async () => {
+      let attempts = 0;
+      const alwaysLimited: EnrichmentProvider = {
+        name: "Limited", scope: "external", supports: () => true,
+        lookup: async () => { attempts++; throw new RateLimitError("rate limited"); },
+      };
+      const { iocs: out, summary } = await enrichIocs([ioc({ value: "h1", type: "hash" })], {
+        providers: [alwaysLimited], sleep: noSleep, now, retry: { retries: 1, backoffMs: 1 },
+      });
+      expect(attempts).toBe(2);          // initial + 1 retry
+      expect(summary.errors).toBe(1);
+      expect(out[0].enrichments).toBeUndefined();
+    });
+
+    it("honours Retry-After (via the sleep it drives) before retrying", async () => {
+      let attempts = 0;
+      const slept: number[] = [];
+      const limited: EnrichmentProvider = {
+        name: "Limited", scope: "external", supports: () => true,
+        lookup: async () => { attempts++; if (attempts === 1) throw new RateLimitError("rate limited", 7000); return { source: "Limited", verdict: "harmless" }; },
+      };
+      await enrichIocs([ioc({ value: "h1", type: "hash" })], {
+        providers: [limited], now, sleep: async (ms) => { slept.push(ms); }, random: () => 0,
+      });
+      expect(slept).toEqual([7000]);
     });
   });
 });

--- a/companion/tests/enrichment/infraProviders.test.ts
+++ b/companion/tests/enrichment/infraProviders.test.ts
@@ -177,6 +177,14 @@ describe("ShodanProvider (host lookup)", () => {
     await expect(rl.lookup("ip", "1.2.3.4")).rejects.toThrow(/rate limit/i);
   });
 
+  it("throws a RateLimitError carrying the parsed Retry-After on 429 (#78)", async () => {
+    const rl = new ShodanProvider({
+      apiKey: "k",
+      fetchFn: vi.fn(async () => new Response("", { status: 429, headers: { "retry-after": "5" } })),
+    });
+    await expect(rl.lookup("ip", "1.2.3.4")).rejects.toMatchObject({ name: "RateLimitError", retryAfterMs: 5000 });
+  });
+
   it("only supports IP IOCs", async () => {
     const sh = new ShodanProvider({ apiKey: "k", fetchFn: vi.fn(async () => jsonResponse({})) });
     expect(sh.supports("ip")).toBe(true);

--- a/companion/tests/enrichment/provider.test.ts
+++ b/companion/tests/enrichment/provider.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { RateLimitError, parseRetryAfterMs, withRateLimitRetry } from "../../src/enrichment/provider.js";
+
+describe("parseRetryAfterMs", () => {
+  it("returns undefined for a missing header", () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs("")).toBeUndefined();
+  });
+
+  it("parses a whole-number-of-seconds header to ms", () => {
+    expect(parseRetryAfterMs("30")).toBe(30_000);
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+
+  it("parses an HTTP-date header relative to the given clock", () => {
+    const now = Date.parse("2026-01-01T00:00:00Z");
+    expect(parseRetryAfterMs("Thu, 01 Jan 2026 00:00:05 GMT", now)).toBe(5000);
+  });
+
+  it("never returns a negative wait (a past date clamps to 0)", () => {
+    const now = Date.parse("2026-01-01T00:00:10Z");
+    expect(parseRetryAfterMs("Thu, 01 Jan 2026 00:00:00 GMT", now)).toBe(0);
+  });
+
+  it("returns undefined for garbage it can't parse as seconds or a date", () => {
+    expect(parseRetryAfterMs("not-a-value")).toBeUndefined();
+  });
+});
+
+describe("withRateLimitRetry", () => {
+  const noRandom = () => 0;   // deterministic: no extra jitter on top of the computed wait
+
+  it("returns the result immediately when fn succeeds", async () => {
+    const r = await withRateLimitRetry(async () => "ok", { sleep: async () => {}, random: noRandom });
+    expect(r).toBe("ok");
+  });
+
+  it("does not retry a plain error (only RateLimitError triggers a retry)", async () => {
+    let calls = 0;
+    await expect(withRateLimitRetry(async () => { calls++; throw new Error("boom"); }, { sleep: async () => {}, random: noRandom }))
+      .rejects.toThrow("boom");
+    expect(calls).toBe(1);
+  });
+
+  it("retries a RateLimitError up to the configured limit, then throws", async () => {
+    let calls = 0;
+    const slept: number[] = [];
+    await expect(withRateLimitRetry(
+      async () => { calls++; throw new RateLimitError("rate limited"); },
+      { retries: 2, backoffMs: 100, sleep: async (ms) => { slept.push(ms); }, random: noRandom },
+    )).rejects.toThrow(RateLimitError);
+    expect(calls).toBe(3);              // initial attempt + 2 retries
+    expect(slept).toEqual([100, 200]);  // exponential backoff, doubling each attempt
+  });
+
+  it("succeeds on a later attempt after retrying", async () => {
+    let calls = 0;
+    const r = await withRateLimitRetry(async () => {
+      calls++;
+      if (calls < 3) throw new RateLimitError("rate limited");
+      return "recovered";
+    }, { retries: 5, backoffMs: 10, sleep: async () => {}, random: noRandom });
+    expect(r).toBe("recovered");
+    expect(calls).toBe(3);
+  });
+
+  it("honours the server's Retry-After over the computed exponential backoff", async () => {
+    const slept: number[] = [];
+    await expect(withRateLimitRetry(
+      async () => { throw new RateLimitError("rate limited", 5000); },
+      { retries: 1, backoffMs: 100, sleep: async (ms) => { slept.push(ms); }, random: noRandom },
+    )).rejects.toThrow(RateLimitError);
+    expect(slept).toEqual([5000]);   // 5s from Retry-After, not the 100ms backoff schedule
+  });
+
+  it("adds jitter on top of the wait without ever waiting less than requested", async () => {
+    const slept: number[] = [];
+    await expect(withRateLimitRetry(
+      async () => { throw new RateLimitError("rate limited", 1000); },
+      { retries: 1, sleep: async (ms) => { slept.push(ms); }, random: () => 0.5 },
+    )).rejects.toThrow(RateLimitError);
+    expect(slept[0]).toBeGreaterThanOrEqual(1000);
+    expect(slept[0]).toBeLessThanOrEqual(1200);   // up to 20% jitter
+  });
+
+  it("caps exponential backoff at maxBackoffMs", async () => {
+    const slept: number[] = [];
+    await expect(withRateLimitRetry(
+      async () => { throw new RateLimitError("rate limited"); },
+      { retries: 3, backoffMs: 1000, maxBackoffMs: 1500, sleep: async (ms) => { slept.push(ms); }, random: noRandom },
+    )).rejects.toThrow(RateLimitError);
+    expect(slept).toEqual([1000, 1500, 1500]);   // 1000·2^0, capped at 1500 from attempt 1 onward
+  });
+});

--- a/companion/tests/enrichment/providers.test.ts
+++ b/companion/tests/enrichment/providers.test.ts
@@ -35,6 +35,14 @@ describe("VirusTotalProvider", () => {
     await expect(rl.lookup("hash", "x")).rejects.toThrow(/rate limit/i);
   });
 
+  it("throws a RateLimitError carrying the parsed Retry-After on 429 (#78)", async () => {
+    const rl = new VirusTotalProvider({
+      apiKey: "k",
+      fetchFn: vi.fn(async () => new Response("", { status: 429, headers: { "retry-after": "20" } })),
+    });
+    await expect(rl.lookup("hash", "x")).rejects.toMatchObject({ name: "RateLimitError", retryAfterMs: 20_000 });
+  });
+
   it("addresses a URL by unpadded base64url", async () => {
     const fetchFn = vi.fn(async () => jsonResponse({ data: { id: "u", attributes: { last_analysis_stats: { malicious: 0, harmless: 80 } } } }));
     const vt = new VirusTotalProvider({ apiKey: "k", fetchFn });


### PR DESCRIPTION
Fixes #78.

## Summary
- Add configurable ± jitter to the enrichment inter-call delay (`enrichService.ts`, `chainValidate.ts`).
- Add a shared `withRateLimitRetry()` helper (`provider.ts`): providers now throw a `RateLimitError` on 429 carrying the parsed `Retry-After`; a single 429 triggers bounded backoff+retry instead of aborting the lookup.
- `sleep`/`random`/backoff stay injectable for deterministic tests.
- Wired through `server.ts` via `DFIR_ENRICH_JITTER_MS`, `DFIR_ENRICH_RETRIES`, `DFIR_ENRICH_RETRY_BACKOFF_MS`.

## Test plan
- [x] New/updated unit tests for jitter, retry, and Retry-After parsing
- [ ] `npm test` (not run in this environment — please verify before merge)

Generated with [Claude Code](https://claude.ai/code)