### PR TITLE
fix: cap import-undo-stack size and fix concurrent-write race

### DIFF
--- a/companion/.env.example
+++ b/companion/.env.example
@@ -259,6 +259,11 @@ DFIR_AI_AUTO_SYNTHESIZE_MS=8000
 # level is a full copy of investigation state, so depth is bounded.
 # DFIR_IMPORT_UNDO_DEPTH=10
 
+# Import undo/redo aggregate byte budget (MB). Depth alone doesn't bound the file's actual size —
+# for a case whose timeline has grown large, even a few full-state snapshots can be tens/hundreds
+# of MB. Oldest checkpoints are evicted first once the stack's total serialized size exceeds this.
+# DFIR_UNDO_MAX_MB=200
+
 # Cross-source correlation window (seconds). The same artifact reported by different tools is
 # merged into one corroborated event when they share a hash, OR the same path within this window.
 # 0 = require an exact-time path match (hash matching is always exact).

--- a/companion/src/analysis/importUndo.ts
+++ b/companion/src/analysis/importUndo.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import type { InvestigationState } from "./stateTypes.js";
 
 // Per-case UNDO / REDO of imports (#76). A single import can flood the dashboard — it grows the
@@ -27,54 +28,103 @@ export interface ImportUndoStack {
 // is a full copy of the investigation state, so the depth is bounded (override via DFIR_IMPORT_UNDO_DEPTH).
 export const DEFAULT_UNDO_DEPTH = 10;
 
+// Depth alone doesn't bound the file's actual size: 10 full-state snapshots of a case whose
+// timeline has grown into the tens-of-thousands of events is tens-to-hundreds of MB "by design".
+// A large bulk import (many files in quick succession) can balloon the undo stack into the
+// hundreds of MB and, combined with every checkpoint re-serializing the whole growing stack,
+// contribute to an OOM. So checkpoints are ALSO capped by aggregate serialized size, evicting the
+// oldest first — override via DFIR_UNDO_MAX_MB. 200MB keeps the stack far below multi-GB heap
+// budgets while still giving a useful amount of undo history for small-to-medium cases.
+export const DEFAULT_UNDO_MAX_BYTES = 200 * 1024 * 1024;
+
+// Read DFIR_UNDO_MAX_MB (megabytes) from the environment; falls back to DEFAULT_UNDO_MAX_BYTES on
+// an unset, zero, negative, or unparseable value (mirrors atomicWriteRetries()'s parsing).
+export function undoMaxBytesFromEnv(): number {
+  const n = Number(process.env.DFIR_UNDO_MAX_MB);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) * 1024 * 1024 : DEFAULT_UNDO_MAX_BYTES;
+}
+
 export function emptyUndoStack(): ImportUndoStack {
   return { undo: [], redo: [] };
 }
 
+function checkpointBytes(c: ImportCheckpoint): number {
+  return Buffer.byteLength(JSON.stringify(c.state));
+}
+
+// Drop oldest-first entries until the list's total serialized size fits `maxBytes`. Always keeps
+// at least the newest entry, even if it alone exceeds the budget — undo becomes single-level for
+// a case that large rather than unavailable. A non-positive maxBytes disables the cap.
+function capBySize(list: ImportCheckpoint[], maxBytes: number): ImportCheckpoint[] {
+  if (!(maxBytes > 0) || list.length === 0) return list;
+  const sizes = list.map(checkpointBytes);
+  let total = sizes.reduce((a, b) => a + b, 0);
+  let start = 0;
+  while (total > maxBytes && start < list.length - 1) {
+    total -= sizes[start];
+    start++;
+  }
+  return start === 0 ? list : list.slice(start);
+}
+
 // Push a PRE-import checkpoint onto the undo stack. A new import invalidates the redo history
-// (standard undo/redo semantics — you can't redo past a fresh branch). Caps the undo depth,
-// dropping the oldest checkpoints first.
+// (standard undo/redo semantics — you can't redo past a fresh branch). Caps the undo depth AND
+// aggregate byte size, dropping the oldest checkpoints first.
 export function pushCheckpoint(
   stack: ImportUndoStack,
   checkpoint: ImportCheckpoint,
   maxDepth: number = DEFAULT_UNDO_DEPTH,
+  maxBytes: number = DEFAULT_UNDO_MAX_BYTES,
 ): ImportUndoStack {
   const depth = Math.max(1, Math.floor(maxDepth));
-  const undo = [...stack.undo, checkpoint];
-  return { undo: undo.length > depth ? undo.slice(undo.length - depth) : undo, redo: [] };
+  let undo = [...stack.undo, checkpoint];
+  if (undo.length > depth) undo = undo.slice(undo.length - depth);
+  return { undo: capBySize(undo, maxBytes), redo: [] };
 }
 
 // Undo the latest import: pop the top pre-import checkpoint to RESTORE, and push the CURRENT
 // (post-import) state onto the redo stack so it can be re-applied. Returns null when there is
 // nothing to undo. The redo entry inherits the popped checkpoint's label (redoing re-applies that
