### PR TITLE
fix(synthesis): floor High/Critical findings whose claimed IP is absent from cited events

### DIFF
--- a/companion/src/analysis/findingGrounding.ts
+++ b/companion/src/analysis/findingGrounding.ts
@@ -35,10 +35,34 @@ const DETECTION_RANK = SEVERITY_RANK.Low;
 // ever LOWERS confidence, so trust never boosts a high-trust finding, it only reins in a low-trust one.
 export const LOW_TRUST_THRESHOLD = 0.7;
 export const LOW_TRUST_CONFIDENCE_CAP = 55;
+// A High/Critical finding that names a specific IP in its own title/description, but whose cited
+// in-scope events never mention that IP, is citing evidence that does not back its own claim — a
+// subtler ungroundedness than an empty relatedEventIds list (both the id-existence check above and the
+// AI's own citation can look fine while the claim's content is simply wrong). Deep-pass on veridia-breach
+// (2026-07-22) produced exactly this: "External RDP logon from public IP 45.33.32.156" cited three benign
+// internal-IP logons (real event ids, wrong content) instead of the one event that actually matched.
+// IP-only by design — concrete, regex-extractable, and the exact entity type that produced that false
+// positive — not a general fact-checker.
+export const CONTENT_MISMATCH_CONFIDENCE_CAP = 40;
+export const CONTENT_MISMATCH_SEVERITY_FLOOR: Severity = "Medium";
 
 function appendReason(existing: string | undefined, note: string): string {
   const base = (existing ?? "").trim();
   return base ? `${base} | ${note}` : note;
+}
+
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+function extractIpv4(text: string): string[] {
+  return [...new Set(text.match(IPV4_RE) ?? [])];
+}
+
+// IPs the finding's own text claims but that never appear anywhere in its cited supporting events —
+// empty when every claimed IP is actually backed, or when the finding names no IP at all.
+function claimedIpsNotInEvidence(f: Finding, supporting: readonly ForensicEvent[]): string[] {
+  const claimed = extractIpv4(`${f.title} ${f.description}`);
+  if (!claimed.length) return [];
+  const evidenceIps = new Set(extractIpv4(supporting.map((e) => `${e.description} ${e.message ?? ""}`).join(" ")));
+  return claimed.filter((ip) => !evidenceIps.has(ip));
 }
 
 export interface GroundingInput {
@@ -120,6 +144,7 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
     let confidence = f.confidence;
     let confidenceReason = f.confidenceReason;
     let ungrounded = false;
+    let contentMismatch = false;
 
     // KEV is an independent corroboration signal (an external catalog confirms active exploitation),
     // so it exempts a finding from the single-source cap alongside 2+ tools / intel / graph linkage.
@@ -159,16 +184,34 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
       }
     }
 
