### PR TITLE
fix(tests): kill the .env cross-file race and the 5s timeout false positives (#173)

### DIFF
--- a/companion/tests/server/aiReload.test.ts
+++ b/companion/tests/server/aiReload.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, rm, readFile } from "node:fs/promises";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import request from "supertest";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp, setServerLogger } from "../../src/server.js";
@@ -9,26 +9,25 @@ import { createConsoleLogger } from "../../src/logging/logger.js";
 
 // POST /settings/ai-reload (#181, the first-run wizard's save→reload→test flow) applies the saved
 // DFIR_AI_* values from .env into process.env so /diagnostics/ai-test sees them WITHOUT a restart.
-// reloadEnvPrefix reads .env from process.cwd(); we write a temp .env there and restore it after.
-const ENV_PATH = resolve(process.cwd(), ".env");
+//
+// reloadEnvPrefix resolves its .env via resolveEnvFilePath(), which honours DFIR_ENV_FILE before
+// falling back to cwd/.env — so we point it at a per-file temp .env (issue #173). This test used to
+// snapshot-and-restore the developer's REAL companion/.env, which raced with setupWizard.test.ts
+// (the other file doing the same) under parallel runs: a transient read error was indistinguishable
+// from "no .env existed", and the restore step then deleted the real file. Never touch cwd/.env.
+let envPath: string;
+let envRoot: string;
 
 let app: ReturnType<typeof createApp>;
