### PR TITLE
Add playbook task dependency graph (dependsOn, blocked state, cycle detection)

### DIFF
--- a/companion/src/analysis/playbook.ts
+++ b/companion/src/analysis/playbook.ts
@@ -462,11 +462,17 @@ export interface PlaybookTaskWithGraph extends PlaybookTask {
 // gated on them stays blocked until they revisit that). A dependency id with no matching task
 // (pruned auto-task pending re-derive, or a deleted custom task) is treated as satisfied so a
 // stale reference can never block forever.
+// A task that is itself already resolved (done or skipped) is never reported as blocked: "blocked"
+// means "you cannot start this yet", which is meaningless once the work is finished or waived, and a
+// finished task still flying a red `blocked` badge makes the badge harder to trust at a glance.
+// blockedBy is still populated so the unmet dependencies remain inspectable.
+const RESOLVED_STATUSES = new Set<PlaybookStatus>(["done", "skipped"]);
+
 export function withBlockedState(tasks: readonly PlaybookTask[]): PlaybookTaskWithGraph[] {
   const byId = new Map(tasks.map((t) => [t.id, t] as const));
   return tasks.map((t) => {
     const blockedBy = (t.dependsOn ?? []).filter((depId) => byId.get(depId)?.status !== "done" && byId.has(depId));
-    return { ...t, blocked: blockedBy.length > 0, blockedBy };
+    return { ...t, blocked: blockedBy.length > 0 && !RESOLVED_STATUSES.has(t.status), blockedBy };
   });
 }
 

--- a/companion/src/analysis/playbook.ts
+++ b/companion/src/analysis/playbook.ts
@@ -36,6 +36,7 @@ export const playbookTaskSchema = z.object({
   assignee: z.string().optional(),
   dueDate: z.string().optional(),         // free-form date, e.g. "2026-06-15"
   notes: z.string().optional(),
+  dependsOn: z.array(z.string()).optional(),   // ids of tasks that must be "done" first (issue #81)
   order: z.number().catch(0),
   createdAt: z.string(),
   updatedAt: z.string(),
@@ -308,10 +309,10 @@ export interface MergeResult {
 }
 
 // A pristine auto-task is one the analyst hasn't engaged with — still `todo`, no assignee,
-// due date, or notes. Such a task may be safely pruned when its seed disappears; anything the
-// analyst touched is kept.
+// due date, notes, or dependency edges. Such a task may be safely pruned when its seed
+// disappears; anything the analyst touched is kept.
 function isPristineAuto(t: PlaybookTask): boolean {
-  return t.source !== "custom" && !!t.sourceKey && t.status === "todo" && !t.assignee && !t.dueDate && !t.notes;
+  return t.source !== "custom" && !!t.sourceKey && t.status === "todo" && !t.assignee && !t.dueDate && !t.notes && !t.dependsOn?.length;
 }
 
 // Return the next sequential display ID (T001, T002, …) from the current task list.
@@ -387,7 +388,11 @@ export function mergePlaybook(existing: PlaybookTask[], seeds: DerivedTaskSeed[]
     }
   }
 
-  // Prune pristine auto-tasks whose seed is no longer derived.
+  // Prune pristine auto-tasks whose seed is no longer derived. A pruned task's id may still be
+  // referenced by another task's dependsOn — left as-is (not stripped): since an auto-task's id
+  // IS its stable sourceKey, if the same finding/next-step re-derives later the id reappears and
+  // the edge reconnects on its own. withBlockedState treats a currently-dangling reference as
+  // non-blocking in the meantime (see below).
   const seedKeys = new Set(seeds.map((s) => s.sourceKey));
   const pruned = result.filter((t) => {
     if (t.sourceKey && !seedKeys.has(t.sourceKey) && isPristineAuto(t)) {
@@ -397,6 +402,72 @@ export function mergePlaybook(existing: PlaybookTask[], seeds: DerivedTaskSeed[]
     return true;
   });
   return { tasks: pruned, changed };
+}
+
+// ── Dependency graph (issue #81) ──────────────────────────────────────────────────────────
+// Tasks can declare `dependsOn: string[]` (other task ids) to express "blocked until". The
+// edges live on the depending task itself (not a separate store), so they ride along with
+// mergePlaybook's normal preserve-analyst-edits path automatically.
+
+export class PlaybookValidationError extends Error {}
+
+// DFS cycle check over the CURRENT edges, with `taskId`'s edges hypothetically replaced by
+// `newDependsOn` — used to reject an edit that would introduce a cycle (including a direct
+// self-dependency) BEFORE it's persisted.
+function wouldCreateCycle(tasks: readonly PlaybookTask[], taskId: string, newDependsOn: readonly string[]): boolean {
+  const byId = new Map(tasks.map((t) => [t.id, t] as const));
+  const edgesOf = (id: string): readonly string[] => (id === taskId ? newDependsOn : byId.get(id)?.dependsOn ?? []);
+  const visiting = new Set<string>();
+  const done = new Set<string>();
+  const dfs = (id: string): boolean => {
+    if (visiting.has(id)) return true;
+    if (done.has(id)) return false;
+    visiting.add(id);
+    for (const dep of edgesOf(id)) {
+      if (dfs(dep)) return true;
+    }
+    visiting.delete(id);
+    done.add(id);
+    return false;
+  };
+  return dfs(taskId);
+}
+
+export interface DependsOnValidation {
+  ok: boolean;
+  error?: string;
+  dependsOn?: string[];
+}
+
+// Validate a proposed dependsOn edit for `taskId`: every id must name a task that exists in
+// this playbook (self-references are dropped rather than rejected — harmless no-op), and the
+// resulting graph must stay acyclic. Returns the normalized (deduped) edge list on success.
+export function validateDependsOn(tasks: readonly PlaybookTask[], taskId: string, dependsOn: readonly string[]): DependsOnValidation {
+  const ids = Array.from(new Set(dependsOn.filter((id) => id !== taskId)));
+  const known = new Set(tasks.map((t) => t.id));
+  const unknown = ids.filter((id) => !known.has(id));
+  if (unknown.length) return { ok: false, error: `unknown task id(s): ${unknown.join(", ")}` };
+  if (wouldCreateCycle(tasks, taskId, ids)) return { ok: false, error: "that dependency would create a cycle" };
+  return { ok: true, dependsOn: ids };
+}
+
+export interface PlaybookTaskWithGraph extends PlaybookTask {
+  blocked: boolean;
+  blockedBy: string[];   // ids of unmet dependencies that still exist in this playbook
+}
+
+// Attach derived blocked/ready state from each task's dependsOn edges — computed on read, never
+// persisted. A task is blocked while at least one dependency EXISTS and is not yet "done";
+// skipped dependencies still block (the analyst explicitly chose not to do them, so anything
+// gated on them stays blocked until they revisit that). A dependency id with no matching task
+// (pruned auto-task pending re-derive, or a deleted custom task) is treated as satisfied so a
+// stale reference can never block forever.
+export function withBlockedState(tasks: readonly PlaybookTask[]): PlaybookTaskWithGraph[] {
+  const byId = new Map(tasks.map((t) => [t.id, t] as const));
+  return tasks.map((t) => {
+    const blockedBy = (t.dependsOn ?? []).filter((depId) => byId.get(depId)?.status !== "done" && byId.has(depId));
+    return { ...t, blocked: blockedBy.length > 0, blockedBy };
+  });
 }
 
 export interface PlaybookStats {

--- a/companion/src/analysis/playbookStore.ts
+++ b/companion/src/analysis/playbookStore.ts
@@ -14,6 +14,8 @@ import {
   mergePlaybook,
   nextShortId,
   sortPlaybookTasks,
+  validateDependsOn,
+  PlaybookValidationError,
 } from "./playbook.js";
 
 // Per-case playbook store: a trackable checklist auto-derived from the case's next
@@ -44,6 +46,7 @@ export interface PlaybookTaskPatch {
   assignee?: string;
   dueDate?: string;
   notes?: string;
+  dependsOn?: string[];   // task ids that must be "done" first (issue #81); [] clears all edges
 }
 
 function normalizeStatus(s: unknown): PlaybookStatus | undefined {
@@ -100,9 +103,18 @@ export class PlaybookStore {
 
   // Patch a task's editable fields. Optional string fields (assignee/dueDate/notes) are
   // SET when a non-empty value is given and CLEARED when an explicit empty string is sent.
+  // A `dependsOn` edit is validated (unknown ids / cycles) BEFORE anything is persisted —
+  // throws PlaybookValidationError on a bad edge so the route can surface a 400.
   // Returns the updated task, or null if not found.
   async update(caseId: string, taskId: string, patch: PlaybookTaskPatch): Promise<PlaybookTask | null> {
     const tasks = await this.load(caseId);
+    if (!tasks.some((t) => t.id === taskId)) return null;
+    let dependsOn: string[] | undefined;
+    if (patch.dependsOn !== undefined) {
+      const validation = validateDependsOn(tasks, taskId, patch.dependsOn);
+      if (!validation.ok) throw new PlaybookValidationError(validation.error!);
+      dependsOn = validation.dependsOn;
+    }
     let updated: PlaybookTask | null = null;
     const next = tasks.map((t) => {
       if (t.id !== taskId) return t;
@@ -119,6 +131,10 @@ export class PlaybookStore {
         const v = String(patch[field]).trim();
         if (v) merged[field] = v;
         else delete merged[field];
+      }
+      if (dependsOn !== undefined) {
+        if (dependsOn.length) merged.dependsOn = dependsOn;
+        else delete merged.dependsOn;
       }
       updated = merged;
       return merged;

--- a/companion/src/routes/playbookHunts.ts
+++ b/companion/src/routes/playbookHunts.ts
@@ -1,7 +1,7 @@
 import type { Express, Request, Response } from "express";
 import { logActivity } from "../analysis/activityLog.js";
 import type { NewPlaybookTask, PlaybookTaskPatch } from "../analysis/playbookStore.js";
-import { PLAYBOOK_STATUSES, playbookStats, type PlaybookStatus, type PlaybookTask } from "../analysis/playbook.js";
+import { PLAYBOOK_STATUSES, playbookStats, withBlockedState, PlaybookValidationError, type PlaybookStatus, type PlaybookTask } from "../analysis/playbook.js";
 import { selectFreshHunts, pendingHuntTasks, mergePersistedHunts, EMPTY_PERSISTED_HUNTS, PLAYBOOK_HUNT_SUGGEST_MAX_DEFAULT } from "../analysis/playbookHunt.js";
 import { DEFAULT_PLAYBOOK_CONTROL } from "../analysis/playbookControl.js";
 import { buildHuntingProfile } from "../analysis/huntOutcomes.js";
@@ -111,7 +111,7 @@ export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): vo
       logActivity(options.activityLogStore, options.onActivity, req.params.id, {
         category: "settings", action: "playbook-control", detail: `IR templates ${control.useTemplates ? "enabled" : "disabled"}`,
       });
-      return res.status(200).json({ control, tasks, stats: playbookStats(tasks) });
+      return res.status(200).json({ control, tasks: withBlockedState(tasks), stats: playbookStats(tasks) });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -125,7 +125,7 @@ export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): vo
       // Persisted AI hunt suggestions, filtered to tasks that are UNCHANGED since generation (#70) —
       // so they survive a page refresh but a reworded/deleted task drops its stale hunt.
       const huntSuggestions = await loadFreshHunts(req.params.id, tasks);
-      return res.status(200).json({ tasks, stats: playbookStats(tasks), control: await loadPlaybookControl(req.params.id), huntSuggestions });
+      return res.status(200).json({ tasks: withBlockedState(tasks), stats: playbookStats(tasks), control: await loadPlaybookControl(req.params.id), huntSuggestions });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -138,7 +138,7 @@ export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): vo
     try {
       const tasks = await syncPlaybook(req.params.id);
       options.onPlaybook?.(req.params.id);
-      return res.status(200).json({ tasks, stats: playbookStats(tasks), control: await loadPlaybookControl(req.params.id) });
+      return res.status(200).json({ tasks: withBlockedState(tasks), stats: playbookStats(tasks), control: await loadPlaybookControl(req.params.id) });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -238,7 +238,7 @@ export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): vo
     try {
       const tasks = await options.playbookStore.reorder(req.params.id, ids);
       options.onPlaybook?.(req.params.id);
-      return res.status(200).json({ tasks, stats: playbookStats(tasks) });
+      return res.status(200).json({ tasks: withBlockedState(tasks), stats: playbookStats(tasks) });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -282,6 +282,7 @@ export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): vo
     if (typeof req.body?.assignee === "string") patch.assignee = req.body.assignee;
     if (typeof req.body?.dueDate === "string") patch.dueDate = req.body.dueDate;
     if (typeof req.body?.notes === "string") patch.notes = req.body.notes;
+    if (Array.isArray(req.body?.dependsOn)) patch.dependsOn = req.body.dependsOn.map(String);
     try {
       const updated = await options.playbookStore.update(req.params.id, req.params.taskId, patch);
       if (!updated) return res.status(404).json({ error: "playbook task not found" });
@@ -298,6 +299,7 @@ export function registerPlaybookHuntsRoutes(app: Express, ctx: RouteContext): vo
       });
       return res.status(200).json(updated);
     } catch (err) {
+      if (err instanceof PlaybookValidationError) return res.status(400).json({ error: err.message });
       return res.status(500).json({ error: (err as Error).message });
     }
   });

--- a/companion/tests/analysis/playbook.test.ts
+++ b/companion/tests/analysis/playbook.test.ts
@@ -5,6 +5,8 @@ import {
   mergePlaybook,
   playbookStats,
   sortPlaybookTasks,
+  validateDependsOn,
+  withBlockedState,
   type PlaybookTask,
 } from "../../src/analysis/playbook.js";
 
@@ -219,6 +221,96 @@ describe("playbookStats", () => {
 
   it("is 0% for an empty playbook", () => {
     expect(playbookStats([]).completionPct).toBe(0);
+  });
+});
+
+describe("dependency graph (issue #81)", () => {
+  const mk = (id: string, over: Partial<PlaybookTask> = {}): PlaybookTask => ({
+    id, title: id, description: "", status: "todo", priority: "medium", source: "custom", order: 0, createdAt: NOW, updatedAt: NOW, ...over,
+  });
+
+  describe("withBlockedState", () => {
+    it("is not blocked when it has no dependencies", () => {
+      const [t] = withBlockedState([mk("a")]);
+      expect(t).toMatchObject({ blocked: false, blockedBy: [] });
+    });
+
+    it("is blocked while a dependency is not done", () => {
+      const tasks = [mk("a"), mk("b", { dependsOn: ["a"] })];
+      const [, b] = withBlockedState(tasks);
+      expect(b).toMatchObject({ blocked: true, blockedBy: ["a"] });
+    });
+
+    it("unblocks once every dependency is done", () => {
+      const tasks = [mk("a", { status: "done" }), mk("b", { dependsOn: ["a"] })];
+      const [, b] = withBlockedState(tasks);
+      expect(b).toMatchObject({ blocked: false, blockedBy: [] });
+    });
+
+    it("a skipped dependency still blocks (analyst must revisit it)", () => {
+      const tasks = [mk("a", { status: "skipped" }), mk("b", { dependsOn: ["a"] })];
+      const [, b] = withBlockedState(tasks);
+      expect(b.blocked).toBe(true);
+    });
+
+    it("a dangling dependency (task no longer exists) never blocks", () => {
+      const [b] = withBlockedState([mk("b", { dependsOn: ["ghost"] })]);
+      expect(b).toMatchObject({ blocked: false, blockedBy: [] });
+    });
+  });
+
+  describe("validateDependsOn", () => {
+    it("accepts a valid edge to an existing task", () => {
+      const tasks = [mk("a"), mk("b")];
+      expect(validateDependsOn(tasks, "b", ["a"])).toEqual({ ok: true, dependsOn: ["a"] });
+    });
+
+    it("rejects an unknown task id", () => {
+      const r = validateDependsOn([mk("a")], "a", ["nope"]);
+      expect(r.ok).toBe(false);
+      expect(r.error).toMatch(/unknown task id/);
+    });
+
+    it("drops a self-reference as a harmless no-op rather than rejecting it", () => {
+      const tasks = [mk("a")];
+      expect(validateDependsOn(tasks, "a", ["a"])).toEqual({ ok: true, dependsOn: [] });
+    });
+
+    it("rejects a direct 2-cycle (a depends on b, b would depend on a)", () => {
+      const tasks = [mk("a", { dependsOn: ["b"] }), mk("b")];
+      const r = validateDependsOn(tasks, "b", ["a"]);
+      expect(r.ok).toBe(false);
+      expect(r.error).toMatch(/cycle/);
+    });
+
+    it("rejects an indirect cycle through a longer chain", () => {
+      const tasks = [mk("a", { dependsOn: ["b"] }), mk("b", { dependsOn: ["c"] }), mk("c")];
+      const r = validateDependsOn(tasks, "c", ["a"]);
+      expect(r.ok).toBe(false);
+    });
+
+    it("dedups repeated ids", () => {
+      const tasks = [mk("a"), mk("b")];
+      expect(validateDependsOn(tasks, "b", ["a", "a"])).toEqual({ ok: true, dependsOn: ["a"] });
+    });
+  });
+
+  describe("mergePlaybook + dependsOn", () => {
+    it("preserves dependsOn edges across a re-derive (auto-task id is a stable sourceKey)", () => {
+      const seeds = derivePlaybookTasks({ ...emptyState("c1"), nextSteps: [nextStep(), nextStep({ id: "ns2", action: "Isolate host" })] });
+      const base = mergePlaybook([], seeds, NOW).tasks.map((t) =>
+        t.id === "next_step:ns2" ? { ...t, dependsOn: ["next_step:ns1"] } : t,
+      );
+      const { tasks } = mergePlaybook(base, seeds, "2026-06-12T00:00:00.000Z");
+      expect(tasks.find((t) => t.id === "next_step:ns2")!.dependsOn).toEqual(["next_step:ns1"]);
+    });
+
+    it("does NOT prune a pristine auto-task that carries a dependency edge", () => {
+      const seeds = derivePlaybookTasks({ ...emptyState("c1"), nextSteps: [nextStep()] });
+      const base = mergePlaybook([], seeds, NOW).tasks.map((t) => ({ ...t, dependsOn: ["custom:1"] }));
+      const { tasks } = mergePlaybook(base, [], NOW);   // seed disappeared, but the task has an edge
+      expect(tasks).toHaveLength(1);
+    });
   });
 });
 

--- a/companion/tests/analysis/playbook.test.ts
+++ b/companion/tests/analysis/playbook.test.ts
@@ -257,6 +257,18 @@ describe("dependency graph (issue #81)", () => {
       const [b] = withBlockedState([mk("b", { dependsOn: ["ghost"] })]);
       expect(b).toMatchObject({ blocked: false, blockedBy: [] });
     });
+
+    it.each(["done", "skipped"] as const)(
+      "a %s task is never itself reported blocked, however unmet its dependencies are",
+      (status) => {
+        // "blocked" means "you cannot start this yet" — meaningless once the work is finished or
+        // waived. A completed task still flying a red `blocked` badge devalues the badge everywhere.
+        const tasks = [mk("a", { status: "todo" }), mk("b", { status, dependsOn: ["a"] })];
+        const [, b] = withBlockedState(tasks);
+        expect(b.blocked).toBe(false);
+        expect(b.blockedBy).toEqual(["a"]);   // still inspectable — only the flag is suppressed
+      },
+    );
   });
 
   describe("validateDependsOn", () => {

--- a/companion/tests/analysis/playbookStore.test.ts
+++ b/companion/tests/analysis/playbookStore.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { PlaybookStore } from "../../src/analysis/playbookStore.js";
+import { PlaybookValidationError } from "../../src/analysis/playbook.js";
 import { emptyState, type InvestigationState } from "../../src/analysis/stateTypes.js";
 
 function stateWith(over: Partial<InvestigationState>): InvestigationState {
@@ -102,5 +103,55 @@ describe("PlaybookStore", () => {
     const state = stateWith({ nextSteps: [{ id: "ns1", priority: "low", action: "Pull logs", rationale: "", pointer: "" }] });
     const out = await store.sync("c1", state);
     expect(out.map((t) => t.source).sort()).toEqual(["custom", "next_step"]);
+  });
+
+  describe("dependsOn (issue #81)", () => {
+    it("sets a dependency edge to an existing task", async () => {
+      const a = await store.add("c1", { title: "a" });
+      const b = await store.add("c1", { title: "b" });
+      const updated = await store.update("c1", b.id, { dependsOn: [a.id] });
+      expect(updated!.dependsOn).toEqual([a.id]);
+    });
+
+    it("clears dependencies with an empty array", async () => {
+      const a = await store.add("c1", { title: "a" });
+      const b = await store.add("c1", { title: "b" });
+      await store.update("c1", b.id, { dependsOn: [a.id] });
+      const cleared = await store.update("c1", b.id, { dependsOn: [] });
+      expect(cleared!.dependsOn).toBeUndefined();
+    });
+
+    it("rejects a dependency on an unknown task id", async () => {
+      const a = await store.add("c1", { title: "a" });
+      await expect(store.update("c1", a.id, { dependsOn: ["nope"] })).rejects.toThrow(PlaybookValidationError);
+    });
+
+    it("rejects an edge that would create a cycle", async () => {
+      const a = await store.add("c1", { title: "a" });
+      const b = await store.add("c1", { title: "b" });
+      await store.update("c1", b.id, { dependsOn: [a.id] });
+      await expect(store.update("c1", a.id, { dependsOn: [b.id] })).rejects.toThrow(/cycle/);
+      // The original edge on b is untouched by the rejected attempt.
+      expect((await store.load("c1")).find((t) => t.id === b.id)!.dependsOn).toEqual([a.id]);
+    });
+
+    it("drops a self-dependency as a no-op instead of rejecting it", async () => {
+      const a = await store.add("c1", { title: "a" });
+      const r = await store.update("c1", a.id, { dependsOn: [a.id] });
+      expect(r!.dependsOn).toBeUndefined();
+    });
+
+    it("preserves a dependency edge on an auto-derived task across sync (id-is-sourceKey invariant)", async () => {
+      const state = stateWith({
+        nextSteps: [
+          { id: "ns1", priority: "high", action: "Pull logs", rationale: "r", pointer: "host" },
+          { id: "ns2", priority: "high", action: "Isolate host", rationale: "r", pointer: "host" },
+        ],
+      });
+      await store.sync("c1", state);
+      await store.update("c1", "next_step:ns2", { dependsOn: ["next_step:ns1"] });
+      const after = await store.sync("c1", state);
+      expect(after.find((t) => t.id === "next_step:ns2")!.dependsOn).toEqual(["next_step:ns1"]);
+    });
   });
 });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4240,8 +4240,15 @@
       .pb-task.pb-done .pb-title{text-decoration:line-through}
       .pb-task.pb-skipped{opacity:.5}
       .pb-task.pb-skipped .pb-title{text-decoration:line-through;color:var(--c-7d8696)}
+      .pb-task.pb-blocked{border-left-color:var(--c-ff7b8a)}
+      .pb-blocked-badge{font-size:10px;font-weight:bold;color:var(--c-ff7b8a);background:var(--c-5a1722);border-radius:9px;padding:1px 7px;white-space:nowrap}
       .pb-row1{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
-      .pb-row2{display:flex;align-items:center;gap:8px;margin-top:6px}
+      .pb-row2{display:flex;align-items:center;gap:8px;margin-top:6px;flex-wrap:wrap}
+      .pb-deps-btn{background:var(--c-161d2b);color:var(--c-9aa4b2);border:1px solid var(--c-2a3346);border-radius:5px;cursor:pointer;font-size:11px;padding:3px 8px}
+      .pb-deps-btn:hover{color:#fff;border-color:var(--c-3a4658)}
+      .pb-deps-panel{width:100%;margin-top:6px;padding:8px;border:1px solid var(--c-2a3346);border-radius:6px;background:var(--c-161d2b);display:flex;flex-direction:column;gap:4px;max-height:160px;overflow:auto}
+      .pb-dep-opt{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--c-cdd6e3);cursor:pointer}
+      .pb-dep-opt input{cursor:pointer}
       .pb-status{background:var(--c-161d2b);color:var(--c-cdd6e3);border:1px solid var(--c-2a3346);border-radius:5px;font-size:11px;padding:2px 4px}
       .pb-title{flex:1;min-width:160px;font-size:13px;color:var(--c-e6edf3)}
       .pb-desc{font-size:11px;color:var(--c-8a94a6);margin:5px 0 0;white-space:pre-wrap}
@@ -7326,6 +7333,7 @@
     // preserved), so loading the panel always reflects the latest synthesis.
     let playbookTasks = [];
     let pbOpenOnly = false;
+    let pbDepsOpen = {};          // task id -> is its "depends on" editor panel expanded?
     let pbHuntFlat = [];          // AI-suggested Velociraptor hunts (#70), in severity order; each carries taskId
     let pbHuntCollapsed = {};     // suggestion index -> collapsed? (default false = expanded)
     const PB_STATUS = [["todo", "To do"], ["in_progress", "In progress"], ["done", "Done"], ["skipped", "Skipped"]];
@@ -7370,13 +7378,20 @@
         const src = t.source === "custom" ? "custom" : (t.source === "finding" ? "from finding" : "from next step");
         const findingLink = t.relatedFindingId ? `<a href="#" class="pb-finding-link" title="Go to findings" onclick="pbJumpFinding();return false">↳ finding</a>` : "";
         const desc = t.description ? `<div class="pb-desc">${esc(t.description)}</div>` : "";
-        return `<div class="pb-task pb-${escAttr(t.status)}" data-id="${escAttr(t.id)}" ${canDrag ? 'draggable="true"' : ""}>` +
+        const blockedByTitles = (t.blockedBy || []).map(id => {
+          const dep = playbookTasks.find(o => o.id === id);
+          return dep ? (dep.shortId || dep.title) : id;
+        });
+        const blockedBadge = t.blocked ? `<span class="pb-blocked-badge" title="Blocked by: ${escAttr(blockedByTitles.join(", "))}">⛔ blocked</span>` : "";
+        const depCount = (t.dependsOn || []).length;
+        return `<div class="pb-task pb-${escAttr(t.status)}${t.blocked ? " pb-blocked" : ""}" data-id="${escAttr(t.id)}" ${canDrag ? 'draggable="true"' : ""}>` +
           `<div class="pb-row1">` +
             `<span class="pb-drag ${canDrag ? "" : "pb-drag-off"}" title="Drag to reorder">⠿</span>` +
             (t.shortId ? `<span class="pb-shortid">${esc(t.shortId)}</span>` : "") +
             `<select class="pb-status" onchange="pbPatch('${escAttr(t.id)}',{status:this.value})">${opts}</select>` +
             `<span class="pb-pri pb-pri-${escAttr(t.priority)}">${esc(t.priority)}</span>` +
             `<span class="pb-title">${esc(t.title)}</span>` +
+            blockedBadge +
             `<span class="pb-src">${src}</span>${findingLink}` +
             `<span class="pb-move">` +
               `<button onclick="pbMove('${escAttr(t.id)}',-1)" title="Move up">▲</button>` +
@@ -7387,7 +7402,9 @@
           `<div class="pb-row2">` +
             `<input class="pb-assignee" placeholder="assignee" value="${escAttr(t.assignee || "")}" onchange="pbPatch('${escAttr(t.id)}',{assignee:this.value})" />` +
             `<input class="pb-due" type="date" value="${escAttr(t.dueDate || "")}" onchange="pbPatch('${escAttr(t.id)}',{dueDate:this.value})" title="Due date" />` +
+            `<button type="button" class="pb-deps-btn" onclick="pbToggleDeps('${escAttr(t.id)}')" title="Set which tasks must be done before this one can start">🔗 depends on${depCount ? ` (${depCount})` : ""}</button>` +
           `</div>` +
+          pbDepsPanel(t) +
           renderTaskHunts(t.id) +
         `</div>`;
       }).join("");
