### PR TITLE
Add pure event-relevance scoring + dashboard low-signal chip (#75)

### DIFF
--- a/companion/src/analysis/eventRelevance.ts
+++ b/companion/src/analysis/eventRelevance.ts
@@ -28,6 +28,17 @@ function hasStructuredIdentity(e: ForensicEvent): boolean {
 // same thing it means to the selector's reserved RARE fill.
 const RARE_SCORE_MIN = 0.34;
 
+// Count of DISTINCT REAL tool sources backing an event — the same unit correlate.ts, sourceTrust.ts,
+// iocCorroboration.ts and the dashboard's realSourceCount() all use. Empty strings and the legacy
+// "unknown source" placeholder are not tools, and a repeated source name is still ONE tool, so
+// neither may inflate the count. Over-claiming that two tools agree is worse than missing a match:
+// an uncorroborated Info row must not be promoted out of the "low" tier by a placeholder.
+function realSourceCount(e: ForensicEvent): number {
+  const set = new Set<string>();
+  for (const s of e.sources ?? []) if (s && s !== "unknown source") set.add(s);
+  return set.size;
+}
+
 export function scoreEventRelevance(
   e: ForensicEvent,
   rarityOf?: (e: ForensicEvent) => number,
@@ -42,7 +53,7 @@ export function scoreEventRelevance(
   const reasons: string[] = [];
   if (hasStructuredIdentity(e)) reasons.push("structured identity (hash/path/process chain)");
   if (e.mitreTechniques.length > 0) reasons.push("ATT&CK technique tagged");
-  if ((e.sources?.length ?? 0) >= 2) reasons.push("corroborated by multiple sources");
+  if (realSourceCount(e) >= 2) reasons.push("corroborated by multiple sources");
   if (rarityOf && rarityOf(e) >= RARE_SCORE_MIN) reasons.push("rare pattern in this case");
 
   if (reasons.length > 0) {

--- a/companion/src/analysis/eventRelevance.ts
+++ b/companion/src/analysis/eventRelevance.ts
@@ -1,0 +1,62 @@
+import type { ForensicEvent } from "./stateTypes.js";
+
+// Pure per-event relevance scoring (issue #75), evaluated against the same signals
+// `synthSelect.ts`'s reserved-budget classes already use for selection: severity, finding linkage,
+// structured identity (hash/path/process chain), ATT&CK technique tags, cross-source corroboration,
+// and (optionally) corpus rarity. It does NOT replace or feed the selector — `synthSelect.ts` is
+// unchanged and its selection is byte-identical with or without this module. This is an orthogonal,
+// additive display signal: the dashboard uses it to flag rows least likely to matter (see #75's
+// "🐇 low signal" ask) without touching what synthesis actually reads.
+//
+// Class → tier mapping this subsumes: anchor → high; corroborated/technique/rare → medium (a
+// structured hash/path/process-chain identity gets the same medium tier, even with no reserved
+// class of its own — it's the connective tissue a kill-chain read needs); anchor_context/earliest/
+// spread are POSITIONAL (near an anchor, or chronological), not content signals, so they aren't
+// modeled here — a context event's content can independently be low, medium, or high.
+export type RelevanceTier = "high" | "medium" | "low";
+
+export interface RelevanceScore {
+  tier: RelevanceTier;
+  reasons: string[];
+}
+
+function hasStructuredIdentity(e: ForensicEvent): boolean {
+  return !!(e.sha256 || e.md5 || e.path || e.processName || e.parentName || e.chainSignature);
+}
+
+// Prevalence threshold mirrors synthSelect.ts's RARE_SCORE_MIN so a "rare" verdict here means the
+// same thing it means to the selector's reserved RARE fill.
+const RARE_SCORE_MIN = 0.34;
+
+export function scoreEventRelevance(
+  e: ForensicEvent,
+  rarityOf?: (e: ForensicEvent) => number,
+): RelevanceScore {
+  if (e.severity === "Critical" || e.severity === "High") {
+    return { tier: "high", reasons: [`${e.severity} severity`] };
+  }
+  if (e.relatedFindingIds.length > 0) {
+    return { tier: "high", reasons: ["linked to a finding"] };
+  }
+
+  const reasons: string[] = [];
+  if (hasStructuredIdentity(e)) reasons.push("structured identity (hash/path/process chain)");
+  if (e.mitreTechniques.length > 0) reasons.push("ATT&CK technique tagged");
+  if ((e.sources?.length ?? 0) >= 2) reasons.push("corroborated by multiple sources");
+  if (rarityOf && rarityOf(e) >= RARE_SCORE_MIN) reasons.push("rare pattern in this case");
+
+  if (reasons.length > 0) {
+    return { tier: "medium", reasons };
+  }
+
+  if (e.severity === "Info") {
+    return { tier: "low", reasons: ["Info-severity telemetry with no structured identity, technique tag, or corroboration"] };
+  }
+  // Medium/Low severity with none of the above signals: still a graded detection (a tool judged it),
+  // just uncorroborated — treat as medium rather than low so a lone real detection isn't buried.
+  return { tier: "medium", reasons: ["graded detection, uncorroborated"] };
+}
+
+export function isLowRelevance(e: ForensicEvent, rarityOf?: (e: ForensicEvent) => number): boolean {
+  return scoreEventRelevance(e, rarityOf).tier === "low";
+}

--- a/companion/tests/analysis/eventRelevance.test.ts
+++ b/companion/tests/analysis/eventRelevance.test.ts
@@ -44,6 +44,21 @@ describe("scoreEventRelevance", () => {
     expect(scoreEventRelevance(e).tier).toBe("medium");
   });
 
+  // Corroboration is counted in DISTINCT REAL tools, the same unit correlate.ts/sourceTrust.ts/
+  // iocCorroboration.ts and the dashboard's realSourceCount() use. A placeholder or a repeated name
+  // must not fake a second tool — otherwise a pure Info hunt row gets promoted out of "low" and the
+  // dashboard chip (which does filter/dedup) disagrees with this module it claims to mirror.
+  it("does not count the 'unknown source' placeholder as corroboration", () => {
+    const e = ev("i-placeholder", "Info", { sources: ["unknown source", "ToolA"] });
+    expect(scoreEventRelevance(e).tier).toBe("low");
+    expect(isLowRelevance(e)).toBe(true);
+  });
+
+  it("does not count a repeated source name as corroboration", () => {
+    const e = ev("i-dupe", "Info", { sources: ["ToolA", "ToolA"] });
+    expect(scoreEventRelevance(e).tier).toBe("low");
+  });
+
   it("scores a rare event (via rarityOf) as medium, and ignores rarityOf when omitted", () => {
     const e = ev("j", "Info");
     expect(scoreEventRelevance(e, () => 0.9).tier).toBe("medium");

--- a/companion/tests/analysis/eventRelevance.test.ts
+++ b/companion/tests/analysis/eventRelevance.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { scoreEventRelevance, isLowRelevance } from "../../src/analysis/eventRelevance.js";
+import { selectSynthesisEventsAnnotated } from "../../src/analysis/synthSelect.js";
+import type { ForensicEvent, Severity } from "../../src/analysis/stateTypes.js";
+
+function ev(id: string, sev: Severity, extra: Partial<ForensicEvent> = {}): ForensicEvent {
+  return {
+    id,
+    timestamp: "2026-05-20T09:00:00Z",
+    description: id,
+    severity: sev,
+    mitreTechniques: [],
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+    ...extra,
+  };
+}
+
+describe("scoreEventRelevance", () => {
+  it("scores Critical/High as high regardless of other signals", () => {
+    expect(scoreEventRelevance(ev("a", "Critical")).tier).toBe("high");
+    expect(scoreEventRelevance(ev("b", "High")).tier).toBe("high");
+  });
+
+  it("scores a finding-linked event as high even at low severity", () => {
+    const e = ev("c", "Info", { relatedFindingIds: ["f1"] });
+    expect(scoreEventRelevance(e).tier).toBe("high");
+  });
+
+  it("scores a structured hash/path/process-chain event as medium", () => {
+    expect(scoreEventRelevance(ev("d", "Low", { sha256: "abc123" })).tier).toBe("medium");
+    expect(scoreEventRelevance(ev("e", "Info", { path: "c:\\windows\\temp\\x.exe" })).tier).toBe("medium");
+    expect(scoreEventRelevance(ev("f", "Info", { processName: "powershell.exe" })).tier).toBe("medium");
+    expect(scoreEventRelevance(ev("g", "Info", { chainSignature: "sig1" })).tier).toBe("medium");
+  });
+
+  it("scores an ATT&CK-technique-tagged event as medium", () => {
+    const e = ev("h", "Info", { mitreTechniques: ["T1059"] });
+    expect(scoreEventRelevance(e).tier).toBe("medium");
+  });
+
+  it("scores a cross-source-corroborated event as medium", () => {
+    const e = ev("i", "Info", { sources: ["ToolA", "ToolB"] });
+    expect(scoreEventRelevance(e).tier).toBe("medium");
+  });
+
+  it("scores a rare event (via rarityOf) as medium, and ignores rarityOf when omitted", () => {
+    const e = ev("j", "Info");
+    expect(scoreEventRelevance(e, () => 0.9).tier).toBe("medium");
+    expect(scoreEventRelevance(e, () => 0.1).tier).toBe("low");
+    expect(scoreEventRelevance(e).tier).toBe("low");
+  });
+
+  it("scores a pure Info hunt row with no structured id, technique, or corroboration as low", () => {
+    const e = ev("k", "Info");
+    expect(scoreEventRelevance(e).tier).toBe("low");
+    expect(isLowRelevance(e)).toBe(true);
+  });
+
+  it("scores an uncorroborated Medium/Low-severity graded detection as medium, not low", () => {
+    expect(scoreEventRelevance(ev("l", "Medium")).tier).toBe("medium");
+    expect(scoreEventRelevance(ev("m", "Low")).tier).toBe("medium");
+  });
+
+  it("never returns low for a non-Info severity event", () => {
+    const sevs: Severity[] = ["Critical", "High", "Medium", "Low"];
+    for (const sev of sevs) {
+      expect(scoreEventRelevance(ev(`n-${sev}`, sev)).tier).not.toBe("low");
+    }
+  });
+});
+
+// Consistency check against the existing budgeted selector (issue #75's acceptance criteria: this
+// scorer must not regress selection coverage). It doesn't feed selectSynthesisEvents at all — these
+// assertions just confirm the two independent signals agree on what matters, so a future caller could
+// safely use the score as a display hint without it contradicting what synthesis actually reads.
+describe("scoreEventRelevance vs. the budgeted selector's classes", () => {
+  it("agrees with every class the selector already reserves budget for", () => {
+    const events: ForensicEvent[] = [
+      ev("anchor1", "Critical"),
+      ev("corrob1", "Low", { sources: ["ToolA", "ToolB"] }),
+      ev("tech1", "Low", { mitreTechniques: ["T1059"] }),
+      ev("chain1", "Low", { sha256: "deadbeef" }),
+    ];
+    // Add enough Info noise so the selector actually has to budget rather than keep everything.
+    for (let i = 0; i < 50; i++) {
+      events.push(ev(`noise${i}`, "Info", { timestamp: `2026-05-20T${String(i % 24).padStart(2, "0")}:30:00Z` }));
+    }
+
+    const { classOf } = selectSynthesisEventsAnnotated(events, 10);
+
+    expect(classOf.get("anchor1")).toBe("anchor");
+    expect(scoreEventRelevance(events.find((e) => e.id === "anchor1")!).tier).toBe("high");
+
+    for (const id of ["corrob1", "tech1", "chain1"]) {
+      const e = events.find((x) => x.id === id)!;
+      expect(scoreEventRelevance(e).tier).toBe("medium");
+    }
+
+    // Plain Info noise the selector didn't guarantee a seat for scores low — the two systems point
+    // at the same rows as least valuable, without this module changing which rows are actually chosen.
+    const noiseSample = events.find((e) => e.id === "noise0")!;
+    expect(isLowRelevance(noiseSample)).toBe(true);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1040,6 +1040,8 @@
     .prev-chip { font-size: 10px; font-weight: 600; border-radius: 4px; padding: 0 6px; white-space: nowrap; cursor: help; }
     .prev-common { color: var(--c-9aa4b2); border: 1px solid var(--c-2a3146); }
     .prev-rare { color: var(--c-ffb454, #ffb454); border: 1px solid var(--c-5a4a2a, #5a4a2a); }
+    /* Low-relevance chip (#75) — client mirror of eventRelevance.ts's "low" tier. */
+    .lowsig-chip { color: var(--c-6b7280); border: 1px solid var(--c-2a3146); }
     /* Raw-file (EVTX/PCAP) prompt banner — prominent, at the top of the content. #211 */
     .raw-banner { font-size: 13px; color: var(--c-e6e9ef); margin: 0 0 12px; padding: 11px 14px;
       border: 1px solid #7a5c1a; border-left: 4px solid #e0a72c; border-radius: 8px; background: #241a08; }
@@ -5008,6 +5010,10 @@
       // Prevalence baseline (#15b): how common this activity pattern is across the case.
       const prevChip = prevalenceChip(e);
       if (prevChip) parts.push(prevChip);
+      // Relevance (#75): flag rows the deterministic scorer rates lowest — Info telemetry with no
+      // finding link, structured identity, ATT&CK tag, or corroboration.
+      const lowSigChip = lowSignalChip(e);
+      if (lowSigChip) parts.push(lowSigChip);
       const ev = (show("evidence") && caseId) ? evidenceLinks(caseId, e.sourceScreenshots) : "";
       if (ev) parts.push(ev.replace(/^<br>/, ""));
       if (!parts.length) return { title, toggle: "", panel: "" };
@@ -13848,6 +13854,24 @@
       if (st.count >= 20) return `<span class="prev-chip prev-common" title="This pattern is common in this case — likely routine baseline activity.">≈ seen ${st.count}×${esc(hosts)}</span>`;
       if (st.count <= 2) return `<span class="prev-chip prev-rare" title="This pattern is rare in this case — more likely to be signal than noise.">◆ rare (${st.count}×)</span>`;
       return "";
+    }
+
+    // Low-relevance row flag (#75, client mirror of companion/src/analysis/eventRelevance.ts's
+    // scoreEventRelevance): Critical/High severity, a finding link, a structured hash/path/process-chain
+    // identity, an ATT&CK tag, or 2+ corroborating sources all clear it — what's left is Info-severity
+    // telemetry with none of those signals, the class of row least likely to matter to the story. A
+    // display hint only; it does not change what selectSynthesisEvents feeds to synthesis.
+    function isLowSignalEvent(e) {
+      if (e.severity !== "Info") return false;
+      if (e.relatedFindingIds && e.relatedFindingIds.length) return false;
+      if (e.sha256 || e.md5 || e.path || e.processName || e.parentName || e.chainSignature) return false;
+      if (e.mitreTechniques && e.mitreTechniques.length) return false;
+      const realSrc = (e.sources || []).filter(s => s && s !== "unknown source");
+      return realSrc.length < 2;
+    }
+    function lowSignalChip(e) {
+      if (!isLowSignalEvent(e)) return "";
+      return `<span class="prev-chip lowsig-chip" title="Info-severity telemetry with no finding link, structured identity, ATT&amp;CK tag, or multi-source corroboration — likely low signal">🐇 low signal</span>`;
     }
     function renderTimelineEvents(ft) {
       // Build the prevalence index over the full loaded timeline (baseline is a corpus property), not the

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -13866,8 +13866,11 @@
       if (e.relatedFindingIds && e.relatedFindingIds.length) return false;
       if (e.sha256 || e.md5 || e.path || e.processName || e.parentName || e.chainSignature) return false;
       if (e.mitreTechniques && e.mitreTechniques.length) return false;
-      const realSrc = (e.sources || []).filter(s => s && s !== "unknown source");
-      return realSrc.length < 2;
+      // realSourceCount() is the shared corroboration unit: it drops the "unknown source" placeholder
+      // AND dedups, so a repeated source name can't fake corroboration and clear the flag. Called with
+      // no `hidden` set on purpose — relevance is a property of the event, not of the analyst's current
+      // source filter, so the chip must not appear/disappear as they toggle sources.
+      return realSourceCount(e.sources) < 2;
     }
     function lowSignalChip(e) {
       if (!isLowSignalEvent(e)) return "";


### PR DESCRIPTION
## Summary
- Adds `companion/src/analysis/eventRelevance.ts`: a pure per-event relevance scorer (high/medium/low) mirroring the signals `synthSelect.ts`'s reserved-budget classes already use (severity, finding linkage, structured hash/path/process identity, ATT&CK tags, corroboration). Additive/orthogonal - `synthSelect.ts` is unchanged.
- Adds tests incl. a consistency check against the existing selector's classes.
- Adds a "🐇 low signal" dashboard chip (client mirror) for Info-severity rows with no finding link, structured identity, ATT&CK tag, or corroboration, shared by the forensic and super-timeline.

Scoped down from the full "unify the selector into one score" ask per the issue's own triage comment: the budgeted selector isn't a gap, so this keeps it untouched and only adds the scoring/display parts.

Closes #75.

## Test plan
- [ ] `npm test` in `companion/` (could not run in this sandbox - please verify in CI)
- [ ] Manually check the 🐇 low signal chip appears on Info-severity super-timeline rows

Generated with [Claude Code](https://claude.ai/code)