### PR TITLE
Add run-to-run hunt diffing (#80)

### DIFF
--- a/companion/src/analysis/huntOutcomes.ts
+++ b/companion/src/analysis/huntOutcomes.ts
@@ -13,6 +13,8 @@
 // filled if/when the analyst collects their results into the case. The VQL fingerprint is the dedup
 // key that guarantees a deployed hunt is never re-proposed.
 
+import type { HuntRunDiff } from "./huntRunDiff.js";
+
 export type HuntOutcomeSource = "fleet" | "playbook" | "technique" | "bundle";
 export type HuntOutcomeStatus = "deployed" | "collected";
 
@@ -40,6 +42,12 @@ export interface HuntOutcome {
   addedIocs?: number;         // collected: IOCs new to the case (cumulative)
   resultSummary?: string;     // collected: compact, e.g. "10 results, +1 new event" / "no results"
   collectedAt?: string;       // collected: ISO
+  // Run-to-run diff (#80): what's new/gone vs this hunt's PREVIOUS run of the same VQL fingerprint (a
+  // re-deploy of a recurring/scheduled hunt), as opposed to addedEvents/addedIocs above which are
+  // cumulative against the whole CASE. Set by the caller (server.ts, via HuntRunSnapshotStore) since
+  // computing it needs I/O; absent when this fingerprint has no prior run to diff against yet, or for
+  // bundles (no fingerprint to key a run history on).
+  runDiff?: HuntRunDiff;
 }
 
 // Cap retained outcomes per case (newest first) so the side file stays small; override per case with
@@ -123,6 +131,7 @@ export interface HuntCollectResult {
   addedEvents: number;
   addedIocs: number;
   collectedAt: string;        // ISO
+  runDiff?: HuntRunDiff;      // #80: this run vs the fingerprint's previous run, when one was computed
 }
 
 // Compact human summary of a collected hunt. Leads with the rows the hunt RETURNED (the count that
@@ -169,6 +178,7 @@ export function fillOutcome(
       addedIocs,
       resultSummary: summarizeResult(resultRows, addedEvents, addedIocs),
       collectedAt: result.collectedAt,
+      runDiff: result.runDiff ?? o.runDiff,   // keep the last-computed diff when this collect didn't recompute one
     };
   });
 }

