### PR TITLE
fix(grading): grade plaintext secret spillage on every surface, not just Sysmon

### DIFF
--- a/companion/src/analysis/bashHistoryImport.ts
+++ b/companion/src/analysis/bashHistoryImport.ts
@@ -10,12 +10,13 @@
 // domains in the command line become IOCs. Reuses siemImport's aggregation + IOC sink.
 
 import {
-  addIoc, aggregateEvents, cleanIp, hasPlausibleTld,
+  addIoc, aggregateEvents, cleanIp, hasPlausibleTld, worst,
   type MappedEvent, type SiemImportOptions, type SiemIoc, type SiemParseResult,
   maxEventsDefault,
 } from "./siemImport.js";
 import type { Severity } from "./stateTypes.js";
 import { reconTechniques } from "./reconTechniques.js";
+import { secretSpillSignal } from "./secretSpillRules.js";
 
 export interface BashHistoryImportOptions extends SiemImportOptions {
   // The account the history belongs to (derived from the filename by the pipeline, e.g.
@@ -126,9 +127,19 @@ function classify(command: string): { severity: Severity; mitre: string[] } {
   // every command regardless of the severity rule, so the enumeration phase is identified even
   // though shell-history recon stays Info.
   const recon = reconTechniques("", command);
+  // A secret typed into the shell (an AWS key, a PAT, a token) is at rest in this file — it must be
+  // at least Medium so it reaches the forensic timeline synthesis reads, whichever CMD_RULE (if
+  // any) also matched. See secretSpillRules.ts for why this is shared across every importer.
+  const spill = secretSpillSignal(command);
   for (const rule of CMD_RULES) {
-    if (rule.re.test(command)) return { severity: rule.severity, mitre: [...new Set([...rule.mitre, ...recon])] };
+    if (rule.re.test(command)) {
+      return {
+        severity: spill ? worst(rule.severity, "Medium") : rule.severity,
+        mitre: [...new Set([...rule.mitre, ...recon, ...(spill?.mitre ?? [])])],
+      };
+    }
   }
+  if (spill) return { severity: "Medium", mitre: [...new Set([...recon, ...spill.mitre])] };
   return { severity: "Info", mitre: recon };
 }
 

--- a/companion/src/analysis/combinedLogImport.ts
+++ b/companion/src/analysis/combinedLogImport.ts
@@ -48,9 +48,10 @@
 // here (that cap is shared code, not specific to this format).
 
 import type { Severity } from "./stateTypes.js";
-import { aggregateEvents, addIoc, mergeRowIocs, oneLine, type MappedEvent, type SiemIoc, type SiemParseResult,
+import { aggregateEvents, addIoc, mergeRowIocs, oneLine, worst, type MappedEvent, type SiemIoc, type SiemParseResult,
   maxEventsDefault,
 } from "./siemImport.js";
+import { secretSpillSignal } from "./secretSpillRules.js";
 
 export interface CombinedLogImportOptions {
   aggregate?: boolean;
@@ -157,14 +158,24 @@ export function mapCombinedLogLine(line: string, sink: Map<string, SiemIoc>): Ma
   const uaTag = ua ? ` (ua ${ua})` : "";
   const description = oneLine(`${method} ${uri} -> ${status}${bytesTag}${userTag}${refTag}${uaTag}`).slice(0, 600);
 
+  // A secret carried in the request URI or the Referer is a spill the moment this line is written.
+  // Graded Medium (see secretSpillRules.ts) so it reaches the forensic timeline synthesis reads —
+  // web logs are otherwise Info-by-default and land in the analyst-only super-timeline.
+  const spill = secretSpillSignal(`${uri} ${referer}`);
+
   return {
     timestamp,
     description,
-    severity,
-    mitre,
+    severity: spill ? worst(severity, "Medium") : severity,
+    mitre: spill ? [...new Set([...mitre, ...spill.mitre])] : mitre,
     // Aggregate by method+host+path (query string dropped) so pagination/param variants collapse
-    // together while a genuinely different path/host stays distinct.
-    aggKey: `weblog|${method}|${host}|${uri.split("?")[0]}|${status}`.toLowerCase().slice(0, 400),
+    // together while a genuinely different path/host stays distinct. A spill-bearing line gets its
+    // OWN key: aggregation is first-description-wins, so without this a secret-carrying request
+    // merges into a busier ref-less sibling on the same path and its secret vanishes from the
+    // description — leaving a Medium with no visible reason. Measured on the spillage-full-matrix
+    // benchmark: the JWT in a Referer on `GET /` produced no distinguishable event at all.
+    aggKey: `weblog|${method}|${host}|${uri.split("?")[0]}|${status}${spill ? `|spill:${spill.families.join(",")}` : ""}`
+      .toLowerCase().slice(0, 400),
     sources: [COMBINED_LOG_SOURCE],
   };
 }

--- a/companion/src/analysis/ecarImport.ts
+++ b/companion/src/analysis/ecarImport.ts
@@ -45,6 +45,7 @@ import {
 } from "./siemImport.js";
 import { reconTechniques } from "./reconTechniques.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
+import { secretSpillSignal } from "./secretSpillRules.js";
 
 type Row = Record<string, unknown>;
 
@@ -135,8 +136,14 @@ export function mapEcarRecord(rec: Row, sink: Map<string, SiemIoc>): MappedEvent
       const parentName = baseName(parent);
       const grade = isSuspiciousCmd(image, cmd);
       const tc = tradecraftSignal(image, cmd);
+      // A credential passed on the command line is visible to every user on the host (ps/proc) and
+      // is now in EDR telemetry forever — Medium regardless of what the process is. Without this an
+      // ECAR-reported spill (e.g. a Linux service started with a postgres:// URI carrying its
+      // password) graded Info and never reached the forensic timeline synthesis reads, while the
+      // SAME spill reported by Windows Sysmon graded Medium. See secretSpillRules.ts.
+      const spill = secretSpillSignal(cmd);
       const strong = grade === "strong" || tc?.weight === "strong";
-      const flagged = Boolean(grade) || Boolean(tc);
+      const flagged = Boolean(grade) || Boolean(tc) || Boolean(spill);
       const severity: Severity = strong ? "High" : flagged ? "Medium" : "Info";
       const desc = `Process created: ${cmd || image || "(unknown)"}` +
         (parentName ? ` (parent ${parentName})` : "") + at;
@@ -148,7 +155,7 @@ export function mapEcarRecord(rec: Row, sink: Map<string, SiemIoc>): MappedEvent
       // Discovery / credential-access recon tagging (whoami, net group /domain, find -name *.env,
       // cat .env, …) plus deterministic tradecraft techniques (Defender-disable, tunneling, exfil…)
       // so the enumeration/tradecraft phase is identified even when each command stays Info.
-      const mitre = [...new Set([...(flagged ? ["T1059"] : []), ...(tc?.mitre ?? []), ...reconTechniques(image, cmd)])];
+      const mitre = [...new Set([...(flagged ? ["T1059"] : []), ...(tc?.mitre ?? []), ...(spill?.mitre ?? []), ...reconTechniques(image, cmd)])];
       return {
         ...base, severity,
         mitre,

--- a/companion/src/analysis/secretSpillRules.ts
+++ b/companion/src/analysis/secretSpillRules.ts
@@ -1,0 +1,133 @@
+// Deterministic "credential material in plaintext" grading, applied to event TEXT rather than to a
+// process command line. This is the surface-agnostic sibling of `tradecraftRules.ts`, and it exists
+// for the same reason that module's Linux section does: the SAME secret graded differently — or not
+// at all — depending on which importer happened to carry it.
+//
+// Measured on the EvidenceForge `spillage-full-matrix-test` benchmark (11 planted secrets across 5
+// surfaces): every one was extracted correctly, but only 2 reached the forensic timeline, and both
+// only because they happened to ride inside a Windows Sysmon EID 1 process-create event that the
+// Sysmon grader already scored. The AWS key in bash history, the Slack token and shared secret in
+// syslog, the GCP key / fine-grained PAT / Stripe key / JWT in web-log URLs and Referer headers,
+// and the database URI in Linux ECAR process telemetry ALL graded Info — and Info is demoted to the
+// analyst-only super-timeline, which AI synthesis never reads. Nine of eleven spills were therefore
+// invisible to the model no matter how good the model was. Grading belongs here, in one shared
+// table every importer consults, not in whichever importer got lucky.
+//
+// Severity contribution is Medium, never High, and that is deliberate. A structurally-valid token
+// in a log line is a real exposure and must be VISIBLE to synthesis, but it is a lead rather than a
+// verdict: the value may be revoked, a test fixture, or an example in documentation. This mirrors
+// the "weak" tier in tradecraftRules (dual-use → Medium) and the same call bashHistoryImport
+// already makes for `cat .env`.
+//
+// False-positive discipline (see the "does not fire on ordinary text" tests): every rule is
+// anchored on a vendor-specific literal prefix plus a minimum length of key material, so ordinary
+// auth chatter ("Failed password for invalid user admin", "authentication failure") cannot match.
+// Values that are already masked / redacted are excluded outright — re-flagging a redacted line
+// manufactures a Medium out of evidence that the secret was handled correctly.
+//
+// Pure + table-driven + unit-tested. No AI.
+
+export interface SecretSpillRule {
+  /** Vendor/family label, matching the EvidenceForge spillage family names. */
+  family: string;
+  re: RegExp;
+}
+
+// A run of characters that reads as MASKED rather than as key material: three or more consecutive
+// mask characters, or a bracketed redaction marker. Checked against the whole line before any rule
+// runs, and again against each captured value.
+const MASKED = /\*{3,}|x{6,}|•{3,}|\[?\bREDACTED\b\]?|<[A-Z_]{3,}>|\.{5,}/i;
+
+// Key material must not be a single repeated character (AAAAAAAA…) — generator placeholders and
+// column-padding both look like that, and neither is a secret.
+const DEGENERATE = /^(.)\1+$/;
+
+export const SECRET_SPILL_RULES: SecretSpillRule[] = [
+  // ───────────── Cloud provider keys ─────────────
+  // AWS access key id: AKIA/ASIA/AGPA/AIDA + 16 uppercase-alnum. The prefix is assigned by AWS and
+  // does not occur in prose, so the literal + fixed length is enough on its own.
+  { family: "aws_iam", re: /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|ANPA)[A-Z0-9]{16}\b/ },
+  // Google/GCP API key: AIza + 35 url-safe chars.
+  { family: "gcp_api_key", re: /\bAIza[A-Za-z0-9_-]{35}\b/ },
+
+  // ───────────── Source-control tokens ─────────────
+  // Fine-grained PAT first: `github_pat_` would also satisfy a loose `ghp_`-style rule, and matching
+  // the more specific family keeps the reported label accurate.
+  { family: "github_fine_pat", re: /\bgithub_pat_[A-Za-z0-9_]{50,}\b/ },
+  // Classic PAT / OAuth / refresh / server / user-to-server tokens: 36+ chars after the prefix.
+  { family: "github_pat", re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b/ },
+
+  // ───────────── SaaS tokens ─────────────
+  // Slack bot/user/app/refresh token: xoxb- / xoxp- / xoxa- / xoxr- / xoxs- plus at least two
+  // hyphen-separated segments, the last of which is the secret half.
+  { family: "slack_token", re: /\bxox[baprs]-[A-Za-z0-9]{8,}-[A-Za-z0-9-]{16,}\b/ },
+  // Stripe secret / restricted key. The publishable `pk_` prefix is deliberately NOT here: it is
+  // designed to be public and appears in every checkout page's source.
+  { family: "stripe_key", re: /\b(?:sk|rk)_(?:test|live)_[A-Za-z0-9]{16,}\b/ },
+
+  // ───────────── Structured tokens ─────────────
+  // JWT: three base64url segments. The header segment is anchored on the `eyJ` that any JSON header
+  // base64-encodes to, and BOTH remaining segments are required so a bare header (which carries no
+  // secret) does not match.
+  { family: "jwt", re: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/ },
+
+  // ───────────── Connection strings ─────────────
+  // A database/broker URI carrying inline credentials — `scheme://user:password@host`. The password
+  // group is required, so an ordinary credential-free DSN (`postgres://db-01:5432/reports`) does not
+  // match. `:` and `@` are excluded from the password class so a bare `host:port` cannot masquerade.
+  {
+    family: "db_uri",
+    re: /\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp|mssql|jdbc:[a-z]+|ftp|sftp):\/\/[^\s:/@]+:[^\s:/@]{4,}@/i,
+  },
+
+  // ───────────── Generic assigned secrets ─────────────
+  // The catch-all, and the only rule that is not anchored on a vendor literal — so it is the most
+  // constrained. A credential NOUN, then an assignment (`=`/`:`) or a single space, then 12+ chars
+  // of material that must contain BOTH cases plus a digit or punctuation mark. That last constraint
+  // is what separates `shared secret EvidenceForgeFake-wPndDbHjZm!` (flagged) from
+  // `password authentication failed` and `Starting Secret Service daemon` (not flagged) — ordinary
+  // English words following the noun are single-case and carry no digits or symbols.
+  {
+    family: "password_generic",
+    re: /\b(?:pass(?:word|wd|phrase)?|pwd|secret|api[_-]?key|api[_-]?token|auth[_-]?token|access[_-]?token|bearer)\b["']?\s*[=:]?\s*["']?([A-Za-z0-9][A-Za-z0-9!@#$%^&*()_+=.,\/~-]{11,})/i,
+  },
+];
+
+// Extra gate for the generic rule only: the captured value must look like key material rather than
+// like the next English word in a sentence.
+function looksLikeKeyMaterial(value: string): boolean {
+  if (value.length < 12) return false;
+  if (DEGENERATE.test(value)) return false;
+  if (MASKED.test(value)) return false;
+  const hasUpper = /[A-Z]/.test(value);
+  const hasLower = /[a-z]/.test(value);
+  const hasDigitOrSymbol = /[0-9!@#$%^&*()_+=.,\/~-]/.test(value);
+  return hasUpper && hasLower && hasDigitOrSymbol;
+}
+
+/**
+ * The credential families a piece of event text exposes in plaintext, or null.
+ *
+ * Surface-agnostic by design: callers pass whatever text they already build for the event
+ * description (a shell command, a syslog message, a request line + Referer, a process command
+ * line), so the same secret grades identically regardless of which sensor reported it.
+ */
+export function secretSpillSignal(text: string): { families: string[]; mitre: string[] } | null {
+  if (!text || !text.trim()) return null;
+  // A line whose secret is already masked is evidence of correct handling, not of a spill.
+  if (MASKED.test(text)) return null;
+
+  const families = new Set<string>();
+  for (const rule of SECRET_SPILL_RULES) {
+    const m = rule.re.exec(text);
+    if (!m) continue;
+    // The generic rule captures its value and must clear the key-material gate; the vendor-anchored
+    // rules are specific enough that matching at all is sufficient.
+    if (rule.family === "password_generic" && !looksLikeKeyMaterial(m[1] ?? "")) continue;
+    families.add(rule.family);
+  }
+  if (!families.size) return null;
+  // T1552.001 (Unsecured Credentials: Credentials In Files) is the technique every surface here
+  // maps to — the credential is at rest in a log, a history file, or a URL that gets logged.
+  return { families: [...families], mitre: ["T1552.001"] };
+}

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -25,6 +25,7 @@ import type { Severity } from "./stateTypes.js";
 import { toUtcIso } from "./timeUtc.js";
 import { reconTechniques } from "./reconTechniques.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
+import { secretSpillSignal } from "./secretSpillRules.js";
 
 export interface SiemImportOptions {
   // Collapse repetitive identical events into one counted row. Default true.
@@ -700,6 +701,15 @@ export function mapWindows(rec: Row, host: string, iocSink: Map<string, SiemIoc>
     if (tc) {
       severity = worst(severity, tc.weight === "strong" ? "High" : "Medium");
       for (const t of tc.mitre) if (!mitre.includes(t)) mitre.push(t);
+    }
+    // A credential passed on the command line is readable by any user on the host and is now in the
+    // event log forever. Graded here explicitly rather than relying on whichever tradecraft rule
+    // happened to also match, so the same secret grades identically on every sensor — see
+    // secretSpillRules.ts.
+    const spill = secretSpillSignal(cmd);
+    if (spill) {
+      severity = worst(severity, "Medium");
+      for (const t of spill.mitre) if (!mitre.includes(t)) mitre.push(t);
     }
     // Tag discovery / credential-access recon (whoami, net group /domain, dir /s, findstr password,
     // .ssh/id_rsa, …) so the case identifies the enumeration phase even when each command is Info/Low.

--- a/companion/src/analysis/syslogImport.ts
+++ b/companion/src/analysis/syslogImport.ts
@@ -31,6 +31,7 @@ import { aggregateEvents, addIoc, cleanIp, oneLine, worst, type MappedEvent, typ
   maxEventsDefault,
 } from "./siemImport.js";
 import { parseSshAuth, markSshBruteForce, type SshAuthEvent } from "./sshBruteForce.js";
+import { secretSpillSignal } from "./secretSpillRules.js";
 
 export interface SyslogImportOptions {
   aggregate?: boolean;
@@ -178,7 +179,12 @@ function mapParsedSyslog(p: ParsedSyslog, sink: Map<string, SiemIoc>): MappedEve
   }
 
   const sev = p.pri != null ? p.pri % 8 : null;
-  const severity: Severity = (sev != null && sev <= 2) || AUTH_FAIL.test(p.message) ? "Low" : "Info";
+  const base: Severity = (sev != null && sev <= 2) || AUTH_FAIL.test(p.message) ? "Low" : "Info";
+  // An application that logs a token / password / connection string in the clear has spilled it to
+  // every downstream log consumer. Medium so it reaches the forensic timeline synthesis reads —
+  // syslog is otherwise Info-by-default, which demotes it to the analyst-only super-timeline.
+  const spill = secretSpillSignal(p.message);
+  const severity: Severity = spill ? worst(base, "Medium") : base;
 
   const appTag = p.app ? `${p.app}: ` : "";
   const description = oneLine(`syslog ${appTag}${p.message}`).slice(0, 600);
@@ -190,8 +196,11 @@ function mapParsedSyslog(p: ParsedSyslog, sink: Map<string, SiemIoc>): MappedEve
     timestamp: p.timestamp,
     description,
     severity,
-    mitre: [],
-    aggKey: `syslog|${p.host}|${p.app}|${template}`.toLowerCase().slice(0, 400),
+    mitre: spill?.mitre ?? [],
+    // A spill-bearing line gets its own key: the template masks digit runs, so two different
+    // tokens from the same daemon would otherwise collapse into one first-description-wins row.
+    aggKey: `syslog|${p.host}|${p.app}|${template}${spill ? `|spill:${spill.families.join(",")}` : ""}`
+      .toLowerCase().slice(0, 400),
     sources: [SYSLOG_SOURCE],
     ...(p.host ? { asset: p.host } : {}),
   };

--- a/companion/tests/analysis/combinedLogImport.test.ts
+++ b/companion/tests/analysis/combinedLogImport.test.ts
@@ -157,14 +157,25 @@ describe("parseCombinedLog", () => {
     expect(r.events[0].count).toBe(3);
   });
 
-  it("preserves a secret-bearing referer as a url IOC even when its request line aggregates away", () => {
-    // A benign /dashboard hit (no referer) lands FIRST, so it wins the aggregated event's
-    // description; the secret-referer /dashboard hit collapses into it. The url IOC must survive.
+  // Aggregation is first-description-wins, so a secret-bearing request that merges into a busier
+  // ref-less sibling on the same path loses its secret from the description entirely. The url IOC
+  // survived, but there was no event to anchor it to — on the spillage-full-matrix benchmark the
+  // JWT in a Referer on `GET /` produced no distinguishable event at all. A spill now keys its own
+  // group, so both the event AND the IOC survive.
+  it("keeps a secret-bearing referer in its own event rather than aggregating it into a clean sibling", () => {
     const benign = '10.66.20.30 - - [16/May/2024:13:59:30 +0000] "GET /dashboard HTTP/1.1" 200 3787 "-" "curl/8"';
     const r = parseCombinedLog([benign, REFERER_SPILL].join("\n"));
     const dash = r.events.filter((e) => e.description.includes("/dashboard"));
-    expect(dash).toHaveLength(1);
-    expect(dash[0].count).toBe(2);
+    expect(dash).toHaveLength(2);
+
+    const clean = dash.find((e) => !e.description.includes("sk_test_"))!;
+    expect(clean.severity).toBe("Info");
+    expect(clean.count).toBeUndefined();          // singleton — the spill no longer merges into it
+
+    const spill = dash.find((e) => e.description.includes("sk_test_"))!;
+    expect(spill.severity).toBe("Medium");
+    expect(spill.mitreTechniques).toContain("T1552.001");
+
     expect(r.iocs.some((i) => i.type === "url" && i.value.includes("sk_test_EvidenceForgeFake0BGU06yXEsv2"))).toBe(true);
   });
 

--- a/companion/tests/analysis/secretSpillRules.test.ts
+++ b/companion/tests/analysis/secretSpillRules.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { secretSpillSignal } from "../../src/analysis/secretSpillRules.js";
+
+// Fixtures for the eleven surfaces exercised by the EvidenceForge `spillage-full-matrix-test`
+// scenario. The values are synthetic ("EvidenceForgeFake") and cryptographically worthless, but
+// they are SHAPE-accurate by design — which is exactly what secret scanners (GitHub push
+// protection) match on. So every token is assembled at runtime and no full-length literal ever
+// appears in source, the same convention syslogImport.test.ts already uses for its Slack token.
+const FAKE = "EvidenceForgeFake";
+const AWS_KEY = ["AKIA", "EVIDENCEFORGEFAK"].join("");                       // AKIA + 16
+const GH_PAT = ["ghp", "_", `${FAKE}0Yl4nQxsCkGvHzTbWpF`].join("");         // ghp_ + 36
+const GH_FINE = ["github", "_pat_", "11ABCDEFGHIJKLMNOPQRST_", "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdefghijkl9"].join("");
+const SLACK = ["xoxb", "32926872419", "2302548692720", `${FAKE}NgxR2jaCkfeCIUn3GZNVGjPU`].join("-");
+const GCP_KEY = ["AIza", `Sy${FAKE}0kHqLmNpQrStUvWx`].join("");             // AIza + 35
+const STRIPE = ["sk", "test", `${FAKE}0BGU06yXEsv2`].join("_");             // sk_test_ + 24
+const JWT = ["eyJhbGciOiJIUzI1NiJ9", `PLrHlT5ZCqAkOKuZTbSs8l${FAKE}`, "q49IPRweqJIPujRX6DlFYJ2OcXnuAvXW"].join(".");
+// Split for the same reason: a spelled-out DSN with inline credentials is a shape TruffleHog's
+// Postgres detector reports as an unverified secret, and CI runs with --results=verified,unknown.
+const PG = ["post", "gres"].join("");
+
+describe("secretSpillRules — credential material in event text", () => {
+  it("flags an AWS IAM access key id", () => {
+    const r = secretSpillSignal(`aws configure set aws_access_key_id ${AWS_KEY}`);
+    expect(r?.families).toContain("aws_iam");
+    expect(r?.mitre).toContain("T1552.001");
+  });
+
+  it("flags a classic GitHub PAT", () => {
+    expect(secretSpillSignal(`git remote set-url origin https://${GH_PAT}@github.com/x/y.git`)
+      ?.families).toContain("github_pat");
+  });
+
+  it("flags a fine-grained GitHub PAT", () => {
+    expect(secretSpillSignal(`curl -H 'Authorization: bearer ${GH_FINE}'`)
+      ?.families).toContain("github_fine_pat");
+  });
+
+  it("flags a Slack bot token", () => {
+    expect(secretSpillSignal(`alertbot: posting to slack with token ${SLACK}`)
+      ?.families).toContain("slack_token");
+  });
+
+  it("flags a GCP API key", () => {
+    expect(secretSpillSignal(`GET /v1/geocode?key=${GCP_KEY}`)
+      ?.families).toContain("gcp_api_key");
+  });
+
+  it("flags a Stripe secret key", () => {
+    expect(secretSpillSignal(`GET /dashboard -> 200 (ref https://portal.example.com/login?token=${STRIPE})`)
+      ?.families).toContain("stripe_key");
+  });
+
+  it("flags a JWT", () => {
+    expect(secretSpillSignal(`(ref https://app.example.com/dashboard?jwt=${JWT})`)
+      ?.families).toContain("jwt");
+  });
+
+  it("flags a database URI carrying inline credentials", () => {
+    expect(secretSpillSignal(`${PG}://reportsvc:${FAKE}R2p@db-01.example.com:5432/reports`)
+      ?.families).toContain("db_uri");
+  });
+
+  it("flags a bearer/API token assigned on a command line", () => {
+    expect(secretSpillSignal(`cmd.exe /c set API_TOKEN=${FAKE}P6QAohyaDZgPGfOTsNYGKTmq`)
+      ?.families).toContain("password_generic");
+  });
+
+  it("flags a generic shared secret logged in plaintext", () => {
+    expect(secretSpillSignal(`app: loaded shared secret ${FAKE}-wPndDbHjZm! from /etc/users/secret.conf`)
+      ?.families).toContain("password_generic");
+  });
+
+  it("is surface-agnostic — the same secret grades identically from any importer's text", () => {
+    for (const text of [
+      `aws s3 ls --profile x  # ${AWS_KEY}`,                          // shell history
+      `syslog app: deploy used ${AWS_KEY}`,                            // syslog
+      `GET /api?key=${AWS_KEY} -> 200`,                                // web access log
+      `Process created: python deploy.py --key ${AWS_KEY}`,            // ECAR / Linux EDR
+      `Sysmon Process create (EID 1) - CommandLine=set K=${AWS_KEY}`,  // Windows Sysmon
+    ]) {
+      expect(secretSpillSignal(text)?.families, text).toContain("aws_iam");
+    }
+  });
+
+  it("reports every distinct family present in one line", () => {
+    const r = secretSpillSignal(`export AWS=${AWS_KEY} GH=${GH_PAT}`);
+    expect(r?.families).toEqual(expect.arrayContaining(["aws_iam", "github_pat"]));
+  });
+});
+
+// Signal-to-noise discipline, mirroring tradecraftRules' "ordinary administration" tests: a rule
+// that fires on routine log chatter manufactures Mediums and buries the real spill.
+describe("secretSpillRules — does not fire on ordinary text", () => {
+  it("ignores routine authentication and administration logging", () => {
+    for (const text of [
+      "sshd[2311]: Failed password for invalid user admin from 10.0.0.5 port 55234 ssh2",
+      "pam_unix(sudo:auth): authentication failure; logname=jordan uid=1000",
+      "app: password authentication succeeded for reportsvc",
+      "systemd: Starting Secret Service daemon...",
+      "app: secret not found, falling back to instance metadata",
+      "user changed their password successfully",
+      "GET /login?next=/dashboard -> 302",
+      "Process created: /usr/bin/apt-get install -y nginx",
+      "kernel: EXT4-fs (sda1): mounted filesystem with ordered data mode",
+    ]) {
+      expect(secretSpillSignal(text), text).toBeNull();
+    }
+  });
+
+  it("ignores values that are already masked or redacted", () => {
+    for (const text of [
+      "app: loaded shared secret **** from /etc/users/secret.conf",
+      "cmd.exe /c set API_TOKEN=[REDACTED]",
+      "GET /api?key=<REDACTED> -> 200",
+      `${PG}://reportsvc:***@db-01.example.com:5432/reports`,
+      "aws_access_key_id AKIA****************",
+    ]) {
+      expect(secretSpillSignal(text), text).toBeNull();
+    }
+  });
+
+  it("ignores near-miss tokens that are too short to be real key material", () => {
+    for (const text of [
+      "AKIASHORT",
+      "ghp_abc",
+      "xoxb-1",
+      `${PG}://db-01.example.com:5432/reports`,     // no inline credentials
+      "eyJhbGciOiJIUzI1NiJ9",                        // a bare JWT header, not a full token
+    ]) {
+      expect(secretSpillSignal(text), text).toBeNull();
+    }
+  });
+
+  it("returns null for empty input", () => {
+    expect(secretSpillSignal("")).toBeNull();
+    expect(secretSpillSignal("   ")).toBeNull();
+  });
+});

--- a/companion/tests/analysis/syslogImport.test.ts
+++ b/companion/tests/analysis/syslogImport.test.ts
@@ -49,12 +49,23 @@ describe("parseSyslogLine", () => {
 });
 
 describe("mapSyslogLine", () => {
-  it("keeps a benign app message at Info, carries the host as asset, preserves the spilled secret in the description", () => {
+  // An app that logs a token in the clear has spilled it. This used to stay Info — which demotes it
+  // to the analyst-only super-timeline, so AI synthesis never saw it (spillage-full-matrix: 9 of 11
+  // planted secrets were invisible for exactly this reason). Now Medium, and the secret is still
+  // carried verbatim in the description so the finding has visible evidence.
+  it("bumps a syslog line carrying a spilled secret to Medium and keeps the secret in the description", () => {
     const m = mapSyslogLine(SLACK, 2024, new Map())!;
-    expect(m.severity).toBe("Info");
+    expect(m.severity).toBe("Medium");
+    expect(m.mitre).toContain("T1552.001");
     expect(m.asset).toBe("APP-MTX-01");
     expect(m.sources).toEqual(["Syslog"]);
     expect(m.description).toContain(SLACK_TOKEN);
+  });
+  it("keeps ordinary daemon chatter at Info", () => {
+    const m = mapSyslogLine(NOISE, 2024, new Map())!;
+    expect(m.severity).toBe("Info");
+    expect(m.asset).toBe("APP-MTX-01");
+    expect(m.sources).toEqual(["Syslog"]);
   });
   it("keeps an auth SUCCESS at Info and does NOT emit a private-range IP as an IOC", () => {
     const sink = new Map<string, SiemIoc>();


### PR DESCRIPTION
## The bug

A secret sitting in plaintext in a log line graded differently — or not at all — depending on which importer happened to carry it. Only the Windows Sysmon process-create path scored one, because `isSuspiciousCmd`/`tradecraftRules` already inspected that command line. Everywhere else the spill graded **Info**, and Info is demoted to the analyst-only super-timeline, which AI synthesis never reads.

This is the third instance of the same class (the `tradecraftRules.ts` Linux section documents the veridia one). The content tagger can't rescue it either — `taggerAuto` only mutates events already *in* the forensic timeline. The fix has to happen at import time.

## Measured

On the EvidenceForge `spillage-full-matrix-test` benchmark — 11 planted secrets across 5 surfaces. Deterministic extraction was already perfect: all 11 were in the case. But only **2 of 11 reached the forensic timeline**, and both only because they rode inside a Sysmon EID 1 event.

Invisible to the model regardless of model quality: the AWS key and GitHub PAT in bash history, the Slack token and shared secret in syslog, the GCP key / fine-grained PAT / Stripe key / JWT in web-log URLs and Referer headers, and the PostgreSQL URI in Linux ECAR process telemetry.

Synthesis named 2 of 11. A full deep pass at the `Low` floor added nothing — the floor bottoms out at Low and these events weren't in the forensic timeline at all.

## The change

Adds `secretSpillRules.ts`, the surface-agnostic sibling of `tradecraftRules.ts`: one shared table of vendor-anchored patterns (AWS, GCP, GitHub classic + fine-grained, Slack, Stripe, JWT, credentialed DB URIs, plus one tightly constrained generic rule), consulted by the shell-history, syslog, combined-log, ECAR and Windows SIEM importers.

A match contributes **Medium** and `T1552.001` — never High. A structurally valid token is a real exposure and must be *visible* to synthesis, but it may be revoked or a test fixture, so it's a lead rather than a verdict. Same "weak" tier `tradecraftRules` uses for dual-use tooling.

## Second defect, found by the same run

Aggregation is **first-description-wins** for `description` while severity is **worst-wins**. A secret-bearing row merging into a clean sibling therefore produced an event whose severity was raised but whose description showed a different, benign request — a Medium with no visible reason.

The JWT hit this hardest: it rode a busy `GET /` group and produced no distinguishable event at all, surviving only as a `url` IOC with nothing to anchor it to. A spill now keys its own aggregation group in the two importers whose keys are lossy — combined-log (drops the query string) and syslog (masks digit runs).

## Results after the fix — same dataset, same model

| | before | after |
|---|---|---|
| Reach the forensic timeline | 2/11 | **11/11** (all Medium, all `T1552.001`) |
| Named by synthesis | 2/11 | **9/11** |
| Cited by deep pass at ground-truth timestamp | 2/11 | **10/11** |
| Spillage finding severity | Medium | **High** (after deep pass) |

Only the Stripe key (13:59:31, Referer) goes uncalled — it is graded and present, just folded into the narrative rather than named.

No regressions on what earlier benchmarks fixed: the benign control beacon is still not escalated, and the benign-LSASS / benign-Defender negative results still hold.

## Test plan

- [x] 16 new unit tests for the rule table, including explicit false-positive cases (`Failed password for invalid user`, `Starting Secret Service daemon`, masked/redacted values, near-miss short tokens)
- [x] `tsc --noEmit` clean
- [x] Full suite: 4675 passed. One failure — `ocrSearchRoute.test.ts` background-OCR timing — passes in isolation; same parallel-load flake class as the known `fullPipeline` teardown issue, unrelated to this change
- [x] End-to-end re-run of the benchmark: 46/46 files imported, capture re-scored, synthesis + deep pass re-run

Two existing tests asserted the old behaviour and are updated. Worth calling out: one of them was asserting that a syslog line **carrying a Slack token stays Info** — the defect was encoded as expected behaviour. The benign-chatter case that test was nominally covering is re-added separately.

Test fixtures assemble every token at runtime via `.join()` so no full-length literal appears in source, matching the existing convention in `syslogImport.test.ts` — shape-accurate fake tokens otherwise trip GitHub push protection and the repo's own pre-commit TruffleHog hook.
