### PR TITLE
ci: add TruffleHog verified-secret scanning to pre-commit and CI

### DIFF
--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -1,0 +1,28 @@
+name: TruffleHog Secret Scan
+
+# Verified-credential secret scan, alongside the pattern/PII scan in betterleaks-scan.yml.
+# TruffleHog tests each detected credential against its real API (e.g. an AWS key gets a live
+# GetCallerIdentity call), so it only fails on active, exploitable secrets rather than
+# secret-shaped strings — a different signal than betterleaks' regex rules.
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog Scan
+        uses: trufflesecurity/trufflehog@v3.95.9
+        with:
+          version: 3.95.9
+          extra_args: --results=verified,unknown

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -4,10 +4,17 @@ name: TruffleHog Secret Scan
 # TruffleHog tests each detected credential against its real API (e.g. an AWS key gets a live
 # GetCallerIdentity call), so it only fails on active, exploitable secrets rather than
 # secret-shaped strings — a different signal than betterleaks' regex rules.
+#
+# push is scoped to master (not '**'): the Action computes its scan range from
+# github.event.before, which is all-zeros on a brand-new branch's first push, and it falls back
+# to scanning the ENTIRE git history rather than just the new commits. Every feature branch here
+# starts life as a new branch, so a '**' trigger would full-history-rescan (and re-surface any
+# already-fixed/allowlisted finding) on every branch's first push. pull_request already covers
+# feature branches correctly, bounding the scan to base...head.
 
 on:
   push:
-    branches: ['**']
+    branches: [master]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,14 @@ repos:
           - '--config'
           - '.betterleaks-config.toml'
           - '--verbose'
+
+  # TruffleHog verifies detected credentials against their actual API (e.g. an AWS key is
+  # tested with a real GetCallerIdentity call), so it only fails the commit on live, active
+  # secrets rather than secret-shaped strings — a different signal than betterleaks' regex/PII
+  # rules above. `language: golang` means pre-commit builds the trufflehog binary via `go
+  # install` on first run (needs Go on PATH), then caches it.
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.95.9
+    hooks:
+      - id: trufflehog
+        name: TruffleHog

--- a/companion/tests/analysis/anonymize.test.ts
+++ b/companion/tests/analysis/anonymize.test.ts
@@ -171,7 +171,7 @@ describe("anonymizer — secret redaction (one-way)", () => {
   });
   it("redacts a URL userinfo password", () => {
     const a = createAnonymizer(policy({}, true), NONE);
-    const out = a.apply("conn https://svc:s3cr3tPW@10.0.0.5/api");
+    const out = a.apply("conn https://svc:s3cr3tPW@10.0.0.5/api"); // trufflehog:ignore
     expect(out).not.toContain("s3cr3tPW");
     expect(out).toContain(SECRET_PLACEHOLDER);
   });


### PR DESCRIPTION
## Summary
- Add TruffleHog as a second pre-commit hook (`.pre-commit-config.yaml`), pinned to v3.95.9, alongside the existing betterleaks hook
- Add `.github/workflows/trufflehog-scan.yml` running the official `trufflesecurity/trufflehog` Action, pinned to the same v3.95.9 tag

TruffleHog live-verifies detected credentials against their real APIs (e.g. an AWS key gets an actual `GetCallerIdentity` call), so it only fails on active/exploitable secrets — a different, complementary signal to betterleaks' regex/PII rules already in place.

## Test plan
- [x] `pre-commit run trufflehog --all-files` passes locally (verified this session)
- [x] Both hooks (betterleaks + TruffleHog) passed on this commit
- [ ] CI run on this PR (trufflehog-scan.yml) is green