### PR TITLE
fix(ingest): stop silently losing evidence on import — races, Zeek conn, Linux staging, empty-import notes

### DIFF
--- a/companion/src/analysis/bashHistoryImport.ts
+++ b/companion/src/analysis/bashHistoryImport.ts
@@ -17,6 +17,7 @@ import {
 import type { Severity } from "./stateTypes.js";
 import { reconTechniques } from "./reconTechniques.js";
 import { secretSpillSignal } from "./secretSpillRules.js";
+import { tradecraftSignal } from "./tradecraftRules.js";
 
 export interface BashHistoryImportOptions extends SiemImportOptions {
   // The account the history belongs to (derived from the filename by the pipeline, e.g.
@@ -127,19 +128,28 @@ function classify(command: string): { severity: Severity; mitre: string[] } {
   // every command regardless of the severity rule, so the enumeration phase is identified even
   // though shell-history recon stays Info.
   const recon = reconTechniques("", command);
-  // A secret typed into the shell (an AWS key, a PAT, a token) is at rest in this file — it must be
-  // at least Medium so it reaches the forensic timeline synthesis reads, whichever CMD_RULE (if
-  // any) also matched. See secretSpillRules.ts for why this is shared across every importer.
+  // Two SHARED tables are consulted alongside the shell-history-specific CMD_RULES above, because
+  // the same command must not score differently depending on which sensor reported it:
+  //   - secretSpillSignal: a secret typed into the shell (an AWS key, a PAT, a token) is at rest in
+  //     this file, so it must reach at least Medium whichever CMD_RULE (if any) also matched.
+  //   - tradecraftSignal: the table ECAR/osquery/SIEM/memory grade with. Consulting only CMD_RULES
+  //     here was the same divergence tradecraftRules exists to end, pointing the other way.
+  // Worst severity wins and techniques are unioned, so no table can soften another.
   const spill = secretSpillSignal(command);
+  const tc = tradecraftSignal("", command);
+  const tcSeverity: Severity = tc ? (tc.weight === "strong" ? "High" : "Medium") : "Info";
+  const sharedSeverity: Severity = spill ? worst(tcSeverity, "Medium") : tcSeverity;
+  const sharedMitre = [...(spill?.mitre ?? []), ...(tc?.mitre ?? [])];
+
   for (const rule of CMD_RULES) {
     if (rule.re.test(command)) {
       return {
-        severity: spill ? worst(rule.severity, "Medium") : rule.severity,
-        mitre: [...new Set([...rule.mitre, ...recon, ...(spill?.mitre ?? [])])],
+        severity: worst(rule.severity, sharedSeverity),
+        mitre: [...new Set([...rule.mitre, ...sharedMitre, ...recon])],
       };
     }
   }
-  if (spill) return { severity: "Medium", mitre: [...new Set([...recon, ...spill.mitre])] };
+  if (spill || tc) return { severity: sharedSeverity, mitre: [...new Set([...sharedMitre, ...recon])] };
   return { severity: "Info", mitre: recon };
 }
 

--- a/companion/src/analysis/networkImport.ts
+++ b/companion/src/analysis/networkImport.ts
@@ -242,6 +242,84 @@ function mapZeekNotice(row: Row, host: string, sink: Map<string, SiemIoc>): Mapp
   };
 }
 