--- a/companion/src/analysis/huntRunDiff.ts
+++ b/companion/src/analysis/huntRunDiff.ts
@@ -1,0 +1,142 @@
+// Run-to-run hunt diffing (issue #80) — the pure, unit-tested core.
+//
+// huntOutcomes.ts records a hit/miss delta against the whole CASE (resultRows snapshot,
+// addedEvents/addedIocs cumulative after dedup) and dedups by VQL fingerprint, but that says nothing
+// about a re-run of the SAME hunt (same fingerprint, a fresh Velociraptor huntId): an analyst
+// re-deploying a recurring/scheduled hunt has no way to see which rows/hosts are new since the LAST
+// time it ran. This module closes that gap: a bounded snapshot of each run's result rows is kept per
+// fingerprint (HuntRunSnapshotStore), and diffHuntRuns compares consecutive runs — the hunt-result
+// analog of diffIocs.ts / timelineDiff.ts.
+
+export interface HuntRunSnapshot {
+  rowKeys: string[];   // stable per-row fingerprints, capped — the run's row-identity set
+  hosts: string[];     // distinct host identifiers extracted from the rows, capped
+}
+
+export interface HuntRunDiff {
+  addedRows: number;
+  removedRows: number;
+  addedHosts: string[];    // hosts present in this run, not the previous one
+  removedHosts: string[];  // hosts present in the previous run, not this one
+  isFirstRun: boolean;     // no previous snapshot for this fingerprint yet — nothing to diff against
+}
+
+// Per-snapshot cap on distinct row keys / hosts so a hunt returning tens of thousands of rows doesn't
+// blow up the persisted side file. Good enough to detect "something changed since last time", not a
+// full audit log — a hunt whose distinct rows exceed this may show spurious added/removed noise at the
+// margin (which rows survive the cap can vary run to run).
+export const HUNT_RUN_SNAPSHOT_MAX_ROWS = 500;
+
+// Field names likely to carry a host identity across Velociraptor artifacts (client-info style columns
+// first, then common OS/EDR spellings). First match wins per row.
+const HOST_FIELDS = ["Fqdn", "fqdn", "Hostname", "hostname", "ClientId", "client_id", "Computer", "computer", "Host", "host"];
+
+function extractHost(row: unknown): string | undefined {
+  if (!row || typeof row !== "object") return undefined;
+  const obj = row as Record<string, unknown>;
+  for (const field of HOST_FIELDS) {
+    const v = obj[field];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+// A stable identity for a row: sorted-key JSON so field ORDER never causes a false "new" row, but any
+// value change does (exact-match identity, mirroring diffIocs/diffTimeline's approach).
+function rowKey(row: unknown): string {
+  if (row && typeof row === "object" && !Array.isArray(row)) {
+    const obj = row as Record<string, unknown>;
+    const sorted = Object.keys(obj).sort().map((k) => [k, obj[k]] as const);
+    return JSON.stringify(sorted);
+  }
+  return JSON.stringify(row);
+}
+
+function dedupeCapped(values: readonly string[], max: number): string[] {
+  return [...new Set(values)].slice(0, Math.max(0, Math.floor(max)));
+}
+
+// Build a bounded snapshot of one hunt run's rows, from the artifact -> rows map a collect() returns.
+export function buildHuntRunSnapshot(rowsByArtifact: Record<string, unknown[]>, maxRows: number = HUNT_RUN_SNAPSHOT_MAX_ROWS): HuntRunSnapshot {
+  const rowKeys: string[] = [];
+  const hosts: string[] = [];
+  for (const rows of Object.values(rowsByArtifact ?? {})) {
+    for (const row of rows ?? []) {
+      rowKeys.push(rowKey(row));
+      const host = extractHost(row);
+      if (host) hosts.push(host);
+    }
+  }
+  return { rowKeys: dedupeCapped(rowKeys, maxRows), hosts: dedupeCapped(hosts, maxRows) };
+}
+
+// Compare this run's snapshot against the PREVIOUS run's (undefined when this fingerprint has never
+// been collected before — isFirstRun true, nothing meaningful to diff yet). Pure.
+export function diffHuntRuns(previous: HuntRunSnapshot | undefined, current: HuntRunSnapshot): HuntRunDiff {
+  const prevRows = new Set(previous?.rowKeys ?? []);
+  const curRows = new Set(current.rowKeys);
+  const prevHosts = new Set(previous?.hosts ?? []);
+  const curHosts = new Set(current.hosts);
+  let addedRows = 0;
+  let removedRows = 0;
+  for (const k of curRows) if (!prevRows.has(k)) addedRows++;
+  for (const k of prevRows) if (!curRows.has(k)) removedRows++;
+  const addedHosts: string[] = [];
+  const removedHosts: string[] = [];
+  for (const h of curHosts) if (!prevHosts.has(h)) addedHosts.push(h);
+  for (const h of prevHosts) if (!curHosts.has(h)) removedHosts.push(h);
+  return {
+    addedRows,
+    removedRows,
+    addedHosts: addedHosts.sort(),
+    removedHosts: removedHosts.sort(),
+    isFirstRun: previous === undefined,
+  };
+}
+
+// True when nothing changed (and it isn't the first run) — lets callers skip surfacing an empty diff.
+export function isEmptyHuntRunDiff(diff: HuntRunDiff): boolean {
+  return !diff.isFirstRun && diff.addedRows === 0 && diff.removedRows === 0 && diff.addedHosts.length === 0 && diff.removedHosts.length === 0;
+}
+
+// Compact human summary for the dashboard hunt-profile view, mirroring huntOutcomes.ts's summarizeResult.
+export function summarizeHuntRunDiff(diff: HuntRunDiff): string {
+  if (diff.isFirstRun) return "first run — no prior run to compare";
+  const parts: string[] = [];
+  if (diff.addedRows > 0) parts.push(`+${diff.addedRows} row${diff.addedRows === 1 ? "" : "s"} since last run`);
+  if (diff.addedHosts.length) parts.push(`${diff.addedHosts.length} new host${diff.addedHosts.length === 1 ? "" : "s"}`);
+  if (diff.removedRows > 0) parts.push(`-${diff.removedRows} row${diff.removedRows === 1 ? "" : "s"}`);
+  if (!parts.length) return "no change since last run";
+  return parts.join(", ");
+}
+
+// One case's ledger entry: the latest run snapshot recorded for a given VQL fingerprint, plus which
+// huntId produced it — lets the caller (server.ts) tell "same run, more rows trickled in" apart from
+// "a genuinely new run just started" before deciding whether a diff is meaningful to show.
+export interface HuntRunRecord {
+  vqlFingerprint: string;
+  huntId: string;
+  capturedAt: string;   // ISO
+  snapshot: HuntRunSnapshot;
+}
+
+// Cap distinct fingerprints tracked per case (oldest-touched evicted first) so the side file stays
+// small across a long investigation with many distinct hunts.
+export const HUNT_RUN_RECORDS_MAX = 50;
+
+export function findHuntRunRecord(records: readonly HuntRunRecord[], vqlFingerprint: string): HuntRunRecord | undefined {
+  if (!vqlFingerprint) return undefined;
+  return records.find((r) => r.vqlFingerprint === vqlFingerprint);
+}
+
+// Upsert the record for one fingerprint (prepended, newest first) and cap the tracked-fingerprint
+// count. Pure — returns a new array, never mutates the input.
+export function upsertHuntRunRecord(
+  records: readonly HuntRunRecord[],
+  input: HuntRunRecord,
+  max: number = HUNT_RUN_RECORDS_MAX,
+): HuntRunRecord[] {
+  const rest = records.filter((r) => r.vqlFingerprint !== input.vqlFingerprint);
+  const cap = Number.isFinite(max) && max > 0 ? Math.floor(max) : HUNT_RUN_RECORDS_MAX;
+  return [input, ...rest].slice(0, cap);
+}

--- a/companion/src/analysis/huntRunSnapshotStore.ts
+++ b/companion/src/analysis/huntRunSnapshotStore.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { CaseStore } from "../storage/caseStore.js";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { HuntRunRecord } from "./huntRunDiff.js";
+
+// Per-case persistence for run-to-run hunt diffing (#80): the latest result-row snapshot recorded per
+// VQL fingerprint (state/hunt-run-snapshots.json), so a re-run of the same hunt can show what's new
+// since the last one. A sibling to HuntOutcomeStore (which is keyed by huntId, not fingerprint, and
+// carries the case-cumulative delta rather than a per-run snapshot). Writes go through atomicWrite
+// (Dropbox/OneDrive-safe temp-rename), like every other side-file store.
+
+export class HuntRunSnapshotStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "hunt-run-snapshots.json");
+  }
+
+  // Records for the case, newest-touched first. [] when the file is absent or malformed — a corrupt
+  // side file must never sink a hunt collection.
+  async load(caseId: string): Promise<HuntRunRecord[]> {
+    try {
+      const parsed = JSON.parse(await readFile(this.path(caseId), "utf8")) as unknown;
+      return Array.isArray(parsed) ? (parsed as HuntRunRecord[]) : [];
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      if (err instanceof SyntaxError) return [];
+      throw err;
+    }
+  }
+
+  async save(caseId: string, records: readonly HuntRunRecord[]): Promise<void> {
+    await atomicWrite(this.path(caseId), JSON.stringify(records, null, 2));
+  }
+}

