### PR TITLE
refactor(reports): replace ReportWriter's 16 positional params with an options object

### DIFF
--- a/companion/scripts/push-notion.ts
+++ b/companion/scripts/push-notion.ts
@@ -61,7 +61,11 @@ async function main(): Promise<void> {
   const store = new CaseStore(casesRoot);
   const stateStore = new StateStore(store);
   // Build a ReportWriter so the exported content matches the report (same scope/legitimate filters).
-  const reportWriter = new ReportWriter(store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), new ReportMetaStore(store));
+  const reportWriter = new ReportWriter(store, stateStore, {
+    scope: new ScopeStore(store),
+    falsePositives: new FalsePositiveStore(store),
+    reportMeta: new ReportMetaStore(store),
+  });
   const state = await reportWriter.filteredState(caseId);
   const meta = await new ReportMetaStore(store).load(caseId);
   const exportStore = new NotionExportStore(store);

--- a/companion/scripts/push-timesketch.ts
+++ b/companion/scripts/push-timesketch.ts
@@ -37,7 +37,11 @@ async function main(): Promise<void> {
   const store = new CaseStore(casesRoot);
   const stateStore = new StateStore(store);
   // Build a ReportWriter so the pushed timeline matches the report (same scope/legitimate filters).
-  const reportWriter = new ReportWriter(store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), new ReportMetaStore(store));
+  const reportWriter = new ReportWriter(store, stateStore, {
+    scope: new ScopeStore(store),
+    falsePositives: new FalsePositiveStore(store),
+    reportMeta: new ReportMetaStore(store),
+  });
   const state = await reportWriter.filteredState(caseId);
 
   console.log(`Pushing "${caseId}" to ${process.env.DFIR_TIMESKETCH_URL} …`);

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -78,25 +78,63 @@ export interface ReportPaths {
   stateJson: string;
 }
 
+// The optional stores ReportWriter draws on for report sections. Named fields instead of a long
+// positional tail (#176): two branches each appending a new store to the constructor's end used to
+// collide on the same slot, silently leaving one store `undefined` with no type error — see #176 for
+// the incident that motivated this.
+export interface ReportWriterOptions {
+  scope?: ScopeStore;
+  falsePositives?: FalsePositiveStore;
+  reportMeta?: ReportMetaStore;
+  customerExposure?: CustomerExposureStore;
+  notebook?: NotebookStore;
+  assetOverrides?: AssetOverridesStore;
+  playbook?: PlaybookStore;
+  reportTemplates?: ReportTemplateStore;
+  reportTemplateControl?: ReportTemplateControlStore;
+  kevStore?: KevStore;
+  hypothesisStore?: HypothesisStore;
+  synthMeta?: SynthMetaStore;   // #11 deferred: second-look collection leads in the report
+  lateralPathDismissals?: LateralPathDismissStore;   // analyst-rejected lateral chains
+  reportVersions?: ReportVersionStore;   // #77 report versioning (diff & rollback)
+}
+
 export class ReportWriter {
+  private readonly scope?: ScopeStore;
+  private readonly falsePositives?: FalsePositiveStore;
+  private readonly reportMeta?: ReportMetaStore;
+  private readonly customerExposure?: CustomerExposureStore;
+  private readonly notebook?: NotebookStore;
+  private readonly assetOverrides?: AssetOverridesStore;
+  private readonly playbook?: PlaybookStore;
+  private readonly reportTemplates?: ReportTemplateStore;
+  private readonly reportTemplateControl?: ReportTemplateControlStore;
+  private readonly kevStore?: KevStore;
+  private readonly hypothesisStore?: HypothesisStore;
+  private readonly synthMeta?: SynthMetaStore;
+  private readonly lateralPathDismissals?: LateralPathDismissStore;
+  private readonly reportVersions?: ReportVersionStore;
+
   constructor(
     private readonly cases: CaseStore,
     private readonly state: StateStore,
-    private readonly scope?: ScopeStore,
-    private readonly falsePositives?: FalsePositiveStore,
-    private readonly reportMeta?: ReportMetaStore,
-    private readonly customerExposure?: CustomerExposureStore,
-    private readonly notebook?: NotebookStore,
-    private readonly assetOverrides?: AssetOverridesStore,
-    private readonly playbook?: PlaybookStore,
-    private readonly reportTemplates?: ReportTemplateStore,
-    private readonly reportTemplateControl?: ReportTemplateControlStore,
-    private readonly kevStore?: KevStore,
-    private readonly hypothesisStore?: HypothesisStore,
-    private readonly synthMeta?: SynthMetaStore,   // #11 deferred: second-look collection leads in the report
-    private readonly lateralPathDismissals?: LateralPathDismissStore,   // analyst-rejected lateral chains
-    private readonly reportVersions?: ReportVersionStore,   // #77 report versioning (diff & rollback)
-  ) {}
+    opts: ReportWriterOptions = {},
+  ) {
+    this.scope = opts.scope;
+    this.falsePositives = opts.falsePositives;
+    this.reportMeta = opts.reportMeta;
+    this.customerExposure = opts.customerExposure;
+    this.notebook = opts.notebook;
+    this.assetOverrides = opts.assetOverrides;
+    this.playbook = opts.playbook;
+    this.reportTemplates = opts.reportTemplates;
+    this.reportTemplateControl = opts.reportTemplateControl;
+    this.kevStore = opts.kevStore;
+    this.hypothesisStore = opts.hypothesisStore;
+    this.synthMeta = opts.synthMeta;
+    this.lateralPathDismissals = opts.lateralPathDismissals;
+    this.reportVersions = opts.reportVersions;
+  }
 
   // Second-look collection leads (investigation-guidance #11, deferred): requests the raw re-query made
   // that matched NOTHING — each an actionable "collect this next" gap. Lives in synth-meta, not state, so

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -3081,7 +3081,22 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const clickupExportStore = new ClickUpExportStore(store);
   const irisExportStore = new IrisExportStore(store);
   const lateralPathDismissStore = new LateralPathDismissStore(store);
