### PR TITLE
Add per-importer health breakdown to /diagnostics

### DIFF
--- a/companion/src/analysis/diagnostics.ts
+++ b/companion/src/analysis/diagnostics.ts
@@ -6,6 +6,7 @@
 import { isLocalAiProvider } from "./anonymize.js";
 import { visionEnv } from "../config/aiEnv.js";
 import type { DiskStats, DiskWarningLevel, DiskWarnThresholds } from "./diskWarn.js";
+import type { ImporterLoadError } from "./importerStore.js";
 
 /** Human-readable byte size (binary units, 1 decimal place under 100). */
 export function formatBytes(bytes: number): string {
@@ -145,6 +146,55 @@ export function countByKind(errors: readonly AiError[]): Record<string, number> 
   return out;
 }
 
+// ── Per-importer health (#84) ───────────────────────────────────────────────────────────
+// A single per-importer breakdown consolidating the three places import health was previously
+// split across: aggregate attempts (above), per-case import-meta, and registry load-errors
+// (importerStore.ts). In-memory, per-importer-id; resets on restart like the rings above —
+// updated by dispatchImport's custom-importer branch (server.ts) after every run.
+export interface ImporterRunStat {
+  lastRunAt: string; // ISO-8601
+  lastStatus: "ok" | "error";
+  total: number;   // records found in the container (last run)
+  kept: number;     // events emitted (last run)
+  dropped: number;  // records not represented (last run)
+  lastError: string | null;
+}
+
+// One row of the diagnostics per-importer table: static registry meta + live run stats merged.
+// An importer that loaded but never ran shows null stat fields rather than being omitted — the
+// analyst should see it's registered but idle, not silently absent from the table.
+export interface ImporterHealth {
+  id: string;
+  label: string;
+  file: string;
+  priority: number;
+  lastRunAt: string | null;
+  lastStatus: "ok" | "error" | null;
+  total: number | null;
+  kept: number | null;
+  dropped: number | null;
+  lastError: string | null;
+}
+
+/** Merge custom-importer registry meta with their live run stats into the per-importer table. */
+export function summarizeImporterHealth(
+  meta: readonly { id: string; label: string; file: string; priority: number }[],
+  runStats: ReadonlyMap<string, ImporterRunStat>,
+): ImporterHealth[] {
+  return meta.map((m) => {
+    const s = runStats.get(m.id);
+    return {
+      id: m.id, label: m.label, file: m.file, priority: m.priority,
+      lastRunAt: s?.lastRunAt ?? null,
+      lastStatus: s?.lastStatus ?? null,
+      total: s?.total ?? null,
+      kept: s?.kept ?? null,
+      dropped: s?.dropped ?? null,
+      lastError: s?.lastError ?? null,
+    };
+  });
+}
+
 // ── Cases overview & on-demand size scan ────────────────────────────────────────────────
 export interface CaseSize {
   caseId: string;
@@ -213,6 +263,8 @@ export interface DiagnosticsReport {
     attempts: ImportAttemptStats;
     recentFailures: ImporterFailure[];
     customImporters: number;
+    perImporter: ImporterHealth[]; // per-custom-importer breakdown (#84)
+    loadErrors: ImporterLoadError[]; // malformed *.json specs (importerStore.loadAll), shown alongside
   };
   backups: {
     enabled: boolean;
@@ -278,6 +330,22 @@ export function buildDiagnosticsText(r: DiagnosticsReport): string {
     }
   } else {
     lines.push("  recent failures: none");
+  }
+  if (r.importers.perImporter.length) {
+    lines.push(`  per-importer health (${r.importers.perImporter.length}):`);
+    for (const p of r.importers.perImporter) {
+      const run = p.lastRunAt
+        ? `${p.lastStatus} — ${p.kept ?? 0}/${p.total ?? 0} kept, ${p.dropped ?? 0} dropped, last run ${p.lastRunAt}`
+        : "never run";
+      lines.push(`    ${p.id} (${p.label}): ${run}`);
+      if (p.lastError) lines.push(`      last error: ${p.lastError}`);
+    }
+  }
+  if (r.importers.loadErrors.length) {
+    lines.push(`  spec load errors (${r.importers.loadErrors.length}):`);
+    for (const e of r.importers.loadErrors) {
+      lines.push(`    ${e.file}: ${e.errors.map((x) => `${x.path}: ${x.message}`).join("; ")}`);
+    }
   }
   return lines.join("\n");
 }

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -78,7 +78,7 @@ import { parseCsv, chunkToCsvText } from "./csvImport.js";
 import { parseLogLines } from "./logImport.js";
 import { aggregateLogLines, type AggregateStats } from "./logAggregate.js";
 import { parseThorReport, type ThorImportOptions } from "./thorImport.js";