--- a/companion/src/analysis/investigationStateFiles.ts
+++ b/companion/src/analysis/investigationStateFiles.ts
@@ -20,6 +20,7 @@ export const SNAPSHOT_STATE_FILES = [
   "synth-meta.json",        // when synthesis last ran + findings diff (investigation history)
   "import-meta.json",       // when the last import ran + timeline/IOC diff (investigation history)
   "hunt-outcomes.json",     // #157 per-case hunting profile (what was hunted, what hit/missed) — investigation data
+  "hunt-run-snapshots.json", // #80 per-fingerprint latest run snapshot, so a hunt re-run diff stays in sync with hunt-outcomes.json across an undo
   "dwell-windows.json",     // analyst-defined attacker-presence windows (label/start/end) — investigation data
   "pinned-findings.json",   // #220 analyst-pinned key findings (ordered shortlist) — analyst decision, travels with the case
 ] as const;

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -1822,17 +1822,23 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
           // computed when this collect belongs to a DIFFERENT huntId than the fingerprint's last
           // recorded run (a genuine re-deploy, not just pulling stragglers off the same running hunt).
           let runDiff: HuntRunDiff | undefined;
-          const fp = cur.find((o) => o.huntId === job.huntId)?.vqlFingerprint || "";
+          const fp = cur.find((o) => o.huntId === huntId)?.vqlFingerprint || "";   // `huntId` (param) === job.huntId, and stays non-null inside this closure (job is a reassignable `let`)
           if (fp && options.huntRunSnapshotStore) {
             try {
               const records = await options.huntRunSnapshotStore.load(caseId);
               const prevRecord = findHuntRunRecord(records, fp);
               const snapshot = buildHuntRunSnapshot(map);
-              if (!prevRecord || prevRecord.huntId !== job.huntId) {
-                runDiff = diffHuntRuns(prevRecord?.snapshot, snapshot);
-                const next = upsertHuntRunRecord(records, { vqlFingerprint: fp, huntId: job.huntId, capturedAt: new Date().toISOString(), snapshot });
-                await options.huntRunSnapshotStore.save(caseId, next);
-              }
+              // A run-diff is only SURFACED for a genuinely new run — no prior snapshot, or a different
+              // huntId (a real re-deploy). A same-huntId re-collect is just stragglers checking into the
+              // SAME running hunt, so it produces no diff of its own.
+              const isNewRun = !prevRecord || prevRecord.huntId !== job.huntId;
+              if (isNewRun) runDiff = diffHuntRuns(prevRecord?.snapshot, snapshot);
+              // But ALWAYS advance the stored baseline to this collect's full result set — including
+              // same-huntId re-collects — so the NEXT run diffs against the COMPLETE previous run rather
+              // than its first partial collect (which would otherwise falsely report later-arriving rows
+              // as "new since last run").
+              const next = upsertHuntRunRecord(records, { vqlFingerprint: fp, huntId: job.huntId, capturedAt: new Date().toISOString(), snapshot });
+              await options.huntRunSnapshotStore.save(caseId, next);
             } catch (e) { logLine(`[hunt-run-diff] snapshot failed for hunt ${job.huntId}: ${(e as Error).message}`); }
           }
           // resultRows = the rows the hunt RETURNED (what the analyst sees); addedEvents = new-to-case

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -118,6 +118,8 @@ import { type PlaybookTask } from "./analysis/playbook.js";
 import { PlaybookHuntStore } from "./analysis/playbookHuntStore.js";
 import { HuntOutcomeStore } from "./analysis/huntOutcomeStore.js";
 import { recordDeploy, fillOutcome, HUNT_OUTCOME_MAX_DEFAULT, type HuntDeployInput } from "./analysis/huntOutcomes.js";
+import { HuntRunSnapshotStore } from "./analysis/huntRunSnapshotStore.js";
+import { buildHuntRunSnapshot, diffHuntRuns, findHuntRunRecord, upsertHuntRunRecord, type HuntRunDiff } from "./analysis/huntRunDiff.js";
 import { PlaybookControlStore, DEFAULT_PLAYBOOK_CONTROL, type PlaybookControl } from "./analysis/playbookControl.js";
 import { AssetOverridesStore } from "./analysis/assetOverrides.js";
 import { IocAliasStore } from "./analysis/iocAlias.js";
