### PR TITLE
docs(env): restructure .env.example + default to the CLI providers

### DIFF
--- a/companion/.env.example
+++ b/companion/.env.example
@@ -1,962 +1,747 @@
-# DFIR Companion environment configuration.
-# Copy this file to `.env` (same folder) and fill in values.
-# `.env` is gitignored, so your real key never gets committed.
+# DFIR Companion — environment configuration
+# Copy to `.env` in this folder and edit. `.env` is gitignored, so real keys never get committed.
+# Everything is optional except §1; commented-out lines show the built-in default.
+#
+# CONTENTS
+#   1  Core            cases root, port, host, body size
+#   2  AI providers    vision / synthesis / velociraptor-hunt / second-opinion  ← start here
+#   3  AI tuning       timeouts, token budgets, prompt overrides
+#   4  Ingest          drop folder, importers, event caps, push webhook
+#   5  Detection       deterministic tuning (no AI): gaps, beacons, timestomp, phases…
+#   6  Enrichment      threat-intel keys + rate limits
+#   7  Exposure        customer credential-leak check
+#   8  Integrations    IRIS, Timesketch, Notion, ClickUp, notifications
+#   9  Velociraptor    API, triage bundles, live monitoring
+#  10  Local tools     Hayabusa, Suricata, Snort, YARA
+#  11  Capture         screenshots, OCR, anonymization
+#  12  UI limits       mobile, presentation, pinned findings, hunt platforms
+#  13  NSRL            known-good hash sets
+#  14  Operations      logging, jobs, backups, disk, updates
 
-# Where case folders are written. Relative paths resolve against the companion/ directory.
-# Tip: prefer a path OUTSIDE a synced folder (Dropbox / OneDrive / Google Drive). The sync
-# client briefly locks files while uploading, which can collide with the atomic state save
-# (the companion retries through it, but a local path avoids the churn). Case data is local
-# and gitignored regardless.
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. CORE
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Where case folders are written. Relative paths resolve against companion/.
+# Prefer a path OUTSIDE a synced folder (Dropbox/OneDrive/GDrive) — sync clients lock files
+# mid-upload and collide with the atomic state save (it retries, but a local path avoids churn).
 DFIR_CASES_ROOT=./cases
 
-# How many times the atomic state save retries the final rename when it hits a transient Windows lock
-# (EPERM/EBUSY/EACCES from antivirus real-time scan, the search indexer, or a sync client holding
-# investigation.json open). Linear backoff capped at 1s, so the default 20 ≈ 8.4s total before it gives
-# up. Raise it if large imports still fail with "EPERM ... rename ...tmp -> investigation.json"; better
-# still, exclude the cases root from real-time scanning. Unset/0/invalid keeps the default.
-# DFIR_ATOMIC_WRITE_RETRIES=20
+# Port the server binds to (1-65535). The extension and dashboard must use the same one.
+DFIR_PORT=4773
 
-# Folder for user-authored DECLARATIVE importers (the *.json importer definitions you drop in to
-# teach the Companion a new file format without code; Settings → Importers). Default: an importers/
-# dir BESIDE the cases root. Absolute paths are used as-is; a relative path anchors to the cases-root
-# parent. Files auto-load at startup; edit + Reload (Settings → Importers) to apply without a restart.
+# Bind interface. 127.0.0.1 = localhost-only (the OPSEC default).
+# TEAM SETUP: set 0.0.0.0 so several analysts on the LAN can open
+# http://<server-ip>:<DFIR_PORT>/dashboard. Each sets their name in Settings → Investigator name;
+# imports, markers, comments and AI results sync live over WebSocket.
+# ⚠ There is NO built-in auth — keep it on a trusted segment or behind a reverse proxy (Basic/mTLS).
+# The Docker image sets 0.0.0.0; compose maps the port back to 127.0.0.1 on the host.
+DFIR_HOST=127.0.0.1
+
+# Max request body (MB). Bulk CSV/log/THOR/SIEM imports send the whole file — raise on HTTP 413.
+# Beyond a few hundred MB you approach V8's max string length; split the export instead.
+DFIR_MAX_BODY_MB=256
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. AI PROVIDERS
+# ══════════════════════════════════════════════════════════════════════════════
+# Leave DFIR_VISION_PROVIDER unset to run capture-only (no AI at all).
+#
+# FOUR INDEPENDENT ROLES — each can use a different provider/model:
+#   VISION          screenshots only. MUST be multimodal. High volume → keep it cheap.
+#   SYNTH           ALL text work: CSV extraction, log triage, synthesis, ask/explain.
+#                   Falls back to the vision model if unset.
+#   VELO            Velociraptor VQL hunt generation only (many models botch VQL).
+#   SECOND_OPINION  optional QA cross-check (§2.4).
+#
+# ⚠ Do NOT economise on SYNTH. CSV/log extraction is text reasoning, not OCR, and a weak model
+# fails SILENTLY — returning zero events rather than wrong ones. Measured (`npm run eval:real`):
+# gpt-4o-mini found ZERO of six large mega.nz transfers in a proxy log every run; gemini-2.5-pro
+# found them every time on identical input. A missed event is invisible; a bad OCR read is not.
+#
+# NAMING: screenshot config uses DFIR_VISION_*. The old DFIR_AI_PROVIDER/MODEL/KEY/BASE_URL/
+# IMAGE_DETAIL names still work as a deprecated fallback; DFIR_VISION_* wins when both are set.
+
+# ── 2.1 Vision — screenshots ──────────────────────────────────────────────────
+# openai | openrouter | ollama | litellm | gemini | anthropic | claude-code
+# (codex is text-only and cannot go here — see §2.5)
+DFIR_VISION_PROVIDER=claude-code
+DFIR_VISION_MODEL=haiku
+# Leave KEY/BASE_URL COMMENTED OUT unless you need them — claude-code authenticates via its own
+# CLI login. Do not set them to an empty value: the legacy DFIR_AI_* fallback uses `??`, so an
+# empty string still counts as "set" and would shadow an existing DFIR_AI_KEY/DFIR_AI_BASE_URL.
+# DFIR_VISION_KEY=sk-replace-me
+# DFIR_VISION_BASE_URL=
+
+# Image detail for OpenAI/OpenRouter vision models: high | low | auto.
+# "high" tiles at full resolution so small text (usernames, hostnames in Velociraptor tables)
+# reads accurately. Use "low" only to cut cost.
+DFIR_VISION_IMAGE_DETAIL=high
+
+# ── 2.2 Synthesis — all text work ─────────────────────────────────────────────
+DFIR_AI_SYNTH_PROVIDER=claude-code
+DFIR_AI_SYNTH_MODEL=claude-sonnet-5
+# DFIR_AI_SYNTH_KEY=               # falls back to the vision key when unset
+# DFIR_AI_SYNTH_BASE_URL=          # falls back to DFIR_VISION_BASE_URL when unset
+
+# ── 2.3 Velociraptor hunt model ───────────────────────────────────────────────
+# Default when unset: openrouter / anthropic/claude-haiku-4.5. Key falls back to DFIR_VISION_KEY.
+# DFIR_AI_VELO_PROVIDER=openrouter
+# DFIR_AI_VELO_MODEL=anthropic/claude-haiku-4.5
+# DFIR_AI_VELO_KEY=
+# DFIR_AI_VELO_BASE_URL=
+
+# ── 2.4 Second LLM opinion (#116) ─────────────────────────────────────────────
+# A DIFFERENT model independently re-synthesizes the case; a reconcile pass surfaces where it
+# disagrees with the primary synthesis (added/dropped findings, severity, ATT&CK) for per-item
+# accept/reject. Setting _MODEL IS the opt-in — the dashboard button is hidden without it.
+# Use a provider DIFFERENT from your synthesis model; same-provider models share blind spots.
+# Costs two extra text calls per run. Provider/key/base-url fall back to the vision config.
+DFIR_AI_SECOND_OPINION_PROVIDER=codex
+DFIR_AI_SECOND_OPINION_MODEL=gpt-5.6-sol
+# DFIR_AI_SECOND_OPINION_KEY=
+# DFIR_AI_SECOND_OPINION_BASE_URL=
+
+# ── 2.5 Provider recipes ──────────────────────────────────────────────────────
+#
+# Claude Code CLI — no API key, uses your `claude` subscription login  [DEFAULT ABOVE]
+#   Run `claude auth login` once. Handles BOTH vision and text.
+#   Models: haiku (cheap, vision-capable) · claude-sonnet-5 (best balance) · opus (deepest).
+#   Bare aliases (haiku/sonnet/opus) resolve on the CLI; a concrete id pins the exact version.
+#   Settings → AI shows a connection card (Re-check / one-click Connect).
+#   Subscription rate limits apply; cost is reported per-token even though nothing is charged.
+#   DFIR_AI_CLAUDE_CODE_BIN=       # only if `claude` isn't on PATH
+#
+# Codex CLI — no API key, uses `codex login` / OPENAI_API_KEY / CODEX_API_KEY  [2ND OPINION ABOVE]
+#   TEXT-ONLY: `codex exec` has no image input, so codex can only be the synth / velo /
+#   second-opinion provider — never DFIR_VISION_PROVIDER.
+#   Leave the model blank to use whatever the CLI itself defaults to.
+#   DFIR_AI_CODEX_BIN=             # only if `codex` isn't on PATH
+#   ⚠ SLOW: it's a local agent process, not a completion API. One synthesis measured 4m46s
+#     (~286s) on a 45K-char prompt, so the 180000 fallback times out on an ordinary case —
+#     keep DFIR_AI_TIMEOUT_MS high (§3).
+#   ⚠ VERSION: verified against codex-cli 0.144.6 and 0.39.0, which emit COMPLETELY different
+#     `--json` schemas (0.39: {"id","msg":{…}} / 0.144: {"type":"item.completed","item":{…}}).
+#     The provider parses both, but treat the schema as unstable: after a codex upgrade the
+#     symptom is NOT a crash but "Codex returned no content" (or wrong text). Capture the new
+#     shape with `codex exec --json --skip-git-repo-check --sandbox read-only -C . "reply PONG"`
+#     and compare against parseCodexOutput() in src/providers/codex.ts.
+#
+# OpenAI              vision gpt-4o-mini          · text gpt-4o (or o3 for deeper analysis)
+# Gemini              vision gemini-2.5-flash     · text gemini-2.5-pro (1M context)
+# Anthropic           vision claude-haiku-4-5-20251001 · text claude-sonnet-4-6 / claude-opus-4-8
+#                     → also raise DFIR_AI_CONTEXT_TOKENS to 200000
+# OpenRouter          e.g. text google/gemini-2.5-pro
+#
+# Ollama — fully offline, no proxy
+#   `ollama pull llama3.2-vision`, `ollama serve`, then:
+#   DFIR_VISION_PROVIDER=ollama / MODEL=llama3.2-vision / KEY= (ignored)
+#   DFIR_VISION_BASE_URL=http://localhost:11434/v1
+#   Without BASE_URL the ollama provider targets hosted Ollama Cloud, which DOES need a key.
+#
+# LiteLLM proxy — one gateway over Ollama/vLLM/100+ backends
+#   `litellm --model ollama/llama3.1` (port 4000), then PROVIDER=litellm / MODEL=ollama/llama3.1.
+#   BASE_URL defaults to http://localhost:4000/v1 — set it only to change host/port.
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. AI TUNING
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Per-request timeout (ms). This is PER CALL, not per operation: a synthesis that triggers the
+# automatic second-look re-synthesis makes two sequential calls, each with a fresh budget — so
+# size it for the SLOWEST SINGLE call. CLI providers are slow (claude-code 300-400s typical,
+# codex ~286s measured), which is why the default is generous.
+DFIR_AI_TIMEOUT_MS=800000
+
+# Max completion tokens per request. Bounds cost AND stops OpenRouter reserving the model's full
+# max output in its credit check — the usual cause of HTTP 402 on a big request despite credits.
+# Too low truncates large syntheses (the parser repairs truncation, but findings get dropped).
+DFIR_AI_MAX_TOKENS=16000
+
+# Model context window (tokens). Every prompt is budgeted to fit: the synthesis/ask timeline is
+# trimmed and CSV/log imports are split, instead of a cryptic upstream "maximum context length"
+# 400. Raise for bigger-context models — Claude 200000, Gemini 1M.
+DFIR_AI_CONTEXT_TOKENS=128000
+
+# Max forensic events sent to the synthesis prompt (most-severe first). Critical/High events
+# always produce a finding via the deterministic safety net even if omitted from the prompt.
+DFIR_AI_SYNTH_MAX_EVENTS=300
+
+# Max causal edges from the evidence-chain graph fed to "Ask the case" (GraphRAG, #98,
+# highest-severity first) so the model can trace multi-hop attack paths via real relationships.
+DFIR_ASK_GRAPH_MAX_EDGES=120
+
+# Extended thinking / chain-of-thought budget for SYNTHESIS only (#121). OFF (0) by default;
+# >=1024 to engage. Better at multi-hop attack-path reasoning, costs extra output tokens.
+# Anthropic + OpenRouter reasoning models only; others ignore it. For a one-off, prefer the
+# dashboard's "🧠 deep" checkbox (uses this value, or 8000 when unset) — no restart needed.
+# DFIR_AI_SYNTH_THINKING_TOKENS=8000
+
+# Log per-call prompt-cache read/write (Anthropic). Caching is automatic — the static system
+# prompt is the cacheable prefix; case content and screenshots are NEVER cached. A prefix under
+# the model minimum (1024 tokens; 2048 on Haiku) silently no-ops.
+# DFIR_AI_DEBUG_USAGE=1
+
+# Log-template collapsing (#10): raw log lines are grouped into counted templates before being
+# sent, so a huge log can't blow the budget. Caps distinct templates kept; a cap-hit is flagged
+# as a coverage blind spot on import.
+# DFIR_LOG_MAX_TEMPLATES=
+
+# Add a "§3.4 Synthesis coverage" footnote to the exported report (#62). The dashboard card
+# always shows read-vs-omitted counts; this only controls the report section.
+# DFIR_REPORT_SYNTH_COVERAGE=1
+
+# ── Custom prompts ────────────────────────────────────────────────────────────
+# Override any built-in prompt, in priority order:
+#   DFIR_AI_<NAME>_PROMPT       inline text (read at startup — restart to apply)
+#   DFIR_AI_<NAME>_PROMPT_FILE  file path (re-read per call — edit and it applies next analysis)
+# A missing/unreadable file logs a warning and falls back to the built-in.
+# Run `npm run prompts:eject` to write the defaults to ./prompts as a starting point.
+# DFIR_AI_SYSTEM_PROMPT_FILE=./prompts/system.txt              # per-screenshot extraction
+# DFIR_AI_CSV_PROMPT_FILE=./prompts/csv.txt
+# DFIR_AI_LOG_PROMPT_FILE=./prompts/log.txt
+# DFIR_AI_SYNTH_PROMPT_FILE=./prompts/synthesis.txt            # holistic synthesis
+# DFIR_AI_ASK_PROMPT_FILE=./prompts/ask.txt                    # case Q&A
+# DFIR_AI_EXEC_PROMPT_FILE=./prompts/exec-summary.txt          # executive summary
+# DFIR_AI_NARRATIVE_PROMPT=
+# DFIR_AI_NARRATIVE_PROMPT_FILE=./prompts/narrative.txt        # narrative timeline
+# DFIR_AI_HUNTS_PROMPT_FILE=./prompts/hunts.txt                # fleet hunts (#57)
+# DFIR_AI_PBHUNTS_PROMPT_FILE=./prompts/pbhunts.txt            # per-playbook-task hunts (#70)
+# DFIR_AI_GAPHYP_PROMPT_FILE=./prompts/gap-hypothesis.txt      # timeline-gap hypotheses (#96)
+# DFIR_AI_QUERYXLATE_PROMPT_FILE=./prompts/query-translate.txt # NL → VQL/KQL/ES|QL/SPL/Sigma/YARA
+# DFIR_AI_RECONCILE_PROMPT_FILE=./prompts/reconcile.txt        # second-opinion reconcile (#116)
+# DFIR_AI_MEMNEXT_PROMPT_FILE=./prompts/memory-next-step.txt   # next Volatility command (#101)
+# DFIR_AI_IMPORTGEN_PROMPT=
+# DFIR_AI_IMPORTGEN_PROMPT_FILE=./prompts/importgen.txt        # custom-importer authoring prompt
+# DFIR_AI_STARREDREPORT_PROMPT_FILE=./prompts/starred-report.txt
+# DFIR_AI_VIEWSUMMARY_PROMPT_FILE=./prompts/view-summary.txt
+
+# Per-feature generation caps
+# DFIR_HUNT_SUGGEST_MAX=8          # AI-suggested fleet hunts per generation
+# DFIR_HUNT_OUTCOME_MAX=50         # deployed-hunt outcomes retained per case (feedback loop)
+# DFIR_PBHUNT_SUGGEST_MAX=30       # playbook hunts per generation (one per task)
+# DFIR_PBHUNT_MAX_EVENTS=120       # timeline events fed to the playbook-hunt prompt
+# DFIR_PBHUNT_MAX_ARTIFACTS=150    # Velociraptor artifact names listed (grounds the AI in real ones)
+# DFIR_GAP_HYPOTHESIS_MAX=5        # gaps hypothesised per call (worst-first)
+# DFIR_GAP_HYPOTHESIS_CONTEXT=8    # events either side of a gap fed to the prompt
+# DFIR_MEMORY_NEXTSTEP_MAX=8       # memory-forensics next-step commands per generation
+
+# Live synthesis while capturing: re-derive findings a few seconds after each screenshot batch
+# (debounced). Each run is one synthesis call — raise the debounce or turn off to cut cost.
+DFIR_AI_AUTO_SYNTHESIZE=on
+DFIR_AI_AUTO_SYNTHESIZE_MS=8000
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. INGEST
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Evidence drop folder — each case gets drop/; anything copied in (including subfolders) is
+# auto-detected and imported in the background, then moved to drop/_processed/ or drop/_failed/.
+# Failures surface in the 📥 Drop banner and any notification channel. ON by default.
+# DFIR_DROP_ENABLED=on
+# DFIR_DROP_POLL_S=10              # sweep interval per case (clamped 2..600)
+# DFIR_DROP_MAX_BYTES=209715200    # per-file cap (200 MB); larger → use Import-from-path
+
+# Folder for user-authored DECLARATIVE importers (*.json definitions that teach the Companion a
+# new file format without code; Settings → Importers). Default: importers/ beside the cases root.
+# Relative paths anchor to the cases-root parent. Auto-loaded at startup; Reload applies edits.
 # DFIR_IMPORTERS_DIR=
 
