### PR TITLE
Add per-model performance telemetry to synth-meta (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ All companion behavior is configured via env vars (`companion/.env` or shell). C
 | `DFIR_AI_MAX_TOKENS` | `16000` | Max completion tokens; too low truncates synthesis, prevents OpenRouter 402 on low balance |
 | `DFIR_AI_SYNTH_MAX_EVENTS` | `300` | Cap on forensic events sent to synthesis; Critical/High always get a finding regardless |
 | `DFIR_REPORT_SYNTH_COVERAGE` | _(off)_ | Set truthy to add a **§3.4 Synthesis coverage** footnote to the report — "considered N of M in-window events (K omitted: budget/filtered)", the token estimate, and how many high-severity omissions the safety-net backfill recovered. The dashboard synth-meta card always shows this line; this flag only controls whether it also appears in the exported report |
+| `DFIR_REPORT_MODEL_PERF` | _(off)_ | Set truthy to add a **§3.5 Model performance** footnote to the report — the synthesis model, findings count vs how many the safety-net backfill had to add, parse retries, and (when a second opinion has run) how often `DFIR_AI_SECOND_OPINION_MODEL` agreed with `DFIR_AI_MODEL`/`DFIR_AI_SYNTH_MODEL`. The dashboard synth-meta card always shows this; this flag only controls whether it also appears in the exported report |
 | `DFIR_AI_CONTEXT_TOKENS` | `128000` | Model context window; raise for Claude/Gemini (200k/1M) to send more per call |
 | `DFIR_VISION_IMAGE_DETAIL` | `high` | `high` \| `low` \| `auto` (OpenAI/OpenRouter); `high` tiles at full res for small-text OCR |
 | `DFIR_AI_AUTO_SYNTHESIZE` | `on` | Re-synthesize during capture: `on` \| `off` |

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -185,6 +185,12 @@ DFIR_AI_SYNTH_MAX_EVENTS=300
 # detail not every report should carry).
 # DFIR_REPORT_SYNTH_COVERAGE=1
 
+# Per-model quality telemetry (#74): the dashboard's synth-meta card always shows the last synthesis
+# model, findings vs safety-net backfill count, and (when a second opinion has run) the second-opinion
+# agreement rate — so DFIR_AI_MODEL/DFIR_AI_SYNTH_MODEL/DFIR_AI_SECOND_OPINION_MODEL can be compared
+# empirically. Set this truthy to ALSO add a "§3.5 Model performance" footnote to the exported report.
+# DFIR_REPORT_MODEL_PERF=1
+
 # Minimum severity an imported event needs to enter the FORENSIC timeline (default Low). The
 # Companion is a post-detection layer, so the forensic timeline should hold graded signal (source
 # verdicts + our deterministic rules), not raw telemetry. At the default `Low`, Info-severity

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -4945,15 +4945,24 @@ export class AnalysisPipeline {
     // it to extended thinking; OpenRouter to its unified `reasoning`; other providers ignore it. Only
     // synthesis reasons step-by-step — extraction stays cheap.
     const synthThinkingTokens = resolveSynthThinkingBudget(opts, Number(process.env.DFIR_AI_SYNTH_THINKING_TOKENS) || 0);
+    // Per-model quality telemetry (#74): count retries the synthesis call actually needed (a failed
+    // parse/schema-mismatch attempt increments this; withRetry itself has no hook, so this counts on
+    // catch inside the retried closure). Surfaced on synth-meta so a flaky model shows up empirically.
+    let synthParseRetries = 0;
     const delta = await withRetry(async () => {
-      const parsed = await this.analyzeRestored(
-        caseId,
-        state,
-        synthProvider,
-        { systemPrompt: getSynthesisPrompt(), userPrompt, images: [], ...(synthThinkingTokens > 0 ? { thinkingTokens: synthThinkingTokens } : {}), ...(opts.signal ? { signal: opts.signal } : {}) },
-        "synthesis",
-      );
-      return stripAiExtractedFrom(deltaSchema.parse(parsed));
+      try {
+        const parsed = await this.analyzeRestored(
+          caseId,
+          state,
+          synthProvider,
+          { systemPrompt: getSynthesisPrompt(), userPrompt, images: [], ...(synthThinkingTokens > 0 ? { thinkingTokens: synthThinkingTokens } : {}), ...(opts.signal ? { signal: opts.signal } : {}) },
+          "synthesis",
+        );
+        return stripAiExtractedFrom(deltaSchema.parse(parsed));
+      } catch (err) {
+        synthParseRetries++;
+        throw err;
+      }
     }, retries, backoffMs);
 
     // Anchor finding timestamps to the last real event time (fallback: existing state time).
@@ -4993,6 +5002,8 @@ export class AnalysisPipeline {
     // missed. Restricted to the events synthesis actually considered (scopedEvents).
     const eligibleIds = new Set(scopedEvents.map((e) => e.id));
     const backfilled = backfillHighSeverityFindings(linked, eligibleIds, ts);
+    // #74: how many findings the safety net had to add — a proxy for detections synthModel itself missed.
+    const highSeverityBackfillCount = backfilled.findings.length - linked.findings.length;
     // Log gap analysis (#83): a COMPLETE-silence gap — a window where every source went dark — is the
     // classic signature of cleared logs / a stopped collector, so escalate it to a finding here too.
     // Gaps are derived on read (not persisted); only the complete ones earn a persisted finding, and
@@ -5192,6 +5203,10 @@ export class AnalysisPipeline {
       iocCount: next.iocs.length,
       selectionCounts: { ...selection.counts },   // #4: the evidence mix the model saw
       coverage: synthCoverage,                     // #62: included/omitted coverage audit
+      synthModel: this.opts.synthesisModelLabel ?? `${synthProvider.name}/${synthProvider.model}`, // #74
+      findingsCount: next.findings.length,          // #74
+      highSeverityBackfillCount,                    // #74
+      parseRetries: synthParseRetries,              // #74
     });
     // Notify on new/escalated findings (issue #58). Best-effort, fire-and-forget — never blocks or
     // fails synthesis. Only on a real run, so a skipped (unchanged) re-synthesis sends nothing.
@@ -5352,6 +5367,18 @@ export class AnalysisPipeline {
     }
 
     await this.opts.secondOpinionStore.save(caseId, record);
+    // Per-model quality telemetry (#74): stamp the agreement rate onto synth-meta so modelA vs modelB
+    // can be compared empirically across runs, not just eyeballed on this one second-opinion panel.
+    const deltaCount = record.deltas.length;
+    const denom = record.agreementCount + deltaCount;
+    await this.opts.synthMetaStore?.recordSecondOpinionPerf(caseId, {
+      modelA,
+      modelB,
+      agreementCount: record.agreementCount,
+      deltaCount,
+      agreementRate: denom > 0 ? record.agreementCount / denom : 0,
+      at: record.generatedAt,
+    });
     return record;
   }
 

--- a/companion/src/analysis/synthMeta.ts
+++ b/companion/src/analysis/synthMeta.ts
@@ -30,6 +30,23 @@ const secondLookSchema = z.object({
 
 export type SecondLookMeta = z.infer<typeof secondLookSchema>;
 
+// Second-opinion agreement telemetry (issue #74): how often the second-opinion model (DFIR_AI_SECOND_
+// OPINION_MODEL) agrees with the primary synthesis model (DFIR_AI_MODEL / DFIR_AI_SYNTH_MODEL) on the
+// SAME case, so the two can be compared empirically rather than just eyeballed. Recorded by
+// AnalysisPipeline.secondOpinion() itself — a separate, on-demand call, not part of every synthesis run
+// — via SynthMetaStore.recordSecondOpinionPerf, the same load-merge-save pattern as recordSecondLook, so
+// a later plain record() write (from the NEXT ordinary synthesis run) never silently wipes it.
+const secondOpinionPerfSchema = z.object({
+  modelA: z.string().catch(""),        // primary synthesis model label
+  modelB: z.string().catch(""),        // second-opinion model label
+  agreementCount: z.number().catch(0), // findings BOTH models independently raised
+  deltaCount: z.number().catch(0),     // points where they disagreed (b_only/a_only/severity/mitre_*)
+  agreementRate: z.number().catch(0),  // agreementCount / (agreementCount + deltaCount); 0 when both are 0
+  at: z.string().catch(""),            // when this second-opinion run completed
+});
+
+export type SecondOpinionPerf = z.infer<typeof secondOpinionPerfSchema>;
+
 // Synthesis coverage audit (issue #62): how much of the case the LAST real synthesis run actually put
 // in front of the model, and what it left out and why. The model can only read a bounded slice of a
 // large timeline (selectSynthesisEvents caps at DFIR_AI_SYNTH_MAX_EVENTS / the token budget), so the
@@ -111,6 +128,17 @@ export const synthMetaSchema = z.object({
   selectionCounts: z.record(z.string(), z.number()).optional().catch(undefined),
   // Synthesis coverage audit (#62): what the model saw vs what was left out, and why.
   coverage: synthesisCoverageSchema.nullable().optional().catch(undefined),
+  // Per-model quality telemetry (issue #74): the synthesis model used THIS run, how many findings it
+  // produced, how many of those the deterministic Critical/High safety net had to backfill (a proxy for
+  // detections the model itself missed), and how many parse retries the call needed (withRetry silently
+  // swallowed these before). Lets DFIR_AI_MODEL / DFIR_AI_SYNTH_MODEL be compared empirically across runs.
+  // Optional/lenient; absent on old files.
+  synthModel: z.string().optional().catch(undefined),
+  findingsCount: z.number().optional().catch(undefined),
+  highSeverityBackfillCount: z.number().optional().catch(undefined),
+  parseRetries: z.number().optional().catch(undefined),
+  // Second-opinion agreement (issue #74): set only by secondOpinion() runs — see secondOpinionPerfSchema.
+  secondOpinionPerf: secondOpinionPerfSchema.nullable().optional().catch(undefined),
 });
 
 export type SynthMeta = z.infer<typeof synthMetaSchema>;
@@ -123,6 +151,37 @@ export interface SynthPerfMetrics {
   iocCount: number;
   selectionCounts?: Record<string, number>;   // #4: per-class counts of the events the model saw
   coverage?: SynthesisCoverage;               // #62: included/omitted coverage audit for this run
+  synthModel?: string;                        // #74: "<provider>/<model>" that ran this synthesis
+  findingsCount?: number;                     // #74: total findings after this run
+  highSeverityBackfillCount?: number;         // #74: of those, how many the deterministic safety net added
+  parseRetries?: number;                      // #74: retries the synthesis JSON parse needed
+}
+
+export type ModelPerfSnapshot = Pick<SynthMeta, "synthModel" | "findingsCount" | "highSeverityBackfillCount" | "parseRetries" | "secondOpinionPerf">;
+
+// One-line human summary of the per-model quality fields, for the report footnote. Returns null when
+// there's nothing to say (no synth model recorded and no second-opinion run). Each clause is omitted
+// when its underlying count is zero/absent, mirroring coverageLabel's style.
+export function modelPerfLabel(m: ModelPerfSnapshot): string | null {
+  const parts: string[] = [];
+  if (m.synthModel) {
+    let s = `Synthesis ran on **${m.synthModel}**`;
+    if (m.findingsCount !== undefined) s += ` — ${m.findingsCount} finding${m.findingsCount === 1 ? "" : "s"}`;
+    if (m.highSeverityBackfillCount) {
+      s += ` (${m.highSeverityBackfillCount} recovered by the high-severity safety net, not raised by the model itself)`;
+    }
+    if (m.parseRetries) s += `, ${m.parseRetries} parse retr${m.parseRetries === 1 ? "y" : "ies"}`;
+    parts.push(s + ".");
+  }
+  const so = m.secondOpinionPerf;
+  if (so && (so.modelA || so.modelB)) {
+    parts.push(
+      `Second opinion (**${so.modelB || "model B"}**) vs primary (**${so.modelA || "model A"}**): agreed on ` +
+        `${so.agreementCount} finding${so.agreementCount === 1 ? "" : "s"}, ${so.deltaCount} disagreement${so.deltaCount === 1 ? "" : "s"} ` +
+        `(${Math.round(so.agreementRate * 100)}% agreement).`,
+    );
+  }
+  return parts.length ? parts.join(" ") : null;
 }
 
 export class SynthMetaStore {
@@ -155,6 +214,16 @@ export class SynthMetaStore {
   async recordSecondLook(caseId: string, secondLook: SecondLookMeta | null): Promise<SynthMeta> {
     const cur = await this.load(caseId);
     const meta: SynthMeta = { ...cur, secondLook };
+    await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
+    return meta;
+  }
+
+  // Stamp a second-opinion agreement snapshot onto the CURRENT synth-meta (#74). Same load-merge-save
+  // shape as recordSecondLook: secondOpinion() runs on demand (not as part of every synthesize() call),
+  // so this must merge onto whatever the last record() wrote rather than replace it. `null` clears it.
+  async recordSecondOpinionPerf(caseId: string, perf: SecondOpinionPerf | null): Promise<SynthMeta> {
+    const cur = await this.load(caseId);
+    const meta: SynthMeta = { ...cur, secondOpinionPerf: perf };
     await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
     return meta;
   }

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -13,7 +13,7 @@ import { detectTimelineAnomalies, anomalyEnvOptions } from "../analysis/timeline
 import { deriveIocSources } from "../analysis/iocCorroboration.js";
 import { scoreIocsFromState } from "../analysis/iocRiskScore.js";
 import { corroborationLabel } from "../analysis/findingGrounding.js";
-import { coverageLabel, type SynthesisCoverage } from "../analysis/synthMeta.js";
+import { coverageLabel, modelPerfLabel, type SynthesisCoverage, type ModelPerfSnapshot } from "../analysis/synthMeta.js";
 import { collectSummary } from "../analysis/collectDirective.js";
 import { attackTechniqueMd } from "../analysis/attack.js";
 import { buildAdversaryHintsResult } from "../analysis/adversaryHints.js";
@@ -290,6 +290,18 @@ function synthesisCoverageNote(coverage: SynthesisCoverage | null | undefined, l
   if (!coverage || coverage.inWindow <= 0) return;
   lines.push("### 3.4 Synthesis coverage", "");
   lines.push(`_${coverageLabel(coverage)}. Events omitted for the prompt size limit remain in the case; any Critical/High among them is still covered by the deterministic safety-net backfill._`, "");
+}
+
+// Model-performance footnote (issue #74) — which model ran the last synthesis, how many findings it
+// produced vs how many the deterministic safety net had to backfill, and (when a second opinion has
+// run) how often the second-opinion model agreed with the primary. Opt-in via DFIR_REPORT_MODEL_PERF
+// (the report writer passes null when the flag is off or nothing was recorded), same posture as the
+// synthesis-coverage footnote — internal methodology detail, not every report should carry it.
+function modelPerformanceNote(modelPerf: ModelPerfSnapshot | null | undefined, lines: string[]): void {
+  const label = modelPerf ? modelPerfLabel(modelPerf) : null;
+  if (!label) return;
+  lines.push("### 3.5 Model performance", "");
+  lines.push(`_${label}_`, "");
 }
 
 function timelineCoverage(state: InvestigationState, lines: string[]): void {
@@ -1006,6 +1018,7 @@ export function renderMarkdownReport(
   hypotheses?: Hypothesis[],
   secondLookLeads: string[] = [],   // #11 deferred: unresolved second-look collection leads
   coverage?: SynthesisCoverage | null,   // #62: synthesis coverage footnote (opt-in via DFIR_REPORT_SYNTH_COVERAGE)
+  modelPerf?: ModelPerfSnapshot | null,  // #74: model-performance footnote (opt-in via DFIR_REPORT_MODEL_PERF)
 ): string {
   const lines: string[] = [];
   const ctx = buildBrandingContext(state, meta);
@@ -1040,6 +1053,7 @@ export function renderMarkdownReport(
       attackPhases(state, lines);
       timelineCoverage(state, lines);
       synthesisCoverageNote(coverage, lines);
+      modelPerformanceNote(modelPerf, lines);
       timelineAnomalies(state, lines);
     },
     investigation: () => investigation(state, lines, exposure, assetGraph, kevCatalog, secondLookLeads),

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -48,7 +48,7 @@ import { CustomerExposureStore, type CustomerExposureSummary } from "../analysis
 import type { NotebookStore, NotebookEntry } from "../analysis/notebookStore.js";
 import type { HypothesisStore } from "../analysis/hypothesisStore.js";
 import type { Hypothesis } from "../analysis/hypothesis.js";
-import type { SynthMetaStore, SynthesisCoverage } from "../analysis/synthMeta.js";
+import type { SynthMetaStore, SynthesisCoverage, ModelPerfSnapshot } from "../analysis/synthMeta.js";
 import type { PlaybookStore } from "../analysis/playbookStore.js";
 import type { PlaybookTask } from "../analysis/playbook.js";
 import { AssetOverridesStore, applyAssetOverrides, emptyOverrides } from "../analysis/assetOverrides.js";
@@ -103,6 +103,19 @@ export class ReportWriter {
     const flag = (process.env.DFIR_REPORT_SYNTH_COVERAGE ?? "").trim().toLowerCase();
     if (!this.synthMeta || flag === "" || flag === "0" || flag === "false" || flag === "off") return null;
     try { return (await this.synthMeta.load(caseId)).coverage ?? null; } catch { return null; }
+  }
+
+  // Model-performance footnote (#74) — OPT-IN via DFIR_REPORT_MODEL_PERF, same posture as the
+  // synthesis-coverage footnote (internal methodology detail, not every report should carry it).
+  private async loadModelPerf(caseId: string): Promise<ModelPerfSnapshot | null> {
+    const flag = (process.env.DFIR_REPORT_MODEL_PERF ?? "").trim().toLowerCase();
+    if (!this.synthMeta || flag === "" || flag === "0" || flag === "false" || flag === "off") return null;
+    try {
+      const meta = await this.synthMeta.load(caseId);
+      return { synthModel: meta.synthModel, findingsCount: meta.findingsCount, highSeverityBackfillCount: meta.highSeverityBackfillCount, parseRetries: meta.parseRetries, secondOpinionPerf: meta.secondOpinionPerf };
+    } catch {
+      return null;
+    }
   }
 
   // Resolve the report template selected for the case (issue #60). Falls back to the default
@@ -403,9 +416,10 @@ export class ReportWriter {
     hypotheses?: Hypothesis[],
     secondLookLeads?: string[],
     coverage?: SynthesisCoverage | null,
+    modelPerf?: ModelPerfSnapshot | null,
   ): RedactedReportContents {
     return {
-      markdown: renderMarkdownReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage),
+      markdown: renderMarkdownReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, modelPerf),
       html: renderHtmlReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, hypotheses),
       findingsCsv: findingsCsv(state),
       iocsCsv: iocsCsv(state),
@@ -438,7 +452,8 @@ export class ReportWriter {
     const kevCatalog = await this.loadKevCatalog();
     const secondLookLeads = await this.loadSecondLookLeads(caseId);
     const coverage = await this.loadCoverage(caseId);
-    const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage);
+    const modelPerf = await this.loadModelPerf(caseId);
+    const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, modelPerf);
     await writeFile(paths.markdown, c.markdown, "utf8");
     await writeFile(paths.html, c.html, "utf8");
     await writeFile(paths.findingsCsv, c.findingsCsv, "utf8");

--- a/companion/tests/analysis/modelPerf.test.ts
+++ b/companion/tests/analysis/modelPerf.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { SynthMetaStore } from "../../src/analysis/synthMeta.js";
+import { SecondOpinionStore } from "../../src/analysis/secondOpinionStore.js";
+import { MockProvider } from "../../src/providers/provider.js";
+import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+// Per-model performance telemetry (issue #74): synthesize() and secondOpinion() should stamp
+// model-quality signals onto synth-meta — the model used, findings vs the deterministic
+// high-severity backfill, parse retries, and (for secondOpinion) the cross-model agreement rate —
+// so DFIR_AI_MODEL / DFIR_AI_SYNTH_MODEL / DFIR_AI_SECOND_OPINION_MODEL can be compared empirically.
+
+function event(id: string, timestamp: string, severity: ForensicEvent["severity"] = "Info", description = "benign"): ForensicEvent {
+  return { id, timestamp, description, severity, mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [] };
+}
+
+// A minimal, valid synthesis delta covering ONE event (e2) with ONE finding — e1 (seeded as
+// Critical, elsewhere) is deliberately left uncovered so the deterministic high-severity safety
+// net has to backfill it.
+const DELTA = JSON.stringify({
+  findings: [{ id: "f1", severity: "Medium", title: "Suspicious login", description: "d", relatedIocs: [], mitreTechniques: [], status: "open", relatedEventIds: ["e2"] }],
+  iocs: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [], timelineNote: "", summary: "s", forensicEvents: [],
+});
+
+// Fails (invalid JSON) for the first `failCount` calls, then returns `goodText`. Lets a test assert
+// synth-meta's parseRetries without withRetry's real backoff slowing the suite (backoffMs is set to
+// ~0 in makePipeline below).
+class FlakyProvider implements AIProvider {
+  readonly name = "flaky";
+  readonly model = "flaky-model";
+  private calls = 0;
+  constructor(private readonly failCount: number, private readonly goodText: string) {}
+  async analyze(_req: AnalyzeRequest): Promise<AnalyzeResult> {
+    this.calls++;
+    return { rawText: this.calls <= this.failCount ? "not valid json" : this.goodText };
+  }
+}
+
+async function makeCase() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-modelperf-"));
+  const caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+  const stateStore = new StateStore(caseStore);
+  const synthMetaStore = new SynthMetaStore(caseStore);
+  const seeded = emptyState("c1");
+  seeded.forensicTimeline.push(event("e1", "2026-05-20T09:00:00.000Z", "Critical", "ransomware note dropped"));
+  seeded.forensicTimeline.push(event("e2", "2026-05-20T09:05:00.000Z", "Info", "logon"));
+  await stateStore.save(seeded);
+  return { caseStore, stateStore, synthMetaStore };
+}
+
+// No Critical/High event here (unlike makeCase()) — the second-opinion test cares only about the
+// agreement/delta arithmetic, and a shared deterministic backfill finding would itself count as an
+// (uninteresting) agreement between A and B, muddying the expected counts below.
+async function makeSecondOpinionCase() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-modelperf-so-"));
+  const caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+  const stateStore = new StateStore(caseStore);
+  const synthMetaStore = new SynthMetaStore(caseStore);
+  const seeded = emptyState("c1");
+  seeded.forensicTimeline.push(event("e2", "2026-05-20T09:05:00.000Z", "Info", "logon"));
+  await stateStore.save(seeded);
+  return { caseStore, stateStore, synthMetaStore };
+}
+
+describe("per-model performance telemetry (#74)", () => {
+  it("records the synthesis model, findings count, and high-severity backfill count", async () => {
+    const { stateStore, synthMetaStore } = await makeCase();
+    const provider = new MockProvider("mock", DELTA, "sonnet-5");
+    const pipeline = new AnalysisPipeline({
+      provider, synthesisProvider: provider, stateStore, synthMetaStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+
+    const meta = await synthMetaStore.load("c1");
+    expect(meta.synthModel).toBe("mock/sonnet-5");
+    expect(meta.findingsCount).toBe(2);              // f1 (model) + the backfilled e1 finding
+    expect(meta.highSeverityBackfillCount).toBe(1);   // e1 (Critical, uncited) recovered by the safety net
+    expect(meta.parseRetries).toBe(0);
+  });
+
+  it("prefers the configured synthesisModelLabel over the provider's raw name/model", async () => {
+    const { stateStore, synthMetaStore } = await makeCase();
+    const provider = new MockProvider("mock", DELTA, "sonnet-5");
+    const pipeline = new AnalysisPipeline({
+      provider, synthesisProvider: provider, stateStore, synthMetaStore,
+      synthesisModelLabel: "Primary (Claude Sonnet 5)",
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+
+    expect((await synthMetaStore.load("c1")).synthModel).toBe("Primary (Claude Sonnet 5)");
+  });
+
+  it("counts parse retries the synthesis call needed", async () => {
+    const { stateStore, synthMetaStore } = await makeCase();
+    const provider = new FlakyProvider(2, DELTA); // fails twice, succeeds on the 3rd (default retries=3)
+    const pipeline = new AnalysisPipeline({
+      provider, synthesisProvider: provider, stateStore, synthMetaStore, backoffMs: 1,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+
+    expect((await synthMetaStore.load("c1")).parseRetries).toBe(2);
+  });
+
+  it("records a second-opinion agreement snapshot without disturbing the synth-model fields", async () => {
+    const { caseStore, stateStore, synthMetaStore } = await makeSecondOpinionCase();
+    const secondOpinionStore = new SecondOpinionStore(caseStore);
+    const primary = new MockProvider("primary", DELTA, "sonnet-5");
+    // Second opinion (dry-run) delta: same shared finding as f1 PLUS one B raises that A doesn't —
+    // one delta (b_only), so agreementRate = 1 / (1 + 1) = 0.5.
+    const secondOpinionDelta = JSON.stringify({
+      findings: [
+        { id: "f1", severity: "Medium", title: "Suspicious login", description: "d", relatedIocs: [], mitreTechniques: [], status: "open", relatedEventIds: ["e2"] },
+        { id: "g2", severity: "High", title: "B only finding", description: "d2", relatedIocs: [], mitreTechniques: [], status: "open", relatedEventIds: [] },
+      ],
+      iocs: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [], timelineNote: "", summary: "s2", forensicEvents: [],
+    });
+    const secondOpinionProvider = new MockProvider("second", secondOpinionDelta, "gpt-5");
+    const pipeline = new AnalysisPipeline({
+      provider: primary, synthesisProvider: primary, stateStore, synthMetaStore,
+      secondOpinionProvider, secondOpinionStore,
+      synthesisModelLabel: "primary/sonnet-5", secondOpinionModelLabel: "second/gpt-5",
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.secondOpinion("c1");
+
+    const meta = await synthMetaStore.load("c1");
+    expect(meta.secondOpinionPerf).toEqual({
+      modelA: "primary/sonnet-5",
+      modelB: "second/gpt-5",
+      agreementCount: 1,
+      deltaCount: 1,
+      agreementRate: 0.5,
+      at: expect.any(String),
+    });
+    // secondOpinion()'s Pass-0 re-synthesis still stamped the ordinary synth-model fields.
+    expect(meta.synthModel).toBe("primary/sonnet-5");
+  });
+});

--- a/companion/tests/analysis/synthMeta.test.ts
+++ b/companion/tests/analysis/synthMeta.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
-import { SynthMetaStore, buildSynthesisCoverage, coverageLabel } from "../../src/analysis/synthMeta.js";
+import { SynthMetaStore, buildSynthesisCoverage, coverageLabel, modelPerfLabel } from "../../src/analysis/synthMeta.js";
 import type { FindingsDiff } from "../../src/analysis/findingsDiff.js";
 
 const DIFF: FindingsDiff = {
@@ -64,6 +64,88 @@ describe("SynthMetaStore", () => {
     await store.record("c1", DIFF, "2026-07-14T10:00:00.000Z", { durationMs: 1, eventCount: 287, iocCount: 3, coverage });
     const meta = await store.load("c1");
     expect(meta.coverage).toEqual(coverage);
+  });
+
+  // Per-model quality telemetry (issue #74).
+  it("stores and loads per-model quality fields", async () => {
+    await store.record("c1", DIFF, "2026-07-18T10:00:00.000Z", {
+      durationMs: 1, eventCount: 287, iocCount: 3,
+      synthModel: "anthropic/claude-sonnet-5",
+      findingsCount: 12,
+      highSeverityBackfillCount: 2,
+      parseRetries: 1,
+    });
+    const meta = await store.load("c1");
+    expect(meta.synthModel).toBe("anthropic/claude-sonnet-5");
+    expect(meta.findingsCount).toBe(12);
+    expect(meta.highSeverityBackfillCount).toBe(2);
+    expect(meta.parseRetries).toBe(1);
+  });
+
+  it("loads fine when per-model quality fields are absent (old record format)", async () => {
+    await store.record("c1", DIFF, "2026-07-18T10:00:00.000Z");
+    const meta = await store.load("c1");
+    expect(meta.synthModel).toBeUndefined();
+    expect(meta.findingsCount).toBeUndefined();
+    expect(meta.highSeverityBackfillCount).toBeUndefined();
+    expect(meta.parseRetries).toBeUndefined();
+    expect(meta.secondOpinionPerf).toBeUndefined();
+  });
+
+  it("records a second-opinion agreement snapshot without disturbing the rest of the meta", async () => {
+    await store.record("c1", DIFF, "2026-07-18T10:00:00.000Z", { durationMs: 1, eventCount: 287, iocCount: 3, synthModel: "anthropic/claude-sonnet-5" });
+    const perf = { modelA: "anthropic/claude-sonnet-5", modelB: "openai/gpt-5", agreementCount: 8, deltaCount: 2, agreementRate: 0.8, at: "2026-07-18T10:05:00.000Z" };
+    await store.recordSecondOpinionPerf("c1", perf);
+    const meta = await store.load("c1");
+    expect(meta.secondOpinionPerf).toEqual(perf);
+    expect(meta.synthModel).toBe("anthropic/claude-sonnet-5"); // untouched by the merge
+  });
+
+  it("clears the second-opinion snapshot with null", async () => {
+    const perf = { modelA: "a", modelB: "b", agreementCount: 1, deltaCount: 1, agreementRate: 0.5, at: "2026-07-18T10:05:00.000Z" };
+    await store.recordSecondOpinionPerf("c1", perf);
+    await store.recordSecondOpinionPerf("c1", null);
+    const meta = await store.load("c1");
+    expect(meta.secondOpinionPerf).toBeNull();
+  });
+
+  it("a plain record() wipes a previously-recorded second-opinion snapshot (same posture as secondLook)", async () => {
+    const perf = { modelA: "a", modelB: "b", agreementCount: 1, deltaCount: 1, agreementRate: 0.5, at: "2026-07-18T10:05:00.000Z" };
+    await store.recordSecondOpinionPerf("c1", perf);
+    await store.record("c1", DIFF, "2026-07-18T11:00:00.000Z", { durationMs: 1, eventCount: 1, iocCount: 0 });
+    const meta = await store.load("c1");
+    expect(meta.secondOpinionPerf).toBeUndefined();
+  });
+});
+
+describe("modelPerfLabel", () => {
+  it("returns null when nothing was recorded", () => {
+    expect(modelPerfLabel({})).toBeNull();
+  });
+
+  it("describes the synthesis model, findings, and backfill/retry counts", () => {
+    const label = modelPerfLabel({ synthModel: "anthropic/claude-sonnet-5", findingsCount: 12, highSeverityBackfillCount: 2, parseRetries: 1 });
+    expect(label).toMatch(/anthropic\/claude-sonnet-5/);
+    expect(label).toMatch(/12 finding/);
+    expect(label).toMatch(/2 recovered by the high-severity safety net/);
+    expect(label).toMatch(/1 parse retry/);
+  });
+
+  it("omits the backfill/retry clauses when zero", () => {
+    const label = modelPerfLabel({ synthModel: "anthropic/claude-sonnet-5", findingsCount: 12, highSeverityBackfillCount: 0, parseRetries: 0 });
+    expect(label).not.toMatch(/safety net/);
+    expect(label).not.toMatch(/retry/);
+  });
+
+  it("adds a second-opinion agreement clause", () => {
+    const label = modelPerfLabel({
+      secondOpinionPerf: { modelA: "anthropic/claude-sonnet-5", modelB: "openai/gpt-5", agreementCount: 8, deltaCount: 2, agreementRate: 0.8, at: "2026-07-18T10:05:00.000Z" },
+    });
+    expect(label).toMatch(/openai\/gpt-5/);
+    expect(label).toMatch(/anthropic\/claude-sonnet-5/);
+    expect(label).toMatch(/8 finding/);
+    expect(label).toMatch(/2 disagreement/);
+    expect(label).toMatch(/80% agreement/);
   });
 });
 

--- a/companion/tests/reports/markdown.test.ts
+++ b/companion/tests/reports/markdown.test.ts
@@ -579,4 +579,31 @@ describe("renderMarkdownReport", () => {
       expect(md).not.toContain("### 3.4 Synthesis coverage");
     });
   });
+
+  describe("model performance footnote (#74)", () => {
+    const modelPerf = { synthModel: "anthropic/claude-sonnet-5", findingsCount: 12, highSeverityBackfillCount: 2, parseRetries: 1 };
+
+    it("renders the model-performance section when a snapshot is passed", () => {
+      const md = renderMarkdownReport(emptyState("c1"), undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, [], undefined, modelPerf);
+      expect(md).toContain("### 3.5 Model performance");
+      expect(md).toContain("anthropic/claude-sonnet-5");
+      expect(md).toContain("12 findings");
+      expect(md).toContain("safety net");
+    });
+
+    it("adds the second-opinion agreement clause when recorded", () => {
+      const withSecondOpinion = {
+        ...modelPerf,
+        secondOpinionPerf: { modelA: "anthropic/claude-sonnet-5", modelB: "openai/gpt-5", agreementCount: 8, deltaCount: 2, agreementRate: 0.8, at: "2026-07-18T10:05:00.000Z" },
+      };
+      const md = renderMarkdownReport(emptyState("c1"), undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, [], undefined, withSecondOpinion);
+      expect(md).toContain("openai/gpt-5");
+      expect(md).toContain("80% agreement");
+    });
+
+    it("omits the model-performance section by default (no snapshot passed)", () => {
+      const md = renderMarkdownReport(emptyState("c1"));
+      expect(md).not.toContain("### 3.5 Model performance");
+    });
+  });
 });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2519,6 +2519,9 @@
           <div class="sfield"><label>Log-extraction template cap<span class="sfield-hint">DFIR_LOG_MAX_TEMPLATES — distinct collapsed log-line templates kept for the AI log-extraction prompt (unset = built-in default)</span></label><input id="env-DFIR_LOG_MAX_TEMPLATES" placeholder="(default)" /></div>
           <div class="sfield"><label>Report synthesis-coverage footnote<span class="sfield-hint">DFIR_REPORT_SYNTH_COVERAGE — add a "§3.4 Synthesis coverage" footnote to the exported report (off by default)</span></label><input id="env-DFIR_REPORT_SYNTH_COVERAGE" placeholder="off" /></div>
         </div>
+        <div class="sfield-row">
+          <div class="sfield"><label>Report model-performance footnote<span class="sfield-hint">DFIR_REPORT_MODEL_PERF — add a "§3.5 Model performance" footnote (synth model, findings vs safety-net backfill, second-opinion agreement rate) to the exported report (off by default)</span></label><input id="env-DFIR_REPORT_MODEL_PERF" placeholder="off" /></div>
+        </div>
       </div>
 
       <!-- Enrichment -->
@@ -9322,7 +9325,23 @@
         const warn = cv.omittedBudget > 0;
         coverage = `<div class="sm-perf" style="margin-top:4px${warn ? ';color:var(--c-ffd93b)' : ''}" title="How much of the in-scope timeline the AI actually read this run (#62). Events omitted for the size limit are still in the case; any Critical/High among them is still covered by the deterministic safety-net backfill.">${txt}</div>`;
       }
-      el.innerHTML = `<div class="sm-line"><span>🧠 Last synthesized <strong>${esc(relTime(m.lastSynthesizedAt))}</strong></span>${perfSpan}<span>${summary}</span></div>${coverage}${evidenceMix}${detail}${secondLook}${largeAdvisory}`;
+      // Per-model quality telemetry (#74): the synthesis model used this run, how many findings it
+      // produced vs how many the deterministic safety net had to backfill (a proxy for missed
+      // detections), and any parse retries — plus the second-opinion agreement rate when one has run.
+      let modelPerf = '';
+      if (m.synthModel) {
+        const bits = [`🤖 <strong>${esc(m.synthModel)}</strong>`];
+        if (m.findingsCount !== undefined) bits.push(`${m.findingsCount.toLocaleString()} finding(s)`);
+        if (m.highSeverityBackfillCount) bits.push(`<span style="color:var(--c-ffd93b)">${m.highSeverityBackfillCount} backfilled by safety net</span>`);
+        if (m.parseRetries) bits.push(`<span style="color:var(--c-ff7a7a)">${m.parseRetries} parse retr${m.parseRetries === 1 ? 'y' : 'ies'}</span>`);
+        modelPerf = `<div class="sm-perf" style="margin-top:4px" title="The synthesis model this run, and quality signals to compare DFIR_AI_MODEL / DFIR_AI_SYNTH_MODEL choices empirically (#74)">${bits.join(' · ')}</div>`;
+      }
+      const so = m.secondOpinionPerf;
+      if (so && (so.modelA || so.modelB)) {
+        const pct = Math.round((so.agreementRate || 0) * 100);
+        modelPerf += `<div class="sm-perf" style="margin-top:4px" title="How often the second-opinion model agreed with the primary synthesis model on this case (#74)">🆚 <strong>${esc(so.modelB)}</strong> vs <strong>${esc(so.modelA)}</strong>: ${so.agreementCount} agreed, ${so.deltaCount} disagreed (${pct}%)</div>`;
+      }
+      el.innerHTML = `<div class="sm-line"><span>🧠 Last synthesized <strong>${esc(relTime(m.lastSynthesizedAt))}</strong></span>${perfSpan}<span>${summary}</span></div>${coverage}${modelPerf}${evidenceMix}${detail}${secondLook}${largeAdvisory}`;
     }
 
     // --- Correlation profile (per-case cross-source event merge window) -------------------------


### PR DESCRIPTION
## Summary
- Extend synth-meta with per-model quality signals: synthesis model, findings count, high-severity safety-net backfill count, and parse retries, recorded on every real synthesis run.
- Add a second-opinion agreement snapshot (agreement/delta counts + rate), recorded by `secondOpinion()`.
- Surface both on the dashboard's synth-meta card, and add an opt-in `DFIR_REPORT_MODEL_PERF` report footnote (§3.5 Model performance).
- Unit and integration tests covering schema serialization, the formatter, report rendering, and the pipeline wiring.

Closes #74.

🤖 Generated with [Claude Code](https://claude.ai/code)