### PR TITLE
Dismiss a lateral-movement chain, and name who carried it

### DIFF
--- a/companion/src/analysis/evidenceGraph.ts
+++ b/companion/src/analysis/evidenceGraph.ts
@@ -366,6 +366,12 @@ export interface LateralHop {
   toTimestamp: string;          // earliest evidence tying the TO host to this hop's hash/account — the hop's order key
   confidence: Confidence;
   rule: "shared-hash" | "shared-account";
+  // WHO/WHAT carried this hop, as a STRUCTURED field: the account for a shared-account hop, the
+  // binary's filename (falling back to a short hash when no path was recorded) for a shared-hash
+  // one. `basis` says the same thing in prose, but consumers must never parse it back out — that
+  // format-coupling is exactly what silently empties a view when the wording changes.
+  actor: string;
+  actorKind: "account" | "binary";
   basis: string;                // human one-liner
   eventIds: string[];           // the two backing events (from-host + to-host sightings) for this hop
 }
@@ -458,18 +464,31 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
     return !!rec && rec.hasPath && rec.vendorOnly && !rec.grave;
   }
 
+  // The binary's filename, for naming WHAT moved ("psexec.exe" reads far better than a hash
+  // prefix). Falls back to the short hash when no path was recorded for the file.
+  const binaryNameByHash = new Map<string, string>();
+  for (const e of timeline) {
+    const key = (e.sha256 ?? e.md5 ?? "").trim().toLowerCase();
+    const p = (e.path ?? "").trim();
+    if (!key || !p || binaryNameByHash.has(key)) continue;
+    const base = p.split(/[\\/]/).pop();
+    if (base) binaryNameByHash.set(key, base);
+  }
+
   // shared-hash hops: chronological chain across every host the binary touched (high confidence).
   const byHash = earliestPerHost((e) => e.sha256 ?? e.md5);
   for (const [h, hosts] of byHash) {
     if (hosts.size < 2) continue;
     if (isInstalledSoftware(h)) continue;              // installed vendor software ≠ movement
     const ordered = [...hosts.values()].sort((a, b) => timeOf(a.timestamp) - timeOf(b.timestamp));
+    const binary = binaryNameByHash.get(h) ?? shortHash(h);
     for (let i = 1; i < ordered.length; i++) {
       const from = ordered[i - 1], to = ordered[i];
       hops.push({
         from: hostNodeId(from.asset!.trim()), to: hostNodeId(to.asset!.trim()),
         fromTimestamp: from.timestamp, toTimestamp: to.timestamp,
         confidence: "high", rule: "shared-hash",
+        actor: binary, actorKind: "binary",
         basis: `same binary ${shortHash(h)}: ${from.asset!.trim()} → ${to.asset!.trim()}`,
         eventIds: [from.id, to.id],
       });
@@ -500,6 +519,7 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
         from: hostNodeId(from.asset!.trim()), to: hostNodeId(to.asset!.trim()),
         fromTimestamp: from.timestamp, toTimestamp: to.timestamp,
         confidence: "medium", rule: "shared-account",
+        actor: acct, actorKind: "account",
         basis: `${acct} active on ${from.asset!.trim()} then ${to.asset!.trim()}`,
         eventIds: [from.id, to.id],
       });