-# --- Evidence drop folder (auto-import inbox) --------------------------------
-# Each case gets a `drop/` folder; anything copied in (subfolders included) is auto-detected and
-# imported in the background via the same chain as the Import button (images → screenshot evidence),
-# then moved to drop/_processed/ (success) or drop/_failed/ (error). Failures surface in the dashboard
-# 📥 Drop banner + any configured notification channel. ON by default.
-# DFIR_DROP_ENABLED=on            # set to "off" to disable the watcher entirely
-# DFIR_DROP_POLL_S=10             # how often (seconds) each case's drop folder is swept (clamped 2..600)
-# DFIR_DROP_MAX_BYTES=209715200   # per-file size cap (default 200 MB); larger files fail with a hint to use Import-from-path
+# Event caps per import
+# DFIR_MAX_EVENTS=2000             # ordinary SIEM/EDR JSON import (most-severe first)
+# DFIR_SUPERTIMELINE_MAX=100000    # Velociraptor super-timeline (MFT/USN/registry) — much higher
 
-# --- Background jobs (#225 — Jobs badge/popover + /api/jobs) -----------------
-# Heavy async operations (import / synthesis / enrichment) are tracked as cancellable jobs. This is
-# just the retention cap on the in-memory job list (oldest FINISHED jobs are evicted; running ones
-# never are). The registry is not persisted — in-flight jobs are lost on restart.
-# DFIR_JOBS_MAX=100
+# Import undo/redo (#76): levels kept so a flooding import can be rolled back and redone. Each
+# level is a full copy of investigation state, so depth is bounded.
+# DFIR_IMPORT_UNDO_DEPTH=10
 
