### PR TITLE
Add pivot-type productivity signal to hunt-suggestion prompts (#72)

### DIFF
--- a/companion/src/analysis/huntOutcomes.ts
+++ b/companion/src/analysis/huntOutcomes.ts
@@ -208,6 +208,7 @@ export interface HuntingProfile {
   missed: number;     // collected AND found nothing
   pending: number;    // deployed but not yet collected
   hunts: HuntOutcome[];
+  pivotProductivity: PivotProductivity[];   // #72: aggregate hit-rate by pivot class
 }
 
 export function buildHuntingProfile(outcomes: readonly HuntOutcome[]): HuntingProfile {
@@ -220,5 +221,83 @@ export function buildHuntingProfile(outcomes: readonly HuntOutcome[]): HuntingPr
     else if (o.foundEvidence) hit++;
     else missed++;
   }
-  return { total: hunts.length, hit, missed, pending, hunts };
+  return { total: hunts.length, hit, missed, pending, hunts, pivotProductivity: buildPivotProductivity(hunts) };
+}
+
+// Aggregate productivity by PIVOT CLASS (issue #72). Per-hunt outcomes already feed the "PRIOR HUNTS"
+// prompt block above, but that's a flat per-hunt list — it doesn't tell the model which KIND of pivot
+// (a hash, a process name, a filesystem path, a network indicator, a registry key) has actually been
+// paying off in this case, so a run of unproductive process-name hunts keeps getting repeated in a
+// different shape. This classifies each outcome's pivot class from its VQL (the plugin/field names are
+// a reliable tell — `glob`/`path` for filesystem, `pslist`/`CommandLine` for process, `hash`/`md5` for
+// hashes, `netstat`/`dns`/`domain` for network, `registry`/`hklm` for the registry) and tallies hit/
+// miss/pending per class so the model can bias toward classes that have found evidence.
+export type PivotType = "hash" | "process" | "path" | "network" | "registry" | "other";
+
+const PIVOT_TYPE_PATTERNS: ReadonlyArray<{ type: PivotType; re: RegExp }> = [
+  { type: "hash", re: /\b(md5|sha1|sha256|sha-1|sha-256|hash)\b/i },
+  { type: "registry", re: /\b(registry|reg_key|hkcu|hklm|hkey_)/i },
+  { type: "network", re: /\b(netstat|connections?|dns|domain|url|http|network)\b/i },
+  { type: "process", re: /\b(pslist|process|commandline|parentname|proc(ess)?tree)\b/i },
+  { type: "path", re: /\b(glob|filename|filepath|path)\b/i },
+];
+
+// Classify one outcome's pivot class from its VQL preview (falls back to the title — bundles carry no
+// VQL). Pure, order-sensitive (first pattern to match wins — hash/registry/network are checked before
+// the broader process/path patterns since e.g. a hash lookup often also globs a directory).
+export function classifyPivotType(outcome: HuntOutcome): PivotType {
+  const text = `${outcome.vqlPreview || ""} ${outcome.title || ""}`;
+  for (const { type, re } of PIVOT_TYPE_PATTERNS) if (re.test(text)) return type;
+  return "other";
+}
+
+export interface PivotProductivity {
+  type: PivotType;
+  total: number;
+  hit: number;
+  missed: number;
+  pending: number;
+}
+
+// Tally hit/missed/pending per pivot class, sorted MOST-productive first (highest hit-rate among
+// collected outcomes, ties broken by volume). Classes with no collected outcomes yet (rate undefined)
+// sort last, ahead of nothing. Only classes with at least one outcome are returned. Pure.
+export function buildPivotProductivity(outcomes: readonly HuntOutcome[]): PivotProductivity[] {
+  const order: PivotType[] = ["hash", "process", "path", "network", "registry", "other"];
+  const tally = new Map<PivotType, PivotProductivity>(order.map((type) => [type, { type, total: 0, hit: 0, missed: 0, pending: 0 }]));
+  for (const o of outcomes ?? []) {
+    const entry = tally.get(classifyPivotType(o))!;
+    entry.total++;
+    if (o.status !== "collected") entry.pending++;
+    else if (o.foundEvidence) entry.hit++;
+    else entry.missed++;
+  }
+  return order
+    .map((type) => tally.get(type)!)
+    .filter((p) => p.total > 0)
+    .sort((a, b) => {
+      const rateA = a.hit + a.missed > 0 ? a.hit / (a.hit + a.missed) : -1;
+      const rateB = b.hit + b.missed > 0 ? b.hit / (b.hit + b.missed) : -1;
+      return rateB - rateA || b.total - a.total;
+    });
+}
+
+// The "HUNT PRODUCTIVITY" prompt block fed alongside `renderPriorHuntsBlock` to the hunt-suggestion
+// prompts — the aggregate signal that lets the model bias toward pivot classes that have historically
+// found evidence in THIS case, not just avoid re-running an exact prior query. "" when there isn't
+// enough collected history yet (nothing to bias on) so the prompt stays lean on a fresh case.
+export function renderHuntProductivityBlock(outcomes: readonly HuntOutcome[]): string {
+  const stats = buildPivotProductivity(outcomes).filter((p) => p.hit + p.missed > 0);
+  if (!stats.length) return "";
+  const lines = stats.map((p) => {
+    const collected = p.hit + p.missed;
+    const rate = Math.round((p.hit / collected) * 100);
+    const pendingNote = p.pending ? `, ${p.pending} pending` : "";
+    return `- ${p.type}: ${p.hit}/${collected} hunts found evidence (${rate}%)${pendingNote}`;
+  });
+  return (
+    `HUNT PRODUCTIVITY BY PIVOT CLASS (this case's history — favor pivot classes below with a high hit ` +
+    `rate; deprioritize classes that keep coming back empty unless a new lead specifically calls for them):\n` +
+    `${lines.join("\n")}\n\n`
+  );
 }

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -139,6 +139,7 @@ import {
 import {
   deployedFingerprints,
   renderPriorHuntsBlock,
+  renderHuntProductivityBlock,
   vqlFingerprint,
   type HuntOutcome,
 } from "./huntOutcomes.js";
@@ -4040,13 +4041,18 @@ export class AnalysisPipeline {
     // there are no recorded outcomes (or no store wired). Also drives the deterministic exclusion below.
     const outcomes = await this.loadHuntOutcomes(caseId);
     const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
+    // Productivity tuning (#72): the aggregate hit-rate by pivot class (hash/process/path/network/
+    // registry) across this case's hunt history, so the model biases toward classes that have found
+    // evidence rather than only avoiding exact repeats (priorHuntsBlock is the per-hunt signal; this
+    // is the aggregate one). "" until there's collected history to bias on.
+    const productivityBlock = renderHuntProductivityBlock(outcomes);
     // Known unknowns (#165): the gaps in the story (silent windows, uncovered ATT&CK phases, likely-
     // next techniques) so suggested hunts target what's MISSING, not just re-confirm what's known.
     const knownUnknownsBlock = await this.knownUnknownsBlock(loaded, scopedEvents, caseId);
 
     // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
     const overhead = estimateTokens(getHuntSuggestPrompt())
-      + estimateTokens(priorHuntsBlock + contextBlock + knownUnknownsBlock + graphBlock + findingsText + iocText + techText + (loaded.attackerPath || "")) + 300;
+      + estimateTokens(priorHuntsBlock + productivityBlock + contextBlock + knownUnknownsBlock + graphBlock + findingsText + iocText + techText + (loaded.attackerPath || "")) + 300;
     const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
     if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
     const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
@@ -4058,6 +4064,7 @@ export class AnalysisPipeline {
       : "";
     const userPrompt =
       priorHuntsBlock +
+      productivityBlock +
       contextBlock +
       knownUnknownsBlock +
       graphBlock +
@@ -4092,8 +4099,10 @@ export class AnalysisPipeline {
     const label = techniqueName ? `${id} (${techniqueName})` : id;
     const outcomes = await this.loadHuntOutcomes(caseId);   // #157 feedback loop (exclude + prior-hunts context)
     const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
+    const productivityBlock = renderHuntProductivityBlock(outcomes);   // #72: aggregate hit-rate by pivot class
     const userPrompt =
       priorHuntsBlock +
+      productivityBlock +
       `Focus EXCLUSIVELY on ONE ATT&CK technique the analyst wants to hunt for proactively across the fleet:\n` +
       `  ${label}\n\n` +
       `This technique has NOT yet been observed in this case. A group whose tradecraft resembles this case is known ` +
@@ -4284,10 +4293,11 @@ export class AnalysisPipeline {
     const contextBlock = buildSynthesisContext(loaded, scopedEvents, kevCatalog);
     const outcomes = await this.loadHuntOutcomes(caseId);   // #157 feedback loop (exclude + prior-hunts context)
     const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
+    const productivityBlock = renderHuntProductivityBlock(outcomes);   // #72: aggregate hit-rate by pivot class
 
     // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
     const overhead = estimateTokens(getPlaybookHuntPrompt())
-      + estimateTokens(priorHuntsBlock + contextBlock + tasksText + endpointsText + artifactsText + findingsText + (loaded.attackerPath || "")) + 300;
+      + estimateTokens(priorHuntsBlock + productivityBlock + contextBlock + tasksText + endpointsText + artifactsText + findingsText + (loaded.attackerPath || "")) + 300;
     const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
     if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
     const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
@@ -4297,6 +4307,7 @@ export class AnalysisPipeline {
       : "";
     const userPrompt =
       priorHuntsBlock +
+      productivityBlock +
       contextBlock +
       `KNOWN ENDPOINTS (hosts — pick a targetHost ONLY from these): ${endpointsText}\n\n` +
       `AVAILABLE VELOCIRAPTOR ARTIFACTS (reference Artifact.<Name> ONLY if <Name> is in this list — else use a raw plugin):\n${artifactsText}\n\n` +

--- a/companion/tests/analysis/huntOutcomes.test.ts
+++ b/companion/tests/analysis/huntOutcomes.test.ts
@@ -7,6 +7,9 @@ import {
   deployedFingerprints,
   renderPriorHuntsBlock,
   buildHuntingProfile,
+  classifyPivotType,
+  buildPivotProductivity,
+  renderHuntProductivityBlock,
   HUNT_OUTCOME_MAX_DEFAULT,
   type HuntOutcome,
 } from "../../src/analysis/huntOutcomes.js";
@@ -253,6 +256,90 @@ describe("buildHuntingProfile", () => {
   });
 
   it("handles an empty case", () => {
-    expect(buildHuntingProfile([])).toEqual({ total: 0, hit: 0, missed: 0, pending: 0, hunts: [] });
+    expect(buildHuntingProfile([])).toEqual({ total: 0, hit: 0, missed: 0, pending: 0, hunts: [], pivotProductivity: [] });
+  });
+});
+
+describe("classifyPivotType", () => {
+  const outcome = (vql: string, title = ""): HuntOutcome =>
+    recordDeploy([], { source: "fleet", title: title || vql, vql, huntId: "H.x", deployedAt: T0 })[0];
+
+  it("classifies hash pivots", () => {
+    expect(classifyPivotType(outcome("SELECT * FROM hash(path=Path) WHERE MD5 = '...'"))).toBe("hash");
+  });
+
+  it("classifies process pivots", () => {
+    expect(classifyPivotType(outcome("SELECT * FROM pslist() WHERE CommandLine =~ 'evil'"))).toBe("process");
+  });
+
+  it("classifies path/filesystem pivots", () => {
+    expect(classifyPivotType(outcome("SELECT FullPath FROM glob(globs='C:/inetpub/**/*.aspx')"))).toBe("path");
+  });
+
+  it("classifies network pivots", () => {
+    expect(classifyPivotType(outcome("SELECT * FROM netstat() WHERE Raddr = '1.2.3.4'"))).toBe("network");
+  });
+
+  it("classifies registry pivots", () => {
+    expect(classifyPivotType(outcome("SELECT * FROM glob(globs='HKLM\\\\Software\\\\Run\\\\*')", "registry run keys"))).toBe("registry");
+  });
+
+  it("falls back to other when nothing matches", () => {
+    expect(classifyPivotType(outcome("SELECT * FROM info()"))).toBe("other");
+  });
+
+  it("falls back to the title for a bundle with no VQL", () => {
+    const bundle = recordDeploy([], { source: "bundle", title: "Fast Triage pslist sweep", huntId: "H.b", deployedAt: T0 })[0];
+    expect(classifyPivotType(bundle)).toBe("process");
+  });
+});
+
+describe("buildPivotProductivity", () => {
+  it("returns [] for no outcomes", () => {
+    expect(buildPivotProductivity([])).toEqual([]);
+  });
+
+  it("tallies hit/missed/pending per pivot class and ranks by hit-rate", () => {
+    let out = recordDeploy([], { source: "fleet", title: "hash a", vql: "SELECT * FROM hash(path=Path)", huntId: "H.1", deployedAt: T0 });
+    out = recordDeploy(out, { source: "fleet", title: "hash b", vql: "SELECT * FROM hash(path=Path)", huntId: "H.2", deployedAt: T0 });
+    out = recordDeploy(out, { source: "fleet", title: "ps a", vql: "SELECT * FROM pslist()", huntId: "H.3", deployedAt: T0 });
+    out = recordDeploy(out, { source: "fleet", title: "ps b", vql: "SELECT * FROM pslist()", huntId: "H.4", deployedAt: T0 });
+    out = fillOutcome(out, "H.1", { addedEvents: 3, addedIocs: 0, collectedAt: T1 });   // hash: hit
+    out = fillOutcome(out, "H.2", { addedEvents: 2, addedIocs: 0, collectedAt: T1 });   // hash: hit
+    out = fillOutcome(out, "H.3", { addedEvents: 0, addedIocs: 0, collectedAt: T1 });   // process: miss
+    // H.4 (process) stays pending
+
+    const stats = buildPivotProductivity(out);
+    expect(stats[0]).toMatchObject({ type: "hash", total: 2, hit: 2, missed: 0, pending: 0 });
+    expect(stats[1]).toMatchObject({ type: "process", total: 2, hit: 0, missed: 1, pending: 1 });
+  });
+
+  it("only includes pivot classes that have at least one outcome", () => {
+    const out = recordDeploy([], { source: "fleet", title: "hash a", vql: "SELECT * FROM hash(path=Path)", huntId: "H.1", deployedAt: T0 });
+    const stats = buildPivotProductivity(out);
+    expect(stats).toHaveLength(1);
+    expect(stats[0].type).toBe("hash");
+  });
+});
+
+describe("renderHuntProductivityBlock", () => {
+  it("is empty when there is no collected history", () => {
+    expect(renderHuntProductivityBlock([])).toBe("");
+    const pendingOnly = recordDeploy([], { source: "fleet", title: "a", vql: "SELECT * FROM pslist()", huntId: "H.1", deployedAt: T0 });
+    expect(renderHuntProductivityBlock(pendingOnly)).toBe("");
+  });
+
+  it("renders hit-rate per pivot class, most productive first, ending in a blank line", () => {
+    let out = recordDeploy([], { source: "fleet", title: "hash a", vql: "SELECT * FROM hash(path=Path)", huntId: "H.1", deployedAt: T0 });
+    out = recordDeploy(out, { source: "fleet", title: "ps a", vql: "SELECT * FROM pslist()", huntId: "H.2", deployedAt: T0 });
+    out = fillOutcome(out, "H.1", { addedEvents: 3, addedIocs: 0, collectedAt: T1 });   // hash: hit
+    out = fillOutcome(out, "H.2", { addedEvents: 0, addedIocs: 0, collectedAt: T1 });   // process: miss
+
+    const block = renderHuntProductivityBlock(out);
+    expect(block).toContain("HUNT PRODUCTIVITY BY PIVOT CLASS");
+    expect(block).toContain("hash: 1/1 hunts found evidence (100%)");
+    expect(block).toContain("process: 0/1 hunts found evidence (0%)");
+    expect(block.indexOf("hash:")).toBeLessThan(block.indexOf("process:"));   // more productive class listed first
+    expect(block.endsWith("\n\n")).toBe(true);
   });
 });

--- a/companion/tests/server/huntOutcomes.test.ts
+++ b/companion/tests/server/huntOutcomes.test.ts
@@ -113,7 +113,7 @@ describe("hunting feedback loop — routes (#157)", () => {
 
   it("GET hunt-outcomes returns an empty profile for a fresh case", async () => {
     const { app } = await makeApp();
-    expect((await request(app).get("/cases/c1/hunt-outcomes")).body).toEqual({ total: 0, hit: 0, missed: 0, pending: 0, hunts: [] });
+    expect((await request(app).get("/cases/c1/hunt-outcomes")).body).toEqual({ total: 0, hit: 0, missed: 0, pending: 0, hunts: [], pivotProductivity: [] });
   });
 
   it("suggest-hunts excludes a VQL that was already deployed", async () => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4172,6 +4172,11 @@
       #sec-huntprofile .hp-detail{margin:0 0 2px 4px}
       #sec-huntprofile .hp-preview-note{color:var(--c-ffb454);font-size:11px;margin:0 0 4px 0}
       #sec-huntprofile .hp-collect-inline{background:var(--c-2d6cdf);border:0;color:#fff;border-radius:4px;padding:1px 8px;font-size:11px;cursor:pointer}
+      #sec-huntprofile .hp-pivots{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px}
+      #sec-huntprofile .hp-pivot{display:flex;align-items:center;gap:5px;background:var(--c-161b22);border:1px solid var(--c-232a33);border-radius:5px;padding:3px 8px;font-size:11px;color:var(--c-c9d1db)}
+      #sec-huntprofile .hp-pivot-type{text-transform:capitalize;color:var(--c-d6deea);font-weight:bold}
+      #sec-huntprofile .hp-pivot-rate{color:#6bcb77}
+      #sec-huntprofile .hp-pivot-rate.hp-pivot-rate-low{color:#9aa4b2}
       #sec-huntprofile .hp-collect-inline:disabled{opacity:.6;cursor:default}
       /* ── Query Translator (NL → hunt queries, #100) ── */
       #sec-nlquery .nlq-empty{color:var(--c-9aa4b2);font-size:12px}
@@ -12198,6 +12203,19 @@
         + `<span><b>${profile.missed}</b> no results</span>`
         + `<span style="color:#6aa9ff"><b>${profile.pending}</b> pending</span>`
         + `</div>`;
+      // Pivot-class productivity (#72): which pivot type (hash/process/path/network/registry) has
+      // actually found evidence in this case — the same aggregate signal fed into the hunt-suggestion
+      // prompt, surfaced here so the analyst can see why the model is favoring/avoiding a class.
+      const pivots = (profile.pivotProductivity || []).filter((p) => p.hit + p.missed > 0);
+      const pivotsBlock = pivots.length ? `<div class="hp-pivots">` + pivots.map((p) => {
+        const collected = p.hit + p.missed;
+        const rate = Math.round((p.hit / collected) * 100);
+        const rateCls = rate >= 50 ? "" : " hp-pivot-rate-low";
+        return `<span class="hp-pivot" title="${escAttr(`${p.hit}/${collected} hunts found evidence${p.pending ? `, ${p.pending} pending` : ""}`)}">`
+          + `<span class="hp-pivot-type">${esc(p.type)}</span>`
+          + `<span class="hp-pivot-rate${rateCls}">${p.hit}/${collected} (${rate}%)</span>`
+          + `</span>`;
+      }).join("") + `</div>` : "";
       const rows = hunts.map((h, i) => {
         const st = h.status === "collected" ? (h.foundEvidence ? HP_STATUS.collectedHit : HP_STATUS.collectedMiss) : HP_STATUS.pending;
         // "not collected yet" not "results not yet collected": ▸ results can show LIVE rows from Velociraptor
@@ -12232,7 +12250,7 @@
           + `<div class="hp-detail" id="hpDetail${i}" hidden></div>`
           + `</div>`;
       }).join("");
-      el.innerHTML = tally + `<div class="hp-list">${rows}</div>`;
+      el.innerHTML = tally + pivotsBlock + `<div class="hp-list">${rows}</div>`;
       const caseId = document.getElementById("caseId").value.trim();
       // Collect (import) a hunt's results into the case + record the outcome. On success (202) the
       // velo_hunt_changed WS event re-renders the panel; only an error restores the button + flags it.


### PR DESCRIPTION
## Summary
- Adds `classifyPivotType`/`buildPivotProductivity`/`renderHuntProductivityBlock` to `huntOutcomes.ts`: an aggregate hit-rate breakdown by pivot class (hash/process/path/network/registry) derived from the existing per-case hunt outcomes.
- Feeds that aggregate signal into the `suggestHunts`/`suggestTechniqueHunts`/`suggestPlaybookHunts` prompts in `pipeline.ts`, alongside the existing per-hunt `renderPriorHuntsBlock`, so the model biases toward pivot classes that have actually found evidence in this case.
- Surfaces the same stats on the dashboard's hunting-profile panel.
- Unit tests for the new classification/productivity/prompt-rendering functions.

Closes #72.

## Test plan
- [ ] `npm test` in `companion/` (could not be run in this sandboxed session — node/npm/npx execution was blocked)
- [ ] Manually verify the dashboard hunting-profile panel renders the new pivot-type badges on a case with collected hunt outcomes
- [ ] Confirm the hunt-suggestion prompt includes the new `HUNT PRODUCTIVITY BY PIVOT CLASS` block when outcomes exist

Generated with [Claude Code](https://claude.ai/code)