### PR TITLE
feat: Codex CLI as a text LLM provider (ambient auth, no API key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,14 @@ All companion behavior is configured via env vars (`companion/.env` or shell). C
 
 The split is **vision vs text**: `DFIR_VISION_MODEL` reads screenshots (must be multimodal); the `DFIR_AI_SYNTH_*` model does **all text work** — CSV extraction, log triage, synthesis, ask/explain. If unset, text work reuses `DFIR_VISION_MODEL`.
 
+**Codex** — set `DFIR_AI_SYNTH_PROVIDER=codex` (also valid for the velo / second-opinion providers)
+to run text work through the local OpenAI **Codex CLI** (`codex exec`), using your ambient codex
+auth — `codex login` or `OPENAI_API_KEY`, **no `DFIR_AI_KEY`**. Codex is **text-only** (it can't
+read screenshots), so pair it with a vision provider for extraction; it sends data to OpenAI
+(non-local). Requires `@openai/codex` installed. Optional `DFIR_AI_CODEX_BIN` points at a
+non-PATH `codex`. Settings → AI shows a codex connection status (not installed / not connected /
+connected) with a one-click Connect action.
+
 Recommended: cheap vision model for screenshots, strong reasoning model for text. Don't economise on the text model — a weak one fails log triage *silently*, returning no events rather than wrong ones (`npm run eval:real` measures exactly this).
 
 | Variable | Default | Meaning |

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -292,6 +292,13 @@ DFIR_VISION_IMAGE_DETAIL=high
 # DFIR_AI_SYNTH_PROVIDER=codex
 # DFIR_AI_SYNTH_MODEL=            # optional; leave blank to use the `codex` CLI's own default model
 # DFIR_AI_CODEX_BIN=              # only if `codex` isn't on PATH (absolute path to the binary)
+# ⚠ RAISE DFIR_AI_TIMEOUT_MS (above) when using codex — 180000 (3 min) is NOT enough. Codex runs as
+# a local agent process, not a plain completion API, so one synthesis is slow: measured live on a
+# mid-size case, a single call took 4m46s (~286s) for a 45K-char prompt. Below that budget it fails
+# with "Codex timed out after 180000ms" on an ordinary case. Use 800000 (~13.3 min), same as the
+# claude-code CLI provider. The budget is PER CALL, not per operation: a run that triggers the
+# automatic second-look re-synthesis makes two sequential calls (~10 min wall-clock), each getting
+# its own fresh timeout — so size it for the slowest SINGLE call, not their combined time.
 
 # --- Velociraptor hunt model (#70) ---------------------------------------------
 # A DEDICATED model used ONLY to generate Velociraptor VQL hunts (the "✨ Suggest

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -260,6 +260,12 @@ DFIR_VISION_IMAGE_DETAIL=high
 #     Text (CSV/log/synthesis):           claude-sonnet-4-6          — best speed/reasoning balance; 200K context
 #                                         claude-opus-4-8            — deepest reasoning for complex cases
 #
+#   Codex CLI  (DFIR_AI_SYNTH_PROVIDER=codex — no API key, uses your `codex login` / ambient auth)
+#     Screenshots (vision):               NOT SUPPORTED — codex exec has no image input; keep
+#                                          DFIR_VISION_PROVIDER on a vision-capable provider above
+#     Text (CSV/log/synthesis):           gpt-5-codex (or whatever model your `codex` CLI defaults to;
+#                                          leave DFIR_AI_SYNTH_MODEL unset to use the CLI's own default)
+#
 # Example — OpenAI two-tier setup:
 # DFIR_VISION_MODEL=gpt-4o-mini        # screenshots (set above)
 # DFIR_AI_SYNTH_MODEL=gpt-4o           # CSV/log/synthesis (set here)
@@ -279,6 +285,13 @@ DFIR_VISION_IMAGE_DETAIL=high
 # DFIR_AI_SYNTH_MODEL=google/gemini-2.5-pro
 # DFIR_AI_SYNTH_KEY=
 # DFIR_AI_SYNTH_BASE_URL=         # synthesis base URL override (falls back to DFIR_VISION_BASE_URL)
+#
+# Example — Codex CLI as the TEXT model (no API key, uses ambient `codex login` / OPENAI_API_KEY /
+# CODEX_API_KEY auth). Codex is text-only (no image input), so it can ONLY be the synth/velo/
+# second-opinion provider — DFIR_VISION_PROVIDER must stay on a vision-capable provider above:
+# DFIR_AI_SYNTH_PROVIDER=codex
+# DFIR_AI_SYNTH_MODEL=            # optional; leave blank to use the `codex` CLI's own default model
+# DFIR_AI_CODEX_BIN=              # only if `codex` isn't on PATH (absolute path to the binary)
 
 # --- Velociraptor hunt model (#70) ---------------------------------------------
 # A DEDICATED model used ONLY to generate Velociraptor VQL hunts (the "✨ Suggest

--- a/companion/README.md
+++ b/companion/README.md
@@ -65,6 +65,7 @@ http://127.0.0.1:4773/dashboard. On startup it logs the resolved cases root, e.g
 | `DFIR_VISION_IMAGE_DETAIL` | `high` \| `low` \| `auto` (default `high` for OCR) |
 | **AI — text model (optional two-tier)** | — |
 | `DFIR_AI_SYNTH_PROVIDER` / `_MODEL` / `_KEY` | Stronger model for ALL text work — CSV extraction, log triage, findings/MITRE/attacker path (unset = reuses `DFIR_VISION_MODEL`). `DFIR_VISION_MODEL` itself is the vision model: screenshots only. |
+| `DFIR_AI_SYNTH_PROVIDER=codex` | Run text work through the local OpenAI Codex CLI (`codex exec`) — text-only, ambient auth (`codex login` / `OPENAI_API_KEY`), no `DFIR_AI_KEY`. Also valid for velo / second-opinion. Optional `DFIR_AI_CODEX_BIN`. Not for extraction (no vision). |
 | **AI — Velociraptor VQL generation** | — |
 | `DFIR_AI_VELO_PROVIDER` / `_MODEL` / `_KEY` | Dedicated model for VQL hunts (many models botch VQL) |
 | **AI — second LLM opinion** | — |

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.32.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "cross-spawn": "^7.0.6",
         "docx": "^9.7.1",
         "dotenv": "^17.4.2",
         "express": "^4.19.2",
@@ -22,6 +23,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/cross-spawn": "^6.0.6",
         "@types/express": "^4.17.21",
         "@types/node": "^20.14.0",
         "@types/supertest": "^6.0.2",
@@ -1282,6 +1284,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1815,7 +1827,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2512,7 +2523,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jszip": {
@@ -2756,7 +2766,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3135,7 +3144,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3148,7 +3156,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4683,7 +4690,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/companion/package.json
+++ b/companion/package.json
@@ -46,6 +46,7 @@
     "package:choco": "node scripts/build-choco.mjs"
   },
   "dependencies": {
+    "cross-spawn": "^7.0.6",
     "docx": "^9.7.1",
     "dotenv": "^17.4.2",
     "express": "^4.19.2",
@@ -59,6 +60,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.6",
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.0",
     "@types/supertest": "^6.0.2",

--- a/companion/src/providers/codex.ts
+++ b/companion/src/providers/codex.ts
@@ -67,9 +67,21 @@ export class CodexProvider implements AIProvider {
 
     const parsed = parseCodexOutput(run.stdout);
     if (!parsed.text) {
-      const hadFailure = (run.code ?? 0) !== 0 || run.stderr.trim().length > 0;
-      if (hadFailure) {
-        const snip = (run.stderr || "no output").replace(/\s+/g, " ").trim().slice(0, 200);
+      // Codex's own `error` events are far more useful than stderr, which carries routine noise
+      // ("Reading prompt from stdin...", MCP-client startup warnings) even on a fully successful
+      // run — so stderr being non-empty is NOT by itself a failure signal.
+      if (parsed.errors.length) {
+        // MCP-client startup failures are unrelated to the request (they come from the user's own
+        // ~/.codex/config.toml) and codex emits them on runs that otherwise succeed. Lead with the
+        // real cause so it isn't pushed past the truncation by that noise.
+        const mcpNoise = (m: string) => /^MCP client\b/i.test(m);
+        const real = parsed.errors.filter((m) => !mcpNoise(m));
+        const chosen = real.length ? real : parsed.errors;
+        const snip = chosen.join("; ").replace(/\s+/g, " ").trim().slice(0, 300);
+        throw new ProviderError(`Codex: ${snip}`, classifyKind(run.code, snip));
+      }
+      if ((run.code ?? 0) !== 0) {
+        const snip = (run.stderr || "no output").replace(/\s+/g, " ").trim().slice(0, 300);
         throw new ProviderError(`Codex: ${snip}`, classifyKind(run.code, run.stderr));
       }
       throw new ProviderError("Codex returned no content", "other");
@@ -79,30 +91,46 @@ export class CodexProvider implements AIProvider {
 }
 
 // ── output parsing ────────────────────────────────────────────────────────────────────────────
-// `codex exec --json` emits newline-delimited JSON events, but the exact schema varies by CLI
-// version — so parse defensively: keep the text of the LAST message-like event, read usage from
-// any event that reports it, and fall back to the raw (non-JSON) stdout if no message event
-// parses. [verify-live] confirm the message/usage field names against a real Codex CLI.
-interface ParsedCodex { text?: string; usage?: ProviderUsage; }
+// `codex exec --json` emits newline-delimited JSON events. Verified against codex-cli 0.39.0, every
+// event is wrapped in an envelope — `{"id":"0","msg":{"type":"agent_message","message":"..."}}` —
+// so the `msg` body is unwrapped before reading fields; older/other shapes are flat, and those still
+// work because the unwrap falls back to the event itself. Kept deliberately defensive (several field
+// spellings, raw-stdout fallback) since the schema is not a stable contract across CLI versions.
+interface ParsedCodex { text?: string; usage?: ProviderUsage; errors: string[]; }
 
 function parseCodexOutput(stdout: string): ParsedCodex {
   let text: string | undefined;
   let usage: ProviderUsage | undefined;
+  const errors: string[] = [];
   for (const line of stdout.split("\n")) {
     const t = line.trim();
     if (!t || t[0] !== "{") continue;
     let evt: unknown;
     try { evt = JSON.parse(t); } catch { continue; }
-    const msg = extractText(evt);
+    const e = asRecord(evt);
+    if (!e) continue;
+    const body = asRecord(e.msg) ?? e;   // unwrap the { id, msg } envelope when present
+    const type = typeof body.type === "string" ? body.type : "";
+    // Match ANY error-ish event type — codex-cli 0.39.0 emits both `error` (MCP startup failures)
+    // and `stream_error` (e.g. "model not found", with a human-readable `message` field). These
+    // must never become the answer: they look exactly like a message event, so a substring match
+    // is used deliberately rather than an equality check on a fixed list of type names. Returning
+    // one as the synthesis result would report a hard failure as a confident finding.
+    if (/error/i.test(type)) {
+      const m = firstString(body.message, body.text);
+      if (m) errors.push(m);
+      continue;
+    }
+    const msg = extractText(body);
     if (msg) text = msg; // last message-like event wins (the final answer)
-    const u = extractUsage(evt);
+    const u = extractUsage(body);
     if (u) usage = u;
   }
   if (!text) {
     const raw = stdout.split("\n").filter((l) => { const t = l.trim(); return t && t[0] !== "{"; }).join("\n").trim();
     if (raw) text = raw;
   }
-  return { ...(text ? { text } : {}), ...(usage ? { usage } : {}) };
+  return { ...(text ? { text } : {}), ...(usage ? { usage } : {}), errors };
 }
 
 function asRecord(v: unknown): Record<string, unknown> | undefined {
@@ -136,7 +164,10 @@ function extractText(evt: unknown): string | undefined {
 function extractUsage(evt: unknown): ProviderUsage | undefined {
   const e = asRecord(evt);
   if (!e) return undefined;
-  const u = asRecord(e.usage) ?? asRecord(e.token_usage)
+  // codex-cli 0.39.0: { type: "token_count", info: { total_token_usage: { input_tokens, output_tokens, … } } }
+  const info = asRecord(e.info);
+  const total = info ? (asRecord(info.total_token_usage) ?? asRecord(info.last_token_usage)) : undefined;
+  const u = total ?? asRecord(e.usage) ?? asRecord(e.token_usage)
     ?? (typeof e.input_tokens === "number" || typeof e.output_tokens === "number" ? e : undefined);
   if (!u) return undefined;
   const inp = numOr(u.input_tokens) ?? numOr(u.prompt_tokens) ?? numOr(u.inputTokens);

--- a/companion/src/providers/codex.ts
+++ b/companion/src/providers/codex.ts
@@ -39,6 +39,9 @@ export class CodexProvider implements AIProvider {
 
     const prompt = `${req.systemPrompt}\n\n${req.userPrompt}`;
     const cwd = tmpdir(); // a neutral dir: codex exec runs read-only, outside any git repo
+    // No PROMPT argument — codex reads it from stdin instead (see codexRunner.ts for why: a
+    // `.cmd`-shimmed CLI on Windows runs through cmd.exe's ~8KB command-line limit, well below a
+    // typical synthesis prompt).
     const args = [
       "exec",
       "--json",
@@ -46,10 +49,9 @@ export class CodexProvider implements AIProvider {
       "--sandbox", "read-only",
       "-C", cwd,
       ...(this.model ? ["-m", this.model] : []),
-      prompt,
     ];
 
-    const run = await this.runner({ bin: this.bin, args, timeoutMs: this.timeoutMs, signal: req.signal, cwd });
+    const run = await this.runner({ bin: this.bin, args, stdin: prompt, timeoutMs: this.timeoutMs, signal: req.signal, cwd });
 
     if (run.spawnError) {
       if (run.spawnError.code === "ENOENT") {

--- a/companion/src/providers/codex.ts
+++ b/companion/src/providers/codex.ts
@@ -1,0 +1,157 @@
+import { tmpdir } from "node:os";
+import {
+  type AIProvider, type AnalyzeRequest, type AnalyzeResult, type ProviderUsage,
+  type ProviderErrorKind, ProviderError,
+} from "./provider.js";
+import { type CodexRunner, defaultCodexRunner } from "./codexRunner.js";
+
+export interface CodexOptions {
+  model: string;         // maps to `codex -m <model>`; "" → omit (codex default)
+  bin?: string;          // DFIR_AI_CODEX_BIN, or "codex" on PATH
+  timeoutMs?: number;
+  runner?: CodexRunner;  // injected in tests; defaults to the real spawn runner
+}
+
+// Text-only provider that drives `codex exec`. Codex is a coding agent, not a vision model, so
+// screenshot extraction is rejected up front; codex is meant for the text/synthesis role.
+export class CodexProvider implements AIProvider {
+  readonly name = "codex";
+  readonly model: string;
+  private readonly bin: string;
+  private readonly timeoutMs: number;
+  private readonly runner: CodexRunner;
+
+  constructor(opts: CodexOptions) {
+    this.model = opts.model;
+    this.bin = opts.bin?.trim() || "codex";
+    this.timeoutMs = opts.timeoutMs ?? 180_000;
+    this.runner = opts.runner ?? defaultCodexRunner;
+  }
+
+  async analyze(req: AnalyzeRequest): Promise<AnalyzeResult> {
+    if (req.images.length > 0) {
+      throw new ProviderError(
+        "Codex is text-only and can't read screenshots. Use a vision provider for extraction " +
+        "and set codex as the text/synthesis model (DFIR_AI_SYNTH_PROVIDER=codex).",
+        "other",
+      );
+    }
+
+    const prompt = `${req.systemPrompt}\n\n${req.userPrompt}`;
+    const cwd = tmpdir(); // a neutral dir: codex exec runs read-only, outside any git repo
+    const args = [
+      "exec",
+      "--json",
+      "--skip-git-repo-check",
+      "--sandbox", "read-only",
+      "-C", cwd,
+      ...(this.model ? ["-m", this.model] : []),
+      prompt,
+    ];
+
+    const run = await this.runner({ bin: this.bin, args, timeoutMs: this.timeoutMs, signal: req.signal, cwd });
+
+    if (run.spawnError) {
+      if (run.spawnError.code === "ENOENT") {
+        throw new ProviderError(
+          `Codex CLI not found (tried "${this.bin}"). Install it (\`npm i -g @openai/codex\`) and run ` +
+          `\`codex login\` (or set OPENAI_API_KEY), or set DFIR_AI_CODEX_BIN to its path.`,
+          "other",
+        );
+      }
+      throw new ProviderError(`Codex failed to start: ${run.spawnError.message}`, "transport");
+    }
+    if (run.timedOut) throw new ProviderError(`Codex timed out after ${this.timeoutMs}ms`, "timeout");
+
+    const parsed = parseCodexOutput(run.stdout);
+    if (!parsed.text) {
+      const hadFailure = (run.code ?? 0) !== 0 || run.stderr.trim().length > 0;
+      if (hadFailure) {
+        const snip = (run.stderr || "no output").replace(/\s+/g, " ").trim().slice(0, 200);
+        throw new ProviderError(`Codex: ${snip}`, classifyKind(run.code, run.stderr));
+      }
+      throw new ProviderError("Codex returned no content", "other");
+    }
+    return { rawText: parsed.text, ...(parsed.usage ? { usage: parsed.usage } : {}) };
+  }
+}
+
+// ── output parsing ────────────────────────────────────────────────────────────────────────────
+// `codex exec --json` emits newline-delimited JSON events, but the exact schema varies by CLI
+// version — so parse defensively: keep the text of the LAST message-like event, read usage from
+// any event that reports it, and fall back to the raw (non-JSON) stdout if no message event
+// parses. [verify-live] confirm the message/usage field names against a real Codex CLI.
+interface ParsedCodex { text?: string; usage?: ProviderUsage; }
+
+function parseCodexOutput(stdout: string): ParsedCodex {
+  let text: string | undefined;
+  let usage: ProviderUsage | undefined;
+  for (const line of stdout.split("\n")) {
+    const t = line.trim();
+    if (!t || t[0] !== "{") continue;
+    let evt: unknown;
+    try { evt = JSON.parse(t); } catch { continue; }
+    const msg = extractText(evt);
+    if (msg) text = msg; // last message-like event wins (the final answer)
+    const u = extractUsage(evt);
+    if (u) usage = u;
+  }
+  if (!text) {
+    const raw = stdout.split("\n").filter((l) => { const t = l.trim(); return t && t[0] !== "{"; }).join("\n").trim();
+    if (raw) text = raw;
+  }
+  return { ...(text ? { text } : {}), ...(usage ? { usage } : {}) };
+}
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return typeof v === "object" && v !== null ? (v as Record<string, unknown>) : undefined;
+}
+function numOr(v: unknown): number | undefined {
+  return typeof v === "number" ? v : undefined;
+}
+function firstString(...vs: unknown[]): string | undefined {
+  for (const v of vs) if (typeof v === "string" && v.trim()) return v;
+  return undefined;
+}
+
+function extractText(evt: unknown): string | undefined {
+  const e = asRecord(evt);
+  if (!e) return undefined;
+  const direct = firstString(e.text, e.message, e.content, e.output_text, e.delta);
+  if (direct) return direct;
+  // content as an array of blocks: [{ type: "text", text: "..." }]
+  const arr = Array.isArray(e.content) ? e.content : Array.isArray(e.output) ? e.output : undefined;
+  if (arr) {
+    const parts = arr.map((b) => { const r = asRecord(b); return r && typeof r.text === "string" ? r.text : ""; }).filter(Boolean);
+    if (parts.length) return parts.join("");
+  }
+  // nested { message: { content|text: ... } }
+  const nested = asRecord(e.message);
+  if (nested) return extractText(nested);
+  return undefined;
+}
+
+function extractUsage(evt: unknown): ProviderUsage | undefined {
+  const e = asRecord(evt);
+  if (!e) return undefined;
+  const u = asRecord(e.usage) ?? asRecord(e.token_usage)
+    ?? (typeof e.input_tokens === "number" || typeof e.output_tokens === "number" ? e : undefined);
+  if (!u) return undefined;
+  const inp = numOr(u.input_tokens) ?? numOr(u.prompt_tokens) ?? numOr(u.inputTokens);
+  const out = numOr(u.output_tokens) ?? numOr(u.completion_tokens) ?? numOr(u.outputTokens);
+  const cost = numOr(u.cost_usd) ?? numOr(u.costUSD) ?? numOr(u.total_cost_usd);
+  if (inp === undefined && out === undefined && cost === undefined) return undefined;
+  return {
+    ...(inp !== undefined ? { inputTokens: inp } : {}),
+    ...(out !== undefined ? { outputTokens: out } : {}),
+    ...(cost !== undefined ? { costUSD: cost } : {}),
+  };
+}
+
+function classifyKind(code: number | null, stderr: string): ProviderErrorKind {
+  const s = (stderr || "").toLowerCase();
+  if (/unauthor|not (logged|signed) in|auth|login|api key|401|403/.test(s)) return "auth";
+  if (/rate limit|quota|429|too many requests/.test(s)) return "rate_limit";
+  if (/5\d\d|network|econn|socket|timed out/.test(s)) return "transport";
+  return code === null ? "transport" : "other";
+}

--- a/companion/src/providers/codex.ts
+++ b/companion/src/providers/codex.ts
@@ -91,15 +91,22 @@ export class CodexProvider implements AIProvider {
 }
 
 // ── output parsing ────────────────────────────────────────────────────────────────────────────
-// `codex exec --json` emits newline-delimited JSON events. Verified against codex-cli 0.39.0, every
-// event is wrapped in an envelope — `{"id":"0","msg":{"type":"agent_message","message":"..."}}` —
-// so the `msg` body is unwrapped before reading fields; older/other shapes are flat, and those still
-// work because the unwrap falls back to the event itself. Kept deliberately defensive (several field
-// spellings, raw-stdout fallback) since the schema is not a stable contract across CLI versions.
+// `codex exec --json` emits newline-delimited JSON events. The schema is NOT a stable contract —
+// two materially different shapes are already confirmed in the wild, so both are handled:
+//
+//   codex-cli 0.39.x   {"id":"0","msg":{"type":"agent_message","message":"PONG"}}
+//                      usage at msg.info.total_token_usage
+//   codex-cli 0.144.x  {"type":"item.completed","item":{"type":"agent_message","text":"PONG"}}
+//                      usage at turn.completed.usage
+//
+// Hence the layered unwrap (`msg`, then `item`, each falling back to the event itself) and the
+// several accepted field spellings. Anything unrecognised degrades to the raw-stdout fallback
+// rather than silently yielding an empty synthesis.
 interface ParsedCodex { text?: string; usage?: ProviderUsage; errors: string[]; }
 
 function parseCodexOutput(stdout: string): ParsedCodex {
-  let text: string | undefined;
+  let agentText: string | undefined;  // from an explicit agent_message — the actual answer
+  let anyText: string | undefined;    // fallback: any other message-like event
   let usage: ProviderUsage | undefined;
   const errors: string[] = [];
   for (const line of stdout.split("\n")) {
@@ -109,23 +116,31 @@ function parseCodexOutput(stdout: string): ParsedCodex {
     try { evt = JSON.parse(t); } catch { continue; }
     const e = asRecord(evt);
     if (!e) continue;
-    const body = asRecord(e.msg) ?? e;   // unwrap the { id, msg } envelope when present
-    const type = typeof body.type === "string" ? body.type : "";
-    // Match ANY error-ish event type — codex-cli 0.39.0 emits both `error` (MCP startup failures)
-    // and `stream_error` (e.g. "model not found", with a human-readable `message` field). These
-    // must never become the answer: they look exactly like a message event, so a substring match
-    // is used deliberately rather than an equality check on a fixed list of type names. Returning
-    // one as the synthesis result would report a hard failure as a confident finding.
-    if (/error/i.test(type)) {
-      const m = firstString(body.message, body.text);
+    const body = asRecord(e.msg) ?? e;          // 0.39.x envelope
+    const payload = asRecord(body.item) ?? body; // 0.144.x item wrapper
+    const outerType = typeof body.type === "string" ? body.type : "";
+    const innerType = typeof payload.type === "string" ? payload.type : "";
+    // Match ANY error-ish type at either level — 0.39.x emits `error` (MCP startup failures) and
+    // `stream_error` (e.g. "model not found"), each with a human-readable `message` that is
+    // shape-identical to an answer. A substring match is used deliberately rather than equality
+    // against a fixed list, because returning one of these as the synthesis result would report a
+    // hard failure as a confident finding.
+    if (/error/i.test(outerType) || /error/i.test(innerType)) {
+      const m = firstString(payload.message, payload.text, body.message, body.text);
       if (m) errors.push(m);
       continue;
     }
-    const msg = extractText(body);
-    if (msg) text = msg; // last message-like event wins (the final answer)
-    const u = extractUsage(body);
+    const msg = extractText(payload);
+    if (msg) {
+      // Prefer a real agent_message: a turn also emits reasoning / command / tool items that carry
+      // their own text, and those must never stand in for the model's answer.
+      if (innerType === "agent_message" || outerType === "agent_message") agentText = msg;
+      else anyText = msg;
+    }
+    const u = extractUsage(body) ?? extractUsage(payload);
     if (u) usage = u;
   }
+  let text = agentText ?? anyText;
   if (!text) {
     const raw = stdout.split("\n").filter((l) => { const t = l.trim(); return t && t[0] !== "{"; }).join("\n").trim();
     if (raw) text = raw;

--- a/companion/src/providers/codexRunner.ts
+++ b/companion/src/providers/codexRunner.ts
@@ -1,4 +1,10 @@
-import { spawn } from "node:child_process";
+// cross-spawn, NOT node:child_process directly: on Windows, an npm-installed CLI (like `codex`) is a
+// `.cmd` shim, and Node refuses to spawn `.cmd`/`.bat` files without `shell: true` (CVE-2024-27980).
+// Naively adding `shell: true` here would be a command-injection hole, since argv is the forensic-
+// evidence prompt (attacker-controlled text) — cross-spawn resolves the shim AND safely quotes each
+// argument instead of using a raw shell string, matching this codebase's no-raw-shell convention
+// (see toolRunner.ts / velociraptorApi.ts) while still working on Windows.
+import spawn from "cross-spawn";
 
 // Result of one Codex CLI invocation. Process-level failures (missing binary, timeout/abort) come
 // back as fields rather than rejections, so the provider maps them to ProviderError uniformly.
@@ -48,7 +54,9 @@ export const defaultCodexRunner: CodexRunner = (opts) =>
     const done = (r: CodexRunResult) => { if (!settled) { settled = true; cleanup(); resolve(r); } };
 
     child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout, stderr, spawnError: err }));
-    child.stdout.on("data", (d) => { stdout += d.toString(); });
-    child.stderr.on("data", (d) => { stderr += d.toString(); });
+    // Non-null: stdio: ["ignore", "pipe", "pipe"] above guarantees these pipes exist; cross-spawn's
+    // return type is the generic ChildProcess (stdout/stderr typed nullable for other stdio configs).
+    child.stdout!.on("data", (d) => { stdout += d.toString(); });
+    child.stderr!.on("data", (d) => { stderr += d.toString(); });
     child.on("close", (code) => done({ code, stdout, stderr, ...(timedOut ? { timedOut: true } : {}) }));
   });

--- a/companion/src/providers/codexRunner.ts
+++ b/companion/src/providers/codexRunner.ts
@@ -18,7 +18,8 @@ export interface CodexRunResult {
 
 export interface CodexRunOptions {
   bin: string;
-  args: string[];       // the prompt is passed as an argument, NOT via stdin (see below)
+  args: string[];
+  stdin: string;         // the prompt, written to the child's stdin and then closed (see below)
   timeoutMs: number;
   signal?: AbortSignal; // external cancellation
   cwd?: string;
@@ -26,9 +27,12 @@ export interface CodexRunOptions {
 
 export type CodexRunner = (opts: CodexRunOptions) => Promise<CodexRunResult>;
 
-// Default runner: spawn the codex CLI, collect stdout/stderr, resolve on close. stdin is IGNORED
-// (not piped) on purpose — some Codex CLI versions deadlock reading stdin, so the prompt is passed
-// as an argument and the child's stdin is closed (/dev/null-like) from the start.
+// Default runner: spawn the codex CLI, feed the prompt via stdin, collect stdout/stderr, resolve on
+// close. The prompt goes over stdin — NOT argv — because `.cmd`-shimmed CLIs (npm-installed `codex`
+// on Windows) run through cmd.exe, whose command-line length limit (~8KB) is far below a typical
+// DFIR synthesis prompt (routinely 20-30K+ chars); `codex exec --help` documents stdin as exactly
+// this large-input path when no PROMPT argument is given. Live-verified this doesn't deadlock on a
+// real `codex exec --json` invocation with a 29K-char stdin payload.
 export const defaultCodexRunner: CodexRunner = (opts) =>
   new Promise<CodexRunResult>((resolve) => {
     let stdout = "";
@@ -37,7 +41,7 @@ export const defaultCodexRunner: CodexRunner = (opts) =>
     let timedOut = false;
 
     const child = spawn(opts.bin, opts.args, {
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
       ...(opts.cwd ? { cwd: opts.cwd } : {}),
     });
 
@@ -54,9 +58,12 @@ export const defaultCodexRunner: CodexRunner = (opts) =>
     const done = (r: CodexRunResult) => { if (!settled) { settled = true; cleanup(); resolve(r); } };
 
     child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout, stderr, spawnError: err }));
-    // Non-null: stdio: ["ignore", "pipe", "pipe"] above guarantees these pipes exist; cross-spawn's
-    // return type is the generic ChildProcess (stdout/stderr typed nullable for other stdio configs).
+    // Non-null: stdio: ["pipe", "pipe", "pipe"] above guarantees these pipes exist; cross-spawn's
+    // return type is the generic ChildProcess (stdout/stderr/stdin typed nullable for other stdio configs).
     child.stdout!.on("data", (d) => { stdout += d.toString(); });
     child.stderr!.on("data", (d) => { stderr += d.toString(); });
     child.on("close", (code) => done({ code, stdout, stderr, ...(timedOut ? { timedOut: true } : {}) }));
+
+    child.stdin!.on("error", () => { /* ignore EPIPE if the child exits before we finish writing */ });
+    child.stdin!.end(opts.stdin);
   });

--- a/companion/src/providers/codexRunner.ts
+++ b/companion/src/providers/codexRunner.ts
@@ -1,0 +1,54 @@
+import { spawn } from "node:child_process";
+
+// Result of one Codex CLI invocation. Process-level failures (missing binary, timeout/abort) come
+// back as fields rather than rejections, so the provider maps them to ProviderError uniformly.
+export interface CodexRunResult {
+  code: number | null;                 // exit code; null when the process was killed
+  stdout: string;
+  stderr: string;
+  spawnError?: NodeJS.ErrnoException;  // set when the process could not be spawned (e.g. ENOENT)
+  timedOut?: boolean;                  // true when killed by the timeout or the external signal
+}
+
+export interface CodexRunOptions {
+  bin: string;
+  args: string[];       // the prompt is passed as an argument, NOT via stdin (see below)
+  timeoutMs: number;
+  signal?: AbortSignal; // external cancellation
+  cwd?: string;
+}
+
+export type CodexRunner = (opts: CodexRunOptions) => Promise<CodexRunResult>;
+
+// Default runner: spawn the codex CLI, collect stdout/stderr, resolve on close. stdin is IGNORED
+// (not piped) on purpose — some Codex CLI versions deadlock reading stdin, so the prompt is passed
+// as an argument and the child's stdin is closed (/dev/null-like) from the start.
+export const defaultCodexRunner: CodexRunner = (opts) =>
+  new Promise<CodexRunResult>((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+
+    const child = spawn(opts.bin, opts.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    });
+
+    const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, opts.timeoutMs);
+    const onAbort = () => { timedOut = true; child.kill("SIGKILL"); };
+    if (opts.signal) {
+      if (opts.signal.aborted) onAbort();
+      else opts.signal.addEventListener("abort", onAbort, { once: true });
+    }
+    const cleanup = () => {
+      clearTimeout(timer);
+      if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
+    };
+    const done = (r: CodexRunResult) => { if (!settled) { settled = true; cleanup(); resolve(r); } };
+
+    child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout, stderr, spawnError: err }));
+    child.stdout.on("data", (d) => { stdout += d.toString(); });
+    child.stderr.on("data", (d) => { stderr += d.toString(); });
+    child.on("close", (code) => done({ code, stdout, stderr, ...(timedOut ? { timedOut: true } : {}) }));
+  });

--- a/companion/src/providers/codexStatus.ts
+++ b/companion/src/providers/codexStatus.ts
@@ -34,7 +34,7 @@ export async function getCodexStatus(opts: GetCodexStatusOptions = {}): Promise<
   const env = opts.env ?? process.env;
   const authFileExists = opts.authFileExists ?? (() => defaultAuthFileExists(env));
 
-  const run = await runner({ bin, args: ["--version"], timeoutMs: opts.timeoutMs ?? 10_000 });
+  const run = await runner({ bin, args: ["--version"], stdin: "", timeoutMs: opts.timeoutMs ?? 10_000 });
   if (run.spawnError) {
     const msg = run.spawnError.code === "ENOENT"
       ? "Codex CLI isn't installed on this machine. Install it (`npm i -g @openai/codex`), then click Re-check."

--- a/companion/src/providers/codexStatus.ts
+++ b/companion/src/providers/codexStatus.ts
@@ -1,7 +1,8 @@
-import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+// cross-spawn: see codexRunner.ts — resolves the Windows `.cmd` shim without a raw shell string.
+import spawn from "cross-spawn";
 import { type CodexRunner, defaultCodexRunner } from "./codexRunner.js";
 
 export type CodexAuthState = "not_installed" | "not_connected" | "connected";

--- a/companion/src/providers/codexStatus.ts
+++ b/companion/src/providers/codexStatus.ts
@@ -1,0 +1,111 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { type CodexRunner, defaultCodexRunner } from "./codexRunner.js";
+
+export type CodexAuthState = "not_installed" | "not_connected" | "connected";
+
+export interface CodexStatus {
+  state: CodexAuthState;
+  authMethod?: string;
+  message: string;
+}
+
+export interface GetCodexStatusOptions {
+  bin?: string;
+  runner?: CodexRunner;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  authFileExists?: () => boolean; // injected in tests; defaults to checking ~/.codex/auth.json
+}
+
+function defaultAuthFileExists(env: NodeJS.ProcessEnv): boolean {
+  const home = env.CODEX_HOME && env.CODEX_HOME.trim() ? env.CODEX_HOME : join(homedir(), ".codex");
+  return existsSync(join(home, "auth.json"));
+}
+
+// Detect whether Codex is installed and authenticated. There is no `codex auth status --json`, so
+// this mirrors the gstack probe: binary presence + (env API key OR ~/.codex/auth.json). Never throws.
+export async function getCodexStatus(opts: GetCodexStatusOptions = {}): Promise<CodexStatus> {
+  const bin = opts.bin?.trim() || "codex";
+  const runner = opts.runner ?? defaultCodexRunner;
+  const env = opts.env ?? process.env;
+  const authFileExists = opts.authFileExists ?? (() => defaultAuthFileExists(env));
+
+  const run = await runner({ bin, args: ["--version"], timeoutMs: opts.timeoutMs ?? 10_000 });
+  if (run.spawnError) {
+    const msg = run.spawnError.code === "ENOENT"
+      ? "Codex CLI isn't installed on this machine. Install it (`npm i -g @openai/codex`), then click Re-check."
+      : `Codex could not be run: ${run.spawnError.message}`;
+    return { state: "not_installed", message: msg };
+  }
+
+  const envKey = (env.OPENAI_API_KEY || env.CODEX_API_KEY || "").trim();
+  if (envKey) {
+    return { state: "connected", authMethod: "api_key", message: "Codex is ready (using an API key from the environment)." };
+  }
+  if (authFileExists()) {
+    return { state: "connected", authMethod: "codex login", message: "Codex is ready (signed in via `codex login`)." };
+  }
+  return {
+    state: "not_connected",
+    message: "Codex is installed but not signed in. Run `codex login` (or set OPENAI_API_KEY), then click Re-check.",
+  };
+}
+
+// Best-effort: start the interactive `codex login` on the host and capture whatever it prints for
+// up to captureMs, extracting the first URL so the UI can show it. The process is detached and its
+// pipe streams are unref'd so it can't keep the server process alive; the reliable confirmation is
+// a subsequent getCodexStatus() (the dashboard's Re-check button).
+export async function startCodexLogin(
+  opts: { bin?: string; captureMs?: number } = {},
+): Promise<{ started: boolean; url?: string; output: string; error?: string }> {
+  const bin = opts.bin?.trim() || "codex";
+  const captureMs = opts.captureMs ?? 8000;
+  return new Promise((resolve) => {
+    let output = "";
+    let settled = false;
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(bin, ["login"], { stdio: ["ignore", "pipe", "pipe"], detached: true });
+    } catch (err) {
+      resolve({ started: false, output: "", error: (err as Error).message });
+      return;
+    }
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const m = output.match(/https?:\/\/\S+/);
+      child.unref();
+      unrefIfPossible(child.stdout);
+      unrefIfPossible(child.stderr);
+      resolve({ started: true, output: output.slice(0, 2000), ...(m ? { url: m[0] } : {}) });
+    };
+    const timer = setTimeout(finish, captureMs);
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ started: false, output, error: err.code === "ENOENT" ? "Codex CLI not found" : err.message });
+    });
+    child.stdout?.on("data", (d) => { output += d.toString(); });
+    child.stderr?.on("data", (d) => { output += d.toString(); });
+    child.on("close", finish);
+  });
+}
+
+// child.stdout/stderr are typed Readable (no unref in the type) but are net.Socket-like handles
+// that support unref() at runtime. Narrow with a type guard instead of `any` so we can safely
+// unref them and let the event loop exit.
+function unrefIfPossible(stream: unknown): void {
+  if (
+    typeof stream === "object" &&
+    stream !== null &&
+    "unref" in stream &&
+    typeof (stream as { unref: unknown }).unref === "function"
+  ) {
+    (stream as { unref: () => void }).unref();
+  }
+}

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from "express";
 import { join, relative } from "node:path";
 import { readFile, stat, readdir, mkdir } from "node:fs/promises";
 import { isLogLevel } from "../logging/logger.js";