-# --- External forensic tools (#211 — Settings → Tools) -----------------------
-# Run your OWN locally-installed tools against raw evidence the Companion can't parse (EVTX/PCAP/files),
-# then ingest the tool's OUTPUT through the existing importers. The Companion never downloads/bundles a
-# binary — you install + update it (repo links are in the dashboard). A tool is OFF until its _BINARY is
-# set. Each tool runs FROM its own binary directory (so tools like Hayabusa find their bundled rules/
-# config). Run/update commands execute on this machine (no shell — args are tokenized; <target>/<output>/
-# <rules> are substituted as whole argv elements). A raw file imported from the dashboard or copied into a
-# case's drop/ folder ASKS first (a confirmation banner); set _AUTO_RUN=on to run without asking. Apply
-# changes without a restart via POST /tools/reconnect (the "Reconnect" button). Master switch: DFIR_TOOL_AUTO_RUN=off.
-# Per tool (<ID> ∈ HAYABUSA | VELOCIRAPTOR_CLI | SURICATA | SNORT | YARA):
-#   DFIR_TOOL_<ID>_BINARY       # executable path (gates on/off)
-#   DFIR_TOOL_<ID>_RUN_ARGS     # args template (blank = built-in default); <target>/<output>/<rules>
-#   DFIR_TOOL_<ID>_RULES        # your rules path for <rules> (Snort/YARA; required to run those)
-#   DFIR_TOOL_<ID>_DEFINITIONS  # extra artifact-definitions path for <definitions> (Velociraptor CLI — the Sigma/Hayabusa artifacts zip)
-#   DFIR_TOOL_<ID>_UPDATE_CMD   # full "update rules" command (blank = tool default / none)
-#   DFIR_TOOL_<ID>_AUTO_RUN     # opt-in; default OFF (a raw drop/import asks first). Set "on" to run without asking
+# Cross-source correlation window (seconds). The same artifact reported by different tools is
+# merged into one corroborated event when they share a hash, OR the same path within this window.
+# 0 = require an exact-time path match (hash matching is always exact).
+DFIR_CORRELATE_WINDOW_S=2
+
+# Push ingest webhook (#84): external tools POST /cases/<id>/push with any auto-detectable
+# payload; the server runs the same import → diff → re-synthesize pipeline and returns 202.
+# Auth via X-DFIR-Key (or Authorization: Bearer). OFF until a token exists — set a global one
+# here and/or a per-case token in Settings → Integrations.
+# ⚠ Set this BEFORE exposing the port (e.g. DFIR_HOST=0.0.0.0 in a container).
+#   curl -X POST http://127.0.0.1:4773/cases/<id>/push -H "X-DFIR-Key: <token>" \
+#        -H "Content-Type: application/json" -d '{"source":"wazuh","events":[ … ]}'
+# DFIR_PUSH_TOKEN=
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. DETECTION TUNING  (all deterministic — no AI calls)
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Minimum severity to enter the FORENSIC timeline. At the default Low, Info telemetry goes to the
+# SUPER-timeline only (still analyst-promotable), which stops synthesis being swamped by thousands
+# of Info rows. Set Info to keep everything; raise to cut harder. IOCs are extracted from EVERY
+# event regardless — only timeline entry is gated, and promotion always bypasses it.
+# Applies to NEW imports only. Per-case override: state/forensic-gate.json.
+# DFIR_FORENSIC_MIN_SEVERITY=Low
+
+# Content-based event tagger (Timesketch-style). Rules in companion/data/tags.yaml tag events by
+# content (event IDs, registry paths, filenames, process lineage) and — on the forensic timeline —
+# raise severity / union MITRE. Edit in-app: Super-Timeline → 🏷 Content tagger.
+# TAGGER_AUTO=true                 # run after every import (false = manual only)
+# TAGGER_SCOPE=both                # forensic | super | both; super = tags only, never mutates severity
+# TAGGER_RULES_FILE=               # custom rule file, overrides dashboard + bundled default
+
+# Attack phases: the timeline is split into phases wherever consecutive events are more than this
+# many seconds apart. Lower for fast intrusions, raise to merge slower activity. (Report §3.2)
+DFIR_PHASE_GAP_S=300
+
+# Beacon / C2 detection: flags outbound channels whose inter-arrival intervals are too regular to
+# be human. MIN_COUNT = events before a channel is considered; MAX_JITTER_PCT = max stddev as % of
+# mean to call it a beacon (lower = only metronome-precise). A hunting lead, NOT a verdict —
+# legitimate software also polls on a timer. (Report §4.9)
+DFIR_BEACON_MIN_COUNT=5
+DFIR_BEACON_MAX_JITTER_PCT=20
+
+# Volume anomalies: bucket the timeline and flag buckets spiking above the peer/self baseline.
+# DFIR_ANOMALY_BUCKET_MINUTES=15
+# DFIR_ANOMALY_SPIKE_FACTOR=5      # × peer baseline to flag
+# DFIR_ANOMALY_SELF_FACTOR=5       # × the asset's OWN history (defaults to spike factor)
+# DFIR_ANOMALY_MIN_EVENTS=3        # floor, avoids flagging noise in sparse timelines
+
+# Log gap analysis (#83): long SILENT periods can mean cleared Event Logs, a stopped collector, or
+# deleted logs. All sources silent = High (earns a finding); one tool quiet while others log =
+# Medium. DENSITY_FACTOR suppresses normal quiet — a gap must also be ≥ this multiple of the median
+# inter-event interval (0 = use the floor only). ACTIVE_HOURS (UTC, supports wrap-around like
+# "22-6") flags only gaps overlapping working hours and SUPERSEDES the density heuristic.
+# MAX_FINDINGS caps how many escalate to findings so a super-timeline case can't flood the list.
+# (Report §3.3)
+DFIR_GAP_MIN_MINUTES=30
+DFIR_GAP_DENSITY_FACTOR=4
+DFIR_GAP_MAX_FINDINGS=5
+# DFIR_GAP_ACTIVE_HOURS=8-18
+# DFIR_GAP_OUTLIER_SPAN=5          # filters wrong-clock strays so one bad timestamp can't
+#                                  # manufacture a multi-year gap (0 = disable)
+
+# SSH brute-force success (T1110.001): an Accepted sshd login preceded by ≥ MIN_FAILS failures
+# from the SAME source IP within WINDOW_MIN minutes is graded Medium. Tune to your lockout policy.
+DFIR_SSH_BRUTEFORCE_MIN_FAILS=5
+DFIR_SSH_BRUTEFORCE_WINDOW_MIN=60
+
+# NTFS timestomp (T1070.006): MFT rows carry both $SI and $FN creation times. Flagged Medium when
+# $SI is backdated more than this many minutes before $FN, or $SI sub-second precision is zeroed
+# while $FN has it. (Default matches Timesketch.)
+DFIR_TIMESTOMP_THRESHOLD_MINUTES=10
+
+# Adversary group hints: rank ATT&CK groups by technique overlap — hypothesis fuel, NOT attribution.
+# Sub-technique aware (exact T1059.001 outweighs base-only T1059). NEXT_MAX caps the "likely next
+# techniques" list, ranked by DISTINCTIVENESS so generic tradecraft is filtered out;
+# NEXT_MAX_PREVALENCE drops anything used by more than this fraction of all groups.
+# Scored from companion/data/attack-groups.json (`npm run data:update-attack`). (Report §4.6.1)
+DFIR_ADVERSARY_MIN_OVERLAP=3
+DFIR_ADVERSARY_TOP_N=5
+DFIR_ADVERSARY_NEXT_MAX=10
+DFIR_ADVERSARY_NEXT_MAX_PREVALENCE=0.33
+
+# D3FEND countermeasures (#178) per identified technique. Offline, from
+# companion/data/d3fend-map.json (`npm run data:update-d3fend`). Caps per technique; the case-wide
+# by-tactic rollup keeps the full set.
+DFIR_D3FEND_MAX_PER_TECHNIQUE=12
+
+# ATT&CK Navigator layer export: the ATT&CK Enterprise version stamped in the exported JSON. Must
+# match your Navigator or it prompts an upgrade on every import. Override when MITRE ships newer.
+# DFIR_ATTACK_VERSION=19
+
+# Case memory (#165) — ground synthesis in what's MISSING. KNOWN_UNKNOWNS_MAX caps the bullets
+# (coverage gaps + uncovered ATT&CK phases + likely-next techniques) injected into synthesis and
+# hunt prompts (0 = drop the block). ADVERSARY_HINTS feeds candidate actors into the SYNTHESIS
+# prompt — OFF by default, because feeding model-derived attribution back into the model is a
+# confirmation-bias loop.
+DFIR_SYNTH_KNOWN_UNKNOWNS_MAX=10
+DFIR_SYNTH_ADVERSARY_HINTS=off
+
+# Learn from dismissals (#65): how many times a marker must be reasoned-dismissed before it
+# generalizes into the "PREVIOUSLY DISMISSED PATTERNS" down-weighting block fed to synthesis.
+# DFIR_LEARNED_PATTERN_MIN_COUNT=
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 6. THREAT-INTEL ENRICHMENT
+# ══════════════════════════════════════════════════════════════════════════════
+# Add a key to enable that provider; "Enrich IOCs" then annotates hashes/IPs/domains/URLs with
+# verdicts. ⚠ OPSEC: this sends indicators to third parties — enable only for IOCs you may query
+# externally. External providers are opt-in per case (default OFF).
+
+# DFIR_VT_KEY=                     # VirusTotal (hash/IP/domain/URL). Free tier ~4 lookups/min.
+# DFIR_ABUSEIPDB_KEY=              # AbuseIPDB (IP reputation)
+# DFIR_HUNTINGCH_KEY=              # abuse.ch unified hunt (hunting.abuse.ch) — one indicator across
+#                                  # every abuse.ch platform: hash → MalwareBazaar + ThreatFox +
+#                                  # URLhaus + YARAify; IP/domain/URL → ThreatFox + URLhaus.
+#                                  # Key from auth.abuse.ch. Falls back to DFIR_MB_KEY if unset.
+# DFIR_MB_KEY=                     # legacy name for the SAME abuse.ch key; still powers Hunting.ch.
+#                                  # There is no standalone MalwareBazaar source anymore.
+# DFIR_ROCKYRACCOON_KEY=           # echotrail Windows process intel — prevalence / LOLBIN / risk /
+#                                  # expected parent / ATT&CK. Free tier 500/mo, 10/min.
+
+# CrowdStrike Falcon — Threat Intelligence ONLY (no endpoint/SIEM data). Needs the Falcon
+# Intelligence subscription. Scopes: "Indicators (Falcon Intelligence): Read", "MalQuery: Read".
+# DFIR_CROWDSTRIKE_CLIENT_ID=
+# DFIR_CROWDSTRIKE_CLIENT_SECRET=
+# DFIR_CROWDSTRIKE_CLOUD=us-1      # us-1 | us-2 | eu-1 | gov-us-1 | gov-us-2
+# DFIR_CROWDSTRIKE_BASE_URL=       # explicit API base (wins over CLOUD)
+
+# Self-hosted platforms — URL + key both required. _CA points at a PEM bundle for a private CA
+# (verification stays ON); _INSECURE=1 skips verification entirely (lab only).
+# DFIR_MISP_URL=
+# DFIR_MISP_KEY=                   # enables MISP enrichment AND push
+# DFIR_MISP_CA=
+# DFIR_MISP_INSECURE=
+# DFIR_MISP_DISTRIBUTION=          # new events: 0=org (default), 1=community, 2=connected, 3=all
+# DFIR_MISP_ANALYSIS=              # new events: 0=initial, 1=ongoing (default), 2=complete
+# DFIR_YETI_URL=
+# DFIR_YETI_KEY=
+# DFIR_YETI_CA=
+# DFIR_YETI_INSECURE=
+# DFIR_OPENCTI_URL=
+# DFIR_OPENCTI_KEY=
+# DFIR_OPENCTI_CA=
+# DFIR_OPENCTI_INSECURE=
+# DFIR_OPENCTI_MALICIOUS_SCORE=    # x_opencti_score >= this → malicious verdict (default 75)
+
+# Keyless providers (still opt-in per case)
+# DFIR_HASHLOOKUP_URL=             # CIRCL hashlookup (#154) — KNOWN-FILE lookup; a hit confirms a
+#                                  # legitimate file, cutting false positives. Override for a mirror.
+# DFIR_RDAP_URL=                   # WHOIS-over-RDAP (default https://rdap.org)
+# DFIR_GEOIP_URL=                  # default https://ipinfo.io/{ip}/json; {ip} substituted else
+#                                  # appended. Also parses ip-api.com / ipwho.is shapes.
+# DFIR_GEOIP_KEY=                  # optional, for a paid/self-hosted backend
+# Shodan host lookup reuses DFIR_SHODAN_KEY from §7 — set it once, both features use it.
+
+# Lookalike / typosquat detection runs entirely on-box (no network) and is therefore LOCAL scope
+# and ON by default. Flags domains imitating a bundled brand list via homoglyph / edit-distance /
+# brand-token impersonation → `suspicious`. Add your own org domains so their typosquats catch too.
+# DFIR_LOOKALIKE_EXTRA_DOMAINS=acmecorp.com,acme-internal.net
+
+# Rate limiting. DELAY_MS is the default gap between lookups; per-provider overrides run each
+# provider at its own safe rate independently.
+# DFIR_ENRICH_DELAY_MS=1500
+# DFIR_ENRICH_MAX=100              # max IOCs per Enrich run (hashes/IPs first)
+# DFIR_ENRICH_DELAY_MS_VIRUSTOTAL=15000   # free tier ~4/min
+# DFIR_ENRICH_DELAY_MS_ROCKYRACCOON=6000  # free tier 10/min
+# DFIR_ENRICH_DELAY_MS_ABUSEIPDB=1000
+# DFIR_ENRICH_DELAY_MS_HUNTINGCH=1000
+# DFIR_ENRICH_DELAY_MS_CROWDSTRIKE=500
+# DFIR_ENRICH_DELAY_MS_MISP=200
+# DFIR_ENRICH_DELAY_MS_YETI=200
+# DFIR_ENRICH_DELAY_MS_OPENCTI=200
+# DFIR_ENRICH_DELAY_MS_REVERSE_DNS=0      # local resolver
+# DFIR_ENRICH_DELAY_MS_WHOIS=1000
+# DFIR_ENRICH_DELAY_MS_GEOIP=1000
+# DFIR_ENRICH_DELAY_MS_SHODAN=1000        # costs query credits
+
+# Reachability gate: a self-hosted MISP/YETI that's DOWN is health-probed, not blasted with one
+# doomed request per IOC. Down providers are skipped and retried; recovery auto-resumes them.
+# DFIR_ENRICH_HEALTH_TTL_MS=60000
+# DFIR_ENRICH_HEALTH_POLL_MS=60000 # 0 disables the poller
+
+# Geographic IP map (#133): plots geo-located IP IOCs. Tiles come from OpenStreetMap when the map
+# is opened — point at an internal tile server for fully on-prem operation.
+# DFIR_GEOMAP_TILE_URL=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+# DFIR_GEOMAP_MAX_MARKERS=2000
+# DFIR_GEOMAP_MAX_FLOWS=500
+# DFIR_GEOMAP_TOP_COUNTRIES=10
+# DFIR_COUNTRY_CENTROIDS_URL=      # for regenerating the offline centroid table
+#                                  # (`npm run data:update-geo`); country-only GeoIP results fall
+#                                  # back to it and are shown as approximate
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 7. CUSTOMER EXPOSURE / CREDENTIAL-LEAK CHECK
+# ══════════════════════════════════════════════════════════════════════════════
+# SEPARATE from IOC enrichment: checks the VICTIM ORG's OWN domains/emails against breach data.
+# Domain searches use only the customer domains you enter (never adversary/IOC domains); case
+# emails are checked only when their domain is one of those. Raw leaked passwords are NEVER
+# persisted — only a "credential material present" flag. Any key enables the panel; the analyst
+# then runs it explicitly. ⚠ OPSEC: sends the customer's own domains/emails to third parties.
+# DFIR_LEAKCHECK_KEY=              # LeakCheck Pro; DOMAIN search needs the Enterprise tier
+# DFIR_LEAKCHECK_DOMAIN_LIMIT=1000 # max records per domain search (LeakCheck max)
+# DFIR_HIBP_KEY=                   # Have I Been Pwned
+# DFIR_HIBP_USER_AGENT=DFIR Companion   # HIBP requires a UA; domain search needs a verified domain
+# DFIR_DEHASHED_KEY=
+# DFIR_DEHASHED_BASE_URL=          # default https://api.dehashed.com/v2
+# DFIR_SHODAN_KEY=                 # attack surface: customer DOMAIN → exposed hosts/ports/CVEs
+#                                  # (hostname: search, uses query credits). No email lookup.
+# DFIR_EXPOSURE_DELAY_MS=1500
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 8. INTEGRATIONS
+# ══════════════════════════════════════════════════════════════════════════════
+# Everywhere below: _CA = PEM bundle for a private CA (verification stays ON);
+# _INSECURE=1 = skip verification entirely (lab only).
+
+# DFIR-IRIS — push a case (assets, IOCs, timeline, summary, notes) and import back. Finds or
+# creates the IRIS case BY NAME (= the Companion case id); re-push adds what's missing and
+# refreshes. Reverse: "Import from IRIS" / `npm run iris:import -- <caseId> <irisCaseIdOrName>`.
+# URL + key both required.
+# DFIR_IRIS_URL=
+# DFIR_IRIS_KEY=                   # IRIS UI: My profile > API Key
+# DFIR_IRIS_CA=
+# DFIR_IRIS_INSECURE=
+# DFIR_IRIS_CUSTOMER_ID=1          # for NEW cases (1 = seeded IrisInitialClient)
+# DFIR_IRIS_CLASSIFICATION_ID=1
+
+# Timesketch — upload the forensic timeline; the managed timeline is clean-replaced on re-push so
+# events never duplicate. URL + user + password all required (the "Export Timesketch JSONL"
+# download works without them). Auth is Timesketch local login, not an API token.
+# DFIR_TIMESKETCH_URL=
+# DFIR_TIMESKETCH_USER=
+# DFIR_TIMESKETCH_PASSWORD=
+# DFIR_TIMESKETCH_TIMELINE=        # default "DFIR-Companion Forensic Timeline"
+# DFIR_TIMESKETCH_CA=
+# DFIR_TIMESKETCH_INSECURE=
+
+# Notion — writes ALL case content inside ONE managed toggle block it owns on the page. Re-export
+# refreshes that block and NEVER touches anything you wrote outside it. Only the token is required.
+# ⚠ Share the target page/database WITH the integration (page ⋯ > Connections), or you get 404.
+# DFIR_NOTION_TOKEN=               # Settings > Connections > develop your own
+# DFIR_NOTION_DATABASE_ID=         # default DB for "new page" exports (preferred)
+# DFIR_NOTION_PARENT_PAGE_ID=      # alternative: create the page under this parent
+# DFIR_NOTION_CONTAINER_TITLE=     # default "🔍 DFIR Companion — Auto-generated"
+# DFIR_NOTION_MAX_TIMELINE=500     # timeline rows written (full timeline stays in the report)
+# DFIR_NOTION_CA=
+# DFIR_NOTION_INSECURE=
+
+# ClickUp — push the Response Playbook (#36) as tasks with status/priority/assignee/due date.
+# Re-push UPDATES the tasks it created rather than duplicating. Token alone enables it.
+# DFIR_CLICKUP_TOKEN=              # Settings > Apps > API Token (pk_…)
+# DFIR_CLICKUP_LIST_ID=            # optional default list (from the URL's …/li/<id>)
+# DFIR_CLICKUP_CA=
+# DFIR_CLICKUP_INSECURE=
+
+# Notifications (#58) — Slack / Teams webhooks, SMTP email, Telegram, with per-channel severity
+# thresholds. NO env key enables this: channels are created in Settings → Notifications and stored
+# in notifications/config.json (starts empty). Telegram: create a bot via @BotFather, add it to the
+# chat, get the chat ID from getUpdates or @getidsbot, paste both into the UI.
+# ⚠ OPSEC: notifications send case content (finding/task titles) to a third party.
+# DFIR_PUBLIC_URL=                 # base URL for deep-links back to the case (default
+#                                  # http://<host>:<port>) — set when reached via hostname/proxy
+# DFIR_NOTIFY_CA=
+# DFIR_NOTIFY_INSECURE=
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 9. VELOCIRAPTOR
+# ══════════════════════════════════════════════════════════════════════════════
+# Run the generated hunt-pivot VQL as a HUNT across all endpoints. OFF unless _API_CONFIG is set.
+# The Companion shells out to the `velociraptor` binary with --api_config (it handles gRPC + mTLS).
+# Create the API config once:
+#   velociraptor --config server.config.yaml config api_client --name dfir \
+#     --role administrator,api api.config.yaml
+# ⚠ SECURITY: this creates artifacts and hunts — i.e. runs analyst-authored VQL on your endpoints.
+# Keep it to a trusted analyst workstation.
+# DFIR_VELOCIRAPTOR_API_CONFIG=    # path to api_client config (enables the feature)
+# DFIR_VELOCIRAPTOR_BINARY=        # default "velociraptor" on PATH; on Windows give the full .exe
+# DFIR_VELOCIRAPTOR_GUI_URL=       # e.g. https://velo:8889 — deep-links launched hunts
+# DFIR_VELOCIRAPTOR_ORG=           # org for the deep link's ?org_id= (default "root")
+# DFIR_VELOCIRAPTOR_TIMEOUT_MS=    # per-query timeout (default 60000)
+# DFIR_VELOCIRAPTOR_MAX_ROWS=      # rows returned to the dashboard (default 1000)
+# DFIR_VELOCIRAPTOR_MAX_OUTPUT=    # cap on interactive query output (default 52428800 = 50 MB)
+# DFIR_VELOCIRAPTOR_COLLECT_MAX_OUTPUT=   # cap for BUNDLE-HUNT collection incl. uploaded reports
+#                                  # (default 268435456 = 256 MB). A single artifact over this is
+#                                  # skipped and logged, not fatal — the rest still import.
+# DFIR_VELOCIRAPTOR_SPAWN_RETRIES= # retries on transient launch locks (AV/sync → "spawn EPERM")
+#
+# ⚠ "grpc: received message larger than max (X vs. 4194304)" is NOT set here and NOT a server
+# setting. It's `max_grpc_recv_size` (default 4 MB) inside the api_client.yaml that
+# DFIR_VELOCIRAPTOR_API_CONFIG points at. Add a top-level `max_grpc_recv_size: 67108864` to that
+# file — no restart needed (the CLI re-reads it per invocation). Do NOT add
+# `velociraptor query --max_message_size`; that flag does not exist and breaks every query.
+
+# Triage bundles: browse CLIENT artifacts, save named bundles (Fast/Full Triage ship by default),
+# run one as a hunt, then auto-collect + import + synthesize after a delay. A hunt stays open until
+# expiry, so results are snapshotted after the wait. Bundles live in bundles/ beside cases/; the
+# in-flight job persists per case (state/velo-hunt.json) and survives a restart.
+# DFIR_VELO_HUNT_WAIT_MIN=         # minutes before auto-collecting (default 10, clamped 1..1440)
+# DFIR_VELO_HUNT_POLL_S=           # hunt-state poll interval (default 30, clamped 5..300)
+#
+# Some bundle artifacts (offline collectors like Generic.Scanner.ThorZIP, Windows.Hayabusa.Rules)
+# put their real data in an UPLOADED file rather than result rows; those are read server-side and
+# auto-imported (json/jsonl/ndjson/csv/txt/log; HTML/binary ignored). The enumerating VQL is
+# version-sensitive — override if the default doesn't match your Velociraptor (keep the placeholders).
+# DFIR_VELOCIRAPTOR_UPLOAD_VQL=          # hunt uploads (keep __HUNT_ID__, Name/ClientId/Content)
+# DFIR_VELOCIRAPTOR_FLOW_UPLOAD_VQL=     # externally pasted single flow (keep __CLIENT_ID__/__FLOW_ID__)
+
+# Live monitoring (#84): stream a CLIENT_EVENT artifact (e.g. Windows.Events.ProcessCreation) into
+# a case as events fire. The last-seen cursor persists per monitor (state/velo-monitor.json) so a
+# restart never re-ingests. Targets one client or ALL enrolled; "auto-monitor" starts an all-clients
+# monitor for every artifact already enabled in Velociraptor's Client Monitoring table. The artifact
+# must be enabled there — the Companion only READS the stream, it never reconfigures endpoints.
+# DFIR_VELO_MONITOR_POLL_S=        # default 30 (clamped 5..3600)
+# DFIR_VELOCIRAPTOR_MONITOR_VQL=       # per-client (__CLIENT_ID__/__ARTIFACT__/__START__/__END__/__LIMIT__)
+# DFIR_VELOCIRAPTOR_MONITOR_ALL_VQL=   # all-clients (__ARTIFACT__/__START__/__END__/__LIMIT__)
+# DFIR_VELOCIRAPTOR_MONITORED_VQL=     # configured client-event artifacts (return an `artifact` column)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 10. LOCAL FORENSIC TOOLS  (#211 — Settings → Tools)
+# ══════════════════════════════════════════════════════════════════════════════
+# Run your OWN installed tools against raw evidence the Companion can't parse (EVTX/PCAP/files),
+# then ingest the tool's OUTPUT through the existing importers. Nothing is ever downloaded or
+# bundled — you install and update the binaries. A tool is OFF until its _BINARY is set, and each
+# runs FROM its own binary directory so bundled rules/config resolve. No shell is used: args are
+# tokenized and <target>/<output>/<rules>/<definitions> are substituted as whole argv elements.
+# A raw import or drop ASKS first unless _AUTO_RUN=on. Apply changes without restart via the
+# "Reconnect" button (POST /tools/reconnect).
+#
+# Per tool, <ID> ∈ HAYABUSA | VELOCIRAPTOR_CLI | SURICATA | SNORT | YARA:
+#   DFIR_TOOL_<ID>_BINARY          executable path (gates the tool on)
+#   DFIR_TOOL_<ID>_RUN_ARGS        args template (blank = built-in default)
+#   DFIR_TOOL_<ID>_RULES           rules path for <rules> (required for Snort/YARA)
+#   DFIR_TOOL_<ID>_DEFINITIONS     extra artifact definitions (Velociraptor CLI: Sigma/Hayabusa zip)
+#   DFIR_TOOL_<ID>_UPDATE_CMD      full "update rules" command (blank = tool default / none)
+#   DFIR_TOOL_<ID>_AUTO_RUN        opt-in; default OFF
 #   DFIR_TOOL_<ID>_TIMEOUT_MS=300000
 #   DFIR_TOOL_<ID>_MAX_OUTPUT=104857600
-#   DFIR_TOOL_<ID>_OUTPUT_FILE  # result filename read back for dir-output tools (Suricata eve.json, Velociraptor results.json)
-# DFIR_TOOL_AUTO_RUN             # master auto-run switch (default on, but per-tool auto-run is off unless set; "off" forces manual-only)
-# DFIR_TOOL_SPAWN_RETRIES=6      # transient spawn-launch retry count (AV/sync-client lock)
+#   DFIR_TOOL_<ID>_OUTPUT_FILE     result file for dir-output tools (Suricata eve.json, …)
+# DFIR_TOOL_AUTO_RUN               # master switch; "off" forces manual-only everywhere
+# DFIR_TOOL_SPAWN_RETRIES=6        # transient spawn-launch retries (AV/sync-client lock)
 # Examples:
 # DFIR_TOOL_HAYABUSA_BINARY=C:\tools\hayabusa\hayabusa.exe
 # DFIR_TOOL_SURICATA_BINARY=/usr/bin/suricata
 # DFIR_TOOL_YARA_BINARY=/usr/bin/yara
 # DFIR_TOOL_YARA_RULES=/opt/yara-rules/index.yar
 
-# Port the localhost server binds to (default 4773). Must be 1-65535.
-# Change this if 4773 is already in use, or to run multiple companions side-by-side.
-# The extension and dashboard must use the same port (http://127.0.0.1:<DFIR_PORT>).
-DFIR_PORT=4773
 
-# Interface the server binds to (default 127.0.0.1 — localhost-only, the OPSEC default).
-# Leave this as-is for a native run. The Docker image sets DFIR_HOST=0.0.0.0 so the
-# container's published port is reachable; docker-compose maps that port back to 127.0.0.1
-# on the HOST, so it is never exposed on your machine's network interfaces. Only set 0.0.0.0
-# yourself if you intentionally want LAN access (then put it behind your own auth/firewall).
-#
-# --- TEAM / MULTI-INVESTIGATOR SETUP -------------------------------------------
-# To share one Companion server with several analysts on the same LAN:
-#   1. Set DFIR_HOST=0.0.0.0 so the server listens on all interfaces.
-#   2. Each analyst opens http://<server-ip>:<DFIR_PORT>/dashboard in their browser.
-#   3. Each analyst sets their display name in Settings → "Investigator name" (saved
-#      locally in the browser). That name is shown on every comment and tag they add.
-#   4. Real-time updates (imports, legitimate markers, scope changes, AI analysis,
-#      comments, tags) are pushed to all connected dashboards via WebSocket instantly.
-# ⚠ There is no built-in authentication — keep the server on a trusted LAN segment
-#   or put it behind a reverse proxy with auth (e.g. nginx + Basic-Auth or mTLS).
-DFIR_HOST=127.0.0.1
+# ══════════════════════════════════════════════════════════════════════════════
+# 11. CAPTURE, OCR & ANONYMIZATION
+# ══════════════════════════════════════════════════════════════════════════════
 