-// same import). Pure — the caller writes `stack` and saves `restore` as the investigation state.
+// same import). The redo stack is capped the same way the undo stack is — otherwise repeated
+// undos with no intervening import grow it without bound. Pure — the caller writes `stack` and
+// saves `restore` as the investigation state.
 export function applyUndo(
   stack: ImportUndoStack,
   current: InvestigationState,
   at: string = new Date().toISOString(),
+  maxDepth: number = DEFAULT_UNDO_DEPTH,
+  maxBytes: number = DEFAULT_UNDO_MAX_BYTES,
 ): { stack: ImportUndoStack; restore: InvestigationState } | null {
   if (stack.undo.length === 0) return null;
   const top = stack.undo[stack.undo.length - 1];
   const redoEntry: ImportCheckpoint = { label: top.label, at, state: current };
+  const depth = Math.max(1, Math.floor(maxDepth));
+  let redo = [...stack.redo, redoEntry];
+  if (redo.length > depth) redo = redo.slice(redo.length - depth);
   return {
-    stack: { undo: stack.undo.slice(0, -1), redo: [...stack.redo, redoEntry] },
+    stack: { undo: stack.undo.slice(0, -1), redo: capBySize(redo, maxBytes) },
     restore: top.state,
   };
 }
 
 // Redo the most-recently-undone import: pop the top redo checkpoint to RESTORE, and push the
-// current state back onto the undo stack. The mirror image of applyUndo. Returns null when there
-// is nothing to redo.
+// current state back onto the undo stack. The mirror image of applyUndo (same depth+size cap on
+// the undo stack it grows). Returns null when there is nothing to redo.
 export function applyRedo(
   stack: ImportUndoStack,
   current: InvestigationState,
   at: string = new Date().toISOString(),
+  maxDepth: number = DEFAULT_UNDO_DEPTH,
+  maxBytes: number = DEFAULT_UNDO_MAX_BYTES,
 ): { stack: ImportUndoStack; restore: InvestigationState } | null {
   if (stack.redo.length === 0) return null;
   const top = stack.redo[stack.redo.length - 1];
   const undoEntry: ImportCheckpoint = { label: top.label, at, state: current };
+  const depth = Math.max(1, Math.floor(maxDepth));
+  let undo = [...stack.undo, undoEntry];
+  if (undo.length > depth) undo = undo.slice(undo.length - depth);
   return {
-    stack: { undo: [...stack.undo, undoEntry], redo: stack.redo.slice(0, -1) },
+    stack: { undo: capBySize(undo, maxBytes), redo: stack.redo.slice(0, -1) },
     restore: top.state,
   };
 }
