### PR TITLE
fix(iocs): keep the bare indicator in an IOC value, annotations in a note

### DIFF
--- a/companion/package.json
+++ b/companion/package.json
@@ -29,6 +29,7 @@
     "deep-pass": "tsx scripts/deep-pass.ts",
     "clean-timeline": "tsx scripts/clean-timeline.ts",
     "dedupe-iocs": "tsx scripts/dedupe-iocs.ts",
+    "repair-ioc-values": "tsx scripts/repair-ioc-values.ts",
     "ocr-index": "tsx scripts/ocr-index.ts",
     "prompts:eject": "tsx scripts/eject-prompts.ts",
     "yeti": "tsx scripts/yeti-lookup.ts",

--- a/companion/scripts/repair-ioc-values.ts
+++ b/companion/scripts/repair-ioc-values.ts
@@ -1,0 +1,67 @@
+// Backfill for cases written before ingest-time IOC value normalization (#177): lift the human
+// annotation baked into an indicator ("10.10.20.15 (DC01)") out into the IOC's `note` field, and
+// canonicalize the value itself. Strict consumers — MISP rejects a non-bare IP with a 403 —
+// exact-match correlation, and value dedup all need `value` to be the bare indicator.
+//
+// Repair-only: an entry whose value can't be salvaged is reported and LEFT ALONE, never dropped.
+// No AI calls. Dry-run by default — shows what WOULD change; pass --apply to save.
+//
+//   npm run repair-ioc-values -- <caseId>            preview the repairs
+//   npm run repair-ioc-values -- <caseId> --apply    actually save them
+import { config as loadDotenv } from "dotenv";
+loadDotenv({ quiet: true });
+
+import { isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { CaseStore } from "../src/storage/caseStore.js";
+import { StateStore } from "../src/analysis/stateStore.js";
+import { repairIocValues } from "../src/analysis/iocRepair.js";
+import { isWellFormedIocValue } from "../src/analysis/iocValue.js";
+
+function short(v: string, max = 70): string {
+  const oneLine = v.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
+}
+
+async function main(): Promise<void> {
+  const caseId = process.argv[2] && !process.argv[2].startsWith("--") ? process.argv[2] : "test1";
+  const apply = process.argv.includes("--apply");
+
+  const raw = process.env.DFIR_CASES_ROOT ?? "cases";
+  const companionDir = fileURLToPath(new URL("../", import.meta.url));
+  const casesRoot = isAbsolute(raw) ? raw : resolve(companionDir, raw);
+
+  const store = new CaseStore(casesRoot);
+  const stateStore = new StateStore(store);
+  const state = await stateStore.load(caseId);
+
+  const { state: repaired, changed } = repairIocValues(state);
+  console.log(`Case "${caseId}": ${state.iocs.length} IOC(s), ${changed.length} with a value to repair.\n`);
+
+  for (const c of changed) {
+    console.log(`  ${c.id}  ${short(c.before)}`);
+    console.log(`  ${" ".repeat(c.id.length)}  -> ${short(c.after)}${c.note ? `   note: ${short(c.note, 40)}` : ""}`);
+  }
+
+  // Anything still malformed after repair is what an export (MISP push) will skip. Name it here so
+  // the operator can fix or remove it deliberately rather than discovering it as a remote rejection.
+  const unusable = repaired.iocs.filter((i) => !isWellFormedIocValue(i.type, i.value));
+  if (unusable.length) {
+    console.log(`\n${unusable.length} IOC(s) are still not valid for their type and will be SKIPPED by strict exports:`);
+    for (const i of unusable) console.log(`  ${i.id}  [${i.type}]  ${short(i.value)}`);
+  }
+
+  if (changed.length === 0) {
+    console.log("\nNothing to repair.");
+    return;
+  }
+  if (!apply) {
+    console.log(`\nDry run. Re-run with --apply to save these ${changed.length} repair(s).`);
+    return;
+  }
+
+  await stateStore.save({ ...repaired, updatedAt: state.updatedAt });
+  console.log(`\nRepaired ${changed.length} IOC value(s).`);
+}
+
+main().catch((e) => console.error("repair-ioc-values error:", e));

--- a/companion/src/analysis/iocRepair.ts
+++ b/companion/src/analysis/iocRepair.ts
@@ -11,6 +11,7 @@
 // risks silently orphaning analyst annotations. New imports no longer create that class going forward;
 // existing ones are left for a future, more careful migration if needed.
 import type { InvestigationState, IOC } from "./stateTypes.js";
+import { repairIocValue } from "./iocValue.js";
 
 export interface IocRepairResult {
   state: InvestigationState;
@@ -28,4 +29,34 @@ export function dedupeIocsById(state: InvestigationState): IocRepairResult {
   }
   if (removed === 0) return { state, removed: 0 };
   return { state: { ...state, iocs: kept }, removed };
+}
+
+export interface IocValueRepairResult {
+  state: InvestigationState;
+  changed: { id: string; before: string; after: string; note?: string }[];
+}
+
+// Backfill for cases written before ingest-time value normalization (#177): lift the human
+// annotation out of each `value` into `note`, and canonicalize the indicator. Repair-ONLY — an
+// entry whose value can't be salvaged is left exactly as it is rather than dropped, because on an
+// existing case that value may be the only record of something an analyst saw. (Ingest is stricter:
+// mergeDelta never CREATES an unusable row in the first place.)
+//
+// Deliberately does NOT collapse rows that end up sharing a value — e.g. a case holding both
+// "10.10.20.15" and "10.10.20.15 (DC01)" keeps two rows after repair. Merging them means remapping
+// every findings.relatedIocs / tag / comment reference from the dropped id to the kept one, which
+// risks silently orphaning analyst annotations; the analyst-facing IOC merge (#82) does that
+// safely and deliberately. Exports dedupe by value regardless, so the pushed result is clean.
+export function repairIocValues(state: InvestigationState): IocValueRepairResult {
+  const changed: IocValueRepairResult["changed"] = [];
+  const iocs = state.iocs.map((ioc) => {
+    const repaired = repairIocValue(ioc);
+    if (!repaired) return ioc;
+    const note = ioc.note ?? repaired.note;
+    if (repaired.value === ioc.value && note === ioc.note) return ioc;
+    changed.push({ id: ioc.id, before: ioc.value, after: repaired.value, ...(note ? { note } : {}) });
+    return { ...ioc, value: repaired.value, ...(note ? { note } : {}) };
+  });
+  if (changed.length === 0) return { state, changed };
+  return { state: { ...state, iocs }, changed };
 }

--- a/companion/src/analysis/iocValue.ts
+++ b/companion/src/analysis/iocValue.ts
@@ -1,0 +1,139 @@
+// Per-type IOC value hygiene (#177). An indicator's `value` must be the BARE indicator and nothing
+// else: any consumer that validates the field (MISP rejects `10.10.20.15 (DC01)` with "IP address
+// has an invalid format"), every exact-match correlation against other tooling, and the value-keyed
+// dedup in stateMerge all break the moment a human annotation is concatenated into it.
+//
+// The deterministic importers already sanitize IPs through siemImport's cleanIp(). The AI extraction
+// path did not: responseSchema only requires `value` to be a non-empty string, so whatever the model
+// emitted was persisted verbatim — host labels ("10.10.20.15 (DC01)"), descriptive suffixes
+// ("northlakeportal.com (exfil endpoint)"), even multi-KB text blobs typed as "ip".
+//
+// Two functions, deliberately with different strictness:
+//
+//   repairIocValue()      — INGEST. Splits the annotation into `note`, canonicalizes the indicator,
+//                           and returns null ONLY for values that cannot be an indicator at all
+//                           (empty, multi-line, absurdly long). A single-line value it cannot
+//                           validate is kept verbatim: dropping an analyst's odd-but-real token
+//                           would silently lose evidence, which is worse than carrying it.
+//   isWellFormedIocValue() — EXPORT. Strict per-type validity, so a push can skip an indicator with
+//                           a specific reason instead of collecting a wall of remote 403s.
+
+export interface RepairedIocValue {
+  value: string;   // the bare indicator
+  note?: string;   // annotation lifted out of the raw value ("DC01", "exfil endpoint", "port 443")
+}
+
+// Longest plausible value per type. Anything past this is a text blob that was mis-typed, not an
+// indicator — the only class we drop outright. Unknown types fall back to OTHER_MAX.
+const MAX_LEN: Record<string, number> = {
+  ip: 45,        // longest full IPv6 form
+  domain: 253,   // RFC 1035 max FQDN
+  hash: 128,     // SHA-512 hex
+  url: 2048,     // conventional browser/proxy ceiling
+  file: 1024,    // generous path
+  process: 512,
+  sid: 184,
+};
+const OTHER_MAX = 512;
+
+// Types whose legitimate values never contain a space-separated parenthetical, so a trailing
+// "(...)" group is safe to read as an annotation. Path-like types are excluded on purpose:
+// "invoice (1).xlsm" is a perfectly ordinary filename.
+const ANNOTATABLE = new Set(["ip", "domain", "url", "hash"]);
+
+const IPV4 = /^\d{1,3}(?:\.\d{1,3}){3}$/;
+const HASH_LEN = /^[a-f0-9]{32}$|^[a-f0-9]{40}$|^[a-f0-9]{64}$/;
+// One or more DNS labels. Single-label hostnames ("DC01") are accepted — they are routinely
+// recorded as domain IOCs — as are underscores, which appear in SRV/DKIM records.
+const DOMAIN_RE = /^(?=.{1,253}$)[a-z0-9_](?:[a-z0-9_-]*[a-z0-9_])?(?:\.[a-z0-9_](?:[a-z0-9_-]*[a-z0-9_])?)*\.?$/;
+// Reject the loopback/placeholder addresses that carry no investigative signal, matching cleanIp.
+const NOISE_IP = new Set(["::1", "127.0.0.1", "0.0.0.0", "::", "-", "::ffff:127.0.0.1"]);
+// Full IPv6 plus every valid "::"-compressed form (mirrors siemImport.ts — a naive "contains a
+// colon" check treats any colon-bearing free-text blob as a valid address).
+const IPV6_RE =
+  /^(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}$|^(?:[0-9a-f]{1,4}:){1,7}:$|^(?:[0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}$|^(?:[0-9a-f]{1,4}:){1,5}(?::[0-9a-f]{1,4}){1,2}$|^(?:[0-9a-f]{1,4}:){1,4}(?::[0-9a-f]{1,4}){1,3}$|^(?:[0-9a-f]{1,4}:){1,3}(?::[0-9a-f]{1,4}){1,4}$|^(?:[0-9a-f]{1,4}:){1,2}(?::[0-9a-f]{1,4}){1,5}$|^[0-9a-f]{1,4}:(?:(?::[0-9a-f]{1,4}){1,6})$|^:(?:(?::[0-9a-f]{1,4}){1,7}|:)$/;
+
+function isValidIp(v: string): boolean {
+  if (NOISE_IP.has(v)) return false;
+  if (IPV4.test(v)) return v.split(".").every((o) => Number(o) <= 255);
+  return IPV6_RE.test(v) && !/^fe80:/i.test(v);
+}
+
+// Strict per-type validity of an ALREADY-TRIMMED value. Free-form types (file, process, sid, other,
+// and anything outside the union) have no canonical shape, so any non-empty single-line value passes.
+export function isWellFormedIocValue(type: string, value: string): boolean {
+  const v = value.trim();
+  if (!v) return false;
+  if (v.length > (MAX_LEN[type] ?? OTHER_MAX)) return false;
+  if (/[\r\n\t]/.test(v)) return false;
+  switch (type) {
+    case "ip":     return isValidIp(v);
+    case "hash":   return HASH_LEN.test(v.toLowerCase());
+    case "domain": return DOMAIN_RE.test(v.toLowerCase());
+    case "url":    return !/\s/.test(v) && /[./]/.test(v);
+    default:       return true;
+  }
+}
+
+// Canonicalize a value that is already believed to be of `type`. Returns "" when it does not
+// canonicalize (the caller then keeps the raw value, or tries the other half of an annotation).
+function canonicalize(type: string, v: string): string {
+  switch (type) {
+    case "ip": {
+      const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(v);
+      const bare = mapped ? mapped[1] : v;
+      return isValidIp(bare) ? bare : "";
+    }
+    // Case is PRESERVED. Validation is case-insensitive (DNS and hex digests both are), but the
+    // stored value keeps the casing it was first seen with — dedup is already case-insensitive, so
+    // rewriting the case would change what analysts see for no correlation benefit.
+    case "hash":   return HASH_LEN.test(v.toLowerCase()) ? v : "";
+    case "domain": return DOMAIN_RE.test(v.toLowerCase()) ? v.replace(/\.$/, "") : "";
+    case "url":    return isWellFormedIocValue("url", v) ? v : "";
+    default:       return v;
+  }
+}
+
+// A trailing parenthetical that is SEPARATED BY WHITESPACE — "10.10.20.15 (DC01)". The whitespace
+// requirement is what keeps "…/wiki/Foo_(bar)" intact: there, the parens belong to the indicator.
+const ANNOTATION_RE = /^([^()]*\S)\s+\(([^()]+)\)$/;
+
+export function repairIocValue(ioc: { type: string; value: string }): RepairedIocValue | null {
+  const type = ioc.type;
+  const raw = (ioc.value ?? "").trim();
+  if (!raw) return null;
+  // Multi-line or oversized: this is a text blob that was mis-typed as an indicator (a whole
+  // PowerShell help page stored as an "ip"), not an annotated indicator. Nothing to salvage.
+  if (/[\r\n]/.test(raw)) return null;
+  if (raw.length > (MAX_LEN[type] ?? OTHER_MAX)) return null;
+
+  const withNote = (value: string, note?: string): RepairedIocValue => {
+    const n = note?.trim();
+    return n && n.toLowerCase() !== value.toLowerCase() ? { value, note: n } : { value };
+  };
+
+  if (ANNOTATABLE.has(type)) {
+    const m = ANNOTATION_RE.exec(raw);
+    if (m) {
+      const outside = m[1].trim();
+      const inside = m[2].trim();
+      // Whichever half canonicalizes as this type is the indicator; the other half is the note.
+      // Covers both "10.10.20.15 (DC01)" and the reversed "FS01 (10.10.20.30)".
+      const fromOutside = canonicalize(type, outside);
+      if (fromOutside) return withNote(fromOutside, inside);
+      const fromInside = canonicalize(type, inside);
+      if (fromInside) return withNote(fromInside, outside);
+    }
+  }
+
+  // "185.220.101.47:443" — the port is context, not part of the address.
+  if (type === "ip") {
+    const withPort = /^(\d{1,3}(?:\.\d{1,3}){3}):(\d{1,5})$/.exec(raw);
+    if (withPort && isValidIp(withPort[1])) return withNote(withPort[1], `port ${withPort[2]}`);
+  }
+
+  const canonical = canonicalize(type, raw);
+  // Kept verbatim when it does not canonicalize: a single-line token we do not recognise may still
+  // be real evidence. isWellFormedIocValue() is what export layers gate on.
+  return { value: canonical || raw };
+}

--- a/companion/src/analysis/manualEntry.ts
+++ b/companion/src/analysis/manualEntry.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import type { ForensicEvent, IOC, Severity } from "./stateTypes.js";
 import { toUtcIso } from "./timeUtc.js";
+import { repairIocValue } from "./iocValue.js";
 
 const SEVERITIES = ["Critical", "High", "Medium", "Low", "Info"] as const;
 const IOC_TYPES = ["ip", "domain", "hash", "file", "process", "url", "other"] as const;
@@ -29,9 +30,22 @@ export const manualEventSchema = z.object({
   path: z.string().trim().optional(),
 });
 
+// `note` carries context that must NOT be concatenated into `value` (#177) — a host label, an
+// observed port, why the analyst added it. If the analyst types the annotated form anyway
+// ("10.10.20.15 (DC01)"), repairIocValue splits it; only a value that cannot be an indicator at
+// all (multi-line paste, absurdly long) is rejected, as a 400 rather than silently stored.
 export const manualIocSchema = z.object({
   type: z.enum(IOC_TYPES),
   value: z.string().trim().min(1, "value is required"),
+  note: z.string().trim().optional(),
+}).superRefine((input, ctx) => {
+  if (!repairIocValue(input)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["value"],
+      message: "value is not a usable indicator (it is multi-line or far longer than any real indicator of this type)",
+    });
+  }
 });
 
 export interface BuildDeps {
@@ -67,10 +81,15 @@ export function buildManualIoc(input: unknown, deps: BuildDeps = {}): IOC {
   const p = manualIocSchema.parse(input);
   const now = deps.now ?? (() => new Date().toISOString());
   const id = deps.id ?? randomUUID;
+  // Non-null: the schema's superRefine already rejected anything repairIocValue can't use.
+  const repaired = repairIocValue(p)!;
+  // An explicit note from the analyst wins over one derived from the value they typed.
+  const note = p.note || repaired.note;
   return {
     id: `manual-${id()}`,
     type: p.type,
-    value: p.value,
+    value: repaired.value,
     firstSeen: now(),
+    ...(note ? { note } : {}),
   };
 }

--- a/companion/src/analysis/seedDemoCase.ts
+++ b/companion/src/analysis/seedDemoCase.ts
@@ -37,7 +37,9 @@ const SHA_BEACON   = "3b4a5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e
 const SHA_MIMIKATZ = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
 const SHA_PAYLOAD  = "f7e6d5c4b3a29180f7e6d5c4b3a29180f7e6d5c4b3a29180f7e6d5c4b3a29180";
 const SHA_RANSOM   = "deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678";
-const SHA_DROPPER  = "cafe0001002003004005006007008009000a000b000c000d000e000f0010001100";
+// 64 hex chars, like the rest — a 66-char value is not a SHA-256 and any consumer that validates
+// digest length (MISP) rejects the whole indicator (#177).
+const SHA_DROPPER  = "cafe0001002003004005006007008009000a000b000c000d000e000f00100011";
 const MD5_BEACON   = "9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d";
 const MD5_MIMIKATZ = "4d3c2b1a0f9e8d7c6b5a4938271605f4";
 

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -8,6 +8,7 @@ import { linkEmailDelivery } from "./initialAccess.js";
 import { linkArchiveToExfil } from "./exfilCorrelate.js";
 import { toUtcIso } from "./timeUtc.js";
 import { matchIocToExclude } from "./iocExclude.js";
+import { repairIocValue } from "./iocValue.js";
 import { sanitizeUncertainties } from "./uncertainty.js";
 
 // Trim a raw collect directive (investigation-guidance #8) to its non-empty string fields; returns
@@ -66,7 +67,16 @@ export function mergeDelta(
   const iocs: IOC[] = state.iocs.map((i) => ({ ...i }));
   const iocIdRemap = new Map<string, string>();
   let nextSeq = nextIocSeq(iocs);
-  for (const incoming of delta.iocs) {
+  for (const rawIncoming of delta.iocs) {
+    // Split any human annotation out of the value BEFORE anything keys on it (#177): the AI
+    // extraction path routinely emits "10.10.20.15 (DC01)", which is not an IP — strict consumers
+    // (MISP) reject it outright, exact-match correlation misses, and the dedup below would treat it
+    // as a different indicator from a bare "10.10.20.15" already in the case. Returns null only for
+    // values that cannot be an indicator at all (empty, multi-line, absurdly long — e.g. a whole
+    // PowerShell help page mis-typed as an "ip"); those are dropped rather than persisted as noise.
+    const repaired = repairIocValue(rawIncoming);
+    if (!repaired) continue;
+    const incoming = { ...rawIncoming, value: repaired.value };
     // Permanently excluded (per-case IOC Exclude List — e.g. ".lan"-style client hostname noise):
     // never create it, so it can never be enriched either (enrichIocs only ever sees state.iocs).
     // The id is deliberately never added to iocIdRemap; a finding's relatedIocs reference falls
@@ -95,9 +105,13 @@ export function mergeDelta(
       if (dup.value.toLowerCase() !== incomingLower && !(dup.aliasValues ?? []).some((a) => a.toLowerCase() === incomingLower)) {
         dup.aliasValues = [...(dup.aliasValues ?? []), incoming.value];
       }
+      // The annotation the value carried is context the existing row may not have yet — keep the
+      // first one seen rather than churning it on every re-import.
+      if (repaired.note && !dup.note) dup.note = repaired.note;
     } else {
       iocs.push({
         id: canonical, type: incoming.type, value: incoming.value, firstSeen: ctx.timestamp,
+        ...(repaired.note ? { note: repaired.note } : {}),
         ...(incoming.extractedFrom?.length ? { extractedFrom: [...incoming.extractedFrom] } : {}),
       });
     }

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -38,6 +38,11 @@ export interface IOC {
   // "evil.com" merged into "www.evil.com". Kept so value-keyed lookups (assetGraph's byValue,
   // event sha256/md5/path matching) still resolve the old value onto this canonical IOC.
   aliasValues?: string[];
+  // Human annotation that used to be concatenated into `value` (#177) — the host label in
+  // "10.10.20.15 (DC01)", a descriptive suffix, an observed port. Split out at ingest by
+  // iocValue.ts so `value` stays the bare indicator (strict consumers like MISP reject anything
+  // else) while the context survives: exports carry it in their comment/annotation field.
+  note?: string;
 }
 
 // Deterministic corroboration rollup for a finding (investigation-guidance #6), computed post-synthesis

--- a/companion/src/integrations/misp/mispPush.ts
+++ b/companion/src/integrations/misp/mispPush.ts
@@ -10,6 +10,7 @@ import type { ForensicEvent, InvestigationState, IOC } from "../../analysis/stat
 import type { MispPushClientLike, MispEventCreate, MispAttrBody } from "./mispPushClient.js";
 import { byEventTime } from "../../analysis/forensicSort.js";
 import { severityRank } from "../../analysis/dashboardViews.js";
+import { repairIocValue, isWellFormedIocValue } from "../../analysis/iocValue.js";
 
 export interface MispPushInput {
   caseId: string;              // Companion case id — used for idempotency tag and event title
@@ -48,6 +49,14 @@ export interface MispPushResult {
 }
 
 const COMPANION_TAG_PREFIX = "dfir-companion:case-";
+
+// Warnings are shown verbatim in the dashboard and the push log. A malformed value can be a
+// multi-KB text blob (an AI-extracted "ip" that is really a page of PowerShell help), so quoting it
+// whole would bury the rest of the warning list.
+function short(value: string, max = 80): string {
+  const oneLine = value.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max)}…` : oneLine;
+}
 
 // Derive the worst severity across all findings → MISP threat_level_id.
 // MISP: 1=High, 2=Medium, 3=Low, 4=Undefined.
@@ -172,19 +181,36 @@ export async function pushCaseToMisp(
 
   // 4. Push IOCs as MISP attributes.
   for (const ioc of input.state.iocs) {
-    const mapped = mapIocType(ioc);
-    if (!mapped) {
+    // Value hygiene (#177) runs FIRST — the mapped MISP type depends on the value (hash length),
+    // so it has to see the bare indicator. MISP validates every attribute value and rejects a
+    // malformed one with a 403 that is historically indistinguishable from an API-key problem.
+    // Repair what is repairable (a case written before ingest-time normalization still holds
+    // "10.10.20.15 (DC01)"), and skip the rest HERE, naming the real reason, rather than
+    // collecting remote rejections.
+    const repaired = repairIocValue(ioc);
+    const value = repaired?.value ?? "";
+    if (!value || !isWellFormedIocValue(ioc.type, value)) {
       attributes.skipped += 1;
-      warnings.push(`ioc skipped (no MISP type for "${ioc.type}"): ${ioc.value}`);
+      warnings.push(`ioc skipped (not a valid ${ioc.type} value — MISP would reject it): ${short(ioc.value)}`);
       continue;
     }
-    const key = ioc.value.trim().toLowerCase();
+    const mapped = mapIocType({ ...ioc, value });
+    if (!mapped) {
+      attributes.skipped += 1;
+      warnings.push(`ioc skipped (no MISP type for "${ioc.type}"): ${short(value)}`);
+      continue;
+    }
+    const key = value.toLowerCase();
     if (existingValues.has(key)) { attributes.existing += 1; continue; }
+    // The annotation that was split out of the value rides along as the attribute comment, so the
+    // host label survives the export instead of being lost with the malformed value.
+    const comment = ioc.note ?? repaired?.note;
     const body: MispAttrBody = {
       type: mapped.type,
-      value: ioc.value,
+      value,
       category: mapped.category,
       to_ids: ioc.type === "ip" || ioc.type === "domain" || ioc.type === "hash" || ioc.type === "url",
+      ...(comment ? { comment } : {}),
     };
     try {
       await client.addAttribute(eventId, body);
@@ -192,7 +218,7 @@ export async function pushCaseToMisp(
       attributes.added += 1;
     } catch (err) {
       attributes.skipped += 1;
-      warnings.push(`ioc "${ioc.value}": ${(err as Error).message}`);
+      warnings.push(`ioc "${short(value)}": ${(err as Error).message}`);
     }
   }
 

--- a/companion/tests/analysis/iocValue.test.ts
+++ b/companion/tests/analysis/iocValue.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { repairIocValue, isWellFormedIocValue } from "../../src/analysis/iocValue.js";
+
+describe("repairIocValue", () => {
+  describe("annotation stripping (#177)", () => {
+    it("moves a trailing host label out of an IP value and into `note`", () => {
+      expect(repairIocValue({ type: "ip", value: "10.10.20.15 (DC01)" }))
+        .toEqual({ value: "10.10.20.15", note: "DC01" });
+    });
+
+    it("handles the reversed form, where the parenthesised half is the indicator", () => {
+      expect(repairIocValue({ type: "ip", value: "FS01 (10.10.20.30)" }))
+        .toEqual({ value: "10.10.20.30", note: "FS01" });
+    });
+
+    it("strips a descriptive annotation from a url value", () => {
+      expect(repairIocValue({ type: "url", value: "northlakeportal.com (wdi-svc.exe download URL)" }))
+        .toEqual({ value: "northlakeportal.com", note: "wdi-svc.exe download URL" });
+    });
+
+    it("strips an annotation from a domain value, keeping the casing it was seen with", () => {
+      expect(repairIocValue({ type: "domain", value: "Evil.Example.COM (C2 domain)" }))
+        .toEqual({ value: "Evil.Example.COM", note: "C2 domain" });
+    });
+
+    it("keeps parentheses that are part of the indicator itself (no space before the paren)", () => {
+      const url = "https://en.wikipedia.org/wiki/Foo_(bar)";
+      expect(repairIocValue({ type: "url", value: url })).toEqual({ value: url });
+    });
+
+    it("never splits on parentheses for path-like types — a filename may legitimately contain them", () => {
+      const path = "C:\\Users\\jsmith\\Downloads\\invoice (1).xlsm";
+      expect(repairIocValue({ type: "file", value: path })).toEqual({ value: path });
+    });
+
+    it("drops an annotation that adds nothing (same text as the indicator)", () => {
+      expect(repairIocValue({ type: "ip", value: "10.0.0.5 (10.0.0.5)" })).toEqual({ value: "10.0.0.5" });
+    });
+  });
+
+  describe("per-type canonicalization", () => {
+    it("unwraps an IPv4-mapped IPv6 address", () => {
+      expect(repairIocValue({ type: "ip", value: "::ffff:10.0.0.1" })).toEqual({ value: "10.0.0.1" });
+    });
+
+    it("splits a trailing port off an IPv4 value", () => {
+      expect(repairIocValue({ type: "ip", value: "185.220.101.47:443" }))
+        .toEqual({ value: "185.220.101.47", note: "port 443" });
+    });
+
+    it("validates a hash case-insensitively but keeps the casing it was seen with", () => {
+      const sha = "3B4A5C6D7E8F9A0B1C2D3E4F5A6B7C8D9E0F1A2B3C4D5E6F7A8B9C0D1E2F3A4B";
+      expect(repairIocValue({ type: "hash", value: sha })).toEqual({ value: sha });
+    });
+
+    it("strips a trailing dot from a fully-qualified domain", () => {
+      expect(repairIocValue({ type: "domain", value: "evil.example.com." })).toEqual({ value: "evil.example.com" });
+    });
+
+    it("trims surrounding whitespace on every type", () => {
+      expect(repairIocValue({ type: "process", value: "  svchost32.exe \n" })).toEqual({ value: "svchost32.exe" });
+    });
+  });
+
+  describe("rejecting unusable values", () => {
+    it("rejects an empty / whitespace-only value", () => {
+      expect(repairIocValue({ type: "ip", value: "   " })).toBeNull();
+    });
+
+    it("rejects a multi-line blob stored as an indicator", () => {
+      const blob = "nd any 'Group Membership'\nsection data is processed if present.\n.PARAMETER Identity\n";
+      expect(repairIocValue({ type: "ip", value: blob })).toBeNull();
+    });
+
+    it("rejects a value far longer than any real indicator of that type", () => {
+      expect(repairIocValue({ type: "ip", value: "1".repeat(200) })).toBeNull();
+      expect(repairIocValue({ type: "domain", value: `${"a".repeat(300)}.com` })).toBeNull();
+    });
+
+    it("keeps a single-line value it cannot validate, rather than dropping evidence", () => {
+      // 66 hex chars — not a real hash length, but it is a plausible analyst-entered token.
+      // Export layers reject it explicitly; ingest must not silently discard it.
+      const odd = "cafe0001002003004005006007008009000a000b000c000d000e000f0010001100";
+      expect(repairIocValue({ type: "hash", value: odd })).toEqual({ value: odd });
+    });
+
+    it("keeps an unknown IOC type verbatim (types outside the union exist in older cases)", () => {
+      expect(repairIocValue({ type: "vulnerability", value: "CVE-2021-44228" }))
+        .toEqual({ value: "CVE-2021-44228" });
+    });
+  });
+});
+
+describe("isWellFormedIocValue", () => {
+  it("accepts bare indicators", () => {
+    expect(isWellFormedIocValue("ip", "10.10.20.15")).toBe(true);
+    expect(isWellFormedIocValue("ip", "2001:db8::1")).toBe(true);
+    expect(isWellFormedIocValue("domain", "evil.example.com")).toBe(true);
+    expect(isWellFormedIocValue("domain", "dc01")).toBe(true);
+    expect(isWellFormedIocValue("url", "http://evil.example/a.ps1")).toBe(true);
+    expect(isWellFormedIocValue("hash", "d41d8cd98f00b204e9800998ecf8427e")).toBe(true);
+  });
+
+  it("rejects the annotated forms that strict consumers (MISP) refuse", () => {
+    expect(isWellFormedIocValue("ip", "10.10.20.15 (DC01)")).toBe(false);
+    expect(isWellFormedIocValue("domain", "evil.example.com (C2)")).toBe(false);
+    expect(isWellFormedIocValue("url", "evil.example (download)")).toBe(false);
+  });
+
+  it("rejects a hash that is not a recognised digest length", () => {
+    expect(isWellFormedIocValue("hash", "cafe0001002003004005006007008009000a000b000c000d000e000f0010001100")).toBe(false);
+    expect(isWellFormedIocValue("hash", "deadbeef")).toBe(false);
+  });
+
+  it("has no opinion on free-form types — they are always well formed once trimmed", () => {
+    expect(isWellFormedIocValue("file", "C:\\Windows\\Temp\\svchost32.exe")).toBe(true);
+    expect(isWellFormedIocValue("other", "jsmith@globaltech.com")).toBe(true);
+  });
+});

--- a/companion/tests/analysis/iocValueIngest.test.ts
+++ b/companion/tests/analysis/iocValueIngest.test.ts
@@ -1,0 +1,139 @@
+// #177: an indicator's `value` must be the bare indicator. These cover the two ingest paths that
+// used to store whatever they were handed — the AI/importer delta merge, and analyst manual entry —
+// plus the backfill for cases already written with an annotation baked in.
+
+import { describe, it, expect } from "vitest";
+import { ZodError } from "zod";
+import { mergeDelta } from "../../src/analysis/stateMerge.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+import type { AnalysisDelta } from "../../src/analysis/responseSchema.js";
+import { buildManualIoc } from "../../src/analysis/manualEntry.js";
+import { repairIocValues } from "../../src/analysis/iocRepair.js";
+
+const baseDelta: AnalysisDelta = {
+  findings: [], iocs: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [],
+  timelineNote: "", summary: "",
+};
+const ctx = { windowSequence: 1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] };
+
+describe("mergeDelta IOC value hygiene (#177)", () => {
+  it("splits a host label out of an extracted IP into `note`", () => {
+    const next = mergeDelta(emptyState("c1"), {
+      ...baseDelta,
+      iocs: [{ id: "i1", type: "ip", value: "10.10.20.15 (DC01)" }],
+    }, ctx);
+    expect(next.iocs).toHaveLength(1);
+    expect(next.iocs[0].value).toBe("10.10.20.15");
+    expect(next.iocs[0].note).toBe("DC01");
+  });
+
+  it("folds the annotated form onto an existing bare indicator instead of creating a second row", () => {
+    let state = mergeDelta(emptyState("c1"), {
+      ...baseDelta,
+      iocs: [{ id: "i1", type: "ip", value: "10.10.20.15" }],
+    }, ctx);
+    state = mergeDelta(state, {
+      ...baseDelta,
+      iocs: [{ id: "i9", type: "ip", value: "10.10.20.15 (DC01)" }],
+    }, ctx);
+    expect(state.iocs).toHaveLength(1);
+    expect(state.iocs[0].value).toBe("10.10.20.15");
+    // The label the duplicate carried is kept as context on the surviving row.
+    expect(state.iocs[0].note).toBe("DC01");
+  });
+
+  it("remaps a finding's relatedIocs onto the repaired IOC", () => {
+    const next = mergeDelta(emptyState("c1"), {
+      ...baseDelta,
+      iocs: [{ id: "i1", type: "ip", value: "10.10.20.30 (FS01)" }],
+      findings: [{ id: "f1", severity: "High", title: "Lateral movement", description: "",
+        relatedIocs: ["i1"], mitreTechniques: [], status: "open" }],
+    }, ctx);
+    expect(next.findings[0].relatedIocs).toEqual([next.iocs[0].id]);
+  });
+
+  it("drops a multi-line text blob mis-typed as an indicator", () => {
+    const next = mergeDelta(emptyState("c1"), {
+      ...baseDelta,
+      iocs: [
+        { id: "i1", type: "ip", value: ".PARAMETER Identity\n\nA display name (e.g. 'Test GPO')\n" },
+        { id: "i2", type: "ip", value: "185.220.101.47" },
+      ],
+    }, ctx);
+    expect(next.iocs.map((i) => i.value)).toEqual(["185.220.101.47"]);
+  });
+
+  it("leaves a clean value (and its absent note) exactly as it was", () => {
+    const next = mergeDelta(emptyState("c1"), {
+      ...baseDelta,
+      iocs: [{ id: "i1", type: "ip", value: "185.220.101.47" }],
+    }, ctx);
+    expect(next.iocs[0].value).toBe("185.220.101.47");
+    expect(next.iocs[0].note).toBeUndefined();
+  });
+});
+
+describe("buildManualIoc value hygiene (#177)", () => {
+  const deps = { now: () => "2026-05-28T10:00:00.000Z", id: () => "fixed" };
+
+  it("splits an annotation the analyst typed into the value field", () => {
+    expect(buildManualIoc({ type: "ip", value: "10.10.10.45 (WKSTN-JSMITH)" }, deps)).toEqual({
+      id: "manual-fixed", type: "ip", value: "10.10.10.45",
+      firstSeen: "2026-05-28T10:00:00.000Z", note: "WKSTN-JSMITH",
+    });
+  });
+
+  it("keeps an explicit note the analyst supplied separately", () => {
+    const ioc = buildManualIoc({ type: "ip", value: "10.10.20.40", note: "WEB01 — DMZ" }, deps);
+    expect(ioc.value).toBe("10.10.20.40");
+    expect(ioc.note).toBe("WEB01 — DMZ");
+  });
+
+  it("prefers the analyst's explicit note over one derived from the value", () => {
+    const ioc = buildManualIoc({ type: "ip", value: "10.10.20.40 (WEB01)", note: "staged archive here" }, deps);
+    expect(ioc.value).toBe("10.10.20.40");
+    expect(ioc.note).toBe("staged archive here");
+  });
+
+  it("rejects a value that cannot be an indicator, so the route answers 400 not 500", () => {
+    expect(() => buildManualIoc({ type: "ip", value: "line one\nline two" }, deps)).toThrow(ZodError);
+  });
+});
+
+describe("repairIocValues backfill (#177)", () => {
+  it("repairs existing rows and reports what changed", () => {
+    const state = {
+      ...emptyState("c1"),
+      iocs: [
+        { id: "i005", type: "ip" as const, value: "10.10.20.15 (DC01)", firstSeen: "2026-05-15T19:51:15.000Z" },
+        { id: "ioc001", type: "ip" as const, value: "185.220.101.47", firstSeen: "2026-05-15T09:51:00.000Z" },
+      ],
+    };
+    const { state: repaired, changed } = repairIocValues(state);
+    expect(changed).toEqual([{ id: "i005", before: "10.10.20.15 (DC01)", after: "10.10.20.15", note: "DC01" }]);
+    expect(repaired.iocs[0]).toMatchObject({ value: "10.10.20.15", note: "DC01" });
+    expect(repaired.iocs[1]).toBe(state.iocs[1]);   // untouched row keeps its identity
+  });
+
+  it("leaves an unsalvageable value in place rather than deleting evidence", () => {
+    const state = {
+      ...emptyState("c1"),
+      iocs: [{ id: "i1", type: "ip" as const, value: "blob\nacross\nlines", firstSeen: "2026-05-15T00:00:00.000Z" }],
+    };
+    const { state: repaired, changed } = repairIocValues(state);
+    expect(changed).toEqual([]);
+    expect(repaired).toBe(state);
+  });
+
+  it("does not collapse rows that end up sharing a value (references stay intact)", () => {
+    const state = {
+      ...emptyState("c1"),
+      iocs: [
+        { id: "i005", type: "ip" as const, value: "10.10.20.15 (DC01)", firstSeen: "2026-05-15T00:00:00.000Z" },
+        { id: "ioc012", type: "ip" as const, value: "10.10.20.15", firstSeen: "2026-05-16T00:00:00.000Z" },
+      ],
+    };
+    const { state: repaired } = repairIocValues(state);
+    expect(repaired.iocs.map((i) => i.id)).toEqual(["i005", "ioc012"]);
+  });
+});

--- a/companion/tests/integrations/misp.test.ts
+++ b/companion/tests/integrations/misp.test.ts
@@ -136,6 +136,75 @@ describe("pushCaseToMisp", () => {
     expect(res.warnings.some((w) => w.includes("mystery-value"))).toBe(true);
   });
 
+  // #177 — MISP validates every attribute value and rejects a malformed one with a 403 that reads
+  // like a permissions failure. The push must send the bare indicator, keep the annotation as the
+  // attribute comment, and refuse locally (with the real reason) anything still unusable.
+  describe("IOC value hygiene (#177)", () => {
+    it("sends the bare indicator and carries the host label in the attribute comment", async () => {
+      const m = new MockMispClient();
+      const state = { ...emptyState("c-ip"), iocs: [ioc({ value: "10.10.20.15 (DC01)", type: "ip" })] };
+      const res = await pushCaseToMisp(m, { caseId: "c-ip", state });
+
+      expect(res.attributes).toMatchObject({ added: 1, skipped: 0 });
+      expect(m.addedAttributes[0].body).toMatchObject({
+        type: "ip-dst", value: "10.10.20.15", comment: "DC01",
+      });
+    });
+
+    it("prefers an explicit IOC note over one derived from the value", async () => {
+      const m = new MockMispClient();
+      const state = {
+        ...emptyState("c-note"),
+        iocs: [ioc({ value: "10.10.20.30", type: "ip", note: "FS01 — file server" })],
+      };
+      await pushCaseToMisp(m, { caseId: "c-note", state });
+      expect(m.addedAttributes[0].body.comment).toBe("FS01 — file server");
+    });
+
+    it("maps hash type from the repaired value, not the annotated one", async () => {
+      const m = new MockMispClient();
+      const sha = "a".repeat(64);
+      const state = { ...emptyState("c-h"), iocs: [ioc({ value: `${sha} (dropper)`, type: "hash" })] };
+      await pushCaseToMisp(m, { caseId: "c-h", state });
+      expect(m.addedAttributes[0].body).toMatchObject({ type: "sha256", value: sha, comment: "dropper" });
+    });
+
+    it("dedupes the annotated form against the bare value already on the event", async () => {
+      const m = new MockMispClient();
+      m.existingAttrs = [{ type: "ip-dst", value: "10.10.20.15" }];
+      const state = { ...emptyState("c-dup"), iocs: [ioc({ value: "10.10.20.15 (DC01)", type: "ip" })] };
+      const res = await pushCaseToMisp(m, { caseId: "c-dup", state });
+      expect(res.attributes).toMatchObject({ added: 0, existing: 1 });
+      expect(m.addedAttributes).toHaveLength(0);
+    });
+
+    it("skips a value that is still invalid for its type, naming the reason locally", async () => {
+      const m = new MockMispClient();
+      const state = {
+        ...emptyState("c-bad"),
+        // 66 hex chars — not a recognised digest length; MISP would reject it.
+        iocs: [ioc({ value: "cafe0001002003004005006007008009000a000b000c000d000e000f0010001100", type: "hash" })],
+      };
+      const res = await pushCaseToMisp(m, { caseId: "c-bad", state });
+      expect(res.attributes).toMatchObject({ added: 0, skipped: 1 });
+      expect(m.addedAttributes).toHaveLength(0);
+      expect(res.warnings.some((w) => w.includes("not a valid hash value"))).toBe(true);
+    });
+
+    it("truncates a mis-typed text blob in the warning instead of quoting it whole", async () => {
+      const m = new MockMispClient();
+      const blob = `.PARAMETER Identity\n${"A display name for the GPO. ".repeat(40)}`;
+      const state = { ...emptyState("c-blob"), iocs: [ioc({ value: blob, type: "ip" })] };
+      const res = await pushCaseToMisp(m, { caseId: "c-blob", state });
+
+      expect(res.attributes).toMatchObject({ added: 0, skipped: 1 });
+      const warning = res.warnings.find((w) => w.includes("not a valid ip value"));
+      expect(warning).toBeDefined();
+      expect(warning!.length).toBeLessThan(200);
+      expect(warning).not.toContain("\n");
+    });
+  });
+
   it("derives threat level from worst finding severity", async () => {
     const m = new MockMispClient();
     const highState = { ...emptyState("c3"), iocs: [], findings: [finding({ id: "f1", title: "t", severity: "High" })] };

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -996,6 +996,9 @@
     .ioc-main-cell { min-width: 0; line-height: 1.5; }
     .ioc-value-line { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; }
     .ioc-value-line .qa-val { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12.5px; word-break: break-all; }
+    /* Context that must NOT live inside the indicator itself (#177) — the host a private IP belongs
+       to, an observed port, why the analyst added it. Shown beside the value, never part of it. */
+    .ioc-note-chip { font-size: 10.5px; color: var(--c-9aa4b2); font-style: italic; }
     .ioc-actions-cell { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: 2px; }
     .vql-result-wrap { overflow: auto; max-height: 260px; border: 1px solid var(--c-2a2f3a); border-radius: 5px; }
     .vql-result { border-collapse: collapse; font-size: 11px; width: 100%; }
@@ -4194,6 +4197,7 @@
         <form class="manual-form" onsubmit="return false">
           <select id="miType" title="IOC type"><option value="ip">ip</option><option value="domain">domain</option><option value="hash">hash</option><option value="url">url</option><option value="file">file</option><option value="process">process</option><option value="other">other</option></select>
           <input id="miValue" placeholder="indicator value" style="flex:1; min-width:240px" />
+          <input id="miNote" placeholder="note (optional) — host, port, why" title="Context to record alongside the indicator. Keep it OUT of the value: a value like &quot;10.10.20.15 (DC01)&quot; is not a valid IP and strict consumers (MISP) reject it." style="flex:1; min-width:180px" />
           <button id="addIocBtn">Add IOC</button>
           <span id="addIocMsg" class="manual-msg"></span>
         </form>
@@ -14171,11 +14175,14 @@
           : fpBtn("ioc", i.value);
         const enrichHtml = enrichBadges(i);
         const tagsHtml = tagPills("ioc", i.id);
+        // Annotation split out of the value at ingest (#177) — e.g. the host label that used to be
+        // concatenated as "10.10.20.15 (DC01)". Kept visible, just never inside the indicator.
+        const noteHtml = i.note ? ` <span class="ioc-note-chip" title="Context recorded with this indicator">${esc(i.note)}</span>` : "";
         return `<div class="ioc-row${isSel ? " ioc-selected" : ""}${isNew ? " ioc-new" : ""}" data-iocid="${escAttr(i.id)}">`
           + `<input type="checkbox" class="ioc-cb ioc-row-cb" data-iocid="${escAttr(i.id)}" ${isSel ? "checked" : ""} title="Select IOC" />`
           + `<span class="ioc-type-cell" title="${escAttr(i.id)}">${esc(i.type)}</span>`
           + `<span class="ioc-main-cell">`
-          +   `<span class="ioc-value-line"><span class="qa-val" data-vtype="${escAttr(i.type)}" data-val="${escAttr(i.value)}" data-iocid="${escAttr(i.id)}">${valueHtml}</span>${newBadge}${iocRiskBadge(i.id)}${iocCorroBadge(i.id)}${iocProvenanceBadge(i.id)}${enrichHtml}${tagsHtml}</span>`
+          +   `<span class="ioc-value-line"><span class="qa-val" data-vtype="${escAttr(i.type)}" data-val="${escAttr(i.value)}" data-iocid="${escAttr(i.id)}">${valueHtml}</span>${noteHtml}${newBadge}${iocRiskBadge(i.id)}${iocCorroBadge(i.id)}${iocProvenanceBadge(i.id)}${enrichHtml}${tagsHtml}</span>`
           + `</span>`
           + `<span class="ioc-actions-cell">${commentChip("ioc", i.id)} ${tagAddBtn("ioc", i.id)} ${huntChip("ioc", i.id)} ${iocChainChip(i.id)} ${fpAction} `
           +   `<button class="ioc-merge-btn" data-iocid="${escAttr(i.id)}" data-value="${escAttr(i.value)}" data-ioctype="${escAttr(i.type)}" title="Merge into another IOC (duplicate indicator)" type="button" style="background:none;border:none;cursor:pointer;padding:1px 2px;color:var(--c-6b7585);font-size:10px">⇄</button>`
@@ -17264,9 +17271,11 @@
       if (!caseId) return;
       const value = document.getElementById("miValue").value.trim();
       if (!value) { document.getElementById("addIocMsg").textContent = "value required"; return; }
-      const body = { type: document.getElementById("miType").value, value };
+      const note = document.getElementById("miNote").value.trim();
+      const body = { type: document.getElementById("miType").value, value, ...(note ? { note } : {}) };
       postManual(`/cases/${encodeURIComponent(caseId)}/iocs`, body, "addIocMsg", () => {
         document.getElementById("miValue").value = "";
+        document.getElementById("miNote").value = "";
       });
     };
     document.getElementById("runCustomerExposure").onclick = runCustomerExposureCheck;


### PR DESCRIPTION
## Problem

An indicator's `value` must be the bare indicator. The AI extraction path stored whatever the model emitted, so IOCs routinely carried a human annotation **inside** the value:

```
10.10.20.15 (DC01)
10.10.20.30 (FS01)
northlakeportal.com (wdi-svc.exe download URL)
```

That is not an IP. MISP rejects the attribute with a 403 (`"IP address has an invalid format"`), exact-match correlation against other tooling misses, and dedup treats it as a different indicator from a bare `10.10.20.15`.

`responseSchema` only required `value` to be a non-empty string, and `mergeDelta` persisted it verbatim. The deterministic importers were already fine — they sanitize through `siemImport`'s `cleanIp()`.

Scanning local cases showed the problem is wider than IPs: `url`-typed IOCs carry the same annotations, and one case holds 26 `ip`-typed IOCs whose value is a multi-KB page of PowerShell help text.

## Approach

New `analysis/iocValue.ts` with two functions, deliberately different in strictness:

| | used by | behaviour |
|---|---|---|
| `repairIocValue()` | ingest | Splits the annotation into `note`, canonicalizes the indicator. Returns `null` **only** for what cannot be an indicator at all (empty, multi-line, absurdly long). A single-line value it cannot validate is kept verbatim — dropping an analyst's odd-but-real token loses evidence. |
| `isWellFormedIocValue()` | export | Strict per-type validity, so a push can skip an indicator with a specific local reason instead of a wall of remote 403s. |

Annotation splitting applies only to `ip`/`domain`/`url`/`hash`, and only when whitespace precedes the paren — so `.../wiki/Foo_(bar)` and `invoice (1).xlsm` stay intact. Either half may be the indicator: `10.10.20.15 (DC01)` and `FS01 (10.10.20.30)` both resolve. Casing is preserved (validation is case-insensitive, and dedup already is, so rewriting case would only churn what analysts see).

## Wired in at three layers

- **Ingest** — `mergeDelta`, the single chokepoint for AI *and* every deterministic importer, plus `buildManualIoc`, where an unusable value is now a `400` rather than a `500`.
- **Export** — the MISP push sends the bare value and carries the annotation in the attribute `comment`, so the host label survives rather than being lost with the malformed value. Anything still invalid is skipped locally with the real reason.
- **Existing cases** — `repairIocValues()` + `npm run repair-ioc-values -- <caseId> [--apply]`, following the existing `dedupe-iocs` dry-run pattern.

Two deliberate constraints on the backfill: it **never deletes** an unsalvageable value, and it **never collapses** rows that end up sharing a value — that needs the reference remapping the analyst IOC merge (#82) already does safely.

Also surfaces `note` in the dashboard IOC list and manual-add form, and fixes the demo seed's `SHA_DROPPER`, which was 66 hex chars and so was itself rejected by any consumer validating digest length.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full suite: 389 files, 4607 passed, 1 skipped, **0 failed**
- [x] 33 new tests across `iocValue`, `iocValueIngest`, and the MISP push
- [x] Dry-run against real cases: `demo` 4 repaired (the exact IOCs from the report) and the 5th failure identified as a 66-char hash; `veridia-deep-pass` 2 repaired; the blob-heavy case 0 repairable, 26 reported and left in place
- [ ] Run `npm run repair-ioc-values -- <caseId> --apply` on affected cases, then re-push to MISP to confirm 0 rejections

Part of #177