+// ───────────────────────── Zeek conn: flow aggregation ─────────────────────────
+// A conn record is one TCP/UDP flow, and a busy sensor emits them by the hundred thousand — far too
+// many to carry one event each, which is why they used to be dropped outright. Dropping them also
+// threw away the one thing only flow telemetry knows: HOW MUCH data moved. On the
+// northpeak-insider-codetheft benchmark the bulk repo clone and the NFS design-doc grab left no
+// trace anywhere else — they are visible only as 1.5 GB pulled from the git server and a single
+// 412 MB NFS read. Folding conn by (src → dst:port/proto) collapses 75,951 rows to ~7,000 and keeps
+// exactly that: peers, connection count, byte totals.
+
+interface FlowAgg {
+  src: string; dst: string; port: string; proto: string; service: string;
+  count: number; origBytes: number; respBytes: number; firstTs: string;
+}
+
+const KB = 1024, MB = KB * 1024, GB = MB * 1024;
+function humanBytes(n: number): string {
+  if (n >= GB) return `${(n / GB).toFixed(1)} GB`;
+  if (n >= MB) return `${(n / MB).toFixed(1)} MB`;
+  if (n >= KB) return `${(n / KB).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function flowKey(row: Row): string {
+  return [
+    str(getCI(row, "id.orig_h")), str(getCI(row, "id.resp_h")),
+    str(getCI(row, "id.resp_p")), str(getCI(row, "proto")),
+  ].join("|");
+}
+
+// Fold one conn record into the running per-flow tally.
+function tallyFlow(row: Row, sink: Map<string, FlowAgg>): void {
+  const key = flowKey(row);
+  const ts = netTime(getCI(row, "ts"));
+  const orig = Number(getCI(row, "orig_bytes")) || 0;
+  const resp = Number(getCI(row, "resp_bytes")) || 0;
+  const existing = sink.get(key);
+  if (existing) {
+    existing.count += 1;
+    existing.origBytes += orig;
+    existing.respBytes += resp;
+    if (ts && ts < existing.firstTs) existing.firstTs = ts;
+    if (!existing.service) existing.service = str(getCI(row, "service"));
+    return;
+  }
+  sink.set(key, {
+    src: str(getCI(row, "id.orig_h")), dst: str(getCI(row, "id.resp_h")),
+    port: str(getCI(row, "id.resp_p")), proto: str(getCI(row, "proto")),
+    service: str(getCI(row, "service")),
+    count: 1, origBytes: orig, respBytes: resp, firstTs: ts,
+  });
+}
+
+function mapFlow(f: FlowAgg, host: string): MappedEvent {
+  const peer = `${f.src} → ${f.dst}${f.port ? `:${f.port}` : ""}`;
+  const proto = [f.proto, f.service].filter(Boolean).join("/");
+  let description = `Flow: ${peer}${proto ? ` (${proto})` : ""}` +
+    ` — ${f.count} connection${f.count === 1 ? "" : "s"},` +
+    ` ${humanBytes(f.origBytes)} sent, ${humanBytes(f.respBytes)} received`;
+  if (host) description += ` @ ${host}`;
+  return {
+    timestamp: f.firstTs,
+    description: description.slice(0, 600),
+    // Pure telemetry: Info keeps it out of the AI prompt (the forensic gate demotes it to the
+    // analyst-only super-timeline) while making it searchable and promotable. No MITRE claim —
+    // a flow on its own asserts nothing about technique.
+    severity: "Info",
+    mitre: [],
+    // Already unique per flow, so the shared aggregator passes these straight through rather than
+    // re-folding them (and the description, not `count`, carries the connection tally).
+    aggKey: `zeek|conn|${f.src}|${f.dst}|${f.port}|${f.proto}`.slice(0, 400),
+    sources: ["Zeek"],
+    ...(host ? { asset: host } : {}),
+    ...(f.src ? { srcIp: f.src } : {}),
+    ...(f.dst ? { dstIp: f.dst } : {}),
+    ...(Number.isFinite(Number(f.port)) && f.port ? { port: Number(f.port) } : {}),
+  };
+}
+
 // ───────────────────────────── host ─────────────────────────────
 
 function pickHost(row: Row): string {
@@ -263,6 +341,8 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
   const iocSink = new Map<string, SiemIoc>();
   const hostTally = new Map<string, number>();
   const mapped: MappedEvent[] = [];
+  const flowSink = new Map<string, FlowAgg>();
+  let flowHost = "";
   let alerts = 0;
   let sawSuricata = false, sawZeek = false;
   // Per-stream Zeek JSON (no `_path`): the filename is the authoritative stream for the whole file.
@@ -298,10 +378,25 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
         mapped.push(m);
         alerts++;
       } else {
+        // conn is folded per-flow (see tallyFlow) and emitted once after the loop, so the byte
+        // totals can be summed across every record in the group.
+        if (zstream === "conn") { tallyFlow(row, flowSink); if (!flowHost && host) flowHost = host; }
         mergeRowIocs(iocSink, rowSink);
       }
     }
   }
+
+  // Select the flows biggest-first and truncate HERE, before handing them to the shared aggregator.
+  // That aggregator caps by "most-severe, then noisiest, then earliest" — and every flow is Info, so
+  // flows sort last and its cut would fall on them in an order that has nothing to do with volume.
+  // On the benchmark that silently discarded the 1.5 GB bulk-clone flow while keeping a 292 KB one
+  // to the same server. Pre-selecting means whatever survives is the high-volume traffic, which is
+  // the entire reason to carry flow rows at all.
+  const flowBudget = opts.maxEvents ?? maxEventsDefault();
+  const flows = [...flowSink.values()]
+    .sort((a, b) => (b.origBytes + b.respBytes) - (a.origBytes + a.respBytes))
+    .slice(0, flowBudget);
+  for (const f of flows) mapped.push(mapFlow(f, flowHost));
 
   const { events, groups } = aggregateEvents(mapped, {
     aggregate: opts.aggregate,

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -2062,6 +2062,44 @@ export class AnalysisPipeline {
     });
   }
 
+  // Record an import that parsed cleanly but contributed nothing.
+  //
+  // Every deterministic importer guards on "no events (and no IOCs) → return the state unchanged".
+  // That guard is correct — an empty delta must not be merged — but returning silently meant the
+  // file was 202-accepted, stored under `imports/`, and left NO trace in the case: the analyst had
+  // no way to tell "ingested and understood" from "silently dropped". On the northpeak benchmark
+  // that hid Zeek conn.json contributing zero events out of 75,951 records, the largest artifact in
+  // the case. A note costs one small timeline row and makes the outcome legible.
+  //
+  // `total` is the importer's own parsed-record count, so the note says how much was READ, not just
+  // that nothing came out — "0 events from 0 records" (wrong format) and "0 events from 75,951
+  // records" (understood but uninteresting) are very different problems.
+  private async noteEmptyImport(
+    caseId: string,
+    opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
+    kind: string,
+    total: number,
+  ): Promise<InvestigationState> {
+    const delta = deltaSchema.parse({
+      findings: [], iocs: [], mitreTechniques: [], forensicEvents: [],
+      threadsOpened: [], threadsClosed: [],
+      timelineNote: `${kind} import: no events from ${total} record(s) — nothing added to the case`,
+      summary: "",
+    });
+    return this.withStateLock(caseId, async () => {
+      let state = await this.opts.stateStore.load(caseId);
+      state = await this.mergeWithAliases(state, delta, {
+        windowSequence: -1,
+        timestamp: opts.importedAt,
+        sourceScreenshots: [opts.label],
+      });
+      await this.opts.stateStore.save(state);
+      this.opts.onState?.(state);
+      opts.onProgress?.(1, 1);
+      return state;
+    });
+  }
+
   // Import a THOR (Nextron) scanner report in JSON-Lines format. Unlike the CSV/log
   // paths this is DETERMINISTIC — THOR's JSON is structured and stable, so each
   // finding maps straight to a forensic event + IOCs with NO AI extraction call.
@@ -2081,7 +2119,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseThorReport(jsonText, opts.thor);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "THOR", parsed.total);
 
     // Assign stable, collision-free ids and validate the delta against the schema
     // (fills defaults like relatedFindingIds). No model call — purely structural.
@@ -2131,7 +2169,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseSiemExport(jsonText, opts.siem);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "SIEM", parsed.total);
 
     const source = detectTool(opts.label) ?? detectTool(parsed.format) ?? "SIEM import";
     const eventIdByAggKey = new Map<string, string>();
@@ -2190,7 +2228,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseEvtxXml(xmlText, opts.siem);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Windows Event Log (XML)", parsed.total);
 
     const source = detectTool(opts.label) ?? "Windows Event Log";
     const raw = {
@@ -2241,7 +2279,7 @@ export class AnalysisPipeline {
     const user = userFromHistoryFilename(opts.label);
     const parsedRaw = parseShellHistoryFile(text, { user });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Shell history", parsed.total);
 
     const raw = {
       findings: [],
@@ -2295,7 +2333,7 @@ export class AnalysisPipeline {
     const parsedRaw = opts.importer.parse(text, { minSeverity: opts.minSeverity });
     opts.onParsed?.(parsedRaw);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, opts.importer.label, parsed.total);
 
     const raw = {
       findings: [],
@@ -2380,7 +2418,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseChainsawReport(jsonText, opts.chainsaw);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Chainsaw", parsed.total);
 
     const fallback = parsed.detections > 0 ? "Chainsaw" : "EVTX";
     const raw = {
@@ -2432,7 +2470,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseHayabusaTimeline(text, opts.hayabusa);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Hayabusa", parsed.total);
 
     const raw = {
       findings: [],
@@ -2491,7 +2529,7 @@ export class AnalysisPipeline {
     // import streams live progress instead of freezing the server on one synchronous pass.
     const parsedRaw = await parseVelociraptorJsonProgress(text, { artifact, ...opts.velociraptor }, opts.onProgress);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Velociraptor", parsed.total);
 
     const eventIdByAggKey = new Map<string, string>();
     const forensicEvents = parsed.events.map((e, i) => {
@@ -2555,7 +2593,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseEcarJson(text, { ...opts.ecar });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "ECAR", parsed.total);
 
     const raw = {
       findings: [],
@@ -2604,7 +2642,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseCombinedLog(text, { ...opts.combinedLog });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Web/proxy access-log", parsed.total);
 
     const eventIdByAggKey = new Map<string, string>();
     const forensicEvents = parsed.events.map((e, i) => {
@@ -2665,7 +2703,7 @@ export class AnalysisPipeline {
     const assumeYear = opts.ciscoAsa?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
     const parsedRaw = parseCiscoAsaLog(text, { ...opts.ciscoAsa, ...(assumeYear !== undefined ? { assumeYear } : {}) });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Cisco ASA", parsed.total);
 
     const raw = {
       findings: [],
@@ -2718,7 +2756,7 @@ export class AnalysisPipeline {
     const assumeYear = opts.snort?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
     const parsedRaw = parseSnortLog(text, { ...opts.snort, ...(assumeYear !== undefined ? { assumeYear } : {}) });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Snort", parsed.total);
 
     const raw = {
       findings: [],
@@ -2767,7 +2805,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseYaraOutput(text, { ...opts.yara });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "YARA", parsed.total);
 
     const raw = {
       findings: [],
@@ -2822,7 +2860,7 @@ export class AnalysisPipeline {
     const assumeYear = opts.syslog?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
     const parsedRaw = parseSyslog(text, { ...opts.syslog, ...(assumeYear !== undefined ? { assumeYear } : {}) });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Syslog", parsed.total);
 
     const raw = {
       findings: [],
@@ -2873,7 +2911,7 @@ export class AnalysisPipeline {
     // routes to the right stream (#197).
     const parsedRaw = parseNetworkLogs(text, { ...opts.network, filename: opts.network?.filename ?? opts.label });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Network", parsed.total);
 
     const eventIdByAggKey = new Map<string, string>();
     const forensicEvents = parsed.events.map((e, i) => {
@@ -2931,7 +2969,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseSocrates(text, opts.socrates);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "SO-CRATES", parsed.total);
 
     const raw = {
       findings: [],
@@ -2981,7 +3019,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseSecurityOnion(text, opts.securityOnion);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Security Onion", parsed.total);
 
     const eventIdByAggKey = new Map<string, string>();
     const forensicEvents = parsed.events.map((e, i) => {
@@ -3039,7 +3077,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseKapeCsv(text, opts.kape);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, `KAPE/${parsed.artifact}`, parsed.total);
 
     const raw = {
       findings: [],
@@ -3089,7 +3127,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseCybertriage(text, opts.cybertriage);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Cyber Triage", parsed.total);
 
     const raw = {
       findings: [],
@@ -3141,7 +3179,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseM365Audit(text, opts.m365);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Microsoft 365", parsed.total);
 
     const raw = {
       findings: [],
@@ -3190,7 +3228,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseCloudTrail(text, opts.aws);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "AWS CloudTrail", parsed.total);
 
     const raw = {
       findings: [],
@@ -3239,7 +3277,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseCloudActivity(text, opts.cloud);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Cloud activity", parsed.total);
 
     const raw = {
       findings: [],
@@ -3289,7 +3327,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseK8sAudit(text, opts.k8s);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Kubernetes audit", parsed.total);
 
     const raw = {
       findings: [],
@@ -3338,7 +3376,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseOsqueryLog(text, opts.osquery);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "osquery", parsed.total);
 
     const raw = {
       findings: [],
@@ -3428,7 +3466,7 @@ export class AnalysisPipeline {
     opts: { label: string; idPrefix: string; importedAt: string; minSeverity?: Severity; onProgress?: (done: number, total: number) => void },
   ): Promise<InvestigationState> {
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Plaso", parsed.total);
 
     const raw = {
       findings: [],
@@ -3478,7 +3516,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseAuditdLog(text, opts.auditd);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "auditd", parsed.total);
 
     const raw = {
       findings: [],
@@ -3529,7 +3567,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseJournald(text, opts.journald);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "journald", parsed.total);
 
     const raw = {
       findings: [],
@@ -3580,7 +3618,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseSysdig(text, opts.sysdig);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "sysdig/Falco", parsed.total);
 
     const raw = {
       findings: [],
@@ -3631,7 +3669,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseWazuhAlerts(text, opts.wazuh);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Wazuh", parsed.total);
 
     const raw = {
       findings: [],
@@ -3682,7 +3720,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseSandboxReport(text, opts.sandbox);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Sandbox", parsed.total);
 
     const raw = {
       findings: [],
@@ -3734,7 +3772,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseMemory(text, { ...opts.memory, filename: opts.label });
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Memory", parsed.total);
 
     const tool = parsed.tool || "Volatility";
     const raw = {
@@ -3787,7 +3825,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseEmail(text, opts.email);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Email", parsed.total);
 
     const raw = {
       findings: [],
@@ -3836,7 +3874,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseTheHive(text, opts.thehive);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "TheHive", parsed.total);
 
     const raw = {
       findings: [],
@@ -3886,7 +3924,7 @@ export class AnalysisPipeline {
   ): Promise<InvestigationState> {
     const parsedRaw = parseIrisCase(data, opts.iris);
     const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.opts.stateStore.load(caseId);
+    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "DFIR-IRIS", parsed.timelineCount);
 
     const raw = {
       findings: [],

--- a/companion/src/analysis/superTimelineStore.ts
+++ b/companion/src/analysis/superTimelineStore.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
 import type { ForensicEvent } from "./stateTypes.js";
+import { StateLock } from "./stateLock.js";
 import { dedupeAppend, capEvents, querySuper, type SuperLabelMap, type SuperQuery, type SuperQueryResult } from "./superTimeline.js";
 
 // Per-case super-timeline: the complete record of every imported event (a copy of the forensic
@@ -14,6 +15,13 @@ import { dedupeAppend, capEvents, querySuper, type SuperLabelMap, type SuperQuer
 export const DEFAULT_SUPER_MAX = 100_000;
 
 export class SuperTimelineStore {
+  // Per-case mutex around the read-modify-write paths (append / setLabels). The import route fires
+  // append() once per imported file, so two imports finishing close together would otherwise read the
+  // same base array and the second atomicWrite would clobber the first — whole files' rows vanishing
+  // silently. atomicWrite makes each write crash-safe, NOT serialized; only this lock makes concurrent
+  // appends additive. Same primitive AnalysisPipeline uses for investigation.json.
+  private readonly lock = new StateLock();
+
   constructor(private readonly cases: CaseStore, private readonly max: number = DEFAULT_SUPER_MAX) {}
 
   private eventsPath(caseId: string): string { return join(this.cases.stateDir(caseId), "super-timeline.json"); }
@@ -43,23 +51,25 @@ export class SuperTimelineStore {
   // report an accurate "+N events" (a re-import of the same rows dedups to +0).
   async append(caseId: string, events: ForensicEvent[]): Promise<number> {
     if (!events.length) return 0;
-    const existing = await this.loadEvents(caseId);
-    const existingIds = new Set(existing.map((e) => e.id));
-    const addedCount = events.filter((e) => !existingIds.has(e.id)).length;
-    const merged = capEvents(dedupeAppend(existing, events), this.max);
-    await atomicWrite(this.eventsPath(caseId), JSON.stringify(merged, null, 2));
-    // Prune label entries for events the cap evicted — otherwise the sidecar map leaks keys forever
-    // (labels are keyed by event id and nothing else garbage-collects them). Only rewrite when something
-    // was actually pruned, so the common append-under-cap path stays a single write.
-    const labels = await this.loadLabels(caseId);
-    const retained = new Set(merged.map((e) => e.id));
-    const pruned = Object.keys(labels).filter((id) => !retained.has(id));
-    if (pruned.length) {
-      const next: SuperLabelMap = {};
-      for (const [id, val] of Object.entries(labels)) if (retained.has(id)) next[id] = val;
-      await atomicWrite(this.labelsPath(caseId), JSON.stringify(next, null, 2));
-    }
-    return addedCount;
+    return this.lock.runExclusive(caseId, async () => {
+      const existing = await this.loadEvents(caseId);
+      const existingIds = new Set(existing.map((e) => e.id));
+      const addedCount = events.filter((e) => !existingIds.has(e.id)).length;
+      const merged = capEvents(dedupeAppend(existing, events), this.max);
+      await atomicWrite(this.eventsPath(caseId), JSON.stringify(merged, null, 2));
+      // Prune label entries for events the cap evicted — otherwise the sidecar map leaks keys forever
+      // (labels are keyed by event id and nothing else garbage-collects them). Only rewrite when something
+      // was actually pruned, so the common append-under-cap path stays a single write.
+      const labels = await this.loadLabels(caseId);
+      const retained = new Set(merged.map((e) => e.id));
+      const pruned = Object.keys(labels).filter((id) => !retained.has(id));
+      if (pruned.length) {
+        const next: SuperLabelMap = {};
+        for (const [id, val] of Object.entries(labels)) if (retained.has(id)) next[id] = val;
+        await atomicWrite(this.labelsPath(caseId), JSON.stringify(next, null, 2));
+      }
+      return addedCount;
+    });
   }
 
   // `labelMap` overrides the built-in per-event label sidecar — the route passes the case's analyst
@@ -79,9 +89,13 @@ export class SuperTimelineStore {
   }
 
   async setLabels(caseId: string, eventId: string, labels: string[]): Promise<void> {
-    const map = await this.loadLabels(caseId);
-    const clean = [...new Set(labels.map((l) => String(l).trim()).filter(Boolean))];
-    if (clean.length) map[eventId] = clean; else delete map[eventId];
-    await atomicWrite(this.labelsPath(caseId), JSON.stringify(map, null, 2));
+    // Same lock as append(): labelling two rows at once is a read-modify-write of one sidecar map,
+    // so without it the second write drops the first row's label.
+    await this.lock.runExclusive(caseId, async () => {
+      const map = await this.loadLabels(caseId);
+      const clean = [...new Set(labels.map((l) => String(l).trim()).filter(Boolean))];
+      if (clean.length) map[eventId] = clean; else delete map[eventId];
+      await atomicWrite(this.labelsPath(caseId), JSON.stringify(map, null, 2));
+    });
   }
 }

--- a/companion/src/analysis/tradecraftRules.ts
+++ b/companion/src/analysis/tradecraftRules.ts
@@ -220,6 +220,24 @@ export const TRADECRAFT_RULES: TradecraftRule[] = [
   // /tmp so ordinary log rotation (`gzip /var/log/...`) and backup jobs (`tar czf /backups/...`)
   // do not fire — see the "ordinary Linux administration" test.
   { re: /\b(?:gzip|bzip2|xz|zip|tar|7za?)\b[^\n]*(?:\.sql\b|\/tmp\/)/i, weight: "weak", ids: ["T1560.001"] },
+
+  // Archive collected data, second shape: the archive is written INTO a user home directory. This is
+  // the Linux counterpart of the robocopy/xcopy staging rule above — on the northpeak-insider-codetheft
+  // benchmark the insider's `tar czf /home/<user>/bk-0514.tgz -C /home/<user>/src .` matched nothing
+  // (no .sql, no /tmp), graded Info, and the archive step of a no-malware theft never reached synthesis.
+  // Anchored on the DESTINATION — the first path argument after the tool and its flags — so a backup
+  // job that READS a home directory but writes elsewhere (`tar czf /backups/home-nightly.tgz /home/dana`)
+  // stays quiet. Weak: a developer tarring their own work tree looks identical, so this is a lead to
+  // triage (and thus VISIBLE to synthesis), not a verdict.
+  { re: /\b(?:gzip|bzip2|xz|zip|tar|7za?)\b\s+(?:-{0,2}[A-Za-z0-9]+\s+)*(?:\/home\/[^\s/]+\/|\/Users\/[^\s/]+\/|~\/)/i,
+    weight: "weak", ids: ["T1560.001"] },
+
+  // Indicator removal: deleting an archive or dump artifact — the closing move of stage → exfil →
+  // clean up (northpeak: `rm -rf .../src .../bk-0514.tgz /tmp/repos.txt`). The T1070.003 rule above
+  // only covers shell-history targets. Scoped to archive/dump extensions so ordinary `rm -rf
+  // node_modules` and log rotation (`rm -f /var/log/syslog.1.gz`) do not fire; bare .gz/.bz2/.xz are
+  // deliberately excluded for that reason, while .tar.gz is matched explicitly.
+  { re: /\brm\b[^\n]*\.(?:tgz|tar\.gz|tar|zip|7z|rar|sql|dump)\b/i, weight: "weak", ids: ["T1070.004"] },
 ];
 
 // The weight + ATT&CK techniques a process command line indicates, or null. Strong wins over weak;

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -1183,6 +1183,12 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // forensic timeline so the AI only synthesizes graded signal. Promotion re-adds them if the analyst
   // wants (it goes through pipeline.promoteSuperTimeline, NOT this gate). Threshold: per-case
   // forensic-gate ?? DFIR_FORENSIC_MIN_SEVERITY ?? "Low". Returns the (possibly unchanged) state.