-# Max request-body size in MB (default 256). Bulk evidence imports (CSV / log / THOR /
-# SIEM-EDR JSON exports) send the whole file in the body, and SIEM/EDR exports are often
-# tens to hundreds of MB — raise this if an import fails with HTTP 413 (request entity too
-# large). Localhost-only, so a large limit is safe. Files beyond a few hundred MB approach
-# V8's max string length; for those, split the export.
-DFIR_MAX_BODY_MB=256
+# Anonymization: replace sensitive victim data (internal IPs, usernames, hostnames, internal
+# domains, emails, profile paths, encoded-command blobs, SIDs) with reversible tokens and one-way
+# redact secrets BEFORE sending text to the AI; real values are restored before they reach the
+# dashboard or state. Per-case toggle ("Anon" button), default ON — set "off" so NEW cases start
+# disabled. With an EXTERNAL vision model, screenshots are OCR-redacted IN MEMORY first (local
+# Tesseract, no cloud OCR) — best-effort, and the dashboard says so. A local Ollama vision model
+# keeps screenshots on-box and skips OCR entirely. Original files on disk are never modified.
+DFIR_ANONYMIZE=on
 
-# Safety cap on events emitted by a single SIEM/EDR JSON import (default 2000, most-severe
-# first). Raise it for a full super-timeline import you want kept whole; see DFIR_SUPERTIMELINE_MAX
-# for the separate (much higher) cap used by Velociraptor super-timeline artifacts.
-# DFIR_MAX_EVENTS=2000
+# Safety-net flush (ms). Screenshots analyze in windows of 4; only a navigation or tab switch
+# flushes early. This sweep drains leftovers so a lone screenshot is still analyzed. 0 disables.
+DFIR_FLUSH_INTERVAL_MS=300000
 
-# --- AI analysis (optional). Leave DFIR_VISION_PROVIDER unset to run capture-only. ---
-#
-# NAMING: the SCREENSHOT (vision) config uses the DFIR_VISION_* prefix. The old DFIR_AI_*
-# names (DFIR_AI_PROVIDER/MODEL/KEY/BASE_URL/IMAGE_DETAIL) are still honored as a DEPRECATED
-# fallback, so an existing .env keeps working — the new DFIR_VISION_* name wins when both are
-# set. The text-work family (DFIR_AI_SYNTH_*) and the tuning vars below are unchanged.
+# Duplicate-screenshot detection: each capture is SHA-256'd and compared to the PREVIOUS one in the
+# case. Treated as duplicate ONLY when byte-identical — any difference at all (one new log row, a
+# moved cursor) is analyzed. Exact-match, never fuzzy. Duplicates are still saved as evidence, just
+# not sent to the AI. Set off to analyze every screenshot.
+# DFIR_DEDUP=on
 
-# One of: openai | openrouter | ollama | litellm | gemini | anthropic
-DFIR_VISION_PROVIDER=openai
+# Screenshot OCR full-text search (#176): each capture is OCR'd locally (Tesseract, on-box) in the
+# BACKGROUND — never blocking capture — and indexed per case, so you can search what you saw in a
+# console (a hostname, "mimikatz", a hash) and jump to the screenshot. Index lives in
+# cases/<id>/metadata/ocr.json and is never sent anywhere. Backfill: `npm run ocr-index -- <caseId>`.
+# DFIR_OCR_SEARCH=on
 
-# Model id understood by your provider. This is the SCREENSHOT model and it MUST support
-# vision. It is also the fallback for all text work (CSV/log/synthesis) when
-# DFIR_AI_SYNTH_MODEL is unset — set that one too; see the two-tier section below.
-DFIR_VISION_MODEL=gpt-4o-mini
+# OCR redaction visibility (both OFF by default). A one-line summary is ALWAYS logged when the
+# redaction pre-pass runs, so you can confirm which path executed even with these unset.
+# DFIR_OCR_DEBUG=1                 # per-screenshot: words read, count redacted, WHICH were blacked
+#                                  # out (local log only — never sent to the cloud)
+# DFIR_OCR_DEBUG_DIR=./ocr-debug   # also write each redacted copy sent to the model, to eyeball it
 
-# Your provider API key.
-DFIR_VISION_KEY=sk-replace-me
 
-# Override the provider's API base URL. Needed for a self-hosted LiteLLM proxy or any
-# OpenAI-compatible local endpoint; leave unset to use the provider's own default.
-# --- Local Ollama (no proxy — simplest fully-offline setup) -------------------------
-# Ollama serves a native OpenAI-compatible API at http://localhost:11434/v1. Pull a model
-# (`ollama pull llama3.2-vision`), make sure `ollama serve` is running, then point here:
-#   DFIR_VISION_PROVIDER=ollama
-#   DFIR_VISION_MODEL=llama3.2-vision   # screenshot EXTRACTION needs a VISION model
-#   DFIR_VISION_KEY=                    # Ollama ignores the key — leave blank
-#   DFIR_VISION_BASE_URL=http://localhost:11434/v1
-# Without DFIR_VISION_BASE_URL the ollama provider targets the hosted Ollama Cloud
-# (https://ollama.com/v1) instead, which DOES need a key. A text-only local model still
-# handles CSV/log/synthesis; only per-screenshot extraction requires vision.
-# --- Local LiteLLM proxy (run your own gateway over Ollama / vLLM / 100+ backends) ---
-# Start the proxy (`litellm --model ollama/llama3.1`, default port 4000), then point here:
-#   DFIR_VISION_PROVIDER=litellm
-#   DFIR_VISION_MODEL=ollama/llama3.1   # whatever model name your proxy config exposes
-#   DFIR_VISION_KEY=                    # blank if the proxy has no master/virtual key
-# The litellm provider defaults DFIR_VISION_BASE_URL to http://localhost:4000/v1 — set this
-# only to change the host/port (e.g. a proxy on another machine). For vision extraction,
-# point DFIR_VISION_MODEL at a multimodal model; text-only models still handle CSV/log/synthesis.
-# DFIR_VISION_BASE_URL=http://localhost:4000/v1
-# --- Claude Code CLI (drives your logged-in `claude` subscription — no API key) ------
-# Run `claude auth login` once on this machine, then point here. One provider handles both
-# screenshot extraction and text synthesis via the same CLI call.
-#   DFIR_VISION_PROVIDER=claude-code
-#   DFIR_VISION_MODEL=sonnet            # alias (haiku/sonnet/opus) or a full model id
-#   DFIR_VISION_KEY=                    # unused — auth comes from the CLI's own login, leave blank
-#   DFIR_AI_CLAUDE_CODE_BIN=            # only if `claude` isn't on PATH (absolute path to the binary)
-# Dashboard: Settings → AI shows a connection status card (not-installed / not-connected /
-# connected) with Re-check + one-click Connect. Subscription rate limits apply; cost is
-# reported as if billed per-token even though nothing is actually charged per call.
+# ══════════════════════════════════════════════════════════════════════════════
+# 12. UI LIMITS
+# ══════════════════════════════════════════════════════════════════════════════
 
