### PR TITLE
fix(import): pre-anchor year-less BSD timestamps to the case's dominant year

### DIFF
--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -90,6 +90,7 @@ import { parseYaraOutput, YARA_SOURCE, type YaraImportOptions } from "./yaraImpo
 import { parseCombinedLog, COMBINED_LOG_SOURCE, type CombinedLogImportOptions } from "./combinedLogImport.js";
 import { parseCiscoAsaLog, CISCO_ASA_SOURCE, type CiscoAsaImportOptions } from "./ciscoAsaImport.js";
 import { parseSyslog, SYSLOG_SOURCE, type SyslogImportOptions } from "./syslogImport.js";
+import { pickImportYear } from "./timeYearClamp.js";
 import { parseNetworkLogs, type NetworkImportOptions } from "./networkImport.js";
 import { parseSocrates, type SocratesImportOptions } from "./socratesImport.js";
 import { parseSecurityOnion, type SecurityOnionImportOptions } from "./securityOnionImport.js";
@@ -2607,7 +2608,12 @@ export class AnalysisPipeline {
       onProgress?: (done: number, total: number) => void;
     },
   ): Promise<InvestigationState> {
-    const parsedRaw = parseCiscoAsaLog(text, { ...opts.ciscoAsa });
+    // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
+    // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
+    // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
+    const priorState = await this.opts.stateStore.load(caseId).catch(() => null);
+    const assumeYear = opts.ciscoAsa?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
+    const parsedRaw = parseCiscoAsaLog(text, { ...opts.ciscoAsa, ...(assumeYear !== undefined ? { assumeYear } : {}) });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
 
@@ -2655,7 +2661,12 @@ export class AnalysisPipeline {
       onProgress?: (done: number, total: number) => void;
     },
   ): Promise<InvestigationState> {
-    const parsedRaw = parseSnortLog(text, { ...opts.snort });
+    // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
+    // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
+    // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
+    const priorState = await this.opts.stateStore.load(caseId).catch(() => null);
+    const assumeYear = opts.snort?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
+    const parsedRaw = parseSnortLog(text, { ...opts.snort, ...(assumeYear !== undefined ? { assumeYear } : {}) });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
 
@@ -2754,7 +2765,12 @@ export class AnalysisPipeline {
       onProgress?: (done: number, total: number) => void;
     },
   ): Promise<InvestigationState> {
-    const parsedRaw = parseSyslog(text, { ...opts.syslog });
+    // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
+    // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
+    // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
+    const priorState = await this.opts.stateStore.load(caseId).catch(() => null);
+    const assumeYear = opts.syslog?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
+    const parsedRaw = parseSyslog(text, { ...opts.syslog, ...(assumeYear !== undefined ? { assumeYear } : {}) });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
     if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
 

--- a/companion/src/analysis/timeYearClamp.ts
+++ b/companion/src/analysis/timeYearClamp.ts
@@ -44,13 +44,11 @@ function setYear(ts: string, year: number): string {
   )).toISOString();
 }
 