+import { getCodexStatus, startCodexLogin } from "../providers/codexStatus.js";
 import { getDiskStats, getDiskWarningLevel, diskWarnEnvThresholds } from "../analysis/diskWarn.js";
 import {
   buildAiDiagnostics, summarizeImportAttempts, countByKind, aggregateCaseSizes, buildDiagnosticsText,
@@ -312,6 +313,19 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
       serverLogger.info(`[diagnostics] AI test failed provider=${provider.name} kind=${kind}: ${(err as Error).message}`);
       return res.status(200).json({ ok: false, provider: provider.name, latencyMs, kind, error: (err as Error).message });
     }
+  });
+
+  // Codex CLI connection status (installed / signed-in) for Settings → AI and the wizard.
+  app.get("/diagnostics/codex-status", async (_req: Request, res: Response) => {
+    const status = await getCodexStatus({ bin: process.env.DFIR_AI_CODEX_BIN });
+    return res.status(200).json({ ok: true, ...status });
+  });
+
+  // Best-effort "Connect" action: start `codex login` on the host and return any auth URL.
+  // Only meaningful when the server runs on the operator's own machine; Re-check confirms success.
+  app.post("/diagnostics/codex-login", async (_req: Request, res: Response) => {
+    const r = await startCodexLogin({ bin: process.env.DFIR_AI_CODEX_BIN });
+    return res.status(200).json({ ok: r.started, ...r });
   });
 
   // ── Startup pre-flight (#179) ─────────────────────────────────────────────────────────

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2443,6 +2443,7 @@ import { OllamaCloudProvider } from "./providers/ollama.js";
 import { LiteLlmProvider } from "./providers/litellm.js";
 import { GeminiProvider } from "./providers/gemini.js";
 import { AnthropicProvider } from "./providers/anthropic.js";
