### PR TITLE
Add DOM-aware fallback tool detection to the extension

### DIFF
--- a/extension/src/adapters/crowdstrike.ts
+++ b/extension/src/adapters/crowdstrike.ts
@@ -14,6 +14,12 @@ export const crowdstrikeAdapter: Adapter = {
     return /(crowdstrike|falcon)/i.test(url.hostname);
   },
 
+  // Fallback for a reverse-proxied / rebranded Falcon console whose hostname doesn't carry
+  // "crowdstrike"/"falcon". The console titles every page "<view> | Falcon".
+  matchDom(doc: Document): boolean {
+    return /(crowdstrike|falcon)/i.test(doc.title);
+  },
+
   apiPatterns: [
     "/detects/",
     "/alerts/",

--- a/extension/src/adapters/elastic.ts
+++ b/extension/src/adapters/elastic.ts
@@ -21,6 +21,16 @@ export const elasticAdapter: Adapter = {
     return false;
   },
 
+  // Fallback for a Kibana behind a reverse proxy on an unbranded host/path (e.g. a vanity URL like
+  // `/soc/`) that matchUrl's host/path/port checks can't recognize. Kibana's SPA has rendered its
+  // root into a `#kibana-body` element since 6.x; the document <title> also carries "Kibana" or
+  // "Elastic" (recent rebrand) for every app view ("Discover - Kibana", "Discover - Elastic").
+  matchDom(doc: Document): boolean {
+    if (doc.getElementById("kibana-body")) return true;
+    if (doc.querySelector('[data-test-subj="kibanaChrome"]')) return true;
+    return /\b(kibana|elastic)\b/i.test(doc.title);
+  },
+
   apiPatterns: [
     "/_search",
     "/_async_search",

--- a/extension/src/adapters/registry.ts
+++ b/extension/src/adapters/registry.ts
@@ -20,10 +20,11 @@ export const ADAPTERS: readonly Adapter[] = [
 ];
 
 /**
- * Return the adapter that recognizes this page URL, or null. Pure — used by the content script as
- * the DEFAULT activation decision (on an unrecognized site, plain screenshot capture is used
- * unless the popup's manual override forces an adapter on — see adapters/override.ts). Invalid
- * URLs yield null rather than throwing.
+ * Return the adapter that recognizes this page URL, or null. Pure. URL-only — see adapterForPage()
+ * below for the DOM-aware version the content script actually calls as its DEFAULT activation
+ * decision (on an unrecognized site, plain screenshot capture is used unless the popup's manual
+ * override forces an adapter on — see adapters/override.ts). Invalid URLs yield null rather than
+ * throwing.
  */
 export function adapterForUrl(href: string): Adapter | null {
   let url: URL;
@@ -46,4 +47,34 @@ export function adapterForUrl(href: string): Adapter | null {
 
 export function adapterById(id: string): Adapter | null {
   return ADAPTERS.find((a) => a.id === id) ?? null;
+}
+
+/**
+ * Same as adapterForUrl, but when no adapter's matchUrl wins, falls back to each adapter's DOM
+ * signature (matchDom) — covers a known tool deployed behind a reverse proxy, a vanity hostname, or
+ * a custom path that the URL alone can't identify (issue #76). URL match always takes precedence:
+ * matchDom is only consulted once every matchUrl has already failed, so a confident URL match is
+ * never shadowed by a coincidental DOM match. `doc` is optional so callers without a DOM (tests,
+ * background/service-worker contexts) still get plain URL-only behavior.
+ */
+export function adapterForPage(href: string, doc?: Document): Adapter | null {
+  const byUrl = adapterForUrl(href);
+  if (byUrl) return byUrl;
+  if (!doc) return null;
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  for (const adapter of ADAPTERS) {
+    if (!adapter.matchDom) continue;
+    try {
+      if (adapter.matchDom(doc)) return adapter;
+    } catch {
+      /* a misbehaving matcher must not break detection of the others */
+    }
+  }
+  return null;
 }

--- a/extension/src/adapters/securityonion.ts
+++ b/extension/src/adapters/securityonion.ts
@@ -20,6 +20,12 @@ export const securityOnionAdapter: Adapter = {
     return /^#\/(alerts|hunt|dashboards)\b/i.test(url.hash);
   },
 
+  // Fallback for SOC pages matchUrl misses — e.g. the app's initial load before the hash router
+  // has picked a view, or a reverse-proxied deployment. SOC titles every page "Security Onion".
+  matchDom(doc: Document): boolean {
+    return /security onion/i.test(doc.title);
+  },
+
   apiPatterns: ["/api/events/"],
 
   extractRows(_url: string, body: unknown): unknown[] | null {

--- a/extension/src/adapters/socrates.ts
+++ b/extension/src/adapters/socrates.ts
@@ -18,6 +18,11 @@ export const socratesAdapter: Adapter = {
     return /\/socrates\.html$/i.test(url.pathname);
   },
 
+  // Fallback for a reverse-proxied deployment where the socrates.html filename isn't in the path.
+  matchDom(doc: Document): boolean {
+    return /socrates/i.test(doc.title);
+  },
+
   apiPatterns: ["/api/events", "/api/sigma-alerts"],
 
   // Both endpoints return a JSON array of record objects. Return the object rows; null otherwise.

--- a/extension/src/adapters/socrates.ts
+++ b/extension/src/adapters/socrates.ts
@@ -19,8 +19,10 @@ export const socratesAdapter: Adapter = {
   },
 
   // Fallback for a reverse-proxied deployment where the socrates.html filename isn't in the path.
+  // The SPA titles itself with the product name, which is hyphenated ("SO-CRATES") — so the
+  // hyphen must be optional to also cover an unhyphenated "SOCRATES" spelling.
   matchDom(doc: Document): boolean {
-    return /socrates/i.test(doc.title);
+    return /so-?crates/i.test(doc.title);
   },
 
   apiPatterns: ["/api/events", "/api/sigma-alerts"],

--- a/extension/src/adapters/splunk.ts
+++ b/extension/src/adapters/splunk.ts
@@ -16,6 +16,12 @@ export const splunkAdapter: Adapter = {
     return false;
   },
 
+  // Fallback for Splunk Web behind a reverse proxy / vanity host that matchUrl's host/path/port
+  // checks miss. Splunk Web titles every page "<view> | Splunk".
+  matchDom(doc: Document): boolean {
+    return /\bsplunk\b/i.test(doc.title);
+  },
+
   // Splunk results arrive via several URL patterns depending on version and deployment.
   // The v2 API (Splunk 9.x) uses /v2/jobs/<sid>/events (not /results); older builds use
   // /jobs/<sid>/results.  __raw is the direct REST pass-through; __proxy is an alternate path.

--- a/extension/src/adapters/types.ts
+++ b/extension/src/adapters/types.ts
@@ -16,6 +16,14 @@ export interface Adapter {
   /** True when this adapter recognizes the page (host / path / port signature). */
   matchUrl(url: URL): boolean;
   /**
+   * Optional DOM signature (title pattern, known root element ids, meta tags), tried only as a
+   * FALLBACK when no adapter's matchUrl wins — see adapterForPage() in registry.ts. Covers tools
+   * deployed behind a reverse proxy, a vanity hostname, or a custom path (e.g. Kibana at `/soc/`,
+   * a self-hosted Velociraptor on an arbitrary host) that matchUrl can't recognize (issue #76).
+   * Pure — accepts an injected Document — so it's unit-testable without a browser.
+   */
+  matchDom?(doc: Document): boolean;
+  /**
    * Regex sources (matched case-insensitively against a response URL) for the tool's data API.
    * The MAIN-world hook only forwards bodies whose URL matches one of these — so we never copy
    * unrelated traffic. Strings (not RegExp) so they survive the postMessage bridge to the page.

--- a/extension/src/adapters/velociraptor.ts
+++ b/extension/src/adapters/velociraptor.ts
@@ -16,6 +16,13 @@ export const velociraptorAdapter: Adapter = {
     return false;
   },
 
+  // Fallback for a self-hosted Velociraptor on an arbitrary host/port that matchUrl can't
+  // recognize (e.g. reverse-proxied off :8889 with no "velociraptor" in the hostname). The GUI's
+  // index.html always sets document.title to exactly "Velociraptor".
+  matchDom(doc: Document): boolean {
+    return /velociraptor/i.test(doc.title);
+  },
+
   apiPatterns: [
     "/api/v1/GetTable",
     "/api/v1/GetHuntResults",

--- a/extension/src/adapters/volweb.ts
+++ b/extension/src/adapters/volweb.ts
@@ -19,6 +19,12 @@ export const volwebAdapter: Adapter = {
     return false;
   },
 
+  // Fallback for a reverse-proxied VolWeb whose hostname/path matchUrl can't recognize. The React
+  // front end titles every page "VolWeb".
+  matchDom(doc: Document): boolean {
+    return /volweb/i.test(doc.title);
+  },
+
   apiPatterns: ["/api/evidence/\\d+/plugin/[^/]+/"],
 
   extractRows(_url: string, body: unknown): unknown[] | null {

--- a/extension/src/artifactCapture.ts
+++ b/extension/src/artifactCapture.ts
@@ -1,9 +1,11 @@
 // Content-script (isolated world) orchestration for automated artifact fetching (issue #102).
 //
 // Flow on a recognized DFIR console:
-//   1. adapterForUrl() decides if this tab is a known tool. Unless the popup forces an override
-//      (see applyAdapter() / onExtensionMessage() below), an unrecognized page does nothing here
-//      — plain screenshot capture still works via content.ts.
+//   1. adapterForPage() decides if this tab is a known tool — by URL first, falling back to each
+//      adapter's DOM signature (matchDom) for tools behind a reverse proxy or vanity hostname/path
+//      that the URL alone doesn't reveal (issue #76). Unless the popup forces an override (see
+//      applyAdapter() / onExtensionMessage() below), an unrecognized page does nothing here — plain
+//      screenshot capture still works via content.ts.
 //   2. We ask the service worker to inject pageHook.js into the MAIN world (executeScript bypasses
 //      page CSP) and hand the hook the adapter's API URL patterns via postMessage.
 //   3. The hook forwards matching API response bodies back; we extract clean rows via the adapter and
@@ -15,7 +17,7 @@
 // All browser-only glue; the pure logic it calls (adapter matching/extraction, matrixToRows) is
 // unit-tested separately.
 
-import { adapterForUrl, adapterById } from "./adapters/registry.js";
+import { adapterForPage, adapterById } from "./adapters/registry.js";
 import type { Adapter, CapturedArtifact } from "./adapters/types.js";
 import { resolveActiveAdapter } from "./adapters/override.js";
 import { matrixToRows } from "./adapters/domTable.js";
@@ -42,7 +44,7 @@ let buttonPos: ButtonPos | null = null;
 let suppressClick = false;
 
 export async function initArtifactCapture(): Promise<void> {
-  detectedAdapterId = adapterForUrl(location.href)?.id ?? null;
+  detectedAdapterId = adapterForPage(location.href, document)?.id ?? null;
 
   // Attach listeners BEFORE activating so we never miss the hook's "ready" handshake or a popup
   // override sent immediately after injection.
@@ -88,7 +90,7 @@ export async function initArtifactCapture(): Promise<void> {
 // an adapter is now active — (re)request the MAIN-world hook with its API patterns. Called once at
 // init, and again whenever the popup changes the override for this tab. Unlike before manual
 // override existed, this now runs (and the listeners above are registered) even on pages
-// adapterForUrl doesn't recognize — cheaply, since applyAdapter() itself no-ops until an adapter
+// adapterForPage doesn't recognize — cheaply, since applyAdapter() itself no-ops until an adapter
 // is actually active — so a later popup override can still activate capture on that page.
 function applyAdapter(): void {
   const id = resolveActiveAdapter(detectedAdapterId, overrideAdapterId);
@@ -109,7 +111,7 @@ function applyAdapter(): void {
 }
 
 // ── Manual override (popup ⇄ this content script) ────────────────────────────────────────────
-// The popup can't reach adapterForUrl's result directly — it lives here, in the tab. These two
+// The popup can't reach adapterForPage's result directly — it lives here, in the tab. These two
 // message kinds (sent via chrome.tabs.sendMessage, which — unlike chrome.runtime.sendMessage from
 // a content script — targets THIS listener, not the service worker's onMessage in
 // serviceWorker.ts) let the popup read and override it. See adapters/override.ts for the

--- a/extension/tests/adapters.test.ts
+++ b/extension/tests/adapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { adapterForUrl, adapterById, ADAPTERS } from "../src/adapters/registry.js";
+import { adapterForUrl, adapterForPage, adapterById, ADAPTERS } from "../src/adapters/registry.js";
 import { splunkAdapter } from "../src/adapters/splunk.js";
 import { velociraptorAdapter, velociraptorSourceLabel } from "../src/adapters/velociraptor.js";
 import { elasticAdapter } from "../src/adapters/elastic.js";
@@ -83,6 +83,90 @@ describe("adapterForUrl", () => {
     expect(adapterById("socrates")?.label).toBe("SO-CRATES");
     expect(adapterById("volweb")?.label).toBe("VolWeb");
     expect(adapterById("nope")).toBeNull();
+  });
+});
+
+// Minimal Document stand-in — matchDom implementations only touch .title / getElementById /
+// querySelector, so a hand-rolled fake (no jsdom dependency) is enough to unit-test them.
+function fakeDoc(opts: { title?: string; ids?: string[]; selectors?: string[] } = {}): Document {
+  const { title = "", ids = [], selectors = [] } = opts;
+  return {
+    title,
+    getElementById: (id: string) => (ids.includes(id) ? ({} as Element) : null),
+    querySelector: (sel: string) => (selectors.includes(sel) ? ({} as Element) : null),
+  } as unknown as Document;
+}
+
+describe("adapter.matchDom (pure, per-adapter DOM signatures)", () => {
+  it("elastic: recognizes Kibana's #kibana-body root, chrome data-test-subj, or a Kibana/Elastic title", () => {
+    expect(elasticAdapter.matchDom!(fakeDoc({ ids: ["kibana-body"] }))).toBe(true);
+    expect(elasticAdapter.matchDom!(fakeDoc({ selectors: ['[data-test-subj="kibanaChrome"]'] }))).toBe(true);
+    expect(elasticAdapter.matchDom!(fakeDoc({ title: "Discover - Kibana" }))).toBe(true);
+    expect(elasticAdapter.matchDom!(fakeDoc({ title: "Discover - Elastic" }))).toBe(true);
+    expect(elasticAdapter.matchDom!(fakeDoc({ title: "Home" }))).toBe(false);
+  });
+
+  it("velociraptor: recognizes the GUI's fixed 'Velociraptor' document title", () => {
+    expect(velociraptorAdapter.matchDom!(fakeDoc({ title: "Velociraptor" }))).toBe(true);
+    expect(velociraptorAdapter.matchDom!(fakeDoc({ title: "Home" }))).toBe(false);
+  });
+
+  it("splunk / crowdstrike / securityonion / socrates / volweb: recognize their product name in the title", () => {
+    expect(splunkAdapter.matchDom!(fakeDoc({ title: "Search | Splunk" }))).toBe(true);
+    expect(splunkAdapter.matchDom!(fakeDoc({ title: "Home" }))).toBe(false);
+    expect(crowdstrikeAdapter.matchDom!(fakeDoc({ title: "Detections | Falcon" }))).toBe(true);
+    expect(crowdstrikeAdapter.matchDom!(fakeDoc({ title: "Home" }))).toBe(false);
+    expect(securityOnionAdapter.matchDom!(fakeDoc({ title: "Security Onion Console" }))).toBe(true);
+    expect(securityOnionAdapter.matchDom!(fakeDoc({ title: "Home" }))).toBe(false);
+    expect(socratesAdapter.matchDom!(fakeDoc({ title: "SO-CRATES" }))).toBe(true);
+    expect(socratesAdapter.matchDom!(fakeDoc({ title: "Home" }))).toBe(false);
+    expect(volwebAdapter.matchDom!(fakeDoc({ title: "VolWeb" }))).toBe(true);
+    expect(volwebAdapter.matchDom!(fakeDoc({ title: "Home" }))).toBe(false);
+  });
+});
+
+describe("adapterForPage (URL match first, DOM signature as fallback)", () => {
+  it("detects Kibana on an unrecognized host/path via its DOM signature (issue #76 acceptance criteria)", () => {
+    expect(adapterForUrl("https://analytics.corp.internal/soc/")).toBeNull();
+    expect(adapterForPage("https://analytics.corp.internal/soc/", fakeDoc({ ids: ["kibana-body"] }))?.id).toBe("elastic");
+    expect(adapterForPage("https://analytics.corp.internal/soc/", fakeDoc({ title: "Discover - Kibana" }))?.id).toBe("elastic");
+  });
+
+  it("detects a self-hosted Velociraptor on an arbitrary host via its DOM signature", () => {
+    expect(adapterForUrl("https://ops.corp.internal/")).toBeNull();
+    expect(adapterForPage("https://ops.corp.internal/", fakeDoc({ title: "Velociraptor" }))?.id).toBe("velociraptor");
+  });
+
+  it("URL match still takes precedence over a conflicting DOM signature", () => {
+    // Splunk-by-URL, but the injected doc's title happens to say "Kibana" — matchUrl must win.
+    expect(adapterForPage("https://splunk.corp.local/en-US/app/search/search", fakeDoc({ title: "Kibana" }))?.id).toBe("splunk");
+  });
+
+  it("falls back to URL-only behavior when no Document is supplied", () => {
+    expect(adapterForPage("https://splunk.corp.local/en-US/app/search/search")?.id).toBe("splunk");
+    expect(adapterForPage("https://example.com/foo")).toBeNull();
+  });
+
+  it("returns null for an unrecognized site even with a doc that matches nothing", () => {
+    expect(adapterForPage("https://example.com/foo", fakeDoc({ title: "Example Domain" }))).toBeNull();
+  });
+
+  it("returns null for non-http schemes and invalid URLs regardless of the doc", () => {
+    expect(adapterForPage("chrome://extensions", fakeDoc({ title: "Velociraptor" }))).toBeNull();
+    expect(adapterForPage("not a url", fakeDoc({ title: "Velociraptor" }))).toBeNull();
+  });
+
+  it("a matchDom that throws does not break detection by a later adapter", () => {
+    // splunk/velociraptor/securityonion/socrates are all tried (in registry order) before elastic,
+    // and are all title-only matchers — a `.title` getter that always throws makes every one of
+    // them throw. Detection must still fall through to elastic, whose matchDom checks
+    // getElementById() first (no title access needed to succeed here).
+    const throwingTitleDoc = {
+      getElementById: (id: string) => (id === "kibana-body" ? ({} as Element) : null),
+      querySelector: () => null,
+      get title(): string { throw new Error("boom"); },
+    } as unknown as Document;
+    expect(adapterForPage("https://analytics.corp.internal/soc/", throwingTitleDoc)?.id).toBe("elastic");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds an optional `matchDom?(doc: Document): boolean` to the `Adapter` interface
- Adds `adapterForPage(href, doc?)` in `registry.ts`: tries URL match first, falls back to DOM signature only when no `matchUrl` wins
- Adds per-adapter `matchDom` implementations (Kibana, Velociraptor, Splunk, CrowdStrike, Security Onion, SO-CRATES, VolWeb)
- Wires `artifactCapture.ts` to call `adapterForPage(location.href, document)`
- Adds unit tests in `adapters.test.ts`

Closes #76.

## Test plan
- [ ] `npm test` in `extension/` (could not be run in this session due to tool permission restrictions on node/npm)
- [ ] Manually verify Kibana behind a reverse proxy is detected

Generated with [Claude Code](https://claude.ai/code)