### PR TITLE
Add @mention parsing + notification dispatch for case comments

### DIFF
--- a/companion/src/analysis/comments.ts
+++ b/companion/src/analysis/comments.ts
@@ -28,8 +28,12 @@ const commentsSchema = z.array(commentSchema).catch([]);
 // appearance so the mention chips read left-to-right the way the analyst typed them.
 // The `@` must NOT be preceded by a word/handle character, so email addresses and IOCs
 // (`bob@example.com`, `user@host`) — routine in DFIR comments — don't parse as a mention of
-// their domain and fire spurious notifications. Keep this in sync with mentionHtml() in dashboard.html.
-const MENTION_RE = /(?<![A-Za-z0-9._@-])@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g;
+// their domain and fire spurious notifications.
+// `.`/`-`/`_` are only legal INSIDE the handle: a handle must start AND end alphanumeric, so
+// sentence punctuation isn't swallowed ("ping @bob." is a mention of `bob`, not `bob.`). Without
+// that, @bob. and @bob de-dup as two different people and the notification names a handle nobody
+// has. Keep this in sync with mentionHtml() in dashboard.html.
+const MENTION_RE = /(?<![A-Za-z0-9._@-])@([a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,62}[a-zA-Z0-9])?)/g;
 
 export function parseMentions(text: string): string[] {
   const seen = new Set<string>();

--- a/companion/src/analysis/comments.ts
+++ b/companion/src/analysis/comments.ts
@@ -16,11 +16,30 @@ export const commentSchema = z.object({
   targetId: z.string(),
   author: z.string(),
   text: z.string(),
+  mentions: z.array(z.string()).catch([]), // @name tokens parsed out of `text` at add-time
   createdAt: z.string(),
 });
 
 export type Comment = z.infer<typeof commentSchema>;
 const commentsSchema = z.array(commentSchema).catch([]);
+
+// Pull `@name` tokens out of comment text (letters/digits/./_/- , 1-64 chars — matches typical
+// investigator handles/usernames). Case-insensitive de-dup, first-seen casing kept, in order of
+// appearance so the mention chips read left-to-right the way the analyst typed them.
+const MENTION_RE = /@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g;
+
+export function parseMentions(text: string): string[] {
+  const seen = new Set<string>();
+  const mentions: string[] = [];
+  for (const m of String(text).matchAll(MENTION_RE)) {
+    const name = m[1];
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    mentions.push(name);
+  }
+  return mentions;
+}
 
 export interface NewComment {
   targetType: string;
@@ -52,12 +71,14 @@ export class CommentsStore {
   // Append a comment (server-assigned id + createdAt). Author/text are trimmed; author
   // falls back to "anonymous". Returns the stored comment.
   async add(caseId: string, input: NewComment): Promise<Comment> {
+    const text = String(input.text).trim();
     const comment: Comment = {
       id: randomUUID(),
       targetType: String(input.targetType).trim(),
       targetId: String(input.targetId).trim(),
       author: (input.author || "").trim() || "anonymous",
-      text: String(input.text).trim(),
+      text,
+      mentions: parseMentions(text),
       createdAt: new Date().toISOString(),
     };
     await this.save(caseId, [...(await this.load(caseId)), comment]);

--- a/companion/src/analysis/comments.ts
+++ b/companion/src/analysis/comments.ts
@@ -26,7 +26,10 @@ const commentsSchema = z.array(commentSchema).catch([]);
 // Pull `@name` tokens out of comment text (letters/digits/./_/- , 1-64 chars — matches typical
 // investigator handles/usernames). Case-insensitive de-dup, first-seen casing kept, in order of
 // appearance so the mention chips read left-to-right the way the analyst typed them.
-const MENTION_RE = /@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g;
+// The `@` must NOT be preceded by a word/handle character, so email addresses and IOCs
+// (`bob@example.com`, `user@host`) — routine in DFIR comments — don't parse as a mention of
+// their domain and fire spurious notifications. Keep this in sync with mentionHtml() in dashboard.html.
+const MENTION_RE = /(?<![A-Za-z0-9._@-])@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g;
 
 export function parseMentions(text: string): string[] {
   const seen = new Set<string>();

--- a/companion/src/analysis/notificationStore.ts
+++ b/companion/src/analysis/notificationStore.ts
@@ -38,11 +38,16 @@ const telegramSchema = z.object({
   chatId: z.string().catch(""),
 });
 
+// NOTE the asymmetry on `mention` vs defaultEvents() in notifications.ts, which is deliberate:
+// a channel created NOW defaults mention ON (the analyst sees the checkbox ticked and opts in),
+// but a channel PERSISTED WITHOUT the key predates #88, so its owner never opted in to anything.
+// Defaulting those to true would silently start pushing comment text to an already-configured
+// Slack/Telegram/email destination on upgrade — the same reason `milestone` defaults off.
 const eventsSchema = z.object({
   critical_finding: z.boolean().catch(true),
   playbook_update: z.boolean().catch(true),
   milestone: z.boolean().catch(false),
-  mention: z.boolean().catch(true),
+  mention: z.boolean().catch(false),
 });
 
 const channelSchema = z.object({
@@ -51,7 +56,7 @@ const channelSchema = z.object({
   name: z.string().catch(""),
   enabled: z.boolean().catch(false),
   minSeverity: z.enum(SEVERITIES).catch("High"),
-  events: eventsSchema.catch({ critical_finding: true, playbook_update: true, milestone: false, mention: true } as Record<NotificationEventKind, boolean>),
+  events: eventsSchema.catch({ critical_finding: true, playbook_update: true, milestone: false, mention: false } as Record<NotificationEventKind, boolean>),
   webhookUrl: z.string().optional(),
   smtp: smtpSchema.optional(),
   telegram: telegramSchema.optional(),

--- a/companion/src/analysis/notificationStore.ts
+++ b/companion/src/analysis/notificationStore.ts
@@ -42,6 +42,7 @@ const eventsSchema = z.object({
   critical_finding: z.boolean().catch(true),
   playbook_update: z.boolean().catch(true),
   milestone: z.boolean().catch(false),
+  mention: z.boolean().catch(true),
 });
 
 const channelSchema = z.object({
@@ -50,7 +51,7 @@ const channelSchema = z.object({
   name: z.string().catch(""),
   enabled: z.boolean().catch(false),
   minSeverity: z.enum(SEVERITIES).catch("High"),
-  events: eventsSchema.catch({ critical_finding: true, playbook_update: true, milestone: false } as Record<NotificationEventKind, boolean>),
+  events: eventsSchema.catch({ critical_finding: true, playbook_update: true, milestone: false, mention: true } as Record<NotificationEventKind, boolean>),
   webhookUrl: z.string().optional(),
   smtp: smtpSchema.optional(),
   telegram: telegramSchema.optional(),

--- a/companion/src/analysis/notifications.ts
+++ b/companion/src/analysis/notifications.ts
@@ -27,8 +27,9 @@ export function isWebhookChannelType(type: NotificationChannelType): boolean {
   return WEBHOOK_CHANNEL_TYPES.includes(type);
 }
 
-// The three signal classes from the issue. The kind is also the per-channel toggle key.
-export const NOTIFICATION_EVENT_KINDS = ["critical_finding", "playbook_update", "milestone"] as const;
+// The signal classes from the issue, plus `mention` (issue #88 — an @name in a case comment). The
+// kind is also the per-channel toggle key.
+export const NOTIFICATION_EVENT_KINDS = ["critical_finding", "playbook_update", "milestone", "mention"] as const;
 export type NotificationEventKind = (typeof NOTIFICATION_EVENT_KINDS)[number];
 
 export const SEVERITIES = ["Critical", "High", "Medium", "Low", "Info"] as const;
@@ -107,13 +108,13 @@ export interface NotificationChannel {
 // ── Filtering ──────────────────────────────────────────────────────────────────────────────
 
 // Does this channel want this event? Gates on: enabled, the per-kind toggle, and — for
-// severity-bearing events (findings/playbook) — the channel's minSeverity. Milestones are
-// lifecycle pings and bypass the threshold (gated only by the `milestone` toggle), so a
-// "critical-only" channel still doesn't get spammed but a milestone-opted channel always does.
+// severity-bearing events (findings/playbook) — the channel's minSeverity. Milestones and mentions
+// are not severity-ranked (a mention has no "how bad" axis), so both bypass the threshold and are
+// gated only by their own toggle.
 export function shouldNotify(channel: NotificationChannel, event: NotificationEvent): boolean {
   if (!channel.enabled) return false;
   if (!channel.events[event.kind]) return false;
-  if (event.kind === "milestone") return true;
+  if (event.kind === "milestone" || event.kind === "mention") return true;
   return SEVERITY_RANK[event.severity] >= SEVERITY_RANK[channel.minSeverity];
 }
 
@@ -195,6 +196,29 @@ export function milestoneEvent(caseId: string, title: string, lines: string[], a
   return { kind: "milestone", caseId, title, severity: "Info", lines: [...lines, `Case: ${caseId}`], at };
 }
 
+// Build a `mention` event for a comment that @mentioned one or more investigators (issue #88).
+// Severity is Info (mentions bypass the threshold — see shouldNotify), so the per-channel
+// `mention` toggle is the only gate.
+export function mentionEvent(
+  caseId: string,
+  targetType: string,
+  targetId: string,
+  author: string,
+  mentions: readonly string[],
+  text: string,
+  at: string,
+): NotificationEvent {
+  const who = mentions.map((m) => `@${m}`).join(", ");
+  return {
+    kind: "mention",
+    caseId,
+    title: `${author} mentioned ${who} in a comment`,
+    severity: "Info",
+    lines: [`On ${targetType} ${targetId}`, truncate(text, 300), `Case: ${caseId}`],
+    at,
+  };
+}
+
 // A generic test event so the analyst can verify a channel end-to-end from Settings.
 export function testEvent(at: string): NotificationEvent {
   return {
@@ -232,6 +256,7 @@ const eventsInputSchema = z
     critical_finding: z.coerce.boolean().optional(),
     playbook_update: z.coerce.boolean().optional(),
     milestone: z.coerce.boolean().optional(),
+    mention: z.coerce.boolean().optional(),
   })
   .optional();
 
@@ -271,6 +296,7 @@ const defaultEvents = (): Record<NotificationEventKind, boolean> => ({
   critical_finding: true,
   playbook_update: true,
   milestone: false,
+  mention: true,
 });
 
 // Validate + normalize a create/update payload into a full channel draft. Webhook channels require

--- a/companion/src/routes/findings.ts
+++ b/companion/src/routes/findings.ts
@@ -13,6 +13,7 @@ import { ScopeStore, type ScopeWindow } from "../analysis/scope.js";
 import { PinLimitError } from "../analysis/pinnedFindings.js";
 import { FINDING_WORKFLOW_STATUSES, type FindingWorkflowStatus } from "../analysis/findingWorkflow.js";
 import { type NotebookEntryType, NOTEBOOK_ENTRY_TYPES } from "../analysis/notebookStore.js";
+import { mentionEvent } from "../analysis/notifications.js";
 import { sanitizeRuleInput } from "../analysis/iocWhitelist.js";
 import { STARRED_LABEL } from "../analysis/superTimeline.js";
 import type { ForensicEvent, Finding } from "../analysis/stateTypes.js";
@@ -58,7 +59,7 @@ import type { RouteContext } from "./context.js";
  * floor, which belongs to the aiSynthesis domain, not analyst annotations).
  */
 export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options, resynthesizeInBackground } = ctx;
+  const { store, options, resynthesizeInBackground, dispatchNotify } = ctx;
 
   // Domain-local stateless disk-backed stores, rebuilt from ctx.store (see module header).
   const falsePositives = new FalsePositiveStore(store);
@@ -450,6 +451,12 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
         category: "collaboration", action: "comment-added", actor: comment.author,
         detail: `comment on ${targetType} ${targetId}`, targetType, targetId,
       });
+      if (comment.mentions.length) {
+        dispatchNotify(mentionEvent(
+          req.params.id, targetType, targetId, comment.author, comment.mentions, comment.text,
+          comment.createdAt,
+        ));
+      }
       return res.status(201).json(comment);
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });

--- a/companion/tests/analysis/comments.test.ts
+++ b/companion/tests/analysis/comments.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
-import { CommentsStore } from "../../src/analysis/comments.js";
+import { CommentsStore, parseMentions } from "../../src/analysis/comments.js";
 
 describe("CommentsStore", () => {
   let store: CommentsStore;
@@ -39,5 +39,22 @@ describe("CommentsStore", () => {
     expect(await store.remove("c1", c.id)).toBe(true);
     expect(await store.load("c1")).toHaveLength(0);
     expect(await store.remove("c1", "does-not-exist")).toBe(false);
+  });
+
+  it("parses @name mentions and stores them on the comment", async () => {
+    const c = await store.add("c1", {
+      targetType: "finding", targetId: "f1", author: "Bob",
+      text: "cc @alice and @Charlie-99 can you check this?",
+    });
+    expect(c.mentions).toEqual(["alice", "Charlie-99"]);
+  });
+
+  it("de-dupes mentions case-insensitively, keeping first-seen casing and order", () => {
+    expect(parseMentions("@Alice ping @alice again, @bob")).toEqual(["Alice", "bob"]);
+  });
+
+  it("returns [] mentions when the text has no @tokens", async () => {
+    const c = await store.add("c1", { targetType: "event", targetId: "e1", author: "Bob", text: "no mentions here" });
+    expect(c.mentions).toEqual([]);
   });
 });

--- a/companion/tests/analysis/comments.test.ts
+++ b/companion/tests/analysis/comments.test.ts
@@ -53,6 +53,16 @@ describe("CommentsStore", () => {
     expect(parseMentions("@Alice ping @alice again, @bob")).toEqual(["Alice", "bob"]);
   });
 
+  it("does not treat email addresses / IOCs as mentions", () => {
+    // The `@` in an email is preceded by a handle char, so it must not parse as a mention.
+    expect(parseMentions("contact bob@example.com about this")).toEqual([]);
+    expect(parseMentions("beacon to admin@evil-domain.net was seen")).toEqual([]);
+    // A real leading mention alongside an email: only the mention, never the email domain.
+    expect(parseMentions("@alice can you check bob@example.com?")).toEqual(["alice"]);
+    // Mid-word @ (e.g. within a token) is not a mention either.
+    expect(parseMentions("path/to@v2/thing")).toEqual([]);
+  });
+
   it("returns [] mentions when the text has no @tokens", async () => {
     const c = await store.add("c1", { targetType: "event", targetId: "e1", author: "Bob", text: "no mentions here" });
     expect(c.mentions).toEqual([]);

--- a/companion/tests/analysis/comments.test.ts
+++ b/companion/tests/analysis/comments.test.ts
@@ -63,6 +63,16 @@ describe("CommentsStore", () => {
     expect(parseMentions("path/to@v2/thing")).toEqual([]);
   });
 
+  it("does not swallow trailing sentence punctuation into the handle", () => {
+    // `.`/`-`/`_` are legal inside a handle but never at the end, so a mention that closes a
+    // sentence still resolves to the real handle (and de-dups against the same handle elsewhere).
+    expect(parseMentions("ping @bob.")).toEqual(["bob"]);
+    expect(parseMentions("@bob, @carol; @dave-")).toEqual(["bob", "carol", "dave"]);
+    expect(parseMentions("@bob. and @bob again")).toEqual(["bob"]);
+    // ...but interior punctuation is still part of the handle.
+    expect(parseMentions("@some-user_name.v2 ok")).toEqual(["some-user_name.v2"]);
+  });
+
   it("returns [] mentions when the text has no @tokens", async () => {
     const c = await store.add("c1", { targetType: "event", targetId: "e1", author: "Bob", text: "no mentions here" });
     expect(c.mentions).toEqual([]);

--- a/companion/tests/analysis/notifications.test.ts
+++ b/companion/tests/analysis/notifications.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -288,6 +288,23 @@ describe("NotificationConfigStore", () => {
     expect(await store.update("nope", blank)).toBeNull();
     expect(await store.remove(added.id)).toBe(true);
     expect(await store.load()).toEqual([]);
+  });
+
+  it("does not auto-opt a pre-#88 channel into mention notifications", async () => {
+    // A config written before @mentions existed has no `mention` key. Its owner never opted in,
+    // so upgrading must NOT silently start pushing comment text to their existing destination.
+    const path = join(await mkdtemp(join(tmpdir(), "dfir-notify-legacy-")), "config.json");
+    const legacy = new NotificationConfigStore(path);
+    await writeFile(path, JSON.stringify([{
+      id: "legacy-1", type: "slack", name: "SOC", enabled: true, minSeverity: "High",
+      events: { critical_finding: true, playbook_update: true, milestone: false },
+      webhookUrl: "https://hooks/legacy", createdAt: NOW, updatedAt: NOW,
+    }]), "utf8");
+    const [ch] = await legacy.load();
+    expect(ch.events.mention).toBe(false);
+    expect(ch.events.critical_finding).toBe(true); // the settings they DID choose are untouched
+    // A channel created now still defaults mentions on — that's a deliberate, visible opt-in.
+    expect(parseChannelInput({ type: "slack", webhookUrl: "https://hooks/new" }).draft!.events.mention).toBe(true);
   });
 
   it("drops malformed channels on read", async () => {

--- a/companion/tests/analysis/notifications.test.ts
+++ b/companion/tests/analysis/notifications.test.ts
@@ -7,6 +7,7 @@ import {
   findingEventsFromDiff,
   playbookTaskEvent,
   milestoneEvent,
+  mentionEvent,
   parseChannelInput,
   applyChannelPatch,
   redactChannel,
@@ -29,7 +30,7 @@ function channel(over: Partial<NotificationChannel> = {}): NotificationChannel {
     name: "Slack",
     enabled: true,
     minSeverity: "High",
-    events: { critical_finding: true, playbook_update: true, milestone: false },
+    events: { critical_finding: true, playbook_update: true, milestone: false, mention: true },
     webhookUrl: "https://hooks.slack.com/services/x",
     createdAt: NOW,
     updatedAt: NOW,
@@ -51,7 +52,7 @@ function finding(over: Partial<Finding> = {}): Finding {
 describe("shouldNotify", () => {
   it("requires enabled + the event-kind toggle", () => {
     expect(shouldNotify(channel({ enabled: false }), event())).toBe(false);
-    expect(shouldNotify(channel({ events: { critical_finding: false, playbook_update: true, milestone: false } }), event())).toBe(false);
+    expect(shouldNotify(channel({ events: { critical_finding: false, playbook_update: true, milestone: false, mention: true } }), event())).toBe(false);
     expect(shouldNotify(channel(), event())).toBe(true);
   });
 
@@ -62,10 +63,17 @@ describe("shouldNotify", () => {
   });
 
   it("milestones bypass the threshold (gated only by the toggle)", () => {
-    const ch = channel({ minSeverity: "Critical", events: { critical_finding: true, playbook_update: true, milestone: true } });
+    const ch = channel({ minSeverity: "Critical", events: { critical_finding: true, playbook_update: true, milestone: true, mention: true } });
     expect(shouldNotify(ch, event({ kind: "milestone", severity: "Info" }))).toBe(true);
-    const off = channel({ minSeverity: "Info", events: { critical_finding: true, playbook_update: true, milestone: false } });
+    const off = channel({ minSeverity: "Info", events: { critical_finding: true, playbook_update: true, milestone: false, mention: true } });
     expect(shouldNotify(off, event({ kind: "milestone", severity: "Info" }))).toBe(false);
+  });
+
+  it("mentions bypass the threshold (gated only by the toggle)", () => {
+    const ch = channel({ minSeverity: "Critical", events: { critical_finding: true, playbook_update: true, milestone: false, mention: true } });
+    expect(shouldNotify(ch, event({ kind: "mention", severity: "Info" }))).toBe(true);
+    const off = channel({ minSeverity: "Info", events: { critical_finding: true, playbook_update: true, milestone: false, mention: false } });
+    expect(shouldNotify(off, event({ kind: "mention", severity: "Info" }))).toBe(false);
   });
 });
 
@@ -121,6 +129,15 @@ describe("playbookTaskEvent / milestoneEvent", () => {
     const ev = milestoneEvent("case-1", "Investigation opened", ["Investigator: ana"], NOW);
     expect(ev.kind).toBe("milestone");
     expect(ev.severity).toBe("Info");
+    expect(ev.lines).toContain("Case: case-1");
+  });
+
+  it("mentionEvent is Info severity and names the mentioned investigators", () => {
+    const ev = mentionEvent("case-1", "finding", "f1", "Alice", ["bob", "carol"], "cc @bob @carol please check", NOW);
+    expect(ev.kind).toBe("mention");
+    expect(ev.severity).toBe("Info");
+    expect(ev.title).toBe("Alice mentioned @bob, @carol in a comment");
+    expect(ev.lines).toContain("On finding f1");
     expect(ev.lines).toContain("Case: case-1");
   });
 });

--- a/companion/tests/integrations/notify.test.ts
+++ b/companion/tests/integrations/notify.test.ts
@@ -38,7 +38,7 @@ function event(over: Partial<NotificationEvent> = {}): NotificationEvent {
 function channel(over: Partial<NotificationChannel> = {}): NotificationChannel {
   return {
     id: "c1", type: "slack", name: "SOC", enabled: true, minSeverity: "High",
-    events: { critical_finding: true, playbook_update: true, milestone: false },
+    events: { critical_finding: true, playbook_update: true, milestone: false, mention: true },
     webhookUrl: "https://hooks.slack.com/services/x", createdAt: NOW, updatedAt: NOW, ...over,
   };
 }

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -1196,7 +1196,9 @@ describe("state and report routes", () => {
     expect(post.status).toBe(201);
     expect(post.body.mentions).toEqual(["bob"]);
 
-    await new Promise((r) => setTimeout(r, 0)); // dispatchNotify is fire-and-forget
+    // dispatchNotify is fire-and-forget AND the notifier loads its channel config from disk before
+    // it fetches, so one microtask tick isn't enough — poll until the send lands (or give up).
+    for (let i = 0; i < 200 && !sent.length; i++) await new Promise((r) => setTimeout(r, 10));
     expect(sent).toEqual(["https://hooks.slack.com/services/mentions"]);
   });
 

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -14,6 +14,8 @@ import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../src/providers
 import { ReportWriter } from "../src/reports/reportWriter.js";
 import { ReportMetaStore } from "../src/reports/reportMeta.js";
 import { CommentsStore } from "../src/analysis/comments.js";
+import { NotificationConfigStore } from "../src/analysis/notificationStore.js";
+import { createNotifier } from "../src/integrations/notify/notifyDispatch.js";
 import { PlaybookStore } from "../src/analysis/playbookStore.js";
 import { PlaybookControlStore } from "../src/analysis/playbookControl.js";
 import { IocWhitelistStore } from "../src/analysis/iocWhitelistStore.js";
@@ -1175,6 +1177,27 @@ describe("state and report routes", () => {
     expect((await request(app).get("/cases/c1/comments")).body).toHaveLength(0);
 
     expect((await request(app).delete("/cases/c1/comments/nope")).status).toBe(404);
+  });
+
+  it("comments: an @mention fires one notification via a configured channel", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-comments-mention-"));
+    const store = new CaseStore(root);
+    const commentsStore = new CommentsStore(store);
+    const notificationStore = new NotificationConfigStore(join(root, "notifications", "config.json"));
+    const sent: string[] = [];
+    const fetchFn = (async (u: string) => { sent.push(String(u)); return new Response("ok", { status: 200 }); }) as typeof fetch;
+    const notifier = createNotifier({ store: notificationStore, fetchFn });
+    const app = createApp(store, { commentsStore, notificationStore, notifier });
+    await store.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    await request(app).post("/notifications").send({ type: "slack", webhookUrl: "https://hooks.slack.com/services/mentions" });
+
+    const post = await request(app).post("/cases/c1/comments")
+      .send({ targetType: "finding", targetId: "f1", author: "Alice", text: "cc @bob can you take a look?" });
+    expect(post.status).toBe(201);
+    expect(post.body.mentions).toEqual(["bob"]);
+
+    await new Promise((r) => setTimeout(r, 0)); // dispatchNotify is fire-and-forget
+    expect(sent).toEqual(["https://hooks.slack.com/services/mentions"]);
   });
 
   it("false-positive: onFalsePositive callback fires on add, batch add, and remove", async () => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5710,8 +5710,10 @@
     // inject markup), then the @token regex only ever matches already-escaped, HTML-safe text.
     function mentionHtml(text) {
       // `@` must not follow a word/handle char so emails/IOCs (bob@example.com) aren't chipped as
-      // mentions. Runs over esc()'d text; keep in sync with MENTION_RE in analysis/comments.ts.
-      return esc(text).replace(/(?<![A-Za-z0-9._@-])@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g, '<span class="mention-chip">@$1</span>');
+      // mentions, and a handle must start AND end alphanumeric so trailing sentence punctuation
+      // ("ping @bob.") stays outside the chip. Runs over esc()'d text; keep in sync with
+      // MENTION_RE in analysis/comments.ts.
+      return esc(text).replace(/(?<![A-Za-z0-9._@-])@([a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,62}[a-zA-Z0-9])?)/g, '<span class="mention-chip">@$1</span>');
     }
 
     function loadComments(caseId) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5709,7 +5709,9 @@
     // Highlight @name tokens as chips in a comment body. esc() first (so the raw text can never
     // inject markup), then the @token regex only ever matches already-escaped, HTML-safe text.
     function mentionHtml(text) {
-      return esc(text).replace(/@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g, '<span class="mention-chip">@$1</span>');
+      // `@` must not follow a word/handle char so emails/IOCs (bob@example.com) aren't chipped as
+      // mentions. Runs over esc()'d text; keep in sync with MENTION_RE in analysis/comments.ts.
+      return esc(text).replace(/(?<![A-Za-z0-9._@-])@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g, '<span class="mention-chip">@$1</span>');
     }
 
     function loadComments(caseId) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -659,6 +659,8 @@
     .comment-item { border-left: 2px solid var(--c-2a2f3a); padding: 6px 10px; margin: 8px 0; }
     .comment-item .meta { color: var(--c-9aa4b2); font-size: 11px; }
     .comment-item .body { white-space: pre-wrap; margin-top: 2px; }
+    .mention-chip { background: var(--c-11202e); color: var(--c-6aa9ff); border: 1px solid var(--c-2d4a6a);
+      border-radius: 8px; padding: 0 5px; font-weight: 600; white-space: nowrap; }
     .comment-del { background: transparent; border: 0; color: var(--c-ff7a7a); cursor: pointer; font-size: 11px; padding: 0 4px; }
     #commentText { width: 100%; box-sizing: border-box; background: var(--c-0f1115); color: var(--c-e6e6e6);
       border: 1px solid var(--c-2a2f3a); border-radius: 6px; padding: 6px; font-family: inherit; resize: vertical; }
@@ -1706,7 +1708,7 @@
     <div class="comment-modal">
       <h3 id="commentTitle">Comments</h3>
       <div id="commentList"></div>
-      <textarea id="commentText" rows="3" placeholder="Add a comment for other investigators…"></textarea>
+      <textarea id="commentText" rows="3" placeholder="Add a comment for other investigators… (@name to mention someone)"></textarea>
       <div style="margin-top:8px; display:flex; gap:8px; align-items:center;">
         <button id="commentPost">Post comment</button>
         <button id="commentClose" style="background:var(--c-2a2f3a);">Close</button>
@@ -3253,8 +3255,8 @@
            playbook updates, and investigation milestones. Global, shared across cases. -->
       <div class="stab-pane" id="stab-notifications">
         <div class="sfield-hint" style="display:block;margin-bottom:8px">
-          Push <strong>new/escalated findings</strong>, <strong>playbook updates</strong>, and <strong>investigation milestones</strong>
-          to Slack, MS Teams, Mattermost, Discord, Telegram, or email — with a per-channel severity threshold and per-event toggles. Global — shared across all cases.
+          Push <strong>new/escalated findings</strong>, <strong>playbook updates</strong>, <strong>investigation milestones</strong>, and
+          <strong>@mentions</strong> in comments to Slack, MS Teams, Mattermost, Discord, Telegram, or email — with a per-channel severity threshold and per-event toggles. Global — shared across all cases.
         </div>
         <div style="background:var(--c-211405);border:1px solid var(--c-5a4a1a);border-radius:6px;padding:6px 9px;font-size:12px;color:var(--c-ffce8a);margin-bottom:12px">
           ⚠ Notifications send case content (finding/task titles) to a third party. Off by default — each channel is opt-in. Don't enable on a sensitive case unless the destination is trusted.
@@ -3312,6 +3314,7 @@
             <label style="display:flex;align-items:center;gap:4px"><input id="ntfEvtFinding" type="checkbox" checked /> findings</label>
             <label style="display:flex;align-items:center;gap:4px"><input id="ntfEvtPlaybook" type="checkbox" checked /> playbook</label>
             <label style="display:flex;align-items:center;gap:4px"><input id="ntfEvtMilestone" type="checkbox" /> milestones</label>
+            <label style="display:flex;align-items:center;gap:4px"><input id="ntfEvtMention" type="checkbox" checked /> mentions</label>
             <label style="display:flex;align-items:center;gap:4px"><input id="ntfEnabled" type="checkbox" checked /> enabled</label>
           </div>
           <div style="display:flex;gap:8px;align-items:center">
@@ -5703,6 +5706,11 @@
         + `title="Comments — collaborate with other investigators">${ICON_COMMENT}${list.length ? " " + list.length : ""}</button>`;
     }
     const investigatorName = () => (localStorage.getItem("dfir.investigator") || "").trim();
+    // Highlight @name tokens as chips in a comment body. esc() first (so the raw text can never
+    // inject markup), then the @token regex only ever matches already-escaped, HTML-safe text.
+    function mentionHtml(text) {
+      return esc(text).replace(/@([a-zA-Z0-9][a-zA-Z0-9._-]{0,63})/g, '<span class="mention-chip">@$1</span>');
+    }
 
     function loadComments(caseId) {
       fetch(`/cases/${caseId}/comments`).then(r => r.json()).then(list => {
@@ -5737,7 +5745,7 @@
       document.getElementById("commentList").innerHTML = list.length
         ? list.map(c => `<div class="comment-item"><div class="meta"><strong style="color:var(--c-cbd3df)">${esc(c.author)}</strong> · `
             + `${esc(new Date(c.createdAt).toLocaleString())} <button class="comment-del" data-id="${escAttr(c.id)}" title="Delete">✕</button></div>`
-            + `<div class="body">${esc(c.text)}</div></div>`).join("")
+            + `<div class="body">${mentionHtml(c.text)}</div></div>`).join("")
         : "<div style='color:var(--c-9aa4b2);font-size:12px'>No comments yet.</div>";
       document.getElementById("commentList").querySelectorAll(".comment-del").forEach(b => b.onclick = () => deleteComment(b.getAttribute("data-id")));
     }
@@ -19033,6 +19041,7 @@
       if (ev.critical_finding) on.push("findings");
       if (ev.playbook_update) on.push("playbook");
       if (ev.milestone) on.push("milestones");
+      if (ev.mention) on.push("mentions");
       return on.length ? on.join(", ") : "nothing";
     }
     function renderNotifications(channels) {
@@ -19071,6 +19080,7 @@
           critical_finding: document.getElementById("ntfEvtFinding").checked,
           playbook_update: document.getElementById("ntfEvtPlaybook").checked,
           milestone: document.getElementById("ntfEvtMilestone").checked,
+          mention: document.getElementById("ntfEvtMention").checked,
         },
       };
       if (type === "email") {


### PR DESCRIPTION
## Summary
- Parses `@name` tokens in comment text (`comments.ts`) and stores them on the `Comment`
- Adds a new `mention` notification event kind, dispatched through the existing `integrations/notify` channel infra (Slack/Teams/Mattermost/Discord/Telegram/email)
- Renders @mentions as chips in the comment modal, plus a "mentions" per-channel toggle in Settings → Notifications

Closes #088

## Test plan
- [x] `comments.test.ts`: mention parsing/dedup
- [x] `notifications.test.ts`: `shouldNotify` + `mentionEvent`
- [x] `server.test.ts`: end-to-end — posting a comment with @bob fires a webhook POST
- [ ] CI/CD: please confirm `npm run build` and `npm test` pass (could not run locally in this sandbox)

Generated with [Claude Code](https://claude.ai/code)