+import { CodexProvider } from "./providers/codex.js";
 import { WebSocketServer } from "ws";
 import { LiveHub } from "./live/hub.js";
 import { ReportWriter as ReportWriterImpl } from "./reports/reportWriter.js";
@@ -2489,6 +2490,7 @@ export function buildProviderFrom(params: ProviderParams): AnalyzeProvider | und
   registry.register(new LiteLlmProvider({ apiKey, model, baseUrl, imageDetail, timeoutMs, maxTokens, contextTokens }));
   registry.register(new GeminiProvider({ apiKey, model, baseUrl, timeoutMs, maxTokens }));
   registry.register(new AnthropicProvider({ apiKey, model, baseUrl, timeoutMs, maxTokens }));
+  registry.register(new CodexProvider({ model, timeoutMs, bin: process.env.DFIR_AI_CODEX_BIN }));
   return registry.get(name);
 }
 

--- a/companion/tests/providers/codex.test.ts
+++ b/companion/tests/providers/codex.test.ts
@@ -76,6 +76,35 @@ describe("CodexProvider", () => {
     expect(out.usage).toEqual({ inputTokens: 6717, outputTokens: 4 });
   });
 
+  // Captured verbatim from codex-cli 0.144.6 — a completely different schema from 0.39.x: no `msg`
+  // envelope, the answer nested under `item`, usage on turn.completed. Parsing only the 0.39 shape
+  // yielded no text at all, surfacing a SUCCESSFUL run as "Codex returned no content".
+  it("parses the codex-cli 0.144 schema: item.completed + turn.completed usage", async () => {
+    const stdout = [
+      '{"type":"thread.started","thread_id":"019f7a40-cb5e-75f0-93da-4649cb9664b5"}',
+      '{"type":"turn.started"}',
+      '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"PONG"}}',
+      '{"type":"turn.completed","usage":{"input_tokens":14174,"cached_input_tokens":9984,"output_tokens":6,"reasoning_output_tokens":0}}',
+    ].join("\n");
+    const out = await new CodexProvider({ model: "m", runner: fakeRunner({ stdout, stderr: "Reading prompt from stdin...\n" }) })
+      .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.rawText).toBe("PONG");
+    expect(out.usage).toEqual({ inputTokens: 14174, outputTokens: 6 });
+  });
+
+  // A turn also emits reasoning / command / tool items that carry their own text. Only the
+  // agent_message is the model's answer — a reasoning item must never stand in for it.
+  it("prefers the agent_message over other item types that also carry text", async () => {
+    const stdout = [
+      '{"type":"item.completed","item":{"id":"i0","type":"reasoning","text":"thinking out loud"}}',
+      '{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"the real answer"}}',
+      '{"type":"item.completed","item":{"id":"i2","type":"command_execution","text":"ls -la"}}',
+    ].join("\n");
+    const out = await new CodexProvider({ model: "m", runner: fakeRunner({ stdout }) })
+      .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.rawText).toBe("the real answer");
+  });
+
   // codex logs MCP-client startup failures as `error` events on runs that otherwise SUCCEED.
   it("ignores error events when a real answer is present", async () => {
     const stdout = [

--- a/companion/tests/providers/codex.test.ts
+++ b/companion/tests/providers/codex.test.ts
@@ -59,6 +59,82 @@ describe("CodexProvider", () => {
     expect(out.usage).toEqual({ inputTokens: 12, outputTokens: 7 });
   });
 
+  // Captured verbatim from a real `codex exec --json` run (codex-cli 0.39.0). Every event is
+  // wrapped in an { id, msg } envelope — the shape the original parser missed, which made a
+  // SUCCESSFUL run surface as "synthesis failed" with stderr noise as the message.
+  it("parses the real codex-cli 0.39 envelope: msg.message + msg.info.total_token_usage", async () => {
+    const stdout = [
+      '{"provider":"openai","workdir":"C:\\\\tmp","approval":"never","model":"gpt-5-codex","sandbox":"read-only"}',
+      '{"prompt":"Reply with exactly: PONG"}',
+      '{"id":"0","msg":{"type":"task_started","model_context_window":null}}',
+      '{"id":"0","msg":{"type":"agent_message","message":"PONG"}}',
+      '{"id":"0","msg":{"type":"token_count","info":{"total_token_usage":{"input_tokens":6717,"cached_input_tokens":0,"output_tokens":4,"total_tokens":6721}}}}',
+    ].join("\n");
+    const out = await new CodexProvider({ model: "m", runner: fakeRunner({ stdout, stderr: "Reading prompt from stdin...\n" }) })
+      .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.rawText).toBe("PONG");
+    expect(out.usage).toEqual({ inputTokens: 6717, outputTokens: 4 });
+  });
+
+  // codex logs MCP-client startup failures as `error` events on runs that otherwise SUCCEED.
+  it("ignores error events when a real answer is present", async () => {
+    const stdout = [
+      '{"id":"","msg":{"type":"error","message":"MCP client for `n8n` failed to start: program not found"}}',
+      '{"id":"0","msg":{"type":"agent_message","message":"the answer"}}',
+    ].join("\n");
+    const out = await new CodexProvider({ model: "m", runner: fakeRunner({ stdout }) })
+      .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.rawText).toBe("the answer");
+  });
+
+  // stderr is non-empty on EVERY successful run ("Reading prompt from stdin..."), so it must not
+  // be treated as a failure signal on its own — and when there IS no answer, codex's own error
+  // events are the useful message, not the stderr noise.
+  it("surfaces codex error events, not stderr noise, when no answer came back", async () => {
+    const stdout = '{"id":"0","msg":{"type":"error","message":"stream error: connection refused"}}';
+    const runner = fakeRunner({ code: 0, stdout, stderr: "Reading prompt from stdin...\nERROR MCP client blah\n" });
+    await expect(
+      new CodexProvider({ model: "m", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] }),
+    ).rejects.toThrow(/stream error: connection refused/);
+  });
+
+  // Regression: captured verbatim from a real failing run (exit code 0, no agent_message, only
+  // `stream_error` events). `stream_error` carries a human-readable `message`, so a parser that
+  // only skips type === "error" returns the ERROR TEXT as the synthesis result — a hard failure
+  // reported as a confident finding. Must reject instead.
+  it("never returns a stream_error as the answer (exit 0, retries exhausted)", async () => {
+    const stdout = [
+      '{"id":"0","msg":{"type":"task_started","model_context_window":null}}',
+      '{"id":"0","msg":{"type":"stream_error","message":"stream error: unexpected status 404 Not Found: {\\"error\\":{\\"message\\":\\"model \'gpt-5-codex\' not found\\"}}; retrying 5/5 in 3.263s…"}}',
+    ].join("\n");
+    const runner = fakeRunner({ code: 0, stdout, stderr: "Reading prompt from stdin...\n" });
+    const call = new CodexProvider({ model: "m", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    await expect(call).rejects.toBeInstanceOf(ProviderError);
+    await expect(call).rejects.toThrow(/model 'gpt-5-codex' not found/);
+  });
+
+  // The real cause must lead the message: MCP-client startup failures come from the user's own
+  // ~/.codex/config.toml, are emitted even on successful runs, and would otherwise push the
+  // actionable error past the 300-char truncation in the dashboard.
+  it("leads with the real error, not MCP-client startup noise", async () => {
+    const stdout = [
+      '{"id":"","msg":{"type":"error","message":"MCP client for `n8n` failed to start: program not found"}}',
+      '{"id":"","msg":{"type":"error","message":"MCP client for `playwright` failed to start: program not found"}}',
+      '{"id":"0","msg":{"type":"stream_error","message":"stream error: unexpected status 404 Not Found: model \'gpt-5\' not found"}}',
+    ].join("\n");
+    const runner = fakeRunner({ code: 0, stdout, stderr: "Reading prompt from stdin...\n" });
+    await expect(
+      new CodexProvider({ model: "m", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] }),
+    ).rejects.toThrow(/^Codex: stream error: unexpected status 404/);
+  });
+
+  it("does not fail a successful run just because stderr has content", async () => {
+    const stdout = '{"id":"0","msg":{"type":"agent_message","message":"fine"}}';
+    const out = await new CodexProvider({ model: "m", runner: fakeRunner({ code: 0, stdout, stderr: "Reading prompt from stdin...\n" }) })
+      .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.rawText).toBe("fine");
+  });
+
   it("falls back to raw stdout when there is no JSON message event", async () => {
     const out = await new CodexProvider({ model: "m", runner: fakeRunner({ stdout: "plain text answer\n" }) })
       .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });

