### PR TITLE
fix(bundles): use null-prototype accumulators in the bundle sanitizers

### DIFF
--- a/companion/src/analysis/artifactBundleStore.ts
+++ b/companion/src/analysis/artifactBundleStore.ts
@@ -33,9 +33,12 @@ export interface ArtifactBundle {
 }
 
 // Per-artifact VQL WHERE filters: keep string values, strip newlines/trailing ';', cap length.
+// Null-prototype accumulator: the keys are untrusted artifact names, and on a plain `{}` an
+// `out["__proto__"] = …` assignment goes through the inherited Object.prototype setter instead of
+// creating an own property — silently dropping the entry. Same reason in the two loops below.
 function sanitizeBundleFilters(raw: unknown): Record<string, string> | undefined {
   if (!raw || typeof raw !== "object") return undefined;
-  const out: Record<string, string> = {};
+  const out: Record<string, string> = Object.create(null);
   for (const [artifact, where] of Object.entries(raw as Record<string, unknown>)) {
     if (typeof where !== "string") continue;
     const w = where.replace(/[\r\n]+/g, " ").replace(/;+\s*$/, "").trim().slice(0, 1000);
@@ -47,10 +50,10 @@ function sanitizeBundleFilters(raw: unknown): Record<string, string> | undefined
 // Keep only object-of-string-ish params; drop nested objects/null. Returns undefined when empty.
 function sanitizeBundleParams(raw: unknown): Record<string, Record<string, string>> | undefined {
   if (!raw || typeof raw !== "object") return undefined;
-  const out: Record<string, Record<string, string>> = {};
+  const out: Record<string, Record<string, string>> = Object.create(null);
   for (const [artifact, params] of Object.entries(raw as Record<string, unknown>)) {
     if (!params || typeof params !== "object") continue;
-    const inner: Record<string, string> = {};
+    const inner: Record<string, string> = Object.create(null);
     for (const [k, v] of Object.entries(params as Record<string, unknown>)) {
       if (v == null || typeof v === "object") continue;
       inner[String(k)] = String(v);

--- a/companion/tests/analysis/artifactBundleStore.test.ts
+++ b/companion/tests/analysis/artifactBundleStore.test.ts
@@ -134,6 +134,32 @@ describe("ArtifactBundleStore", () => {
     expect(saved.params).toEqual({ "A.B": { Keep: "5" } });
   });
 
+  it("stores a '__proto__' artifact key as an own property instead of hitting the prototype setter", async () => {
+    // Built with JSON.parse, not an object literal: in a literal, `__proto__:` is proto-setter
+    // syntax rather than a key. JSON.parse gives a real own property — which is exactly how these
+    // arrive, as a parsed request body.
+    const filters = JSON.parse('{"__proto__":"NOT OSPath =~ \'x\'","A.B":"NOT Z"}');
+    const params = JSON.parse('{"__proto__":{"Evil":"yes"},"A.B":{"Keep":"1"}}');
+    const saved = await store.save({ name: "PP", description: "", artifacts: ["A.B"], filters, params });
+
+    // The accumulators are null-prototype, so nothing was reassigned via the inherited setter...
+    expect(Object.getPrototypeOf(saved.filters!)).toBeNull();
+    expect(Object.getPrototypeOf(saved.params!)).toBeNull();
+    // ...and no global prototype was polluted.
+    expect(({} as Record<string, unknown>).Evil).toBeUndefined();
+    expect(({} as Record<string, unknown>)["A.B"]).toBeUndefined();
+
+    // The entry is kept predictably rather than silently dropped, alongside the normal ones.
+    expect(Object.keys(saved.filters!)).toEqual(["__proto__", "A.B"]);
+    expect(saved.params!["__proto__"]).toEqual({ Evil: "yes" });
+
+    // And it survives the JSON round-trip as a plain, unpolluted object.
+    const reloaded = await store.get(saved.id);
+    expect(Object.getPrototypeOf(reloaded!.filters!)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(reloaded!.filters!, "__proto__")).toBe(true);
+    expect(reloaded!.filters!["A.B"]).toBe("NOT Z");
+  });
+
   it("ships a super-timeline triage built-in flagged superTimelineOnly (no detection artifacts)", async () => {
     const bundle = await store.get("super-timeline-triage");
     expect(bundle).not.toBeNull();


### PR DESCRIPTION
## What

`sanitizeBundleFilters` and `sanitizeBundleParams` in `companion/src/analysis/artifactBundleStore.ts` built their output with a plain `{}` and then assigned `out[key] = value` from untrusted input. For the key `__proto__` that assignment goes through the inherited `Object.prototype` setter instead of creating an own property, so the entry was silently dropped.

## Why it is not urgent

There is **no prototype pollution** — the accumulator is local and discarded after `JSON.stringify`. The practical effect was only that a bundle filter/param keyed on a literal `__proto__` artifact name went missing. Two reviewers independently classified this as a worthwhile follow-up rather than a blocker.

`Object.create(null)` closes the whole class at the assignment site rather than special-casing one key name. The returned objects are only `Object.entries`-iterated, bracket-indexed and JSON-serialized downstream, so the null prototype is safe to let flow outward.

## Test plan

- [x] New regression test covering a `__proto__` artifact key — asserts the prototype is untouched, the entry is kept, and the JSON round-trip yields a plain unpolluted object
- [x] Verified the test **fails** against the unfixed version (guards against a vacuous test)
- [x] Confirmed Vitest `toEqual` treats null-prototype and plain objects as equal, so the pre-existing assertions still hold
- [x] `npm test -- tests/analysis/artifactBundleStore.test.ts` — 20/20
- [x] `tests/integrations` (incl. the Velociraptor consumer) — 328 passed
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)