### PR TITLE
fix(qa): make Memory Next Steps hideable and stop discarding model JSON over a raw control character

### DIFF
--- a/companion/src/analysis/extractJson.ts
+++ b/companion/src/analysis/extractJson.ts
@@ -56,9 +56,59 @@ export function repairTruncatedJson(s: string): string {
   return prefix + neededClosers(prefix);
 }
 
+// JSON forbids raw control characters (U+0000–U+001F) inside string literals, but models
+// routinely emit a LITERAL newline/tab in a long description instead of the \n / \t escape.
+// JSON.parse rejects the whole response for it ("Bad control character in string literal"),
+// and the truncation repair can't help because the bad byte sits mid-response — so an
+// otherwise-perfect answer is thrown away and the caller burns another full AI call.
+// This escapes those characters, but ONLY inside string literals: newlines/tabs BETWEEN
+// tokens are legal JSON whitespace and must survive untouched. Already-escaped sequences
+// pass through unchanged (the escape flag skips the char after a backslash).
+export function escapeControlCharsInStrings(s: string): string {
+  const ESCAPES: Record<string, string> = {
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+  };
+  let out = "";
+  let inStr = false;
+  let esc = false;
+  for (const c of s) {
+    if (inStr) {
+      if (esc) {
+        esc = false;
+        out += c;
+        continue;
+      }
+      if (c === "\\") {
+        esc = true;
+        out += c;
+        continue;
+      }
+      if (c === '"') {
+        inStr = false;
+        out += c;
+        continue;
+      }
+      if (c < " ") {
+        out += ESCAPES[c] ?? `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`;
+        continue;
+      }
+      out += c;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    out += c;
+  }
+  return out;
+}
+
 // Parse model JSON tolerantly: strip fences/prose, then on a parse failure attempt the
-// truncation repair before giving up. Returns the parsed value or throws if even the
-// repair can't parse (so the caller's retry/error path still fires).
+// control-character escape and the truncation repair (individually and combined, since a
+// single response can hit both) before giving up. Returns the parsed value or throws if
+// nothing parses (so the caller's retry/error path still fires).
 export function parseJsonLoose(raw: string): unknown {
   // A response that is ALREADY valid JSON wins outright: extraction is fence-based and a model
   // that quotes a ```fenced``` command inside a description would otherwise get its own response
@@ -75,6 +125,18 @@ export function parseJsonLoose(raw: string): unknown {
   try {
     return JSON.parse(cleaned);
   } catch {
-    return JSON.parse(repairTruncatedJson(cleaned));
+    // Try each repair on its own before the combination, so the least-invasive one wins.
+    const escaped = escapeControlCharsInStrings(cleaned);
+    try {
+      return JSON.parse(escaped);
+    } catch {
+      try {
+        return JSON.parse(repairTruncatedJson(cleaned));
+      } catch {
+        // Escape first, then truncate: neededClosers() tracks string state, and an
+        // unescaped newline would otherwise leave it mid-string at the cut point.
+        return JSON.parse(repairTruncatedJson(escaped));
+      }
+    }
   }
 }

--- a/companion/tests/analysis/extractJson.test.ts
+++ b/companion/tests/analysis/extractJson.test.ts
@@ -61,6 +61,42 @@ describe("repairTruncatedJson / parseJsonLoose", () => {
     expect(parsed.findings.map((f) => f.id)).toEqual(["f1"]);
   });
 
+  // Found by /qa on 2026-07-23: an exec-summary call failed twice in a row with
+  // "Bad control character in string literal in JSON at position 2566", burning a full
+  // AI call per retry. The model emits a LITERAL newline/tab inside a string value
+  // instead of the \n / \t escape, which JSON.parse rejects outright — and the
+  // truncation repair can't help, because the bad byte sits mid-response.
+  it("escapes a literal newline emitted inside a string value", () => {
+    const raw = '{"summary":"line one\nline two","ok":true}';
+    const parsed = parseJsonLoose(raw) as { summary: string; ok: boolean };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.summary).toBe("line one\nline two");
+  });
+
+  it("escapes a literal tab emitted inside a string value", () => {
+    const raw = '{"summary":"col1\tcol2"}';
+    expect((parseJsonLoose(raw) as { summary: string }).summary).toBe("col1\tcol2");
+  });
+
+  it("handles a control character AND truncation in the same response", () => {
+    const raw = '{"findings":[{"id":"f1","d":"a\nb"},{"id":"f2"';
+    const parsed = parseJsonLoose(raw) as { findings: { id: string; d?: string }[] };
+    expect(parsed.findings.map((f) => f.id)).toEqual(["f1"]);
+    expect(parsed.findings[0].d).toBe("a\nb");
+  });
+
+  it("leaves structural whitespace between tokens alone", () => {
+    // Newlines/tabs BETWEEN tokens are legal JSON whitespace — escaping those would
+    // corrupt the document. Only control chars inside string literals get escaped.
+    const pretty = '{\n\t"a": 1,\n\t"b": [2, 3]\n}';
+    expect(parseJsonLoose(pretty)).toEqual({ a: 1, b: [2, 3] });
+  });
+
+  it("does not corrupt an already-escaped \\n inside a string", () => {
+    const raw = '{"cmd":"line1\\nline2"}';
+    expect((parseJsonLoose(raw) as { cmd: string }).cmd).toBe("line1\nline2");
+  });
+
   it("prefers whole-response JSON over a fence that only appears INSIDE a string value", () => {
     // A finding description quoting a fenced command block: fence-extraction would slice the
     // response apart mid-string and throw, even though the raw response is already valid JSON.

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -605,6 +605,38 @@ describe("dashboard.html — deep pass", () => {
   });
 });
 
+// Regression: every dashboard section must be switchable from Settings → section visibility.
+// Found by /qa on 2026-07-23: sec-mem-nextsteps rendered on the dashboard but had no entry in
+// SECTION_DEFS, so it was the one section an analyst could not hide. This guards the whole class
+// rather than that single id — a newly-added <section id="sec-*"> now fails here until it is
+// registered. Report: .gstack/qa-reports/qa-report-localhost-4773-2026-07-23.md
+describe("dashboard.html — section visibility coverage", () => {
+  const load = () => readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+
+  it("registers every rendered section in SECTION_DEFS", async () => {
+    const html = await load();
+    const rendered = [...html.matchAll(/<section id="(sec-[a-z0-9-]+)"/g)].map((m) => m[1]);
+    expect(rendered.length).toBeGreaterThan(30); // sanity: the scrape actually found the sections
+
+    const defsBlock = html.match(/const SECTION_DEFS = \[([\s\S]*?)\n {4}\];/);
+    expect(defsBlock, "SECTION_DEFS block").toBeTruthy();
+    const registered = new Set([...defsBlock![1].matchAll(/id: "(sec-[a-z0-9-]+)"/g)].map((m) => m[1]));
+
+    const missing = [...new Set(rendered)].filter((id) => !registered.has(id));
+    expect(missing, `sections with no visibility toggle: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("keeps a data-gated section hidden until its evidence exists, independent of the toggle", async () => {
+    const html = await load();
+    // The gate is declared closed in markup so the section can't flash before render() runs.
+    expect(html).toMatch(/<section id="sec-mem-nextsteps" data-gate-open=""/);
+    // Visibility is the AND of the user's choice and the data gate — not either one alone.
+    expect(html).toMatch(/isSectionVisible\(id, vis\) && isSectionDataOpen\(el\)/);
+    // The memory-evidence check drives the gate and defers the actual display to applySectionsVis().
+    expect(html).toMatch(/sec\.dataset\.gateOpen = hasMem \? "1" : "";[\s\S]{0,80}applySectionsVis\(\)/);
+  });
+});
+
 describe("dashboard.html — help icon", () => {
   const load = () => readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3904,7 +3904,7 @@
       <div id="forensicTimeline">—</div></section>
     <section id="sec-kill-chain" style="grid-column: 1 / -1"><h2>Kill Chain<span class="ev-sub">events bucketed by their ATT&amp;CK tactic (derived, no AI); a categorization, not a confirmed kill-chain stage — e.g. valid-account use can span entry and lateral movement</span></h2><div id="killChain">—</div></section>
     <!-- Memory Next-Step agent (#101): shown only when Volatility/Rekall memory output is imported. -->
-    <section id="sec-mem-nextsteps" style="grid-column: 1 / -1; display:none"><h2>Memory Next Steps<span class="ev-sub">iterative memory-forensics agent — reads the imported Volatility/Rekall evidence, spots process-tree/injection/network anomalies, and suggests the exact next Volatility command</span><button id="memNextStepsBtn" type="button" title="Ask the AI to read this case's imported memory evidence (process tree, malfind, connections, command lines), identify anomalies, and propose the exact next Volatility 3 command to run" style="margin-left:8px;padding:2px 10px;font-size:11px;text-transform:none;letter-spacing:0;font-weight:400">✨ Suggest next steps</button><span id="memNextStepsMsg" style="margin-left:8px;font-size:11px;font-weight:400;text-transform:none;letter-spacing:0;color:var(--c-9aa4b2)"></span></h2><div id="memNextSteps"></div></section>
+    <section id="sec-mem-nextsteps" data-gate-open="" style="grid-column: 1 / -1; display:none"><h2>Memory Next Steps<span class="ev-sub">iterative memory-forensics agent — reads the imported Volatility/Rekall evidence, spots process-tree/injection/network anomalies, and suggests the exact next Volatility command</span><button id="memNextStepsBtn" type="button" title="Ask the AI to read this case's imported memory evidence (process tree, malfind, connections, command lines), identify anomalies, and propose the exact next Volatility 3 command to run" style="margin-left:8px;padding:2px 10px;font-size:11px;text-transform:none;letter-spacing:0;font-weight:400">✨ Suggest next steps</button><span id="memNextStepsMsg" style="margin-left:8px;font-size:11px;font-weight:400;text-transform:none;letter-spacing:0;color:var(--c-9aa4b2)"></span></h2><div id="memNextSteps"></div></section>
     <style>
       #sec-mem-nextsteps .mns-empty{color:var(--c-9aa4b2);font-size:12px;margin-top:10px}
       #sec-mem-nextsteps .mns-caveat{color:var(--c-ffb454);font-size:12px;margin:10px 0 8px}
@@ -12455,9 +12455,11 @@
       const sec = document.getElementById("sec-mem-nextsteps");
       if (!sec) return;
       const hasMem = (ft || []).some(e => (e.sources || []).some(s => s === "Volatility" || s === "Rekall"));
-      // Respect the user's Settings visibility choice — only un-hide when memory data exists.
-      sec.dataset.hasMem = hasMem ? "1" : "";
-      sec.style.display = hasMem ? "" : "none";
+      // Open/close this section's data gate, then let applySectionsVis() own the actual display so
+      // the user's Settings choice is respected too — it hides the section when EITHER the analyst
+      // switched it off or the case has no memory evidence.
+      sec.dataset.gateOpen = hasMem ? "1" : "";
+      applySectionsVis();
     }
 
     function resetMemNextSteps() {
@@ -18161,6 +18163,9 @@
     const SECTIONS_VIS_KEY = "dfir.sectionsVis";
     const SECTIONS_ORDER_KEY = "dfir.sectionsOrder";
     const SECTION_DEFS = [
+      // Data-gated (see data-gate-open in its markup): stays hidden until the timeline actually
+      // has Volatility/Rekall events, but the analyst can still switch it off here like any other.
+      { id: "sec-mem-nextsteps", label: "Memory Next Steps" },
       { id: "sec-ask",          label: "Ask the LLM" },
       { id: "sec-nlquery",      label: "Query Translator" },
       { id: "sec-exec",         label: "Executive Summary" },
@@ -18250,12 +18255,21 @@
       });
     }
 
+    // A few sections only make sense once the case actually holds the evidence they read (e.g.
+    // Memory Next Steps needs Volatility/Rekall events). Those carry a data-gate-open attribute
+    // that their own render path sets to "1"; an absent attribute means the section has no gate.
+    // Both conditions must hold to show it: the user hasn't hidden it AND its data exists.
+    function isSectionDataOpen(el) {
+      const gate = el.dataset.gateOpen;
+      return gate === undefined || gate === "1";
+    }
+
     function applySectionsVis() {
       applySecOrder();
       const vis = loadSectionsVis();
       SECTION_DEFS.forEach(({ id }) => {
         const el = document.getElementById(id);
-        if (el) el.style.display = isSectionVisible(id, vis) ? "" : "none";
+        if (el) el.style.display = isSectionVisible(id, vis) && isSectionDataOpen(el) ? "" : "none";
       });
     }
 
@@ -18429,8 +18443,20 @@
       if (!view || !Array.isArray(view.sections) || !view.sections.length) return;
       const want = view.sections.filter(id => SECTION_DEFS.some(d => d.id === id));
       const wantSet = new Set(want);
+      const prev = loadSectionsVis();
       const vis = {};
-      SECTION_DEFS.forEach(({ id }) => { vis[id] = wantSet.has(id); });
+      SECTION_DEFS.forEach(({ id }) => {
+        // A data-gated section (e.g. Memory Next Steps) is never part of a view's curated list —
+        // its own evidence gate decides whether it can appear at all — so "absent from the view"
+        // must NOT be read as "hide it", which would pin it off even once its evidence lands.
+        // Carry the analyst's existing choice through untouched instead.
+        const el = document.getElementById(id);
+        if (el && el.dataset.gateOpen !== undefined) {
+          if (prev[id] !== undefined) vis[id] = prev[id];
+          return;
+        }
+        vis[id] = wantSet.has(id);
+      });
       // Order: the view's visible sections first (in its order), then the rest (hidden) in their
       // canonical order so re-enabling one later lands it somewhere sensible.
       const order = [...want, ...SECTION_DEFS.map(d => d.id).filter(id => !wantSet.has(id))];


### PR DESCRIPTION
Two independent defects found during a `/qa` pass on the dashboard.

## 1. Memory Next Steps could not be hidden

`sec-mem-nextsteps` rendered on the dashboard but had no entry in `SECTION_DEFS`, so it was the one section an analyst could not switch off in Settings → section visibility.

Registering it alone wasn't enough: the section is *data-gated* (it only makes sense once the timeline holds Volatility/Rekall events), and its render path owned `style.display` directly, which would have fought the user's toggle. So the gate moved to a `data-gate-open` attribute and `applySectionsVis()` now owns display — a gated section shows only when **both** the analyst has it on **and** its evidence exists.

Also fixed in the same path: applying a dashboard view profile treated "absent from the view's curated list" as "hide it", which would have pinned a gated section off permanently even once its evidence landed. The analyst's existing choice is now carried through untouched for gated sections.

## 2. A literal newline in a model response threw the whole answer away

An exec-summary call failed twice in a row with `Bad control character in string literal in JSON at position 2566`, burning a full AI call per retry. Models routinely emit a **literal** newline or tab inside a long description instead of the `\n` / `\t` escape; `JSON.parse` rejects the entire response for it, and the existing truncation repair can't help because the bad byte sits mid-response.

`parseJsonLoose()` now escapes control characters — but only inside string literals, so newlines/tabs between tokens (legal JSON whitespace) survive untouched, and already-escaped sequences pass through unchanged. The repairs are attempted individually before the combination, so the least-invasive one wins and a response that hits both problems still parses.

## Test plan

- [x] `extractJson.test.ts` — literal newline, literal tab, control-char + truncation together, structural whitespace preserved, already-escaped `\n` not corrupted
- [x] `dashboardHtml.test.ts` — new coverage test asserts **every** rendered `<section id="sec-*">` is registered in `SECTION_DEFS`, so a future unregistered section fails here rather than shipping unhideable; plus the gate/toggle AND-condition
- [x] 75 tests pass locally in both files
- [x] Verified the coverage test also passes against the merged-with-master result (41 sections, 41 registered)