--- a/companion/tests/providers/codex.test.ts
+++ b/companion/tests/providers/codex.test.ts
@@ -23,7 +23,7 @@ describe("CodexProvider", () => {
     expect(runner).not.toHaveBeenCalled();
   });
 
-  it("builds the codex exec invocation with the prompt as one arg", async () => {
+  it("builds the codex exec invocation with the prompt sent over stdin", async () => {
     let captured: CodexRunOptions | undefined;
     const runner = fakeRunner({ stdout: JSON.stringify({ type: "agent_message", text: "ok" }) }, (o) => { captured = o; });
     const p = new CodexProvider({ model: "gpt-5-codex", runner });
@@ -34,8 +34,9 @@ describe("CodexProvider", () => {
     expect(a[0]).toBe("exec");
     expect(a).toEqual(expect.arrayContaining(["--json", "--skip-git-repo-check", "--sandbox", "read-only"]));
     expect(a).toEqual(expect.arrayContaining(["-m", "gpt-5-codex"]));
-    // prompt is the final argument and combines system + user
-    expect(a[a.length - 1]).toBe("SYS\n\nUSER");
+    // no PROMPT argument — it's sent over stdin (Windows argv length limit; see codexRunner.ts)
+    expect(a).not.toContain("SYS\n\nUSER");
+    expect(captured!.stdin).toBe("SYS\n\nUSER");
   });
 
   it("omits -m when the model is empty", async () => {

--- a/companion/tests/providers/codex.test.ts
+++ b/companion/tests/providers/codex.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { CodexProvider } from "../../src/providers/codex.js";
+import type { CodexRunOptions, CodexRunResult } from "../../src/providers/codexRunner.js";
+import { ProviderError } from "../../src/providers/provider.js";
+
+function fakeRunner(result: Partial<CodexRunResult>, capture?: (o: CodexRunOptions) => void) {
+  return vi.fn(async (opts: CodexRunOptions): Promise<CodexRunResult> => {
+    capture?.(opts);
+    return { code: 0, stdout: "", stderr: "", ...result };
+  });
+}
+
+describe("CodexProvider", () => {
+  it("rejects vision requests — codex is text-only", async () => {
+    const runner = fakeRunner({ stdout: "" });
+    const p = new CodexProvider({ model: "gpt-5-codex", runner });
+    await expect(
+      p.analyze({ systemPrompt: "s", userPrompt: "u", images: [{ base64: "AAA", mimeType: "image/png" }] }),
+    ).rejects.toMatchObject({ kind: "other" });
+    await expect(
+      p.analyze({ systemPrompt: "s", userPrompt: "u", images: [{ base64: "AAA", mimeType: "image/png" }] }),
+    ).rejects.toThrow(/text-only|screenshots/i);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("builds the codex exec invocation with the prompt as one arg", async () => {
+    let captured: CodexRunOptions | undefined;
+    const runner = fakeRunner({ stdout: JSON.stringify({ type: "agent_message", text: "ok" }) }, (o) => { captured = o; });
+    const p = new CodexProvider({ model: "gpt-5-codex", runner });
+    const out = await p.analyze({ systemPrompt: "SYS", userPrompt: "USER", images: [] });
+    expect(out.rawText).toBe("ok");
+    expect(p.name).toBe("codex");
+    const a = captured!.args;
+    expect(a[0]).toBe("exec");
+    expect(a).toEqual(expect.arrayContaining(["--json", "--skip-git-repo-check", "--sandbox", "read-only"]));
+    expect(a).toEqual(expect.arrayContaining(["-m", "gpt-5-codex"]));
+    // prompt is the final argument and combines system + user
+    expect(a[a.length - 1]).toBe("SYS\n\nUSER");
+  });
+
+  it("omits -m when the model is empty", async () => {
+    let captured: CodexRunOptions | undefined;
+    const runner = fakeRunner({ stdout: JSON.stringify({ type: "agent_message", text: "x" }) }, (o) => { captured = o; });
+    await new CodexProvider({ model: "", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(captured!.args).not.toContain("-m");
+  });
+
+  it("parses the final message and token usage from NDJSON events", async () => {
+    const stdout = [
+      JSON.stringify({ type: "task_started" }),
+      JSON.stringify({ type: "agent_message", text: "not final" }),
+      JSON.stringify({ type: "agent_message", text: "the answer" }),
+      JSON.stringify({ type: "token_count", usage: { input_tokens: 12, output_tokens: 7 } }),
+    ].join("\n");
+    const out = await new CodexProvider({ model: "m", runner: fakeRunner({ stdout }) })
+      .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.rawText).toBe("the answer");
+    expect(out.usage).toEqual({ inputTokens: 12, outputTokens: 7 });
+  });
+
+  it("falls back to raw stdout when there is no JSON message event", async () => {
+    const out = await new CodexProvider({ model: "m", runner: fakeRunner({ stdout: "plain text answer\n" }) })
+      .analyze({ systemPrompt: "s", userPrompt: "u", images: [] });
+    expect(out.rawText).toBe("plain text answer");
+  });
+
+  it("throws an actionable error when the CLI binary is missing", async () => {
+    const runner = fakeRunner({ code: null, spawnError: Object.assign(new Error("nope"), { code: "ENOENT" }) });
+    await expect(
+      new CodexProvider({ model: "m", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] }),
+    ).rejects.toThrow(/codex login|@openai\/codex|not found/i);
+  });
+
+  it("maps an auth failure (stderr) to an auth error", async () => {
+    const runner = fakeRunner({ code: 1, stdout: "", stderr: "Error: not logged in. Run codex login." });
+    await expect(
+      new CodexProvider({ model: "m", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] }),
+    ).rejects.toMatchObject({ kind: "auth" });
+  });
+
+  it("maps a timeout to a timeout error", async () => {
+    const runner = fakeRunner({ code: null, timedOut: true });
+    await expect(
+      new CodexProvider({ model: "m", timeoutMs: 5, runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] }),
+    ).rejects.toMatchObject({ kind: "timeout" });
+  });
+
+  it("errors when there is no content at all", async () => {
+    const runner = fakeRunner({ code: 1, stdout: "", stderr: "" });
+    await expect(
+      new CodexProvider({ model: "m", runner }).analyze({ systemPrompt: "s", userPrompt: "u", images: [] }),
+    ).rejects.toBeInstanceOf(ProviderError);
+  });
+});

--- a/companion/tests/providers/codex.wiring.test.ts
+++ b/companion/tests/providers/codex.wiring.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { buildProviderFrom } from "../../src/server.js";
+import { isLocalAiProvider } from "../../src/analysis/anonymize.js";
+
+describe("buildProviderFrom — codex wiring", () => {
+  it("resolves the codex provider by name with no API key", () => {
+    const p = buildProviderFrom({ provider: "codex", model: "gpt-5-codex" });
+    expect(p?.name).toBe("codex");
+    expect(p?.model).toBe("gpt-5-codex");
+  });
+
+  it("treats codex as NON-local (evidence leaves the machine to OpenAI)", () => {
+    expect(isLocalAiProvider("codex", undefined)).toBe(false);
+  });
+});

--- a/companion/tests/providers/codexRunner.test.ts
+++ b/companion/tests/providers/codexRunner.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { defaultCodexRunner } from "../../src/providers/codexRunner.js";
+
+// codex's stdin is intentionally ignored (deadlock avoidance), so the child gets its input from
+// argv. These tests spawn a real `node` subprocess to exercise the actual spawn/collect/kill path
+// without depending on the `codex` binary.
+describe("defaultCodexRunner", () => {
+  it("collects stdout with exit code 0", async () => {
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "process.stdout.write('HELLO')"], timeoutMs: 10_000 });
+    expect(r.spawnError).toBeUndefined();
+    expect(r.code).toBe(0);
+    expect(r.stdout).toBe("HELLO");
+  });
+
+  it("captures stderr and a non-zero exit code", async () => {
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "process.stderr.write('boom');process.exit(2)"], timeoutMs: 10_000 });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("boom");
+  });
+
+  it("returns spawnError ENOENT when the binary is missing", async () => {
+    const r = await defaultCodexRunner({ bin: "definitely-not-a-real-binary-xyz", args: [], timeoutMs: 10_000 });
+    expect(r.spawnError?.code).toBe("ENOENT");
+  });
+
+  it("kills the process and sets timedOut when the signal aborts", async () => {
+    const ac = new AbortController();
+    const p = defaultCodexRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], timeoutMs: 60_000, signal: ac.signal });
+    setTimeout(() => ac.abort(), 50);
+    const r = await p;
+    expect(r.timedOut).toBe(true);
+    expect(r.code).toBeNull();
+  });
+
+  it("sets timedOut when timeoutMs elapses", async () => {
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], timeoutMs: 80 });
+    expect(r.timedOut).toBe(true);
+  });
+});