-# Per-request timeout in ms (default 800000 = ~13.3 min). Strong models over a large timeline
-# can take several minutes — raise this if you see "request timed out" during synthesis. This is
-# a PER-CALL budget, not a whole-operation one: a synthesis run that triggers the automatic
-# "second-look" re-synthesis sweep (investigation-guidance #11, one bounded extra AI call when new
-# events get promoted from the super-timeline) makes two sequential calls, each getting its own
-# fresh timeout — so raise this to cover your SLOWEST SINGLE call, not their combined wall-clock.
-# Measured live with claude-code on a mid-size case: a 300-400s single synthesis call is typical.
-DFIR_AI_TIMEOUT_MS=800000
-
-# Max completion tokens per request (default 16000). Bounds cost AND stops OpenRouter
-# from reserving the model's full max output in its per-request credit check — the usual
-# cause of an "HTTP 402" on a large request (e.g. THOR synthesis) when you DO have credits.
-# Too LOW truncates a big synthesis response (the parser repairs truncation, but raise this
-# if you see lots of dropped findings). Too high re-risks 402 on a low balance.
-DFIR_AI_MAX_TOKENS=16000
-
-# Anthropic only: prompt caching is on automatically — the static system prompt is marked as
-# the cacheable prefix so it's billed once and read cheaply across the many extraction calls
-# (case content/screenshots are NEVER cached). Set this to log per-call cache read/write so you
-# can confirm it fires (a prefix under the model's minimum — 1024 tokens; 2048 on Haiku —
-# silently no-ops). Off by default (extraction makes many calls). OpenAI/OpenRouter cache on
-# their own; Ollama/local don't cache.
-# DFIR_AI_DEBUG_USAGE=1
-
-# Log verbosity: debug | info | warn | error (default: info). The server tees every log line
-# to the console AND to files — a global session log (logs/session-<time>.log, beside the cases
-# root) plus a per-case log (cases/<id>/logs/session-<time>.log, the investigation audit trail);
-# a fresh file is created each time the server starts. At `debug` the log traces every AI call
-# (extraction / synthesis / ask / …), each screenshot captured, the OCR redaction pass, prompt
-# anonymization, and every enrichment lookup. Change it live (no restart) from the dashboard's
-# Settings → Logging control; this sets the startup default.
-# DFIR_LOG_LEVEL=info
-
-# Folder for the GLOBAL session log (session-<time>.log). Default: a logs/ folder beside the
-# cases root. Relative paths anchor to companion/ (like DFIR_CASES_ROOT); absolute paths are used
-# as-is. Per-case logs always live inside each case folder (cases/<id>/logs/) so the per-case
-# audit trail travels with the case — DFIR_LOG_DIR does not move those.
-# DFIR_LOG_DIR=./logs
-
-# Max forensic events sent to the synthesis prompt (default 300, most-severe first).
-# A big import (THOR, hundreds of events) is capped here so the request stays affordable
-# and within context. Lower-severity events still stay in the case; Critical/High events
-# always get a finding (deterministic safety net) even if omitted from the prompt.
-DFIR_AI_SYNTH_MAX_EVENTS=300
-
-# Synthesis coverage audit (#62): the dashboard's "last synthesized" card always shows how many
-# in-window events the AI actually read vs left out (and why). Set this truthy to ALSO add a
-# "§3.4 Synthesis coverage" footnote to the exported report (off by default — internal methodology
-# detail not every report should carry).
-# DFIR_REPORT_SYNTH_COVERAGE=1
-
-# Minimum severity an imported event needs to enter the FORENSIC timeline (default Low). The
-# Companion is a post-detection layer, so the forensic timeline should hold graded signal (source
-# verdicts + our deterministic rules), not raw telemetry. At the default `Low`, Info-severity
-# telemetry goes to the SUPER-TIMELINE only (still promotable by the analyst); Low/Medium/High/
-# Critical events populate the forensic timeline as before — this stops synthesis being swamped by
-# thousands of Info rows. Set to `Info` to keep EVERY event in the forensic timeline (the old
-# behavior); raise to `Medium`/`High`/`Critical` to cut more aggressively. IOCs are still extracted
-# from every event (Info included) — only timeline events are gated, and promoting a super event
-# always bypasses the gate. Applies to NEW imports only; existing cases are untouched. Per-case
-# override lives in state/forensic-gate.json (dashboard GET/PUT /cases/:id/forensic-gate).
-# DFIR_FORENSIC_MIN_SEVERITY=Low
-
-# Chain-of-Thought / extended thinking for the SYNTHESIS call (#121). A token budget the model may
-# spend reasoning step-by-step BEFORE writing its findings — better at multi-hop attack-path
-# reasoning on complex cases. OFF by default (0); set >=1024 to engage (a few thousand is typical;
-# it must stay below the model's max output, which the tool raises automatically to fit). Applies to
-# synthesis ONLY (extraction stays cheap). Supported on Anthropic (extended thinking) and via
-# OpenRouter's unified `reasoning` for reasoning-capable models; other providers ignore it. Costs
-# extra output tokens, so leave off unless a case needs the deeper reasoning. This is the GLOBAL
-# default (every synthesis); for a one-off (e.g. the final synthesis at the end of a case) prefer the
-# dashboard's "🧠 deep" checkbox next to AI Re-synthesize / 2nd opinion — it enables deep reasoning
-# for just that run (this budget, or 8000 when unset) with no restart.
-# DFIR_AI_SYNTH_THINKING_TOKENS=8000
-
-# GraphRAG (#98): max causal edges from the evidence-chain graph fed into the "Ask the case"
-# prompt (default 120, highest-severity first). The Ask call serializes the deterministic
-# process-spawn / file-lineage / lateral-movement / network-flow graph so the model can trace
-# multi-hop attack paths ("from the phishing email to the Domain Controller") via real
-# relationships, not just the flat timeline. Raise it for very large cross-host graphs.
-DFIR_ASK_GRAPH_MAX_EDGES=120
-
-# The model's context window, in tokens (default 128000 — the common OpenRouter ceiling).
-# The tool budgets every AI prompt to fit this: it trims the synthesis/ask timeline and
-# splits CSV/log imports into smaller batches, and the provider fails fast with a clear
-# message (or shrinks the reserved output) instead of a cryptic upstream
-# "maximum context length is N tokens" HTTP 400. RAISE it for a bigger-context model
-# (Claude 200k, Gemini 1M) so the tool sends more per call; the default only ever trims
-# genuinely huge prompts.
-DFIR_AI_CONTEXT_TOKENS=128000
-
-# Image detail for OpenAI/OpenRouter vision models: high | low | auto (default high).
-# "high" tiles screenshots at full resolution so small text (usernames, hostnames,
-# domains in Velociraptor tables) is read accurately. Use "low" only to cut cost.
-DFIR_VISION_IMAGE_DETAIL=high
-
-# --- Two-tier models (optional) ------------------------------------------------
-# The split is VISION vs TEXT:
-#
-#   DFIR_VISION_MODEL   (above) — SCREENSHOTS ONLY. Reads each screenshot batch, so it
-#                                 MUST be multimodal. High volume — keep it cheap.
-#   DFIR_AI_SYNTH_MODEL (here)  — ALL TEXT WORK: CSV extraction, log triage, synthesis,
-#                                 ask/explain. Point a strong reasoning model here.
-#                                 If unset, text work falls back to DFIR_VISION_MODEL.
-#
-# CSV/log extraction runs on the TEXT model because it is text reasoning, not OCR — and a
-# weak model fails it silently, returning NO events rather than wrong ones. Measured with
-# `npm run eval:real`: gpt-4o-mini found ZERO of six large CONNECT-to-mega.nz transfers in
-# a proxy log on every run; gemini-2.5-pro found them every time on identical input. Do not
-# economise here: a missed event is invisible, unlike a bad screenshot read.
-#
-# Recommended models by provider:
-#
-#   OpenAI  (DFIR_VISION_PROVIDER=openai)
-#     Screenshots (vision, high-volume):  gpt-4o-mini        — multimodal, accurate OCR, 3× cheaper than gpt-4o
-#     Text (CSV/log/synthesis):           gpt-4o             — strong reasoning; or o3 for deeper analysis
-#
-#   Gemini  (DFIR_VISION_PROVIDER=gemini)
-#     Screenshots (vision, high-volume):  gemini-2.5-flash   — fast, cheap, multimodal, 1M-token context
-#     Text (CSV/log/synthesis):           gemini-2.5-pro     — best reasoning + 1M context fits large timelines
-#
-#   Anthropic  (DFIR_VISION_PROVIDER=anthropic)
-#     Screenshots (vision, high-volume):  claude-haiku-4-5-20251001  — cheapest Claude with vision; set DFIR_AI_CONTEXT_TOKENS=200000
-#     Text (CSV/log/synthesis):           claude-sonnet-4-6          — best speed/reasoning balance; 200K context
-#                                         claude-opus-4-8            — deepest reasoning for complex cases
-#
-#   Claude Code CLI  (DFIR_VISION_PROVIDER=claude-code — no API key, uses your `claude` login)
-#     Screenshots (vision, high-volume):  haiku            — cheapest alias with vision
-#     Text (CSV/log/synthesis):           claude-sonnet-5  — best speed/reasoning balance (an alias
-#                                                             like "sonnet" also works — the CLI resolves
-#                                                             it — a concrete id just pins the exact
-#                                                             version instead of "whatever sonnet means
-#                                                             on this machine's CLI build today")
-#
-#   Codex CLI  (DFIR_AI_SYNTH_PROVIDER=codex — no API key, uses your `codex login` / ambient auth)
-#     Screenshots (vision):               NOT SUPPORTED — codex exec has no image input; keep
-#                                          DFIR_VISION_PROVIDER on a vision-capable provider above
-#     Text (CSV/log/synthesis):           gpt-5-codex (or whatever model your `codex` CLI defaults to;
-#                                          leave DFIR_AI_SYNTH_MODEL unset to use the CLI's own default)
-#
-# Example — OpenAI two-tier setup:
-# DFIR_VISION_MODEL=gpt-4o-mini        # screenshots (set above)
-# DFIR_AI_SYNTH_MODEL=gpt-4o           # CSV/log/synthesis (set here)
-#
-# Example — Gemini two-tier setup:
-# DFIR_VISION_MODEL=gemini-2.5-flash   # screenshots (set above)
-# DFIR_AI_SYNTH_MODEL=gemini-2.5-pro   # CSV/log/synthesis (set here)
-#
-# Example — Anthropic two-tier setup:
-# DFIR_VISION_PROVIDER=anthropic
-# DFIR_VISION_MODEL=claude-haiku-4-5-20251001  # screenshots (set above)
-# DFIR_AI_CONTEXT_TOKENS=200000            # Claude's 200K window — send more per call
-# DFIR_AI_SYNTH_PROVIDER=anthropic
-# DFIR_AI_SYNTH_MODEL=claude-sonnet-4-6    # synthesis (set here)
-#
-# DFIR_AI_SYNTH_PROVIDER=openrouter
-# DFIR_AI_SYNTH_MODEL=google/gemini-2.5-pro
-# DFIR_AI_SYNTH_KEY=
-# DFIR_AI_SYNTH_BASE_URL=         # synthesis base URL override (falls back to DFIR_VISION_BASE_URL)
-#
-# Example — Claude Code CLI two-tier setup (no API key, uses your `claude` login):
-# DFIR_VISION_PROVIDER=claude-code
-# DFIR_VISION_MODEL=haiku                  # screenshots — cheapest alias with vision (set above)
-# DFIR_AI_SYNTH_PROVIDER=claude-code
-# DFIR_AI_SYNTH_MODEL=claude-sonnet-5      # CSV/log/synthesis (set here); pins the exact version — "opus"/"sonnet"/"haiku" aliases also work
-#
-# Example — Codex CLI as the TEXT model (no API key, uses ambient `codex login` / OPENAI_API_KEY /
-# CODEX_API_KEY auth). Codex is text-only (no image input), so it can ONLY be the synth/velo/
-# second-opinion provider — DFIR_VISION_PROVIDER must stay on a vision-capable provider above:
-# DFIR_AI_SYNTH_PROVIDER=codex
-# DFIR_AI_SYNTH_MODEL=            # optional; leave blank to use the `codex` CLI's own default model
-# DFIR_AI_CODEX_BIN=              # only if `codex` isn't on PATH (absolute path to the binary)
-# VERSION: verified end-to-end against codex-cli 0.144.6 (and, earlier, 0.39.0). Those two releases
-# emit COMPLETELY different `--json` event schemas — 0.39 wraps events as {"id","msg":{...}} with the
-# answer in msg.message, 0.144 uses {"type":"item.completed","item":{...}} with the answer in
-# item.text — so the provider parses both. Treat that schema as unstable: a future codex release can
-# change it again, and the symptom is NOT a crash but a synthesis that fails with "Codex returned no
-# content" (or, worse, returns wrong text). If you upgrade codex and synthesis starts failing that
-# way, capture the new shape with:
-#   codex exec --json --skip-git-repo-check --sandbox read-only -C . "reply PONG"
-# and compare it against parseCodexOutput() in companion/src/providers/codex.ts.
-# ⚠ RAISE DFIR_AI_TIMEOUT_MS (above) when using codex — the 180000 (3 min) fallback is NOT enough.
-# Codex runs as a local agent process, not a plain completion API, so one synthesis is slow:
-# measured live on a mid-size case, a single call took 4m46s (~286s) for a 45K-char prompt. Below
-# that budget it fails with "Codex timed out after 180000ms" on an ordinary case. The 800000
-# (~13.3 min) default set above covers it. The budget is PER CALL, not per operation: a run that
-# triggers the automatic second-look re-synthesis makes two sequential calls (~10 min wall-clock),
-# each getting its own fresh timeout — so size it for the slowest SINGLE call, not their combined time.
-
-# --- Velociraptor hunt model (#70) ---------------------------------------------
-# A DEDICATED model used ONLY to generate Velociraptor VQL hunts (the "✨ Suggest
-# Velociraptor hunts" / "Suggested Fleet Hunts" features) — separate from the
-# extraction, synthesis, and OCR models. Many LLMs botch VQL; pin a known-good one here.
-# DEFAULT (when unset): provider=openrouter, model=anthropic/claude-haiku-4.5.
-# The key falls back to DFIR_VISION_KEY, so this works out of the box when your main
-# provider is openrouter. Also settable in the dashboard: Settings → AI.
-# DFIR_AI_VELO_PROVIDER=openrouter
-# DFIR_AI_VELO_MODEL=anthropic/claude-haiku-4.5
-# DFIR_AI_VELO_KEY=               # falls back to DFIR_VISION_KEY when blank
-# DFIR_AI_VELO_BASE_URL=          # falls back to DFIR_VISION_BASE_URL when blank
-
-# --- Second LLM opinion (#116) -------------------------------------------------
-# An on-demand QA cross-check: a DIFFERENT model independently re-synthesizes the case,
-# then a reconcile pass surfaces where it disagrees with the primary synthesis (findings it
-# adds/drops, severity, ATT&CK technique) for per-item analyst accept/reject. DISABLED until
-# DFIR_AI_SECOND_OPINION_MODEL is set (that var IS the opt-in; the dashboard "2nd opinion"
-# button stays hidden otherwise). Pick a model from a DIFFERENT provider than your synthesis
-# model so the opinion is genuinely independent — same-provider models share blind spots. The
-# provider/key/base-url fall back to the vision config (DFIR_VISION_*) so it works on one account.
-# Two text-only AI calls per run; same caching + anonymization invariants as synthesis.
-# DFIR_AI_SECOND_OPINION_MODEL=gpt-4o            # e.g. primary synth = Anthropic, second opinion = OpenAI
-# DFIR_AI_SECOND_OPINION_PROVIDER=openai         # falls back to DFIR_VISION_PROVIDER when blank
-# DFIR_AI_SECOND_OPINION_KEY=                    # falls back to DFIR_VISION_KEY when blank
-# DFIR_AI_SECOND_OPINION_BASE_URL=               # falls back to DFIR_VISION_BASE_URL when blank
-
-# Log-text extraction (#10): raw log lines are collapsed into distinct, counted templates
-# (most-frequent first) before being sent to the AI so a huge log doesn't blow the prompt
-# budget. Caps how many distinct templates are kept (unset = built-in default); a cap-hit is
-# flagged as a coverage blind spot on import.
-# DFIR_LOG_MAX_TEMPLATES=
-
-# --- Custom AI prompts (optional) ----------------------------------------------
-# Override any of the six built-in prompts. Two ways per prompt, in priority order:
-#   DFIR_AI_<NAME>_PROMPT       inline text (read at startup — restart to apply)
-#   DFIR_AI_<NAME>_PROMPT_FILE  path to a file (re-read each AI call — edit the file and it
-#                               applies on the NEXT analysis, no restart needed)
-# <NAME> = SYSTEM (per-screenshot extraction) | CSV | LOG | SYNTH (holistic synthesis) | ASK (case Q&A)
-#          | EXEC (management-facing executive summary) | NARRATIVE (narrative timeline)
-#          | HUNTS (AI-suggested Velociraptor fleet hunts) | PBHUNTS (per-playbook-task hunts)
-#          | GAPHYP (timeline-gap hypotheses) | QUERYXLATE (natural-language → hunt-query translation)
-#          | RECONCILE (second-opinion reconcile pass, #116)
-#          | IMPORTGEN (the custom-importer authoring prompt — GET /importers/prompt / Settings → Importers
-#                       → Copy LLM prompt; you paste it + a sample of your file into any LLM to author a
-#                       declarative importer definition).
-# A missing/empty/unreadable file logs a warning and falls back to the built-in prompt.
-# Run `npm run prompts:eject` to write the defaults to ./prompts as a starting point.
-# DFIR_AI_SYSTEM_PROMPT_FILE=./prompts/system.txt
-# DFIR_AI_CSV_PROMPT_FILE=./prompts/csv.txt
-# DFIR_AI_LOG_PROMPT_FILE=./prompts/log.txt
-# DFIR_AI_SYNTH_PROMPT_FILE=./prompts/synthesis.txt
-# DFIR_AI_ASK_PROMPT_FILE=./prompts/ask.txt
-# DFIR_AI_EXEC_PROMPT_FILE=./prompts/exec-summary.txt
-# DFIR_AI_NARRATIVE_PROMPT=         # inline override for the standalone narrative-timeline prompt
-# DFIR_AI_NARRATIVE_PROMPT_FILE=./prompts/narrative.txt
-# DFIR_AI_HUNTS_PROMPT_FILE=./prompts/hunts.txt   # AI-suggested Velociraptor fleet hunts (#57)
-# DFIR_HUNT_SUGGEST_MAX=8           # max AI-suggested fleet hunts per generation (default 8)
-# DFIR_HUNT_OUTCOME_MAX=50          # max deployed-hunt outcomes retained per case for the feedback loop (#157, default 50)
-# DFIR_AI_PBHUNTS_PROMPT_FILE=./prompts/pbhunts.txt   # AI-suggested per-playbook-task Velociraptor hunts (#70)
-# DFIR_PBHUNT_SUGGEST_MAX=30        # max playbook hunts per generation (default 30 — one per task; press Generate again if the cap is hit)
-# DFIR_PBHUNT_MAX_EVENTS=120        # timeline events fed to the playbook-hunt prompt (default 120; lower = faster/cheaper call)
-# DFIR_PBHUNT_MAX_ARTIFACTS=150     # max Velociraptor CLIENT artifact names listed in the playbook-hunt prompt (relevance-ranked; grounds the AI to real artifacts)
-# DFIR_AI_GAPHYP_PROMPT_FILE=./prompts/gap-hypothesis.txt   # AI hypotheses for timeline gaps (shadow-artifact hunting, #96)
-# DFIR_GAP_HYPOTHESIS_MAX=5         # max gaps hypothesised about per "Hypothesize gaps" call (default 5; worst-first)
-# DFIR_GAP_HYPOTHESIS_CONTEXT=8     # events on each side of a gap fed to the hypothesis prompt (default 8)
-
-# ── Content-based event tagger (Timesketch-style tags.yaml) ─────────────────────────────────────
-# Rules in companion/data/tags.yaml tag events by content (event IDs, registry paths, filenames,
-# process lineage) and — on the forensic timeline — raise severity / union MITRE. Edit rules in-app:
-# Super-Timeline → 🏷 Content tagger → Edit rules. Tags are filterable in both timelines.
-# TAGGER_AUTO=true                  # run automatically after every import (default true; false = manual only)
-# TAGGER_SCOPE=both                 # forensic | super | both (default both); super = tags only, never mutates severity/MITRE
-# TAGGER_RULES_FILE=                # absolute path to a custom rule file, overriding the dashboard file + bundled default
-# DFIR_AI_MEMNEXT_PROMPT_FILE=./prompts/memory-next-step.txt   # AI memory-forensics "next-step" agent — suggests the next Volatility command (#101)
-# DFIR_MEMORY_NEXTSTEP_MAX=8        # max AI-suggested memory next-step commands per generation (default 8)
-# DFIR_AI_QUERYXLATE_PROMPT_FILE=./prompts/query-translate.txt   # natural-language → VQL/KQL/ES|QL/SPL/Sigma/YARA/Suricata translator (#100)
-#                                   # The Query Translator panel + POST /cases/:id/translate-query; platforms gated by DFIR_HUNT_PLATFORMS below.
-# DFIR_AI_RECONCILE_PROMPT_FILE=./prompts/reconcile.txt   # second-opinion reconcile pass — judges each A-vs-B disagreement (#116)
-# DFIR_AI_IMPORTGEN_PROMPT=         # inline override for the custom-importer authoring prompt
-# DFIR_AI_IMPORTGEN_PROMPT_FILE=./prompts/importgen.txt   # the prompt analysts copy to have an LLM write a declarative importer
-# DFIR_AI_STARREDREPORT_PROMPT_FILE=./prompts/starred-report.txt   # TimeSketch-style Starred Events Report over the analyst's starred events
-# DFIR_AI_VIEWSUMMARY_PROMPT_FILE=./prompts/view-summary.txt   # quick AI overview of the current super-timeline view (filters applied)
-
-# --- Threat-intel IOC enrichment (optional) ------------------------------------
-# Add a key to enable that provider; the dashboard "Enrich IOCs" button looks up the
-# case's hashes/IPs/domains/URLs and annotates them with verdicts. ⚠ OPSEC: this sends
-# indicators to third-party services — only enable for IOCs you're OK querying externally.
-# DFIR_VT_KEY=          # VirusTotal (hash/IP/domain/URL). Free tier ~4 lookups/min.
-# DFIR_ABUSEIPDB_KEY=   # AbuseIPDB (IP reputation).
-# DFIR_MB_KEY=          # abuse.ch Auth-Key (legacy var name). There is no standalone MalwareBazaar
-#                       # source anymore — MalwareBazaar is a Hunting.ch back-end. This key still works:
-#                       # it powers Hunting.ch below (same abuse.ch key). Prefer DFIR_HUNTINGCH_KEY.
-# DFIR_HUNTINGCH_KEY=   # Hunting.ch — abuse.ch unified hunt (https://hunting.abuse.ch/). One indicator is
-#                       # looked up across EVERY abuse.ch platform that knows its kind, each hit a separate
-#                       # clickable result: hash -> MalwareBazaar + ThreatFox + URLhaus + YARAify;
-#                       # IP/domain -> ThreatFox + URLhaus(host); URL -> ThreatFox + URLhaus(url).
-#                       # Uses the unified abuse.ch Auth-Key (https://auth.abuse.ch/). OPTIONAL: if unset,
-#                       # Hunting.ch automatically reuses DFIR_MB_KEY (it's the SAME abuse.ch key), so just
-#                       # setting DFIR_MB_KEY enables both. Supersedes the standalone MalwareBazaar provider.
-# DFIR_CROWDSTRIKE_CLIENT_ID=      # CrowdStrike Falcon — Threat Intelligence ONLY (no endpoint/SIEM data).
-# DFIR_CROWDSTRIKE_CLIENT_SECRET=  # OAuth2 API client (Support > API Clients & Keys). Scopes:
-#                                  #   "Indicators (Falcon Intelligence): Read"  (hash/IP/domain/URL intel)
-#                                  #   "MalQuery: Read"                           (hash → sample corpus)
-#                                  # Requires the Falcon Intelligence subscription. Both ID + SECRET enable it.
-# DFIR_CROWDSTRIKE_CLOUD=us-1      # tenant cloud: us-1 (default) | us-2 | eu-1 | gov-us-1 | gov-us-2
-# DFIR_CROWDSTRIKE_BASE_URL=       # optional explicit API base override (wins over CLOUD)
-# DFIR_MISP_URL=        # Your MISP instance URL, e.g. https://misp.example.org (any IOC kind)
-# DFIR_MISP_KEY=        # MISP Auth Key (both URL and key required to enable MISP enrichment AND push)
-# DFIR_MISP_CA=         # Path to a PEM CA bundle if MISP uses an internal/private CA (verification stays ON)
-# DFIR_MISP_INSECURE=   # =1 to accept a self-signed MISP cert WITHOUT verifying (insecure — lab only)
-# DFIR_MISP_DISTRIBUTION= # MISP event distribution for new events: 0=org (default), 1=community, 2=connected, 3=all
-# DFIR_MISP_ANALYSIS=   # MISP analysis state for new events: 0=initial, 1=ongoing (default), 2=complete
-# DFIR_ROCKYRACCOON_KEY= # RockyRaccoon (echotrail) Windows process intel — enriches PROCESS IOCs
-#                       # with prevalence / LOLBIN / risk level / expected parent / ATT&CK.
-#                       # Free tier: 500 req/mo, 10/min — keep DFIR_ENRICH_DELAY_MS high if on.
-# DFIR_YETI_URL=        # Your YETI instance URL, e.g. https://yeti.example.org
-# DFIR_YETI_KEY=        # YETI per-user API key (both URL and key required to enable YETI)
-# DFIR_YETI_CA=         # Path to a PEM CA bundle if YETI uses an internal/private CA (verification stays ON)
-# DFIR_YETI_INSECURE=   # =1 to accept a self-signed YETI cert WITHOUT verifying (insecure — lab only)
-# DFIR_OPENCTI_URL=     # Your OpenCTI instance URL, e.g. https://opencti.example.org (any IOC kind)
-# DFIR_OPENCTI_KEY=     # OpenCTI API token (both URL and key required to enable OpenCTI enrichment)
-# DFIR_OPENCTI_CA=      # Path to a PEM CA bundle if OpenCTI uses an internal/private CA (verification stays ON)
-# DFIR_OPENCTI_INSECURE= # =1 to accept a self-signed OpenCTI cert WITHOUT verifying (insecure — lab only)
-# DFIR_OPENCTI_MALICIOUS_SCORE= # x_opencti_score >= this → malicious verdict (default 75)
-# CIRCL hashlookup (#154): free, keyless KNOWN-FILE lookup for hash IOCs — the known-good angle that
-# complements VirusTotal/Hunting.ch (a hit confirms a known, legitimate file; cuts false positives).
-# Always available; external scope → opt-in per case (default OFF). No API key needed.
-# DFIR_HASHLOOKUP_URL=  # override the base (default https://hashlookup.circl.lu) for a self-hosted / air-gapped mirror
-# IP-infrastructure context (#134): reverse DNS, WHOIS, GeoIP, Shodan host — answer "where did this
-# IP come from, who owns it, what's hosted on it?". Reverse DNS / WHOIS / GeoIP need NO key (always
-# available), but — like all external providers — are opt-in per case (default OFF). Each just adds an
-# `unknown`-verdict context badge (hostnames / netblock+ASN+abuse-contact / country+city+org).
-# DFIR_RDAP_URL=        # WHOIS-over-RDAP base (default https://rdap.org — IANA bootstrap to the right RIR)
-# DFIR_GEOIP_URL=       # GeoIP URL template (default https://ipinfo.io/{ip}/json — keyless HTTPS, Node-friendly;
-#                       # {ip} is substituted (else appended); parser also tolerates ip-api.com + ipwho.is shapes)
-# DFIR_GEOIP_KEY=       # optional GeoIP key (fills {key}, else appended as ?token=) for a paid/self-hosted backend
-#                       # Shodan host lookup (hosted domains / open ports / services / CVEs) reuses
-#                       # DFIR_SHODAN_KEY (see the Customer-exposure section) — set it once, both features use it.
-# DFIR_ENRICH_DELAY_MS=1500   # throttle between external lookups (default for providers with no specific override)
-# Per-provider throttle overrides — each provider runs at its own safe rate instead of the shared delay.
-# The value is the minimum ms between consecutive API calls TO THAT PROVIDER (others proceed independently).
-# Unset = use DFIR_ENRICH_DELAY_MS. Override any subset; omit providers you want at the global rate.
-# RockyRaccoon free tier: 500 req/mo, 10/min → 6000ms recommended. VirusTotal free tier: ~4 lookups/min → 15000ms.
-# DFIR_ENRICH_DELAY_MS_VIRUSTOTAL=15000
-# DFIR_ENRICH_DELAY_MS_ABUSEIPDB=1000
-# DFIR_ENRICH_DELAY_MS_HUNTINGCH=1000
-# DFIR_ENRICH_DELAY_MS_CROWDSTRIKE=500
-# DFIR_ENRICH_DELAY_MS_ROCKYRACCOON=6000
-# DFIR_ENRICH_DELAY_MS_MISP=200
-# DFIR_ENRICH_DELAY_MS_YETI=200
-# DFIR_ENRICH_DELAY_MS_OPENCTI=200
-# DFIR_ENRICH_DELAY_MS_REVERSE_DNS=0   # local resolver, fast — usually no throttle needed
-# DFIR_ENRICH_DELAY_MS_WHOIS=1000      # rdap.org / RIR RDAP — be polite
-# DFIR_ENRICH_DELAY_MS_GEOIP=1000      # ipwho.is free tier is rate-limited
-# DFIR_ENRICH_DELAY_MS_SHODAN=1000     # Shodan host lookups cost query credits
-# DFIR_ENRICH_MAX=100         # max IOCs queried per Enrich run (hashes/IPs first)
-
-# Lookalike / typosquat domain check — the "Lookalike Domain" enrichment provider flags domain IOCs
-# that imitate a bundled list of commonly-impersonated brands (Microsoft, Google, Okta, PayPal, banks,
-# crypto…) via homoglyph, edit-distance, and brand-token impersonation. It runs entirely on-box (no
-# network, nothing sent anywhere), so unlike the external providers above it is LOCAL scope and ON by
-# default — every case gets lookalike flagging with zero config. A hit is a `suspicious` verdict.
-# Add your own org/customer domains (comma-separated) so their typosquats are caught too:
-# DFIR_LOOKALIKE_EXTRA_DOMAINS=acmecorp.com,acme-internal.net
-
-# Geographic IP map (#133). The dashboard 🌍 panel plots geo-located IP IOCs (coordinates from the
-# GeoIP enrichment). Tiles are fetched from OpenStreetMap when the analyst opens the map; point this
-# at an internal/offline tile server for fully on-prem operation.
-# DFIR_GEOMAP_TILE_URL=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
-# DFIR_GEOMAP_MAX_MARKERS=2000
-# DFIR_GEOMAP_MAX_FLOWS=500
-# DFIR_GEOMAP_TOP_COUNTRIES=10
-# DFIR_COUNTRY_CENTROIDS_URL=  # URL for regenerating the offline country-centroid table
-#                               # (run: npm run data:update-geo). IPs with country-only GeoIP
-#                               # enrichment fall back to this table and are shown as approximate.
-# Reachability gate: a self-hosted MISP/YETI that's DOWN is probed (cheap health check),
-# not blasted with one doomed request per IOC. A down provider is skipped and retried later.
-# DFIR_ENRICH_HEALTH_TTL_MS=60000  # cache a provider's up/down verdict this long (default 60s)
-# DFIR_ENRICH_HEALTH_POLL_MS=60000 # background re-probe of down servers; auto-resumes skipped
-#                                  # cases on recovery. Set =0 to disable the poller.
-
-# --- Customer exposure / credential-leak check (optional) --------------------
-# A SEPARATE feature from IOC enrichment: the dashboard "Customer Exposure" panel checks the
-# VICTIM ORG's OWN domains/emails against breach/leak databases. Domain searches use ONLY the
-# customer domains you enter (never adversary/IOC domains); auto-discovered case emails are
-# checked only when their domain is one of those customer domains. Raw leaked passwords are
-# NEVER persisted (only a "credential material present" flag). Add any provider key to enable it;
-# the analyst then runs the check explicitly. ⚠ OPSEC: sends the customer's own domains/emails
-# to these third-party services.
-# DFIR_LEAKCHECK_KEY=              # LeakCheck Pro API key (https://wiki.leakcheck.io/en/api).
-#                                  # Email search = Pro; DOMAIN search needs the Enterprise tier.
-# DFIR_LEAKCHECK_DOMAIN_LIMIT=1000 # max records per domain search (LeakCheck max 1000)
-# DFIR_HIBP_KEY=                   # Have I Been Pwned API key (https://haveibeenpwned.com/api/v3).
-# DFIR_HIBP_USER_AGENT=DFIR Companion   # HIBP requires a User-Agent; domain search needs a verified domain.
-# DFIR_DEHASHED_KEY=               # DeHashed API key (https://app.dehashed.com/documentation/api), v2 search.
-# DFIR_DEHASHED_BASE_URL=          # optional DeHashed API base override (default https://api.dehashed.com/v2)
-# DFIR_SHODAN_KEY=                 # Shodan API key (https://developer.shodan.io/api). Attack-surface
-#                                  # exposure: a customer DOMAIN -> its internet-exposed hosts/ports/
-#                                  # services/CVEs (hostname: search, uses query credits). No email lookup.
-# DFIR_EXPOSURE_DELAY_MS=1500      # throttle between leak-provider lookups (respect rate limits)
-
-# --- DFIR-IRIS case push / import (optional) ---------------------------------
-# Push a case into a DFIR-IRIS instance: the dashboard "Push to IRIS" button (and
-# `npm run iris:push -- <caseId>`) find-or-create the IRIS case BY NAME (= the
-# Companion case id), then push assets->assets, IOCs->IOCs, forensic timeline->timeline,
-# the executive summary->case summary, and every other section->notes. Re-pushing
-# updates: it adds only what's missing and refreshes the summary + Companion notes.
-# The REVERSE — import an existing IRIS case's assets/IOCs/timeline INTO a Companion case —
-# uses the same connection: the dashboard "Import from IRIS" picker, or
-# `npm run iris:import -- <companionCaseId> <irisCaseIdOrName>`.
-# Both URL and key are required to enable the feature.
-# DFIR_IRIS_URL=                  # Your IRIS base URL, e.g. https://iris.example.org
-# DFIR_IRIS_KEY=                  # IRIS API key (IRIS UI: My profile > API Key)
-# DFIR_IRIS_CA=                   # Path to a PEM CA bundle if IRIS uses an internal/private CA
-# DFIR_IRIS_INSECURE=             # =1 to accept a self-signed IRIS cert WITHOUT verifying (lab only)
-# DFIR_IRIS_CUSTOMER_ID=1         # IRIS customer id for NEW cases (default 1 = seeded IrisInitialClient)
-# DFIR_IRIS_CLASSIFICATION_ID=1   # IRIS case classification id for NEW cases (default 1)
-
-# --- Timesketch timeline push (optional) -------------------------------------
-# Push a case's forensic timeline into a Timesketch instance: the dashboard "Push to
-# Timesketch" button (and `npm run timesketch:push -- <caseId>`) log in, find-or-create the
-# sketch BY NAME (= the Companion case id), then upload the timeline as Timesketch events. The
-# managed timeline is clean-replaced on re-push, so events never duplicate. URL + user + password
-# are all required to enable the push (without them the "Export Timesketch JSONL" download still
-# works — it needs no server). Auth is Timesketch local login (no API token in Timesketch).
-# DFIR_TIMESKETCH_URL=            # Your Timesketch base URL, e.g. https://timesketch.example.org
-# DFIR_TIMESKETCH_USER=          # Timesketch local-auth username
-# DFIR_TIMESKETCH_PASSWORD=      # Timesketch local-auth password
-# DFIR_TIMESKETCH_TIMELINE=      # Managed timeline name (default "DFIR-Companion Forensic Timeline")
-# DFIR_TIMESKETCH_CA=            # Path to a PEM CA bundle if Timesketch uses an internal/private CA
-# DFIR_TIMESKETCH_INSECURE=      # =1 to accept a self-signed Timesketch cert WITHOUT verifying (lab only)
-
-# --- Notion export (optional) ------------------------------------------------
-# Export a case into a Notion page so investigators can collaborate around it: the dashboard
-# "Export to Notion" option (and `npm run notion:push -- <caseId> --page <urlOrId>`) writes ALL
-# the Companion's content (findings, timeline, IOCs, MITRE, attacker path, summary…) INSIDE ONE
-# managed toggle block it owns on the page. A re-export refreshes that block with the latest case
-# data and NEVER touches anything you wrote outside it (your notes, pasted finding screenshots).
-# "New page" creates the page (a row in DFIR_NOTION_DATABASE_ID, else a child of
-# DFIR_NOTION_PARENT_PAGE_ID); "Existing page" updates a page you paste. Only the token is
-# required to enable it. ⚠ Share the target page/database WITH the integration (Notion: page ⋯ >
-# Connections > add it), or the API returns 404/permission-denied.
-# DFIR_NOTION_TOKEN=             # Internal-integration secret (Notion: Settings > Connections > develop your own)
-# DFIR_NOTION_DATABASE_ID=       # Default DB for "new page" exports — a "Cases" investigation database (preferred)
-# DFIR_NOTION_PARENT_PAGE_ID=    # Alternative default: create the new page under this parent page
-# DFIR_NOTION_CONTAINER_TITLE=   # Managed block title (default "🔍 DFIR Companion — Auto-generated")
-# DFIR_NOTION_MAX_TIMELINE=500   # Max timeline rows written to Notion (the full timeline stays in the report)
-# DFIR_NOTION_CA=                # Path to a PEM CA bundle if a proxy uses an internal/private CA
-# DFIR_NOTION_INSECURE=          # =1 to accept a self-signed cert WITHOUT verifying (lab only)
-
-# --- ClickUp (optional) ------------------------------------------------------
-# Push the Response Playbook (issue #36) to a ClickUp list as tasks — status, priority, assignee,
-# due date carried across. Re-pushing the same case UPDATES the tasks it created (by remembered id)
-# instead of duplicating. A token alone enables the dashboard's "Push to ClickUp" option (the list
-# id is asked for per push; set DFIR_CLICKUP_LIST_ID to pre-fill a default).
-# DFIR_CLICKUP_TOKEN=            # Personal API token (ClickUp: Settings > Apps > API Token, pk_…)
-# DFIR_CLICKUP_LIST_ID=          # Optional default target list id (the list URL's …/li/<id>)
-# DFIR_CLICKUP_CA=               # Path to a PEM CA bundle if a proxy uses an internal/private CA
-# DFIR_CLICKUP_INSECURE=         # =1 to accept a self-signed cert WITHOUT verifying (lab only)
-
-# --- Notifications (issue #58, optional) -------------------------------------
-# Slack / MS Teams webhooks, SMTP email, and Telegram bot channels for new/escalated findings,
-# playbook updates, and investigation milestones — with a per-channel severity threshold + per-event
-# toggles. There is NO env key to enable this: notification CHANNELS are created in the dashboard
-# (Settings > Notifications) and stored next to cases/ in notifications/config.json (opt-in, starts
-# empty). Telegram setup: create a bot via @BotFather (gives you a token), add it to a chat/group/
-# channel, get the chat ID from getUpdates or @getidsbot, then paste both into the dashboard UI.
-# OPSEC: notifications send case content (finding/task titles) to a third party — don't enable on a
-# sensitive case unless the destination is trusted. The two settings below are optional polish:
-# DFIR_PUBLIC_URL=               # Public base URL used to deep-link a notification back to the case
-#                                # (default http://<host>:<port>). Set when reached via a hostname/proxy.
-# DFIR_NOTIFY_CA=                # Path to a PEM CA bundle for a self-hosted webhook host (e.g. Mattermost)
-# DFIR_NOTIFY_INSECURE=          # =1 to accept a self-signed webhook cert WITHOUT verifying (lab only)
-
-# --- Velociraptor API (optional) ---------------------------------------------
-# Run the hunt-pivot VQL the Companion generates as a HUNT across ALL your Velociraptor endpoints:
-# the 🔍 hunt modal gains a "Run hunt (all clients)" button (with an editable VQL box) that packages
-# the pivot as a client artifact, launches a hunt on every enrolled client, and streams the rows
-# back inline (with each result's source endpoint). Off unless DFIR_VELOCIRAPTOR_API_CONFIG is set.
-# The Companion shells out to the `velociraptor` binary with `--api_config` (the binary handles
-# the gRPC + mTLS), so the binary must be on the host. Create the API config once with:
-#   velociraptor --config server.config.yaml config api_client --name dfir --role administrator,api api.config.yaml
-# SECURITY: this creates artifacts + hunts (runs analyst-authored VQL on your endpoints) — keep it
-# to a trusted localhost analyst workstation; it stays off until you opt in by setting the path.
-# DFIR_VELOCIRAPTOR_API_CONFIG=   # Path to the api_client config (enables the feature)
-# DFIR_VELOCIRAPTOR_BINARY=       # velociraptor executable (default "velociraptor" on PATH; on Windows give the full .exe path)
-# DFIR_VELOCIRAPTOR_GUI_URL=      # Optional Velociraptor GUI base URL (e.g. https://velo:8889) to deep-link launched hunts
-# DFIR_VELOCIRAPTOR_ORG=          # Velociraptor org for the deep link's ?org_id= (default "root"; the GUI needs it before the # fragment)
-# DFIR_VELOCIRAPTOR_TIMEOUT_MS=   # Per-query timeout (default 60000)
-# DFIR_VELOCIRAPTOR_MAX_ROWS=     # Max rows returned to the dashboard (default 1000)
-# DFIR_VELOCIRAPTOR_MAX_OUTPUT=   # Hard cap on captured query output in bytes for interactive queries (default 52428800 = 50 MB)
-# DFIR_VELOCIRAPTOR_COLLECT_MAX_OUTPUT=  # Larger cap for BUNDLE-HUNT collection — rows + uploaded JSON reports (THOR/Hayabusa can
-#                                # be big). Default 268435456 = 256 MB. A single artifact/upload over this is skipped (logged), not fatal;
-#                                # the rest still import. Bounded in practice by Node's max string length, so very large fleets may still need to narrow.
-# A heavy artifact (Hayabusa, a large Evtx/MFT dump) can fail with "grpc: received message larger
-# than max (X vs. 4194304)" — this is NOT set here and NOT a server-side setting: it's the
-# `max_grpc_recv_size` field (default 4 MB) in the api_client.yaml file DFIR_VELOCIRAPTOR_API_CONFIG
-# points to (Velociraptor's ApiClientConfig — confirmed from config/proto/config.proto). Add a
-# top-level `max_grpc_recv_size: 67108864` (or larger, in bytes) to that api_client.yaml file — no
-# CLI flag exists (`velociraptor query --max_message_size` does NOT exist — do not add it, it breaks
-# every query with "unknown long flag") and no server restart is needed, since the CLI reads this
-# file on every invocation.
-# Velociraptor TRIAGE BUNDLES (dashboard "Velociraptor Triage" panel): browse the server's CLIENT
-# artifacts, save named bundles (Fast/Full Triage ship by default), run one as a hunt, then auto-
-# collect + import + synthesize after a delay. The default wait before auto-collecting a bundle hunt
-# (a hunt stays open until its expiry, so we snapshot results after this many minutes; per-run
-# override + per-bundle default also apply; clamped 1..1440). Custom bundles live next to cases/ in a
-# bundles/ dir; the in-flight job persists per case (state/velo-hunt.json) so it survives a restart.
-# DFIR_VELO_HUNT_WAIT_MIN=        # Default minutes before auto-collecting a bundle hunt (default 10)
-# DFIR_VELO_HUNT_POLL_S=          # Poll interval in seconds for checking a hunt's live state in Velociraptor (default 30; clamped 5–300)
-# DFIR_VELOCIRAPTOR_SPAWN_RETRIES= # Retries when launching the velociraptor binary hits a transient lock (AV / sync / concurrent spawn → "spawn EPERM"); default 6, linear backoff capped 500ms
-# Some bundle artifacts (offline collectors like Generic.Scanner.ThorZIP, or Windows.Hayabusa.Rules)
-# put their real triage data in an UPLOADED file rather than result rows — the Companion reads those
-# uploads server-side (json/jsonl/ndjson/csv/txt/log) and auto-detects/imports them (THOR, Hayabusa,
-# etc.; HTML/binary ignored).
-# The VQL that enumerates + reads the uploads is version-sensitive; override it here if the default
-# doesn't match your Velociraptor (keep the __HUNT_ID__ placeholder and a Name/ClientId/Content shape).
-# DFIR_VELOCIRAPTOR_UPLOAD_VQL=   # Override the hunt-uploads VQL (advanced; default works on recent Velociraptor)
-# The same upload-reading mechanism also covers an EXTERNALLY pasted single flow (no hunt) — override
-# its VQL here if needed (keep the __CLIENT_ID__/__FLOW_ID__ placeholders instead of __HUNT_ID__).
-# DFIR_VELOCIRAPTOR_FLOW_UPLOAD_VQL=   # Override the flow-uploads VQL (advanced)
-# Velociraptor LIVE MONITORING (#84 — Settings → Velociraptor → Live Monitoring): stream a CLIENT_EVENT
-# artifact (e.g. Windows.Events.ProcessCreation) from one endpoint into a case as events fire. The
-# companion polls the client's monitoring result set on this interval and imports new rows; the last-
-# seen cursor is persisted per monitor (state/velo-monitor.json) so a restart never re-ingests.
-# A monitor can target ONE client or ALL enrolled clients at once; there's also a one-click "auto-monitor"
-# that starts an all-clients monitor for every artifact already enabled in Velociraptor's Client Monitoring
-# table. The artifact must be enabled in Velociraptor → Client Monitoring for the target client(s) — the
-# Companion only READS the monitoring stream, it never reconfigures your endpoints.
-# DFIR_VELO_MONITOR_POLL_S=       # Default poll interval in seconds for a live monitor (default 30; clamped 5–3600)
-# The read VQL is `source(client_id=, artifact=, start_time=, end_time=)` by default (per-client); the
-# all-clients read iterates `clients()` + `source()`; auto-discovery reads `get_client_monitoring()`.
-# Override any of these for a Velociraptor version where the proto/plugins differ (keep the placeholders):
-# DFIR_VELOCIRAPTOR_MONITOR_VQL=      # Per-client read VQL (__CLIENT_ID__/__ARTIFACT__/__START__/__END__/__LIMIT__)
-# DFIR_VELOCIRAPTOR_MONITOR_ALL_VQL=  # ALL-clients read VQL (__ARTIFACT__/__START__/__END__/__LIMIT__)
-# DFIR_VELOCIRAPTOR_MONITORED_VQL=    # "Configured client-event artifacts" VQL (return an `artifact` column)
-
-# Super-timeline event cap: Velociraptor super-timeline artifacts (e.g. bulk NTFS MFT / USN /
-# registry hunts) are imported un-aggregated and can be enormous, so this is a MUCH higher cap
-# than DFIR_MAX_EVENTS (default 100000). Raise it for a full multi-hundred-thousand-row
-# super-timeline you want kept whole; see DFIR_MAX_EVENTS for ordinary SIEM/EDR imports.
-# DFIR_SUPERTIMELINE_MAX=100000
-
-# --- Push ingest / webhook (optional, #84) -----------------------------------
-# Let external tools push alerts straight into a case in real time: POST /cases/<id>/push with the
-# payload in the body (any shape the Import button auto-detects — a Velociraptor artifact-map, a SIEM
-# alert, a Hayabusa line, { "source": "...", "events": [ ... ] }, or raw text). The server runs the
-# same import → diff → re-synthesize pipeline and returns 202 immediately. Auth is a token in the
-# X-DFIR-Key header (or Authorization: Bearer). Push is OFF until a token is configured — set a GLOBAL
-# token here (covers every case) and/or generate a PER-CASE token in Settings → Integrations → Push ingest.
-# SECURITY: the server binds 127.0.0.1 by default; set this before exposing the port (e.g. DFIR_HOST=0.0.0.0
-# in a container) so external callers must authenticate. Localhost-only single-user tool otherwise.
-#   curl -X POST http://127.0.0.1:4773/cases/<id>/push -H "X-DFIR-Key: <token>" \
-#        -H "Content-Type: application/json" -d '{"source":"wazuh","events":[ { ... } ]}'
-# DFIR_PUSH_TOKEN=                # Global push token (shared secret in X-DFIR-Key). Unset = global push off
-
-# --- Hunt-query platforms (optional) -----------------------------------------
-# The 🔍 hunt-pivot generator emits a card per platform: velociraptor, defender (Defender/Sentinel
-# KQL), elastic (Kibana ES|QL), splunk, sigma, yara, suricata. On most teams only some of these
-# tools exist — trim the modal to yours with an allowlist (comma/space separated, case-insensitive;
-# common aliases like vql/kql/esql/spl/snort are accepted). Unset = ALL platforms shown.
-#   DFIR_HUNT_PLATFORMS=velociraptor                  # show ONLY Velociraptor
-#   DFIR_HUNT_PLATFORMS=velociraptor,sigma,yara       # show just these three
+# Hunt-query platforms shown by the 🔍 pivot generator: velociraptor, defender (KQL), elastic
+# (ES|QL), splunk, sigma, yara, suricata. Trim to the tools your team actually has (comma/space
+# separated, case-insensitive; aliases vql/kql/esql/spl/snort accepted). Unset = show all.
+#   DFIR_HUNT_PLATFORMS=velociraptor,sigma,yara
 # DFIR_HUNT_PLATFORMS=
 