@@ -463,6 +465,10 @@ export interface AppOptions {
   // counts). Recorded on deploy (bundle + suggested fleet/playbook/technique hunts), filled on collect,
   // read by the suggestion routes (exclude + "PRIOR HUNTS" context) and the dashboard hunting profile.
   huntOutcomeStore?: HuntOutcomeStore;
+  // Run-to-run hunt diffing (#80): the latest result-row snapshot per VQL fingerprint, so re-deploying
+  // a recurring/scheduled hunt can show what's new/gone vs its PREVIOUS run (not just vs the whole
+  // case). Sibling to huntOutcomeStore — see huntRunSnapshotStore.ts.
+  huntRunSnapshotStore?: HuntRunSnapshotStore;
   // Live Velociraptor CLIENT_EVENT monitors (#84): per-case pollers that stream a client monitoring
   // artifact's new rows into the push/import pipeline. The store persists each monitor + its cursor so
   // a restart resumes without re-ingesting; onVeloMonitor broadcasts a change to the case's clients.
@@ -1812,9 +1818,26 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       if (options.huntOutcomeStore) {
         try {
           const cur = await options.huntOutcomeStore.load(caseId);
+          // #80: run-to-run diff — only meaningful for a fingerprinted (non-bundle) hunt, and only
+          // computed when this collect belongs to a DIFFERENT huntId than the fingerprint's last
+          // recorded run (a genuine re-deploy, not just pulling stragglers off the same running hunt).
+          let runDiff: HuntRunDiff | undefined;
+          const fp = cur.find((o) => o.huntId === job.huntId)?.vqlFingerprint || "";
+          if (fp && options.huntRunSnapshotStore) {
+            try {
+              const records = await options.huntRunSnapshotStore.load(caseId);
+              const prevRecord = findHuntRunRecord(records, fp);
+              const snapshot = buildHuntRunSnapshot(map);
+              if (!prevRecord || prevRecord.huntId !== job.huntId) {
+                runDiff = diffHuntRuns(prevRecord?.snapshot, snapshot);
+                const next = upsertHuntRunRecord(records, { vqlFingerprint: fp, huntId: job.huntId, capturedAt: new Date().toISOString(), snapshot });
+                await options.huntRunSnapshotStore.save(caseId, next);
+              }
+            } catch (e) { logLine(`[hunt-run-diff] snapshot failed for hunt ${job.huntId}: ${(e as Error).message}`); }
+          }
           // resultRows = the rows the hunt RETURNED (what the analyst sees); addedEvents = new-to-case
           // after dedup. Showing both stops "+1 event" reading as wrong next to a 10-row result table.
-          await options.huntOutcomeStore.save(caseId, fillOutcome(cur, job.huntId, { resultRows: totalRows, addedEvents, addedIocs, collectedAt: new Date().toISOString() }));
+          await options.huntOutcomeStore.save(caseId, fillOutcome(cur, job.huntId, { resultRows: totalRows, addedEvents, addedIocs, collectedAt: new Date().toISOString(), runDiff }));
         } catch (e) { logLine(`[hunt-outcomes] fill failed for hunt ${job.huntId}: ${(e as Error).message}`); }
       }
 
@@ -2926,6 +2949,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const dashboardBaseUrl = (process.env.DFIR_PUBLIC_URL || `http://${host}:${port}`).replace(/\/+$/, "");
   const veloHuntStore = new VeloHuntStore(store);
   const huntOutcomeStore = new HuntOutcomeStore(store);   // #157 hunting feedback loop ledger
+  const huntRunSnapshotStore = new HuntRunSnapshotStore(store);   // #80 run-to-run hunt diffing
   // Live Velociraptor CLIENT_EVENT monitors + generic push ingest (#84). The monitor store persists
   // each poller's cursor (resumed on restart); the push token store holds per-case secrets, and
   // DFIR_PUSH_TOKEN is the global one. Push is OFF until a token is configured (see pushAuth.ts).
@@ -3158,6 +3182,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     kevStore,
     veloHuntStore,
     huntOutcomeStore,
+    huntRunSnapshotStore,
     onVeloHunt: (caseId) => hub.broadcastTo(caseId, { type: "velo_hunt_changed" }),
     veloMonitorStore,
     onVeloMonitor: (caseId) => hub.broadcastTo(caseId, { type: "velo_monitor_changed" }),

--- a/companion/tests/analysis/huntRunDiff.test.ts
+++ b/companion/tests/analysis/huntRunDiff.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildHuntRunSnapshot,
+  diffHuntRuns,
+  isEmptyHuntRunDiff,
+  summarizeHuntRunDiff,
+  findHuntRunRecord,
+  upsertHuntRunRecord,
+  HUNT_RUN_RECORDS_MAX,
+  type HuntRunRecord,
+} from "../../src/analysis/huntRunDiff.js";
+
+const T0 = "2026-06-21T10:00:00.000Z";
+const T1 = "2026-06-21T11:00:00.000Z";
+
+describe("buildHuntRunSnapshot", () => {
+  it("collects a stable key per row and extracts hosts from common field names", () => {
+    const snap = buildHuntRunSnapshot({
+      "Custom.Hunt": [
+        { Fqdn: "host-a", Path: "C:/evil.exe" },
+        { Hostname: "host-b", Path: "C:/other.exe" },
+      ],
+    });
+    expect(snap.rowKeys).toHaveLength(2);
+    expect(snap.hosts.sort()).toEqual(["host-a", "host-b"]);
+  });
+
+  it("dedupes identical rows across artifacts", () => {
+    const row = { ClientId: "C.123", Path: "C:/evil.exe" };
+    const snap = buildHuntRunSnapshot({ A: [row], B: [{ ...row }] });
+    expect(snap.rowKeys).toHaveLength(1);
+    expect(snap.hosts).toEqual(["C.123"]);
+  });
+
+  it("is insensitive to field ORDER within a row (same identity)", () => {
+    const a = buildHuntRunSnapshot({ A: [{ x: 1, y: 2 }] });
+    const b = buildHuntRunSnapshot({ A: [{ y: 2, x: 1 }] });
+    expect(a.rowKeys).toEqual(b.rowKeys);
+  });
+
+  it("treats a value change as a different row", () => {
+    const a = buildHuntRunSnapshot({ A: [{ x: 1 }] });
+    const b = buildHuntRunSnapshot({ A: [{ x: 2 }] });
+    expect(a.rowKeys).not.toEqual(b.rowKeys);
+  });
+
+  it("caps the number of distinct row keys / hosts retained", () => {
+    const rows = Array.from({ length: 20 }, (_, i) => ({ Fqdn: `host-${i}`, i }));
+    const snap = buildHuntRunSnapshot({ A: rows }, 5);
+    expect(snap.rowKeys).toHaveLength(5);
+    expect(snap.hosts).toHaveLength(5);
+  });
+
+  it("handles rows with no host field gracefully", () => {
+    const snap = buildHuntRunSnapshot({ A: [{ foo: "bar" }] });
+    expect(snap.rowKeys).toHaveLength(1);
+    expect(snap.hosts).toHaveLength(0);
+  });
+
+  it("returns an empty snapshot for no rows", () => {
+    expect(buildHuntRunSnapshot({})).toEqual({ rowKeys: [], hosts: [] });
+  });
+});
+
+describe("diffHuntRuns", () => {
+  it("flags a first run (no previous snapshot) and reports nothing as added", () => {
+    const cur = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }] });
+    const diff = diffHuntRuns(undefined, cur);
+    expect(diff.isFirstRun).toBe(true);
+    expect(diff.addedRows).toBe(1);
+    expect(diff.addedHosts).toEqual(["host-a"]);
+  });
+
+  it("reports rows/hosts new since the previous run", () => {
+    const prev = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a", f: 1 }] });
+    const cur = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a", f: 1 }, { Fqdn: "host-b", f: 2 }] });
+    const diff = diffHuntRuns(prev, cur);
+    expect(diff.isFirstRun).toBe(false);
+    expect(diff.addedRows).toBe(1);
+    expect(diff.removedRows).toBe(0);
+    expect(diff.addedHosts).toEqual(["host-b"]);
+    expect(diff.removedHosts).toEqual([]);
+  });
+
+  it("reports rows/hosts that dropped out since the previous run", () => {
+    const prev = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }, { Fqdn: "host-b" }] });
+    const cur = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }] });
+    const diff = diffHuntRuns(prev, cur);
+    expect(diff.removedRows).toBe(1);
+    expect(diff.removedHosts).toEqual(["host-b"]);
+    expect(diff.addedRows).toBe(0);
+  });
+
+  it("shows no change when the same run is re-collected (identical rows)", () => {
+    const snap = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a", v: 1 }] });
+    const diff = diffHuntRuns(snap, snap);
+    expect(isEmptyHuntRunDiff(diff)).toBe(true);
+  });
+
+  it("a re-run against an empty previous run counts every current row as added", () => {
+    const cur = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }] });
+    const diff = diffHuntRuns({ rowKeys: [], hosts: [] }, cur);
+    expect(diff.isFirstRun).toBe(false);
+    expect(diff.addedRows).toBe(1);
+  });
+});
+
+describe("isEmptyHuntRunDiff", () => {
+  it("is false for a first run even with no rows (nothing to compare yet, not 'no change')", () => {
+    const diff = diffHuntRuns(undefined, { rowKeys: [], hosts: [] });
+    expect(isEmptyHuntRunDiff(diff)).toBe(false);
+  });
+});
+
+describe("summarizeHuntRunDiff", () => {
+  it("says so when there's no prior run to compare", () => {
+    const diff = diffHuntRuns(undefined, buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }] }));
+    expect(summarizeHuntRunDiff(diff)).toBe("first run — no prior run to compare");
+  });
+
+  it("summarizes added rows and new hosts", () => {
+    const prev = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }] });
+    const cur = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }, { Fqdn: "host-b" }, { Fqdn: "host-b", extra: 1 }] });
+    const diff = diffHuntRuns(prev, cur);
+    expect(summarizeHuntRunDiff(diff)).toBe("+2 rows since last run, 1 new host");
+  });
+
+  it("reports no change since last run", () => {
+    const snap = buildHuntRunSnapshot({ A: [{ Fqdn: "host-a" }] });
+    expect(summarizeHuntRunDiff(diffHuntRuns(snap, snap))).toBe("no change since last run");
+  });
+});
+
+describe("findHuntRunRecord / upsertHuntRunRecord", () => {
+  const rec = (fp: string, huntId: string): HuntRunRecord => ({
+    vqlFingerprint: fp,
+    huntId,
+    capturedAt: T0,
+    snapshot: { rowKeys: [], hosts: [] },
+  });
+
+  it("finds by fingerprint, undefined when absent or blank", () => {
+    const records = [rec("fp1", "H.1")];
+    expect(findHuntRunRecord(records, "fp1")).toBe(records[0]);
+    expect(findHuntRunRecord(records, "fp2")).toBeUndefined();
+    expect(findHuntRunRecord(records, "")).toBeUndefined();
+  });
+
+  it("upserts by fingerprint (replaces, never duplicates), prepended newest-first", () => {
+    let records = upsertHuntRunRecord([], rec("fp1", "H.1"));
+    records = upsertHuntRunRecord(records, rec("fp2", "H.2"));
+    records = upsertHuntRunRecord(records, { ...rec("fp1", "H.3"), capturedAt: T1 });
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({ vqlFingerprint: "fp1", huntId: "H.3" });
+  });
+
+  it("caps history to max (newest kept)", () => {
+    let records: HuntRunRecord[] = [];
+    for (let i = 0; i < 5; i++) records = upsertHuntRunRecord(records, rec(`fp${i}`, `H.${i}`), 3);
+    expect(records).toHaveLength(3);
+    expect(records.map((r) => r.vqlFingerprint)).toEqual(["fp4", "fp3", "fp2"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input: HuntRunRecord[] = [];
+    const out = upsertHuntRunRecord(input, rec("fp1", "H.1"));
+    expect(input).toHaveLength(0);
+    expect(out).toHaveLength(1);
+  });
+
+  it("defaults to HUNT_RUN_RECORDS_MAX when max is invalid", () => {
+    const out = upsertHuntRunRecord([], rec("fp1", "H.1"), 0);
+    expect(out).toHaveLength(1);
+    expect(HUNT_RUN_RECORDS_MAX).toBeGreaterThan(0);
+  });
+});

--- a/companion/tests/server/huntOutcomes.test.ts
+++ b/companion/tests/server/huntOutcomes.test.ts
@@ -190,7 +190,7 @@ describe("run-to-run hunt diffing (#80)", () => {
     expect(hunts.find((h) => h.huntId === "H.RUN2")?.runDiff).toMatchObject({
       isFirstRun: false, addedRows: 1, removedRows: 0, addedHosts: ["host-b"],
     });
-  });
+  }, 30_000);   // two sequential collect polls (100 x 20ms each) can exceed vitest's 5s default under a loaded parallel run
 
   it("advances the baseline on same-huntId re-collects so a later re-run doesn't re-report stragglers", async () => {
     // Fleet hunt results trickle in: an analyst clicks "Collect" several times on the SAME huntId as
@@ -261,5 +261,5 @@ describe("run-to-run hunt diffing (#80)", () => {
     expect(hunts.find((h) => h.huntId === "H.RUN2")?.runDiff).toMatchObject({
       isFirstRun: false, addedRows: 0, removedRows: 0, addedHosts: [], removedHosts: [],
     });
-  });
+  }, 30_000);   // four sequential collect polls (100 x 20ms each) exceed vitest's 5s default under a loaded parallel run
 });