--- a/companion/tests/providers/codexRunner.test.ts
+++ b/companion/tests/providers/codexRunner.test.ts
@@ -6,26 +6,26 @@ import { defaultCodexRunner } from "../../src/providers/codexRunner.js";
 // without depending on the `codex` binary.
 describe("defaultCodexRunner", () => {
   it("collects stdout with exit code 0", async () => {
-    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "process.stdout.write('HELLO')"], timeoutMs: 10_000 });
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "process.stdout.write('HELLO')"], stdin: "", timeoutMs: 10_000 });
     expect(r.spawnError).toBeUndefined();
     expect(r.code).toBe(0);
     expect(r.stdout).toBe("HELLO");
   });
 
   it("captures stderr and a non-zero exit code", async () => {
-    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "process.stderr.write('boom');process.exit(2)"], timeoutMs: 10_000 });
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "process.stderr.write('boom');process.exit(2)"], stdin: "", timeoutMs: 10_000 });
     expect(r.code).toBe(2);
     expect(r.stderr).toContain("boom");
   });
 
   it("returns spawnError ENOENT when the binary is missing", async () => {
-    const r = await defaultCodexRunner({ bin: "definitely-not-a-real-binary-xyz", args: [], timeoutMs: 10_000 });
+    const r = await defaultCodexRunner({ bin: "definitely-not-a-real-binary-xyz", args: [], stdin: "", timeoutMs: 10_000 });
     expect(r.spawnError?.code).toBe("ENOENT");
   });
 
   it("kills the process and sets timedOut when the signal aborts", async () => {
     const ac = new AbortController();
-    const p = defaultCodexRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], timeoutMs: 60_000, signal: ac.signal });
+    const p = defaultCodexRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], stdin: "", timeoutMs: 60_000, signal: ac.signal });
     setTimeout(() => ac.abort(), 50);
     const r = await p;
     expect(r.timedOut).toBe(true);