-    // Clean the old flag first so a since-corrected finding loses `ungrounded` (idempotent recompute).
-    const { ungrounded: _prev, ...rest } = f;
+    // Content-mismatch check: only worth running on High/Critical (the severities this exists to gate)
+    // and only once the finding actually has cited evidence (an ungrounded finding is already capped above).
+    let severity = f.severity;
+    if (supporting.length > 0 && (f.severity === "Critical" || f.severity === "High")) {
+      const mismatched = claimedIpsNotInEvidence(f, supporting);
+      if (mismatched.length) {
+        contentMismatch = true;
+        severity = CONTENT_MISMATCH_SEVERITY_FLOOR;
+        if ((confidence ?? 100) > CONTENT_MISMATCH_CONFIDENCE_CAP) confidence = CONTENT_MISMATCH_CONFIDENCE_CAP;
+        confidenceReason = appendReason(
+          confidenceReason,
+          `capped: claims ${mismatched.join(", ")} but the cited events never mention it — verify the citation before treating as confirmed`,
+        );
+      }
+    }
+
+    // Clean the old flags first so a since-corrected finding loses them (idempotent recompute).
+    const { ungrounded: _prev, contentMismatch: _prevCm, ...rest } = f;
     return {
       ...rest,
+      severity,
       relatedEventIds,
       corroboration,
       // Stable cross-run identity (issue #69) — recomputed every synthesis so second-opinion deltas
       // key on it instead of the raw title. Deterministic from the (idempotent-safe) title + techniques.
       semanticKey: deriveSemanticKey(f),
       ...(ungrounded ? { ungrounded: true } : {}),
+      ...(contentMismatch ? { contentMismatch: true } : {}),
       ...(confidence !== undefined ? { confidence } : {}),
       ...(confidenceReason !== undefined ? { confidenceReason } : {}),
     };

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -5391,8 +5391,10 @@ export class AnalysisPipeline {
     // supporting in-scope events (forward relatedEventIds AND reverse forensicTimeline links, so the
     // deterministic backfill findings ground correctly), roll up { tools, hosts, intel, graph-linked },
     // flag an uncited finding as `ungrounded`, and CAP an ungrounded/single-source finding's confidence.
-    // Deterministic + idempotent; only ever lowers confidence. Runs last, so it grades the FINAL finding
-    // set (incl. backfills + accepted second-opinion deltas).
+    // Also catches the subtler case where cited ids resolve but the finding's own claimed IP never
+    // appears in their text (`contentMismatch`) — floors High/Critical to Medium (veridia-deep-pass
+    // 2026-07-22). Deterministic + idempotent; only ever lowers confidence/severity. Runs last, so it
+    // grades the FINAL finding set (incl. backfills + accepted second-opinion deltas).
     {
       const evidenceGraph = buildEvidenceGraph(next);
       const graphLinkedEventIds = new Set(evidenceGraph.edges.flatMap((e) => e.eventIds));

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -65,6 +65,12 @@ export interface Finding {
   // in-scope event supports it (a hypothesis, not a fact) → confidence hard-capped + badged.
   // `corroboration` is the rollup above. Both recomputed every synthesis; persisted for display.
   ungrounded?: boolean;
+  // A subtler ungroundedness than `ungrounded`: the finding cites REAL in-scope events (so the id-existence
+  // check above passes), but names a specific IP address in its own title/description that never appears in
+  // the text of any of those cited events — i.e. the claim's content doesn't match its own evidence. Set
+  // post-synthesis by groundAndScoreFindings; High/Critical severity is floored to Medium and confidence
+  // capped when this fires (investigation-guidance follow-up, veridia-deep-pass 2026-07-22).
+  contentMismatch?: boolean;
   corroboration?: FindingCorroboration;
   // Rabbit-hole detection (investigation-guidance #13). `relevance` places the finding relative to the
   // corroborated main attack path: 'connected' (on it) → a lead; 'disconnected' (evidence sits in a

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -571,6 +571,8 @@ function investigation(state: InvestigationState, lines: string[], exposure?: Cu
       // prominent "⚠️ no cited evidence" for an ungrounded finding, so a hypothesis never reads as fact.
       if (f.ungrounded) {
         lines.push(`> ⚠️ **No cited evidence** — treat as a hypothesis, not a fact (confidence capped).`);
+      } else if (f.contentMismatch) {
+        lines.push(`> ⚠️ **Citation mismatch** — a claimed detail (e.g. an IP) never appears in the cited events; severity floored and confidence capped pending verification.`);
       } else if (f.corroboration) {
         lines.push(`- Corroboration: ${corroborationLabel(f)}`);
       }

--- a/companion/tests/analysis/anonymize.test.ts
+++ b/companion/tests/analysis/anonymize.test.ts
@@ -140,6 +140,21 @@ describe("anonymizer — hosts", () => {
     expect(out).not.toContain("dc01");
     expect(a.restore(out)).toBe("logon on dc01");
   });
+
+  // Investigated as part of the veridia-deep-pass false positive (2026-07-22): the model's own synthesis
+  // guessed "anonymization-token collision" as the cause of two hostnames being conflated in an IOC list.
+  // Traced to assign() in anonymize.ts, which keys the token map by the lowercased REAL value (not by an
+  // index alone) — so two distinct real hosts can never be minted the same token within one Anonymizer
+  // instance, and every apply() call gets a fresh instance whose response is restored before persisting
+  // (pipeline.ts analyzeRestored). No collision was found; this locks in the invariant.
+  it("never assigns the same token to two different real hosts", () => {
+    const known: KnownEntities = { hosts: ["ws-mktg-01.veridia.io", "ws-dev-01.veridia.io"], accounts: [], internalDomains: [] };
+    const a = createAnonymizer(policy({ HOST: true }), known);
+    const out = a.apply("seen on ws-mktg-01.veridia.io and separately on ws-dev-01.veridia.io");
+    const tokens = out.match(/ANON_HOST_\d+/g) ?? [];
+    expect(new Set(tokens).size).toBe(2); // two distinct real hosts → two distinct tokens
+    expect(a.restore(out)).toBe("seen on ws-mktg-01.veridia.io and separately on ws-dev-01.veridia.io");
+  });
 });
 
 describe("anonymizer — internal domains", () => {

--- a/companion/tests/analysis/findingGrounding.test.ts
+++ b/companion/tests/analysis/findingGrounding.test.ts
@@ -5,6 +5,8 @@ import {
   UNGROUNDED_CONFIDENCE_CAP,
   SINGLE_SOURCE_CONFIDENCE_CAP,
   HUNT_ARTIFACT_CONFIDENCE_CAP,
+  CONTENT_MISMATCH_CONFIDENCE_CAP,
+  CONTENT_MISMATCH_SEVERITY_FLOOR,
 } from "../../src/analysis/findingGrounding.js";
 import type { Finding, ForensicEvent, IOC, Severity } from "../../src/analysis/stateTypes.js";
 
@@ -96,6 +98,58 @@ describe("groundAndScoreFindings", () => {
     const twice = groundAndScoreFindings({ findings: once, scopedEvents: [ev({ id: "e1", sources: ["OneTool"], asset: "H1" })], iocs: [], graphLinkedEventIds: new Set() });
     expect(twice[0].confidence).toBe(30);
     expect(twice[0].corroboration).toEqual(once[0].corroboration);
+  });
+});
+
+describe("groundAndScoreFindings — content-mismatch (veridia-deep-pass false positive, 2026-07-22)", () => {
+  it("floors severity and caps confidence when a High finding claims an IP absent from its cited events", () => {
+    // Reproduces f13: claims RDP from 45.33.32.156 but cites three internal-IP logons that never mention it.
+    const out = groundAndScoreFindings({
+      findings: [f({
+        id: "f13", severity: "High", confidence: 90,
+        title: "External RDP logon from public IP address 45.33.32.156",
+        description: "A logon consistent with RDP was observed against ws-dev-01 originating from 45.33.32.156.",
+        relatedEventIds: ["40e39", "40e34", "40e2"],
+      })],
+      scopedEvents: [
+        ev({ id: "40e39", asset: "WS-FIN-01", sources: ["Windows Event Log"], description: "Successful logon LogonType=3 IpAddress=10.10.10.51" }),
+        ev({ id: "40e34", asset: "WS-FIN-01", sources: ["Windows Event Log"], description: "Successful logon LogonType=3 IpAddress=10.10.10.50" }),
+        ev({ id: "40e2", asset: "WS-FIN-01", sources: ["Windows Event Log"], description: "Failed logon LogonType=2" }),
+      ],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].contentMismatch).toBe(true);
+    expect(out[0].severity).toBe(CONTENT_MISMATCH_SEVERITY_FLOOR);
+    expect(out[0].confidence).toBe(CONTENT_MISMATCH_CONFIDENCE_CAP);
+    expect(out[0].confidenceReason).toMatch(/45\.33\.32\.156/);
+  });
+
+  it("does not flag a High finding whose claimed IP DOES appear in its cited events", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({
+        id: "f1", severity: "High", confidence: 90,
+        title: "External RDP logon from public IP address 45.33.32.156",
+        description: "RDP from 45.33.32.156.", relatedEventIds: ["e1"],
+      })],
+      scopedEvents: [ev({ id: "e1", asset: "WS-FIN-01", sources: ["Windows Event Log"], description: "LogonType=10 IpAddress=45.33.32.156" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].contentMismatch).toBeUndefined();
+    expect(out[0].severity).toBe("High");
+  });
+
+  it("does not apply the content-mismatch check to Medium/Low findings", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({
+        id: "f1", severity: "Medium", confidence: 90,
+        title: "Possible external logon from 45.33.32.156", description: "",
+        relatedEventIds: ["e1"],
+      })],
+      scopedEvents: [ev({ id: "e1", asset: "WS-FIN-01", sources: ["Windows Event Log"], description: "no IP here" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].contentMismatch).toBeUndefined();
+    expect(out[0].severity).toBe("Medium");
   });
 });
 