-# Cross-source correlation window (seconds, default 2). The same artifact reported by
-# different tools (e.g. a Velociraptor alert + a THOR alert about one file) is merged into
-# one corroborated event when they share a hash, OR the same path with event times within
-# this window. Set 0 to require an exact-time path match (hash matching is always exact).
-DFIR_CORRELATE_WINDOW_S=2
-
-# Attack-phase (temporal burst) detection: the forensic timeline is grouped into phases by
-# the time gap BETWEEN consecutive events. Events more than this many seconds apart start a
-# new phase (default 300 = 5 min). Lower it for fast, tightly-clustered intrusions; raise it
-# to merge slower-paced activity into fewer phases. Surfaced in the dashboard Attack Phases
-# panel and report §3.2. Deterministic — no AI call.
-DFIR_PHASE_GAP_S=300
-
-# Beacon / C2 detection: flag outbound connection channels (source host → destination IP:port)
-# whose inter-arrival intervals are too regular to be human traffic — the classic C2 callback
-# signature. MIN_COUNT is the minimum connection events to a channel before it's considered
-# (default 5); MAX_JITTER_PCT is the maximum interval jitter (stddev as a % of the mean) to call
-# it a beacon (default 20 — lower it to catch only metronome-precise beacons, raise it to surface
-# noisier ones). A hunting lead, NOT a verdict (legitimate software also polls on a timer).
-# Surfaced in the dashboard Beacon Candidates panel + report §4.9. Deterministic — no AI call.
-DFIR_BEACON_MIN_COUNT=5
-DFIR_BEACON_MAX_JITTER_PCT=20
-
-# Timeline volume-anomaly detection: bucket the timeline into fixed windows and flag buckets
-# whose event volume spikes far above the peer/self baseline — a burst of activity that stands
-# out even without a known signature. BUCKET_MINUTES sets the window size (default 15).
-# SPIKE_FACTOR is how many times the peer baseline a bucket must exceed to flag (default 5);
-# SELF_FACTOR is the same but against the asset's OWN historical baseline (default = spike
-# factor). MIN_EVENTS is the floor before a bucket is even considered (default 3, avoids
-# flagging noise in sparse timelines). No AI call.
-# DFIR_ANOMALY_BUCKET_MINUTES=15
-# DFIR_ANOMALY_SPIKE_FACTOR=5
-# DFIR_ANOMALY_SELF_FACTOR=5
-# DFIR_ANOMALY_MIN_EVENTS=3
-
-# Log gap analysis (#83): flag suspiciously long SILENT periods in the forensic timeline — a
-# tampered/cleared log goes quiet, so a hole between events can mean cleared Event Logs, a stopped
-# collector/auditd, or deleted log files. A gap where EVERY source went silent is High (complete
-# silence) and earns a finding; a single tool going quiet while others log is Medium (partial).
-# MIN_MINUTES is the hard floor — a silence shorter than this is never flagged (default 30).
-# DENSITY_FACTOR suppresses normal quiet in a naturally-sparse timeline: a gap must also be ≥ this
-# multiple of the timeline's median inter-event interval (default 4; set 0 to use the floor only).
-# ACTIVE_HOURS (optional, e.g. "8-18", UTC; supports wrap-around like "22-6") flags only gaps that
-# overlap those working hours and SUPERSEDES the density heuristic when set — so expected overnight
-# quiet doesn't trip it. MAX_FINDINGS caps how many complete-silence gaps escalate to a FINDING
-# (default 5; the panel/report still list all of them) so a super-timeline case (MFT/registry rows
-# spanning years) can't flood the findings list. Surfaced in the dashboard Timeline Gaps panel +
-# report §3.3. No AI call.
-DFIR_GAP_MIN_MINUTES=30
-DFIR_GAP_DENSITY_FACTOR=4
-DFIR_GAP_MAX_FINDINGS=5
-# DFIR_GAP_ACTIVE_HOURS=8-18
-# OUTLIER_SPAN_FACTOR filters wrong-clock/wrong-year stray events out of the gap span so one
-# bogus timestamp doesn't manufacture a multi-year "gap" (default 5; set 0 to disable).
-# DFIR_GAP_OUTLIER_SPAN=5
-
-# SSH brute-force-success detection (ATT&CK T1110.001). In a syslog import, a successful sshd login
-# (Accepted password/publickey) preceded by at least MIN_FAILS failed attempts from the SAME source IP
-# within WINDOW_MIN minutes is graded Medium as a brute-force that landed. Tune to your environment's
-# lockout policy; raise MIN_FAILS to cut noise from fat-fingered passwords. No AI call.
-DFIR_SSH_BRUTEFORCE_MIN_FAILS=5
-DFIR_SSH_BRUTEFORCE_WINDOW_MIN=60
-
-# NTFS timestomp detection (ATT&CK T1070.006). MFT imports (Windows.NTFS.MFT via Velociraptor, MFTECmd
-# via KAPE) carry both $STANDARD_INFORMATION ($SI, Created0x10) and $FILE_NAME ($FN, Created0x30)
-# creation times on the same row; a file is flagged Medium when its $SI creation is backdated more
-# than THRESHOLD_MINUTES before its $FN creation, or its $SI sub-second precision is zeroed while $FN
-# has it. THRESHOLD_MINUTES sets the backdating tolerance (default 10, matching Timesketch). No AI call.
-DFIR_TIMESTOMP_THRESHOLD_MINUTES=10
-
-# ATT&CK Navigator layer export (Export → ATT&CK Navigator layer): the MITRE ATT&CK Enterprise
-# version stamped in the exported layer JSON. Must match the ATT&CK version your Navigator runs,
-# or the Navigator prompts to run its upgrade workflow on every import. The build default tracks
-# the current release; override here when MITRE ships a newer version than the build expects.
-# DFIR_ATTACK_VERSION=19
-
-# Adversary group hints: rank known MITRE ATT&CK groups by how many of the case's identified
-# techniques they also use — offline hypothesis fuel, NOT attribution. Scoring is sub-technique-
-# aware (an exact T1059.001 match outweighs a base-only T1059 match). MIN_OVERLAP is the minimum
-# overlapping techniques (counted at base-or-better) to surface a group (default 3); TOP_N caps how
-# many groups are shown (default 5). Scored from the bundled companion/data/attack-groups.json
-# (regenerate with `npm run data:update-attack`). Surfaced in the dashboard panel + report §4.6.1.
-# NEXT_MAX caps the "likely next techniques" emulation list (#121) — techniques the matched groups
-# are known to use that the case hasn't observed yet, ranked by DISTINCTIVENESS (how many matched
-# groups use each × how rare it is across all groups), so generic tradecraft (recon, tooling) is
-# filtered out (predictive hunt priorities, still hypothesis fuel — not attribution; default 10).
-# NEXT_MAX_PREVALENCE drops any suggestion used by more than this fraction of ALL known groups —
-# the "everyone does it" cutoff (default 0.33 = a third of all groups).
-DFIR_ADVERSARY_MIN_OVERLAP=3
-DFIR_ADVERSARY_TOP_N=5
-DFIR_ADVERSARY_NEXT_MAX=10
-DFIR_ADVERSARY_NEXT_MAX_PREVALENCE=0.33
-
-# Defensive countermeasures (#178) — for each ATT&CK technique the case identified, the MITRE D3FEND
-# countermeasures that harden against / detect / isolate it. Offline + deterministic (no AI, no
-# network), resolved from the bundled companion/data/d3fend-map.json (regenerate with
-# `npm run data:update-d3fend`). MAX_PER_TECHNIQUE caps how many countermeasures are listed per
-# technique (default 12; the case-wide by-tactic rollup keeps the full set). Surfaced in the
-# dashboard *Defensive Countermeasures* panel + the toggleable report section.
-DFIR_D3FEND_MAX_PER_TECHNIQUE=12
-
-# Case memory (#165) — ground synthesis + hunts in what's MISSING, and keep a cross-session history.
-# KNOWN_UNKNOWNS_MAX caps the bullets in the "known unknowns" block (timeline coverage gaps +
-# uncovered ATT&CK phases + the matched actors' likely-next techniques) injected into the synthesis
-# and hunt-suggestion prompts (default 10; set 0 to drop the block). ADVERSARY_HINTS feeds the
-# candidate threat actors (the same overlap hints shown in report §4.6.1) into the SYNTHESIS prompt as
-# clearly-labelled hypotheses — OFF by default, because feeding model-derived attribution back into the
-# model is a confirmation-bias loop; set 1/true/on/yes to enable. (Synthesis also always logs each run
-# to the Investigation Log — no toggle.)
-DFIR_SYNTH_KNOWN_UNKNOWNS_MAX=10
-DFIR_SYNTH_ADVERSARY_HINTS=off
-
-# Learn from dismissals (#65) recurrence floor: how many times a marker must be reasoned-
-# dismissed before it generalizes into the "PREVIOUSLY DISMISSED PATTERNS" down-weighting block
-# fed to synthesis (default varies by store; unset = built-in default).
-# DFIR_LEARNED_PATTERN_MIN_COUNT=
-
-# Mobile companion (the read-only PWA at /mobile): per-list caps for the compact phone payload
-# (GET /cases/:id/mobile-summary). Heavy lists are trimmed so the mobile view stays lean; the
-# UI shows "N of M" so nothing is hidden silently. Findings/events default 50, IOCs default 100.
+# Mobile PWA at /mobile — per-list caps for the compact phone payload. The UI shows "N of M" so
+# nothing is hidden silently.
 DFIR_MOBILE_MAX_FINDINGS=50
 DFIR_MOBILE_MAX_EVENTS=50
 DFIR_MOBILE_MAX_IOCS=100
 