-let savedEnv: string | undefined;
-let hadEnv = false;
 
 beforeEach(async () => {
   const root = await mkdtemp(join(tmpdir(), "dfir-aireload-"));
+  envRoot = await mkdtemp(join(tmpdir(), "dfir-aireload-env-"));
+  envPath = join(envRoot, ".env");
+  process.env.DFIR_ENV_FILE = envPath;
   const store = new CaseStore(root);
   setServerLogger(createConsoleLogger("info"));
   app = createApp(store, {});
-  // Snapshot any real .env so we can restore it, then write a known one.
-  try {
-    savedEnv = await readFile(ENV_PATH, "utf8");
-    hadEnv = true;
-  } catch {
-    hadEnv = false;
-    savedEnv = undefined;
-  }
   delete process.env.DFIR_AI_PROVIDER;
   delete process.env.DFIR_AI_MODEL;
   delete process.env.DFIR_VISION_PROVIDER;
@@ -36,13 +35,13 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  if (hadEnv && savedEnv !== undefined) await writeFile(ENV_PATH, savedEnv, "utf8");
-  else await rm(ENV_PATH, { force: true });
+  delete process.env.DFIR_ENV_FILE;
+  await rm(envRoot, { recursive: true, force: true });
 });
 
 describe("/settings/ai-reload", () => {
   it("applies saved DFIR_AI_* values from .env into process.env and reports them", async () => {
-    await writeFile(ENV_PATH, "DFIR_AI_PROVIDER=openai\nDFIR_AI_MODEL=gpt-4o-mini\nUNRELATED=keepme\n", "utf8");
+    await writeFile(envPath, "DFIR_AI_PROVIDER=openai\nDFIR_AI_MODEL=gpt-4o-mini\nUNRELATED=keepme\n", "utf8");
 
     const res = await request(app).post("/settings/ai-reload");
     expect(res.status).toBe(200);
@@ -57,7 +56,7 @@ describe("/settings/ai-reload", () => {
   });
 
   it("also applies the renamed DFIR_VISION_* vision family (screenshot provider)", async () => {
-    await writeFile(ENV_PATH, "DFIR_VISION_PROVIDER=openai\nDFIR_VISION_MODEL=gpt-4o-mini\n", "utf8");
+    await writeFile(envPath, "DFIR_VISION_PROVIDER=openai\nDFIR_VISION_MODEL=gpt-4o-mini\n", "utf8");
 
     const res = await request(app).post("/settings/ai-reload");
     expect(res.status).toBe(200);
@@ -68,7 +67,7 @@ describe("/settings/ai-reload", () => {
   });
 
   it("succeeds with an empty applied list when no DFIR_AI_* keys are present", async () => {
-    await writeFile(ENV_PATH, "UNRELATED=1\n", "utf8");
+    await writeFile(envPath, "UNRELATED=1\n", "utf8");
     const res = await request(app).post("/settings/ai-reload");
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);

--- a/companion/tests/server/setupWizard.test.ts
+++ b/companion/tests/server/setupWizard.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, writeFile, rm, readFile } from "node:fs/promises";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import request from "supertest";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp, setServerLogger } from "../../src/server.js";
@@ -9,30 +9,37 @@ import { createConsoleLogger } from "../../src/logging/logger.js";
 
 // Backend for the comprehensive Setup wizard (#181): generic /settings/reload (allowlisted prefix),
 // /setup/status (configured?-per-integration, derived live from env), /timesketch/reconnect (hot
-// reconnect), and the new /health flags. reloadEnvPrefix reads .env from cwd; snapshot+restore it.
-const ENV_PATH = resolve(process.cwd(), ".env");
+// reconnect), and the new /health flags.
+//
+// reloadEnvPrefix resolves its .env via resolveEnvFilePath(), which honours DFIR_ENV_FILE before
+// falling back to cwd/.env — so we point it at a per-file temp .env (issue #173). This test used to
+// snapshot-and-restore the developer's REAL companion/.env, which raced with aiReload.test.ts (the
+// other file doing the same) under parallel runs: a transient read error was indistinguishable from
+// "no .env existed", and the restore step then deleted the real file. Never touch cwd/.env.
+let envPath: string;
+let envRoot: string;
 
 let app: ReturnType<typeof createApp>;
-let savedEnv: string | undefined;
-let hadEnv = false;
 
 beforeEach(async () => {
   const root = await mkdtemp(join(tmpdir(), "dfir-setup-"));
+  envRoot = await mkdtemp(join(tmpdir(), "dfir-setup-env-"));
+  envPath = join(envRoot, ".env");
+  process.env.DFIR_ENV_FILE = envPath;
   const store = new CaseStore(root);
   setServerLogger(createConsoleLogger("info"));
   app = createApp(store, {});
-  try { savedEnv = await readFile(ENV_PATH, "utf8"); hadEnv = true; } catch { hadEnv = false; savedEnv = undefined; }
   for (const k of ["DFIR_IRIS_URL", "DFIR_IRIS_KEY", "DFIR_VT_KEY", "DFIR_NSRL_DB", "DFIR_NSRL_FILE"]) delete process.env[k];
 });
 
 afterEach(async () => {
-  if (hadEnv && savedEnv !== undefined) await writeFile(ENV_PATH, savedEnv, "utf8");
-  else await rm(ENV_PATH, { force: true });
+  delete process.env.DFIR_ENV_FILE;
+  await rm(envRoot, { recursive: true, force: true });
 });
 
 describe("/settings/reload", () => {
   it("applies an allowlisted prefix and reports the applied keys", async () => {
-    await writeFile(ENV_PATH, "DFIR_IRIS_URL=https://iris.example\nDFIR_IRIS_KEY=abc\nUNRELATED=x\n", "utf8");
+    await writeFile(envPath, "DFIR_IRIS_URL=https://iris.example\nDFIR_IRIS_KEY=abc\nUNRELATED=x\n", "utf8");
     const res = await request(app).post("/settings/reload").send({ prefix: "DFIR_IRIS_" });
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
@@ -61,7 +68,7 @@ describe("/setup/status", () => {
     expect(before.body.enrichment.virustotal).toBe(false);
 
     // Save + reload IRIS + a VT key, then re-check — status reflects the live env (no restart).
-    await writeFile(ENV_PATH, "DFIR_IRIS_URL=https://iris.example\nDFIR_IRIS_KEY=abc\nDFIR_VT_KEY=zzz\n", "utf8");
+    await writeFile(envPath, "DFIR_IRIS_URL=https://iris.example\nDFIR_IRIS_KEY=abc\nDFIR_VT_KEY=zzz\n", "utf8");
     await request(app).post("/settings/reload").send({ prefix: "DFIR_IRIS_" });
     await request(app).post("/settings/reload").send({ prefix: "DFIR_VT_" });
 
@@ -73,7 +80,7 @@ describe("/setup/status", () => {
 
 describe("/timesketch/reconnect", () => {
   it("returns not-configured when DFIR_TIMESKETCH_* are unset", async () => {
-    await writeFile(ENV_PATH, "UNRELATED=1\n", "utf8");
+    await writeFile(envPath, "UNRELATED=1\n", "utf8");
     delete process.env.DFIR_TIMESKETCH_URL;
     delete process.env.DFIR_TIMESKETCH_USER;
     delete process.env.DFIR_TIMESKETCH_PASSWORD;

--- a/companion/vitest.config.ts
+++ b/companion/vitest.config.ts
@@ -5,6 +5,17 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    // Vitest's 5s default is not a statement about how long these tests take — it's a statement
+    // about how long they take ON AN IDLE MACHINE. The suite is ~384 files whose cost is dominated
+    // by module collection/transform, so a full parallel run saturates every core and a test doing
+    // <1s of real work can sit descheduled for >4s and "time out" (issue #173). That produced a
+    // different set of failures on every run, which trains everyone to dismiss real regressions as
+    // flake. 15s keeps genuinely-hung tests failing fast while removing the starvation false
+    // positives — and removes the incentive to keep bumping timeouts one test at a time.
+    testTimeout: 15_000,
+    // Same reasoning for setup/teardown: a beforeEach doing mkdtemp + createApp() starves too, and
+    // a hook timeout fails the whole file rather than one test.
+    hookTimeout: 15_000,
     // Real OCR (TesseractOcrRunner) hits the network for language data and isn't mocked by
     // every test that triggers a capture — off by default so the suite never depends on
     // network access; tests/server/ocrSearchRoute.test.ts opts back in per test.


### PR DESCRIPTION
Part of #173.

Two fixes for the order-dependent test suite: the one genuine cross-file race, and the
timeout default that generates most of the noise around it.

## 1. `aiReload` / `setupWizard` no longer touch the developer's real `.env`

`tests/server/aiReload.test.ts` and `tests/server/setupWizard.test.ts` both resolved
`process.cwd()/.env` — the actual `companion/.env` — snapshotted it, overwrote it with
fixture content, and restored it in `afterEach`. Two files, two parallel workers, one file.

Running **only those two files** together, five times, on an otherwise idle machine:

| Run | Result | Real `.env` after |
|---|---|---|
| 1 | 2 failed | **deleted** |
| 2 | 2 failed | intact |
| 3 | 2 failed | **deleted** |
| 4 | 2 failed | intact |
| 5 | 1 failed | intact |

Each file passes alone (3/3 and 6/6). This is a two-file, zero-load reproduction of #173 —
no CPU contention required.

The data loss comes from the snapshot step: when the `readFile` hits a transient error
(concurrent write from the other worker), the bare `catch { hadEnv = false }` cannot
distinguish "read failed" from "no `.env` existed", so `afterEach` runs
`rm(ENV_PATH, { force: true })` on the real file. The other file's next `beforeEach` then
also sees no file, and the cascade repeats.

This never fired in CI, because CI has no `.env` — `hadEnv` is always false and the `rm` is
a no-op. It only bites developers with a configured install, which is exactly the failure
mode #173 describes: a real bug wearing a flake costume.

**Fix:** `resolveEnvFilePath()` already honours `DFIR_ENV_FILE` ahead of the `cwd/.env`
fallback. Both tests now point it at a per-file `mkdtemp` `.env` and clean it up. No
production code changes; the tests assert exactly what they did before.

## 2. Raise the global test timeout to 15s

#173 asked for a serial baseline to quantify the split. Here it is — one machine, same
commit, same suite (384 files / 4517 tests), nothing else running:

| Mode | Result | Wall clock |
|---|---|---|
| serial (`--no-file-parallelism`) | **384/384 pass, 0 failures** | 1426s |
| parallel (default) | **3 failures**, all `Test timed out in 5000ms` | 279s |

So the suite is not logically order-dependent beyond fix 1 — but serial is **5.1x slower**,
so "just run it serially" is not a fix.

The CPU accounting explains the failures. Serial spends 150s executing tests; parallel
spends 444s executing the *same* tests. Identical work costs ~3x more per test under load,
because the suite's cost is dominated by module collection (627s serial vs 2567s parallel)
and every core is saturated transpiling. A test doing under a second of real work can sit
descheduled well past a 5s budget.

Evidence that this is starvation and not slow tests: in one run, two of three cases of the
*same parameterised test* timed out while the third passed — identical code, identical cost.
And the files that flake are simply the slowest files, not files that share any state.

The repo has been paying for this one test at a time — at least six commits raising an
individual timeout (`c0440d3`, `7867e94`, `85edbd8`, `418de4a`, `43d2cf6`, `90a6ce8`), and
eight per-test overrides currently in the tree. Raising the default removes both the false
positives and the incentive to keep bumping them.

15s keeps a genuinely hung test failing fast while giving a starved one ~15x headroom over
its real cost. Existing per-test overrides above 15s are left alone — they were raised for
real reasons.

## Not addressed here

Two hypotheses in #173 are, as far as I can tell, not real and need no work:

- **Shared temp/case directories** — all 147 files that need one use `mkdtemp`. The only
  non-`mkdtemp` `tmpdir()` uses are deliberate "does not exist" paths.
- **Fixed port reuse** — exactly one test binds a port and it uses `listen(0)`. Everything
  else goes through supertest, which allocates ephemerally.

Still open from #173, deliberately out of scope for this PR:

- Only 8 of the ~147 files that call `mkdtemp` clean up after themselves, so the suite leaks
  temp directories on every run. Measured cost is about 0.2ms per `mkdtemp` even at extreme
  pollution, so it is **not** a timeout cause — but it is real garbage and wants a shared
  `tempRoot()` helper with registered cleanup.
- The `fullPipeline` `ENOTEMPTY` teardown race on Windows still wants a retry-on-removal.

## Test plan

- [x] `aiReload.test.ts` and `setupWizard.test.ts` pass in isolation (3/3 and 6/6)
- [x] The two files run together 6 consecutive times: 9/9 green every time, real `.env`
      byte-identical throughout (before the fix: 4 of 5 runs failed, 2 of 5 deleted it)
- [x] Full parallel suite green 3 consecutive times — 384/384 files, 4516 passed, 1 skipped
- [x] One of those three ran under contention as heavy as the run that originally failed
      (collect 2206s vs 2567s) and still passed
- [x] Full serial suite green — 384/384, the baseline #173 asked for