### PR DESCRIPTION
## Summary
- Investigated a deep-pass false positive (veridia-breach benchmark) where two High-severity findings cited real event ids, but the claim's content (a specific public IP) never appeared in those events' text.
- Ruled out anonymization-token collision as the cause — `createAnonymizer`'s token map is keyed by the real value, so it cannot mint the same token for two different real values within one call; added a regression test locking this in.
- Root cause: `groundAndScoreFindings` only checked that cited event ids *exist* in scope, never that the finding's own claims are actually backed by those events' text.

## Changes
- `findingGrounding.ts`: new content-mismatch check — a High/Critical finding naming an IP absent from its cited supporting events is floored to Medium and confidence-capped, flagged `contentMismatch`.
- `stateTypes.ts`: new `Finding.contentMismatch` field.
- `markdown.ts`: report badge for the new flag.
- Tests: `findingGrounding.test.ts` (positive/negative/severity-scoped cases reproducing the real finding) and `anonymize.test.ts` (collision-safety regression).

## Test plan
- [x] `tests/analysis/findingGrounding.test.ts` — 18/18 passing (3 new)
- [x] `tests/analysis/anonymize.test.ts` — 42/42 passing (1 new)
- [x] Full suite: 387 files / 4571 tests passing, 0 failed
- [x] `tsc --noEmit` clean