### PR TITLE
perf(synthesis): remove the anchor-context cost cliff in selectSynthesisEvents

### DIFF
--- a/companion/src/analysis/synthSelect.ts
+++ b/companion/src/analysis/synthSelect.ts
@@ -55,9 +55,11 @@ function eventMs(e: ForensicEvent): number | null {
   return Number.isNaN(t) ? null : t;
 }
 
-function sameAsset(a: string | undefined, b: string | undefined): boolean {
-  if (!a || !b) return false;
-  return a.trim().toLowerCase() === b.trim().toLowerCase();
+// Two events are "on the same asset" when their asset names match ignoring case and surrounding
+// whitespace (`WIN-01`, `win-01 ` are one host). An absent/empty asset never matches anything —
+// unknown provenance is not evidence of co-location — so it has no key.
+function assetKey(asset: string | undefined): string | null {
+  return asset ? asset.trim().toLowerCase() : null;
 }
 
 // Process/command-line-bearing events are the highest-value context around an anchor (they show what
@@ -67,31 +69,70 @@ function isProcessLike(e: ForensicEvent): boolean {
   return /\b(cmd|powershell|pwsh|bash|sh|wscript|cscript|rundll32|regsvr32|mshta|\.exe|\.ps1|\.dll|-enc|-e[nc]{0,2} |http)\b/i.test(e.description ?? "");
 }
 
+// An event pre-resolved for the anchor-context scan: timestamp parsed once and process-likeness
+// (a regex over the description) evaluated once, instead of per anchor it is compared against.
+interface TimedEvent {
+  readonly e: ForensicEvent;
+  readonly ms: number;
+  readonly procRank: 0 | 1;   // 0 = process-like (preferred context), 1 = everything else
+}
+
+// Index of the first entry with ms >= target, in an ms-ascending list.
+function lowerBound(list: readonly TimedEvent[], target: number): number {
+  let lo = 0;
+  let hi = list.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (list[mid].ms < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
 // The same-host events within ±ANCHOR_WINDOW of each anchor, best-first per anchor (process-like, then
 // nearest in time), interleaved ROUND-ROBIN across anchors so a single busy anchor can't hog the whole
 // context budget. Already-claimed events (anchors, earliest) are skipped by the caller's fill guard.
+//
+// The timeline is bucketed by normalised asset ONCE up front. Scanning the whole timeline per anchor
+// instead is O(anchors × events) — invisible on most cases, because more anchors than `max` short-
+// circuits into the severity-trim branch above, but brutal on the shape that DOES reach here with a
+// long timeline: a big case carrying a few hundred genuine Critical/High rows. `byTime` is already
+// event-time ascending, so each bucket is too, and each anchor can binary-search straight to its
+// window instead of re-testing (and re-parsing) every event in the case.
 function anchorContextCandidates(
   byTime: ForensicEvent[],
   anchors: ForensicEvent[],
   claimed: ReadonlySet<string>,
 ): ForensicEvent[] {
+  // Undated and asset-less events can never satisfy the same-asset/window test, so they're dropped
+  // here once rather than re-rejected for every anchor.
+  const byAsset = new Map<string, TimedEvent[]>();
+  for (const e of byTime) {
+    const key = assetKey(e.asset);
+    if (key === null) continue;
+    const ms = eventMs(e);
+    if (ms === null) continue;
+    const entry: TimedEvent = { e, ms, procRank: isProcessLike(e) ? 0 : 1 };
+    const bucket = byAsset.get(key);
+    if (bucket) bucket.push(entry);
+    else byAsset.set(key, [entry]);
+  }
+
   const perAnchor: ForensicEvent[][] = [];
   for (const a of anchors) {
+    const key = assetKey(a.asset);
     const am = eventMs(a);
-    if (am === null || !a.asset) continue;
-    const near = byTime.filter((e) => {
-      if (e.id === a.id || claimed.has(e.id)) return false;
-      if (!sameAsset(e.asset, a.asset)) return false;
-      const em = eventMs(e);
-      return em !== null && Math.abs(em - am) <= ANCHOR_WINDOW_MS;
-    });
-    near.sort((x, y) => {
-      const px = isProcessLike(x) ? 0 : 1;
-      const py = isProcessLike(y) ? 0 : 1;
-      if (px !== py) return px - py;
-      return Math.abs((eventMs(x) as number) - am) - Math.abs((eventMs(y) as number) - am);
-    });
-    if (near.length) perAnchor.push(near.slice(0, PER_ANCHOR_CONTEXT_CAP));
+    if (am === null || key === null) continue;
+    const bucket = byAsset.get(key);
+    if (!bucket) continue;
+    const near: TimedEvent[] = [];
+    for (let i = lowerBound(bucket, am - ANCHOR_WINDOW_MS); i < bucket.length && bucket[i].ms <= am + ANCHOR_WINDOW_MS; i++) {
+      const t = bucket[i];
+      if (t.e.id === a.id || claimed.has(t.e.id)) continue;
+      near.push(t);
+    }
+    near.sort((x, y) => (x.procRank - y.procRank) || (Math.abs(x.ms - am) - Math.abs(y.ms - am)));
+    if (near.length) perAnchor.push(near.slice(0, PER_ANCHOR_CONTEXT_CAP).map((t) => t.e));
   }
   // Round-robin flatten, de-duped (a context event near two anchors appears once).
   const out: ForensicEvent[] = [];

--- a/companion/src/analysis/synthSelect.ts
+++ b/companion/src/analysis/synthSelect.ts
@@ -193,9 +193,15 @@ export function selectSynthesisEventsAnnotated(
   }
 
   const remaining = Math.max(0, max - classOf.size);
-  const fill = (candidates: ForensicEvent[], cap: number, cls: SelectionClass): void => {
+  // Each class's candidates are produced LAZILY. Every provider below is at least a full pass over the
+  // timeline (the anchor-context one buckets and windows it; the rare one sorts), and a class's turn can
+  // arrive with nothing left to give: an earlier class filled the budget, or — the common case on a
+  // detection-heavy timeline — the anchors themselves consumed it and `remaining` is 0. Building a
+  // candidate list only to discard it was pure waste, worst on exactly the cases already under pressure.
+  const fill = (candidates: () => ForensicEvent[], cap: number, cls: SelectionClass): void => {
+    if (cap <= 0 || capacityLeft() <= 0) return;
     let added = 0;
-    for (const e of candidates) {
+    for (const e of candidates()) {
       if (added >= cap || capacityLeft() <= 0) break;
       if (classOf.has(e.id)) continue;
       classOf.set(e.id, cls);
@@ -204,26 +210,34 @@ export function selectSynthesisEventsAnnotated(
   };
 
   // RESERVED FILL 1: same-host context around each anchor.
-  const anchors = events.filter((e) => classOf.get(e.id) === "anchor");
-  fill(anchorContextCandidates(byTime, anchors, new Set(classOf.keys())), Math.floor(remaining * BUDGET_ANCHOR_CONTEXT), "anchor_context");
+  fill(
+    () => anchorContextCandidates(byTime, events.filter((e) => classOf.get(e.id) === "anchor"), new Set(classOf.keys())),
+    Math.floor(remaining * BUDGET_ANCHOR_CONTEXT),
+    "anchor_context",
+  );
 
   // RESERVED FILL 2: cross-source-corroborated events (correlate.ts already merged their sources).
-  fill(byTime.filter((e) => !classOf.has(e.id) && (e.sources?.length ?? 0) >= 2), Math.floor(remaining * BUDGET_CORROBORATED), "corroborated");
+  fill(() => byTime.filter((e) => !classOf.has(e.id) && (e.sources?.length ?? 0) >= 2), Math.floor(remaining * BUDGET_CORROBORATED), "corroborated");
 
   // RESERVED FILL 3: ATT&CK-technique-tagged events regardless of severity (behavioral signal).
-  fill(byTime.filter((e) => !classOf.has(e.id) && (e.mitreTechniques?.length ?? 0) > 0), Math.floor(remaining * BUDGET_TECHNIQUE), "technique");
+  fill(() => byTime.filter((e) => !classOf.has(e.id) && (e.mitreTechniques?.length ?? 0) > 0), Math.floor(remaining * BUDGET_TECHNIQUE), "technique");
 
   // RESERVED FILL 4 (prevalence #15): RARE events — a low-prevalence pattern (seen once or twice in the
   // whole case) is far more likely to be signal than the 500× nightly-robocopy baseline, yet grades Low
   // and never won a seat. Only active when a rarity function is supplied; rarest first. Additive — with
   // no rarityOf the selection is byte-identical to before.
   if (rarityOf) {
-    const rareCandidates = byTime
-      .filter((e) => !classOf.has(e.id) && rarityOf(e) >= RARE_SCORE_MIN)
-      .sort((a, b) => rarityOf(b) - rarityOf(a) || byEventTime(a, b));
+    const rare = rarityOf;
     // Guarantee at least one rare seat when any rare candidate exists (the whole point: a 1-off must not
-    // be crowded out by baseline noise), even when the fractional budget rounds to 0 at a small cap.
-    if (rareCandidates.length) fill(rareCandidates, Math.max(1, Math.floor(remaining * BUDGET_RARE)), "rare");
+    // be crowded out by baseline noise), even when the fractional budget rounds to 0 at a small cap. An
+    // empty candidate list fills nothing on its own, so the floor of 1 costs a seat only when earned.
+    fill(
+      () => byTime
+        .filter((e) => !classOf.has(e.id) && rare(e) >= RARE_SCORE_MIN)
+        .sort((a, b) => rare(b) - rare(a) || byEventTime(a, b)),
+      Math.max(1, Math.floor(remaining * BUDGET_RARE)),
+      "rare",
+    );
   }
 
   // SPREAD remainder: keep whole activity bursts (burstDetect phases) rather than shredding clusters

--- a/companion/tests/analysis/loadTest.test.ts
+++ b/companion/tests/analysis/loadTest.test.ts
@@ -342,13 +342,22 @@ describe("load test — 10k synthetic events", { timeout: 120_000 }, () => {
   });
 
   it("selectSynthesisEvents stays bounded and stratifies the timeline", () => {
-    // The one path here that gets an absolute ceiling rather than a growth ratio: its cost
-    // is NOT monotonic in the timeline length. On this synthetic data it measures ~29ms at
-    // 1250 events, ~100ms at 2500, ~5ms at 5000 and ~14ms at 10000 — reproducibly, across
-    // independently generated states. The selection budget fills at different rates
-    // depending on how the anchor/context/spread quotas land, so a ratio between any two
-    // sizes says nothing. The ceiling is ~20x the worst measurement, so contention cannot
-    // reach it, while a quadratic regression on 10k events (seconds at least) still would.
+    // The one path here that gets an absolute ceiling rather than a growth ratio, because its
+    // cost is still not monotonic in the timeline length — though only mildly, and for a
+    // structural reason rather than an algorithmic one. A timeline whose Critical/High rows
+    // outnumber the budget short-circuits into the severity-trim branch and skips the reserved
+    // fills entirely, so two sizes either side of that threshold run DIFFERENT code and a ratio
+    // between them compares nothing meaningful. On this synthetic data (~10% Critical/High, so
+    // the threshold falls between 2500 and 3000 events) the whole 1250→10000 range now costs
+    // single-digit milliseconds, varying by a factor of ~2 with no cliff anywhere in it.
+    //
+    // The much larger swing this comment used to record (~29ms at 1250, ~100ms at 2500 — a 20x
+    // inversion against 5000) was a genuine defect, not a property of the algorithm: the
+    // anchor-context fill re-scanned the whole timeline once per anchor. That is fixed, and
+    // synthSelect.test.ts now guards the complexity directly, holding the timeline constant and
+    // varying only the anchor count so no threshold sits between the two measurements.
+    // The ceiling below stays deliberately loose — contention cannot reach it, while a
+    // reintroduced quadratic on 10k events (seconds at least) still would.
     const measured = bestOf(() => selectSynthesisEvents(state.forensicTimeline, 300), 5);
     console.log(`[load] selectSynthesisEvents (${TARGET_EVENT_COUNT} events): ${measured.ms.toFixed(1)}ms`);
     expect(measured.ms, `selectSynthesisEvents took ${measured.ms.toFixed(1)}ms on ${TARGET_EVENT_COUNT} events`)

--- a/companion/tests/analysis/synthSelect.test.ts
+++ b/companion/tests/analysis/synthSelect.test.ts
@@ -37,6 +37,23 @@ describe("selectSynthesisEvents", () => {
     expect(times).toEqual([...times].sort());
   });
 
+  it("builds no candidate list for a reserved class it has no budget to fill", () => {
+    // 20 Critical anchors exactly fill a budget of 20, so every reserved class afterwards arrives with
+    // nothing to give. Each class's candidates cost at least a full pass over the timeline, so assembling
+    // one here is pure waste — and `rarityOf` is the one builder a caller can observe, which makes it the
+    // probe: any call to it means a list was built and thrown away.
+    const events: ForensicEvent[] = [];
+    for (let i = 0; i < 20; i++) events.push(ev(`crit${i}`, `2026-05-20T${String(i).padStart(2, "0")}:00:00Z`, "Critical"));
+    for (let i = 0; i < 30; i++) events.push(ev(`low${i}`, `2026-05-21T${String(i % 24).padStart(2, "0")}:00:00Z`, "Low"));
+
+    let rarityCalls = 0;
+    const picked = selectSynthesisEvents(events, 20, (e) => { rarityCalls++; return e.id.startsWith("low") ? 1 : 0; });
+
+    expect(picked.length).toBe(20);
+    expect(picked.every((e) => e.severity === "Critical")).toBe(true);   // budget went entirely to anchors
+    expect(rarityCalls).toBe(0);
+  });
+
   it("keeps the severest when Critical/High alone exceed the budget", () => {
     const events = Array.from({ length: 50 }, (_, i) => ev(`c${i}`, `2026-05-20T${String(i % 24).padStart(2, "0")}:00:00Z`, "Critical"));
     expect(selectSynthesisEvents(events, 10).length).toBe(10);

--- a/companion/tests/analysis/synthSelect.test.ts
+++ b/companion/tests/analysis/synthSelect.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { selectSynthesisEvents, buildSynthesisContext } from "../../src/analysis/synthSelect.js";
+import { selectSynthesisEvents, selectSynthesisEventsAnnotated, buildSynthesisContext } from "../../src/analysis/synthSelect.js";
 import { emptyState, type ForensicEvent, type Severity } from "../../src/analysis/stateTypes.js";
 
 function ev(id: string, t: string, sev: Severity): ForensicEvent {
   return { id, timestamp: t, description: id, severity: sev, mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [] };
+}
+
+function host(e: ForensicEvent, asset: string, processName?: string): ForensicEvent {
+  return { ...e, asset, processName };
 }
 
 describe("selectSynthesisEvents", () => {
@@ -36,6 +40,103 @@ describe("selectSynthesisEvents", () => {
   it("keeps the severest when Critical/High alone exceed the budget", () => {
     const events = Array.from({ length: 50 }, (_, i) => ev(`c${i}`, `2026-05-20T${String(i % 24).padStart(2, "0")}:00:00Z`, "Critical"));
     expect(selectSynthesisEvents(events, 10).length).toBe(10);
+  });
+
+  // The anchor-context scenario: `lead` filler occupies the 15 guaranteed EARLIEST seats so the
+  // interesting events are claimed by the anchor-context fill (not by the earliest guarantee), and
+  // `tail` filler pushes the timeline past the budget so the reserved fills actually run.
+  function anchorScenario(...middle: ForensicEvent[]): ForensicEvent[] {
+    const lead = Array.from({ length: 20 }, (_, i) =>
+      host(ev(`lead${i}`, `2026-05-19T${String(i % 24).padStart(2, "0")}:30:00Z`, "Info"), "WIN-50"));
+    const tail = Array.from({ length: 40 }, (_, i) =>
+      host(ev(`tail${i}`, `2026-05-21T${String(i % 24).padStart(2, "0")}:30:00Z`, "Info"), "WIN-50"));
+    return [...lead, ...middle, ...tail];
+  }
+
+  it("pulls same-host events within the anchor window in as context", () => {
+    // A High anchor on WIN-01, with quiet Low events on WIN-01 inside the ±15min window, one WIN-01
+    // event well OUTSIDE it, and same-time noise on an unrelated host.
+    const events = anchorScenario(
+      host(ev("anchor", "2026-05-20T12:00:00Z", "High"), "WIN-01"),
+      host(ev("near-proc", "2026-05-20T12:05:00Z", "Low"), "WIN-01", "powershell.exe"),
+      host(ev("near-plain", "2026-05-20T12:01:00Z", "Low"), "WIN-01"),
+      host(ev("far-same-host", "2026-05-20T14:00:00Z", "Low"), "WIN-01"),
+      host(ev("other-host", "2026-05-20T12:02:00Z", "Low"), "WIN-99"),
+    );
+
+    const { events: picked, classOf } = selectSynthesisEventsAnnotated(events, 40);
+    expect(picked.map((e) => e.id)).toContain("anchor");
+    expect(classOf.get("near-proc")).toBe("anchor_context");
+    expect(classOf.get("near-plain")).toBe("anchor_context");
+    // Out-of-window / other-host events can still win a later spread seat, so assert on the CLASS
+    // rather than mere absence — that is what pins the window and the same-host rule.
+    expect(classOf.get("far-same-host")).not.toBe("anchor_context");
+    expect(classOf.get("other-host")).not.toBe("anchor_context");
+  });
+
+  it("prefers process-like events when an anchor has more context than its per-anchor share", () => {
+    const events = anchorScenario(
+      host(ev("anchor", "2026-05-20T12:00:00Z", "High"), "WIN-01"),
+      host(ev("near-plain", "2026-05-20T12:01:00Z", "Low"), "WIN-01"),        // closer in time…
+      host(ev("near-proc", "2026-05-20T12:05:00Z", "Low"), "WIN-01", "powershell.exe"), // …but this ran something
+    );
+    // max 19 = 1 anchor + 15 earliest + 3 remaining → a single anchor-context seat, so only the
+    // best-ranked candidate can take it.
+    const classOf = selectSynthesisEventsAnnotated(events, 19).classOf;
+    expect(classOf.get("near-proc")).toBe("anchor_context");
+    expect(classOf.get("near-plain")).not.toBe("anchor_context");
+  });
+
+  it("matches same-host context case-insensitively and ignoring surrounding whitespace", () => {
+    const events = anchorScenario(
+      host(ev("anchor", "2026-05-20T12:00:00Z", "High"), "WIN-01"),
+      host(ev("padded", "2026-05-20T12:03:00Z", "Low"), "  win-01 "),
+    );
+    expect(selectSynthesisEventsAnnotated(events, 40).classOf.get("padded")).toBe("anchor_context");
+  });
+
+  // Complexity guard for the anchor-context fill, which used to re-scan the WHOLE timeline once per
+  // anchor — cost growing with anchors × events. It only bites in the regime asserted below: the fill
+  // runs solely while the Critical/High anchors FIT the budget (more anchors than `max` short-circuits
+  // into the severity-trim branch), so the shape that hurts is a long timeline carrying a few hundred
+  // genuine detections — an ordinary big case, not a pathological one.
+  //
+  // Both runs use the SAME timeline and differ only in how many events are graded High, which isolates
+  // the defective term: 10× the anchors multiplied the old implementation's work by ~10, while a
+  // windowed per-asset lookup leaves it essentially flat. Asserting that RATIO rather than a millisecond
+  // bound keeps the test honest on a shared CI runner — machine speed cancels out instead of forcing a
+  // threshold so loose it catches nothing.
+  it("does not get proportionally slower as a timeline gains anchors", () => {
+    const hosts = Array.from({ length: 20 }, (_, i) => `HOST-${i}`);
+    const start = Date.parse("2026-05-20T00:00:00Z");
+    const build = (anchorEvery: number): ForensicEvent[] =>
+      Array.from({ length: 20_000 }, (_, i) => {
+        const e = ev(`e${i}`, new Date(start + i * 30_000).toISOString(), i % anchorEvery === 0 ? "High" : "Low");
+        e.description = `powershell.exe ran step ${i}`;
+        return host(e, hosts[i % hosts.length]);
+      });
+
+    const fewAnchors = build(1000);    // 20 anchors
+    const manyAnchors = build(100);    // 200 anchors
+    // Preconditions: both stay under the budget (so neither takes the anchor-overflow short-circuit)
+    // and both leave real budget for the context fill. If either flips, this silently stops measuring
+    // the path it was written to measure.
+    expect(manyAnchors.filter((e) => e.severity === "High").length).toBe(200);
+    expect(fewAnchors.filter((e) => e.severity === "High").length).toBe(20);
+
+    const timeOf = (evts: ForensicEvent[]): number => {
+      let best = Infinity;
+      for (let i = 0; i < 3; i++) {          // min-of-3 — the fastest run is the least noise-polluted
+        const t0 = performance.now();
+        selectSynthesisEvents(evts, 300);
+        best = Math.min(best, performance.now() - t0);
+      }
+      return best;
+    };
+
+    timeOf(fewAnchors);                       // discarded: warm the JIT so neither run pays compilation
+    // Measured: ~1.0 with the windowed lookup, 4.2–5.2 when each anchor rescans the timeline.
+    expect(timeOf(manyAnchors) / timeOf(fewAnchors)).toBeLessThan(2);
   });
 });
 


### PR DESCRIPTION
## Problem

`selectSynthesisEvents` had a reproducible non-monotonic cost — a 2500-event timeline cost ~20x more than a 5000-event one.

The cause was not the selected/total ratio but a **threshold**. When the Critical/High anchors exceed `max`, selection short-circuits into the severity-trim branch and skips the whole reserved-budget fill. Below that threshold the fill runs, and `anchorContextCandidates` re-filtered the **entire timeline once per anchor**, re-parsing every timestamp and re-normalising every asset name — **O(anchors x events)**.

With ~10% Critical/High rows and `max=300`, the flip lands between 2500 and 3000 events, and it is razor-sharp:

| events | anchors | short-circuit? | before | after |
|---|---|---|---|---|
| 2500 | 254 | no | 54-62ms | **5.5ms** |
| 2900 | 294 | no | 66-73ms | **2.4ms** |
| 3000 | 303 | **yes** | 2.0ms | 1.7ms |

100 extra events cut cost 33x. The sizes that looked "fast" were skipping the work, not doing it quickly.

That reframes the worst case: not a huge timeline, but a **long one carrying a few hundred genuine detections** — an ordinary big case, where anchors stay under budget while the timeline grows. Measured on that shape: 20k events 386ms, 40k 823ms, 100k **2101ms**.

## Changes

**1. Window the anchor-context scan per asset.** Bucket the timeline by normalised asset once, carrying each event's parsed timestamp and process-likeness, then binary-search each anchor's window. 40k sparse case: **823ms -> 97ms**.

**2. Build reserved-class candidates only when budget remains.** All four fills passed evaluated arguments, so each candidate list was built even with no seats to give — worst where the budget is tightest, since anchors alone can consume `max`. A 20-anchor case with a budget of 20 called `rarityOf` **88 times to fill zero seats**. `fill()` now takes a thunk and returns early on zero cap or capacity.

**3. Correct a stale note in the load test.** #189 recorded the old swing as inherent to the algorithm and used it to justify an absolute ceiling. That swing *was* this defect. The ceiling is still right, but for a narrower reason now stated precisely: two sizes either side of the anchor threshold execute different code, so a ratio between them compares nothing.

## Verification

**Selection output is unchanged** — byte-identical across **336 generated cases** spanning sizes, budgets, rarity on/off, anchor-heavy shapes that leave zero fill budget, and edge cases aimed at the new assumptions: mixed UTC offsets (the binary search relies on ms-ordering, not string-ordering), unparseable and empty timestamps, whitespace-only and missing assets.

New tests, all verified to **fail without the corresponding fix**:

- Four cases pinning anchor-context semantics: window bound, same-host rule, process-like priority, case/whitespace-insensitive matching.
- A **complexity guard** that holds the timeline constant and varies only the anchor count. 10x the anchors leaves cost flat (**0.96-1.08x**) with the windowed lookup but multiplied it **4.17-5.17x** before. Asserting that ratio rather than a millisecond bound keeps it honest on a shared runner — machine speed cancels out instead of forcing a threshold so loose it catches nothing.
- A **deterministic, timing-free** check that no candidate list is built without budget, using `rarityOf` as the probe: `88 -> 0` calls.

Full suite green (383 files, 4480 tests), typecheck clean.