-  const reportWriter = new ReportWriterImpl(store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore, new CustomerExposureStore(store), notebookStore, assetOverridesStore, playbookStore, reportTemplateStore, reportTemplateControlStore, kevStore, hypothesisStore, synthMetaStore, lateralPathDismissStore, reportVersionStore);
+  const reportWriter = new ReportWriterImpl(store, stateStore, {
+    scope: new ScopeStore(store),
+    falsePositives: new FalsePositiveStore(store),
+    reportMeta: reportMetaStore,
+    customerExposure: new CustomerExposureStore(store),
+    notebook: notebookStore,
+    assetOverrides: assetOverridesStore,
+    playbook: playbookStore,
+    reportTemplates: reportTemplateStore,
+    reportTemplateControl: reportTemplateControlStore,
+    kevStore,
+    hypothesisStore,
+    synthMeta: synthMetaStore,
+    lateralPathDismissals: lateralPathDismissStore,
+    reportVersions: reportVersionStore,
+  });
 
   // Automatic state backup (#180): snapshot SNAPSHOT_STATE_FILES before synthesis + on a timer.
   const backupConfig = resolveBackupConfig(process.env);

--- a/companion/tests/fullPipeline.test.ts
+++ b/companion/tests/fullPipeline.test.ts
@@ -78,7 +78,7 @@ async function freshFullPipelineApp() {
   const store = new CaseStore(root);
   const stateStore = new StateStore(store);
   const reportMetaStore = new ReportMetaStore(store);
-  const reportWriter = new ReportWriter(store, stateStore, undefined, undefined, reportMetaStore);
+  const reportWriter = new ReportWriter(store, stateStore, { reportMeta: reportMetaStore });
 
   const mockEnrichProvider = {
     name: "MockTI",

--- a/companion/tests/reports/reportWriter.test.ts
+++ b/companion/tests/reports/reportWriter.test.ts
@@ -57,7 +57,7 @@ describe("ReportWriter", () => {
       { id: markerId("event", "e2"), kind: "event", ref: "e2", reason: "other", note: "client's maintenance", markedAt: "2026-05-28T10:00:00Z", markedBy: "anonymous", label: "client admin maintenance window" },
     ]);
 
-    const writer = new ReportWriter(caseStore, stateStore, undefined, falsePositives);
+    const writer = new ReportWriter(caseStore, stateStore, { falsePositives });
     const paths = await writer.writeAll("c1");
 
     const forensic = await readFile(paths.forensicTimelineCsv, "utf8");
@@ -83,7 +83,7 @@ describe("ReportWriter", () => {
       { id: markerId("event", "e2"), kind: "event", ref: "e2", reason: "other", note: "client's maintenance", markedAt: "2026-05-28T10:00:00Z", markedBy: "anonymous", label: "client admin maintenance window" },
     ]);
 
-    const writer = new ReportWriter(caseStore, stateStore, undefined, falsePositives);
+    const writer = new ReportWriter(caseStore, stateStore, { falsePositives });
     const csv = await writer.incidentTimelineCsv("c1");
 
     expect(csv).toContain("timestamp,endTimestamp,count,severity,description");
@@ -110,7 +110,7 @@ describe("ReportWriter", () => {
         markedAt: "2026-05-28T10:00:00Z", markedBy: "anonymous", label: "client admin maintenance window" },
     ]);
 
-    const writer = new ReportWriter(caseStore, stateStore, undefined, falsePositives);
+    const writer = new ReportWriter(caseStore, stateStore, { falsePositives });
     const buf = await writer.docx("c1");
 
     expect(Buffer.isBuffer(buf)).toBe(true);
@@ -142,7 +142,7 @@ describe("ReportWriter", () => {
         markedAt: "2026-05-28T10:00:00Z", markedBy: "anonymous", label: "client admin maintenance window" },
     ]);
 