--- a/companion/tests/server/huntOutcomes.test.ts
+++ b/companion/tests/server/huntOutcomes.test.ts
@@ -3,12 +3,14 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import request from "supertest";
+import type { Express } from "express";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { VeloHuntStore } from "../../src/analysis/veloHuntStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { HuntOutcomeStore } from "../../src/analysis/huntOutcomeStore.js";
+import { HuntRunSnapshotStore } from "../../src/analysis/huntRunSnapshotStore.js";
 import { recordDeploy, vqlFingerprint } from "../../src/analysis/huntOutcomes.js";
 import { MockProvider } from "../../src/providers/provider.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
@@ -38,11 +40,13 @@ async function makeApp(opts: { provider?: MockProvider; runner?: VqlRunner; with
     imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
   });
   const huntOutcomeStore = new HuntOutcomeStore(store);
+  const huntRunSnapshotStore = new HuntRunSnapshotStore(store);
   const app = createApp(store, {
     pipeline, stateStore,
     importMetaStore: new ImportMetaStore(store),
     veloHuntStore: new VeloHuntStore(store),
     huntOutcomeStore,
+    huntRunSnapshotStore,
     aiConfigured: Boolean(provider),
     ...(opts.withVelo === false ? {} : { velociraptorClient: new VelociraptorClient(veloCfg, opts.runner ?? runner) }),
   });
