### PR TITLE
Add report versioning with diff & rollback (#77)

### DIFF
--- a/companion/src/reports/reportVersionStore.ts
+++ b/companion/src/reports/reportVersionStore.ts
@@ -51,6 +51,17 @@ function maxVersions(): number {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_MAX_VERSIONS;
 }
 
+// Version ids are generated internally as `${iso-timestamp}-${uuid8}` (see snapshot()), so they only
+// ever contain [A-Za-z0-9-]. The diff/restore routes accept the id straight from user-controlled
+// query/path params, so anything outside this shape (a path separator, `..`, a null byte) must be
+// rejected before it reaches join()/readFile — otherwise `from=../../../../etc/hostname` would escape
+// the report-versions directory and read an arbitrary .json off disk (path traversal).
+const VALID_VERSION_ID = /^[A-Za-z0-9_-]+$/;
+
+function isValidVersionId(id: string): boolean {
+  return VALID_VERSION_ID.test(id);
+}
+
 export class ReportVersionStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -63,6 +74,9 @@ export class ReportVersionStore {
   }
 
   private recordPath(caseId: string, id: string): string {
+    // Defence in depth — snapshot() only ever passes a freshly generated id, but never build a path
+    // from an id that could contain traversal sequences.
+    if (!isValidVersionId(id)) throw new Error(`invalid report version id: ${id}`);
     return join(this.dir(caseId), `${id}.json`);
   }
 
@@ -86,6 +100,9 @@ export class ReportVersionStore {
   // The full snapshot (markdown + meta + diff state) for one version id, or null if it doesn't exist
   // (already pruned, or never existed).
   async get(caseId: string, id: string): Promise<ReportVersionRecord | null> {
+    // The diff/restore routes pass this id straight from user input. A malformed id can't correspond
+    // to a real version, so treat it as "not found" (404) rather than risk a traversal in recordPath.
+    if (!isValidVersionId(id)) return null;
     try {
       return JSON.parse(await readFile(this.recordPath(caseId, id), "utf8")) as ReportVersionRecord;
     } catch (err) {

--- a/companion/src/reports/reportVersionStore.ts
+++ b/companion/src/reports/reportVersionStore.ts
@@ -1,0 +1,139 @@
+import { readFile, unlink, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID, createHash } from "node:crypto";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import type { Finding, IOC, ForensicEvent } from "../analysis/stateTypes.js";
+import type { ReportMeta } from "./reportMeta.js";
+
+// Report versioning (#77): every `writeAll()` (report generation) snapshots the rendered markdown +
+// the human-authored report-meta + the diff-relevant slice of state (findings/IOCs/forensic timeline)
+// into a side file under state/report-versions/, so an analyst can see what changed between two
+// generated reports (reusing findingsDiff/iocsDiff/timelineDiff) and roll back to a prior version's
+// editable meta. Like HuntOutcomeStore, a side file NOT part of InvestigationState — re-synthesis
+// never touches it. Writes go through atomicWrite (Dropbox/OneDrive-safe temp-rename).
+//
+// Two files per case: a lightweight `index.json` (summaries, read for listing) and one `<id>.json`
+// per version (the heavier markdown + meta + diff state, read only on demand for a diff or restore).
+// This mirrors the report itself (which is regenerable) rather than InvestigationState: the version
+// store is an audit trail, not a source of truth, so a corrupt/missing entry degrades to "fewer
+// versions available" rather than breaking anything.
+
+export interface ReportVersionDiffState {
+  findings: Finding[];
+  iocs: IOC[];
+  forensicTimeline: ForensicEvent[];
+}
+
+export interface ReportVersionSummary {
+  id: string;
+  createdAt: string;   // ISO timestamp
+  version: string;     // auto-numbered "v1", "v2", ... (display label)
+  manualVersion: string; // the human-authored revisions[] latest entry's version string, if any ("" if none)
+  contentHash: string; // sha256 of the rendered markdown — lets snapshot() dedupe unchanged regenerations
+  findingsCount: number;
+  iocsCount: number;
+  eventsCount: number;
+}
+
+export interface ReportVersionRecord extends ReportVersionSummary {
+  markdown: string;
+  meta: ReportMeta;
+  state: ReportVersionDiffState;
+}
+
+// Cap the number of retained versions per case (oldest pruned first) so state/report-versions/ can't
+// grow unbounded on a long-running case that regenerates the report often. Override via env.
+const DEFAULT_MAX_VERSIONS = 50;
+
+function maxVersions(): number {
+  const n = Number(process.env.DFIR_REPORT_VERSION_MAX);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_MAX_VERSIONS;
+}
+
+export class ReportVersionStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private dir(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "report-versions");
+  }
+
+  private indexPath(caseId: string): string {
+    return join(this.dir(caseId), "index.json");
+  }
+
+  private recordPath(caseId: string, id: string): string {
+    return join(this.dir(caseId), `${id}.json`);
+  }
+
+  // The case's version summaries, newest first. [] when absent or malformed — a corrupt index must
+  // never break report generation or the dashboard.
+  async list(caseId: string): Promise<ReportVersionSummary[]> {
+    try {
+      const parsed = JSON.parse(await readFile(this.indexPath(caseId), "utf8")) as unknown;
+      return Array.isArray(parsed) ? (parsed as ReportVersionSummary[]) : [];
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      if (err instanceof SyntaxError) return [];
+      throw err;
+    }
+  }
+
+  private async saveIndex(caseId: string, summaries: readonly ReportVersionSummary[]): Promise<void> {
+    await atomicWrite(this.indexPath(caseId), JSON.stringify(summaries, null, 2));
+  }
+
+  // The full snapshot (markdown + meta + diff state) for one version id, or null if it doesn't exist
+  // (already pruned, or never existed).
+  async get(caseId: string, id: string): Promise<ReportVersionRecord | null> {
+    try {
+      return JSON.parse(await readFile(this.recordPath(caseId, id), "utf8")) as ReportVersionRecord;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      if (err instanceof SyntaxError) return null;
+      throw err;
+    }
+  }
+
+  // Persist a version snapshot after a report regeneration. Skips writing a new version (returns the
+  // existing latest summary instead) when the rendered markdown is byte-identical to the most recent
+  // version — a re-generation with nothing changed shouldn't grow the history. Best-effort: callers
+  // (ReportWriter.writeAll) should swallow errors from this so a version-store failure never breaks
+  // report generation itself.
+  async snapshot(
+    caseId: string,
+    input: { markdown: string; meta: ReportMeta; state: ReportVersionDiffState },
+  ): Promise<ReportVersionSummary> {
+    const contentHash = createHash("sha256").update(input.markdown).digest("hex");
+    const existing = await this.list(caseId);
+    const latest = existing[0];
+    if (latest && latest.contentHash === contentHash) return latest;
+
+    const createdAt = new Date().toISOString();
+    const id = `${createdAt.replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
+    const manualVersion = input.meta.revisions.length
+      ? input.meta.revisions[input.meta.revisions.length - 1].version
+      : "";
+    const summary: ReportVersionSummary = {
+      id,
+      createdAt,
+      version: `v${existing.length + 1}`,
+      manualVersion,
+      contentHash,
+      findingsCount: input.state.findings.length,
+      iocsCount: input.state.iocs.length,
+      eventsCount: input.state.forensicTimeline.length,
+    };
+    const record: ReportVersionRecord = { ...summary, markdown: input.markdown, meta: input.meta, state: input.state };
+
+    await mkdir(this.dir(caseId), { recursive: true });
+    await atomicWrite(this.recordPath(caseId, id), JSON.stringify(record));
+    const updated = [summary, ...existing];
+    const cap = maxVersions();
+    const kept = updated.slice(0, cap);
+    const pruned = updated.slice(cap);
+    await this.saveIndex(caseId, kept);
+    await Promise.all(pruned.map((p) => unlink(this.recordPath(caseId, p.id)).catch(() => {})));
+    return summary;
+  }
+}

--- a/companion/src/reports/reportVersionStore.ts
+++ b/companion/src/reports/reportVersionStore.ts
@@ -62,6 +62,16 @@ function isValidVersionId(id: string): boolean {
   return VALID_VERSION_ID.test(id);
 }
 
+// The next auto-numbered display label. Derived from the newest retained summary's own label rather
+// than from the list length: once the history hits the retention cap (maxVersions) the list stops
+// growing, so `v${list.length + 1}` would hand out the SAME label to every subsequent version (with a
+// cap of 2 you get v3, v3, v3…). Counting up from the newest label keeps them monotonic and unique.
+function nextVersionLabel(existing: readonly ReportVersionSummary[]): string {
+  const latest = existing[0];
+  const n = latest ? /^v(\d+)$/.exec(latest.version)?.[1] : undefined;
+  return `v${n ? Number(n) + 1 : existing.length + 1}`;
+}
+
 export class ReportVersionStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -134,7 +144,7 @@ export class ReportVersionStore {
     const summary: ReportVersionSummary = {
       id,
       createdAt,
-      version: `v${existing.length + 1}`,
+      version: nextVersionLabel(existing),
       manualVersion,
       contentHash,
       findingsCount: input.state.findings.length,

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -59,6 +59,7 @@ import { applyAnonDeep, type RedactedReportContents } from "../analysis/redacted
 import type { ReportMeta } from "./reportMeta.js";
 import type { KevStore } from "../analysis/kevStore.js";
 import type { KevCatalog } from "../analysis/kev.js";
+import type { ReportVersionStore } from "./reportVersionStore.js";
 
 export interface ReportPaths {
   markdown: string;
@@ -86,6 +87,7 @@ export class ReportWriter {
     private readonly kevStore?: KevStore,
     private readonly hypothesisStore?: HypothesisStore,
     private readonly synthMeta?: SynthMetaStore,   // #11 deferred: second-look collection leads in the report
+    private readonly reportVersions?: ReportVersionStore,   // #77 report versioning (diff & rollback)
   ) {}
 
   // Second-look collection leads (investigation-guidance #11, deferred): requests the raw re-query made
@@ -446,6 +448,18 @@ export class ReportWriter {
     await writeFile(paths.timelineCsv, c.timelineCsv, "utf8");
     await writeFile(paths.forensicTimelineCsv, c.forensicTimelineCsv, "utf8");
     await writeFile(paths.stateJson, c.stateJson, "utf8");
+    // #77 report versioning: snapshot markdown + meta + the diff-relevant slice of state so the
+    // dashboard can diff two generations and roll back to a prior version's editable meta.
+    // Best-effort — a version-store failure must never break report generation itself.
+    if (this.reportVersions) {
+      try {
+        await this.reportVersions.snapshot(caseId, {
+          markdown: c.markdown,
+          meta,
+          state: { findings: state.findings, iocs: state.iocs, forensicTimeline: state.forensicTimeline },
+        });
+      } catch { /* best-effort — see comment above */ }
+    }
     return paths;
   }
 

--- a/companion/src/routes/reportVersions.ts
+++ b/companion/src/routes/reportVersions.ts
@@ -1,0 +1,74 @@
+import type { Express, Request, Response } from "express";
+import { diffFindings } from "../analysis/findingsDiff.js";
+import { diffIocs } from "../analysis/iocsDiff.js";
+import { diffTimeline } from "../analysis/timelineDiff.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Report versioning (#77): list the version snapshots a case has accumulated (one per report
+ * regeneration, deduped when nothing changed — see ReportVersionStore.snapshot), diff two of them
+ * (added/removed findings + severity changes, IOC changes, timeline changes — reusing the same
+ * *Diff.ts primitives the import pipeline uses), and restore an earlier version's editable
+ * report-meta (title page, distribution, BIA, glossary, recommendations…) as the CURRENT report-meta,
+ * so the next "Generate Report" click renders with it. Restoring does not touch findings/IOCs/timeline
+ * (those come from the live investigation state, not the archived version) and does not regenerate the
+ * report itself — the analyst reviews the restored fields, then regenerates from the dashboard as usual.
+ */
+export function registerReportVersionsRoutes(app: Express, ctx: RouteContext): void {
+  const { options } = ctx;
+
+  app.get("/cases/:id/report-versions", async (req: Request, res: Response) => {
+    if (!options.reportVersionStore) return res.status(501).json({ error: "report versioning not configured" });
+    try {
+      return res.status(200).json(await options.reportVersionStore.list(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Diff two stored versions' findings/IOCs/forensic-timeline. `from`/`to` are version ids from the
+  // list above; `to` defaults to the most recent version when omitted.
+  app.get("/cases/:id/report-versions/diff", async (req: Request, res: Response) => {
+    if (!options.reportVersionStore) return res.status(501).json({ error: "report versioning not configured" });
+    const caseId = req.params.id;
+    const fromId = typeof req.query.from === "string" ? req.query.from : "";
+    let toId = typeof req.query.to === "string" ? req.query.to : "";
+    if (!fromId) return res.status(400).json({ error: "from is required" });
+    try {
+      if (!toId) {
+        const versions = await options.reportVersionStore.list(caseId);
+        toId = versions[0]?.id ?? "";
+      }
+      const [from, to] = await Promise.all([
+        options.reportVersionStore.get(caseId, fromId),
+        toId ? options.reportVersionStore.get(caseId, toId) : Promise.resolve(null),
+      ]);
+      if (!from || !to) return res.status(404).json({ error: "version not found" });
+      return res.status(200).json({
+        from: { id: from.id, createdAt: from.createdAt, version: from.version },
+        to: { id: to.id, createdAt: to.createdAt, version: to.version },
+        findings: diffFindings(from.state.findings, to.state.findings),
+        iocs: diffIocs(from.state.iocs, to.state.iocs),
+        timeline: diffTimeline(from.state.forensicTimeline, to.state.forensicTimeline),
+      });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Restore a prior version's editable report-meta as the case's CURRENT report-meta. Returns the
+  // saved (normalized) meta so the dashboard's report-meta form can refresh in place.
+  app.post("/cases/:id/report-versions/:versionId/restore", async (req: Request, res: Response) => {
+    if (!options.reportVersionStore) return res.status(501).json({ error: "report versioning not configured" });
+    if (!options.reportMetaStore) return res.status(501).json({ error: "report metadata not configured" });
+    const caseId = req.params.id;
+    try {
+      const version = await options.reportVersionStore.get(caseId, req.params.versionId);
+      if (!version) return res.status(404).json({ error: "version not found" });
+      const saved = await options.reportMetaStore.save(caseId, version.meta);
+      return res.status(200).json(saved);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -30,6 +30,7 @@ import { registerTaggerRoutes } from "./routes/tagger.js";
 import { registerPlaybookHuntsRoutes } from "./routes/playbookHunts.js";
 import { registerAiSynthesisRoutes } from "./routes/aiSynthesis.js";
 import { registerReportsExportRoutes } from "./routes/reportsExport.js";
+import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
@@ -93,6 +94,7 @@ import type { StateStore } from "./analysis/stateStore.js";
 import type { ReportWriter } from "./reports/reportWriter.js";
 import type { IocBlocklistFormat, IocBlocklistOptions, BlocklistIocType } from "./reports/iocBlocklist.js";
 import { ReportMetaStore } from "./reports/reportMeta.js";
+import { ReportVersionStore } from "./reports/reportVersionStore.js";
 import { ReportTemplateStore } from "./reports/reportTemplateStore.js";
 import { ReportTemplateControlStore } from "./reports/reportTemplateControl.js";
 import { DashboardViewStore } from "./analysis/dashboardViewStore.js";
@@ -253,6 +255,10 @@ export interface AppOptions {
   // Human-authored report metadata (title page, distribution, BIA, glossary, recommendations…)
   // edited from the dashboard and merged into report.md.
   reportMetaStore?: ReportMetaStore;
+  // Report versioning (#77): one snapshot per report regeneration (markdown + meta + content hash +
+  // the diff-relevant slice of state), powering a version list, a diff view, and rollback of the
+  // editable report-meta.
+  reportVersionStore?: ReportVersionStore;
   // Custom report templates (issue #60): GLOBAL branded layouts (accent, cover, header/footer,
   // section selection) + the per-case selection of which template renders the report.
   reportTemplateStore?: ReportTemplateStore;
@@ -793,6 +799,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerPlaybookHuntsRoutes(app, ctx);
   registerAiSynthesisRoutes(app, ctx);
   registerReportsExportRoutes(app, ctx);
+  registerReportVersionsRoutes(app, ctx);
   // Case-password routes first (mirrors their original registration order, right after the case-lock gate),
   // then the case-core catch-all (lifecycle, archives, integration pushes, importers, jobs, settings, static
   // app shell). Both register before the terminal error handler at the end of createApp.
@@ -2945,6 +2952,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     max: Number(process.env.DFIR_JOBS_MAX) || undefined,
   });
   const reportMetaStore = new ReportMetaStore(store);
+  const reportVersionStore = new ReportVersionStore(store);   // #77 report versioning (diff & rollback)
   const reportTemplateControlStore = new ReportTemplateControlStore(store);
   const activityLogStore = new ActivityLogStore(store);
   const commentsStore = new CommentsStore(store);
@@ -2976,7 +2984,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const notionExportStore = new NotionExportStore(store);
   const clickupExportStore = new ClickUpExportStore(store);
   const irisExportStore = new IrisExportStore(store);
-  const reportWriter = new ReportWriterImpl(store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore, new CustomerExposureStore(store), notebookStore, assetOverridesStore, playbookStore, reportTemplateStore, reportTemplateControlStore, kevStore, hypothesisStore, synthMetaStore);
+  const reportWriter = new ReportWriterImpl(store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore, new CustomerExposureStore(store), notebookStore, assetOverridesStore, playbookStore, reportTemplateStore, reportTemplateControlStore, kevStore, hypothesisStore, synthMetaStore, reportVersionStore);
 
   // Automatic state backup (#180): snapshot SNAPSHOT_STATE_FILES before synthesis + on a timer.
   const backupConfig = resolveBackupConfig(process.env);
@@ -3066,6 +3074,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     // ocrRunner is undefined in that case), so give createApp its own always-available runner.
     ocrRunner: ocrRunner ?? new TesseractOcrRunner(),
     reportMetaStore,
+    reportVersionStore,
     reportTemplateStore,
     reportTemplateControlStore,
     dashboardViewStore,

--- a/companion/tests/reports/reportVersionStore.test.ts
+++ b/companion/tests/reports/reportVersionStore.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { ReportVersionStore } from "../../src/reports/reportVersionStore.js";
+import { emptyReportMeta } from "../../src/reports/reportMeta.js";
+
+let caseStore: CaseStore;
+let versions: ReportVersionStore;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-report-versions-"));
+  caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  versions = new ReportVersionStore(caseStore);
+});
+
+const emptyDiffState = () => ({ findings: [], iocs: [], forensicTimeline: [] });
+
+describe("ReportVersionStore", () => {
+  it("returns [] when no versions exist yet", async () => {
+    expect(await versions.list("c1")).toEqual([]);
+  });
+
+  it("snapshots a version and lists it newest first", async () => {
+    const first = await versions.snapshot("c1", { markdown: "# report v1", meta: emptyReportMeta(), state: emptyDiffState() });
+    expect(first.version).toBe("v1");
+
+    const second = await versions.snapshot("c1", { markdown: "# report v2", meta: emptyReportMeta(), state: emptyDiffState() });
+    expect(second.version).toBe("v2");
+
+    const list = await versions.list("c1");
+    expect(list.map((v) => v.id)).toEqual([second.id, first.id]);
+  });
+
+  it("skips writing a new version when the markdown is unchanged", async () => {
+    const first = await versions.snapshot("c1", { markdown: "# same", meta: emptyReportMeta(), state: emptyDiffState() });
+    const again = await versions.snapshot("c1", { markdown: "# same", meta: emptyReportMeta(), state: emptyDiffState() });
+    expect(again.id).toBe(first.id);
+    expect(await versions.list("c1")).toHaveLength(1);
+  });
+
+  it("retrieves a full record by id, including markdown/meta/state", async () => {
+    const meta = { ...emptyReportMeta(), organization: "ExampleCorp" };
+    const state = { findings: [{ id: "f1", severity: "Critical" as const, title: "Ransomware deployed", description: "d", relatedIocs: [], sourceScreenshots: [], mitreTechniques: [], firstSeen: "t0", lastUpdated: "t1", status: "open" as const }], iocs: [], forensicTimeline: [] };
+    const summary = await versions.snapshot("c1", { markdown: "# report", meta, state });
+
+    const record = await versions.get("c1", summary.id);
+    expect(record?.markdown).toBe("# report");
+    expect(record?.meta.organization).toBe("ExampleCorp");
+    expect(record?.state.findings).toHaveLength(1);
+    expect(record?.findingsCount).toBe(1);
+  });
+
+  it("returns null for a missing version id", async () => {
+    expect(await versions.get("c1", "ghost")).toBeNull();
+  });
+
+  it("prunes the oldest versions beyond DFIR_REPORT_VERSION_MAX", async () => {
+    const prev = process.env.DFIR_REPORT_VERSION_MAX;
+    process.env.DFIR_REPORT_VERSION_MAX = "2";
+    try {
+      const v1 = await versions.snapshot("c1", { markdown: "# 1", meta: emptyReportMeta(), state: emptyDiffState() });
+      await versions.snapshot("c1", { markdown: "# 2", meta: emptyReportMeta(), state: emptyDiffState() });
+      const v3 = await versions.snapshot("c1", { markdown: "# 3", meta: emptyReportMeta(), state: emptyDiffState() });
+
+      const list = await versions.list("c1");
+      expect(list).toHaveLength(2);
+      expect(list.map((v) => v.id)).toEqual([v3.id, expect.any(String)]);
+      expect(await versions.get("c1", v1.id)).toBeNull(); // pruned
+    } finally {
+      if (prev === undefined) delete process.env.DFIR_REPORT_VERSION_MAX;
+      else process.env.DFIR_REPORT_VERSION_MAX = prev;
+    }
+  });
+
+  it("carries the manual revision label from report-meta when present", async () => {
+    const meta = { ...emptyReportMeta(), revisions: [{ version: "1.0", date: "2026-01-01", author: "a", comments: "initial" }] };
+    const summary = await versions.snapshot("c1", { markdown: "# report", meta, state: emptyDiffState() });
+    expect(summary.manualVersion).toBe("1.0");
+  });
+});

--- a/companion/tests/reports/reportVersionStore.test.ts
+++ b/companion/tests/reports/reportVersionStore.test.ts
@@ -86,6 +86,22 @@ describe("ReportVersionStore", () => {
     }
   });
 
+  it("keeps auto-numbered labels unique after pruning at the retention cap", async () => {
+    const prev = process.env.DFIR_REPORT_VERSION_MAX;
+    process.env.DFIR_REPORT_VERSION_MAX = "2";
+    try {
+      for (let i = 1; i <= 4; i++) {
+        await versions.snapshot("c1", { markdown: `# ${i}`, meta: emptyReportMeta(), state: emptyDiffState() });
+      }
+      // Once the cap is reached the list stops growing, so a length-derived label would repeat "v3"
+      // for every later version. Labels must keep counting up from the newest retained one.
+      expect((await versions.list("c1")).map((v) => v.version)).toEqual(["v4", "v3"]);
+    } finally {
+      if (prev === undefined) delete process.env.DFIR_REPORT_VERSION_MAX;
+      else process.env.DFIR_REPORT_VERSION_MAX = prev;
+    }
+  });
+
   it("carries the manual revision label from report-meta when present", async () => {
     const meta = { ...emptyReportMeta(), revisions: [{ version: "1.0", date: "2026-01-01", author: "a", comments: "initial" }] };
     const summary = await versions.snapshot("c1", { markdown: "# report", meta, state: emptyDiffState() });

--- a/companion/tests/reports/reportVersionStore.test.ts
+++ b/companion/tests/reports/reportVersionStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
@@ -55,6 +55,17 @@ describe("ReportVersionStore", () => {
 
   it("returns null for a missing version id", async () => {
     expect(await versions.get("c1", "ghost")).toBeNull();
+  });
+
+  it("refuses a path-traversal id even when it would resolve to a real sibling file", async () => {
+    // Plant a JSON file one level above the report-versions dir. Without id validation,
+    // get("c1", "../secret") would resolve to <report-versions>/../secret.json and read it.
+    const stateDir = caseStore.stateDir("c1");
+    await writeFile(join(stateDir, "secret.json"), JSON.stringify({ markdown: "TOP SECRET" }), "utf8");
+
+    expect(await versions.get("c1", "../secret")).toBeNull();
+    expect(await versions.get("c1", "..%2Fsecret")).toBeNull();
+    expect(await versions.get("c1", "/etc/hostname")).toBeNull();
   });
 
   it("prunes the oldest versions beyond DFIR_REPORT_VERSION_MAX", async () => {

--- a/companion/tests/server/reportVersionsRoutes.test.ts
+++ b/companion/tests/server/reportVersionsRoutes.test.ts
@@ -18,9 +18,14 @@ async function harness() {
   const stateStore = new StateStore(store);
   const reportMetaStore = new ReportMetaStore(store);
   const reportVersionStore = new ReportVersionStore(store);
+  // NOTE the argument count: reportVersions is the LAST constructor parameter, and master's
+  // lateralPathDismissals sits immediately before it. These are positional, so an off-by-one here
+  // silently lands the store in the wrong slot and leaves `reportVersions` undefined — the version
+  // list then stays empty and every test in this file fails with "expected [] to have a length of 1".
   const reportWriter = new ReportWriter(
     store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore,
     undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+    undefined,            // lateralPathDismissals — not exercised here
     reportVersionStore,
   );
   const app = createApp(store, { stateStore, reportWriter, reportMetaStore, reportVersionStore });

--- a/companion/tests/server/reportVersionsRoutes.test.ts
+++ b/companion/tests/server/reportVersionsRoutes.test.ts
@@ -102,4 +102,21 @@ describe("report-versions routes", () => {
     expect((await request(app).get("/cases/c1/report-versions/diff?from=ghost&to=ghost2")).status).toBe(404);
     expect((await request(app).post("/cases/c1/report-versions/ghost/restore")).status).toBe(404);
   });
+
+  it("rejects a path-traversal version id instead of reading an arbitrary file (404, not 200/500)", async () => {
+    const { app } = await harness();
+    // Generate one real version so a valid `to` exists and can't be the reason for a 404.
+    await request(app).post("/cases/c1/report");
+    const real = (await request(app).get("/cases/c1/report-versions")).body[0];
+    const traversal = encodeURIComponent("../../../../../../../../etc/hostname");
+
+    const diffFrom = await request(app).get(`/cases/c1/report-versions/diff?from=${traversal}&to=${real.id}`);
+    expect(diffFrom.status).toBe(404);
+
+    const diffTo = await request(app).get(`/cases/c1/report-versions/diff?from=${real.id}&to=${traversal}`);
+    expect(diffTo.status).toBe(404);
+
+    const restore = await request(app).post(`/cases/c1/report-versions/${traversal}/restore`);
+    expect(restore.status).toBe(404);
+  });
 });

--- a/companion/tests/server/reportVersionsRoutes.test.ts
+++ b/companion/tests/server/reportVersionsRoutes.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ScopeStore } from "../../src/analysis/scope.js";
+import { FalsePositiveStore } from "../../src/analysis/falsePositive.js";
+import { ReportMetaStore } from "../../src/reports/reportMeta.js";
+import { ReportVersionStore } from "../../src/reports/reportVersionStore.js";
+import { ReportWriter } from "../../src/reports/reportWriter.js";
+
+async function harness() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-rv-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const reportMetaStore = new ReportMetaStore(store);
+  const reportVersionStore = new ReportVersionStore(store);
+  const reportWriter = new ReportWriter(
+    store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore,
+    undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+    reportVersionStore,
+  );
+  const app = createApp(store, { stateStore, reportWriter, reportMetaStore, reportVersionStore });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, store };
+}
+
+describe("report-versions routes", () => {
+  it("returns [] before any report has been generated", async () => {
+    const { app } = await harness();
+    const res = await request(app).get("/cases/c1/report-versions");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("records a version on each distinct report generation", async () => {
+    const { app } = await harness();
+    await request(app).put("/cases/c1/report-meta").send({ organization: "ExampleCorp" });
+    expect((await request(app).post("/cases/c1/report")).status).toBe(200);
+
+    const afterFirst = await request(app).get("/cases/c1/report-versions");
+    expect(afterFirst.body).toHaveLength(1);
+    expect(afterFirst.body[0].version).toBe("v1");
+
+    // Regenerating with nothing changed must not add a second version.
+    expect((await request(app).post("/cases/c1/report")).status).toBe(200);
+    expect((await request(app).get("/cases/c1/report-versions")).body).toHaveLength(1);
+
+    // A change to report-meta changes the rendered markdown, so it adds v2.
+    await request(app).put("/cases/c1/report-meta").send({ organization: "NewCorp Inc" });
+    expect((await request(app).post("/cases/c1/report")).status).toBe(200);
+    const afterSecond = await request(app).get("/cases/c1/report-versions");
+    expect(afterSecond.body).toHaveLength(2);
+    expect(afterSecond.body[0].version).toBe("v2"); // newest first
+  });
+
+  it("diffs findings/IOCs/timeline between two versions", async () => {
+    const { app, store } = await harness();
+    const { StateStore: SS } = await import("../../src/analysis/stateStore.js");
+    const stateStore = new SS(store);
+    const { emptyState } = await import("../../src/analysis/stateTypes.js");
+
+    const s1 = emptyState("c1");
+    s1.findings.push({ id: "f1", severity: "Low", title: "Suspicious login", description: "d", relatedIocs: [], sourceScreenshots: [], mitreTechniques: [], firstSeen: "t0", lastUpdated: "t1", status: "open" });
+    await stateStore.save(s1);
+    await request(app).post("/cases/c1/report");
+    const v1 = (await request(app).get("/cases/c1/report-versions")).body[0];
+
+    const s2 = emptyState("c1");
+    s2.findings.push({ id: "f1", severity: "Critical", title: "Suspicious login", description: "d", relatedIocs: [], sourceScreenshots: [], mitreTechniques: [], firstSeen: "t0", lastUpdated: "t1", status: "open" });
+    s2.findings.push({ id: "f2", severity: "High", title: "Ransomware deployed", description: "d", relatedIocs: [], sourceScreenshots: [], mitreTechniques: [], firstSeen: "t0", lastUpdated: "t1", status: "open" });
+    await stateStore.save(s2);
+    await request(app).post("/cases/c1/report");
+    const v2 = (await request(app).get("/cases/c1/report-versions")).body[0];
+
+    const diff = await request(app).get(`/cases/c1/report-versions/diff?from=${v1.id}&to=${v2.id}`);
+    expect(diff.status).toBe(200);
+    expect(diff.body.findings.added).toEqual(["Ransomware deployed"]);
+    expect(diff.body.findings.severityChanged).toEqual([{ title: "Suspicious login", from: "Low", to: "Critical" }]);
+  });
+
+  it("restores a prior version's editable report-meta", async () => {
+    const { app } = await harness();
+    await request(app).put("/cases/c1/report-meta").send({ organization: "OriginalCorp" });
+    await request(app).post("/cases/c1/report");
+    const v1 = (await request(app).get("/cases/c1/report-versions")).body[0];
+
+    await request(app).put("/cases/c1/report-meta").send({ organization: "OverwrittenCorp" });
+    expect((await request(app).get("/cases/c1/report-meta")).body.organization).toBe("OverwrittenCorp");
+
+    const restore = await request(app).post(`/cases/c1/report-versions/${v1.id}/restore`);
+    expect(restore.status).toBe(200);
+    expect(restore.body.organization).toBe("OriginalCorp");
+    expect((await request(app).get("/cases/c1/report-meta")).body.organization).toBe("OriginalCorp");
+  });
+
+  it("404s a diff/restore against an unknown version id", async () => {
+    const { app } = await harness();
+    expect((await request(app).get("/cases/c1/report-versions/diff?from=ghost&to=ghost2")).status).toBe(404);
+    expect((await request(app).post("/cases/c1/report-versions/ghost/restore")).status).toBe(404);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1608,6 +1608,7 @@
       <option value="ioc-blocklist">IOC block-list…</option>
       <option value="redacted">Redacted case package (ZIP)…</option>
       <option value="save-template">Save as Template…</option>
+      <option value="report-versions">Report versions (diff &amp; rollback)…</option>
     </select>
     <select id="pushSelect" class="toolbar-select" data-tip="Push this case to an external platform" style="display:none">
       <option value="">Push to…</option>
@@ -2021,6 +2022,29 @@
         <button id="reDownload">Build &amp; download</button>
         <button id="reCancel" style="background:var(--c-2a2f3a);">Cancel</button>
         <span id="reMsg" style="color:var(--c-9aa4b2); font-size:12px;"></span>
+      </div>
+    </div>
+  </div>
+
+  <div id="reportVersionsOverlay" class="comment-overlay">
+    <div class="comment-modal" style="max-width:640px">
+      <h3>Report versions</h3>
+      <p style="color:var(--c-9aa4b2); font-size:12px; margin:0 0 10px">
+        One snapshot per report regeneration (a re-generation with nothing changed doesn't add a new
+        entry). Diff two versions to see what changed in findings, IOCs and the timeline, or restore an
+        earlier version's editable report metadata (title page, distribution, BIA, glossary,
+        recommendations…) — restoring does not touch findings/IOCs/timeline and does not regenerate the
+        report; re-run <em>Generate report</em> afterward.</p>
+      <div id="rvList" style="max-height:200px; overflow:auto; font-size:12px; margin-bottom:10px; border:1px solid var(--c-2a2f3a); border-radius:4px; padding:6px;">loading…</div>
+      <div style="display:flex; gap:10px; align-items:center; margin-bottom:8px; flex-wrap:wrap;">
+        <label style="font-size:12px;">From <select id="rvFrom" style="margin-left:4px;"></select></label>
+        <label style="font-size:12px;">To <select id="rvTo" style="margin-left:4px;"></select></label>
+        <button id="rvDiff" type="button">Diff</button>
+      </div>
+      <div id="rvDiffResult" style="font-size:12px; max-height:220px; overflow:auto;"></div>
+      <div style="margin-top:10px; display:flex; gap:8px; align-items:center;">
+        <button id="rvCancel" style="background:var(--c-2a2f3a);">Close</button>
+        <span id="rvMsg" style="color:var(--c-9aa4b2); font-size:12px;"></span>
       </div>
     </div>
   </div>
@@ -15016,6 +15040,92 @@
       }
     }
 
+    // ── Report versions: diff & rollback (#77) ────────────────────────────────
+    function openReportVersions() {
+      document.getElementById("rvMsg").textContent = "";
+      document.getElementById("rvDiffResult").innerHTML = "";
+      document.getElementById("reportVersionsOverlay").classList.add("open");
+      loadReportVersions();
+    }
+    function closeReportVersions() { document.getElementById("reportVersionsOverlay").classList.remove("open"); }
+
+    async function loadReportVersions() {
+      const caseId = document.getElementById("caseId").value.trim();
+      const list = document.getElementById("rvList");
+      const fromSel = document.getElementById("rvFrom");
+      const toSel = document.getElementById("rvTo");
+      if (!caseId) { list.textContent = "no case loaded"; return; }
+      list.textContent = "loading…";
+      try {
+        const res = await fetch(`/cases/${encodeURIComponent(caseId)}/report-versions`);
+        const versions = await res.json();
+        if (!res.ok) throw new Error(versions.error || ("HTTP " + res.status));
+        if (!versions.length) {
+          list.textContent = "no versions yet — generate a report to create one";
+          fromSel.innerHTML = ""; toSel.innerHTML = "";
+          return;
+        }
+        list.innerHTML = versions.map(v => `
+          <div style="display:flex; justify-content:space-between; align-items:center; gap:8px; padding:4px 0; border-bottom:1px solid var(--c-2a2f3a);">
+            <span>${esc(v.version)}${v.manualVersion ? ` (rev ${esc(v.manualVersion)})` : ""} — ${esc(new Date(v.createdAt).toLocaleString())}
+              · ${v.findingsCount} finding(s), ${v.iocsCount} IOC(s), ${v.eventsCount} event(s)</span>
+            <button data-restore="${escAttr(v.id)}" style="font-size:11px; flex:none;">Restore meta</button>
+          </div>`).join("");
+        list.querySelectorAll("[data-restore]").forEach(btn =>
+          btn.onclick = () => doRestoreReportVersion(btn.getAttribute("data-restore")));
+        const opts = versions.map(v => `<option value="${escAttr(v.id)}">${esc(v.version)} — ${esc(new Date(v.createdAt).toLocaleString())}</option>`).join("");
+        fromSel.innerHTML = opts;
+        toSel.innerHTML = opts;
+        fromSel.selectedIndex = Math.min(1, versions.length - 1); // default: previous version
+        toSel.selectedIndex = 0;                                  // default: most recent
+      } catch (err) {
+        list.textContent = "failed to load: " + err.message;
+      }
+    }
+
+    async function doReportVersionsDiff() {
+      const caseId = document.getElementById("caseId").value.trim();
+      const from = document.getElementById("rvFrom").value;
+      const to = document.getElementById("rvTo").value;
+      const out = document.getElementById("rvDiffResult");
+      if (!caseId || !from || !to) return;
+      out.textContent = "diffing…";
+      try {
+        const q = new URLSearchParams({ from, to }).toString();
+        const res = await fetch(`/cases/${encodeURIComponent(caseId)}/report-versions/diff?${q}`);
+        const d = await res.json();
+        if (!res.ok) throw new Error(d.error || ("HTTP " + res.status));
+        const rows = [];
+        if (d.findings.added.length) rows.push(`<div>+ <strong>Findings added:</strong> ${d.findings.added.map(esc).join(", ")}</div>`);
+        if (d.findings.removed.length) rows.push(`<div>− <strong>Findings removed:</strong> ${d.findings.removed.map(esc).join(", ")}</div>`);
+        if (d.findings.severityChanged.length) rows.push(`<div>~ <strong>Severity changed:</strong> ${d.findings.severityChanged.map(s => `${esc(s.title)} (${esc(s.from)} → ${esc(s.to)})`).join(", ")}</div>`);
+        if (d.iocs.added.length) rows.push(`<div>+ <strong>IOCs added:</strong> ${d.iocs.added.map(i => esc(i.value)).join(", ")}</div>`);
+        if (d.iocs.removed.length) rows.push(`<div>− <strong>IOCs removed:</strong> ${d.iocs.removed.map(i => esc(i.value)).join(", ")}</div>`);
+        if (d.timeline.added.length) rows.push(`<div>+ <strong>Timeline events added:</strong> ${d.timeline.added.length}</div>`);
+        if (d.timeline.removed.length) rows.push(`<div>− <strong>Timeline events removed:</strong> ${d.timeline.removed.length}</div>`);
+        out.innerHTML = rows.length ? rows.join("") : "no differences between these versions";
+      } catch (err) {
+        out.textContent = "diff failed: " + err.message;
+      }
+    }
+
+    async function doRestoreReportVersion(id) {
+      const caseId = document.getElementById("caseId").value.trim();
+      const msg = document.getElementById("rvMsg");
+      if (!caseId || !id) return;
+      if (!confirm("Restore this version's report metadata (title page, distribution, BIA, glossary, recommendations)? This overwrites the CURRENT report-meta. It does not touch findings/IOCs/timeline and does not regenerate the report.")) return;
+      msg.textContent = "restoring…";
+      try {
+        const res = await fetch(`/cases/${encodeURIComponent(caseId)}/report-versions/${encodeURIComponent(id)}/restore`, { method: "POST" });
+        const body = await res.json();
+        if (!res.ok) throw new Error(body.error || ("HTTP " + res.status));
+        fillReportMeta(body); // refresh the report-meta form in place, if open
+        msg.textContent = "restored ✓ — regenerate the report to render it";
+      } catch (err) {
+        msg.textContent = "restore failed: " + err.message;
+      }
+    }
+
     // ── ZIP case archive (unencrypted, "(no password)" in the filename) ─────
     function openZipArchive() {
       document.getElementById("zaRemoveFromList").checked = false;
@@ -15741,6 +15851,9 @@
     document.getElementById("reDownload").onclick = doRedactedExport;
     document.getElementById("reCancel").onclick = closeRedactedExport;
     document.getElementById("redactedExportOverlay").addEventListener("click", (e) => { if (e.target.id === "redactedExportOverlay") closeRedactedExport(); });
+    document.getElementById("rvDiff").onclick = doReportVersionsDiff;
+    document.getElementById("rvCancel").onclick = closeReportVersions;
+    document.getElementById("reportVersionsOverlay").addEventListener("click", (e) => { if (e.target.id === "reportVersionsOverlay") closeReportVersions(); });
     document.getElementById("eeDownload").onclick = doEncryptedExport;
     document.getElementById("eeCancel").onclick = closeEncryptedExport;
     document.getElementById("encryptedExportOverlay").addEventListener("click", (e) => { if (e.target.id === "encryptedExportOverlay") closeEncryptedExport(); });
@@ -16336,6 +16449,8 @@
         openRedactedExport();
       } else if (action === "save-template") {
         openSaveTemplate();
+      } else if (action === "report-versions") {
+        openReportVersions();
       }
     };
 


### PR DESCRIPTION
## Summary
- Add `ReportVersionStore` (side file under `state/report-versions/`, following the `HuntOutcomeStore`/`atomicWrite` pattern) that snapshots each generated report (markdown + meta + content hash), deduping unchanged regenerations and pruning beyond a cap.
- Add a diff route reusing the existing `diffFindings`/`diffIocs`/`diffTimeline` primitives.
- Add rollback: restore a prior version's editable report-meta.
- Add a "Report versions" dashboard modal to browse, diff, and restore.

Closes #77.

## Test plan
- [ ] `cd companion && npm ci && npm run build` (not run in the authoring environment — npm/npx required approval that wasn't available)
- [ ] `npm test` — covers new `reportVersionStore.test.ts` and `reportVersionsRoutes.test.ts`
- [ ] Manually generate a report twice with a report-meta change in between, confirm two versions appear, diff them, and restore the first

Generated with [Claude Code](https://claude.ai/code)