### PR TITLE
fix(ci): unblock the secret scan (eval.local false positive) + record verified codex versions

### DIFF
--- a/.betterleaks-config.toml
+++ b/.betterleaks-config.toml
@@ -27,7 +27,7 @@ targetRules = ["internal-hostname"]
 regexTarget = "line"
 regexes = [
   '''(?i)[\w.-]+\.corp\b''',
-  '''(?i)\b(?:windomain|storage|adatumlab|corp|velociraptor|globaltech|northstar-branch|ai|d|companion|windmill|dc|wiz-scope|lab|dfir-companion|acme)\.local\b''',
+  '''(?i)\b(?:windomain|storage|adatumlab|corp|velociraptor|globaltech|northstar-branch|ai|d|companion|windmill|dc|wiz-scope|lab|dfir-companion|acme|eval)\.local\b''',
   '''(?i)\b(?:client01|other)\.lan\b''',
   '''(?i)\b(?:docker|m|s|hash|misp|api)\.internal\b''',
 ]

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -321,6 +321,15 @@ DFIR_VISION_IMAGE_DETAIL=high
 # DFIR_AI_SYNTH_PROVIDER=codex
 # DFIR_AI_SYNTH_MODEL=            # optional; leave blank to use the `codex` CLI's own default model
 # DFIR_AI_CODEX_BIN=              # only if `codex` isn't on PATH (absolute path to the binary)
+# VERSION: verified end-to-end against codex-cli 0.144.6 (and, earlier, 0.39.0). Those two releases
+# emit COMPLETELY different `--json` event schemas — 0.39 wraps events as {"id","msg":{...}} with the
+# answer in msg.message, 0.144 uses {"type":"item.completed","item":{...}} with the answer in
+# item.text — so the provider parses both. Treat that schema as unstable: a future codex release can
+# change it again, and the symptom is NOT a crash but a synthesis that fails with "Codex returned no
+# content" (or, worse, returns wrong text). If you upgrade codex and synthesis starts failing that
+# way, capture the new shape with:
+#   codex exec --json --skip-git-repo-check --sandbox read-only -C . "reply PONG"
+# and compare it against parseCodexOutput() in companion/src/providers/codex.ts.
 # ⚠ RAISE DFIR_AI_TIMEOUT_MS (above) when using codex — the 180000 (3 min) fallback is NOT enough.
 # Codex runs as a local agent process, not a plain completion API, so one synthesis is slow:
 # measured live on a mid-size case, a single call took 4m46s (~286s) for a 45K-char prompt. Below


### PR DESCRIPTION
Two small follow-ups to #157.

## 1. The secret scan has been red on master and every PR

The **Secret & PII Scan** required check has failed since `b355da8` on a single
finding: the `internal-hostname` rule matching `"https://eval.local/"`, a
placeholder introduced by #135. A gate that is always red trains everyone to
ignore it — the opposite of what a secret scanner is for. It also meant #157 had
to be merged with a red check.

Notably the string is **not in the working tree**. It survives only in commit
`4736261`'s patch content, and the workflow scans full history
(`betterleaks git .` with `fetch-depth: 0`), so no source edit can clear it —
only config can.

`.betterleaks-config.toml` already carries an `internal-hostname` allowlist for
exactly this class of demo/test hostname (`velociraptor.local`, `acme.local`,
`dfir-companion.local`, …). `eval` was simply missing from it, so it is added
there — rather than ignoring the file, disabling the rule, or pinning a brittle
fingerprint.

**The rule stays ON.** Verified the pattern suppresses the flagged line while a
genuinely new internal FQDN (`customerdc01.local`) is still caught, and
confirmed on CI: the scan is green on this branch.

## 2. Record which codex CLI versions the provider was verified against

`.env.example` now documents that the provider is verified end-to-end against
**codex-cli 0.144.6** and, earlier, **0.39.0** — and that those two releases emit
*completely different* `--json` event schemas, which is why the parser handles
both shapes.

The important part for whoever hits this next: a schema drift does **not** crash.
It shows up as `"Codex returned no content"` — or, worse, wrong text — so the
note includes the failure signature, the one-liner to capture the new event
shape, and where to compare it (`parseCodexOutput` in `providers/codex.ts`).

## Test plan

- [x] Secret & PII Scan green on this branch (first pass since `b355da8`)
- [x] Allowlist verified to still catch a new internal FQDN, not just blanket-ignore
- [x] Docs-only change to `.env.example`; no runtime code touched