@@ -136,5 +140,55 @@ describe("hunting feedback loop — routes (#157)", () => {
     const after = await request(app).post("/cases/c1/velociraptor/suggest-hunts").send({});
     expect(after.body.suggestions).toEqual([]);
     expect(vqlFingerprint(vql)).toBeTruthy();
+  });
+});
+
+// #80: run-to-run hunt diffing — re-deploying the SAME VQL fingerprint (a recurring/scheduled hunt)
+// must show what's new/gone vs its OWN previous run, not just the cumulative case delta.
+describe("run-to-run hunt diffing (#80)", () => {
+  async function waitForCollected(app: Express, huntId: string) {
+    for (let i = 0; i < 100; i++) {
+      const profile = (await request(app).get("/cases/c1/hunt-outcomes")).body;
+      const h = (profile.hunts ?? []).find((x: { huntId?: string }) => x.huntId === huntId);
+      if (h && h.status === "collected") return profile.hunts as Array<Record<string, unknown>>;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    throw new Error(`hunt ${huntId} never collected`);
+  }
+
+  it("diffs a re-run against its own previous run's rows/hosts, not the whole case", async () => {
+    let huntSeq = 0;
+    const rowsByHunt: Record<string, unknown[]> = {
+      "H.RUN1": [{ Fqdn: "host-a", Message: "m1" }],
+      "H.RUN2": [{ Fqdn: "host-a", Message: "m1" }, { Fqdn: "host-b", Message: "m2" }],
+    };
+    const runner: VqlRunner = async (statements) => {
+      const p = statements[0];
+      if (p.includes("hunt(") && p.includes("artifacts=")) {
+        huntSeq += 1;
+        return { rows: [{ Hunt: { HuntId: `H.RUN${huntSeq}`, state: "RUNNING" } }], raw: "" };
+      }
+      if (p.includes("hunt_results(")) {
+        const m = p.match(/hunt_id='([^']+)'/);
+        return { rows: (m && rowsByHunt[m[1]]) || [], raw: "" };
+      }
+      return { rows: [], raw: "" };
+    };
+    const { app } = await makeApp({ runner });
+    const vql = "SELECT * FROM pslist()";
+
+    // First deploy + collect: nothing to diff against yet.
+    await request(app).post("/cases/c1/velociraptor/deploy-hunt").send({ vql, title: "recurring hunt", source: "fleet" });
+    expect((await request(app).post("/cases/c1/velociraptor/collect").send({ huntId: "H.RUN1" })).status).toBe(202);
+    let hunts = await waitForCollected(app, "H.RUN1");
+    expect(hunts.find((h) => h.huntId === "H.RUN1")?.runDiff).toMatchObject({ isFirstRun: true });
+
+    // Re-deploy the SAME vql (a fresh huntId — a genuine re-run) + collect: diff vs H.RUN1's snapshot.
+    await request(app).post("/cases/c1/velociraptor/deploy-hunt").send({ vql, title: "recurring hunt", source: "fleet" });
+    expect((await request(app).post("/cases/c1/velociraptor/collect").send({ huntId: "H.RUN2" })).status).toBe(202);
+    hunts = await waitForCollected(app, "H.RUN2");
+    expect(hunts.find((h) => h.huntId === "H.RUN2")?.runDiff).toMatchObject({
+      isFirstRun: false, addedRows: 1, removedRows: 0, addedHosts: ["host-b"],
+    });
   });
 });

