### PR TITLE
test: per-run temp root, wall-clock polling, and tolerant teardown (#173)

### DIFF
--- a/companion/tests/fullPipeline.test.ts
+++ b/companion/tests/fullPipeline.test.ts
@@ -63,7 +63,13 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await Promise.all(tempRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  // Best-effort: on Windows the sync client/indexer can still hold a handle inside the tree here,
+  // and rm() then throws ENOTEMPTY from the afterEach — failing a test that actually passed. That
+  // teardown race is the oldest symptom in issue #173. Nothing is leaked by tolerating it: these
+  // roots live under the per-run temp root that tests/setup/tempRoot.ts removes when the run ends.
+  await Promise.all(
+    tempRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true }).catch(() => {})),
+  );
 });
 
 async function freshFullPipelineApp() {

--- a/companion/tests/helpers/poll.ts
+++ b/companion/tests/helpers/poll.ts
@@ -1,0 +1,57 @@
+/**
+ * Deadline-based polling for tests (issue #173).
+ *
+ * The suite is full of `for (let i = 0; i < 100; i++) { check(); await sleep(20); }` loops. That
+ * spells a budget of "100 iterations", which developers read as "2 seconds" — but it is really
+ * "2 seconds of SLEEPING plus 100 round-trips", and under a loaded parallel run the round-trips
+ * dominate and the sleeps overrun. Worse, when such a loop gives up it throws its OWN error, so
+ * raising `testTimeout` cannot save it: the loop is the binding constraint, not Vitest.
+ *
+ * Measured on the #80 hunt-diff test, whose four sequential 100x20ms waits made it fail ~50% of
+ * runs under heavy disk load — on master, with no source change involved.
+ *
+ * `pollFor` takes a WALL-CLOCK budget instead. The number of attempts then scales with how slow
+ * the machine actually is, which is the property the iteration count was trying and failing to
+ * express. Callers must still ensure the test's own timeout exceeds the sum of its poll budgets —
+ * see POLL_TIMEOUT_MS users for the arithmetic.
+ */
+export const POLL_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 20;
+
+export interface PollOptions {
+  /** Wall-clock budget. Keep the caller's test timeout above the SUM of its polls. */
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+/**
+ * Call `probe` until it returns a value that is neither `undefined` nor `null`, then return it.
+ * Throws with `description` if the budget expires — phrase it as what never happened, e.g.
+ * "hunt H.RUN1 reporting 2 result rows".
+ */
+export async function pollFor<T>(
+  description: string | (() => string),
+  probe: () => Promise<T | undefined | null>,
+  options: PollOptions = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? POLL_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? POLL_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+  let attempts = 0;
+
+  for (;;) {
+    attempts++;
+    const result = await probe();
+    if (result !== undefined && result !== null) return result;
+    if (Date.now() >= deadline) {
+      // Resolve the description LAST, so a caller can pass a closure that reports what it actually
+      // observed. "never reached the state, last saw X after N attempts in Ms" is the difference
+      // between a diagnosable failure and one that gets waved away as flake (issue #173).
+      const what = typeof description === "function" ? description() : description;
+      throw new Error(
+        `timed out after ${timeoutMs}ms (${attempts} attempts) waiting for: ${what}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}

--- a/companion/tests/server/huntOutcomes.test.ts
+++ b/companion/tests/server/huntOutcomes.test.ts
@@ -10,6 +10,7 @@ import { StateStore } from "../../src/analysis/stateStore.js";
 import { VeloHuntStore } from "../../src/analysis/veloHuntStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { HuntOutcomeStore } from "../../src/analysis/huntOutcomeStore.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
 import { HuntRunSnapshotStore } from "../../src/analysis/huntRunSnapshotStore.js";
 import { recordDeploy, vqlFingerprint } from "../../src/analysis/huntOutcomes.js";
 import { MockProvider } from "../../src/providers/provider.js";
@@ -78,19 +79,20 @@ describe("hunting feedback loop — routes (#157)", () => {
     await request(app).post("/cases/c1/velociraptor/deploy-hunt").send({ vql: "SELECT * FROM pslist()", title: "ps hunt", source: "fleet" });
     expect((await request(app).post("/cases/c1/velociraptor/collect").send({ huntId: "H.DEPLOY1" })).status).toBe(202);
 
-    let hunt: { status: string; foundEvidence?: boolean } | undefined;
-    for (let i = 0; i < 100; i++) {
-      hunt = (await request(app).get("/cases/c1/hunt-outcomes")).body.hunts[0];
-      if (hunt && hunt.status === "collected") break;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    expect(hunt?.status).toBe("collected");
-    expect(hunt?.foundEvidence).toBe(true);
+    const hunt = await pollFor<{ status: string; foundEvidence?: boolean }>(
+      "the deployed hunt to reach status=collected",
+      async () => {
+        const h = (await request(app).get("/cases/c1/hunt-outcomes")).body.hunts[0];
+        return h && h.status === "collected" ? h : undefined;
+      },
+    );
+    expect(hunt.status).toBe("collected");
+    expect(hunt.foundEvidence).toBe(true);
     const profile = (await request(app).get("/cases/c1/hunt-outcomes")).body;
     expect(profile).toMatchObject({ hit: 1, pending: 0 });
     expect(profile.hunts[0].resultRows).toBe(1);          // the row the hunt returned is surfaced
     expect(profile.hunts[0].resultSummary).toContain("result");
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   it("hunt-rows returns a tracked hunt's result rows on demand, 404s for an unknown hunt", async () => {
     const { app } = await makeApp();
@@ -147,13 +149,11 @@ describe("hunting feedback loop — routes (#157)", () => {
 // must show what's new/gone vs its OWN previous run, not just the cumulative case delta.
 describe("run-to-run hunt diffing (#80)", () => {
   async function waitForCollected(app: Express, huntId: string) {
-    for (let i = 0; i < 100; i++) {
+    return pollFor<Array<Record<string, unknown>>>(`hunt ${huntId} to be collected`, async () => {
       const profile = (await request(app).get("/cases/c1/hunt-outcomes")).body;
       const h = (profile.hunts ?? []).find((x: { huntId?: string }) => x.huntId === huntId);
-      if (h && h.status === "collected") return profile.hunts as Array<Record<string, unknown>>;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    throw new Error(`hunt ${huntId} never collected`);
+      return h && h.status === "collected" ? (profile.hunts as Array<Record<string, unknown>>) : undefined;
+    });
   }
 
   it("diffs a re-run against its own previous run's rows/hosts, not the whole case", async () => {
@@ -190,7 +190,8 @@ describe("run-to-run hunt diffing (#80)", () => {
     expect(hunts.find((h) => h.huntId === "H.RUN2")?.runDiff).toMatchObject({
       isFirstRun: false, addedRows: 1, removedRows: 0, addedHosts: ["host-b"],
     });
-  }, 30_000);   // two sequential collect polls (100 x 20ms each) can exceed vitest's 5s default under a loaded parallel run
+    // TWO sequential waitForCollected polls, so the test timeout must clear 2x the poll budget.
+  }, POLL_TIMEOUT_MS * 3);
 
   it("advances the baseline on same-huntId re-collects so a later re-run doesn't re-report stragglers", async () => {
     // Fleet hunt results trickle in: an analyst clicks "Collect" several times on the SAME huntId as
@@ -227,13 +228,18 @@ describe("run-to-run hunt diffing (#80)", () => {
     // Poll until the outcome's resultRows reflects a collect that returned `rows` rows — the only visible
     // signal that a same-huntId re-collect (which never changes status away from "collected") completed.
     async function waitForResultRows(huntId: string, rows: number) {
-      for (let i = 0; i < 100; i++) {
-        const profile = (await request(app).get("/cases/c1/hunt-outcomes")).body;
-        const h = (profile.hunts ?? []).find((x: { huntId?: string }) => x.huntId === huntId);
-        if (h && h.resultRows === rows) return;
-        await new Promise((r) => setTimeout(r, 20));
-      }
-      throw new Error(`hunt ${huntId} never reported ${rows} result rows`);
+      const seen: unknown[] = [];
+      await pollFor(
+        () =>
+          `hunt ${huntId} to report ${rows} result rows ` +
+          `(observed resultRows: ${JSON.stringify([...new Set(seen.map(String))])})`,
+        async () => {
+          const profile = (await request(app).get("/cases/c1/hunt-outcomes")).body;
+          const h = (profile.hunts ?? []).find((x: { huntId?: string }) => x.huntId === huntId);
+          seen.push(h?.resultRows);
+          return h && h.resultRows === rows ? true : undefined;
+        },
+      );
     }
 
     // First deploy + first (partial) collect — one host so far.
@@ -261,5 +267,8 @@ describe("run-to-run hunt diffing (#80)", () => {
     expect(hunts.find((h) => h.huntId === "H.RUN2")?.runDiff).toMatchObject({
       isFirstRun: false, addedRows: 0, removedRows: 0, addedHosts: [], removedHosts: [],
     });
-  }, 30_000);   // four sequential collect polls (100 x 20ms each) exceed vitest's 5s default under a loaded parallel run
+    // FOUR sequential polls (3x waitForResultRows + 1x waitForCollected). At the old 30s this test
+    // could not survive its own worst case — 4 x 10s of polling — which is how it came to fail ~50%
+    // of runs under load. The timeout now clears the full poll budget with headroom (issue #173).
+  }, POLL_TIMEOUT_MS * 5);
 });

--- a/companion/tests/setup/tempRoot.ts
+++ b/companion/tests/setup/tempRoot.ts
@@ -1,0 +1,53 @@
+import { rm, readdir } from "node:fs/promises";
+
+/**
+ * Vitest globalSetup — removes the per-run temp root created in vitest.config.ts (issue #173).
+ *
+ * ~147 test files call mkdtemp() and only 8 of them ever clean up, so every run used to strand a
+ * few thousand `dfir-*` directories in the OS temp dir. They accumulated to 388,954 before this
+ * was noticed. That is not what makes tests time out (measured: ~0.2ms extra per mkdtemp even at
+ * that scale), but it is real garbage: ~520k files of NTFS metadata that nothing ever collects.
+ *
+ * Rather than migrate 139 files to a cleanup helper — a large diff that regresses the moment
+ * someone writes a bare mkdtemp() — vitest.config.ts points TEMP/TMP/TMPDIR at ONE per-run
+ * directory for the whole worker pool. Node's os.tmpdir() reads those on every call, so every
+ * existing mkdtemp(join(tmpdir(), ...)) lands inside it with no test change at all, and future
+ * tests are covered for free. This hook then deletes that single root when the run ends.
+ *
+ * Per-run (not shared) matters: two suites running concurrently — which is how #173 was
+ * originally observed — get separate roots and cannot delete each other's directories.
+ */
+const REMOVE_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 200;
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function teardown(): Promise<void> {
+  const root = process.env.DFIR_TEST_TMP_ROOT;
+  if (!root) return;
+
+  // Windows strands handles briefly after a process exits (Dropbox/AV/indexer mid-scan), so a
+  // single rm can lose to ENOTEMPTY/EBUSY on a tree this size. Retry rather than fail the run —
+  // a leftover temp dir must never be the reason a green suite reports failure.
+  for (let attempt = 1; attempt <= REMOVE_ATTEMPTS; attempt++) {
+    try {
+      await rm(root, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      if (attempt === REMOVE_ATTEMPTS) {
+        let leftover = "";
+        try {
+          leftover = ` (${(await readdir(root)).length} entries left)`;
+        } catch {
+          // Root is already gone or unreadable — nothing useful to report.
+        }
+        console.warn(
+          `[tempRoot] could not remove the test temp root after ${REMOVE_ATTEMPTS} attempts: ` +
+            `${root}${leftover} — ${(err as Error).message}`,
+        );
+        return;
+      }
+      await delay(RETRY_DELAY_MS * attempt);
+    }
+  }
+}

--- a/companion/vitest.config.ts
+++ b/companion/vitest.config.ts
@@ -1,7 +1,21 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { defineConfig } from "vitest/config";
+
+// ONE temp root per run, so the ~147 test files that call mkdtemp() stop stranding directories in
+// the OS temp dir (issue #173 — 388,954 had piled up). Node reads TEMP/TMP/TMPDIR on every
+// os.tmpdir() call, so pointing them here redirects every existing mkdtemp(join(tmpdir(), ...))
+// into this root with no test change, and covers tests not written yet. tests/setup/tempRoot.ts
+// deletes it when the run ends. Kept short ("dfir-vt-") because it prefixes every temp path in the
+// suite and Windows still has a 260-char limit in play.
+const runTempRoot = mkdtempSync(join(tmpdir(), "dfir-vt-"));
+// Handed to the globalSetup teardown, which runs in this same (main) process.
+process.env.DFIR_TEST_TMP_ROOT = runTempRoot;
 
 export default defineConfig({
   test: {
+    globalSetup: ["tests/setup/tempRoot.ts"],
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts"],
@@ -19,6 +33,13 @@ export default defineConfig({
     // Real OCR (TesseractOcrRunner) hits the network for language data and isn't mocked by
     // every test that triggers a capture — off by default so the suite never depends on
     // network access; tests/server/ocrSearchRoute.test.ts opts back in per test.
-    env: { DFIR_OCR_SEARCH: "off" },
+    env: {
+      DFIR_OCR_SEARCH: "off",
+      // Redirect the worker pool's temp dir into the per-run root above. All three names are set
+      // because Node checks TEMP then TMP on Windows and TMPDIR elsewhere.
+      TEMP: runTempRoot,
+      TMP: runTempRoot,
+      TMPDIR: runTempRoot,
+    },
   },
 });


### PR DESCRIPTION
Part of #173 — the remaining items after #194 (the `.env` race and the 5s timeout default).

Three changes, plus one finding that turned into #195.

## 1. One temp root per run, deleted when the run ends

~147 test files call `mkdtemp()` and only 8 ever clean up, so every run stranded roughly a
thousand `dfir-*` directories in the OS temp dir. **388,954** had accumulated since late June.

To be clear about what this is and isn't: it is **not** what makes tests time out. Measured
at ~0.2ms extra per `mkdtemp` even at that scale (0.82ms in a clean dir vs 1.03ms in the
polluted one). I suspected it was a cause, benchmarked it, and it wasn't. It is simply real
garbage — ~520k files of NTFS metadata that nothing collects — growing every run.

Rather than migrate 139 files onto a cleanup helper (a large diff that regresses the moment
someone writes a bare `mkdtemp()`), `vitest.config.ts` points `TEMP`/`TMP`/`TMPDIR` at one
per-run directory. Node reads those on every `os.tmpdir()` call, so every existing
`mkdtemp(join(tmpdir(), ...))` lands inside it **with no test change**, and tests not yet
written are covered for free. `tests/setup/tempRoot.ts` removes that single root on teardown,
with retries because Windows strands handles briefly.

Per-run rather than shared matters: two suites running concurrently — how #173 was originally
observed — get separate roots and cannot delete each other's directories.

**Reviewer caveat:** `src/providers/codex.ts` uses `os.tmpdir()` as the cwd it spawns codex
in, so during tests that cwd now points at the per-run root. Harmless (the root exists for the
whole run), but it is real coupling between a test-only change and production code, and I'd
rather flag it than have someone discover it.

## 2. Polling on a wall-clock budget, with diagnosable failures

The suite is full of `for (let i = 0; i < 100; i++) { check(); await sleep(20); }`. That reads
as "2 seconds" but is really "2 seconds of *sleeping* plus 100 round-trips", and under load the
round-trips dominate. Worse, when such a loop gives up it throws its **own** error — so raising
`testTimeout` (what #194 did) cannot rescue it. The loop is the binding constraint, not Vitest.

`pollFor()` takes a wall-clock budget, so attempts scale with how slow the machine actually is.
The #80 hunt-diff test also had **four** sequential 100x20ms waits against a 30s timeout — a
40s worst case in a 30s box — so its timeout is now derived from the poll budget and cannot
drift out of step again.

The important half is diagnosability:

```
before: hunt H.RUN1 never reported 2 result rows
after:  timed out after 10000ms (236 attempts) waiting for: hunt H.RUN1 to report
        2 result rows (observed resultRows: ["1"])
```

## 3. `fullPipeline` teardown no longer fails a passing test

The oldest symptom in #173: `afterEach`'s `rm()` throws `ENOTEMPTY` when the sync client or
indexer still holds a handle, failing a test whose assertions all passed. Cleanup is now
best-effort. Nothing leaks — those roots live under the per-run root that change 1 removes.

## What this does NOT fix

Change 2's better error message immediately paid for itself by disproving my own theory. I
expected the poll budget to be the hunt-diff flake's cause. It is not:

```
hunt H.RUN1 to report 2 result rows (observed resultRows: ["1"])   — 236 attempts / 10s
```

The value is **stuck**, not late. A repeat collect on the same huntId sometimes never lands,
and no amount of extra time helps. A/B, 6 runs per arm interleaved under identical load:

| Arm | Failures |
|---|---|
| master, unmodified | 3 / 6 |
| with these changes | 3 / 6 |

Identical — it predates this branch. Filed as **#195** with the full evidence.

That test is deliberately **left failing rather than skipped**. It fails ~25-50% under heavy
disk load and ~0% idle. The visible red is the only reason it was ever diagnosed instead of
waved through as flake, which is the exact failure mode #173 was opened about.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Probe test confirmed `mkdtemp` resolves inside the per-run root, and the root is gone
      after the run
- [x] Full suite green — **384/384 files, 4516 passed, 1 skipped** — run while ~150k temp
      directories were being deleted in the background, i.e. under heavier disk load than
      the runs that originally failed
- [x] Zero temp roots left behind afterwards
- [x] A/B (12 runs) establishing that the remaining hunt-diff failure is pre-existing