-# Pinned findings (#220): how many findings an analyst can pin to the sticky top strip at once.
-# The pin is a curated shortlist, so this is deliberately small to avoid clutter (default 5).
-# DFIR_MAX_PINNED_FINDINGS=5
-
-# Presentation / timeline-replay mode (#177; the read-only slide deck at /cases/:id/present and its
-# standalone-HTML export): per-deck caps on the findings + timeline-event slides so a large case
-# stays presentable. Findings default 40, events default 200.
+# Presentation / timeline-replay mode (#177) at /cases/:id/present and its standalone HTML export.
 DFIR_PRESENT_MAX_FINDINGS=40
 DFIR_PRESENT_MAX_EVENTS=200
 
-# Import undo/redo (#76): how many import levels to keep so an import that floods the dashboard can
-# be rolled back (and redone). Each level is a full copy of the investigation state (findings, IOCs,
-# timeline, MITRE, attacker path), so the depth is bounded. Default 10.
-# DFIR_IMPORT_UNDO_DEPTH=10
+# Pinned findings (#220): how many can sit in the sticky top strip. Deliberately small — the pin
+# is a curated shortlist, not a second findings list.
+# DFIR_MAX_PINNED_FINDINGS=5
 
-# Live synthesis: while capturing, re-derive findings/attacker path automatically a
-# few seconds after each batch of screenshots (debounced). on | off (default on).
-# Each run is one synthesis AI call — raise the debounce or turn off to cut cost.
-DFIR_AI_AUTO_SYNTHESIZE=on
-DFIR_AI_AUTO_SYNTHESIZE_MS=8000
 