-import { parseSiemExport, resolveExtractedFrom, type SiemImportOptions } from "./siemImport.js";
+import { parseSiemExport, resolveExtractedFrom, type SiemImportOptions, type SiemParseResult } from "./siemImport.js";
 import { parseEvtxXml } from "./evtxXmlImport.js";
 import { parseShellHistoryFile, userFromHistoryFilename } from "./bashHistoryImport.js";
 import { parseChainsawReport, type ChainsawImportOptions } from "./chainsawImport.js";
@@ -2197,9 +2197,14 @@ export class AnalysisPipeline {
       importedAt: string;
       minSeverity?: Severity;
       onProgress?: (done: number, total: number) => void;
+      // Per-importer health (#84): fired with the raw parse stats (total/kept/dropped/format) right
+      // after parsing, BEFORE the zero-events early return, so a run that legitimately produced
+      // nothing still counts as a completed (not failed) run in the diagnostics table.
+      onParsed?: (result: SiemParseResult) => void;
     },
   ): Promise<InvestigationState> {
     const parsedRaw = opts.importer.parse(text, { minSeverity: opts.minSeverity });
+    opts.onParsed?.(parsedRaw);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
 

--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -10,7 +10,7 @@ import type { TimesketchClient } from "../integrations/timesketch/timesketchClie
 import type { EnrichmentProvider } from "../enrichment/provider.js";
 import type { ProviderHealthCache } from "../enrichment/providerHealth.js";
 import type { NsrlDb } from "../analysis/nsrlDb.js";
-import type { ImporterFailure, AiError } from "../analysis/diagnostics.js";
+import type { ImporterFailure, AiError, ImporterRunStat } from "../analysis/diagnostics.js";
 import type { Severity, InvestigationState } from "../analysis/stateTypes.js";
 import type { ToolConfig } from "../integrations/tools/toolConfig.js";
 import type { CustomTool } from "../integrations/tools/customToolStore.js";
@@ -54,6 +54,7 @@ export interface RouteContext {
   readonly appStartedAt: number;
   readonly recentImportFailures: ImporterFailure[]; // diagnostics ring, mutated in place by recordImportFailure
   readonly recentAiErrors: AiError[]; // diagnostics ring, mutated in place by recordAiError
+  readonly importerRunStats: Map<string, ImporterRunStat>; // per-custom-importer last-run health (#84), keyed by importer id, mutated in place by dispatchImport
   // The HMAC secret (persisted next to the cases root) that signs/verifies case-unlock cookies. Graduated
   // for routes/casePassword.ts's unlock route: the staying case-lock GATE (createCaseLockGate) + readUnlockState
   // use the SAME secret, so it's graduated (a stable readonly value), not recomputed per module.

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -5,7 +5,7 @@ import { isLogLevel } from "../logging/logger.js";
 import { getDiskStats, getDiskWarningLevel, diskWarnEnvThresholds } from "../analysis/diskWarn.js";
 import {
   buildAiDiagnostics, summarizeImportAttempts, countByKind, aggregateCaseSizes, buildDiagnosticsText,
-  type DiagnosticsReport, type ScannedFile,
+  summarizeImporterHealth, type DiagnosticsReport, type ScannedFile,
 } from "../analysis/diagnostics.js";
 import {
   buildPreflightReport, buildPreflightText,
@@ -240,6 +240,8 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
           attempts: summarizeImportAttempts(importTimestamps, now),
           recentFailures: recentImportFailures.slice(0, 20),
           customImporters: importerRegistry.importers.size,
+          perImporter: summarizeImporterHealth(importerRegistry.meta, ctx.importerRunStats),
+          loadErrors: importerRegistry.errors,
         },
         backups: options.backupManager
           ? await (async () => {

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -182,7 +182,7 @@ import { type NotionPushOptions } from "./integrations/notion/notionPush.js";
 import { NotionExportStore } from "./integrations/notion/notionExportStore.js";
 import { ClickUpClient } from "./integrations/clickup/clickupClient.js";
 import { ClickUpExportStore } from "./integrations/clickup/clickupExportStore.js";
-import type { ImporterFailure, AiError } from "./analysis/diagnostics.js";
+import type { ImporterFailure, AiError, ImporterRunStat } from "./analysis/diagnostics.js";
 import type { PreflightReport } from "./analysis/preflight.js";
 import { NotificationConfigStore } from "./analysis/notificationStore.js";
 import { seedDemoCase } from "./analysis/seedDemoCase.js";
@@ -597,6 +597,12 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     recentAiErrors.unshift({ at: new Date().toISOString(), caseId, phase, kind, detail: (err as Error)?.message ?? String(err) });
     if (recentAiErrors.length > DIAG_RING) recentAiErrors.length = DIAG_RING;
   }
+  // Per-importer health (#84): last run's outcome per custom (declarative) importer id. Keyed by
+  // spec.id, one entry per importer — NOT a ring, since only the latest run matters for a health view.
+  const importerRunStats = new Map<string, ImporterRunStat>();
+  function recordImporterRun(id: string, patch: Omit<ImporterRunStat, "lastRunAt">): void {
+    importerRunStats.set(id, { ...patch, lastRunAt: new Date().toISOString() });
+  }
 
   // Deep link a notification back to the case dashboard (when a public base URL is configured).
   const caseLink = (caseId: string): string | undefined =>
@@ -699,6 +705,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     appStartedAt,
     recentImportFailures,
     recentAiErrors,
+    importerRunStats,
     hasAiProvider,
     // Case-lifecycle graduations (routes/caseLifecycle.ts + routes/casePassword.ts): the unlock-cookie
     // secret, the per-case state mutex, the drop-inbox creator, the importer registry-reload + precedence
@@ -1066,7 +1073,19 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     if (!pipeline) return Promise.reject(new Error("AI pipeline not configured"));
     // A user-authored declarative importer takes the matching kind first (its id is the kind).
     const custom = importerRegistry.importers.get(kind);
-    if (custom) return pipeline.importDeclarative(caseId, text, { importer: custom, ...base });
+    if (custom) {
+      let parsed: { total: number; kept: number; dropped: number } | null = null;
+      return pipeline.importDeclarative(caseId, text, {
+        importer: custom, ...base,
+        onParsed: (r) => {
+          parsed = { total: r.total, kept: r.kept, dropped: r.dropped };
+          recordImporterRun(kind, { lastStatus: "ok", ...parsed, lastError: null });
+        },
+      }).catch((err) => {
+        recordImporterRun(kind, { lastStatus: "error", total: parsed?.total ?? 0, kept: parsed?.kept ?? 0, dropped: parsed?.dropped ?? 0, lastError: (err as Error)?.message ?? String(err) });
+        throw err;
+      });
+    }
     switch (kind) {
       case "thor": return pipeline.importThor(caseId, text, base);
       case "siem": return pipeline.importSiem(caseId, text, base);

--- a/companion/tests/analysis/diagnostics.test.ts
+++ b/companion/tests/analysis/diagnostics.test.ts
@@ -7,8 +7,10 @@ import {
   countByKind,
   aggregateCaseSizes,
   buildDiagnosticsText,
+  summarizeImporterHealth,
   type AiError,
   type DiagnosticsReport,
+  type ImporterRunStat,
 } from "../../src/analysis/diagnostics.js";
 
 describe("formatBytes", () => {
@@ -195,9 +197,41 @@ function sampleReport(): DiagnosticsReport {
         { at: "2026-06-17T00:00:00.000Z", caseId: "case-1", kind: "siem", filename: "alerts.json", error: "bad JSON" },
       ],
       customImporters: 0,
+      perImporter: [],
+      loadErrors: [],
     },
   };
 }
+
+describe("summarizeImporterHealth", () => {
+  const meta = [
+    { id: "acme-edr", label: "Acme EDR", file: "acme-edr.json", priority: 10 },
+    { id: "acme-proxy", label: "Acme Proxy", file: "acme-proxy.json", priority: 20 },
+  ];
+
+  it("shows null stat fields for an importer that loaded but never ran", () => {
+    const health = summarizeImporterHealth(meta, new Map());
+    expect(health).toEqual([
+      { id: "acme-edr", label: "Acme EDR", file: "acme-edr.json", priority: 10, lastRunAt: null, lastStatus: null, total: null, kept: null, dropped: null, lastError: null },
+      { id: "acme-proxy", label: "Acme Proxy", file: "acme-proxy.json", priority: 20, lastRunAt: null, lastStatus: null, total: null, kept: null, dropped: null, lastError: null },
+    ]);
+  });
+
+  it("merges in the live run stat for an importer that has run", () => {
+    const stat: ImporterRunStat = { lastRunAt: "2026-06-17T00:00:00.000Z", lastStatus: "ok", total: 100, kept: 40, dropped: 60, lastError: null };
+    const runStats = new Map([["acme-edr", stat]]);
+    const health = summarizeImporterHealth(meta, runStats);
+    expect(health[0]).toEqual({ id: "acme-edr", label: "Acme EDR", file: "acme-edr.json", priority: 10, ...stat });
+    expect(health[1].lastStatus).toBeNull(); // untouched importer stays "never run"
+  });
+
+  it("surfaces the last error for a failed run", () => {
+    const stat: ImporterRunStat = { lastRunAt: "2026-06-17T00:00:00.000Z", lastStatus: "error", total: 0, kept: 0, dropped: 0, lastError: "malformed record at row 3" };
+    const health = summarizeImporterHealth(meta, new Map([["acme-proxy", stat]]));
+    expect(health[1].lastStatus).toBe("error");
+    expect(health[1].lastError).toBe("malformed record at row 3");
+  });
+});
 
 describe("buildDiagnosticsText", () => {
   it("produces a human-readable, key-free blob", () => {
@@ -209,6 +243,22 @@ describe("buildDiagnosticsText", () => {
     expect(text).toContain("recent AI errors: billing=1");
     expect(text).toContain("attempts: 2 (24h) · 9 (7d) · 12 total");
     expect(text).toContain("case-1 siem alerts.json: bad JSON");
+  });
+
+  it("lists per-importer health and spec load errors when present", () => {
+    const r = sampleReport();
+    r.importers.perImporter = [
+      { id: "acme-edr", label: "Acme EDR", file: "acme-edr.json", priority: 10, lastRunAt: "2026-06-17T00:00:00.000Z", lastStatus: "ok", total: 100, kept: 40, dropped: 60, lastError: null },
+      { id: "acme-proxy", label: "Acme Proxy", file: "acme-proxy.json", priority: 20, lastRunAt: null, lastStatus: null, total: null, kept: null, dropped: null, lastError: null },
+    ];
+    r.importers.loadErrors = [
+      { file: "broken.json", errors: [{ path: "(file)", message: "not valid JSON: Unexpected token" }] },
+    ];
+    const text = buildDiagnosticsText(r);
+    expect(text).toContain("acme-edr (Acme EDR): ok — 40/100 kept, 60 dropped");
+    expect(text).toContain("acme-proxy (Acme Proxy): never run");
+    expect(text).toContain("spec load errors (1)");
+    expect(text).toContain("broken.json: (file): not valid JSON: Unexpected token");
   });
 
   it("renders the not-configured AI case", () => {

--- a/companion/tests/server/importerRoutes.test.ts
+++ b/companion/tests/server/importerRoutes.test.ts
@@ -73,4 +73,24 @@ describe("custom importer routes", () => {
     expect(r.status).toBe(200);
     expect((await request(app).get("/importers")).body.precedence).toBe("external-first");
   });
+
+  // Per-importer health (#84): a successful custom-importer run should show up in /diagnostics'
+  // per-importer breakdown with last-run age, rows parsed, and no error.
+  it("records a successful custom-importer run in /diagnostics' per-importer breakdown", async () => {
+    const { app } = await harness();
+    await request(app).post("/importers").send({ spec: EXAMPLE_IMPORTER_SPEC });
+    await request(app).post("/cases/c1/import").send({ text: MDE_CSV, filename: "advanced-hunting.csv" });
+
+    let row: { lastStatus?: string } | undefined;
+    for (let i = 0; i < 40 && row?.lastStatus == null; i++) {
+      const diag = await request(app).get("/diagnostics");
+      row = diag.body.report.importers.perImporter.find((p: { id: string }) => p.id === "mde-advanced-hunting");
+      if (row?.lastStatus == null) await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(row).toBeTruthy();
+    expect(row!.lastStatus).toBe("ok");
+    expect((row as { kept?: number }).kept).toBeGreaterThan(0);
+    expect((row as { lastRunAt?: string }).lastRunAt).toBeTruthy();
+    expect((row as { lastError?: string | null }).lastError).toBeNull();
+  });
 });

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -18723,6 +18723,38 @@
         <span style="color:#9aa4b2">${esc(label)}</span>
         <span style="text-align:right${color ? `;color:${color}` : ""}">${value}</span></div>`;
     }
+    // Per-importer health table (#84): one row per custom (declarative) importer — last-run age,
+    // success/fail, rows parsed (kept/total, dropped), last error — plus malformed-spec load errors
+    // from the registry, so all import health signals for custom importers live in one place.
+    function renderPerImporterHealth(im) {
+      const perImporter = im.perImporter || [];
+      const loadErrors = im.loadErrors || [];
+      if (!perImporter.length && !loadErrors.length) return "";
+      let html = `<div style="margin-top:10px;border-top:1px solid var(--c-2a2f3a);padding-top:8px">
+        <div style="color:#9aa4b2;margin-bottom:4px">Per-importer breakdown (${perImporter.length}):</div>`;
+      if (perImporter.length) {
+        html += `<div style="max-height:220px;overflow:auto">` + perImporter.map(p => {
+          const ok = p.lastStatus === "ok";
+          const statusColor = p.lastStatus == null ? "#7e8aa0" : ok ? "#5ad17a" : "#ff9f9f";
+          const statusText = p.lastStatus == null ? "never run" : ok ? "ok" : "failed";
+          const age = p.lastRunAt ? diagFmtAge(Date.now() - Date.parse(p.lastRunAt)) + " ago" : "—";
+          const rows = p.lastStatus != null ? `${p.kept ?? 0}/${p.total ?? 0} kept, ${p.dropped ?? 0} dropped` : "—";
+          return `<div style="border-left:2px solid ${ok ? "#2a5a3a" : p.lastStatus ? "#5a2a2a" : "#3a3f4a"};padding:2px 0 2px 8px;margin:3px 0;font-family:monospace;font-size:11.5px">
+            <span style="color:#cbd3df">${esc(p.label)}</span> <span style="color:#7e8aa0">(${esc(p.id)})</span>
+            — <span style="color:${statusColor}">${statusText}</span> · ${age} · ${rows}
+            ${p.lastError ? `<br><span style="color:#ffb0b0">${esc(p.lastError)}</span>` : ""}</div>`;
+        }).join("") + `</div>`;
+      }
+      if (loadErrors.length) {
+        html += `<div style="margin-top:6px;color:#9aa4b2">Spec load errors (${loadErrors.length}):</div>`;
+        html += `<div style="max-height:160px;overflow:auto;margin-top:3px">` + loadErrors.map(e =>
+          `<div style="border-left:2px solid #5a2a2a;padding:2px 0 2px 8px;margin:3px 0;font-family:monospace;font-size:11.5px">
+            <span style="color:#ff9f9f">${esc(e.file)}</span><br>
+            ${e.errors.map(x => `<span style="color:#ffb0b0">${esc(x.path)}: ${esc(x.message)}</span>`).join("<br>")}</div>`).join("") + `</div>`;
+      }
+      html += `</div>`;
+      return html;
+    }
     function renderDiagnostics(report, cost) {
       const d = report.disk;
       const lvlColor = DIAG_LEVEL_COLOR[d.level] || "#cbd3df";
@@ -18780,6 +18812,7 @@
       } else {
         impRows += diagRow("Recent failures", "none", "#5ad17a");
       }
+      impRows += renderPerImporterHealth(im);
       const importers = diagCard("Importer health", impRows);
       const bk = report.backups || {};
       let backupsCard = "";


### PR DESCRIPTION
Persists per-custom-importer run stats (last run, status, rows parsed/kept/dropped, last error) and surfaces a per-importer table on the /diagnostics panel, alongside malformed-spec load errors from the importer registry.

Closes #84

Generated with [Claude Code](https://claude.ai/code)