-// Re-anchor events whose year is an outlier onto the timeline's dominant year (see module header).
-// Returns a new array; events already on the dominant year (or undated) pass through unchanged. When no
-// year dominates, or the timeline is too small, the input is returned as-is.
-export function clampOutlierYears(events: readonly ForensicEvent[], opts: YearClampOptions = {}): ForensicEvent[] {
-  const dominantFraction = opts.dominantFraction ?? DEFAULT_YEAR_CLAMP_DOMINANT_FRACTION;
-  const minEvents = opts.minEvents ?? YEAR_CLAMP_MIN_EVENTS;
-
+// The modal (most frequent) year among an event array's DATED timestamps, or null when none are dated.
+// Shared by clampOutlierYears (post-hoc correction across the whole timeline) and pickImportYear
+// (a pre-emptive default for a year-less parser) — both need "what year does this case's evidence
+// actually live in."
+function modalYear(events: readonly ForensicEvent[]): { year: number; count: number; dated: number } | null {
   const byYear = new Map<number, number>();
   let dated = 0;
   for (const e of events) {
@@ -59,12 +57,24 @@ export function clampOutlierYears(events: readonly ForensicEvent[], opts: YearCl
     dated++;
     byYear.set(y, (byYear.get(y) ?? 0) + 1);
   }
-  if (dated < minEvents || byYear.size < 2) return [...events];
+  if (dated === 0) return null;
+  let year = 0;
+  let count = -1;
+  for (const [y, c] of byYear) if (c > count) { year = y; count = c; }
+  return { year, count, dated };
+}
 
-  let dominantYear = 0;
-  let dominantCount = -1;
-  for (const [y, c] of byYear) if (c > dominantCount) { dominantYear = y; dominantCount = c; }
-  if (dominantCount / dated < dominantFraction) return [...events]; // no clear anchor → leave untouched
+// Re-anchor events whose year is an outlier onto the timeline's dominant year (see module header).
+// Returns a new array; events already on the dominant year (or undated) pass through unchanged. When no
+// year dominates, or the timeline is too small, the input is returned as-is.
+export function clampOutlierYears(events: readonly ForensicEvent[], opts: YearClampOptions = {}): ForensicEvent[] {
+  const dominantFraction = opts.dominantFraction ?? DEFAULT_YEAR_CLAMP_DOMINANT_FRACTION;
+  const minEvents = opts.minEvents ?? YEAR_CLAMP_MIN_EVENTS;
+
+  const m = modalYear(events);
+  if (!m || m.dated < minEvents) return [...events];
+  if (m.count / m.dated < dominantFraction) return [...events]; // no clear anchor → leave untouched
+  const dominantYear = m.year;
 
   return events.map((e) => {
     const y = yearOf(e.timestamp);
@@ -76,4 +86,24 @@ export function clampOutlierYears(events: readonly ForensicEvent[], opts: YearCl
     }
     return next;
   });
+}
+
+// Best-guess year for a NEW year-less import (Cisco ASA / Snort / syslog), to use as the parser's
+// `assumeYear` instead of blindly stamping the current calendar year.
+//
+// Blindly defaulting to "now" is wrong whenever the evidence is historical (the common case), and
+// clampOutlierYears cannot always fix it after the fact: that guard is a MINORITY-outlier correction
+// (≥90% of the timeline must already agree on the real year). A single large year-less import — e.g. a
+// Cisco ASA or Snort log covering the whole incident window — can itself contribute a big enough slice
+// of the merged timeline that the wrong year is no longer a small minority, so the ≥90% bar is never
+// crossed and the stray year survives (see the "meridian espionage" ground-truth benchmark, where an
+// ASA log alone was ~27% of the final timeline).
+//
+// Picks the case's already-established modal year among its existing DATED events (when there are
+// enough to trust); otherwise returns undefined so the caller falls back to its current-year default —
+// there's no better guess for the very first import of a case. Pure.
+export function pickImportYear(existingEvents: readonly ForensicEvent[], minEvents = 3): number | undefined {
+  const m = modalYear(existingEvents);
+  if (!m || m.dated < minEvents) return undefined;
+  return m.year;
 }

--- a/companion/tests/analysis/timeYearClamp.test.ts
+++ b/companion/tests/analysis/timeYearClamp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clampOutlierYears } from "../../src/analysis/timeYearClamp.js";
+import { clampOutlierYears, pickImportYear } from "../../src/analysis/timeYearClamp.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
 
 function ev(id: string, timestamp: string, extra: Partial<ForensicEvent> = {}): ForensicEvent {
@@ -73,5 +73,43 @@ describe("clampOutlierYears", () => {
     expect(out.find((e) => e.id === "u")!.timestamp).toBe("");
     expect(out.find((e) => e.id === "bad")!.timestamp).toBe("not-a-date");
     expect(out.find((e) => e.id === "old")!.timestamp).toBe("2024-05-14T12:00:00.000Z");
+  });
+
+  // Regression for the "meridian espionage" ground-truth benchmark: a Cisco ASA / Snort log with
+  // year-less BSD timestamps, imported while the machine's calendar year was 2026, defaulted its whole
+  // batch to 2026. When that batch is itself a large enough share of the merged timeline, the wrong
+  // year is no longer a small minority — so the ≥90% dominant-year guard never fires and the strays
+  // survive uncorrected. This is NOT a bug in clampOutlierYears' math; it's the reason a post-hoc
+  // minority-outlier correction can't be the only defense — see pickImportYear below.
+  it("does NOT correct a large year-less-defaulted batch that is not a small minority", () => {
+    const events = [...body(2024, 30), ...body(2026, 12)]; // 2026 is 29% of the dated timeline
+    const out = clampOutlierYears(events);
+    expect(out.map((e) => e.timestamp)).toEqual(events.map((e) => e.timestamp)); // untouched
+  });
+});
+
+describe("pickImportYear", () => {
+  it("picks the case's already-established dominant year", () => {
+    const existing = body(2024, 30);
+    expect(pickImportYear(existing)).toBe(2024);
+  });
+
+  it("returns undefined when there isn't enough dated history to trust", () => {
+    expect(pickImportYear([])).toBeUndefined();
+    expect(pickImportYear(body(2024, 2))).toBeUndefined(); // below the default minEvents (3)
+  });
+
+  it("prevents the large-batch regression: pre-stamping the import lands it on the right year", () => {
+    // Same shape as the clampOutlierYears regression above, but using pickImportYear the way
+    // pipeline.ts's importCiscoAsa/importSnort/importSyslog now do: consult the CASE's existing dated
+    // events BEFORE parsing the year-less batch, instead of defaulting to the current calendar year.
+    const existing = body(2024, 30);
+    const assumedYear = pickImportYear(existing) ?? new Date().getUTCFullYear();
+    expect(assumedYear).toBe(2024);
+    // The year-less batch, stamped with `assumedYear` at parse time (simulating snortImport.ts /
+    // ciscoAsaImport.ts / syslogImport.ts), never lands as a 2026 outlier in the first place.
+    const freshlyStamped = body(assumedYear, 12);
+    const merged = [...existing, ...freshlyStamped];
+    expect(merged.every((e) => new Date(e.timestamp).getUTCFullYear() === 2024)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Cisco ASA / Snort / syslog imports stamp year-less BSD-style timestamps with the current calendar year, relying on `clampOutlierYears` to re-anchor strays onto the dominant year afterward.
- That guard only corrects a small minority (>=90% dominance required); a single large year-less import can be too big a share of the timeline for it to ever fire, so the whole batch stays mis-dated.
- Repro: importing the EvidenceForge "apt-espionage-defense-contractor" ground-truth dataset landed 11,429 Cisco ASA events + 414 Snort events in 2026 (the actual current year) instead of 2024 (the real evidence year), which fabricated a bogus "727-day timeline gap" finding and mis-dated a real JA3/C2 finding.
- Fix: `pickImportYear()` in `timeYearClamp.ts` picks the case's already-established modal year from existing dated events as the `assumeYear` default, instead of blindly using "now". Wired into `importCiscoAsa`/`importSnort`/`importSyslog` in `pipeline.ts`. `clampOutlierYears` itself is unchanged — still the safety net for genuine minority strays.

## Test plan
- [x] Added regression tests in `companion/tests/analysis/timeYearClamp.test.ts` reproducing the large-batch failure mode and confirming `pickImportYear` prevents it (10/10 pass)
- [x] `npx tsc --noEmit` clean
- [x] Full suite: 4395 passed / 2 failed (pre-existing, unrelated flakes: a perf-timing budget in `loadTest.test.ts`, a route timeout in `iocExcludeRoutes.test.ts`)