@@ -149,7 +199,19 @@ function normalizeList(v: unknown): ImportCheckpoint[] {
 }
 
 export class ImportUndoStore {
-  constructor(private readonly cases: CaseStore, private readonly maxDepth: number = DEFAULT_UNDO_DEPTH) {}
+  // Per-case async mutex guarding the load->mutate->save critical section (see mutate()). Without
+  // it, two concurrent load-modify-save calls on the same case's undo stack (e.g. overlapping
+  // bulk-import requests) race: the second save clobbers the first, silently dropping a
+  // checkpoint, and both writers spawn simultaneous multi-MB atomic-write temp files for the same
+  // file. Private (not the pipeline's shared StateLock) — this only ever guards
+  // import-undo-stack.json, mirrors HypothesisStore's own lock.
+  private readonly lock = new StateLock();
+
+  constructor(
+    private readonly cases: CaseStore,
+    private readonly maxDepth: number = DEFAULT_UNDO_DEPTH,
+    private readonly maxBytes: number = DEFAULT_UNDO_MAX_BYTES,
+  ) {}
 
   private path(caseId: string): string {
     return join(this.cases.stateDir(caseId), "import-undo-stack.json");
@@ -158,6 +220,11 @@ export class ImportUndoStore {
   // How many undo levels this store keeps (used by the push helper + surfaced in the summary).
   depth(): number {
     return Math.max(1, Math.floor(this.maxDepth));
+  }
+
+  // Aggregate byte budget applied on top of depth (used by the push/undo/redo helpers).
+  byteBudget(): number {
+    return this.maxBytes;
   }
 
   async load(caseId: string): Promise<ImportUndoStack> {
@@ -171,5 +238,16 @@ export class ImportUndoStore {
 
   async save(caseId: string, stack: ImportUndoStack): Promise<void> {
     await atomicWrite(this.path(caseId), JSON.stringify(stack, null, 2));
+  }
+
+  // Atomically load -> transform -> save under this case's lock. Use this instead of manual
+  // load()/save() pairs for any read-modify-write (pushing a checkpoint, undo, redo) so concurrent
+  // callers serialize instead of racing.
+  async mutate<T>(caseId: string, fn: (stack: ImportUndoStack) => { stack: ImportUndoStack; result: T }): Promise<T> {
+    return this.lock.runExclusive(caseId, async () => {
+      const { stack, result } = fn(await this.load(caseId));
+      await this.save(caseId, stack);
+      return result;
+    });
   }
 }

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -1722,20 +1722,27 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
   // Undo the latest import: restore the full pre-import state (findings/IOCs/timeline/MITRE/attacker
   // path), push the current state to redo. No AI re-synthesis — the snapshot is the exact prior state.
   app.post("/cases/:id/import/undo", async (req: Request, res: Response) => {
-    if (!options.importUndoStore || !options.stateStore) return res.status(501).json({ error: "import undo not configured" });
+    const undoStore = options.importUndoStore;
+    if (!undoStore || !options.stateStore) return res.status(501).json({ error: "import undo not configured" });
     const caseId = req.params.id;
     try {
-      const stack = await options.importUndoStore.load(caseId);
       const state = await options.stateStore.load(caseId);
-      const result = applyUndo(stack, state);
-      if (!result) return res.status(400).json({ error: "nothing to undo" });
-      const next = await restoreImportState(caseId, result.restore);
-      await options.importUndoStore.save(caseId, result.stack);
+      let restore: InvestigationState | undefined;
+      // Atomic load->pop->save under the store's per-case lock (mirrors pushImportCheckpoint) so
+      // an undo/redo can't race a concurrent import's checkpoint push on the same file.
+      const summary = await undoStore.mutate(caseId, (stack) => {
+        const result = applyUndo(stack, state, undefined, undoStore.depth(), undoStore.byteBudget());
+        if (!result) return { stack, result: null };
+        restore = result.restore;
+        return { stack: result.stack, result: summarizeUndoStack(result.stack, undoStore.depth()) };
+      });
+      if (!summary || !restore) return res.status(400).json({ error: "nothing to undo" });
+      const next = await restoreImportState(caseId, restore);
       // The "last import" banner / NEW row highlights describe a change that has now been rolled back.
       if (options.importMetaStore) { try { await options.importMetaStore.clear(caseId); options.onImportMeta?.(caseId); } catch { /* non-fatal */ } }
       options.onImportUndo?.(caseId);
       if (next) options.onState?.(next);
-      return res.status(200).json(summarizeUndoStack(result.stack, options.importUndoStore.depth()));
+      return res.status(200).json(summary);
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -1743,19 +1750,24 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
 
   // Redo the most-recently-undone import: re-apply its full state.
   app.post("/cases/:id/import/redo", async (req: Request, res: Response) => {
-    if (!options.importUndoStore || !options.stateStore) return res.status(501).json({ error: "import undo not configured" });
+    const undoStore = options.importUndoStore;
+    if (!undoStore || !options.stateStore) return res.status(501).json({ error: "import undo not configured" });
     const caseId = req.params.id;
     try {
-      const stack = await options.importUndoStore.load(caseId);
       const state = await options.stateStore.load(caseId);
-      const result = applyRedo(stack, state);
-      if (!result) return res.status(400).json({ error: "nothing to redo" });
-      const next = await restoreImportState(caseId, result.restore);
-      await options.importUndoStore.save(caseId, result.stack);
+      let restore: InvestigationState | undefined;
+      const summary = await undoStore.mutate(caseId, (stack) => {
+        const result = applyRedo(stack, state, undefined, undoStore.depth(), undoStore.byteBudget());
+        if (!result) return { stack, result: null };
+        restore = result.restore;
+        return { stack: result.stack, result: summarizeUndoStack(result.stack, undoStore.depth()) };
+      });
+      if (!summary || !restore) return res.status(400).json({ error: "nothing to redo" });
+      const next = await restoreImportState(caseId, restore);
       if (options.importMetaStore) { try { await options.importMetaStore.clear(caseId); options.onImportMeta?.(caseId); } catch { /* non-fatal */ } }
       options.onImportUndo?.(caseId);
       if (next) options.onState?.(next);
-      return res.status(200).json(summarizeUndoStack(result.stack, options.importUndoStore.depth()));
+      return res.status(200).json(summary);
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -145,7 +145,7 @@ import { CustomToolStore, customToolToConfig, normalizeExt, type CustomTool } fr
 import { TemplateStore } from "./analysis/templateStore.js";
 import { diffTimeline, addedForensicEvents } from "./analysis/timelineDiff.js";
 import { diffIocs } from "./analysis/iocsDiff.js";
-import { ImportUndoStore, pushCheckpoint } from "./analysis/importUndo.js";
+import { ImportUndoStore, pushCheckpoint, undoMaxBytesFromEnv } from "./analysis/importUndo.js";
 import { IocWhitelistStore } from "./analysis/iocWhitelistStore.js";
 import { whitelistMatches } from "./analysis/iocWhitelist.js";
 import { sanitizeExcludeRuleInput, matchIocToExclude, type IocExcludeRule } from "./analysis/iocExclude.js";
@@ -2327,11 +2327,17 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // import can be rolled back. Best-effort — undo is a convenience and must NEVER break the import.
   // Callers gate on whether the import actually changed anything (no checkpoint for a no-op re-import).
   async function pushImportCheckpoint(caseId: string, beforeState: InvestigationState, label: string): Promise<void> {
-    if (!options.importUndoStore) return;
+    const undoStore = options.importUndoStore;
+    if (!undoStore) return;
     try {
-      const stack = await options.importUndoStore.load(caseId);
-      const next = pushCheckpoint(stack, { label, at: new Date().toISOString(), state: beforeState }, options.importUndoStore.depth());
-      await options.importUndoStore.save(caseId, next);
+      // Atomic load->push->save under the store's per-case lock: overlapping imports (e.g. bulk
+      // import firing requests seconds apart while the previous one's async work is still in
+      // flight) must not race on the same undo-stack file (lost checkpoints, duplicate huge
+      // simultaneous tmp writes).
+      await undoStore.mutate(caseId, (stack) => ({
+        stack: pushCheckpoint(stack, { label, at: new Date().toISOString(), state: beforeState }, undoStore.depth(), undoStore.byteBudget()),
+        result: undefined,
+      }));
       options.onImportUndo?.(caseId);
     } catch { /* non-fatal */ }
   }
@@ -3058,7 +3064,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const importMetaStore = new ImportMetaStore(store);
   const dropStatusStore = new DropStatusStore(store);   // evidence drop-folder last-sweep summary
   // #76: import undo/redo. Depth is the number of import levels kept (each = a full timeline+IOC copy).
-  const importUndoStore = new ImportUndoStore(store, Number(process.env.DFIR_IMPORT_UNDO_DEPTH) || undefined);
+  const importUndoStore = new ImportUndoStore(store, Number(process.env.DFIR_IMPORT_UNDO_DEPTH) || undefined, undoMaxBytesFromEnv());
   const notionExportStore = new NotionExportStore(store);
   const clickupExportStore = new ClickUpExportStore(store);
   const irisExportStore = new IrisExportStore(store);

--- a/companion/tests/analysis/importUndo.test.ts
+++ b/companion/tests/analysis/importUndo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
@@ -12,6 +12,8 @@ import {
   applyRedo,
   summarizeUndoStack,
   normalizeStack,
+  undoMaxBytesFromEnv,
+  DEFAULT_UNDO_MAX_BYTES,
   type ImportUndoStack,
 } from "../../src/analysis/importUndo.js";
 
@@ -48,6 +50,69 @@ describe("importUndo pure operations", () => {
     stack = pushCheckpoint(stack, cp("c", 3, 3, 1, "c"), 3);
     stack = pushCheckpoint(stack, cp("d", 4, 4, 1, "d"), 3); // exceeds depth 3 -> "a" drops
     expect(stack.undo.map((c) => c.label)).toEqual(["b", "c", "d"]);
+  });
+
+  it("pushCheckpoint also evicts oldest checkpoints once the stack exceeds a byte budget, even under the depth cap", () => {
+    // Each state carries ~2000 events; a byte budget sized for ~2.5 of them forces eviction well
+    // before the depth cap (10) would ever kick in — this is the unbounded-growth regression (#?):
+    // 10 full-state snapshots of a large case is tens-to-hundreds of MB by design.
+    let stack: ImportUndoStack = emptyUndoStack();
+    const big = (tag: string, label: string) => cp(tag, 2000, 0, 0, label);
+    const oneSize = Buffer.byteLength(JSON.stringify(big("x", "x").state));
+    const budget = Math.floor(oneSize * 2.5);
+
+    stack = pushCheckpoint(stack, big("a", "a"), 10, budget);
+    stack = pushCheckpoint(stack, big("b", "b"), 10, budget);
+    stack = pushCheckpoint(stack, big("c", "c"), 10, budget);
+    stack = pushCheckpoint(stack, big("d", "d"), 10, budget);
+
+    const totalBytes = stack.undo.reduce((sum, c) => sum + Buffer.byteLength(JSON.stringify(c.state)), 0);
+    expect(totalBytes).toBeLessThanOrEqual(budget);
+    expect(stack.undo.length).toBeLessThan(4); // count cap (10) never triggered — size cap did
+    expect(stack.undo[stack.undo.length - 1].label).toBe("d"); // newest always survives
+  });
+
+  it("pushCheckpoint keeps at least the newest checkpoint even if it alone exceeds the byte budget", () => {
+    const huge = cp("huge", 500, 0, 0, "huge");
+    const tinyBudget = 10; // smaller than any real checkpoint
+    const stack = pushCheckpoint(emptyUndoStack(), huge, 10, tinyBudget);
+    expect(stack.undo).toHaveLength(1);
+    expect(stack.undo[0].label).toBe("huge");
+  });
+
+  it("a non-positive maxBytes disables the size cap (count cap still applies)", () => {
+    let stack: ImportUndoStack = emptyUndoStack();
+    stack = pushCheckpoint(stack, cp("a", 500, 0, 0, "a"), 2, 0);
+    stack = pushCheckpoint(stack, cp("b", 500, 0, 0, "b"), 2, 0);
+    expect(stack.undo.map((c) => c.label)).toEqual(["a", "b"]);
+  });
+
+  it("undoMaxBytesFromEnv reads DFIR_UNDO_MAX_MB (in MB) and falls back to the default", () => {
+    const prev = process.env.DFIR_UNDO_MAX_MB;
+    try {
+      delete process.env.DFIR_UNDO_MAX_MB;
+      expect(undoMaxBytesFromEnv()).toBe(DEFAULT_UNDO_MAX_BYTES);
+      process.env.DFIR_UNDO_MAX_MB = "50";
+      expect(undoMaxBytesFromEnv()).toBe(50 * 1024 * 1024);
+      process.env.DFIR_UNDO_MAX_MB = "not-a-number";
+      expect(undoMaxBytesFromEnv()).toBe(DEFAULT_UNDO_MAX_BYTES);
+    } finally {
+      if (prev === undefined) delete process.env.DFIR_UNDO_MAX_MB; else process.env.DFIR_UNDO_MAX_MB = prev;
+    }
+  });
+
+  it("applyUndo caps the growing redo stack by depth+size so repeated undos don't grow it unboundedly", () => {
+    let stack: ImportUndoStack = emptyUndoStack();
+    stack = pushCheckpoint(stack, cp("a", 1, 0, 0, "a"));
+    stack = pushCheckpoint(stack, cp("b", 1, 0, 0, "b"));
+    stack = pushCheckpoint(stack, cp("c", 1, 0, 0, "c"));
+    let current = mkState("cur", 1, 0, 0);
+    for (let i = 0; i < 3; i++) {
+      const r = applyUndo(stack, current, "2026-06-13T00:00:00Z", 2)!;
+      stack = r.stack;
+      current = r.restore;
+    }
+    expect(stack.redo.length).toBeLessThanOrEqual(2); // depth cap applied to redo too
   });
 
   it("applyUndo / applyRedo return null when there is nothing to do", () => {
@@ -134,9 +199,11 @@ describe("importUndo pure operations", () => {
 
 describe("ImportUndoStore", () => {
   let store: ImportUndoStore;
+  let cases: CaseStore;
+  let root: string;
   beforeEach(async () => {
-    const root = await mkdtemp(join(tmpdir(), "dfir-importundo-"));
-    const cases = new CaseStore(root);
+    root = await mkdtemp(join(tmpdir(), "dfir-importundo-"));
+    cases = new CaseStore(root);
     await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
     store = new ImportUndoStore(cases, 5);
   });
@@ -159,5 +226,40 @@ describe("ImportUndoStore", () => {
 
   it("exposes its configured depth", () => {
     expect(store.depth()).toBe(5);
+  });
+
+  it("the persisted stack file stays under the configured byte budget after growing far past DEFAULT_UNDO_DEPTH imports (#unbounded-undo-growth)", async () => {
+    // Regression for the reported bug: a bulk import of many files against a case whose state
+    // keeps growing (mirrors 50 files ballooning a case from ~0 to 41,660 events) must not let
+    // the undo-stack file balloon into the hundreds of MB. Depth alone (5 here) is not enough to
+    // bound it — the byte budget must actually cap the file on disk.
+    const budgetBytes = 1_000_000; // 1MB — small so the test runs fast but still exercises real disk I/O
+    const bounded = new ImportUndoStore(cases, 5, budgetBytes);
+    let growingEvents = 200;
+    for (let i = 0; i < 15; i++) { // well past the depth cap of 5
+      growingEvents += 200; // each successive pre-import state is bigger, like a real bulk import
+      await bounded.mutate("c1", (stack) => ({
+        stack: pushCheckpoint(stack, cp(`s${i}`, growingEvents, 0, 0, `import ${i}`), bounded.depth(), bounded.byteBudget()),
+        result: undefined,
+      }));
+    }
+    const raw = await readFile(join(cases.stateDir("c1"), "import-undo-stack.json"), "utf8");
+    expect(Buffer.byteLength(raw)).toBeLessThan(budgetBytes * 1.5); // headroom for JSON formatting/metadata, not unbounded
+  });
+
+  it("mutate() serializes concurrent load-modify-save calls so no checkpoint is lost to a race", async () => {
+    // Regression: pushImportCheckpoint used to load(), pushCheckpoint(), save() with no lock —
+    // two overlapping imports (e.g. bulk import 1.5s apart while the previous one's async work is
+    // still in flight) race on the same file: the second save clobbers the first (lost update),
+    // and both writers spawn simultaneous multi-MB atomic-write temp files for the same case.
+    const labels = Array.from({ length: 8 }, (_, i) => `import-${i}`);
+    await Promise.all(labels.map((label) =>
+      store.mutate("c1", (stack) => ({
+        stack: pushCheckpoint(stack, cp(label, 1, 0, 0, label), 20),
+        result: undefined,
+      })),
+    ));
+    const loaded = await store.load("c1");
+    expect(loaded.undo.map((c) => c.label).sort()).toEqual([...labels].sort());
   });
 });


### PR DESCRIPTION
## Summary
- `DEFAULT_UNDO_DEPTH` bounded checkpoint COUNT but not aggregate size, so a bulk import against a growing case (50 files, 0 -> 41,660 events) inflated `import-undo-stack.json` to ~229MB and contributed to a server OOM.
- `pushImportCheckpoint()` did an unlocked load-modify-save, letting overlapping imports race and spawn multiple simultaneous multi-MB atomic-write temp files for the same case.
- `pushCheckpoint`/`applyUndo`/`applyRedo` now also cap by aggregate serialized size (`DFIR_UNDO_MAX_MB`, default 200MB), evicting oldest first; the redo stack (previously fully unbounded by count) gets the same depth+size cap.
- `ImportUndoStore` gains a private `StateLock`-backed `mutate()` for atomic load->transform->save, used by `pushImportCheckpoint` and the undo/redo routes instead of racy manual load()+save() pairs.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `tests/analysis/importUndo.test.ts` (16 tests, incl. size eviction, env parsing, redo-stack capping, concurrent `mutate()` not losing checkpoints, on-disk file size regression)
- [x] `tests/server/importUndoRoutes.test.ts` (4 tests, undo/redo routes still round-trip through `mutate()`)
- [x] Full suite: 4394 passed, 5 pre-existing unrelated failures (claude/codex binary timeouts, eval-harness flake) unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)