### PR TITLE
fix(config): remove committed merge-conflict markers from .env.example

### DIFF
--- a/companion/.env.example
+++ b/companion/.env.example
@@ -663,7 +663,6 @@ DFIR_FLUSH_INTERVAL_MS=300000
 # 12. UI LIMITS
 # ══════════════════════════════════════════════════════════════════════════════
 
-<<<<<<< HEAD
 # Per-request timeout in ms (default 180000). Strong models over a large timeline
 # can take >60s — raise this if you see "request timed out" during synthesis.
 DFIR_AI_TIMEOUT_MS=180000
@@ -1174,12 +1173,6 @@ DFIR_VISION_IMAGE_DETAIL=high
 # common aliases like vql/kql/esql/spl/snort are accepted). Unset = ALL platforms shown.
 #   DFIR_HUNT_PLATFORMS=velociraptor                  # show ONLY Velociraptor
 #   DFIR_HUNT_PLATFORMS=velociraptor,sigma,yara       # show just these three
-=======
-# Hunt-query platforms shown by the 🔍 pivot generator: velociraptor, defender (KQL), elastic
-# (ES|QL), splunk, sigma, yara, suricata. Trim to the tools your team actually has (comma/space
-# separated, case-insensitive; aliases vql/kql/esql/spl/snort accepted). Unset = show all.
-#   DFIR_HUNT_PLATFORMS=velociraptor,sigma,yara
->>>>>>> master
 # DFIR_HUNT_PLATFORMS=
 
 # Mobile PWA at /mobile — per-list caps for the compact phone payload. The UI shows "N of M" so


### PR DESCRIPTION
`companion/.env.example` has had `<<<<<<< HEAD` / `=======` / `>>>>>>> master` markers committed in it (lines 666, 1177, 1182). That is the file users copy to create their `.env`, and `scripts/build-sea.mjs` bundles it into the packaged binary — so the markers ship to users.

## What was resolved

The conflict region spanned ~510 lines, but the two sides were only ever two versions of the same trailing `DFIR_HUNT_PLATFORMS` note:

- **Kept:** the fuller, documented side (the 510-line block, ending with the 7-line explanation and its two worked examples).
- **Dropped:** a 4-line condensed restatement of that same note.

Verified before choosing — the dropped side contributes **no** variable the kept side lacks (0 unique `DFIR_*` names on the dropped side, 165 on the kept side), so nothing is lost.

## Diff

7 deleted lines: the 3 conflict markers and the 4-line duplicate stanza. No other content, and no line-ending churn.