-    const writer = new ReportWriter(caseStore, stateStore, undefined, falsePositives);
+    const writer = new ReportWriter(caseStore, stateStore, { falsePositives });
     const s = await writer.mobileSummary("c1");
 
     expect(s.caseId).toBe("c1");
@@ -173,7 +173,7 @@ describe("ReportWriter", () => {
         markedAt: "2026-05-28T10:00:00Z", markedBy: "anonymous", label: "client admin maintenance window" },
     ]);
 
-    const writer = new ReportWriter(caseStore, stateStore, undefined, falsePositives);
+    const writer = new ReportWriter(caseStore, stateStore, { falsePositives });
     const layer = await writer.attackLayer("c1");
 
     const ids = layer.techniques.map((t) => t.techniqueID);
@@ -204,7 +204,7 @@ describe("ReportWriter", () => {
         note: "known-good resolver", markedAt: "2026-05-28T10:00:00Z", markedBy: "anonymous" },
     ]);
 
-    const writer = new ReportWriter(caseStore, stateStore, undefined, falsePositives);
+    const writer = new ReportWriter(caseStore, stateStore, { falsePositives });
     const geo = await writer.geoMap("c1");
 
     expect(geo.markers).toHaveLength(1);

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -1654,7 +1654,7 @@ describe("state and report routes", () => {
     const store = new CaseStore(root);
     const stateStore = new StateStore(store);
     const reportMetaStore = new ReportMetaStore(store);
-    const reportWriter = new ReportWriter(store, stateStore, undefined, undefined, reportMetaStore);
+    const reportWriter = new ReportWriter(store, stateStore, { reportMeta: reportMetaStore });
     const app = createApp(store, { stateStore, reportWriter });
     await store.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
     const seeded = (await import("../src/analysis/stateTypes.js")).emptyState("c1");
@@ -1693,7 +1693,7 @@ describe("state and report routes", () => {
     const store = new CaseStore(root);
     const stateStore = new StateStore(store);
     const reportMetaStore = new ReportMetaStore(store);
-    const reportWriter = new ReportWriter(store, stateStore, undefined, undefined, reportMetaStore);
+    const reportWriter = new ReportWriter(store, stateStore, { reportMeta: reportMetaStore });
     const app = createApp(store, { stateStore, reportWriter, reportMetaStore });
     await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
 

--- a/companion/tests/server/geoMap.test.ts
+++ b/companion/tests/server/geoMap.test.ts
@@ -139,7 +139,7 @@ describe("GET /cases/:id/geo-map (#133)", () => {
     ]);
     const app2 = createApp(cases2, {
       stateStore: stateStore2,
-      reportWriter: new ReportWriter(cases2, stateStore2, undefined, legitStore2),
+      reportWriter: new ReportWriter(cases2, stateStore2, { falsePositives: legitStore2 }),
     });
 
     const res = await request(app2).get("/cases/c1/geo-map");

--- a/companion/tests/server/lateralPathDismiss.test.ts
+++ b/companion/tests/server/lateralPathDismiss.test.ts
@@ -35,7 +35,7 @@ async function seedCaseWithOneChain(caseId: string): Promise<void> {
 
 function appWith(dismissStore: LateralPathDismissStore) {
   return createApp(store, {
-    reportWriter: new ReportWriter(store, stateStore, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, dismissStore),
+    reportWriter: new ReportWriter(store, stateStore, { lateralPathDismissals: dismissStore }),
     lateralPathDismissStore: dismissStore,
   });
 }

--- a/companion/tests/server/reportTemplateRoutes.test.ts
+++ b/companion/tests/server/reportTemplateRoutes.test.ts
@@ -20,10 +20,13 @@ async function harness() {
   const reportMetaStore = new ReportMetaStore(store);
   const reportTemplateStore = new ReportTemplateStore(join(root, "report-templates"));
   const reportTemplateControlStore = new ReportTemplateControlStore(store);
-  const reportWriter = new ReportWriter(
-    store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore,
-    undefined, undefined, undefined, undefined, reportTemplateStore, reportTemplateControlStore,
-  );
+  const reportWriter = new ReportWriter(store, stateStore, {
+    scope: new ScopeStore(store),
+    falsePositives: new FalsePositiveStore(store),
+    reportMeta: reportMetaStore,
+    reportTemplates: reportTemplateStore,
+    reportTemplateControl: reportTemplateControlStore,
+  });
   const app = createApp(store, { stateStore, reportWriter, reportMetaStore, reportTemplateStore, reportTemplateControlStore });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
   return { app, store };

--- a/companion/tests/server/reportVersionsRoutes.test.ts
+++ b/companion/tests/server/reportVersionsRoutes.test.ts
@@ -18,16 +18,12 @@ async function harness() {
   const stateStore = new StateStore(store);
   const reportMetaStore = new ReportMetaStore(store);
   const reportVersionStore = new ReportVersionStore(store);
-  // NOTE the argument count: reportVersions is the LAST constructor parameter, and master's
-  // lateralPathDismissals sits immediately before it. These are positional, so an off-by-one here
-  // silently lands the store in the wrong slot and leaves `reportVersions` undefined — the version
-  // list then stays empty and every test in this file fails with "expected [] to have a length of 1".
-  const reportWriter = new ReportWriter(
-    store, stateStore, new ScopeStore(store), new FalsePositiveStore(store), reportMetaStore,
-    undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined,
-    undefined,            // lateralPathDismissals — not exercised here
-    reportVersionStore,
-  );
+  const reportWriter = new ReportWriter(store, stateStore, {
+    scope: new ScopeStore(store),
+    falsePositives: new FalsePositiveStore(store),
+    reportMeta: reportMetaStore,
+    reportVersions: reportVersionStore,
+  });
   const app = createApp(store, { stateStore, reportWriter, reportMetaStore, reportVersionStore });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
   return { app, store };


### PR DESCRIPTION
## Summary
- `ReportWriter`'s constructor took 2 required + 14 optional **positional** params. Two branches independently appending a store to the tail collided on the same slot during the #162 merge, silently leaving one store `undefined` (no type error, since every param is optional) — see #176 for the full incident writeup.
- Replaces the positional tail with a single `ReportWriterOptions` object. Named fields make slot collisions structurally impossible, and a typo is now a compile error instead of a silently swallowed `undefined`.
- Updated all 11 call sites: production wiring in `server.ts`, the `push-notion.ts`/`push-timesketch.ts` scripts, and 8 test files (including `reportVersionsRoutes.test.ts`, whose comment documenting the original collision is no longer needed and was removed).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Full suite: 4567/4569 passed, 386/387 files. The one failure (`secondOpinion.test.ts` timeout) doesn't reference `ReportWriter` and passes clean in isolation — pre-existing flake under parallel load, unrelated to this change.

Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)