+  //
+  // The demote is CASE-WIDE, so with concurrent imports it can fire between another import's
+  // pre-import snapshot and that import's dual-write, stripping rows the owning import had not yet
+  // copied to super — they would then exist in neither timeline. The capture below closes that:
+  // an event may only leave the forensic timeline after it is written to the super-timeline in this
+  // same critical section. append() dedups by id, so re-capturing a row the seam already wrote is free.
   async function demoteForensicForCase(caseId: string): Promise<InvestigationState> {
     return runStateExclusive(caseId, async () => {
       const state = await options.stateStore!.load(caseId);
@@ -1193,6 +1199,16 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       );
       const { kept, demoted } = demoteBelowSeverity(state.forensicTimeline, min);
       if (!demoted.length) return state;
+      if (options.superTimelineStore) {
+        try {
+          await options.superTimelineStore.append(caseId, demoted);
+          options.onSuperTimeline?.(caseId);
+        } catch {
+          // Capture failed — keep the rows in the forensic timeline rather than dropping them
+          // on the floor; the next import/demote will retry.
+          return state;
+        }
+      }
       const next = { ...state, forensicTimeline: kept };
       await options.stateStore!.save(next);
       options.onState?.(next);

--- a/companion/tests/analysis/bashHistoryImport.test.ts
+++ b/companion/tests/analysis/bashHistoryImport.test.ts
@@ -103,6 +103,33 @@ describe("parseShellHistoryFile — classification + IOCs", () => {
     expect(exfil?.mitreTechniques).toContain("T1567.002");
   });
 
+  // bashHistoryImport kept its OWN CMD_RULES and was the one importer that never consulted the shared
+  // tradecraftRules table, so a command the ECAR/osquery/SIEM paths graded Medium stayed Info when it
+  // arrived via shell history — the exact divergence those shared rules were introduced to end, just
+  // in the opposite direction. On northpeak-insider-codetheft that hid the insider's staging archive
+  // and post-exfil cleanup, both of which reached the case only through bash_history.
+  it("also applies the shared tradecraft table, so staging + cleanup are not Info", () => {
+    const ops = [
+      "tar czf /home/arjun.mehta/bk-0514.tgz -C /home/arjun.mehta/src .",
+      "rm -rf /home/arjun.mehta/src /home/arjun.mehta/bk-0514.tgz /tmp/repos.txt",
+    ].join("\n");
+    const r = parseShellHistoryFile(ops, { user: "arjun.mehta" });
+    const tar = r.events.find((e) => /tar czf/.test(e.description));
+    expect(tar?.severity).toBe("Medium");
+    expect(tar?.mitreTechniques).toContain("T1560.001");
+    const cleanup = r.events.find((e) => /rm -rf/.test(e.description));
+    expect(cleanup?.severity).toBe("Medium");
+    expect(cleanup?.mitreTechniques).toContain("T1070.004");
+  });
+
+  it("keeps the worse of the two tables when both fire", () => {
+    // CMD_RULES grades history-tampering High; the shared table grades it strong (also High). The
+    // union of techniques must survive, and a High from either side must not be softened to Medium.
+    const r = parseShellHistoryFile("rm -f ~/.bash_history", { user: "u" });
+    expect(r.events[0]?.severity).toBe("High");
+    expect(r.events[0]?.mitreTechniques).toContain("T1070.003");
+  });
+
   it("aggregates identical repeated commands into one counted row", () => {
     const r = parseShellHistoryFile("ls\nls\nls\nid", { user: "u" });
     const ls = r.events.find((e) => /: ls$/.test(e.description));

--- a/companion/tests/analysis/networkImport.test.ts
+++ b/companion/tests/analysis/networkImport.test.ts
@@ -163,11 +163,57 @@ describe("parseNetworkLogs — Zeek per-stream JSON (no _path)", () => {
     expect(domains).toContain("alt.bad.test");
   });
 
-  it("treats conn telemetry as IOC-free flow — no events, no noise rows", () => {
-    const r = parseNetworkLogs([conn, conn].map((o) => JSON.stringify(o)).join("\n"), { filename: "conn.json" });
+  // conn used to produce NOTHING — no events, no IOCs, no super-timeline rows. On the
+  // northpeak-insider-codetheft benchmark that silently discarded 75,951 records (the single
+  // largest artifact in the case) behind a 202-accepted, and with them the only evidence of the
+  // bulk repo clone (1.5 GB pulled from the git server) and the NFS design-doc grab (a single
+  // 412 MB read). conn is now folded into ONE flow row per src→dst:port/proto carrying the
+  // connection count and byte totals — the volume IS the signal for bulk collection.
+  it("folds conn telemetry into one aggregated flow row per src->dst:port", () => {
+    const rows = [
+      { ...conn, ts: 1512115205, orig_bytes: 100, resp_bytes: 900, "id.resp_p": 443, service: "ssl" },
+      { ...conn, ts: 1512115209, orig_bytes: 200, resp_bytes: 800, "id.resp_p": 443, service: "ssl" },
+      { ...conn, ts: 1512115211, orig_bytes: 5, resp_bytes: 5, "id.resp_p": 22 },
+    ];
+    const r = parseNetworkLogs(rows.map((o) => JSON.stringify(o)).join("\n"), { filename: "conn.json" });
     expect(r.format).toBe("zeek");
-    expect(r.events).toHaveLength(0);
+    expect(r.events).toHaveLength(2);                       // :443 folded from 2 rows, :22 alone
+    const https = r.events.find((e) => /:443/.test(e.description));
+    expect(https?.description).toMatch(/10\.0\.0\.5/);
+    expect(https?.description).toMatch(/10\.0\.0\.9/);
+    expect(https?.description).toMatch(/2 connection/);
+    expect(https?.description).toMatch(/300 B sent/);        // 100 + 200 origin bytes
+    expect(https?.description).toMatch(/1\.7 KB received/);  // 900 + 800 = 1700 responder bytes
+    // Info: pure telemetry. The forensic gate demotes it to the analyst-only super-timeline, so a
+    // busy sensor cannot flood the AI prompt — it becomes searchable, not synthesized.
+    expect(https?.severity).toBe("Info");
+    // Earliest connection in the group timestamps the row.
+    expect(https?.timestamp).toBe(new Date(1512115205 * 1000).toISOString());
+  });
+
+  it("still extracts NO IOCs from conn — every external peer would swamp the IOC list", () => {
+    // The benchmark's conn.json alone holds 3,710 distinct external responder IPs. Promoting those
+    // to IOCs buries the handful that matter (see the "IOC/MITRE not discriminative" problem);
+    // real destination IOCs come from dns/http/ssl and the firewall/proxy importers.
+    const r = parseNetworkLogs(JSON.stringify({ ...conn, "id.resp_h": "203.0.113.9" }), { filename: "conn.json" });
     expect(r.iocs).toHaveLength(0);
+  });
+
+  it("keeps the HIGHEST-VOLUME flows when the event cap truncates", () => {
+    // The shared aggregator caps by "most-severe, then noisiest, then earliest". Every flow is Info
+    // with no count, so its cut falls on flows in TIME order — which is why the big transfer here is
+    // deliberately the LAST and LEAST recent-ordered one: a cap that ignores volume keeps 10.0.0.1
+    // and drops the 10 MB flow, exactly the failure that hid the benchmark's 1.5 GB bulk clone
+    // behind a 292 KB flow to the same server.
+    const rows = [
+      { ...conn, ts: 1512115200, "id.resp_h": "10.0.0.1", "id.resp_p": 80, orig_bytes: 1, resp_bytes: 1 },
+      { ...conn, ts: 1512115300, "id.resp_h": "10.0.0.3", "id.resp_p": 80, orig_bytes: 2, resp_bytes: 2 },
+      { ...conn, ts: 1512119999, "id.resp_h": "10.0.0.2", "id.resp_p": 80, orig_bytes: 5_000_000, resp_bytes: 5_000_000 },
+    ];
+    const r = parseNetworkLogs(rows.map((o) => JSON.stringify(o)).join("\n"), { filename: "conn.json", maxEvents: 1 });
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0]?.description).toMatch(/10\.0\.0\.2/);
+    expect(r.events[0]?.description).toMatch(/4\.8 MB received/);   // 5,000,000 B
   });
 
   it("zeekStreamFromName strips seq prefix + extension", () => {

--- a/companion/tests/analysis/pipeline.test.ts
+++ b/companion/tests/analysis/pipeline.test.ts
@@ -998,3 +998,44 @@ describe("synthesize — deep-pass observations block", () => {
     expect(provider.requests.length).toBeGreaterThan(afterFirst);
   });
 });
+
+// An import that parses cleanly but yields nothing used to be a SILENT no-op: every importer
+// returned the unchanged state, so the file was 202-accepted, stored under `imports/`, and left no
+// trace in the case at all. On the northpeak benchmark that hid the fact that Zeek conn.json —
+// 75,951 records, the largest artifact in the case — had contributed zero events. The analyst could
+// not tell "ingested and understood" from "silently dropped". Every importer now records a note.
+describe("pipeline import — empty imports are recorded, not silently dropped", () => {
+  it("notes a network import that parses records but produces no events or IOCs", async () => {
+    const pipeline = new AnalysisPipeline({
+      stateStore,
+      imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+    });
+    // Zeek ntp records: a real stream that carries neither an IOC nor a timeline-worthy event.
+    const ntp = [
+      { ts: 1715713200, uid: "N1", "id.orig_h": "10.0.0.5", "id.resp_h": "10.0.0.1", version: 4, stratum: 3 },
+      { ts: 1715713260, uid: "N2", "id.orig_h": "10.0.0.6", "id.resp_h": "10.0.0.1", version: 4, stratum: 3 },
+    ].map((o) => JSON.stringify(o)).join("\n");
+
+    const state = await pipeline.importNetwork("c1", ntp, {
+      label: "0007_ntp.json", idPrefix: "n1", importedAt: "2026-05-28T10:00:00.000Z",
+    });
+
+    expect(state.forensicTimeline).toHaveLength(0);
+    const note = state.timeline.at(-1);
+    expect(note, "an empty import must still leave a timeline note").toBeDefined();
+    expect(note?.description).toMatch(/no events/i);
+    expect(note?.description).toMatch(/2 record/);          // says how much was parsed
+    expect(note?.sourceScreenshots).toContain("0007_ntp.json");
+  });
+
+  it("notes an empty shell-history import too (the guard is shared across importers)", async () => {
+    const pipeline = new AnalysisPipeline({
+      stateStore,
+      imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+    });
+    const state = await pipeline.importBashHistory("c1", "", {
+      label: "0008_empty.bash_history", idPrefix: "b1", importedAt: "2026-05-28T10:00:00.000Z",
+    });
+    expect(state.timeline.at(-1)?.description).toMatch(/no events/i);
+  });
+});

--- a/companion/tests/analysis/superTimelineStore.test.ts
+++ b/companion/tests/analysis/superTimelineStore.test.ts
@@ -83,6 +83,32 @@ describe("SuperTimelineStore", () => {
     expect(all.labelsAvailable).toEqual(["key-evidence"]);
   });
 
+  // Regression: append() is a read-modify-write (load -> merge -> atomicWrite). The import route
+  // fires it once per imported file, so two imports finishing close together used to read the same
+  // base array and the second write clobbered the first — rows vanished silently. atomicWrite makes
+  // each write crash-safe, not serialized; only a per-case lock makes concurrent appends additive.
+  it("serializes concurrent appends so no batch is clobbered", async () => {
+    const batches = Array.from({ length: 12 }, (_, b) =>
+      Array.from({ length: 5 }, (_, i) =>
+        ev({ id: `b${b}e${i}`, timestamp: `2026-06-0${(b % 9) + 1}T00:0${i}:00Z` })),
+    );
+    await Promise.all(batches.map((batch) => store.append("c1", batch)));
+    const r = await store.query("c1", {});
+    expect(r.total).toBe(60);
+    // Every batch must be represented — a clobber shows up as whole batches missing, not stray rows.
+    for (let b = 0; b < 12; b++) {
+      expect(r.events.filter((e) => e.id.startsWith(`b${b}e`))).toHaveLength(5);
+    }
+  });
+
+  it("serializes concurrent setLabels so no label is clobbered", async () => {
+    await store.append("c1", Array.from({ length: 6 }, (_, i) =>
+      ev({ id: `L${i}`, timestamp: `2026-06-0${i + 1}T00:00:00Z` })));
+    await Promise.all(Array.from({ length: 6 }, (_, i) => store.setLabels("c1", `L${i}`, [`tag${i}`])));
+    const r = await store.query("c1", {});
+    expect(r.labelsAvailable.sort()).toEqual(["tag0", "tag1", "tag2", "tag3", "tag4", "tag5"]);
+  });
+
   it("tolerates a malformed events file (returns empty rather than throwing)", async () => {
     await store.append("c1", [ev({ id: "e1", timestamp: "2026-06-01T00:00:00Z" })]);
     await writeFile(join(cases.stateDir("c1"), "super-timeline.json"), "{ not json", "utf8");

--- a/companion/tests/analysis/tradecraftRules.test.ts
+++ b/companion/tests/analysis/tradecraftRules.test.ts
@@ -279,6 +279,40 @@ describe("tradecraftRules — Linux/Unix attacker tradecraft", () => {
     }
   });
 
+  // Gap found on the EvidenceForge northpeak-insider-codetheft benchmark: the insider's staging
+  // archive (`tar czf /home/<user>/bk-0514.tgz -C /home/<user>/src .`) and the post-exfil cleanup
+  // (`rm -rf .../src .../bk-0514.tgz /tmp/repos.txt`) matched NOTHING — the archive rule above is
+  // scoped to .sql/​/tmp, and the T1070.003 rule only covers shell-history targets. Both graded Info,
+  // were demoted to the analyst-only super-timeline, and so the "archive then upload then delete"
+  // spine of a no-malware insider theft was invisible to synthesis. Windows already grades the
+  // equivalent staging primitive (robocopy/xcopy) unconditionally; Linux had no counterpart.
+  it("flags archiving INTO a user home directory as staging (T1560.001)", () => {
+    for (const cmd of [
+      "tar czf /home/arjun.mehta/bk-0514.tgz -C /home/arjun.mehta/src .",
+      "tar -czf ~/staging.tar.gz ~/src",
+      "zip -r /Users/dana/out.zip /Users/dana/work",
+      "gzip -9 /home/deploy/customers.csv",
+      "7z a /home/svc/archive.7z /srv/data",
+    ]) {
+      const r = sig(cmd);
+      expect(r, cmd).not.toBeNull();
+      expect(r?.mitre, cmd).toContain("T1560.001");
+    }
+  });
+
+  it("flags deletion of an archive/dump artifact as indicator removal (T1070.004)", () => {
+    for (const cmd of [
+      "rm -rf /home/arjun.mehta/src /home/arjun.mehta/bk-0514.tgz /tmp/repos.txt",
+      "rm -f /tmp/export-4291.sql",
+      "rm /var/tmp/staging.tar.gz",
+      "rm -rf /opt/out.zip",
+    ]) {
+      const r = sig(cmd);
+      expect(r, cmd).not.toBeNull();
+      expect(r?.mitre, cmd).toContain("T1070.004");
+    }
+  });
+
   it("does not fire on ordinary Linux administration", () => {
     for (const cmd of [
       "ls -la /var/backups/",
@@ -290,6 +324,12 @@ describe("tradecraftRules — Linux/Unix attacker tradecraft", () => {
       "tar czf /backups/etc-$(date +%F).tar.gz /etc",
       "cat /etc/hostname",
       "vim /opt/app/config.yaml",
+      // Backup jobs READ a home directory but write outside it — the destination is what marks
+      // staging, so a home-dir SOURCE must stay quiet or every nightly backup becomes a finding.
+      "tar czf /backups/home-nightly.tgz /home/dana",
+      "rsync -a /home/dana/ /mnt/backup/dana/",
+      "rm -rf /home/dana/project/node_modules",    // ordinary dev cleanup, no archive/dump artifact
+      "rm -f /var/log/syslog.1.gz",                // log rotation, not staged-archive cleanup
     ]) {
       expect(sig(cmd), cmd).toBeNull();
     }

--- a/companion/tests/storage/caseStore.test.ts
+++ b/companion/tests/storage/caseStore.test.ts
@@ -238,3 +238,28 @@ describe("CaseStore.deleteCaseFolder", () => {
     expect(s.isFile()).toBe(true);
   });
 });
+
+describe("CaseStore.nextImportSeq", () => {
+  it("hands out a distinct sequence to each concurrent caller", async () => {
+    // nextImportSeq derives the next number by COUNTING the imports log, and callers append to that
+    // log only later (after writing the blob). Concurrent imports therefore all read the same count
+    // and get the SAME seq — they overwrite each other's stored evidence file and hand the importer
+    // the same idPrefix, so their events collide by id and the state merge dedups all but one away.
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "seq-1", name: "n", investigator: "i", aiProvider: null });
+    const seqs = await Promise.all(Array.from({ length: 12 }, () => store.nextImportSeq("seq-1")));
+    expect(new Set(seqs).size).toBe(12);
+    expect([...seqs].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  it("resumes from the on-disk log for a case with existing imports", async () => {
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "seq-2", name: "n", investigator: "i", aiProvider: null });
+    await store.appendImport("seq-2", {
+      caseId: "seq-2", sequenceNumber: 1, importedAt: new Date().toISOString(),
+      filename: "0001_a.log", originalName: "a.log", rows: 0, bytes: 1,
+    });
+    // A fresh store (server restart) must pick up where the log left off, not restart at 1.
+    expect(await new CaseStore(root).nextImportSeq("seq-2")).toBe(2);
+  });
+});


### PR DESCRIPTION
Found while running the EvidenceForge **northpeak-insider-codetheft** ground truth (200 files, a
no-malware insider source-code theft) end to end. Four independent ways the pipeline lost or hid
evidence, each verified against that dataset rather than only in unit tests.

## 1. Concurrent imports discarded each other's events

Importing a multi-file dataset lost events outright: **100 of 200 files ended up with zero
super-timeline rows**, and some evidence (a staging `tar czf`, its matching `rm -rf`) ended up in
neither timeline — it imported perfectly in isolation and vanished in bulk.

Two unsynchronised read-modify-writes remained after #214 landed:

- `SuperTimelineStore.append` / `setLabels` — load, merge, `atomicWrite`, no lock, so the second of
  two overlapping appends clobbered the first. `atomicWrite` makes a write crash-safe, not serialized.
- `demoteForensicForCase` prunes sub-threshold events **case-wide**, so it could fire between another
  import's pre-import snapshot and that import's dual-write to super, deleting rows that had been
  copied nowhere. It now captures demoted rows into the super-timeline inside the same critical
  section, and leaves them in forensic if that capture fails.

Verified: a 12-way concurrent import probe goes from 20/240 rows to 240/240; on the real dataset,
files represented in the super-timeline go from 100/200 to 193/200 (the remaining 7 are Zeek streams
that yield IOCs but no timeline events by design).

The third cause — `nextImportSeq` handing out duplicate sequence numbers — was diagnosed here
independently and then found already fixed on master by #214, more thoroughly than the version in
this branch (per case+kind, captures included). Master's implementation is kept; only the regression
tests for it survive from this side.

## 2. Zeek `conn.json` was discarded entirely

It imported 202-accepted and produced **nothing** — no events, no IOCs, no super rows. That silently
dropped 75,951 records, the single largest artifact in the case, and with them the only evidence that
exists anywhere for two ground-truth steps: neither the bulk repo clone nor the NFS document grab
leaves a command line, and both are visible only as volume.

conn is now folded into one row per `(src → dst:port/proto)` with connection count and byte totals
(75,951 records to ~7,000 rows, about a second). The two missing steps now read straight off the
timeline as a 1.4 GB pull from the git server and a single 393.8 MB NFS read.

Deliberately **Info** — the forensic gate demotes flows to the analyst-only super-timeline, so a busy
sensor makes them searchable and promotable without flooding the AI prompt — and still **no IOCs**
from conn, because that one file holds 3,710 distinct external peers.

One subtlety worth flagging for review: the shared aggregator caps by "most-severe, then noisiest,
then earliest". Every flow is Info, so flows sort last and its cut lands on them in an order unrelated
to volume — the first cut of this change kept a 292 KB flow to the git server and dropped the 1.4 GB
one. Flows are therefore selected biggest-first and truncated *before* the aggregator sees them.

## 3. Linux staging and post-exfil cleanup were ungraded

`tar czf /home/<user>/archive.tgz -C /home/<user>/src .` matched nothing (the archive rule was scoped
to `.sql` or `/tmp/`), and deleting a staged archive matched nothing (the T1070.003 rule only covers
shell-history targets). Both graded Info and never reached synthesis, so the archive→upload→delete
spine of the case was invisible at both ends while Windows already grades the equivalent staging
primitive (robocopy/xcopy) unconditionally.

- **T1560.001** now also fires when an archive is written *into* a user home directory, anchored on
  the **destination** so a backup job that reads `/home` but writes elsewhere stays quiet.
- **T1070.004** for `rm` of an archive/dump artifact, scoped to archive/dump extensions so
  `rm -rf node_modules` and log rotation do not fire.
- Structurally, `bashHistoryImport.classify()` was the one importer that never consulted the shared
  `tradecraftRules` table. It now consults it alongside `secretSpillSignal` (from #219), taking the
  worst severity and the union of techniques, so no table can soften another.

Blast radius measured over the dataset's 2,508 shell commands: **each new rule matches exactly one
command, and both are true positives.** The case's forensic timeline grows by 2 events.

## 4. Imports that parsed cleanly but contributed nothing were silent

All **34** deterministic importers guarded the empty case with a bare
`return this.opts.stateStore.load(caseId)`. The guard is right — an empty delta must not be merged —
but returning silently meant a file was 202-accepted, stored under `imports/`, and left no trace at
all. An analyst could not tell "ingested and understood" from "silently dropped". **This is how the
conn.json hole stayed invisible.**

They now share one `noteEmptyImport()` helper, so the case records e.g.

```
Network import: no events from 405 record(s) — nothing added to the case   [0001_ntp.json]
```

The count is the importer's own parsed total, because "0 events from 0 records" (wrong format) and
"0 events from 75,951 records" (understood, nothing worth grading) are different problems.

## Effect on AI synthesis — stated honestly

Only #3 changes what the model sees. #1 and #2 restore the **analyst-searchable** record; the forensic
timeline the AI reads was provably byte-identical before and after #1 (same hash over sorted
`timestamp|severity|description`).

For #3, scored 3 runs per arm. Storyline-step coverage is **flat** (5,4,4 → 5,4,5 after discounting a
scoring cue of mine that misfired). What moved consistently is the shape of the conclusion: the top
finding goes High → **Critical** and quotes the actual archiving command instead of inferring "an
archive" from the uploads, a dedicated **High "Anti-forensic cleanup"** finding appears where there
was none in any of 3 control runs, and T1070 appears in 3/3 versus 0/3. The control matters: three
synthesis passes on the pre-grading case — two of which saw the prior run's findings in-prompt — never
produced that finding, so re-synthesis alone does not invent it.

Also worth knowing for anyone benchmarking here: **the step metric carries ±1 noise on identical
input**, and re-synthesis runs on one case are not independent samples (the prompt carries prior
findings). Only the first synthesis after a fresh import is a clean draw.

## Test plan

- [x] `npm test` — 400/401 test files pass; the one failure (`codexStatus`) passes in isolation and is
      a pre-existing parallel-run flake, unrelated to these changes
- [x] `npx tsc --noEmit` clean
- [x] New tests: concurrent `append`/`setLabels`, concurrent `nextImportSeq`, conn flow folding +
      no-IOC guarantee + cap-keeps-biggest, archive-into-home + rm-of-archive + an expanded
      "ordinary Linux administration" no-fire list, shared-table wiring in shell history, and empty
      imports leaving a note (both guard shapes)
- [x] Full 200-file dataset re-imported end to end after each change, not just unit-tested

Part of the ingest-integrity work alongside #214.