--- a/companion/tests/server/huntOutcomes.test.ts
+++ b/companion/tests/server/huntOutcomes.test.ts
@@ -191,4 +191,75 @@ describe("run-to-run hunt diffing (#80)", () => {
       isFirstRun: false, addedRows: 1, removedRows: 0, addedHosts: ["host-b"],
     });
   });
+
+  it("advances the baseline on same-huntId re-collects so a later re-run doesn't re-report stragglers", async () => {
+    // Fleet hunt results trickle in: an analyst clicks "Collect" several times on the SAME huntId as
+    // clients check in. The stored baseline must track the LATEST full result set of the run, not stay
+    // frozen at the first (partial) collect — otherwise rows that arrived in the 2nd/3rd collect are
+    // falsely reported as "new" when the hunt is later re-deployed under a fresh huntId.
+    let huntSeq = 0;
+    // Rows returned for the current H.RUN1 collect — mutated between collect requests to simulate
+    // stragglers checking in. H.RUN2 (the re-deploy) returns the SAME complete set as H.RUN1 ended with.
+    const completeRows = [
+      { Fqdn: "host-a", Message: "m1" },
+      { Fqdn: "host-b", Message: "m2" },
+      { Fqdn: "host-c", Message: "m3" },
+    ];
+    let run1Rows: unknown[] = [completeRows[0]];
+    const runner: VqlRunner = async (statements) => {
+      const p = statements[0];
+      if (p.includes("hunt(") && p.includes("artifacts=")) {
+        huntSeq += 1;
+        return { rows: [{ Hunt: { HuntId: `H.RUN${huntSeq}`, state: "RUNNING" } }], raw: "" };
+      }
+      if (p.includes("hunt_results(")) {
+        const m = p.match(/hunt_id='([^']+)'/);
+        const id = m && m[1];
+        if (id === "H.RUN1") return { rows: run1Rows, raw: "" };
+        if (id === "H.RUN2") return { rows: completeRows, raw: "" };
+        return { rows: [], raw: "" };
+      }
+      return { rows: [], raw: "" };
+    };
+    const { app } = await makeApp({ runner });
+    const vql = "SELECT * FROM pslist()";
+
+    // Poll until the outcome's resultRows reflects a collect that returned `rows` rows — the only visible
+    // signal that a same-huntId re-collect (which never changes status away from "collected") completed.
+    async function waitForResultRows(huntId: string, rows: number) {
+      for (let i = 0; i < 100; i++) {
+        const profile = (await request(app).get("/cases/c1/hunt-outcomes")).body;
+        const h = (profile.hunts ?? []).find((x: { huntId?: string }) => x.huntId === huntId);
+        if (h && h.resultRows === rows) return;
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      throw new Error(`hunt ${huntId} never reported ${rows} result rows`);
+    }
+
+    // First deploy + first (partial) collect — one host so far.
+    await request(app).post("/cases/c1/velociraptor/deploy-hunt").send({ vql, title: "recurring hunt", source: "fleet" });
+    expect((await request(app).post("/cases/c1/velociraptor/collect").send({ huntId: "H.RUN1" })).status).toBe(202);
+    await waitForResultRows("H.RUN1", 1);
+
+    // Two more collects on the SAME huntId as stragglers check in (2 hosts, then 3). These must update
+    // the baseline but NOT surface a run-diff of their own.
+    run1Rows = [completeRows[0], completeRows[1]];
+    expect((await request(app).post("/cases/c1/velociraptor/collect").send({ huntId: "H.RUN1" })).status).toBe(202);
+    await waitForResultRows("H.RUN1", 2);
+
+    run1Rows = [...completeRows];
+    expect((await request(app).post("/cases/c1/velociraptor/collect").send({ huntId: "H.RUN1" })).status).toBe(202);
+    await waitForResultRows("H.RUN1", 3);
+
+    // Re-deploy the SAME vql under a fresh huntId (a genuine re-run) whose result set equals H.RUN1's
+    // COMPLETE final set. Because the baseline advanced on every collect, nothing is new: had the
+    // baseline stayed frozen at the first partial collect (1 host), host-b and host-c would be falsely
+    // reported as added here.
+    await request(app).post("/cases/c1/velociraptor/deploy-hunt").send({ vql, title: "recurring hunt", source: "fleet" });
+    expect((await request(app).post("/cases/c1/velociraptor/collect").send({ huntId: "H.RUN2" })).status).toBe(202);
+    const hunts = await waitForCollected(app, "H.RUN2");
+    expect(hunts.find((h) => h.huntId === "H.RUN2")?.runDiff).toMatchObject({
+      isFirstRun: false, addedRows: 0, removedRows: 0, addedHosts: [], removedHosts: [],
+    });
+  });
 });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4164,6 +4164,7 @@
       #sec-huntprofile .hp-src{color:var(--c-9aa4b2);font-size:10px;text-transform:uppercase;letter-spacing:.04em}
       #sec-huntprofile .hp-result{color:var(--c-c9d1db)}
       #sec-huntprofile .hp-tech{color:var(--c-6aa9ff);font-size:11px}