@@ -33,7 +33,7 @@ describe("defaultCodexRunner", () => {
   });
 
   it("sets timedOut when timeoutMs elapses", async () => {
-    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], timeoutMs: 80 });
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "setTimeout(()=>{},60000)"], stdin: "", timeoutMs: 80 });
     expect(r.timedOut).toBe(true);
   });
 });

--- a/companion/tests/providers/codexStatus.test.ts
+++ b/companion/tests/providers/codexStatus.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { getCodexStatus, startCodexLogin } from "../../src/providers/codexStatus.js";
+import type { CodexRunOptions, CodexRunResult } from "../../src/providers/codexRunner.js";
+
+function runnerReturning(r: Partial<CodexRunResult>) {
+  return vi.fn(async (_o: CodexRunOptions): Promise<CodexRunResult> => ({ code: 0, stdout: "", stderr: "", ...r }));
+}
+
+describe("getCodexStatus", () => {
+  it("reports not_installed on ENOENT", async () => {
+    const runner = runnerReturning({ code: null, spawnError: Object.assign(new Error("x"), { code: "ENOENT" }) });
+    const s = await getCodexStatus({ runner, env: {}, authFileExists: () => false });
+    expect(s.state).toBe("not_installed");
+  });
+
+  it("reports connected via an environment API key", async () => {
+    const runner = runnerReturning({ stdout: "codex-cli 0.99.0" });
+    const s = await getCodexStatus({ runner, env: { OPENAI_API_KEY: "sk-xxx" }, authFileExists: () => false });
+    expect(s.state).toBe("connected");
+    expect(s.authMethod).toBe("api_key");
+  });
+
+  it("reports connected via ~/.codex/auth.json", async () => {
+    const runner = runnerReturning({ stdout: "codex-cli 0.99.0" });
+    const s = await getCodexStatus({ runner, env: {}, authFileExists: () => true });
+    expect(s.state).toBe("connected");
+    expect(s.authMethod).toBe("codex login");
+  });
+
+  it("reports not_connected when installed but no key and no auth file", async () => {
+    const runner = runnerReturning({ stdout: "codex-cli 0.99.0" });
+    const s = await getCodexStatus({ runner, env: {}, authFileExists: () => false });
+    expect(s.state).toBe("not_connected");
+    expect(s.message).toMatch(/codex login|OPENAI_API_KEY/);
+  });
+
+  it("checks the binary with `codex --version`", async () => {
+    let captured: CodexRunOptions | undefined;
+    const runner = vi.fn(async (o: CodexRunOptions): Promise<CodexRunResult> => { captured = o; return { code: 0, stdout: "v", stderr: "" }; });
+    await getCodexStatus({ runner, env: { OPENAI_API_KEY: "k" }, authFileExists: () => false });
+    expect(captured!.args).toEqual(["--version"]);
+  });
+});
+
+describe("startCodexLogin", () => {
+  it("returns started:false with an error when the binary is missing", async () => {
+    const r = await startCodexLogin({ bin: "definitely-not-a-real-binary-xyz", captureMs: 500 });
+    expect(r.started).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2413,6 +2413,7 @@
               <option value="litellm">litellm</option>
               <option value="gemini">gemini</option>
               <option value="anthropic">anthropic</option>
+              <option value="codex">codex (text-only, no key)</option>
             </select>
           </div>
           <div class="sfield"><label>Text model<span class="sfield-hint">DFIR_AI_SYNTH_MODEL — CSV/log + synthesis</span></label><input id="env-DFIR_AI_SYNTH_MODEL" placeholder="e.g. gpt-4o" /></div>
@@ -2421,6 +2422,58 @@
           <div class="sfield"><label>Synth API key<span class="sfield-hint">DFIR_AI_SYNTH_KEY</span></label><input id="env-DFIR_AI_SYNTH_KEY" type="password" placeholder="(not set)" autocomplete="new-password" /></div>
           <div class="sfield"><label>Synth base URL<span class="sfield-hint">DFIR_AI_SYNTH_BASE_URL</span></label><input id="env-DFIR_AI_SYNTH_BASE_URL" /></div>
         </div>
+        <div id="codex-status" class="sfield" style="display:none;padding:8px 10px;border-radius:8px;border:1px solid var(--c-2a2f3a,#2a2f3a);background:var(--c-161b22,#161b22)">
+          <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+            <span id="cx-status-dot" style="width:9px;height:9px;border-radius:50%;background:#6b7280"></span>
+            <span id="cx-status-msg" style="font-size:12px">Checking Codex…</span>
+            <button type="button" id="cx-recheck" class="btn-mini" style="margin-left:auto">Re-check</button>
+            <button type="button" id="cx-connect" class="btn-mini" style="display:none">Connect</button>
+          </div>
+          <div id="cx-connect-hint" style="font-size:11px;color:var(--c-9aa4b2);margin-top:6px;display:none"></div>
+        </div>
+        <script>
+        (function () {
+          var sel = document.getElementById('env-DFIR_AI_SYNTH_PROVIDER');
+          var card = document.getElementById('codex-status');
+          if (!sel || !card) return;
+          var dot = document.getElementById('cx-status-dot');
+          var msg = document.getElementById('cx-status-msg');
+          var connectBtn = document.getElementById('cx-connect');
+          var hint = document.getElementById('cx-connect-hint');
+          function paint(s) {
+            var colors = { connected: '#16a34a', not_connected: '#d97706', not_installed: '#dc2626' };
+            dot.style.background = colors[s.state] || '#6b7280';
+            msg.textContent = s.message || s.state;
+            connectBtn.style.display = s.state === 'not_connected' ? '' : 'none';
+          }
+          function refresh() {
+            msg.textContent = 'Checking Codex…';
+            fetch('/diagnostics/codex-status').then(function (r) { return r.json(); })
+              .then(paint).catch(function () { msg.textContent = 'Status check failed.'; });
+          }
+          function toggle() {
+            var on = sel.value === 'codex';
+            card.style.display = on ? '' : 'none';
+            if (on) refresh();
+          }
+          sel.addEventListener('change', toggle);
+          document.getElementById('cx-recheck').addEventListener('click', refresh);
+          connectBtn.addEventListener('click', function () {
+            hint.style.display = '';
+            hint.textContent = 'Starting sign-in…';
+            fetch('/diagnostics/codex-login', { method: 'POST' }).then(function (r) { return r.json(); })
+              .then(function (r) {
+                if (r.url) hint.innerHTML = 'Open this URL to finish signing in, then click Re-check:<br><a href="' + escAttr(r.url) + '" target="_blank" rel="noopener">' + esc(r.url) + '</a>';
+                else if (r.started) hint.textContent = 'Sign-in started on the host. Complete it in the browser that opened, then click Re-check.';
+                else hint.textContent = (r.error || 'Could not start sign-in') + '. Run `codex login` (or set OPENAI_API_KEY) on the host, then click Re-check.';
+              }).catch(function () { hint.textContent = 'Run `codex login` (or set OPENAI_API_KEY) on the host, then click Re-check.'; });
+          });
+          toggle();
+          // The settings panel populates selects asynchronously without firing 'change', so re-check
+          // shortly after load to reflect a previously-saved codex synth provider.
+          setTimeout(toggle, 1200);
+        })();
+        </script>
         <div class="settings-group-head">Velociraptor hunt model (used ONLY for generating Velociraptor VQL hunts — many models botch VQL)</div>
         <p class="rm-hint" style="font-size:11px;color:var(--c-9aa4b2);margin:2px 0 8px">Dedicated model for <strong>✨ Suggest Velociraptor hunts</strong> (and the Fleet Hunts suggester), separate from the synthesis/OCR models. Default: <code>openrouter</code> / <code>anthropic/claude-haiku-4.5</code>. Leave the key blank to reuse the main AI key.</p>
         <div class="sfield-row">
@@ -2434,6 +2487,7 @@
               <option value="litellm">litellm</option>
               <option value="gemini">gemini</option>
               <option value="anthropic">anthropic</option>
+              <option value="codex">codex (text-only, no key)</option>
             </select>
           </div>
           <div class="sfield"><label>Velo model<span class="sfield-hint">DFIR_AI_VELO_MODEL</span></label><input id="env-DFIR_AI_VELO_MODEL" placeholder="anthropic/claude-haiku-4.5" /></div>
@@ -2455,6 +2509,7 @@
               <option value="litellm">litellm</option>
               <option value="gemini">gemini</option>
               <option value="anthropic">anthropic</option>
+              <option value="codex">codex (text-only, no key)</option>
             </select>
           </div>
           <div class="sfield"><label>2nd-opinion model<span class="sfield-hint">DFIR_AI_SECOND_OPINION_MODEL</span></label><input id="env-DFIR_AI_SECOND_OPINION_MODEL" placeholder="e.g. gpt-4o — set this to enable the feature" /></div>
@@ -3552,6 +3607,7 @@
                   <option value="litellm">LiteLLM (local proxy)</option>
                   <option value="gemini">Gemini</option>
                   <option value="anthropic">Anthropic</option>
+                  <option value="codex">Codex (text-only, no key)</option>
                 </select>
               </div>
               <div class="wiz-field">


### PR DESCRIPTION
## Summary

Adds a **`codex`** AI provider that drives the OpenAI **Codex CLI** (`codex exec`) as a **text-only** LLM backend, using ambient codex auth (`codex login` or `OPENAI_API_KEY` / `CODEX_API_KEY`) — **no `DFIR_AI_KEY`**. It powers text work — synthesis, case Q&A, second-opinion, and velo-hunts — via `DFIR_AI_SYNTH_PROVIDER=codex` (and the velo / second-opinion provider vars).

Sibling to the Claude Code provider (PR #156). Codex `exec` is a text coding agent with **no image input**, so — unlike Claude Code — it is **not** offered for screenshot extraction; vision requests are rejected with an actionable error.

## What's included

- **`codexRunner.ts`** — generic child-process seam, resolve-never-reject; **stdin is ignored** (`stdio: ["ignore","pipe","pipe"]`) because some Codex CLI versions deadlock on stdin — the prompt goes in argv.
- **`codex.ts`** — `CodexProvider`: rejects `req.images` up front; builds `codex exec --json --skip-git-repo-check --sandbox read-only -C <tmp> [-m <model>] "<system>\n\n<user>"`; **defensive NDJSON parse** of the final message + token usage with a **raw-stdout fallback**; errors → `ProviderError` kinds. Registered in `buildProviderFrom`; **non-local** for anonymization (data goes to OpenAI).
- **`codexStatus.ts`** + `GET /diagnostics/codex-status`, `POST /diagnostics/codex-login` — detector (binary present + env key **or** `~/.codex/auth.json`) → *not-installed / not-connected / connected*; best-effort `codex login` (detached, pipes unref'd).
- **Dashboard** — `codex` option in the **text selects only** (synth / velo / second-opinion / wizard-synth) — deliberately **not** the vision/extraction selects; a connection-status card (Re-check + Connect) near the synth provider select.
- **Docs** — README + `companion/README.md` (text-only, ambient auth, caveats).

## Verification & the one caveat

**Codex CLI is not installed on the build host**, so — per the agreed approach — this is built against the documented `codex exec` interface and **unit-tested with a mocked runner**; there is no live smoke test yet.

- [x] `npx tsc --noEmit` clean (whole project)
- [x] Full suite green — **4127 tests** incl. 22 new codex tests (runner, provider, status detector, wiring)
- [ ] **[verify-live]** — on a host with `@openai/codex` installed + `codex login`: confirm the `--json` event schema (final-message field, token-usage fields) matches the defensive parser, and the exact flag spellings (`--sandbox`, `-m`). The parser falls back to raw stdout if the shape differs, and these points are listed in the design spec.
- [ ] Reviewer: manual UI pass — pick **codex** as the synth provider in Settings → AI, confirm the status card renders.

## Notes / follow-ups

- `codexRunner` duplicates the claude-code provider's runner (that one lives on PR #156, not on `master`). **Follow-up once both merge:** dedupe into one generic `cliRunner`.
- `.env.example` codex example not added here (sandbox blocks `.env.*` writes) — documented in both READMEs + the Settings UI; quick follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)