### PR TITLE
fix(grounding): floor unconfirmed lateral-movement findings (actor-provenance gate)

### DIFF
--- a/companion/src/analysis/findingGrounding.ts
+++ b/companion/src/analysis/findingGrounding.ts
@@ -12,7 +12,7 @@
 // It only ever LOWERS confidence (never invents grounding, never raises a score) and is pure + idempotent.
 
 import type { Finding, ForensicEvent, IOC, FindingCorroboration, Severity, NextStep } from "./stateTypes.js";
-import { classifyVerdict, iocHasBehavioralEvent } from "./iocAnchors.js";
+import { classifyVerdict, iocHasBehavioralEvent, shortHost } from "./iocAnchors.js";
 import { SEVERITY_RANK } from "./forensicGate.js";
 import { extractCveIds } from "./kev.js";
 import { trustForSources, type SourceTrustMap } from "./sourceTrust.js";
@@ -46,6 +46,23 @@ export const LOW_TRUST_CONFIDENCE_CAP = 55;
 export const CONTENT_MISMATCH_CONFIDENCE_CAP = 40;
 export const CONTENT_MISMATCH_SEVERITY_FLOOR: Severity = "Medium";
 
+// Actor-provenance gate for lateral-movement findings (meridian-tax-ransomware benchmark 2026-07-23).
+// A High/Critical finding that claims the attacker moved/pivoted TO a host counts as confirmed only if
+// that destination is itself tied to the attack. The failure this gates: the AI saw a harvested-but-also-
+// legitimate admin account (kevin.obrien) logged onto WS-17 in its own routine session — and an entirely
+// uninvolved user (nathan.brooks) logged onto WS-09 — and wired both benign logons into "RDP lateral
+// movement". A benign LogonType=3 event grades Low, which is >= DETECTION_RANK, so it slips past the
+// hunt-artifact/single-source caps and even earned confidence 82 in the deep pass. The gate: a lateral
+// claim naming a destination host that has NO High/Critical event of its own in scope, and whose own cited
+// evidence carries no High/Critical event and no graph edge, is resting on ordinary login noise — floor it.
+export const LATERAL_UNCONFIRMED_CONFIDENCE_CAP = 40;
+export const LATERAL_UNCONFIRMED_SEVERITY_FLOOR: Severity = "Medium";
+// Lateral-movement / pivot language in a finding's own title or description. Deliberately targets the
+// destination-reaching claim ("moved laterally to", "pivoted to", "RDP to <host>"), not mere mentions of
+// a remote host, so a finding that only *references* another host isn't swept in.
+const LATERAL_MOVEMENT_RE =
+  /\b(lateral\s+movement|moved\s+laterally|pivot(?:ed|ing|s)?|remote(?:d)?\s+(?:in)?to|rdp(?:'?d)?\s+(?:in)?to|logged?\s+(?:in|on)to|smb\s+(?:admin\s+)?share|remote\s+(?:desktop|services)\b)/i;
+
 function appendReason(existing: string | undefined, note: string): string {
   const base = (existing ?? "").trim();
   return base ? `${base} | ${note}` : note;
@@ -63,6 +80,44 @@ function claimedIpsNotInEvidence(f: Finding, supporting: readonly ForensicEvent[
   if (!claimed.length) return [];
   const evidenceIps = new Set(extractIpv4(supporting.map((e) => `${e.description} ${e.message ?? ""}`).join(" ")));
   return claimed.filter((ip) => !evidenceIps.has(ip));
+}
+
+// The set of case host short-names that carry at least one High/Critical event in scope — the hosts the
+// evidence itself confirms as attack-involved (LSASS dump, ransomware, exfil, log-clear, …). A lateral
+// claim whose destination is NOT in this set has to earn its grading from its own cited evidence.
+function confirmedCompromisedHosts(scopedEvents: readonly ForensicEvent[]): Set<string> {
+  const out = new Set<string>();
+  for (const e of scopedEvents) {
+    if ((e.severity === "Critical" || e.severity === "High") && e.asset) out.add(shortHost(e.asset));
+  }
+  return out;
+}
+
+// Host short-names a lateral-movement finding names as a DESTINATION but that no High/Critical event in
+// the case pins to the attack. Empty ⇒ not a lateral claim, or every named host is independently confirmed.
+// The check is host-token based (short-host), so "…to WS-17.meridiancpa.com" and "WS-17" both resolve.
+function unconfirmedLateralDestinations(
+  f: Finding,
+  supporting: readonly ForensicEvent[],
+  compromisedHosts: ReadonlySet<string>,
+): string[] {
+  if (!LATERAL_MOVEMENT_RE.test(`${f.title} ${f.description}`)) return [];
+  // If the finding's OWN cited evidence carries a High/Critical event or a benign-defeating anchor, defer:
+  // something concrete ties the movement to the attack, so let the normal caps handle it.
+  const hasHighSupport = supporting.some((e) => e.severity === "Critical" || e.severity === "High");
+  if (hasHighSupport) return [];
+  // Extract only hosts that are the DESTINATION of the movement — the grammatical object of a
+  // reach-verb (to / onto / into / toward / reached / targeted <HOST>). This is deliberately narrower
+  // than "any host token the finding names": a discovery finding that mentions "…not DC-01… staging for
+  // lateral movement" trips the LATERAL_MOVEMENT_RE gate above but names no movement *destination*, so it
+  // must not be floored. A pivot's SOURCE host follows "from", never a reach-verb, so it's excluded too.
+  const dests = new Set<string>();
+  for (const m of `${f.title} ${f.description}`.matchAll(
+    /\b(?:to|onto|into|towards?|reach(?:ed|ing)?|target(?:ed|ing)?)\s+(?:the\s+)?(?:host\s+)?([A-Za-z][A-Za-z0-9]*-\d{1,3})\b/gi,
+  )) {
+    dests.add(shortHost(m[1]));
+  }
+  return [...dests].filter((h) => !compromisedHosts.has(h));
 }
 
 export interface GroundingInput {
@@ -110,6 +165,8 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
   const scopedById = new Map(scopedEvents.map((e) => [e.id, e] as const));
   const iocById = new Map(iocs.map((i) => [i.id, i] as const));
   const intelIocs = intelFlaggedIocIds(iocs);
+  // Hosts the evidence independently confirms as attack-involved — the actor-provenance gate's allow-list.
+  const compromisedHosts = confirmedCompromisedHosts(scopedEvents);
 
   return findings.map((f) => {
     // Supporting in-scope events: forward links (finding.relatedEventIds present in scope) UNION reverse
@@ -145,6 +202,7 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
     let confidenceReason = f.confidenceReason;
     let ungrounded = false;
     let contentMismatch = false;
+    let lateralUnconfirmed = false;
 
     // KEV is an independent corroboration signal (an external catalog confirms active exploitation),
     // so it exempts a finding from the single-source cap alongside 2+ tools / intel / graph linkage.
@@ -200,8 +258,25 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
       }
     }
 
+    // Actor-provenance gate: a High/Critical lateral-movement claim to a host with no High/Critical event
+    // of its own, resting only on benign authentication telemetry, is floored to Medium. Runs on the
+    // possibly-already-floored severity, so a finding both content-mismatched and lateral-unconfirmed keeps
+    // the lower confidence. Skipped once the content-mismatch gate already floored it (same target severity).
+    if ((severity === "Critical" || severity === "High")) {
+      const unconfirmed = unconfirmedLateralDestinations(f, supporting, compromisedHosts);
+      if (unconfirmed.length) {
+        lateralUnconfirmed = true;
+        severity = LATERAL_UNCONFIRMED_SEVERITY_FLOOR;
+        if ((confidence ?? 100) > LATERAL_UNCONFIRMED_CONFIDENCE_CAP) confidence = LATERAL_UNCONFIRMED_CONFIDENCE_CAP;
+        confidenceReason = appendReason(
+          confidenceReason,
+          `capped: claims lateral movement to ${unconfirmed.join(", ")}, which has no confirmed malicious activity of its own — the cited logon(s) may be a legitimate session by a reused account; confirm the source is a compromised node before treating as a pivot`,
+        );
+      }
+    }
+
     // Clean the old flags first so a since-corrected finding loses them (idempotent recompute).
-    const { ungrounded: _prev, contentMismatch: _prevCm, ...rest } = f;
+    const { ungrounded: _prev, contentMismatch: _prevCm, lateralUnconfirmed: _prevLu, ...rest } = f;
     return {
       ...rest,
       severity,
@@ -212,6 +287,7 @@ export function groundAndScoreFindings(input: GroundingInput): Finding[] {
       semanticKey: deriveSemanticKey(f),
       ...(ungrounded ? { ungrounded: true } : {}),
       ...(contentMismatch ? { contentMismatch: true } : {}),
+      ...(lateralUnconfirmed ? { lateralUnconfirmed: true } : {}),
       ...(confidence !== undefined ? { confidence } : {}),
       ...(confidenceReason !== undefined ? { confidenceReason } : {}),
     };

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -76,6 +76,15 @@ export interface Finding {
   // post-synthesis by groundAndScoreFindings; High/Critical severity is floored to Medium and confidence
   // capped when this fires (investigation-guidance follow-up, veridia-deep-pass 2026-07-22).
   contentMismatch?: boolean;
+  // A High/Critical LATERAL-MOVEMENT finding whose named destination host has NO independently-confirmed
+  // malicious activity of its own (no High/Critical event on that host in scope) and whose cited evidence
+  // is only benign authentication telemetry (no High/Critical supporting event, not graph-linked) — the
+  // claim rests on an ordinary logon by a compromised-but-also-legitimate account, not on the attack.
+  // Set post-synthesis by groundAndScoreFindings; High/Critical is floored to Medium and confidence capped
+  // when it fires (meridian-tax-ransomware benchmark 2026-07-23: kevin.obrien's own WS-17 session and an
+  // uninvolved user's WS-09 logon were both fabricated into "RDP lateral movement"; the deep pass then
+  // HARDENED the WS-17 one from confidence 45 → 82 by citing the real-but-benign logon).
+  lateralUnconfirmed?: boolean;
   corroboration?: FindingCorroboration;
   // Rabbit-hole detection (investigation-guidance #13). `relevance` places the finding relative to the
   // corroborated main attack path: 'connected' (on it) → a lead; 'disconnected' (evidence sits in a

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -573,6 +573,8 @@ function investigation(state: InvestigationState, lines: string[], exposure?: Cu
         lines.push(`> ⚠️ **No cited evidence** — treat as a hypothesis, not a fact (confidence capped).`);
       } else if (f.contentMismatch) {
         lines.push(`> ⚠️ **Citation mismatch** — a claimed detail (e.g. an IP) never appears in the cited events; severity floored and confidence capped pending verification.`);
+      } else if (f.lateralUnconfirmed) {
+        lines.push(`> ⚠️ **Unconfirmed lateral movement** — the destination host has no confirmed malicious activity of its own; the cited logon may be a legitimate session by a reused account. Severity floored and confidence capped until the source is tied to a compromised node.`);
       } else if (f.corroboration) {
         lines.push(`- Corroboration: ${corroborationLabel(f)}`);
       }

--- a/companion/tests/analysis/findingGrounding.test.ts
+++ b/companion/tests/analysis/findingGrounding.test.ts
@@ -7,6 +7,8 @@ import {
   HUNT_ARTIFACT_CONFIDENCE_CAP,
   CONTENT_MISMATCH_CONFIDENCE_CAP,
   CONTENT_MISMATCH_SEVERITY_FLOOR,
+  LATERAL_UNCONFIRMED_CONFIDENCE_CAP,
+  LATERAL_UNCONFIRMED_SEVERITY_FLOOR,
 } from "../../src/analysis/findingGrounding.js";
 import type { Finding, ForensicEvent, IOC, Severity } from "../../src/analysis/stateTypes.js";
 
@@ -150,6 +152,80 @@ describe("groundAndScoreFindings — content-mismatch (veridia-deep-pass false p
     });
     expect(out[0].contentMismatch).toBeUndefined();
     expect(out[0].severity).toBe("Medium");
+  });
+});
+
+describe("groundAndScoreFindings — actor-provenance (lateral movement) gate", () => {
+  // The meridian benchmark class: a lateral-movement claim to a host that has NO High/Critical event of
+  // its own, resting only on a benign LogonType=3 by a reused account, must be floored — not left at the
+  // deep pass's confidence 82.
+  it("floors a High RDP-pivot finding whose destination host has no confirmed malicious activity", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({
+        id: "f5", severity: "High", confidence: 82,
+        title: "Lateral movement via RDP from RDGW-01 to WS-17",
+        description: "The attacker pivoted via RDP to WS-17, reusing the harvested credential to authenticate.",
+        relatedEventIds: ["e-ws17-logon"],
+      })],
+      scopedEvents: [
+        // WS-17 carries only a benign Low logon — no High/Critical event pins it to the attack.
+        ev({ id: "e-ws17-logon", asset: "WS-17.meridiancpa.com", severity: "Low", sources: ["Windows Event Log"], description: "Successful logon (EID 4624) MERIDIANCPA\\kevin.obrien LogonType=3" }),
+        // The real attack High events live on OTHER hosts.
+        ev({ id: "e-rdgw", asset: "RDGW-01.meridiancpa.com", severity: "High", sources: ["Sysmon"], description: "comsvcs MiniDump LSASS" }),
+      ],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].lateralUnconfirmed).toBe(true);
+    expect(out[0].severity).toBe(LATERAL_UNCONFIRMED_SEVERITY_FLOOR);
+    expect(out[0].confidence).toBe(LATERAL_UNCONFIRMED_CONFIDENCE_CAP);
+    expect(out[0].confidenceReason).toMatch(/ws-17/i);
+  });
+
+  it("does NOT floor a pivot to a host that HAS its own confirmed High/Critical activity (real WS-12 spread)", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({
+        id: "f12", severity: "Critical", confidence: 90,
+        title: "Ransomware spread laterally to WS-12",
+        description: "The attacker pivoted to WS-12 and detonated the identical binary.",
+        relatedEventIds: ["e-ws12-enc"],
+      })],
+      scopedEvents: [
+        ev({ id: "e-ws12-enc", asset: "WS-12.meridiancpa.com", severity: "High", sources: ["Sysmon"], description: "msidxsvc.exe --enc" }),
+      ],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].lateralUnconfirmed).toBeUndefined();
+    expect(out[0].severity).toBe("Critical");
+  });
+
+  it("does NOT floor when the lateral finding's OWN cited evidence includes a High/Critical event", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({
+        id: "f1", severity: "High", confidence: 88,
+        title: "Lateral movement via RDP to WS-33",
+        description: "Pivot to WS-33 followed immediately by credential dumping.",
+        relatedEventIds: ["e-high"],
+      })],
+      // WS-33 has no High event of its own in scope, BUT the finding cites a High event → defer to normal caps.
+      scopedEvents: [ev({ id: "e-high", asset: "WS-33", severity: "High", sources: ["Sysmon"], description: "comsvcs MiniDump on WS-33" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].lateralUnconfirmed).toBeUndefined();
+    expect(out[0].severity).toBe("High");
+  });
+
+  it("does NOT touch a non-lateral finding that merely names an uncompromised host", () => {
+    const out = groundAndScoreFindings({
+      findings: [f({
+        id: "f1", severity: "High", confidence: 80,
+        title: "LSASS credential dumping observed",
+        description: "comsvcs MiniDump ran; note that WS-17 was also seen in baseline traffic.",
+        relatedEventIds: ["e1"],
+      })],
+      scopedEvents: [ev({ id: "e1", asset: "RDGW-01", severity: "Low", sources: ["Sysmon"], description: "comsvcs MiniDump" })],
+      iocs: [], graphLinkedEventIds: new Set(),
+    });
+    expect(out[0].lateralUnconfirmed).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

On the `meridian-tax-ransomware` EvidenceForge benchmark, both AI synthesis and the deep pass fabricated an **"RDP lateral movement RDGW-01 → WS-17 / WS-09"** step that isn't in the ground truth. Root cause is **account-identity conflation**:

- **WS-17** is `kevin.obrien`'s own recurring benign workstation session — he's the domain-admin account whose credential the attacker *later* harvested, but these logons are his normal work.
- **WS-09**'s logon belonged to `nathan.brooks`, an entirely uninvolved user the model never checked.

A benign `LogonType=3` event grades **Low**, which is at/above the detection cut, so it slipped every existing confidence cap. Worse, the **deep pass hardened** the WS-17 finding from confidence 45 → **82** by citing the real-but-benign logon — reading more evidence reinforced the hallucination. The fabricated pivot also crowded out the real RDGW-01 → FS-01 RunAs pivot, so the narrative can't explain how the attacker reached the file server.

## Fix

An **actor-provenance gate** in `groundAndScoreFindings` (same deterministic pass as the `contentMismatch` floor). A High/Critical finding is floored to **Medium / confidence ≤ 40** with a new `lateralUnconfirmed` flag + report badge when **all** of:

1. its text claims lateral movement **to a destination host** (grammatical object of to/onto/into/reached/targeted), and
2. that destination has **no High/Critical event of its own** in scope, and
3. its **own cited evidence** carries no High/Critical event.

Design points:
- **Deferral on real High/Critical support** keeps genuine pivots and the real scheduled-task persistence finding untouched.
- **Destination-only host extraction** (not any host token) so a discovery finding that names the DC (`…not DC-01… staging for lateral movement`) is not false-floored.
- Runs at the end of **both** synthesis and the deep pass, so extra reading can no longer promote an unconfirmed pivot.

## Validation

Deterministic re-gate on the real `meridian-gt` saved state — exactly one finding changes:

| Finding | Before | After |
|---|---|---|
| Lateral movement RDGW-01 → WS-17 | High / 82 | **Medium / 40, flagged** |
| Host/domain discovery on RDGW-01 (names DC-01) | High / 70 | High / 70 |
| Persistence via scheduled task | High / 78 | High / 78 |

- 4 new unit tests (floors the WS-17 class; spares a real WS-12 spread; spares a finding citing its own High event; ignores non-lateral findings).
- Full suite **3099/3099** green; typecheck clean.

## Files
- `src/analysis/findingGrounding.ts` — the gate
- `src/analysis/stateTypes.ts` — `lateralUnconfirmed` flag
- `src/reports/markdown.ts` — report badge
- `tests/analysis/findingGrounding.test.ts` — 4 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)