+      #sec-huntprofile .hp-rundiff{background:#ffb84d22;color:#ffb84d;border:1px solid #ffb84d55;border-radius:3px;padding:0 6px;font-size:10px;white-space:nowrap}
       #sec-huntprofile .hp-collect{margin-left:auto;background:var(--c-2d6cdf);border:0;color:#fff;border-radius:4px;padding:1px 8px;font-size:11px;cursor:pointer}
       #sec-huntprofile .hp-collect:disabled{opacity:.6;cursor:default}
       #sec-huntprofile .hp-collect-err{background:var(--c-ff9f43);color:#1a1f29}
@@ -12207,6 +12208,18 @@
           const u = attackUrl(t);
           return u ? `<a href="${escAttr(u)}" target="_blank" rel="noopener" class="hp-tech">${esc(t)}</a>` : `<span class="hp-tech">${esc(t)}</span>`;
         }).join(" ");
+        // #80: what's new vs THIS hunt's previous run (a re-deploy of the same VQL), not the whole case —
+        // only set once a second run of the same fingerprint has actually been collected.
+        const runDiffBadge = (() => {
+          const rd = h.runDiff;
+          if (!rd || rd.isFirstRun) return "";
+          const parts = [];
+          if (rd.addedRows > 0) parts.push(`+${rd.addedRows} row${rd.addedRows === 1 ? "" : "s"}`);
+          if ((rd.addedHosts || []).length) parts.push(`${rd.addedHosts.length} new host${rd.addedHosts.length === 1 ? "" : "s"}`);
+          if (!parts.length) return ` <span class="hp-rundiff" title="No new rows or hosts since this hunt's previous run">= vs last run</span>`;
+          const title = (rd.addedHosts || []).length ? `New hosts since last run: ${rd.addedHosts.join(", ")}` : "New rows since this hunt's previous run";
+          return ` <span class="hp-rundiff" title="${escAttr(title)}">↻ ${esc(parts.join(", "))} vs last run</span>`;
+        })();
         // Any hunt with a Velociraptor hunt id stays collectible — fleet results trickle in as clients
         // check in, so the button REMAINS after a collect so the analyst can re-pull stragglers (counts
         // accumulate; a hit is never downgraded). Pending → "Collect now"; collected → "Re-collect".
@@ -12225,6 +12238,7 @@
           + `<span class="hp-src">${esc(h.source || "")}</span>`
           + `<span class="hp-title">${esc(h.title || "(untitled hunt)")}</span>`
           + `<span class="hp-result">— ${esc(result)}</span>`
+          + runDiffBadge
           + (techs ? ` ${techs}` : "")
           + resultsToggle
           + collectBtn


### PR DESCRIPTION
## Summary
- Adds `huntRunDiff.ts`: pure, unit-tested `buildHuntRunSnapshot`/`diffHuntRuns` to compare a hunt's result rows/hosts across consecutive runs of the same VQL fingerprint.
- Adds `HuntRunSnapshotStore`, a fingerprint-keyed sibling to `HuntOutcomeStore` that retains only the latest bounded snapshot per fingerprint (capped fingerprints + capped rows).
- Wires the diff into `importVeloHuntResults`: a genuine re-deploy of a recurring/scheduled hunt now records `HuntOutcome.runDiff`.
- Surfaces it on the dashboard hunt-profile view as a "vs last run" badge.

Closes #80.

## Test plan
- [x] `tests/analysis/huntRunDiff.test.ts` — pure diff/snapshot/history-cap functions
- [x] `tests/server/huntOutcomes.test.ts` — end-to-end deploy→collect→re-deploy→collect flow via a mocked Velociraptor runner
- [ ] `npm ci && npm run build && npm test` in `companion/` — not run in this sandbox, please verify before merge

Generated with [Claude Code](https://claude.ai/code)