### PR TITLE
feat: Claude Code CLI as an LLM provider (subscription auth, no API key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ All importers are **deterministic (no AI call)**, read the artifact's own timest
 ### AI analysis
 - **Guided AI setup** — the Setup wizard's first step picks provider → model (cheap/strong suggestions) → key → optional base URL, then runs a live connectivity test before you leave
 - **Two-phase** — cheap per-window vision (extraction) + strong text-only synthesis (findings/IOCs/MITRE/attacker path)
-- **Providers** — OpenAI, OpenRouter, Ollama, LiteLLM, Gemini; optional two-tier (cheap extract + strong synth) with context budgeting
+- **Providers** — OpenAI, OpenRouter, Ollama, LiteLLM, Gemini, Anthropic, Claude Code; optional two-tier (cheap extract + strong synth) with context budgeting
 - **EDR/SIEM consoles as evidence** — detections extracted; analyst navigation filtered (real detections never dropped)
 - **Severity-aware findings** — Critical/High rows become findings; deterministic auto-creation for missed high-severity events
 - **Confidence scoring + reasoning** — every finding carries a 0–100% confidence (weighing evidence strength, tool corroboration, and model certainty) plus a one-line reason; a persistent per-case min-confidence filter (survives reload) hides low-confidence findings on demand
@@ -572,9 +572,10 @@ All companion behavior is configured via env vars (`companion/.env` or shell). C
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `DFIR_VISION_PROVIDER` | — | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` \| `anthropic`; unset = capture-only |
+| `DFIR_VISION_PROVIDER` | — | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` \| `anthropic` \| `claude-code`; unset = capture-only |
 | `DFIR_VISION_MODEL` | — | Model id (e.g. `gpt-4o-mini`, `gemini-2.5-flash`); **must support vision** for screenshot extraction |
-| `DFIR_VISION_KEY` | — | Provider API key; leave blank for an auth-less local proxy |
+| `DFIR_VISION_KEY` | — | Provider API key; leave blank for an auth-less local proxy or for `claude-code` (uses your logged-in `claude` CLI subscription instead) |
+| `DFIR_AI_CLAUDE_CODE_BIN` | `claude` on PATH | `claude-code` only: absolute path to the `claude` binary if it isn't on PATH |
 | `DFIR_VISION_BASE_URL` | provider default | Override base URL — for a local LiteLLM proxy or any OpenAI-compatible endpoint |
 | `DFIR_AI_TIMEOUT_MS` | `180000` | Per-request timeout (ms); raise for strong models on large timelines |
 | `DFIR_AI_MAX_TOKENS` | `16000` | Max completion tokens; too low truncates synthesis, prevents OpenRouter 402 on low balance |
@@ -588,6 +589,12 @@ All companion behavior is configured via env vars (`companion/.env` or shell). C
 | `DFIR_ANONYMIZE` | `on` | Tokenize victim IPs/hosts/users/paths before AI calls: `on` \| `off` |
 
 > The screenshot/vision vars above (`DFIR_VISION_PROVIDER` / `DFIR_VISION_MODEL` / `DFIR_VISION_KEY` / `DFIR_VISION_BASE_URL` / `DFIR_VISION_IMAGE_DETAIL`) were renamed from the `DFIR_AI_*` prefix; the legacy `DFIR_AI_PROVIDER` / `DFIR_AI_MODEL` / `DFIR_AI_KEY` / `DFIR_AI_BASE_URL` / `DFIR_AI_IMAGE_DETAIL` names still work as a deprecated fallback (the new name wins when both are set).
+
+**Claude Code** — uses your logged-in Claude subscription via the `claude` CLI, no API key; handles
+vision + text (screenshot extraction *and* synthesis). Requires the `claude` CLI installed and
+`claude auth login` completed on the host. Consumes your subscription rate limits (heavy extraction
+can exhaust them); reported cost is API-equivalent, not out-of-pocket. Settings → AI shows a
+connection status (not installed / not connected / connected) with a one-click Connect action.
 
 ### AI — text model (two-tier, optional)
 

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -138,6 +138,16 @@ DFIR_VISION_KEY=sk-replace-me
 # only to change the host/port (e.g. a proxy on another machine). For vision extraction,
 # point DFIR_VISION_MODEL at a multimodal model; text-only models still handle CSV/log/synthesis.
 # DFIR_VISION_BASE_URL=http://localhost:4000/v1
+# --- Claude Code CLI (drives your logged-in `claude` subscription — no API key) ------
+# Run `claude auth login` once on this machine, then point here. One provider handles both
+# screenshot extraction and text synthesis via the same CLI call.
+#   DFIR_VISION_PROVIDER=claude-code
+#   DFIR_VISION_MODEL=sonnet            # alias (haiku/sonnet/opus) or a full model id
+#   DFIR_VISION_KEY=                    # unused — auth comes from the CLI's own login, leave blank
+#   DFIR_AI_CLAUDE_CODE_BIN=            # only if `claude` isn't on PATH (absolute path to the binary)
+# Dashboard: Settings → AI shows a connection status card (not-installed / not-connected /
+# connected) with Re-check + one-click Connect. Subscription rate limits apply; cost is
+# reported as if billed per-token even though nothing is actually charged per call.
 
 # Per-request timeout in ms (default 180000). Strong models over a large timeline
 # can take >60s — raise this if you see "request timed out" during synthesis.
@@ -260,6 +270,11 @@ DFIR_VISION_IMAGE_DETAIL=high
 #     Text (CSV/log/synthesis):           claude-sonnet-4-6          — best speed/reasoning balance; 200K context
 #                                         claude-opus-4-8            — deepest reasoning for complex cases
 #
+#   Claude Code CLI  (DFIR_VISION_PROVIDER=claude-code — no API key, uses your `claude` login)
+#     Screenshots (vision, high-volume):  haiku    — cheapest alias with vision
+#     Text (CSV/log/synthesis):           sonnet   — best speed/reasoning balance
+#                                         opus     — deepest reasoning for complex cases
+#
 # Example — OpenAI two-tier setup:
 # DFIR_VISION_MODEL=gpt-4o-mini        # screenshots (set above)
 # DFIR_AI_SYNTH_MODEL=gpt-4o           # CSV/log/synthesis (set here)
@@ -279,6 +294,12 @@ DFIR_VISION_IMAGE_DETAIL=high
 # DFIR_AI_SYNTH_MODEL=google/gemini-2.5-pro
 # DFIR_AI_SYNTH_KEY=
 # DFIR_AI_SYNTH_BASE_URL=         # synthesis base URL override (falls back to DFIR_VISION_BASE_URL)
+#
+# Example — Claude Code CLI two-tier setup (no API key, uses your `claude` login):
+# DFIR_VISION_PROVIDER=claude-code
+# DFIR_VISION_MODEL=haiku              # screenshots — cheapest alias with vision (set above)
+# DFIR_AI_SYNTH_PROVIDER=claude-code
+# DFIR_AI_SYNTH_MODEL=sonnet           # CSV/log/synthesis (set here); "opus" for deepest reasoning
 
 # --- Velociraptor hunt model (#70) ---------------------------------------------
 # A DEDICATED model used ONLY to generate Velociraptor VQL hunts (the "✨ Suggest

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -149,9 +149,14 @@ DFIR_VISION_KEY=sk-replace-me
 # connected) with Re-check + one-click Connect. Subscription rate limits apply; cost is
 # reported as if billed per-token even though nothing is actually charged per call.
 
-# Per-request timeout in ms (default 180000). Strong models over a large timeline
-# can take >60s — raise this if you see "request timed out" during synthesis.
-DFIR_AI_TIMEOUT_MS=180000
+# Per-request timeout in ms (default 800000 = ~13.3 min). Strong models over a large timeline
+# can take several minutes — raise this if you see "request timed out" during synthesis. This is
+# a PER-CALL budget, not a whole-operation one: a synthesis run that triggers the automatic
+# "second-look" re-synthesis sweep (investigation-guidance #11, one bounded extra AI call when new
+# events get promoted from the super-timeline) makes two sequential calls, each getting its own
+# fresh timeout — so raise this to cover your SLOWEST SINGLE call, not their combined wall-clock.
+# Measured live with claude-code on a mid-size case: a 300-400s single synthesis call is typical.
+DFIR_AI_TIMEOUT_MS=800000
 
 # Max completion tokens per request (default 16000). Bounds cost AND stops OpenRouter
 # from reserving the model's full max output in its per-request credit check — the usual
@@ -271,9 +276,12 @@ DFIR_VISION_IMAGE_DETAIL=high
 #                                         claude-opus-4-8            — deepest reasoning for complex cases
 #
 #   Claude Code CLI  (DFIR_VISION_PROVIDER=claude-code — no API key, uses your `claude` login)
-#     Screenshots (vision, high-volume):  haiku    — cheapest alias with vision
-#     Text (CSV/log/synthesis):           sonnet   — best speed/reasoning balance
-#                                         opus     — deepest reasoning for complex cases
+#     Screenshots (vision, high-volume):  haiku            — cheapest alias with vision
+#     Text (CSV/log/synthesis):           claude-sonnet-5  — best speed/reasoning balance (an alias
+#                                                             like "sonnet" also works — the CLI resolves
+#                                                             it — a concrete id just pins the exact
+#                                                             version instead of "whatever sonnet means
+#                                                             on this machine's CLI build today")
 #
 # Example — OpenAI two-tier setup:
 # DFIR_VISION_MODEL=gpt-4o-mini        # screenshots (set above)
@@ -297,9 +305,9 @@ DFIR_VISION_IMAGE_DETAIL=high
 #
 # Example — Claude Code CLI two-tier setup (no API key, uses your `claude` login):
 # DFIR_VISION_PROVIDER=claude-code
-# DFIR_VISION_MODEL=haiku              # screenshots — cheapest alias with vision (set above)
+# DFIR_VISION_MODEL=haiku                  # screenshots — cheapest alias with vision (set above)
 # DFIR_AI_SYNTH_PROVIDER=claude-code
-# DFIR_AI_SYNTH_MODEL=sonnet           # CSV/log/synthesis (set here); "opus" for deepest reasoning
+# DFIR_AI_SYNTH_MODEL=claude-sonnet-5      # CSV/log/synthesis (set here); pins the exact version — "opus"/"sonnet"/"haiku" aliases also work
 
 # --- Velociraptor hunt model (#70) ---------------------------------------------
 # A DEDICATED model used ONLY to generate Velociraptor VQL hunts (the "✨ Suggest

--- a/companion/README.md
+++ b/companion/README.md
@@ -58,9 +58,10 @@ http://127.0.0.1:4773/dashboard. On startup it logs the resolved cases root, e.g
 | `DFIR_LOG_LEVEL` | `debug`/`info`/`warn`/`error` (default `info`); live toggle via Settings |
 | `DFIR_LOG_DIR` | Global session log folder (beside cases root) |
 | **AI — extraction** | — |
-| `DFIR_VISION_PROVIDER` | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` (unset = capture-only) |
+| `DFIR_VISION_PROVIDER` | `openai` \| `openrouter` \| `ollama` \| `litellm` \| `gemini` \| `anthropic` \| `claude-code` (unset = capture-only) |
 | `DFIR_VISION_MODEL` | Model id (must support vision for screenshot extraction) |
-| `DFIR_VISION_KEY` | Provider API key (blank for auth-less local proxy) |
+| `DFIR_VISION_KEY` | Provider API key (blank for auth-less local proxy, or for `claude-code` — uses your logged-in `claude` CLI subscription) |
+| `DFIR_AI_CLAUDE_CODE_BIN` | `claude-code` only: path to the `claude` binary if it isn't on PATH |
 | `DFIR_VISION_BASE_URL` | Override API base URL (for LiteLLM or OpenAI-compatible endpoints) |
 | `DFIR_VISION_IMAGE_DETAIL` | `high` \| `low` \| `auto` (default `high` for OCR) |
 | **AI — text model (optional two-tier)** | — |
@@ -93,6 +94,15 @@ can skip LiteLLM entirely — set `DFIR_VISION_PROVIDER=ollama`, `DFIR_VISION_BA
 and `DFIR_VISION_MODEL` to a pulled model (a **vision** model such as `llama3.2-vision` for screenshot
 extraction). Leave `DFIR_VISION_KEY` blank — Ollama ignores it. *Without* `DFIR_VISION_BASE_URL` the `ollama`
 provider targets hosted Ollama Cloud (`https://ollama.com/v1`), which does need a key.
+
+**Claude Code** — uses your logged-in Claude subscription via the `claude` CLI, no API key; handles
+vision + text (screenshot extraction *and* synthesis). Requires the `claude` CLI installed and
+`claude auth login` completed on the host. Set `DFIR_AI_PROVIDER=claude-code` and `DFIR_AI_MODEL`
+to `haiku` / `sonnet` / `opus` / a full model id; optional `DFIR_AI_CLAUDE_CODE_BIN` points at a
+non-PATH `claude` binary. Caveats: consumes your subscription rate limits (heavy extraction can
+exhaust them); the reported cost is API-equivalent, not out-of-pocket; higher fixed per-call
+overhead than the raw API. Settings → AI (and the setup wizard) show a live connection status
+(not installed / not connected / connected) with a one-click Connect action.
 
 Self-hosted enrichment TLS: if your **MISP**, **YETI**, or **OpenCTI** instance presents an internal-CA
 or self-signed cert, set `DFIR_MISP_CA` / `DFIR_YETI_CA` / `DFIR_OPENCTI_CA` to a PEM CA-bundle path to trust a

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -1767,8 +1767,12 @@ export class AnalysisPipeline {
     const cache =
       (u.cacheReadTokens ? ` cacheRead=${u.cacheReadTokens}` : "") +
       (u.cacheCreationTokens ? ` cacheWrite=${u.cacheCreationTokens}` : "");
+    // resolvedModel: the concrete model id actually served, when the provider reports one — e.g.
+    // claude-code's --model alias ("sonnet") resolves to "claude-sonnet-4-6" server-side; surfacing
+    // it here means DFIR_AI_SYNTH_MODEL=sonnet doesn't leave the exact version silently ambiguous.
+    const resolved = u.resolvedModel && u.resolvedModel !== provider.model ? ` resolvedModel=${u.resolvedModel}` : "";
     this.log.debug(
-      `AI call [${label}] done provider=${provider.name} in=${u.inputTokens ?? "?"} out=${u.outputTokens ?? "?"}${cache}`,
+      `AI call [${label}] done provider=${provider.name} model=${provider.model}${resolved} in=${u.inputTokens ?? "?"} out=${u.outputTokens ?? "?"}${cache}`,
       { caseId },
     );
   }

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -4,7 +4,7 @@ import { createInterface } from "node:readline";
 import { join as joinPath } from "node:path";
 import { createHash } from "node:crypto";
 import { z } from "zod";
-import type { AIProvider, AnalyzeImage, AnalyzeRequest, AnalyzeResult } from "../providers/provider.js";
+import { ProviderError, type AIProvider, type AnalyzeImage, type AnalyzeRequest, type AnalyzeResult, type ProviderErrorKind } from "../providers/provider.js";
 import { createConsoleLogger, normalizeLogLevel, type Logger } from "../logging/logger.js";
 import { createAnonymizer, deriveKnownEntities, type CustomEntity } from "./anonymize.js";
 import { toAnonPolicy, type AnonControlStore } from "./anonControl.js";
@@ -1540,13 +1540,29 @@ function mergePinnedQuestions(pinned: InvestigationQuestion[], current: Investig
   return [...byId.values()];
 }
 
-async function withRetry<T>(fn: () => Promise<T>, retries: number, backoffMs: number): Promise<T> {
+// Error kinds where the failure is inherent to the call (bad/expired creds, exhausted quota, a hung
+// process) rather than a transient blip — retrying just re-runs into the same wall, tripling the wait
+// before the analyst sees the same error.
+const NON_RETRYABLE_KINDS = new Set<ProviderErrorKind>(["auth", "rate_limit", "timeout"]);
+
+function isRetryableError(err: unknown): boolean {
+  return !(err instanceof ProviderError && NON_RETRYABLE_KINDS.has(err.kind));
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries: number,
+  backoffMs: number,
+  onError?: (err: unknown, attempt: number, willRetry: boolean) => void,
+): Promise<T> {
   let attempt = 0;
   for (;;) {
     try {
       return await fn();
     } catch (err) {
-      if (attempt >= retries) throw err;
+      const willRetry = attempt < retries && isRetryableError(err);
+      onError?.(err, attempt, willRetry);
+      if (!willRetry) throw err;
       await new Promise((r) => setTimeout(r, backoffMs * 2 ** attempt));
       attempt++;
     }
@@ -1583,6 +1599,23 @@ export class AnalysisPipeline {
   // SAME caseId — that nests onto the outer call's own unresolved promise and deadlocks.
   private withStateLock<T>(caseId: string, fn: () => Promise<T>): Promise<T> {
     return this.opts.stateLock ? this.opts.stateLock.runExclusive(caseId, fn) : fn();
+  }
+
+  // Wraps the module-level withRetry() with server-log visibility: every AI call site in this class
+  // routes through here instead of calling withRetry() directly. Previously a failed/retried AI call
+  // was silent everywhere except the dashboard's error badge and the case Activity Log — the server
+  // console/session log showed only the DEBUG "AI call [label] ..." line for each attempt's START,
+  // never why an attempt failed. Each failed attempt now logs a WARN with the case id, call label,
+  // provider error kind (when available), and whether it's retrying or giving up.
+  private withRetry<T>(caseId: string, label: string, fn: () => Promise<T>, retries: number, backoffMs: number): Promise<T> {
+    return withRetry(fn, retries, backoffMs, (err, attempt, willRetry) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      const kind = err instanceof ProviderError ? ` kind=${err.kind}` : "";
+      this.log.warn(
+        `AI call [${label}] attempt ${attempt + 1} failed${kind}: ${msg}${willRetry ? " — retrying" : " — giving up"}`,
+        { caseId },
+      );
+    });
   }
 
   private async getKevCatalog(): Promise<KevCatalog | undefined> {
@@ -1794,7 +1827,7 @@ export class AnalysisPipeline {
       const retries = this.opts.retries ?? 3;
       const backoffMs = this.opts.backoffMs ?? 500;
 
-      const delta = await withRetry(async () => {
+      const delta = await this.withRetry(caseId, "extract", async () => {
         const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getSystemPrompt(), userPrompt, images }, "extract");
         return stripAiExtractedFrom(deltaSchema.parse(parsed));
       }, retries, backoffMs);
@@ -1860,7 +1893,7 @@ export class AnalysisPipeline {
           `Read each row's OWN time column for event times — do not use the current time:\n\n${csvChunk}\n\n` +
           `Return the JSON delta.`;
 
-        const delta = await withRetry(async () => {
+        const delta = await this.withRetry(caseId, "csv", async () => {
           const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getCsvPrompt(), userPrompt, images: [], ...(opts.signal ? { signal: opts.signal } : {}) }, "csv");
           return stripAiExtractedFrom(deltaSchema.parse(parsed));
         }, retries, backoffMs);
@@ -1950,7 +1983,7 @@ export class AnalysisPipeline {
           `Emit an aggregated event ONLY for security-relevant patterns; skip routine noise:\n\n${patternText}\n\n` +
           `Return the JSON delta.`;
 
-        const delta = await withRetry(async () => {
+        const delta = await this.withRetry(caseId, "log", async () => {
           const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getLogPrompt(), userPrompt, images: [], ...(opts.signal ? { signal: opts.signal } : {}) }, "log");
           return stripAiExtractedFrom(deltaSchema.parse(parsed));
         }, retries, backoffMs);
@@ -3849,7 +3882,7 @@ export class AnalysisPipeline {
       `CURRENT QUESTIONS:\n${questionsText}\n\n` +
       `ANALYST QUESTION: ${question.trim()}\n\nAnswer it as JSON.`;
 
-    return withRetry(async () => {
+    return this.withRetry(caseId, "ask", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getAskPrompt(), userPrompt, images: [] }, "ask");
       return askSchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
@@ -3916,7 +3949,7 @@ export class AnalysisPipeline {
       + (contextEvents.map((e) => renderEv(e)).join("\n") || "(no context events)")
       + `\n\nExplain the focal event as JSON.`;
 
-    return withRetry(async () => {
+    return this.withRetry(caseId, "explain-event", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getExplainEventPrompt(), userPrompt, images: [] }, "explain-event");
       return explainEventSchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
@@ -4070,7 +4103,7 @@ export class AnalysisPipeline {
       `Propose the fleet-hunts as JSON.`;
 
     const limit = Number(process.env.DFIR_HUNT_SUGGEST_MAX) || HUNT_SUGGEST_MAX_DEFAULT;
-    return withRetry(async () => {
+    return this.withRetry(caseId, "suggest-hunts", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getHuntSuggestPrompt(), userPrompt, images: [] }, "suggest-hunts");
       const { suggestions } = huntSuggestionsResponseSchema.parse(parsed);
       return this.excludeDeployedHunts(sanitizeHuntSuggestions(suggestions, limit), outcomes);
@@ -4103,7 +4136,7 @@ export class AnalysisPipeline {
       `PIVOTABLE INDICATORS:\n${iocText}\n\n` +
       `Set every suggestion's mitreTechniques to ["${id}"]. Propose the hunt(s) as JSON.`;
     const limit = Number(process.env.DFIR_HUNT_SUGGEST_MAX) || HUNT_SUGGEST_MAX_DEFAULT;
-    return withRetry(async () => {
+    return this.withRetry(caseId, "hunt-technique", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getHuntSuggestPrompt(), userPrompt, images: [] }, "hunt-technique");
       const { suggestions } = huntSuggestionsResponseSchema.parse(parsed);
       return this.excludeDeployedHunts(sanitizeHuntSuggestions(suggestions, limit), outcomes);
@@ -4141,7 +4174,7 @@ export class AnalysisPipeline {
       `Propose the next Volatility 3 commands as JSON.`;
 
     const limit = Number(process.env.DFIR_MEMORY_NEXTSTEP_MAX) || MEMORY_NEXTSTEP_MAX_DEFAULT;
-    return withRetry(async () => {
+    return this.withRetry(caseId, "memory-next-steps", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getMemoryNextStepPrompt(), userPrompt, images: [] }, "memory-next-steps");
       const { suggestions } = memoryNextStepResponseSchema.parse(parsed);
       return sanitizeMemoryNextSteps(suggestions, limit);
@@ -4175,7 +4208,7 @@ export class AnalysisPipeline {
       `TARGET PLATFORMS (emit one query per key, grounded in the schema shown):\n${guide}\n\n` +
       `ANALYST REQUEST: ${request.trim()}\n\nTranslate it as JSON.`;
 
-    return withRetry(async () => {
+    return this.withRetry(caseId, "translate-query", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getQueryTranslatePrompt(), userPrompt, images: [] }, "translate-query");
       const { interpretation, queries } = queryTranslationResponseSchema.parse(parsed);
       return { interpretation: sanitizeInterpretation(interpretation), queries: sanitizeQueryTranslations(queries, targets) };
@@ -4194,7 +4227,7 @@ export class AnalysisPipeline {
       `MATCHABLE FIELDS (use ONLY these): ${MATCHABLE_FIELDS.join(", ")}\n\n` +
       `ANALYST REQUEST: ${description.trim()}\n\n` +
       `Return the rule as JSON (or a decline).`;
-    return withRetry(async () => {
+    return this.withRetry(caseId, "suggest-tagger-rule", async () => {
       const parsed = await this.analyzeRestored(
         caseId, loaded, provider,
         { systemPrompt: getTaggerRulePrompt(), userPrompt, images: [] },
@@ -4239,7 +4272,7 @@ export class AnalysisPipeline {
       `${gapsText}\n\n` +
       `Hypothesise the attacker activity for each gap as JSON.`;
 
-    const aiHypotheses = await withRetry(async () => {
+    const aiHypotheses = await this.withRetry(caseId, "hypothesize-gaps", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getGapHypothesisPrompt(), userPrompt, images: [] }, "hypothesize-gaps");
       const { hypotheses } = gapHypothesesResponseSchema.parse(parsed);
       return sanitizeGapHypotheses(hypotheses, validGapIds, focusGaps.length);
@@ -4308,7 +4341,7 @@ export class AnalysisPipeline {
       `Propose the per-task hunts as JSON.`;
 
     const limit = Number(process.env.DFIR_PBHUNT_SUGGEST_MAX) || PLAYBOOK_HUNT_SUGGEST_MAX_DEFAULT;
-    return withRetry(async () => {
+    return this.withRetry(caseId, "suggest-playbook-hunts", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getPlaybookHuntPrompt(), userPrompt, images: [] }, "suggest-playbook-hunts");
       const { suggestions } = playbookHuntResponseSchema.parse(parsed);
       return this.excludeDeployedHunts(sanitizePlaybookHuntSuggestions(suggestions, endpointsByTaskId, endpoints, limit), outcomes);
@@ -4348,7 +4381,7 @@ export class AnalysisPipeline {
       `Write the narrative timeline as JSON.`;
 
     const narrativeSchema = z.object({ narrativeTimeline: z.string().catch("") });
-    const result = await withRetry(async () => {
+    const result = await this.withRetry(caseId, "narrative", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: narrativePrompt, userPrompt, images: [] }, "narrative");
       return narrativeSchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
@@ -4390,7 +4423,7 @@ export class AnalysisPipeline {
       `FORENSIC TIMELINE (${scopedEvents.length} in-scope events):\n${timelineText}\n\n` +
       `Write the executive summary as JSON.`;
 
-    return withRetry(async () => {
+    return this.withRetry(caseId, "exec-summary", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getExecSummaryPrompt(), userPrompt, images: [] }, "exec-summary");
       return execSummarySchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
@@ -4434,7 +4467,7 @@ export class AnalysisPipeline {
       `\n\nWrite the starred events report as JSON.`;
 
     const mdSchema = z.object({ markdown: z.string().min(1) });
-    const result = await withRetry(async () => {
+    const result = await this.withRetry(caseId, "starred-report", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "starred-report");
       return mdSchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
@@ -4461,7 +4494,7 @@ export class AnalysisPipeline {
       `\n\nWrite the overview as JSON.`;
 
     const mdSchema = z.object({ markdown: z.string().min(1) });
-    const result = await withRetry(async () => {
+    const result = await this.withRetry(caseId, "view-summary", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "view-summary");
       return mdSchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
@@ -4527,7 +4560,7 @@ export class AnalysisPipeline {
       `RELEVANT D3FEND COUNTERMEASURES (the defensive technique/sensor for each — cite alongside the ATT&CK mitigation where it fits):\n${d3fendText}\n\n` +
       `Write the incident-specific remediation plan as JSON.`;
 
-    return withRetry(async () => {
+    return this.withRetry(caseId, "remediation", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getRemediationPrompt(), userPrompt, images: [] }, "remediation");
       return remediationPlanSchema.parse(parsed);
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
@@ -4587,7 +4620,7 @@ export class AnalysisPipeline {
       `Review each open hypothesis for supporting AND refuting evidence, and return the JSON.`;
 
     const knownHypotheses = new Map(open.map((h) => [h.id, h.title] as const));
-    return withRetry(async () => {
+    return this.withRetry(caseId, "hypothesis-review", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getHypothesisReviewPrompt(), userPrompt, images: [] }, "hypothesis-review");
       const result = hypothesisReviewSchema.parse(parsed);
       return { reviews: sanitizeHypothesisReviews(result.reviews, knownHypotheses, validEventIds) };
@@ -4612,7 +4645,7 @@ export class AnalysisPipeline {
       `ANCHOR ITEM (just marked false positive): [${anchorId}] ${anchorLabel}\n\n` +
       `OTHER ITEMS IN THIS CASE:\n${list}\n\n` +
       "Which of the other items are likely the same false-positive pattern?";
-    return withRetry(async () => {
+    return this.withRetry(caseId, "fp-similarity", async () => {
       const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getFpSimilarityPrompt(), userPrompt, images: [] }, "fp-similarity");
       const result = fpSimilaritySchema.parse(parsed);
       const valid = new Set(candidateIds);
@@ -4945,7 +4978,7 @@ export class AnalysisPipeline {
     // it to extended thinking; OpenRouter to its unified `reasoning`; other providers ignore it. Only
     // synthesis reasons step-by-step — extraction stays cheap.
     const synthThinkingTokens = resolveSynthThinkingBudget(opts, Number(process.env.DFIR_AI_SYNTH_THINKING_TOKENS) || 0);
-    const delta = await withRetry(async () => {
+    const delta = await this.withRetry(caseId, "synthesis", async () => {
       const parsed = await this.analyzeRestored(
         caseId,
         state,
@@ -5341,7 +5374,7 @@ export class AnalysisPipeline {
       const retries = this.opts.retries ?? 3;
       const backoffMs = this.opts.backoffMs ?? 500;
       try {
-        const parsed = await withRetry(async () => {
+        const parsed = await this.withRetry(caseId, "second-opinion-reconcile", async () => {
           const raw = await this.analyzeRestored(caseId, a, provider, { systemPrompt: getReconcilePrompt(), userPrompt, images: [] }, "second-opinion-reconcile");
           return reconcileResponseSchema.parse(raw);
         }, retries, backoffMs);

--- a/companion/src/providers/claudeCode.ts
+++ b/companion/src/providers/claudeCode.ts
@@ -25,6 +25,11 @@ interface ClaudeResultEvent {
     cache_creation_input_tokens?: number;
     cache_read_input_tokens?: number;
   };
+  // Keyed by the CONCRETE model id actually served (e.g. "claude-sonnet-4-6") — present even when
+  // --model was given as an alias ("sonnet"/"haiku"/"opus"), which the CLI resolves before billing.
+  // Confirmed live: a single-key object in the normal case; more than one key would mean the CLI
+  // fell back to a different model mid-call, so we just report the first for a resolved-model label.
+  modelUsage?: Record<string, unknown>;
 }
 
 // Isolation flags: replace the default system prompt, load NO settings/hooks/CLAUDE.md, no MCP,
@@ -110,13 +115,15 @@ export class ClaudeCodeProvider implements AIProvider {
     if (!text) throw new ProviderError("Claude Code returned no content", "other");
 
     const u = resultEvent.usage;
-    const hasUsage = !!u || resultEvent.total_cost_usd !== undefined;
+    const resolvedModel = Object.keys(resultEvent.modelUsage ?? {})[0];
+    const hasUsage = !!u || resultEvent.total_cost_usd !== undefined || !!resolvedModel;
     const usage: ProviderUsage | undefined = hasUsage ? {
       ...(u?.input_tokens !== undefined ? { inputTokens: u.input_tokens } : {}),
       ...(u?.output_tokens !== undefined ? { outputTokens: u.output_tokens } : {}),
       ...(u?.cache_creation_input_tokens !== undefined ? { cacheCreationTokens: u.cache_creation_input_tokens } : {}),
       ...(u?.cache_read_input_tokens !== undefined ? { cacheReadTokens: u.cache_read_input_tokens } : {}),
       ...(resultEvent.total_cost_usd !== undefined ? { costUSD: resultEvent.total_cost_usd } : {}),
+      ...(resolvedModel ? { resolvedModel } : {}),
     } : undefined;
 
     return { rawText: text, ...(usage ? { usage } : {}) };

--- a/companion/src/providers/claudeCode.ts
+++ b/companion/src/providers/claudeCode.ts
@@ -25,11 +25,21 @@ interface ClaudeResultEvent {
     cache_creation_input_tokens?: number;
     cache_read_input_tokens?: number;
   };
-  // Keyed by the CONCRETE model id actually served (e.g. "claude-sonnet-4-6") — present even when
-  // --model was given as an alias ("sonnet"/"haiku"/"opus"), which the CLI resolves before billing.
-  // Confirmed live: a single-key object in the normal case; more than one key would mean the CLI
-  // fell back to a different model mid-call, so we just report the first for a resolved-model label.
-  modelUsage?: Record<string, unknown>;
+  // Keyed by the CONCRETE model id(s) actually invoked (e.g. "claude-sonnet-4-6") — present even
+  // when --model was given as an alias ("sonnet"/"haiku"/"opus"), which the CLI resolves before
+  // billing. Confirmed live: NOT always a single key — a call can also carry a small internal
+  // Haiku sub-call (routing/classification, a handful of output tokens) alongside the primary
+  // generation, so picking "the first key" is wrong; see pickResolvedModel() below.
+  modelUsage?: Record<string, { outputTokens?: number }>;
+}
+
+// modelUsage can hold more than one model per call (a cheap internal routing/classification
+// sub-call plus the primary generation) — the entry with the most OUTPUT tokens is the one that
+// actually produced the response text, so that's the "resolved model" worth surfacing/logging.
+function pickResolvedModel(modelUsage: ClaudeResultEvent["modelUsage"]): string | undefined {
+  const entries = Object.entries(modelUsage ?? {});
+  if (entries.length === 0) return undefined;
+  return entries.reduce((best, cur) => ((cur[1]?.outputTokens ?? 0) > (best[1]?.outputTokens ?? 0) ? cur : best))[0];
 }
 
 // Isolation flags: replace the default system prompt, load NO settings/hooks/CLAUDE.md, no MCP,
@@ -115,7 +125,7 @@ export class ClaudeCodeProvider implements AIProvider {
     if (!text) throw new ProviderError("Claude Code returned no content", "other");
 
     const u = resultEvent.usage;
-    const resolvedModel = Object.keys(resultEvent.modelUsage ?? {})[0];
+    const resolvedModel = pickResolvedModel(resultEvent.modelUsage);
     const hasUsage = !!u || resultEvent.total_cost_usd !== undefined || !!resolvedModel;
     const usage: ProviderUsage | undefined = hasUsage ? {
       ...(u?.input_tokens !== undefined ? { inputTokens: u.input_tokens } : {}),

--- a/companion/src/providers/claudeCode.ts
+++ b/companion/src/providers/claudeCode.ts
@@ -1,0 +1,136 @@
+import {
+  type AIProvider, type AnalyzeRequest, type AnalyzeResult, type ProviderUsage,
+  type ProviderErrorKind, ProviderError,
+} from "./provider.js";
+import { type ClaudeRunner, defaultClaudeRunner } from "./claudeRunner.js";
+
+export interface ClaudeCodeOptions {
+  model: string;         // maps to --model (alias like "haiku" or a full id); "" → omit the flag
+  bin?: string;          // DFIR_AI_CLAUDE_CODE_BIN, or "claude" on PATH
+  timeoutMs?: number;
+  runner?: ClaudeRunner; // injected in tests; defaults to the real spawn runner
+}
+
+// The claude CLI's terminal stream-json event (fields we consume).
+interface ClaudeResultEvent {
+  type: "result";
+  subtype?: string;
+  is_error?: boolean;
+  api_error_status?: number | string | null;
+  result?: string;
+  total_cost_usd?: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+// Isolation flags: replace the default system prompt, load NO settings/hooks/CLAUDE.md, no MCP,
+// and NO tools. The empty tool allowlist also strips tool schemas that otherwise cost ~15k input
+// tokens per call, and guarantees a single-turn call can't hang on a tool-permission prompt.
+const ISOLATION_ARGS = ["--strict-mcp-config", "--setting-sources", "", "--allowed-tools", ""];
+
+export class ClaudeCodeProvider implements AIProvider {
+  readonly name = "claude-code";
+  readonly model: string;
+  private readonly bin: string;
+  private readonly timeoutMs: number;
+  private readonly runner: ClaudeRunner;
+
+  constructor(opts: ClaudeCodeOptions) {
+    this.model = opts.model;
+    this.bin = opts.bin?.trim() || "claude";
+    this.timeoutMs = opts.timeoutMs ?? 180_000;
+    this.runner = opts.runner ?? defaultClaudeRunner;
+  }
+
+  async analyze(req: AnalyzeRequest): Promise<AnalyzeResult> {
+    const content: unknown[] = [{ type: "text", text: req.userPrompt }];
+    for (const img of req.images) {
+      content.push({ type: "image", source: { type: "base64", media_type: img.mimeType, data: img.base64 } });
+    }
+    const stdin = JSON.stringify({ type: "user", message: { role: "user", content } }) + "\n";
+
+    const args = [
+      "-p",
+      "--input-format", "stream-json",
+      "--output-format", "stream-json",
+      "--verbose",
+      ...(this.model ? ["--model", this.model] : []),
+      "--system-prompt", req.systemPrompt,
+      ...ISOLATION_ARGS,
+    ];
+
+    const run = await this.runner({ bin: this.bin, args, stdin, timeoutMs: this.timeoutMs, signal: req.signal });
+
+    if (run.spawnError) {
+      if (run.spawnError.code === "ENOENT") {
+        throw new ProviderError(
+          `Claude Code CLI not found (tried "${this.bin}"). Install Claude Code and run \`claude auth login\`, ` +
+          `or set DFIR_AI_CLAUDE_CODE_BIN to its path.`,
+          "other",
+        );
+      }
+      throw new ProviderError(`Claude Code failed to start: ${run.spawnError.message}`, "transport");
+    }
+    if (run.timedOut) {
+      throw new ProviderError(`Claude Code timed out after ${this.timeoutMs}ms`, "timeout");
+    }
+
+    // Parse newline-delimited JSON events: keep the terminal `result`, and note any rejected rate limit.
+    let resultEvent: ClaudeResultEvent | undefined;
+    let rateLimited = false;
+    for (const line of run.stdout.split("\n")) {
+      const t = line.trim();
+      if (!t) continue;
+      let evt: unknown;
+      try { evt = JSON.parse(t); } catch { continue; }
+      const e = evt as { type?: string; rate_limit_info?: { status?: string } };
+      if (e.type === "result") resultEvent = evt as ClaudeResultEvent;
+      else if (e.type === "rate_limit_event" && e.rate_limit_info?.status && e.rate_limit_info.status !== "allowed") {
+        rateLimited = true;
+      }
+    }
+
+    if (!resultEvent) {
+      const snip = (run.stderr || run.stdout).replace(/\s+/g, " ").trim().slice(0, 200);
+      const kind: ProviderErrorKind = rateLimited ? "rate_limit" : "transport";
+      throw new ProviderError(`Claude Code produced no result (exit ${run.code ?? "null"})${snip ? ` — ${snip}` : ""}`, kind);
+    }
+
+    if (resultEvent.is_error || (resultEvent.subtype && resultEvent.subtype !== "success")) {
+      const kind = classify(resultEvent, rateLimited);
+      const msg = resultEvent.result?.trim() || `Claude Code error (${resultEvent.subtype ?? "unknown"})`;
+      throw new ProviderError(`Claude Code: ${msg}`, kind);
+    }
+
+    const text = resultEvent.result;
+    if (!text) throw new ProviderError("Claude Code returned no content", "other");
+
+    const u = resultEvent.usage;
+    const hasUsage = !!u || resultEvent.total_cost_usd !== undefined;
+    const usage: ProviderUsage | undefined = hasUsage ? {
+      ...(u?.input_tokens !== undefined ? { inputTokens: u.input_tokens } : {}),
+      ...(u?.output_tokens !== undefined ? { outputTokens: u.output_tokens } : {}),
+      ...(u?.cache_creation_input_tokens !== undefined ? { cacheCreationTokens: u.cache_creation_input_tokens } : {}),
+      ...(u?.cache_read_input_tokens !== undefined ? { cacheReadTokens: u.cache_read_input_tokens } : {}),
+      ...(resultEvent.total_cost_usd !== undefined ? { costUSD: resultEvent.total_cost_usd } : {}),
+    } : undefined;
+
+    return { rawText: text, ...(usage ? { usage } : {}) };
+  }
+}
+
+function classify(e: ClaudeResultEvent, rateLimited: boolean): ProviderErrorKind {
+  if (rateLimited) return "rate_limit";
+  const status = typeof e.api_error_status === "number" ? e.api_error_status : undefined;
+  if (status === 401 || status === 403) return "auth";
+  if (status === 429) return "rate_limit";
+  if (status !== undefined && status >= 500) return "transport";
+  const msg = (e.result ?? "").toLowerCase();
+  if (/log ?in|unauthor|not signed in|authenticate|auth/.test(msg)) return "auth";
+  if (/rate limit|quota|usage limit/.test(msg)) return "rate_limit";
+  return "other";
+}

--- a/companion/src/providers/claudeCodeStatus.ts
+++ b/companion/src/providers/claudeCodeStatus.ts
@@ -1,0 +1,103 @@
+import { spawn } from "node:child_process";
+import { type ClaudeRunner, defaultClaudeRunner } from "./claudeRunner.js";
+
+export type ClaudeAuthState = "not_installed" | "not_connected" | "connected";
+
+export interface ClaudeCodeStatus {
+  state: ClaudeAuthState;
+  email?: string;
+  subscriptionType?: string;
+  authMethod?: string;
+  message: string;
+}
+
+// Detect whether Claude Code is installed and signed in. Never throws — a spawn/parse failure
+// resolves to a not_installed / not_connected state with a human message.
+export async function getClaudeCodeStatus(
+  opts: { bin?: string; runner?: ClaudeRunner; timeoutMs?: number } = {},
+): Promise<ClaudeCodeStatus> {
+  const bin = opts.bin?.trim() || "claude";
+  const runner = opts.runner ?? defaultClaudeRunner;
+  const run = await runner({ bin, args: ["auth", "status", "--json"], stdin: "", timeoutMs: opts.timeoutMs ?? 15_000 });
+
+  if (run.spawnError) {
+    const msg = run.spawnError.code === "ENOENT"
+      ? "Claude Code isn't installed on this machine. Install it from https://claude.com/claude-code, then click Re-check."
+      : `Claude Code could not be run: ${run.spawnError.message}`;
+    return { state: "not_installed", message: msg };
+  }
+
+  let parsed: { loggedIn?: boolean; email?: string; subscriptionType?: string; authMethod?: string } = {};
+  try { parsed = JSON.parse(run.stdout.trim()) as typeof parsed; } catch { /* treat unparseable output as not connected */ }
+
+  if (parsed.loggedIn) {
+    const tail = `${parsed.email ? ` as ${parsed.email}` : ""}${parsed.subscriptionType ? ` · ${parsed.subscriptionType} plan` : ""}`;
+    return {
+      state: "connected",
+      ...(parsed.email ? { email: parsed.email } : {}),
+      ...(parsed.subscriptionType ? { subscriptionType: parsed.subscriptionType } : {}),
+      ...(parsed.authMethod ? { authMethod: parsed.authMethod } : {}),
+      message: `Signed in${tail}.`,
+    };
+  }
+  return {
+    state: "not_connected",
+    message: "Claude Code is installed but not signed in. Run `claude auth login` on this machine (or `claude setup-token` for headless/Docker), then click Re-check.",
+  };
+}
+
+// child.stdout/stderr are typed as Readable | null, but when spawned with stdio: "pipe" they are
+// actually net.Socket-like handles that support unref() at runtime. Narrow with a type guard
+// instead of `any` so we can safely unref them and let the event loop exit.
+function unrefIfPossible(stream: unknown): void {
+  if (
+    typeof stream === "object" &&
+    stream !== null &&
+    "unref" in stream &&
+    typeof (stream as { unref: unknown }).unref === "function"
+  ) {
+    (stream as { unref: () => void }).unref();
+  }
+}
+
+// Best-effort: start the interactive `claude auth login` on the host and capture whatever it
+// prints for up to captureMs, extracting the first URL so the UI can show it. The process is
+// detached and left running so the operator can complete the browser OAuth; the reliable
+// confirmation is a subsequent getClaudeCodeStatus() (the dashboard's Re-check button).
+export async function startClaudeLogin(
+  opts: { bin?: string; captureMs?: number } = {},
+): Promise<{ started: boolean; url?: string; output: string; error?: string }> {
+  const bin = opts.bin?.trim() || "claude";
+  const captureMs = opts.captureMs ?? 8000;
+  return new Promise((resolve) => {
+    let output = "";
+    let settled = false;
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(bin, ["auth", "login"], { stdio: ["ignore", "pipe", "pipe"], detached: true });
+    } catch (err) {
+      resolve({ started: false, output: "", error: (err as Error).message });
+      return;
+    }
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const m = output.match(/https?:\/\/\S+/);
+      child.unref();
+      unrefIfPossible(child.stdout);
+      unrefIfPossible(child.stderr);
+      resolve({ started: true, output: output.slice(0, 2000), ...(m ? { url: m[0] } : {}) });
+    };
+    const timer = setTimeout(finish, captureMs);
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ started: false, output, error: err.code === "ENOENT" ? "Claude Code CLI not found" : err.message });
+    });
+    child.stdout?.on("data", (d) => { output += d.toString(); });
+    child.stderr?.on("data", (d) => { output += d.toString(); });
+    child.on("close", finish);
+  });
+}

--- a/companion/src/providers/claudeRunner.ts
+++ b/companion/src/providers/claudeRunner.ts
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+
+// Result of one CLI invocation. Process-level failures (missing binary, timeout/abort) come
+// back as fields rather than rejections, so the provider maps them to ProviderError uniformly.
+export interface ClaudeRunResult {
+  code: number | null;                 // exit code; null when the process was killed
+  stdout: string;
+  stderr: string;
+  spawnError?: NodeJS.ErrnoException;  // set when the process could not be spawned (e.g. ENOENT)
+  timedOut?: boolean;                  // true when killed by the timeout or the external signal
+}
+
+export interface ClaudeRunOptions {
+  bin: string;
+  args: string[];
+  stdin: string;      // written to the child's stdin, which is then closed
+  timeoutMs: number;
+  signal?: AbortSignal; // external cancellation (#225)
+}
+
+export type ClaudeRunner = (opts: ClaudeRunOptions) => Promise<ClaudeRunResult>;
+
+// Default runner: spawn the claude CLI, feed stdin, collect stdout/stderr, resolve on close.
+export const defaultClaudeRunner: ClaudeRunner = (opts) =>
+  new Promise<ClaudeRunResult>((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+
+    const child = spawn(opts.bin, opts.args, { stdio: ["pipe", "pipe", "pipe"] });
+
+    const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, opts.timeoutMs);
+    const onAbort = () => { timedOut = true; child.kill("SIGKILL"); };
+    if (opts.signal) {
+      if (opts.signal.aborted) onAbort();
+      else opts.signal.addEventListener("abort", onAbort, { once: true });
+    }
+    const cleanup = () => {
+      clearTimeout(timer);
+      if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
+    };
+    const done = (r: ClaudeRunResult) => { if (!settled) { settled = true; cleanup(); resolve(r); } };
+
+    child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout, stderr, spawnError: err }));
+    child.stdout.on("data", (d) => { stdout += d.toString(); });
+    child.stderr.on("data", (d) => { stderr += d.toString(); });
+    child.on("close", (code) => done({ code, stdout, stderr, ...(timedOut ? { timedOut: true } : {}) }));
+
+    child.stdin.on("error", () => { /* ignore EPIPE if the child exits before we finish writing */ });
+    child.stdin.end(opts.stdin);
+  });

--- a/companion/src/providers/provider.ts
+++ b/companion/src/providers/provider.ts
@@ -25,6 +25,11 @@ export interface ProviderUsage {
   cacheCreationTokens?: number; // input tokens written to the cache on this call
   cacheReadTokens?: number;     // input tokens served from the cache on this call
   costUSD?: number;             // real dollar cost, when the provider reports one (OpenRouter only today)
+  // The concrete model id the provider actually served the request with, when it differs from (or
+  // resolves) the configured DFIR_*_MODEL — e.g. an alias like "sonnet" resolving to
+  // "claude-sonnet-4-6". Only the claude-code provider reports this today (its CLI's result event
+  // echoes the resolved id back); other providers leave it unset.
+  resolvedModel?: string;
 }
 
 export interface AnalyzeResult {

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -137,7 +137,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
     const deepReasoning = (req.body as { deepReasoning?: unknown })?.deepReasoning === true;
     const reqThinking = Number((req.body as { thinkingTokens?: unknown })?.thinkingTokens);
     const thinkingTokens = Number.isFinite(reqThinking) && reqThinking > 0 ? Math.floor(reqThinking) : undefined;
-    options.onAiStatus?.(caseId, { status: "analyzing", at: new Date().toISOString(), detail: deepReasoning ? "synthesizing (deep reasoning)" : "synthesizing conclusions" });
+    options.onAiStatus?.(caseId, { status: "analyzing", phase: "synthesizing", at: new Date().toISOString(), detail: deepReasoning ? "synthesizing (deep reasoning)" : "synthesizing conclusions" });
     // #225: track this manual synthesis as a cancellable job so the analyst can abort a long run.
     // exclusive: a second re-synthesize for the same case (double-click, or racing the "Generate
     // hypotheses" button / a live auto-synthesis) supersedes rather than running alongside it.
@@ -201,7 +201,7 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
     const caseId = req.params.id;
     // Same per-run deep-reasoning toggle (#121) as /synthesize — flows into both model A & B passes.
     const deepReasoning = (req.body as { deepReasoning?: unknown })?.deepReasoning === true;
-    options.onAiStatus?.(caseId, { status: "analyzing", at: new Date().toISOString(), detail: deepReasoning ? "running second opinion (deep reasoning)" : "running second opinion" });
+    options.onAiStatus?.(caseId, { status: "analyzing", phase: "synthesizing", at: new Date().toISOString(), detail: deepReasoning ? "running second opinion (deep reasoning)" : "running second opinion" });
     try {
       const record = await options.pipeline.secondOpinion(caseId, { deepReasoning });
       options.onAiStatus?.(caseId, { status: "idle", at: new Date().toISOString() });

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -7,6 +7,7 @@ import {
   buildAiDiagnostics, summarizeImportAttempts, countByKind, aggregateCaseSizes, buildDiagnosticsText,
   type DiagnosticsReport, type ScannedFile,
 } from "../analysis/diagnostics.js";
+import { getClaudeCodeStatus, startClaudeLogin } from "../providers/claudeCodeStatus.js";
 import {
   buildPreflightReport, buildPreflightText,
   type PreflightItem, type PreflightReport,
@@ -312,6 +313,19 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
       serverLogger.info(`[diagnostics] AI test failed provider=${provider.name} kind=${kind}: ${(err as Error).message}`);
       return res.status(200).json({ ok: false, provider: provider.name, latencyMs, kind, error: (err as Error).message });
     }
+  });
+
+  // Claude Code connection status (installed / signed-in) for Settings → AI and the wizard.
+  app.get("/diagnostics/claude-code-status", async (_req: Request, res: Response) => {
+    const status = await getClaudeCodeStatus({ bin: process.env.DFIR_AI_CLAUDE_CODE_BIN });
+    return res.status(200).json({ ok: true, ...status });
+  });
+
+  // Best-effort "Connect" action: start `claude auth login` on the host and return any auth URL.
+  // Only meaningful when the server runs on the operator's own machine; Re-check confirms success.
+  app.post("/diagnostics/claude-code-login", async (_req: Request, res: Response) => {
+    const r = await startClaudeLogin({ bin: process.env.DFIR_AI_CLAUDE_CODE_BIN });
+    return res.status(200).json({ ok: r.started, ...r });
   });
 
   // ── Startup pre-flight (#179) ─────────────────────────────────────────────────────────

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2443,6 +2443,7 @@ import { OllamaCloudProvider } from "./providers/ollama.js";
 import { LiteLlmProvider } from "./providers/litellm.js";
 import { GeminiProvider } from "./providers/gemini.js";
 import { AnthropicProvider } from "./providers/anthropic.js";
+import { ClaudeCodeProvider } from "./providers/claudeCode.js";
 import { WebSocketServer } from "ws";
 import { LiveHub } from "./live/hub.js";
 import { ReportWriter as ReportWriterImpl } from "./reports/reportWriter.js";
@@ -2489,6 +2490,7 @@ export function buildProviderFrom(params: ProviderParams): AnalyzeProvider | und
   registry.register(new LiteLlmProvider({ apiKey, model, baseUrl, imageDetail, timeoutMs, maxTokens, contextTokens }));
   registry.register(new GeminiProvider({ apiKey, model, baseUrl, timeoutMs, maxTokens }));
   registry.register(new AnthropicProvider({ apiKey, model, baseUrl, timeoutMs, maxTokens }));
+  registry.register(new ClaudeCodeProvider({ model, timeoutMs, bin: process.env.DFIR_AI_CLAUDE_CODE_BIN }));
   return registry.get(name);
 }
 

--- a/companion/tests/providers/claudeCode.test.ts
+++ b/companion/tests/providers/claudeCode.test.ts
@@ -55,6 +55,22 @@ describe("ClaudeCodeProvider", () => {
     expect(out.usage).toEqual({ inputTokens: 10, outputTokens: 20, cacheCreationTokens: 30, cacheReadTokens: 40, costUSD: 0.042 });
   });
 
+  it("resolves the model that actually produced the output, not just the first modelUsage key", async () => {
+    // Captured live: a --model claude-sonnet-5 call reports modelUsage for BOTH the primary
+    // generation AND a small internal Haiku sub-call, with claude-haiku-4-5-20251001 listed FIRST
+    // despite claude-sonnet-5 being the one that wrote the actual response (5 output tokens vs 13
+    // — small counts either way, but the ordering is what previously fooled Object.keys()[0]).
+    const runner = fakeRunner({ stdout: resultLine({
+      result: "hi",
+      modelUsage: {
+        "claude-haiku-4-5-20251001": { inputTokens: 343, outputTokens: 13, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 },
+        "claude-sonnet-5": { inputTokens: 2, outputTokens: 30874, cacheReadInputTokens: 12635, cacheCreationInputTokens: 7154 },
+      },
+    }) });
+    const out = await new ClaudeCodeProvider({ model: "claude-sonnet-5", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.usage?.resolvedModel).toBe("claude-sonnet-5");
+  });
+
   it("throws an actionable error when the CLI binary is missing", async () => {
     const runner = fakeRunner({ code: null, spawnError: Object.assign(new Error("nope"), { code: "ENOENT" }) });
     const p = new ClaudeCodeProvider({ model: "haiku", runner });

--- a/companion/tests/providers/claudeCode.test.ts
+++ b/companion/tests/providers/claudeCode.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { ClaudeCodeProvider } from "../../src/providers/claudeCode.js";
+import type { ClaudeRunOptions, ClaudeRunResult } from "../../src/providers/claudeRunner.js";
+
+// Build a fake runner that captures the invocation and returns canned stdout lines.
+function fakeRunner(result: Partial<ClaudeRunResult>, capture?: (o: ClaudeRunOptions) => void) {
+  return vi.fn(async (opts: ClaudeRunOptions): Promise<ClaudeRunResult> => {
+    capture?.(opts);
+    return { code: 0, stdout: "", stderr: "", ...result };
+  });
+}
+
+const resultLine = (obj: Record<string, unknown>) => JSON.stringify({ type: "result", subtype: "success", is_error: false, ...obj });
+
+describe("ClaudeCodeProvider", () => {
+  it("builds the isolated stream-json invocation and encodes text + image blocks", async () => {
+    let captured: ClaudeRunOptions | undefined;
+    const runner = fakeRunner({ stdout: resultLine({ result: '{"summary":"ok"}' }) }, (o) => { captured = o; });
+    const p = new ClaudeCodeProvider({ model: "haiku", runner });
+    const out = await p.analyze({
+      systemPrompt: "SYS",
+      userPrompt: "USER",
+      images: [{ base64: "AAA", mimeType: "image/webp" }],
+    });
+    expect(out.rawText).toBe('{"summary":"ok"}');
+    expect(p.name).toBe("claude-code");
+    // args
+    const a = captured!.args;
+    expect(a).toContain("-p");
+    expect(a).toEqual(expect.arrayContaining(["--input-format", "stream-json", "--output-format", "stream-json", "--verbose"]));
+    expect(a).toEqual(expect.arrayContaining(["--model", "haiku"]));
+    expect(a).toEqual(expect.arrayContaining(["--system-prompt", "SYS"]));
+    expect(a).toEqual(expect.arrayContaining(["--strict-mcp-config", "--setting-sources", "", "--allowed-tools", ""]));
+    // stdin message
+    const msg = JSON.parse(captured!.stdin.trim());
+    expect(msg.type).toBe("user");
+    expect(msg.message.content[0]).toEqual({ type: "text", text: "USER" });
+    expect(msg.message.content[1]).toEqual({ type: "image", source: { type: "base64", media_type: "image/webp", data: "AAA" } });
+  });
+
+  it("omits --model when the model is empty", async () => {
+    let captured: ClaudeRunOptions | undefined;
+    const runner = fakeRunner({ stdout: resultLine({ result: "x" }) }, (o) => { captured = o; });
+    await new ClaudeCodeProvider({ model: "", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(captured!.args).not.toContain("--model");
+  });
+
+  it("maps usage and total_cost_usd from the result event", async () => {
+    const runner = fakeRunner({ stdout: resultLine({
+      result: "hi",
+      total_cost_usd: 0.042,
+      usage: { input_tokens: 10, output_tokens: 20, cache_creation_input_tokens: 30, cache_read_input_tokens: 40 },
+    }) });
+    const out = await new ClaudeCodeProvider({ model: "haiku", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.usage).toEqual({ inputTokens: 10, outputTokens: 20, cacheCreationTokens: 30, cacheReadTokens: 40, costUSD: 0.042 });
+  });
+
+  it("throws an actionable error when the CLI binary is missing", async () => {
+    const runner = fakeRunner({ code: null, spawnError: Object.assign(new Error("nope"), { code: "ENOENT" }) });
+    const p = new ClaudeCodeProvider({ model: "haiku", runner });
+    await expect(p.analyze({ systemPrompt: "s", userPrompt: "u", images: [] })).rejects.toThrow(/not found.*claude auth login/i);
+  });
+
+  it("maps a rejected rate_limit_event to a rate_limit error", async () => {
+    const stdout = [
+      JSON.stringify({ type: "rate_limit_event", rate_limit_info: { status: "rejected" } }),
+      resultLine({ is_error: true, subtype: "error", result: "usage limit reached" }),
+    ].join("\n");
+    const runner = fakeRunner({ stdout });
+    const p = new ClaudeCodeProvider({ model: "haiku", runner });
+    await expect(p.analyze({ systemPrompt: "s", userPrompt: "u", images: [] }))
+      .rejects.toMatchObject({ kind: "rate_limit" });
+  });
+
+  it("maps a timeout to a timeout error", async () => {
+    const runner = fakeRunner({ code: null, timedOut: true });
+    const p = new ClaudeCodeProvider({ model: "haiku", timeoutMs: 5, runner });
+    await expect(p.analyze({ systemPrompt: "s", userPrompt: "u", images: [] }))
+      .rejects.toMatchObject({ kind: "timeout" });
+  });
+
+  it("errors as transport when no result event is produced", async () => {
+    const runner = fakeRunner({ code: 1, stdout: "", stderr: "boom" });
+    const p = new ClaudeCodeProvider({ model: "haiku", runner });
+    await expect(p.analyze({ systemPrompt: "s", userPrompt: "u", images: [] }))
+      .rejects.toMatchObject({ kind: "transport" });
+    await expect(p.analyze({ systemPrompt: "s", userPrompt: "u", images: [] }))
+      .rejects.toThrow("boom");
+  });
+});

--- a/companion/tests/providers/claudeCode.wiring.test.ts
+++ b/companion/tests/providers/claudeCode.wiring.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { buildProviderFrom } from "../../src/server.js";
+import { isLocalAiProvider } from "../../src/analysis/anonymize.js";
+
+describe("buildProviderFrom — claude-code wiring", () => {
+  it("resolves the claude-code provider by name with no API key", () => {
+    const p = buildProviderFrom({ provider: "claude-code", model: "haiku" });
+    expect(p?.name).toBe("claude-code");
+    expect(p?.model).toBe("haiku");
+  });
+
+  it("treats claude-code as NON-local (evidence leaves the machine to Anthropic)", () => {
+    // Anonymization must still apply, exactly as for the hosted `anthropic` provider.
+    expect(isLocalAiProvider("claude-code", undefined)).toBe(false);
+  });
+});

--- a/companion/tests/providers/claudeCodeStatus.test.ts
+++ b/companion/tests/providers/claudeCodeStatus.test.ts
@@ -47,7 +47,8 @@ describe("startClaudeLogin", () => {
     expect(r.error).toBeTruthy();
   });
 
-  it("captures a printed URL and resolves started:true via finish()", async () => {
+  // Relies on the OS reading the "#!/bin/sh" shebang to exec the shim, which only POSIX does.
+  it.skipIf(process.platform === "win32")("captures a printed URL and resolves started:true via finish()", async () => {
     const dir = mkdtempSync(join(tmpdir(), "cc-login-"));
     const shim = join(dir, "claude");
     // Ignores its args ("auth login"), prints a URL, exits immediately.

--- a/companion/tests/providers/claudeCodeStatus.test.ts
+++ b/companion/tests/providers/claudeCodeStatus.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { writeFileSync, chmodSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getClaudeCodeStatus, startClaudeLogin } from "../../src/providers/claudeCodeStatus.js";
+import type { ClaudeRunOptions, ClaudeRunResult } from "../../src/providers/claudeRunner.js";
+
+function runnerReturning(r: Partial<ClaudeRunResult>) {
+  return vi.fn(async (_o: ClaudeRunOptions): Promise<ClaudeRunResult> => ({ code: 0, stdout: "", stderr: "", ...r }));
+}
+
+describe("getClaudeCodeStatus", () => {
+  it("reports connected with email and plan", async () => {
+    const runner = runnerReturning({ stdout: JSON.stringify({ loggedIn: true, email: "a@b.com", subscriptionType: "max", authMethod: "claude.ai" }) });
+    const s = await getClaudeCodeStatus({ runner });
+    expect(s.state).toBe("connected");
+    expect(s.email).toBe("a@b.com");
+    expect(s.subscriptionType).toBe("max");
+    expect(s.message).toMatch(/a@b\.com/);
+  });
+
+  it("reports not_connected when loggedIn is false", async () => {
+    const runner = runnerReturning({ stdout: JSON.stringify({ loggedIn: false }) });
+    const s = await getClaudeCodeStatus({ runner });
+    expect(s.state).toBe("not_connected");
+    expect(s.message).toMatch(/claude auth login/);
+  });
+
+  it("reports not_installed on ENOENT", async () => {
+    const runner = runnerReturning({ code: null, spawnError: Object.assign(new Error("x"), { code: "ENOENT" }) });
+    const s = await getClaudeCodeStatus({ runner });
+    expect(s.state).toBe("not_installed");
+  });
+
+  it("runs the auth status --json subcommand", async () => {
+    let captured: ClaudeRunOptions | undefined;
+    const runner = vi.fn(async (o: ClaudeRunOptions): Promise<ClaudeRunResult> => { captured = o; return { code: 0, stdout: JSON.stringify({ loggedIn: true }), stderr: "" }; });
+    await getClaudeCodeStatus({ runner });
+    expect(captured!.args).toEqual(["auth", "status", "--json"]);
+  });
+});
+
+describe("startClaudeLogin", () => {
+  it("returns started:false with an error when the binary is missing", async () => {
+    const r = await startClaudeLogin({ bin: "definitely-not-a-real-binary-xyz", captureMs: 500 });
+    expect(r.started).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+
+  it("captures a printed URL and resolves started:true via finish()", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cc-login-"));
+    const shim = join(dir, "claude");
+    // Ignores its args ("auth login"), prints a URL, exits immediately.
+    writeFileSync(shim, '#!/bin/sh\necho "Visit https://example.com/oauth?code=abc to sign in"\n');
+    chmodSync(shim, 0o755);
+    const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
+    expect(r.started).toBe(true);
+    expect(r.url).toBe("https://example.com/oauth?code=abc");
+  });
+});

--- a/companion/tests/providers/claudeRunner.test.ts
+++ b/companion/tests/providers/claudeRunner.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { defaultClaudeRunner } from "../../src/providers/claudeRunner.js";
+
+// A tiny node program that echoes its stdin back with a prefix, so we exercise the real
+// spawn + stdin-write + stdout-collect path without depending on the `claude` binary.
+const ECHO = 'let d="";process.stdin.on("data",x=>d+=x);process.stdin.on("end",()=>process.stdout.write("GOT:"+d));';
+
+describe("defaultClaudeRunner", () => {
+  it("feeds stdin and collects stdout with exit code 0", async () => {
+    const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", ECHO], stdin: "hello", timeoutMs: 10_000 });
+    expect(r.spawnError).toBeUndefined();
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("GOT:hello");
+  });
+
+  it("reports a non-zero exit code", async () => {
+    const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", "process.exit(3)"], stdin: "", timeoutMs: 10_000 });
+    expect(r.code).toBe(3);
+  });
+
+  it("returns spawnError ENOENT when the binary is missing", async () => {
+    const r = await defaultClaudeRunner({ bin: "definitely-not-a-real-binary-xyz", args: [], stdin: "", timeoutMs: 10_000 });
+    expect(r.spawnError?.code).toBe("ENOENT");
+  });
+
+  it("kills the process and sets timedOut when the signal aborts", async () => {
+    const ac = new AbortController();
+    const p = defaultClaudeRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], stdin: "", timeoutMs: 60_000, signal: ac.signal });
+    setTimeout(() => ac.abort(), 50);
+    const r = await p;
+    expect(r.timedOut).toBe(true);
+    expect(r.code).toBeNull();
+  });
+
+  it("sets timedOut when timeoutMs elapses", async () => {
+    const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], stdin: "", timeoutMs: 80 });
+    expect(r.timedOut).toBe(true);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -10359,8 +10359,14 @@
         // routes only reuse this AI-status channel to drive the progress bar, so relabel their
         // updates honestly instead of claiming "AI: processing…" while the AI is off. Import
         // updates are recognisable by the detail text ("importing …" / "<kind> import — N/M");
-        // screenshot extraction + synthesis (genuine AI) keep the AI label. Belt-and-suspenders:
-        // when AI is off, ANY activity on this channel can only be ingest, so treat it as such.
+        // screenshot extraction + synthesis (genuine AI) keep the AI label.
+        // NOTE: the `!aiEnabled` fallback below is belt-and-suspenders for the AUTO live-analysis loop
+        // ONLY — aiEnabled is the per-case "live analysis paused/resumed" toggle, not "is AI configured".
+        // Manual on-demand AI (Re-synthesize, Second opinion, Ask …) can run while that toggle is OFF,
+        // so every server route emitting one of those MUST set `phase: "synthesizing"` (checked first,
+        // below) rather than relying on this fallback — otherwise a genuine AI call gets mislabeled
+        // "deterministic import — not AI" whenever the analyst has paused live analysis (found live: the
+        // second-opinion badge showed that exact false label with the toggle off — see aiSynthesis.ts).
         const isIngest = !!m || (evt.detail && /^importing\b/i.test(evt.detail)) || !aiEnabled;
         if (evt.phase === "synthesizing") setAi("analyzing", "synthesizing findings… " + (evt.detail || ""));
         else if (evt.detail && /^enriching IOC/.test(evt.detail)) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2376,10 +2376,65 @@
               <option value="litellm">litellm</option>
               <option value="gemini">gemini</option>
               <option value="anthropic">anthropic</option>
+              <option value="claude-code">claude code (subscription, no key)</option>
             </select>
           </div>
           <div class="sfield"><label>Model (screenshots, must support vision)<span class="sfield-hint">DFIR_VISION_MODEL</span></label><input id="env-DFIR_VISION_MODEL" placeholder="gpt-4o-mini" /></div>
         </div>
+        <div id="claude-code-status" class="sfield" style="display:none;padding:8px 10px;border-radius:8px;border:1px solid var(--c-2a2f3a,#2a2f3a);background:var(--c-161b22,#161b22)">
+          <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+            <span id="cc-status-dot" style="width:9px;height:9px;border-radius:50%;background:#6b7280;flex:0 0 auto"></span>
+            <span id="cc-status-msg" style="font-size:12px">Checking Claude Code…</span>
+            <button type="button" id="cc-recheck" style="margin-left:auto;font-size:11px;padding:3px 10px">Re-check</button>
+            <button type="button" id="cc-connect" style="display:none;font-size:11px;padding:3px 10px">Connect</button>
+          </div>
+          <div id="cc-connect-hint" style="font-size:11px;color:var(--c-9aa4b2);margin-top:6px;display:none"></div>
+        </div>
+        <script>
+        (function () {
+          var sel = document.getElementById('env-DFIR_VISION_PROVIDER');
+          var card = document.getElementById('claude-code-status');
+          if (!sel || !card) return;
+          var dot = document.getElementById('cc-status-dot');
+          var msg = document.getElementById('cc-status-msg');
+          var connectBtn = document.getElementById('cc-connect');
+          var hint = document.getElementById('cc-connect-hint');
+
+          function paint(s) {
+            var colors = { connected: '#16a34a', not_connected: '#d97706', not_installed: '#dc2626' };
+            dot.style.background = colors[s.state] || '#6b7280';
+            msg.textContent = s.message || s.state;
+            connectBtn.style.display = s.state === 'not_connected' ? '' : 'none';
+          }
+          function refresh() {
+            msg.textContent = 'Checking Claude Code…';
+            fetch('/diagnostics/claude-code-status').then(function (r) { return r.json(); })
+              .then(paint).catch(function () { msg.textContent = 'Status check failed.'; });
+          }
+          function toggle() {
+            var on = sel.value === 'claude-code';
+            card.style.display = on ? '' : 'none';
+            if (on) refresh();
+          }
+          sel.addEventListener('change', toggle);
+          document.getElementById('cc-recheck').addEventListener('click', refresh);
+          connectBtn.addEventListener('click', function () {
+            hint.style.display = '';
+            hint.textContent = 'Starting sign-in…';
+            fetch('/diagnostics/claude-code-login', { method: 'POST' }).then(function (r) { return r.json(); })
+              .then(function (r) {
+                if (r.url) hint.innerHTML = 'Open this URL to finish signing in, then click Re-check:<br><a href="' + escAttr(r.url) + '" target="_blank" rel="noopener">' + esc(r.url) + '</a>';
+                else if (r.started) hint.textContent = 'Sign-in started on the host. Complete it in the browser that opened, then click Re-check.';
+                else hint.textContent = (r.error || 'Could not start sign-in') + '. Run `claude auth login` in a terminal on the host, then click Re-check.';
+              }).catch(function () { hint.textContent = 'Run `claude auth login` in a terminal on the host, then click Re-check.'; });
+          });
+          // Settings modal re-opens can populate env-DFIR_VISION_PROVIDER's value programmatically
+          // (fetchEnvSettings sets .value directly, which does not fire a 'change' event), so also
+          // re-check whenever that happens (see the matching dispatchEvent in fetchEnvSettings).
+          sel.addEventListener('dfir:envloaded', toggle);
+          toggle();
+        })();
+        </script>
         <div class="sfield-row">
           <div class="sfield"><label>API key<span class="sfield-hint">DFIR_VISION_KEY</span></label><input id="env-DFIR_VISION_KEY" type="password" placeholder="(not set)" autocomplete="new-password" /></div>
           <div class="sfield"><label>Base URL override<span class="sfield-hint">DFIR_VISION_BASE_URL — leave blank for provider default</span></label><input id="env-DFIR_VISION_BASE_URL" placeholder="e.g. http://localhost:11434/v1" /></div>
@@ -2413,6 +2468,7 @@
               <option value="litellm">litellm</option>
               <option value="gemini">gemini</option>
               <option value="anthropic">anthropic</option>
+              <option value="claude-code">claude code (subscription, no key)</option>
             </select>
           </div>
           <div class="sfield"><label>Text model<span class="sfield-hint">DFIR_AI_SYNTH_MODEL — CSV/log + synthesis</span></label><input id="env-DFIR_AI_SYNTH_MODEL" placeholder="e.g. gpt-4o" /></div>
@@ -2434,6 +2490,7 @@
               <option value="litellm">litellm</option>
               <option value="gemini">gemini</option>
               <option value="anthropic">anthropic</option>
+              <option value="claude-code">claude code (subscription, no key)</option>
             </select>
           </div>
           <div class="sfield"><label>Velo model<span class="sfield-hint">DFIR_AI_VELO_MODEL</span></label><input id="env-DFIR_AI_VELO_MODEL" placeholder="anthropic/claude-haiku-4.5" /></div>
@@ -2455,6 +2512,7 @@
               <option value="litellm">litellm</option>
               <option value="gemini">gemini</option>
               <option value="anthropic">anthropic</option>
+              <option value="claude-code">claude code (subscription, no key)</option>
             </select>
           </div>
           <div class="sfield"><label>2nd-opinion model<span class="sfield-hint">DFIR_AI_SECOND_OPINION_MODEL</span></label><input id="env-DFIR_AI_SECOND_OPINION_MODEL" placeholder="e.g. gpt-4o — set this to enable the feature" /></div>
@@ -3518,7 +3576,17 @@
                 <option value="litellm">LiteLLM (local proxy)</option>
                 <option value="gemini">Gemini</option>
                 <option value="anthropic">Anthropic</option>
+                <option value="claude-code">Claude Code (subscription, no key)</option>
               </select>
+            </div>
+            <div id="claude-code-status-wizard" class="wiz-field" style="display:none;padding:8px 10px;border-radius:8px;border:1px solid var(--c-2a2f3a,#2a2f3a);background:var(--c-161b22,#161b22)">
+              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+                <span id="cc-status-dot-wizard" style="width:9px;height:9px;border-radius:50%;background:#6b7280;flex:0 0 auto"></span>
+                <span id="cc-status-msg-wizard" style="font-size:12px">Checking Claude Code…</span>
+                <button type="button" id="cc-recheck-wizard" style="margin-left:auto;font-size:11px;padding:3px 10px">Re-check</button>
+                <button type="button" id="cc-connect-wizard" style="display:none;font-size:11px;padding:3px 10px">Connect</button>
+              </div>
+              <div id="cc-connect-hint-wizard" style="font-size:11px;color:var(--c-9aa4b2);margin-top:6px;display:none"></div>
             </div>
             <div class="wiz-row">
               <div class="wiz-field">
@@ -3552,6 +3620,7 @@
                   <option value="litellm">LiteLLM (local proxy)</option>
                   <option value="gemini">Gemini</option>
                   <option value="anthropic">Anthropic</option>
+                  <option value="claude-code">Claude Code (subscription, no key)</option>
                 </select>
               </div>
               <div class="wiz-field">
@@ -17287,6 +17356,7 @@
           if (!el) continue;
           if (el.tagName === "SELECT") {
             el.value = val || "";
+            el.dispatchEvent(new Event("dfir:envloaded"));
           } else if (el.type === "password") {
             el.value = "";
             el.placeholder = val === "••••••••" ? "(already set)" : "(not set)";
@@ -17507,7 +17577,50 @@
       wizEl("wizBaseUrlField").style.display = "none"; wizEl("wizTestSaveBtn").disabled = false;
       wizEl("wizSynthProvider").value = ""; wizEl("wizSynthModel").value = ""; wizEl("wizSynthKey").value = "";
       wizEl("wizSynthBaseUrl").value = ""; wizEl("wizSynthResult").textContent = ""; wizEl("wizSynthSaveBtn").disabled = false;
+      const ccWizCard = wizEl("claude-code-status-wizard"); if (ccWizCard) ccWizCard.style.display = "none";
     }
+    // Claude Code connection-status card mirrored inside the wizard's own AI step (distinct
+    // cc-*-wizard ids so it doesn't collide with the Settings → AI instance). No hard "ready" gate
+    // exists anywhere in this wizard — Next/Back/Done are never blocked on step completion (every
+    // step, including AI, is explicitly optional/skippable) — so this only surfaces status, it does
+    // not gate navigation.
+    (function () {
+      var sel = wizEl("wizProvider");
+      var card = wizEl("claude-code-status-wizard");
+      if (!sel || !card) return;
+      var dot = wizEl("cc-status-dot-wizard");
+      var msg = wizEl("cc-status-msg-wizard");
+      var connectBtn = wizEl("cc-connect-wizard");
+      var hint = wizEl("cc-connect-hint-wizard");
+      function paint(s) {
+        var colors = { connected: "#16a34a", not_connected: "#d97706", not_installed: "#dc2626" };
+        dot.style.background = colors[s.state] || "#6b7280";
+        msg.textContent = s.message || s.state;
+        connectBtn.style.display = s.state === "not_connected" ? "" : "none";
+      }
+      function refresh() {
+        msg.textContent = "Checking Claude Code…";
+        fetch("/diagnostics/claude-code-status").then(r => r.json()).then(paint)
+          .catch(() => { msg.textContent = "Status check failed."; });
+      }
+      function toggleCcWizCard() {
+        const on = sel.value === "claude-code";
+        card.style.display = on ? "" : "none";
+        if (on) refresh();
+      }
+      sel.addEventListener("change", toggleCcWizCard);
+      connectBtn.addEventListener("click", () => {
+        hint.style.display = "";
+        hint.textContent = "Starting sign-in…";
+        fetch("/diagnostics/claude-code-login", { method: "POST" }).then(r => r.json())
+          .then(r => {
+            if (r.url) hint.innerHTML = "Open this URL to finish signing in, then click Re-check:<br><a href=\"" + escAttr(r.url) + "\" target=\"_blank\" rel=\"noopener\">" + esc(r.url) + "</a>";
+            else if (r.started) hint.textContent = "Sign-in started on the host. Complete it in the browser that opened, then click Re-check.";
+            else hint.textContent = (r.error || "Could not start sign-in") + ". Run `claude auth login` in a terminal on the host, then click Re-check.";
+          }).catch(() => { hint.textContent = "Run `claude auth login` in a terminal on the host, then click Re-check."; });
+      });
+      wizEl("cc-recheck-wizard").addEventListener("click", refresh);
+    })();
     wizEl("wizProvider").addEventListener("change", e => {
       const p = e.target.value, hint = wizEl("wizModelHint");
       hint.innerHTML = WIZ_MODEL_HINTS[p] || "";
@@ -17517,7 +17630,9 @@
     async function wizSaveAndTestAi() {
       const provider = wizEl("wizProvider").value, model = wizEl("wizModel").value.trim();
       const key = wizEl("wizKey").value.trim(), baseUrl = wizEl("wizBaseUrl").value.trim();
-      const result = wizEl("wizResult"), local = LOCAL_PROVIDERS.has(provider);
+      // claude-code needs no API key (it shells out to the locally-signed-in Claude Code CLI), same
+      // as the LOCAL_PROVIDERS (ollama/litellm) exemption below.
+      const result = wizEl("wizResult"), local = LOCAL_PROVIDERS.has(provider) || provider === "claude-code";
       if (!provider) { result.style.color = "#ffb05a"; result.textContent = "Pick a provider first."; return; }
       if (!model) { result.style.color = "#ffb05a"; result.textContent = "Enter an extraction model."; return; }
       if (!key && !local) { result.style.color = "#ffb05a"; result.textContent = "Enter an API key (or pick a local provider)."; return; }


### PR DESCRIPTION
## Summary

Adds a **`claude-code`** AI provider that drives the local Claude Code CLI (`claude -p`) instead of a hosted HTTP API — using the operator's **logged-in Claude subscription, no API key**. One unified `stream-json` path handles both screenshot **extraction (vision)** and **text synthesis**. Selectable via `DFIR_VISION_PROVIDER=claude-code` (or the legacy `DFIR_AI_PROVIDER`) and reachable through every builder entry point — extraction, synthesis, second-opinion, and velo-hunts.

## What's included

- **`claudeRunner.ts`** — injectable process seam with a resolve-never-reject contract (spawn/timeout/abort surface as fields, not throws).
- **`claudeCode.ts`** — `ClaudeCodeProvider implements AIProvider`. Sends one user message (text + base64 image blocks) via `--input-format stream-json`; parses the terminal `result` event; maps token usage + `total_cost_usd` into `ProviderUsage`, and errors into `ProviderError` kinds (`auth`/`rate_limit`/`transport`/`timeout`/`other`). Runs isolated: `--system-prompt`, `--strict-mcp-config`, `--setting-sources ""`, `--allowed-tools ""` (also cuts per-call context overhead ~18k→2.8k tokens).
- **Registry wiring** in `buildProviderFrom`; treated as **non-local** by anonymization (evidence is anonymized before leaving to Anthropic, same as the hosted `anthropic` provider).
- **Connection status** — `claude auth status --json` detector → *not-installed / not-connected / connected*, exposed via `GET /diagnostics/claude-code-status` and a best-effort `POST /diagnostics/claude-code-login`.
- **Dashboard UI** — `claude-code` option in the provider selects, a status card in Settings → AI and the first-run wizard with **Re-check** and a one-click **Connect**; the login URL is HTML-escaped before injection.
- **Docs** — README + `companion/README.md` provider tables (caveats: subscription rate limits, API-equivalent cost, requires `claude auth login`).

## How it was built & reviewed

Implemented via a spec → plan → task-by-task pipeline. Each task got an independent spec+quality review; review-driven fixes applied (vacuous test assertions, a `startClaudeLogin` handle leak, label casing, XSS hardening on the login-URL hint). Final whole-branch review: **ready to merge**, no Critical/Important.

## Test plan

- [x] `npx tsc --noEmit` clean (whole project) against current `master`
- [x] Provider suite green — 65 tests incl. 20 new claude-code tests (runner, provider, status detector, wiring)
- [x] Live smoke test against the real `claude` CLI returned model output + usage incl. `costUSD`
- [x] Rebased onto latest `origin/master`; adapted UI wiring to master's `DFIR_AI_*` → `DFIR_VISION_*` provider-var rename (status card now hooks `env-DFIR_VISION_PROVIDER`)
- [ ] Reviewer: manual UI pass — select **claude code** in Settings → AI, confirm the status card shows *connected*; set `DFIR_AI_CLAUDE_CODE_BIN=/no/such/claude` and confirm *not installed*

## Notes / follow-ups

- The `companion/.env.example` provider-example block could not be added in this environment (sandbox blocks writes to `.env.*`); the provider is documented in both READMEs and the Settings UI instead — worth a one-line follow-up to add the commented example.
- Non-blocking hardening ideas from review: `classify()` could emit `billing`/`context` kinds; `getClaudeCodeStatus` could distinguish a timeout from not-connected; skip retries on `auth`/`rate_limit` for the spawned-CLI path; dedupe the two status-card IIFEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)