-# Safety-net flush interval (ms, default 300000 = 5 min). Screenshots are analyzed in windows;
-# a `timer`/`click` capture buffers until a window fills (4) — only a page navigation or tab
-# switch flushes early. This background sweep drains any leftover buffer on the interval so a
-# lone screenshot is still analyzed instead of waiting indefinitely. Set 0 to disable.
-DFIR_FLUSH_INTERVAL_MS=300000
-
-# Duplicate-screenshot detection. To avoid re-analyzing the SAME frame captured repeatedly
-# (e.g. a timer firing on a static screen), each capture's bytes are hashed (SHA-256) and
-# compared to the previous capture in the same case. A capture is treated as a duplicate ONLY
-# when it is byte-identical to the one before it — i.e. the screen did not change at all. Any
-# difference whatsoever (one new log row, a moved cursor) → analyzed. This is exact-match, not
-# fuzzy: it never collapses two different-looking pages. Duplicates are still saved as evidence,
-# just not sent to the AI. Set DFIR_DEDUP=off to analyze EVERY screenshot regardless.
-# DFIR_DEDUP=on
-
-# Screenshot OCR full-text search (#176). Each captured screenshot is OCR'd locally (Tesseract,
-# on-box, no cloud) in the BACKGROUND after it's saved — never blocking capture — and the text is
-# indexed per case so you can full-text search what you saw in consoles (a hostname, "mimikatz", a
-# hash, an error message) from the dashboard filter bar and jump straight to the screenshot. The
-# index lives in cases/<id>/metadata/ocr.json (gitignored with cases/, never sent anywhere). Set
-# DFIR_OCR_SEARCH=off to disable OCR-on-capture if performance is a concern; backfill an older case
-# any time with `npm run ocr-index -- <caseId>`.
-# DFIR_OCR_SEARCH=on
-
-# Anonymization: replace sensitive victim data (internal IPs, usernames, hostnames, internal
-# domains, emails, user-profile paths, PowerShell encoded-command blobs, user SIDs) with reversible
-# tokens and one-way-redact secrets BEFORE
-# sending text to the AI; real values are restored before they reach the dashboard/state. Per-case
-# toggle in the dashboard ("Anon" button), default ON. Set to "off" to make NEW cases default to
-# disabled.
-# Note: with an EXTERNAL vision model, screenshots are OCR-redacted IN-MEMORY before they are sent —
-# local Tesseract.js (on-box, no cloud OCR) blacks out words matching the case entity set. It's
-# best-effort (the dashboard still warns). A local Ollama vision model (DFIR_VISION_MODEL) keeps
-# screenshots on-box and skips OCR entirely. The original screenshot files on disk are never modified.
-DFIR_ANONYMIZE=on
-
-# OCR redaction visibility (both OFF by default). A concise one-line summary —
-# "[OCR] case=… redaction ran on N screenshot(s) — scrubbed M word(s)…" — is ALWAYS logged when the
-# OCR pre-pass runs, so you can confirm which path executed even with these unset.
-#   DFIR_OCR_DEBUG=1            per-screenshot log: words OCR read, # redacted, and WHICH words were
-#                              blacked out (local log only — these values are never sent to the cloud).
-#   DFIR_OCR_DEBUG_DIR=<path>  also write each redacted copy sent to the model to <path>/<caseId>/ so
-#                              you can eyeball the black boxes. The original evidence is never touched.
-# DFIR_OCR_DEBUG=1
-# DFIR_OCR_DEBUG_DIR=./ocr-debug
-
-# NSRL known-good hashes (#63). A global set of known-software file hashes (NIST NSRL / RDS). A
-# forensic event whose file hash — or an IOC whose value — matches is auto-marked FALSE POSITIVE on
-# import (reversible, shown in "False Positives"), reducing false positives. Manage it in
-# Settings → NSRL (paste an NSRLFile.txt RDS CSV, a hashdeep CSV, or a hash-per-line list — or use the
-# tab's "load from a file on the server" field, the in-UI equivalent of this var). For large RDS sets,
-# point this at the file(s) on disk (`;`-separated) to pre-load them at server startup; ingest is
-# idempotent. Opt-in: the set starts empty (NSRL lists "known", not strictly "known-good"
-# — some sets include hacktools, and a known hash can still be malicious in context).
+# ══════════════════════════════════════════════════════════════════════════════
+# 13. NSRL KNOWN-GOOD HASHES  (#63)
+# ══════════════════════════════════════════════════════════════════════════════
+# A forensic event whose file hash — or an IOC whose value — matches a known-software hash is
+# auto-marked FALSE POSITIVE on import (reversible, listed under "False Positives").
+# Opt-in: the set starts empty. NSRL lists "known", not strictly "known-good" — some sets include
+# hacktools, and a known hash can still be malicious in context.
+#
+# Small/medium sets — paste or load in Settings → NSRL, or pre-load files at startup
+# (`;`-separated; ingest is idempotent). Accepts NSRLFile.txt RDS CSV, hashdeep CSV, or hash-per-line.
 # DFIR_NSRL_FILE=C:\rds\NSRLFile.txt;C:\rds\extra-hashes.txt
-
-# ── Case lifecycle & disk-space warnings (#119) ─────────────────────────────────────────────────────
-# Disk-usage threshold that triggers the dashboard's WARNING banner (orange) on the cases-root
-# filesystem. When set, this value is the "danger" level (orange/amber); the warning level is 15
-# percentage points below it, and critical (red) is 10 pp above it. Leave unset to use the built-in
-# defaults: warn at 70%, danger at 85%, critical at 95%. Set to 0 to disable the check.
-# DFIR_DISK_WARN_PCT=85
-
-# ── Health / Diagnostics (#118) ─────────────────────────────────────────────────────────────────────
-# Max number of files the on-demand case-size scan (Settings → Diagnostics → "Compute case sizes",
-# GET /diagnostics/sizes) will visit before stopping (the result is flagged truncated). Bounds the walk
-# on pathologically large case trees. The default /diagnostics summary never scans files, so this only
-# affects the explicit size button. Default 100000.
-# DFIR_DIAG_MAX_FILES=100000
-
-# ──────────────────────────────────────────────────────────────────────────────────────────────────
-# Automatic state backup / rotation (#180). The Companion snapshots all per-case state files before
-# each synthesis (and on a time-based schedule) so the investigator can roll back a bad synthesis or
-# recover from accidental data loss.  Settings → Diagnostics → "Load case backups" / "Restore".
 #
-# DFIR_STATE_BACKUP_RETAIN        — max total backup files kept per case (oldest pruned). Default 24.
-#                                   Set 0 to keep every backup (unbounded).
-# DFIR_STATE_BACKUP_PRE_SYNTH_RETAIN — how many of those slots are always reserved for pre-synthesis
-#                                   backups so frequent scheduled backups can't crowd them out. Default 10.
-# DFIR_STATE_BACKUP_INTERVAL_MS   — time-based backup interval in milliseconds. Default 3600000 (1 h).
-#                                   Set 0 to disable scheduled backups (pre-synthesis backups still run).
-#
-# DFIR_STATE_BACKUP_RETAIN=24
-# DFIR_STATE_BACKUP_PRE_SYNTH_RETAIN=10
-# DFIR_STATE_BACKUP_INTERVAL_MS=3600000
-
-# ──────────────────────────────────────────────────────────────────────────────────────────────────
-# NSRL RDS SQLite database (#63). For the FULL ~160 GB NSRL Reference Data Set — far too large to load
-# into memory — point this at the "Modern RDS minimal" SQLite file (RDS_*.db). The Companion queries
-# it READ-ONLY, on demand (one indexed lookup per hash), against the METADATA table. Matching keys on
-# sha256/md5, so index the column(s) FIRST (one-time, big speedup) — see the NSRL section in
-# companion/README.md:  CREATE INDEX … ON METADATA(sha256);  ANALYZE;
-# When set, the path is env-managed (the Settings → NSRL connect field is read-only); leave it unset to
-# connect/disconnect a DB from the dashboard instead (that path persists in nsrl/db-path.txt).
+# FULL ~160 GB RDS — point at the "Modern RDS minimal" SQLite (RDS_*.db). Queried READ-ONLY, one
+# indexed lookup per hash against METADATA, matching on sha256/md5. INDEX THE COLUMNS FIRST (one
+# time, big speedup):  CREATE INDEX … ON METADATA(sha256);  ANALYZE;   (see companion/README.md)
+# When set, the path is env-managed and the Settings → NSRL connect field goes read-only.
 # DFIR_NSRL_DB=D:\NSRL\RDS_2026.03.1_modern.db
 
-# ── Update check (#127) ──────────────────────────────────────────────────────────────────────────────
-# Opt-in "newer release available" notice. Default OFF. When enabled the server checks GitHub Releases
-# at most once / 24h (on startup + on demand) and shows a dashboard banner if a newer version exists.
-# It NEVER downloads or installs anything — the banner only links to the release page.
-#   unset    → off; the Settings → Updates toggle controls it (persisted).
-#   1/true   → default on (the toggle can still turn it off at runtime).
-#   0/false  → locked off entirely (the toggle is disabled; for locked-down deployments).
-# DFIR_UPDATE_CHECK=1
-# Override the repo it checks (for forks). Format: owner/name. Defaults to hasamba/DFIR-Companion.
-# DFIR_UPDATE_REPO=hasamba/DFIR-Companion
 
-# ── Read-only deployments / AppImage (#127) ──────────────────────────────────────────────────────────
-# Point the server at a .env file outside the binary's own folder. Needed for the read-only Linux
-# AppImage (its payload is a read-only mount) and useful for any read-only deployment. Absolute path.
-# The Linux AppImage's launcher defaults this to "$PWD/.env" (the directory you run it from).
+# ══════════════════════════════════════════════════════════════════════════════
+# 14. OPERATIONS
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Log verbosity: debug | info | warn | error. Every line is teed to the console AND to files — a
+# global log (logs/session-<time>.log beside the cases root) plus a per-case log
+# (cases/<id>/logs/, the investigation audit trail); a fresh file per server start. At `debug`,
+# every AI call, screenshot, OCR redaction, anonymization and enrichment lookup is traced.
+# Changeable live in Settings → Logging; this only sets the startup default.
+# DFIR_LOG_LEVEL=info
+
+# Folder for the GLOBAL session log. Relative paths anchor to companion/. Per-case logs always stay
+# inside each case folder so the audit trail travels with the case — this does not move those.
+# DFIR_LOG_DIR=./logs
+
+# Atomic-save retries for the final rename when it hits a transient Windows lock (EPERM/EBUSY/
+# EACCES from AV, the search indexer, or a sync client holding investigation.json). Linear backoff
+# capped at 1s, so 20 ≈ 8.4s total. Raise if large imports still fail with
+# "EPERM … rename …tmp -> investigation.json" — better still, exclude the cases root from AV scans.
+# DFIR_ATOMIC_WRITE_RETRIES=20
+
+# Background jobs (#225): heavy async work (import/synthesis/enrichment) is tracked as cancellable
+# jobs. This is only the retention cap on the in-memory list (oldest FINISHED evicted; running ones
+# never are). Not persisted — in-flight jobs are lost on restart.
+# DFIR_JOBS_MAX=100
+
+# Automatic state backup (#180): all per-case state is snapshotted before each synthesis and on a
+# schedule, so a bad synthesis can be rolled back. Settings → Diagnostics → Load case backups.
+# DFIR_STATE_BACKUP_RETAIN=24            # total kept per case (0 = unbounded)
+# DFIR_STATE_BACKUP_PRE_SYNTH_RETAIN=10  # slots reserved for pre-synthesis backups so scheduled
+#                                        # ones can't crowd them out
+# DFIR_STATE_BACKUP_INTERVAL_MS=3600000  # 0 disables scheduled backups (pre-synthesis still runs)
+
+# Disk-usage warning (#119) on the cases-root filesystem. The value you set is the DANGER level;
+# warning sits 15 points below and critical 10 above. Unset = warn 70 / danger 85 / critical 95.
+# 0 disables the check.
+# DFIR_DISK_WARN_PCT=85
+
+# Max files visited by the on-demand case-size scan (Settings → Diagnostics → Compute case sizes).
+# Bounds the walk on pathological trees; the result is flagged truncated. The default /diagnostics
+# summary never scans files.
+# DFIR_DIAG_MAX_FILES=100000
+
+# Update check (#127): opt-in "newer release available" notice. Checks GitHub Releases at most once
+# per 24h and shows a banner — it NEVER downloads or installs anything.
+#   unset → off, Settings → Updates controls it   |   1/true → on   |   0/false → locked off
+# DFIR_UPDATE_CHECK=1
+# DFIR_UPDATE_REPO=hasamba/DFIR-Companion   # override for forks (owner/name)
+
+# Read-only deployments / AppImage (#127): point the server at a .env outside the binary's folder.
+# Absolute path. The Linux AppImage launcher defaults this to "$PWD/.env".
 # DFIR_ENV_FILE=/home/analyst/dfir/.env


### PR DESCRIPTION
Stacked on #171 (which also edits `.env.example`) so the diff stays clean —
GitHub will retarget this to `master` automatically once #171 merges.

## 1 & 2 — Concise + reordered

`.env.example` had grown to **962 lines**, with AI configuration spread across
five separate places (provider block at L102, two-tier at L248, velociraptor
model at L341, second opinion at L353, prompts at L373) and unrelated sections
wedged in between — the content tagger sat in the middle of the AI config.

Now **14 numbered sections with a table of contents**, ordered by how often you
touch them:

> Core → **AI providers** → AI tuning → Ingest → Detection → Enrichment →
> Exposure → Integrations → Velociraptor → Local tools → Capture → UI limits →
> NSRL → Operations

All four AI roles (vision / synth / velo / second-opinion) now sit together at
the top, with the provider recipes directly beneath.

**962 → 747 lines (−22%).** Prose was cut aggressively, but every hard-won
operational gotcha is kept verbatim in substance — the gRPC
`max_grpc_recv_size` trap, the `EPERM … rename` retry guidance, the measured
"a weak SYNTH model fails **silently**, returning zero events" eval result, and
the OPSEC warnings.

## 3 — New defaults (subscription CLIs, no API key)

| Role | Provider | Model |
|---|---|---|
| Vision / OCR | `claude-code` | `haiku` |
| Synthesis | `claude-code` | `claude-sonnet-5` |
| Second opinion | `codex` | `gpt-5.6-sol` |

Second opinion on a genuinely different provider from synthesis, which is what
that feature is for — same-provider models share blind spots.

⚠ **`DFIR_AI_SECOND_OPINION_MODEL` is itself the opt-in for that feature**, so it
is now **enabled by default** (two extra text calls per run). Flagging in case
you'd rather it ship documented-but-commented.

## A bug caught during review

The natural way to write the new defaults is `DFIR_VISION_KEY=` /
`DFIR_VISION_BASE_URL=` (empty — claude-code needs no key). That would have been
a **silent regression**: `visionEnv()` resolves the legacy `DFIR_AI_*` fallback
with `??`, and an empty string is *not* nullish, so an empty `DFIR_VISION_KEY`
would **shadow an existing `DFIR_AI_KEY`** and break upgrades from an older
`.env`. Those lines are left commented, with a note in the file explaining why
they must not be set to empty.

## Verification

- [x] **All 230 variables preserved** — zero dropped, zero added (diffed mechanically)
- [x] No duplicate active keys
- [x] Only active-value changes are the three provider pairs above
- [x] Full suite green — 4155 passed / 1 skipped
- [x] `build-sea.mjs` copies the file verbatim (no parsing), so packaging is unaffected

## Not changed

`DFIR_AI_CONTEXT_TOKENS` stays at `128000`. With Claude now the default it could
go to `200000` (the file's own guidance says so), but under-setting it only trims
prompts whereas over-setting causes hard API errors — worth a deliberate decision
rather than a drive-by.