--- a/companion/src/analysis/lateralPathDismiss.ts
+++ b/companion/src/analysis/lateralPathDismiss.ts
@@ -1,0 +1,129 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import type { LateralPath } from "./evidenceGraph.js";
+
+// Analyst dismissal of a reconstructed lateral-movement chain (#92 follow-up).
+//
+// WHY THIS IS NOT A FALSE-POSITIVE MARKER: a false positive says "this EVIDENCE is wrong" and
+// removes the underlying events from the whole case — the timeline, the report, every other graph.
+// A lateral path is an INFERENCE drawn from evidence that is usually perfectly real: the logons
+// happened, the binary really is on both hosts, but "therefore the attacker pivoted A → B → C" is
+// the wrong conclusion. Forcing an analyst to discard real evidence to silence a bad conclusion
+// would hide facts they never disputed, so dismissal is its own, narrower decision.
+//
+// WHAT IT KEYS ON: lateral paths are derived on every read and never stored, so there is no
+// durable id to hang a dismissal on — `LateralPath.id` is positional (lateral-path:0, :1) and
+// shifts as soon as the data changes. The ordered HOST SEQUENCE is used instead, because that is
+// precisely the claim being rejected, and it survives the same route being rebuilt from different
+// underlying evidence after a re-import.
+export interface LateralPathDismissal {
+  id: string;
+  key: string;          // ordered host sequence — the durable anchor (see lateralPathKey)
+  hostIds: string[];    // the route as dismissed, kept readable for the review/undo list
+  note: string;         // why the analyst rejected it (free text, may be empty)
+  dismissedAt: string;  // ISO timestamp
+}
+
+// A path annotated with its dismissal state, for the "show dismissed" review view.
+export type AnnotatedLateralPath = LateralPath & { dismissed: boolean; dismissalNote?: string };
+
+// The claim's identity: the ordered hosts, normalized so trivial formatting differences between a
+// stored dismissal and a freshly derived path cannot cause a silent miss.
+export function lateralPathKey(hostIds: readonly string[]): string {
+  return hostIds.map((h) => h.trim().toLowerCase()).join(">");
+}
+
+function dismissedKeys(dismissals: readonly LateralPathDismissal[]): Map<string, LateralPathDismissal> {
+  const byKey = new Map<string, LateralPathDismissal>();
+  // Re-derive the key from hostIds rather than trusting the stored `key`, so a hand-edited or
+  // older file can't hold a stale/mis-normalized anchor that silently matches nothing.
+  for (const d of dismissals) byKey.set(d.hostIds?.length ? lateralPathKey(d.hostIds) : d.key, d);
+  return byKey;
+}
+
+// Drop dismissed routes. EXACT sequence match only: A→B→C→D is a different claim than A→B→C (the
+// attacker reached one more host), so dismissing the shorter chain must never hide the longer one.
+export function filterDismissedPaths<T extends LateralPath>(
+  paths: readonly T[],
+  dismissals: readonly LateralPathDismissal[],
+): T[] {
+  if (dismissals.length === 0) return [...paths];
+  const byKey = dismissedKeys(dismissals);
+  return paths.filter((p) => !byKey.has(lateralPathKey(p.hostIds)));
+}
+
+// Keep every path but flag the dismissed ones — powers the review/undo view, where the analyst
+// needs to SEE what they dismissed in order to restore it.
+export function annotateDismissedPaths(
+  paths: readonly LateralPath[],
+  dismissals: readonly LateralPathDismissal[],
+): AnnotatedLateralPath[] {
+  const byKey = dismissedKeys(dismissals);
+  return paths.map((p) => {
+    const hit = byKey.get(lateralPathKey(p.hostIds));
+    return { ...p, dismissed: !!hit, ...(hit?.note ? { dismissalNote: hit.note } : {}) };
+  });
+}
+
+// Build a dismissal record for a route. Returns null when the route is not a chain (a path needs
+// at least two hosts), so a malformed request can't persist an anchor that matches nothing.
+export function buildDismissal(hostIds: readonly string[], note: string, now = new Date()): LateralPathDismissal | null {
+  const hosts = hostIds.map((h) => h.trim()).filter((h) => h.length > 0);
+  if (hosts.length < 2) return null;
+  return {
+    id: randomUUID(),
+    key: lateralPathKey(hosts),
+    hostIds: hosts,
+    note: note.trim(),
+    dismissedAt: now.toISOString(),
+  };
+}
+
+// Per-case persistence, mirroring FalsePositiveStore: one JSON file in the case's state dir.
+export class LateralPathDismissStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "lateral-path-dismissals.json");
+  }
+
+  async load(caseId: string): Promise<LateralPathDismissal[]> {
+    try {
+      const raw = JSON.parse(await readFile(this.path(caseId), "utf8")) as unknown;
+      if (!Array.isArray(raw)) return [];
+      return raw.filter((d): d is LateralPathDismissal => {
+        const o = d as Partial<LateralPathDismissal>;
+        return typeof o?.id === "string" && Array.isArray(o.hostIds) && o.hostIds.length >= 2;
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+  }
+
+  async save(caseId: string, dismissals: LateralPathDismissal[]): Promise<void> {
+    await atomicWrite(this.path(caseId), JSON.stringify(dismissals, null, 2));
+  }
+
+  // Add a dismissal, replacing any existing one for the same route so re-dismissing updates the
+  // note instead of accumulating duplicates. Returns the stored record, or null if invalid.
+  async add(caseId: string, hostIds: readonly string[], note: string): Promise<LateralPathDismissal | null> {
+    const record = buildDismissal(hostIds, note);
+    if (!record) return null;
+    const existing = await this.load(caseId);
+    await this.save(caseId, [...existing.filter((d) => lateralPathKey(d.hostIds) !== record.key), record]);
+    return record;
+  }
+
+  // Restore a route by its key. Returns true when something was actually removed.
+  async remove(caseId: string, key: string): Promise<boolean> {
+    const existing = await this.load(caseId);
+    const remaining = existing.filter((d) => lateralPathKey(d.hostIds) !== key.trim().toLowerCase());
+    if (remaining.length === existing.length) return false;
+    await this.save(caseId, remaining);
+    return true;
+  }
+}

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -3,7 +3,7 @@ import { byEventTime } from "../analysis/forensicSort.js";
 import { emptyReportMeta, type ReportMeta, type ReportRevision } from "./reportMeta.js";
 import { deriveGlossary } from "./glossary.js";
 import { buildAssetGraph, type AssetGraph } from "../analysis/assetGraph.js";
-import { buildEvidenceGraph, buildLateralPaths } from "../analysis/evidenceGraph.js";
+import { buildEvidenceGraph, buildLateralPaths, type LateralPath } from "../analysis/evidenceGraph.js";
 import { buildAttackPhases, DEFAULT_GAP_SECONDS } from "../analysis/burstDetect.js";
 import { detectBeacons, beaconEnvOptions, BEACON_CAVEAT } from "../analysis/beaconDetect.js";
 import { buildGeoMap } from "../analysis/geoMap.js";
@@ -512,7 +512,7 @@ function kevCorrelation(state: InvestigationState, exposure: CustomerExposureSum
   lines.push("");
 }
 
-function investigation(state: InvestigationState, lines: string[], exposure?: CustomerExposureSummary, prebuiltGraph?: AssetGraph, kevCatalog?: KevCatalog, secondLookLeads: string[] = []): void {
+function investigation(state: InvestigationState, lines: string[], exposure?: CustomerExposureSummary, prebuiltGraph?: AssetGraph, kevCatalog?: KevCatalog, secondLookLeads: string[] = [], prebuiltPaths?: LateralPath[]): void {
   lines.push("## 4 Investigation", "");
 
   lines.push("### 4.1 Attack path", "");
@@ -636,7 +636,7 @@ function investigation(state: InvestigationState, lines: string[], exposure?: Cu
     lines.push("");
   }
 
-  chainOfEvidence(state, lines);
+  chainOfEvidence(state, lines, prebuiltPaths);
   beaconCandidates(state, lines);
   geographicDistribution(state, lines);
 }
@@ -702,7 +702,7 @@ function geographicDistribution(state: InvestigationState, lines: string[]): voi
 // 4.8 Chain of evidence — the causal view derived from the forensic timeline: which process
 // spawned which (process execution chains), which binary/account moved between hosts
 // (lateral movement), file write→execute lineage, and network flows (src→dst).
-function chainOfEvidence(state: InvestigationState, lines: string[]): void {
+function chainOfEvidence(state: InvestigationState, lines: string[], prebuiltPaths?: LateralPath[]): void {
   lines.push("### 4.8 Chain of evidence", "");
   const graph = buildEvidenceGraph(state);
   if (graph.edges.length === 0) {
@@ -735,13 +735,18 @@ function chainOfEvidence(state: InvestigationState, lines: string[]): void {
 
   // Ordered lateral-movement PATHS (#92) — ...→pivot→target chains reconstructed from the
   // pairwise lateral_move edges above, chronologically sequenced rather than pairwise.
-  const paths = buildLateralPaths(state);
+  // prebuiltPaths (with analyst dismissals already applied) is used when available, so a chain the
+  // analyst rejected does not reappear in the report.
+  const paths = prebuiltPaths ?? buildLateralPaths(state);
   if (paths.length > 0) {
     lines.push("**Lateral movement paths**", "");
-    lines.push("| Path | Confidence | First seen | Last seen |", "| --- | --- | --- | --- |");
+    // "Via" names the account(s)/binary(ies) that carried the chain — the route alone says where
+    // the attacker went but not who or what moved, which is the actionable half for the reader.
+    lines.push("| Path | Via | Confidence | First seen | Last seen |", "| --- | --- | --- | --- | --- |");
     for (const p of paths) {
       const route = p.hostIds.map((id) => cellMd(name(id))).join(" → ");
-      lines.push(`| ${route} | ${p.confidence} | ${p.startTime || "—"} | ${p.endTime || "—"} |`);
+      const via = [...new Set(p.hops.map((h) => h.actor).filter(Boolean))].map((a) => cellMd(a)).join(", ") || "—";
+      lines.push(`| ${route} | ${via} | ${p.confidence} | ${p.startTime || "—"} | ${p.endTime || "—"} |`);
     }
     lines.push("");
   }
@@ -1019,6 +1024,7 @@ export function renderMarkdownReport(
   hypotheses?: Hypothesis[],
   secondLookLeads: string[] = [],   // #11 deferred: unresolved second-look collection leads
   coverage?: SynthesisCoverage | null,   // #62: synthesis coverage footnote (opt-in via DFIR_REPORT_SYNTH_COVERAGE)
+  lateralPaths?: LateralPath[],   // prebuilt with analyst dismissals applied; derived here when absent
 ): string {
   const lines: string[] = [];
   const ctx = buildBrandingContext(state, meta);
@@ -1055,7 +1061,7 @@ export function renderMarkdownReport(
       synthesisCoverageNote(coverage, lines);
       timelineAnomalies(state, lines);
     },
-    investigation: () => investigation(state, lines, exposure, assetGraph, kevCatalog, secondLookLeads),
+    investigation: () => investigation(state, lines, exposure, assetGraph, kevCatalog, secondLookLeads, lateralPaths),
     conclusions: () => conclusions(state, meta, lines),
     hypotheses: () => {
       if (hypotheses && hypotheses.length > 0) hypothesesSection(hypotheses, lines);

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -52,6 +52,13 @@ import type { SynthMetaStore, SynthesisCoverage } from "../analysis/synthMeta.js
 import type { PlaybookStore } from "../analysis/playbookStore.js";
 import type { PlaybookTask } from "../analysis/playbook.js";
 import { AssetOverridesStore, applyAssetOverrides, emptyOverrides } from "../analysis/assetOverrides.js";
+import {
+  LateralPathDismissStore,
+  filterDismissedPaths,
+  annotateDismissedPaths,
+  type LateralPathDismissal,
+  type AnnotatedLateralPath,
+} from "../analysis/lateralPathDismiss.js";
 import { buildBrandingContext, defaultReportTemplate, renderTemplateString, type ReportTemplate } from "./reportTemplate.js";
 import type { ReportTemplateStore } from "./reportTemplateStore.js";
 import type { ReportTemplateControlStore } from "./reportTemplateControl.js";
@@ -86,6 +93,7 @@ export class ReportWriter {
     private readonly kevStore?: KevStore,
     private readonly hypothesisStore?: HypothesisStore,
     private readonly synthMeta?: SynthMetaStore,   // #11 deferred: second-look collection leads in the report
+    private readonly lateralPathDismissals?: LateralPathDismissStore,   // analyst-rejected lateral chains
   ) {}
 
   // Second-look collection leads (investigation-guidance #11, deferred): requests the raw re-query made
@@ -215,9 +223,17 @@ export class ReportWriter {
 
   // Ordered lateral-movement chains (entry host → pivot → ... → target, #92) for the case, derived
   // on demand with the same scope/legitimate filtering as the report. An optional time `window`
-  // (#83) narrows it to events in that range.
-  async lateralPaths(caseId: string, window?: TimeWindow): Promise<LateralPath[]> {
-    return buildLateralPaths(await this.loadFilteredState(caseId), window);
+  // (#83) narrows it to events in that range. Chains the analyst has DISMISSED are dropped — pass
+  // includeDismissed to get them back, each flagged, for the review/undo view.
+  async lateralPaths(caseId: string, window?: TimeWindow, includeDismissed = false): Promise<LateralPath[] | AnnotatedLateralPath[]> {
+    const paths = buildLateralPaths(await this.loadFilteredState(caseId), window);
+    const dismissals = await this.loadLateralPathDismissals(caseId);
+    return includeDismissed ? annotateDismissedPaths(paths, dismissals) : filterDismissedPaths(paths, dismissals);
+  }
+
+  private async loadLateralPathDismissals(caseId: string): Promise<LateralPathDismissal[]> {
+    if (!this.lateralPathDismissals) return [];
+    try { return await this.lateralPathDismissals.load(caseId); } catch { return []; }
   }
 
   // Temporal attack phases (bursts of activity grouped by time gap) for the case, derived on
@@ -410,9 +426,10 @@ export class ReportWriter {
     hypotheses?: Hypothesis[],
     secondLookLeads?: string[],
     coverage?: SynthesisCoverage | null,
+    lateralPaths?: LateralPath[],
   ): RedactedReportContents {
     return {
-      markdown: renderMarkdownReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage),
+      markdown: renderMarkdownReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths),
       html: renderHtmlReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, hypotheses),
       findingsCsv: findingsCsv(state),
       iocsCsv: iocsCsv(state),
@@ -445,7 +462,9 @@ export class ReportWriter {
     const kevCatalog = await this.loadKevCatalog();
     const secondLookLeads = await this.loadSecondLookLeads(caseId);
     const coverage = await this.loadCoverage(caseId);
-    const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage);
+    // Lateral chains the analyst dismissed must not reappear in the written report.
+    const lateralPaths = filterDismissedPaths(buildLateralPaths(state), await this.loadLateralPathDismissals(caseId));
+    const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths);
     await writeFile(paths.markdown, c.markdown, "utf8");
     await writeFile(paths.html, c.html, "utf8");
     await writeFile(paths.findingsCsv, c.findingsCsv, "utf8");
@@ -479,6 +498,12 @@ export class ReportWriter {
     const template = await this.loadTemplate(caseId);
     const kevCatalog = await this.loadKevCatalog();
     const secondLookLeads = applyAnonDeep(await this.loadSecondLookLeads(caseId), redact);
-    return this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads);
+    // Dismissals are anchored on REAL host ids, but this state is anonymized — so run them through
+    // the same redaction before matching, exactly as the asset overrides above are.
+    const lateralPaths = filterDismissedPaths(
+      buildLateralPaths(state),
+      applyAnonDeep(await this.loadLateralPathDismissals(caseId), redact),
+    );
+    return this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, undefined, lateralPaths);
   }
 }

--- a/companion/src/routes/analysisGraph.ts
+++ b/companion/src/routes/analysisGraph.ts
@@ -140,10 +140,50 @@ export function registerAnalysisGraphRoutes(app: Express, ctx: RouteContext): vo
   // from the current state with the same scope/legitimate filtering as the report. Optional
   // ?from/?until (#83). Complements /evidence-graph's pairwise lateral_move edges with the
   // temporal sequencing they deliberately don't encode.
+  // ?includeDismissed=1 returns analyst-dismissed chains too, each flagged — that is what powers
+  // the review/undo view; without it they are omitted.
   app.get("/cases/:id/lateral-paths", async (req: Request, res: Response) => {
     if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
     try {
-      return res.status(200).json(await options.reportWriter.lateralPaths(req.params.id, timeWindow(req)));
+      const includeDismissed = req.query.includeDismissed === "1" || req.query.includeDismissed === "true";
+      return res.status(200).json(await options.reportWriter.lateralPaths(req.params.id, timeWindow(req), includeDismissed));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Analyst dismissal of a reconstructed lateral chain. Distinct from a false-positive marker: this
+  // rejects the INFERENCE ("the attacker did not pivot A → B → C") without discarding the underlying
+  // evidence, which is usually real and still belongs in the timeline. Keyed on the ordered host
+  // sequence because paths are derived per read and their ids are positional (see lateralPathDismiss.ts).
+  app.get("/cases/:id/lateral-path-dismissals", async (req: Request, res: Response) => {
+    if (!options.lateralPathDismissStore) return res.status(501).json({ error: "lateral path dismissals not configured" });
+    try {
+      return res.status(200).json(await options.lateralPathDismissStore.load(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.post("/cases/:id/lateral-path-dismissals", async (req: Request, res: Response) => {
+    if (!options.lateralPathDismissStore) return res.status(501).json({ error: "lateral path dismissals not configured" });
+    try {
+      const hostIds = Array.isArray(req.body?.hostIds) ? (req.body.hostIds as unknown[]).filter((h): h is string => typeof h === "string") : [];
+      const dismissal = await options.lateralPathDismissStore.add(req.params.id, hostIds, typeof req.body?.note === "string" ? req.body.note : "");
+      if (!dismissal) return res.status(400).json({ error: "hostIds must name at least two hosts" });
+      return res.status(201).json(dismissal);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Restore a dismissed chain. The key is the ordered host sequence (a>b>c), URL-encoded.
+  app.delete("/cases/:id/lateral-path-dismissals/:key", async (req: Request, res: Response) => {
+    if (!options.lateralPathDismissStore) return res.status(501).json({ error: "lateral path dismissals not configured" });
+    try {
+      const removed = await options.lateralPathDismissStore.remove(req.params.id, req.params.key);
+      if (!removed) return res.status(404).json({ error: "dismissal not found" });
+      return res.status(204).end();
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -120,6 +120,7 @@ import { HuntOutcomeStore } from "./analysis/huntOutcomeStore.js";
 import { recordDeploy, fillOutcome, HUNT_OUTCOME_MAX_DEFAULT, type HuntDeployInput } from "./analysis/huntOutcomes.js";
 import { PlaybookControlStore, DEFAULT_PLAYBOOK_CONTROL, type PlaybookControl } from "./analysis/playbookControl.js";
 import { AssetOverridesStore } from "./analysis/assetOverrides.js";
+import { LateralPathDismissStore } from "./analysis/lateralPathDismiss.js";
 import { IocAliasStore } from "./analysis/iocAlias.js";
 import { SynthMetaStore } from "./analysis/synthMeta.js";
 import { AiCostStore } from "./analysis/aiCost.js";
@@ -343,6 +344,10 @@ export interface AppOptions {
   // pings dashboard clients over the WS to re-fetch the graph when overrides change.
   assetOverridesStore?: AssetOverridesStore;
   onAssetOverrides?: (caseId: string) => void;
+  // Analyst-dismissed lateral-movement chains, persisted per case in
+  // state/lateral-path-dismissals.json. Rejects a derived INFERENCE without discarding the
+  // underlying evidence the way a false-positive marker would.
+  lateralPathDismissStore?: LateralPathDismissStore;
   // Entity merging for duplicate IOCs (#82). iocAliasStore persists per-case merge aliases (state/
   // ioc-aliases.json) so a future re-synthesis routes the merged-away value onto its canonical IOC
   // instead of recreating it (see pipeline.ts's mergeWithAliases). onIocMerge pings dashboard
@@ -2987,7 +2992,8 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const notionExportStore = new NotionExportStore(store);
   const clickupExportStore = new ClickUpExportStore(store);
   const irisExportStore = new IrisExportStore(store);
-  const reportWriter = new ReportWriterImpl(store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore, new CustomerExposureStore(store), notebookStore, assetOverridesStore, playbookStore, reportTemplateStore, reportTemplateControlStore, kevStore, hypothesisStore, synthMetaStore);
+  const lateralPathDismissStore = new LateralPathDismissStore(store);
+  const reportWriter = new ReportWriterImpl(store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore, new CustomerExposureStore(store), notebookStore, assetOverridesStore, playbookStore, reportTemplateStore, reportTemplateControlStore, kevStore, hypothesisStore, synthMetaStore, lateralPathDismissStore);
 
   // Automatic state backup (#180): snapshot SNAPSHOT_STATE_FILES before synthesis + on a timer.
   const backupConfig = resolveBackupConfig(process.env);
@@ -3115,6 +3121,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     onPlaybook: (caseId) => hub.broadcastTo(caseId, { type: "playbook_changed" }),
     assetOverridesStore,
     onAssetOverrides: (caseId) => hub.broadcastTo(caseId, { type: "asset_overrides_changed" }),
+    lateralPathDismissStore,
     iocAliasStore,
     onIocMerge: (caseId) => hub.broadcastTo(caseId, { type: "ioc_merge_changed" }),
     onFalsePositive: (caseId) => hub.broadcastTo(caseId, { type: "false_positive_changed" }),

--- a/companion/tests/analysis/evidenceGraph.test.ts
+++ b/companion/tests/analysis/evidenceGraph.test.ts
@@ -436,6 +436,43 @@ describe("buildLateralPaths — ordered lateral-movement chains (#92)", () => {
     expect(buildLateralPaths(s)).toEqual([]);
   });
 
+  // A route is only half the story: "WKSTN → FS01 → WEB01" does not say WHO moved. The actor is a
+  // STRUCTURED field so the dashboard/report never have to parse it back out of `basis` prose.
+  it("names the account that carried a shared-account hop", () => {
+    const s = emptyState("c1");
+    s.forensicTimeline.push(
+      ev({ id: "e1", asset: "WKSTN-JSMITH", description: "logon by GLOBALTECH\\admin-deploy", timestamp: "2026-05-20T09:00:00Z" }),
+      ev({ id: "e2", asset: "FS01", description: "logon by GLOBALTECH\\admin-deploy", timestamp: "2026-05-20T10:00:00Z" }),
+    );
+    const hop = buildLateralPaths(s)[0].hops[0];
+    expect(hop.actor).toBe("GLOBALTECH\\admin-deploy");
+    expect(hop.actorKind).toBe("account");
+  });
+
+  it("names the binary that carried a shared-hash hop, by filename", () => {
+    const s = emptyState("c1");
+    const path = "C:\\Users\\jdoe\\Downloads\\psexec.exe";
+    s.forensicTimeline.push(
+      ev({ id: "e1", asset: "WS-01", sha256: HASH, path, timestamp: "2026-05-20T09:00:00Z" }),
+      ev({ id: "e2", asset: "WS-02", sha256: HASH, path, timestamp: "2026-05-20T10:00:00Z" }),
+    );
+    const hop = buildLateralPaths(s)[0].hops[0];
+    expect(hop.actor).toBe("psexec.exe");        // not a hash prefix — the analyst reads a name
+    expect(hop.actorKind).toBe("binary");
+  });
+
+  it("falls back to a short hash when the binary's path was never recorded", () => {
+    const s = emptyState("c1");
+    s.forensicTimeline.push(
+      ev({ id: "e1", asset: "WS-01", sha256: HASH, timestamp: "2026-05-20T09:00:00Z" }),
+      ev({ id: "e2", asset: "WS-02", sha256: HASH, timestamp: "2026-05-20T10:00:00Z" }),
+    );
+    const hop = buildLateralPaths(s)[0].hops[0];
+    expect(hop.actorKind).toBe("binary");
+    expect(hop.actor.length).toBeGreaterThan(0);
+    expect(HASH.startsWith(hop.actor.replace(/…$/, ""))).toBe(true);
+  });
+
   // Spread the same binary over three hosts from a given on-disk location.
   function estateWide(path: string, extra: Partial<ForensicEvent> = {}) {
     const s = emptyState("c1");

--- a/companion/tests/analysis/lateralPathDismiss.test.ts
+++ b/companion/tests/analysis/lateralPathDismiss.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  lateralPathKey,
+  filterDismissedPaths,
+  annotateDismissedPaths,
+  type LateralPathDismissal,
+} from "../../src/analysis/lateralPathDismiss.js";
+import type { LateralPath } from "../../src/analysis/evidenceGraph.js";
+
+// A lateral path is DERIVED on every read and never stored, so a dismissal cannot key on the
+// path's id — those are positional (lateral-path:0, :1) and shift the moment the data changes.
+// It keys on the ordered host sequence instead: that IS the claim the analyst is rejecting
+// ("the attacker did NOT go A → B → C"), and it survives the same chain being rebuilt from
+// different underlying evidence.
+
+function path(id: string, hostIds: string[]): LateralPath {
+  return {
+    id,
+    hostIds,
+    hops: [],
+    confidence: "medium",
+    startTime: "2026-05-20T09:00:00Z",
+    endTime: "2026-05-20T11:00:00Z",
+  };
+}
+
+function dismissal(hostIds: string[]): LateralPathDismissal {
+  return {
+    id: `d-${hostIds.join("-")}`,
+    key: lateralPathKey(hostIds),
+    hostIds,
+    note: "",
+    dismissedAt: "2026-05-21T00:00:00Z",
+  };
+}
+
+describe("lateralPathKey", () => {
+  it("is the ordered host sequence, so order is part of the identity", () => {
+    expect(lateralPathKey(["host:a", "host:b"])).not.toBe(lateralPathKey(["host:b", "host:a"]));
+  });
+
+  it("is stable regardless of which evidence produced the chain", () => {
+    // Same route, rebuilt from different hops after a re-import — still one claim.
+    expect(lateralPathKey(["host:a", "host:b", "host:c"])).toBe(lateralPathKey(["host:a", "host:b", "host:c"]));
+  });
+
+  it("ignores case and surrounding whitespace in host ids", () => {
+    expect(lateralPathKey([" HOST:A ", "host:B"])).toBe(lateralPathKey(["host:a", "host:b"]));
+  });
+});
+
+describe("filterDismissedPaths", () => {
+  const paths = [
+    path("lateral-path:0", ["host:a", "host:b", "host:c"]),
+    path("lateral-path:1", ["host:x", "host:y"]),
+  ];
+
+  it("removes exactly the dismissed route and leaves the rest", () => {
+    const kept = filterDismissedPaths(paths, [dismissal(["host:a", "host:b", "host:c"])]);
+    expect(kept.map((p) => p.hostIds)).toEqual([["host:x", "host:y"]]);
+  });
+
+  it("still removes the route when it comes back with a different path id", () => {
+    // Re-derivation renumbers the paths; the dismissal must not be defeated by that.
+    const renumbered = [path("lateral-path:7", ["host:a", "host:b", "host:c"])];
+    expect(filterDismissedPaths(renumbered, [dismissal(["host:a", "host:b", "host:c"])])).toEqual([]);
+  });
+
+  it("does NOT remove a longer chain that merely contains the dismissed route", () => {
+    // A → B → C → D is a DIFFERENT claim than A → B → C: the attacker reached one more host.
+    // Silently hiding it would suppress a finding the analyst never rejected.
+    const longer = [path("lateral-path:0", ["host:a", "host:b", "host:c", "host:d"])];
+    expect(filterDismissedPaths(longer, [dismissal(["host:a", "host:b", "host:c"])])).toHaveLength(1);
+  });
+
+  it("does NOT remove the same hosts in a different order", () => {
+    const reversed = [path("lateral-path:0", ["host:c", "host:b", "host:a"])];
+    expect(filterDismissedPaths(reversed, [dismissal(["host:a", "host:b", "host:c"])])).toHaveLength(1);
+  });
+
+  it("returns everything when nothing is dismissed", () => {
+    expect(filterDismissedPaths(paths, [])).toHaveLength(2);
+  });
+});
+
+describe("annotateDismissedPaths", () => {
+  it("keeps every path but flags the dismissed ones, for the review/undo view", () => {
+    const annotated = annotateDismissedPaths(
+      [path("lateral-path:0", ["host:a", "host:b"]), path("lateral-path:1", ["host:x", "host:y"])],
+      [dismissal(["host:a", "host:b"])],
+    );
+    expect(annotated).toHaveLength(2);
+    expect(annotated[0].dismissed).toBe(true);
+    expect(annotated[1].dismissed).toBe(false);
+  });
+
+  it("carries the dismissal note so the analyst can see why it was rejected", () => {
+    const d = { ...dismissal(["host:a", "host:b"]), note: "scheduled backup job, not an attacker" };
+    const annotated = annotateDismissedPaths([path("lateral-path:0", ["host:a", "host:b"])], [d]);
+    expect(annotated[0].dismissalNote).toBe("scheduled backup job, not an attacker");
+  });
+});

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -2,6 +2,35 @@ import { describe, it, expect } from "vitest";
 import { readFile } from "node:fs/promises";
 
 describe("dashboard.html", () => {
+  it("lets the analyst dismiss a lateral chain, and review/restore dismissed ones", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    // Per-row Dismiss, with Restore taking its place once a chain has been dismissed.
+    expect(html).toContain("ev-path-dismiss");
+    expect(html).toContain("ev-path-restore");
+    // The button must say what dismissing does NOT do — the evidence is kept.
+    expect(html).toMatch(/ev-path-dismiss[\s\S]{0,300}underlying evidence stays in the case/);
+    // Dismissed chains are hidden by default; the toggle re-fetches with includeDismissed=1.
+    expect(html).toContain("let evPathsShowDismissed = false");
+    expect(html).toContain("evPathsShowDismissed");
+    expect(html).toMatch(/function loadLateralPaths\(caseId\)[\s\S]{0,400}includeDismissed=1/);
+    // Dismissing POSTs the route's hostIds (the durable anchor), not the positional path id.
+    expect(html).toMatch(/lateral-path-dismissals`[\s\S]{0,300}hostIds: path\.hostIds/);
+    // Restoring DELETEs by the normalized host-sequence key.
+    expect(html).toMatch(/lateral-path-dismissals\/\$\{encodeURIComponent\(key\)\}`, \{ method: "DELETE" \}/);
+    // A dismissed row is visibly struck through and carries the analyst's reason.
+    expect(html).toContain("line-through");
+    expect(html).toContain("dismissalNote");
+  });
+
+  it("names who/what carried each lateral chain, not just the hosts", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    // Read from the hop's STRUCTURED actor field — never parsed back out of the `basis` prose.
+    expect(html).toMatch(/p\.hops \|\| \[\]\)\.map\(\(h\) => h\.actor\)/);
+    expect(html).toContain("via <b>");
+    // De-duplicated: one account carrying every hop is listed once, not once per hop.
+    expect(html).toMatch(/new Set\(\(p\.hops \|\| \[\]\)\.map\(\(h\) => h\.actor\)/);
+  });
+
   it("expands Host & Account Ranking rows to show contributing events + IOCs (#237)", async () => {
     const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
     expect(html).toContain("data-hr-key=");

--- a/companion/tests/server/lateralPathDismiss.test.ts
+++ b/companion/tests/server/lateralPathDismiss.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { createApp, setServerLogger } from "../../src/server.js";
+import { createConsoleLogger } from "../../src/logging/logger.js";
+import { ReportWriter } from "../../src/reports/reportWriter.js";
+import { LateralPathDismissStore, lateralPathKey } from "../../src/analysis/lateralPathDismiss.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+let store: CaseStore;
+let stateStore: StateStore;
+
+function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return { timestamp: "", description: "", severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...p };
+}
+
+// A case whose timeline yields one chain: WS-01 → WS-02, from a tool in a writable location
+// (so the vendor-software filter keeps it).
+async function seedCaseWithOneChain(caseId: string): Promise<void> {
+  await store.createCase({ caseId, name: "n", investigator: "i", aiProvider: null });
+  const state = emptyState(caseId);
+  const path = "C:\\Users\\jdoe\\Downloads\\psexec.exe";
+  state.forensicTimeline.push(
+    ev({ id: "e1", asset: "WS-01", sha256: HASH, path, timestamp: "2026-05-20T09:00:00Z" }),
+    ev({ id: "e2", asset: "WS-02", sha256: HASH, path, timestamp: "2026-05-20T10:00:00Z" }),
+  );
+  await stateStore.save(state);
+}
+
+function appWith(dismissStore: LateralPathDismissStore) {
+  return createApp(store, {
+    reportWriter: new ReportWriter(store, stateStore, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, dismissStore),
+    lateralPathDismissStore: dismissStore,
+  });
+}
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-lateral-dismiss-"));
+  store = new CaseStore(root);
+  stateStore = new StateStore(store);
+  setServerLogger(createConsoleLogger("error"));
+});
+
+describe("lateral path dismissal", () => {
+  it("hides a dismissed chain from the lateral-paths read", async () => {
+    await seedCaseWithOneChain("c1");
+    const app = appWith(new LateralPathDismissStore(store));
+
+    const before = await request(app).get("/cases/c1/lateral-paths");
+    expect(before.status).toBe(200);
+    expect(before.body).toHaveLength(1);
+    const hostIds = before.body[0].hostIds as string[];
+
+    const dismissed = await request(app).post("/cases/c1/lateral-path-dismissals").send({ hostIds, note: "backup job" });
+    expect(dismissed.status).toBe(201);
+
+    const after = await request(app).get("/cases/c1/lateral-paths");
+    expect(after.body).toEqual([]);
+  });
+
+  it("does NOT touch the underlying evidence — dismissing an inference is not a false positive", async () => {
+    await seedCaseWithOneChain("c1");
+    const app = appWith(new LateralPathDismissStore(store));
+    const paths = await request(app).get("/cases/c1/lateral-paths");
+    await request(app).post("/cases/c1/lateral-path-dismissals").send({ hostIds: paths.body[0].hostIds, note: "" });
+
+    // The events that produced the chain are still in the case timeline.
+    const state = await stateStore.load("c1");
+    expect(state.forensicTimeline.map((e) => e.id)).toEqual(["e1", "e2"]);
+  });
+
+  it("returns the dismissed chain, flagged, under ?includeDismissed=1 so it can be reviewed and undone", async () => {
+    await seedCaseWithOneChain("c1");
+    const app = appWith(new LateralPathDismissStore(store));
+    const paths = await request(app).get("/cases/c1/lateral-paths");
+    await request(app).post("/cases/c1/lateral-path-dismissals").send({ hostIds: paths.body[0].hostIds, note: "backup job" });
+
+    const review = await request(app).get("/cases/c1/lateral-paths?includeDismissed=1");
+    expect(review.body).toHaveLength(1);
+    expect(review.body[0].dismissed).toBe(true);
+    expect(review.body[0].dismissalNote).toBe("backup job");
+  });
+
+  it("restores a chain when the dismissal is deleted", async () => {
+    await seedCaseWithOneChain("c1");
+    const app = appWith(new LateralPathDismissStore(store));
+    const paths = await request(app).get("/cases/c1/lateral-paths");
+    const hostIds = paths.body[0].hostIds as string[];
+    await request(app).post("/cases/c1/lateral-path-dismissals").send({ hostIds, note: "" });
+    expect((await request(app).get("/cases/c1/lateral-paths")).body).toEqual([]);
+
+    const del = await request(app).delete(`/cases/c1/lateral-path-dismissals/${encodeURIComponent(lateralPathKey(hostIds))}`);
+    expect(del.status).toBe(204);
+    expect((await request(app).get("/cases/c1/lateral-paths")).body).toHaveLength(1);
+  });
+
+  it("survives re-derivation: the dismissal still applies after the case is re-read", async () => {
+    await seedCaseWithOneChain("c1");
+    const dismissStore = new LateralPathDismissStore(store);
+    const app = appWith(dismissStore);
+    const paths = await request(app).get("/cases/c1/lateral-paths");
+    await request(app).post("/cases/c1/lateral-path-dismissals").send({ hostIds: paths.body[0].hostIds, note: "" });
+
+    // A brand-new app instance (fresh stores, nothing cached) must honour the persisted dismissal.
+    const reopened = appWith(new LateralPathDismissStore(store));
+    expect((await request(reopened).get("/cases/c1/lateral-paths")).body).toEqual([]);
+  });
+
+  it("lists dismissals and rejects a route that is not a chain", async () => {
+    await seedCaseWithOneChain("c1");
+    const app = appWith(new LateralPathDismissStore(store));
+    await request(app).post("/cases/c1/lateral-path-dismissals").send({ hostIds: ["host:ws-01", "host:ws-02"], note: "n" });
+
+    const list = await request(app).get("/cases/c1/lateral-path-dismissals");
+    expect(list.status).toBe(200);
+    expect(list.body).toHaveLength(1);
+    expect(list.body[0].hostIds).toEqual(["host:ws-01", "host:ws-02"]);
+
+    const bad = await request(app).post("/cases/c1/lateral-path-dismissals").send({ hostIds: ["host:only-one"], note: "" });
+    expect(bad.status).toBe(400);
+  });
+
+  it("404s when restoring something that was never dismissed", async () => {
+    await seedCaseWithOneChain("c1");
+    const app = appWith(new LateralPathDismissStore(store));
+    const res = await request(app).delete("/cases/c1/lateral-path-dismissals/host%3Anope%3Ehost%3Anope2");
+    expect(res.status).toBe(404);
+  });
+
+  it("501s when the store isn't configured", async () => {
+    await store.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const app = createApp(store, {});
+    expect((await request(app).get("/cases/c1/lateral-path-dismissals")).status).toBe(501);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5615,7 +5615,13 @@
       fetch(`/cases/${caseId}/evidence-graph${_graphTimeQuery()}`).then(r => r.json()).then(g => {
         evGraphData = g; renderEvidenceGraph();
       }).catch(() => {});
-      fetch(`/cases/${caseId}/lateral-paths${_graphTimeQuery()}`).then(r => r.json()).then(paths => {
+      loadLateralPaths(caseId);
+    }
+    // Lateral chains, optionally including the ones the analyst dismissed (review/undo view).
+    function loadLateralPaths(caseId) {
+      const q = _graphTimeQuery();
+      const url = `/cases/${caseId}/lateral-paths${q}${evPathsShowDismissed ? (q ? "&" : "?") + "includeDismissed=1" : ""}`;
+      return fetch(url).then(r => r.json()).then(paths => {
         evPathsData = paths; renderEvidencePaths();
       }).catch(() => {});
     }
@@ -5788,22 +5794,40 @@
     // from lateral_move + ran_on evidence by real timestamp (buildLateralPaths), listed alongside
     // the pairwise evidence graph. "Highlight" turns on the lateral_move layer (off by default,
     // since it's usually the noisiest) and dims everything except this chain's hosts.
+    // Show analyst-dismissed chains too (the review/undo view). Off by default: a dismissed chain
+    // is one the analyst has already rejected, so it stays out of the way until asked for.
+    let evPathsShowDismissed = false;
+    const evPathBtnStyle = "background:none;border:1px solid var(--c-6b7585);border-radius:3px;cursor:pointer;padding:0 5px;color:var(--c-cbd3df);font-size:10px";
+
     function renderEvidencePaths() {
       const el = document.getElementById("evPathsList");
+      const toggle = evPathsShowDismissed
+        ? `<button type="button" id="evPathsHideDismissed" style="${evPathBtnStyle}">Hide dismissed</button>`
+        : `<button type="button" id="evPathsShowDismissed" style="${evPathBtnStyle}">Show dismissed</button>`;
       if (!evPathsData || !evPathsData.length) {
-        el.innerHTML = "<div style='padding:8px 0;color:var(--c-9aa4b2)'>No multi-hop lateral chains reconstructed yet.</div>";
+        el.innerHTML = "<div style='padding:8px 0;color:var(--c-9aa4b2)'>No multi-hop lateral chains reconstructed yet. " + toggle + "</div>";
         return;
       }
       const confClass = (c) => c === "high" ? "ev-leg-high" : c === "medium" ? "ev-leg-med" : "ev-leg-ran";
       el.innerHTML = evPathsData.map((p, i) => {
         const route = p.hostIds.map((id) => esc((evGraphData?.nodes || []).find((n) => n.id === id)?.label || id)).join(" → ");
-        return `<div class="ev-path-row" style="margin-bottom:4px">`
+        // WHO/WHAT actually moved — the route alone doesn't say. Read from the hop's structured
+        // `actor` field (never parsed out of `basis`), de-duplicated across the chain.
+        const actors = [...new Set((p.hops || []).map((h) => h.actor).filter(Boolean))];
+        const via = actors.length ? ` <span class="ev-sub">via <b>${actors.map(esc).join("</b>, <b>")}</b></span>` : "";
+        // A dismissed row is shown struck-through and dimmed, with Restore in place of Dismiss.
+        const action = p.dismissed
+          ? `<button type="button" class="ev-path-restore" data-path-idx="${i}" style="${evPathBtnStyle}">Restore</button>`
+          : `<button type="button" class="ev-path-dismiss" data-path-idx="${i}" style="${evPathBtnStyle}" title="Reject this chain as a wrong conclusion. The underlying evidence stays in the case.">Dismiss</button>`;
+        return `<div class="ev-path-row" style="margin-bottom:4px${p.dismissed ? ";opacity:.55" : ""}">`
           + `<span class="ev-leg-line ${confClass(p.confidence)}"></span>`
-          + `<b>${route}</b> <span class="ev-sub">${esc(p.confidence)} confidence, ${p.hops.length} hop(s)`
-          + (p.startTime ? `, ${esc(p.startTime)} → ${esc(p.endTime)}` : "") + `</span> `
-          + `<button type="button" class="ev-path-highlight" data-path-idx="${i}" style="background:none;border:1px solid var(--c-6b7585);border-radius:3px;cursor:pointer;padding:0 5px;color:var(--c-cbd3df);font-size:10px">Highlight</button>`
+          + `<b${p.dismissed ? " style='text-decoration:line-through'" : ""}>${route}</b>${via} <span class="ev-sub">${esc(p.confidence)} confidence, ${p.hops.length} hop(s)`
+          + (p.startTime ? `, ${esc(p.startTime)} → ${esc(p.endTime)}` : "")
+          + (p.dismissed ? ` — dismissed${p.dismissalNote ? ": " + esc(p.dismissalNote) : ""}` : "") + `</span> `
+          + `<button type="button" class="ev-path-highlight" data-path-idx="${i}" style="${evPathBtnStyle}">Highlight</button> `
+          + action
           + `</div>`;
-      }).join("");
+      }).join("") + `<div style="margin-top:6px">${toggle}</div>`;
     }
 
     // Kill-chain legend (#93): swatches for the tactics that actually appear in the current graph,
@@ -15491,6 +15515,38 @@
     }));
     document.querySelector("#sec-evidence h2").addEventListener("click", () => {
       setTimeout(() => { if (evGV) evGV.onExpand(); }, 0);
+    });
+    // Dismiss / restore a reconstructed chain. Dismissing rejects the CONCLUSION ("the attacker did
+    // not pivot A → B → C"); it does NOT mark the underlying events as false positives, so the
+    // evidence stays in the timeline and every other view.
+    document.getElementById("evPathsList").addEventListener("click", async (e) => {
+      const caseId = document.getElementById("caseId").value.trim();
+      if (e.target.id === "evPathsShowDismissed" || e.target.id === "evPathsHideDismissed") {
+        evPathsShowDismissed = e.target.id === "evPathsShowDismissed";
+        if (caseId) await loadLateralPaths(caseId);
+        return;
+      }
+      const dismissBtn = e.target.closest(".ev-path-dismiss");
+      if (dismissBtn && evPathsData && caseId) {
+        const path = evPathsData[Number(dismissBtn.dataset.pathIdx)];
+        if (!path) return;
+        const note = prompt("Why is this chain wrong? (optional)") ?? "";
+        const res = await fetch(`/cases/${caseId}/lateral-path-dismissals`, {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ hostIds: path.hostIds, note }),
+        }).catch(() => null);
+        if (res && res.ok) await loadLateralPaths(caseId);
+        return;
+      }
+      const restoreBtn = e.target.closest(".ev-path-restore");
+      if (restoreBtn && evPathsData && caseId) {
+        const path = evPathsData[Number(restoreBtn.dataset.pathIdx)];
+        if (!path) return;
+        const key = path.hostIds.map((h) => String(h).trim().toLowerCase()).join(">");
+        const res = await fetch(`/cases/${caseId}/lateral-path-dismissals/${encodeURIComponent(key)}`, { method: "DELETE" }).catch(() => null);
+        if (res && res.ok) await loadLateralPaths(caseId);
+        return;
+      }
     });
     // Highlight a reconstructed lateral-movement path (#92) in the evidence graph: switch on the
     // lateral_move layer (off by default) if needed, re-render, then dim everything except this


### PR DESCRIPTION
## Summary

Two gaps in the reconstructed lateral-movement chains (#92), both found by using the panel on real cases.

**1. You couldn't reject a chain.** A lateral path is an *inference* drawn from evidence that is usually perfectly real — the logons happened, the binary really is on both hosts — but "therefore the attacker pivoted A → B → C" can still be wrong. The only available tool was a false-positive marker, which says *"this evidence is wrong"* and pulls the events out of the timeline, the report and every other view. That forces an analyst to discard facts they never disputed in order to silence a bad conclusion.

Dismissal is now its own, narrower decision: the chain disappears from the panel, the API and the written report, and the underlying evidence is untouched. `Show dismissed` lists them struck through with the analyst's reason and a `Restore` button.

**2. A chain named only the stations, never who moved.** Each hop now carries structured `actor` / `actorKind` fields, so a row reads `WKSTN-JSMITH → FS01 → WEB01 via GLOBALTECH\admin-deploy`. The report table gains a **Via** column.

## Design notes

- **Anchored on the ordered host sequence, not the path id.** Paths are derived on every read and their ids are positional (`lateral-path:0`), so they shift as soon as the data changes. The host sequence *is* the claim being rejected, and it survives the same route being rebuilt from different evidence after a re-import.
- **Exact sequence match.** Dismissing `A → B → C` deliberately does **not** hide `A → B → C → D` — reaching one more host is a different claim, and hiding it would suppress a finding nobody rejected.
- **`actor` is structured, never parsed out of `basis` prose.** That format-coupling is exactly what silently empties the login graph when wording changes.
- Binaries are named by filename (`psexec.exe` beats a hash prefix), falling back to a short hash when no path was recorded.
- The report renders from state, so filtered paths are threaded in the same way a prebuilt `assetGraph` already is — otherwise a dismissed chain would vanish from the dashboard but reappear in the report. The redacted export anonymizes host ids, so dismissals go through the same redaction before matching, mirroring the asset overrides there.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — **4251 passed**, 373 files
- [x] 10 unit tests (key derivation, exact-match filtering, annotate/undo) + 8 route tests + dashboard markup assertions + 3 actor tests
- [x] Live on a real case: dismiss → chain drops from the API and report; timeline still holds all 18,573 events and 123 lateral edges
- [x] Dismiss/Restore exercised in the browser end-to-end