@@ -7429,9 +7446,38 @@
     function pbPatch(id, patch) {
       const caseId = pbCaseId(); if (!caseId) return;
       fetch(`/cases/${caseId}/playbook/${id}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify(patch) })
-        .then(r => { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+        .then(r => r.json().then(j => ({ ok: r.ok, j })))
+        .then(({ ok, j }) => { if (!ok) throw new Error(j && j.error ? j.error : "HTTP request failed"); })
         .then(() => loadPlaybook(caseId))
-        .catch(e => { const m = document.getElementById("pbMsg"); if (m) m.textContent = "failed (restart the companion server?): " + e.message; });
+        .catch(e => { const m = document.getElementById("pbMsg"); if (m) m.textContent = "failed: " + e.message; loadPlaybook(caseId); });
+    }
+
+    // The collapsible "depends on" checkbox panel for one task — lists every OTHER task so the
+    // analyst can pick which must be "done" before this one is considered ready. Empty string
+    // when collapsed. Kept minimal (native checkboxes, no fancy widget) to match the rest of the
+    // playbook panel's plain-HTML style.
+    function pbDepsPanel(t) {
+      if (!pbDepsOpen[t.id]) return "";
+      const others = playbookTasks.filter(o => o.id !== t.id);
+      if (!others.length) return `<div class="pb-deps-panel"><em style="color:var(--c-9aa4b2);font-size:11px">No other tasks yet.</em></div>`;
+      const cur = new Set(t.dependsOn || []);
+      const rows = others.map(o =>
+        `<label class="pb-dep-opt"><input type="checkbox" ${cur.has(o.id) ? "checked" : ""} onchange="pbToggleDep('${escAttr(t.id)}','${escAttr(o.id)}',this.checked)" /> ` +
+        `${o.shortId ? esc(o.shortId) + " — " : ""}${esc(o.title)}</label>`
+      ).join("");
+      return `<div class="pb-deps-panel">${rows}</div>`;
+    }
+
+    function pbToggleDeps(id) {
+      pbDepsOpen[id] = !pbDepsOpen[id];
+      renderPlaybook();
+    }
+
+    function pbToggleDep(id, depId, checked) {
+      const t = playbookTasks.find(x => x.id === id);
+      const cur = new Set((t && t.dependsOn) || []);
+      if (checked) cur.add(depId); else cur.delete(depId);
+      pbPatch(id, { dependsOn: [...cur] });
     }
 
     function pbDelete(id) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7666,9 +7666,17 @@
       renderPlaybook();
     }
 
+    // Send only dependencies that still name a LIVE task. A stale edge (the dependency's task was
+    // deleted) is retained on the server so an auto-derived task re-derived later reconnects — but it
+    // is never listed in this picker, and the server rejects any dependsOn naming an unknown id. So
+    // resending it made every toggle fail with "unknown task id(s): ..." against an id the analyst
+    // cannot see or untick, permanently freezing that task's dependencies. Filtering to live ids keeps
+    // the picker WYSIWYG: what's ticked is what gets saved, and the stale edge is pruned as a side
+    // effect of the analyst explicitly restating the list.
     function pbToggleDep(id, depId, checked) {
       const t = playbookTasks.find(x => x.id === id);
-      const cur = new Set((t && t.dependsOn) || []);
+      const live = new Set(playbookTasks.map(x => x.id));
+      const cur = new Set(((t && t.dependsOn) || []).filter(d => live.has(d)));
       if (checked) cur.add(depId); else cur.delete(depId);
       pbPatch(id, { dependsOn: [...cur] });
     }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7383,7 +7383,12 @@
           return dep ? (dep.shortId || dep.title) : id;
         });
         const blockedBadge = t.blocked ? `<span class="pb-blocked-badge" title="Blocked by: ${escAttr(blockedByTitles.join(", "))}">⛔ blocked</span>` : "";
-        const depCount = (t.dependsOn || []).length;
+        // Count only edges that still resolve to a live task. A dependency whose task was
+        // deleted stays in `dependsOn` on purpose (an auto-task's id is its stable sourceKey, so
+        // the edge reconnects if the seed re-derives), but such a ghost edge is never listed in
+        // the picker below — counting it would show "(2)" over a panel with one box ticked, and
+        // the analyst would have no way to clear the difference.
+        const depCount = (t.dependsOn || []).filter(id => playbookTasks.some(o => o.id === id)).length;
         return `<div class="pb-task pb-${escAttr(t.status)}${t.blocked ? " pb-blocked" : ""}" data-id="${escAttr(t.id)}" ${canDrag ? 'draggable="true"' : ""}>` +
           `<div class="pb-row1">` +
             `<span class="pb-drag ${canDrag ? "" : "pb-drag-off"}" title="Drag to reorder">⠿</span>` +


### PR DESCRIPTION
## Summary
- Adds optional `dependsOn: string[]` to the playbook task schema so a task can be marked blocked until other tasks are done.
- Blocked/ready state is derived on read (`withBlockedState`), never persisted.
- Edits are validated (unknown ids / cycles rejected with a 400) before persisting.
- Edges live on the depending task itself, so they survive auto-derive re-sync (id-is-sourceKey invariant).
- Dashboard playbook panel shows a blocked badge and a checkbox UI to edit dependencies.

Closes #81.

## Test plan
- [x] Unit tests added for validation, cycle detection, blocked-state derivation, and re-sync preservation
- [ ] CI test suite (could not run locally in this sandbox - no node_modules/npm access)
- [ ] Manual UI check of the new "depends on" panel in the dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)