### PR TITLE
fix(security): exempt /push from case-lock gate (#239)

### DIFF
--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -2155,7 +2155,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4040,7 +4039,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/companion/src/analysis/caseLockGate.ts
+++ b/companion/src/analysis/caseLockGate.ts
@@ -9,7 +9,10 @@ import { unlockCookieName, verifyUnlockToken, parseCookieHeader } from "./casePa
 //  - import: the capture extension's evidence-ingestion route. A background capture
 //    session should keep recording evidence even while the dashboard is locked — it's
 //    write-only and never exposes case content back to the caller.
-const EXEMPT_SUFFIXES = ["/lock-status", "/unlock", "/lock", "/import"];
+//  - push: the generic push-ingest route for external SIEM webhooks / Velociraptor
+//    pollers. Same rationale as import — write-only evidence ingestion must continue
+//    while the dashboard is locked.
+const EXEMPT_SUFFIXES = ["/lock-status", "/unlock", "/lock", "/import", "/push"];
 
 function pathOnly(url: string): string {
   const q = url.indexOf("?");

--- a/companion/tests/analysis/caseLockGate.test.ts
+++ b/companion/tests/analysis/caseLockGate.test.ts
@@ -26,6 +26,7 @@ beforeEach(async () => {
   app.post("/cases/:id/unlock", (_req, res) => res.status(200).json({ ok: true }));
   app.post("/cases/:id/lock", (_req, res) => res.status(200).json({ ok: true }));
   app.post("/cases/:id/import", (_req, res) => res.status(202).json({ ok: true }));
+  app.post("/cases/:id/push", (_req, res) => res.status(202).json({ ok: true }));
   app.get("/cases/:id/state", (_req, res) => res.status(200).json({ ok: true }));
   app.get("/cases/:id/present", (_req, res) => res.status(200).send("<html></html>"));
 });
@@ -36,12 +37,13 @@ describe("createCaseLockGate", () => {
     expect((await request(app).get("/cases/c1/present")).status).toBe(200);
   });
 
-  it("always exempts lock-status, unlock, lock, and import even when a password is set", async () => {
+  it("always exempts lock-status, unlock, lock, import, and push even when a password is set", async () => {
     await store.updateCaseMeta("c1", { password: hashCasePassword("secret123") });
     expect((await request(app).get("/cases/c1/lock-status")).status).toBe(200);
     expect((await request(app).post("/cases/c1/unlock")).status).toBe(200);
     expect((await request(app).post("/cases/c1/lock")).status).toBe(200);
     expect((await request(app).post("/cases/c1/import")).status).toBe(202);
+    expect((await request(app).post("/cases/c1/push")).status).toBe(202);
   });
 
   it("blocks a gated route with a 401 JSON error when locked", async () => {

--- a/companion/tests/server/pushRoute.test.ts
+++ b/companion/tests/server/pushRoute.test.ts
@@ -8,6 +8,7 @@ import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { PushTokenStore } from "../../src/analysis/pushTokenStore.js";
+import { hashCasePassword } from "../../src/analysis/casePassword.js";
 
 // A deterministic (no-AI) THOR alert the importer maps straight to a forensic event.
 const THOR_EVENT = {
@@ -130,5 +131,13 @@ describe("POST /cases/:id/push — generic push ingest", () => {
     // empty events array → empty payload "[]" still detects as something? assert it's a 4xx either way
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(res.status).toBeLessThan(500);
+  });
+
+  it("accepts push to a password-protected (locked) case with a valid push token", async () => {
+    const { app, stateStore } = await makeApp({ pushToken: "secret" });
+    await request(app).post("/cases/c1/password").send({ newPassword: "case-secret" });
+    const res = await request(app).post("/cases/c1/push").set("X-DFIR-Key", "secret").send({ source: "siem", events: [THOR_EVENT] });
+    expect(res.status).toBe(202);
+    expect(await waitForEvents(stateStore, "c1")).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #239

The generic push-ingest route  was not in , unlike  which is explicitly exempted so background capture continues through a lock. External SIEM webhooks and Velociraptor pollers using  received  when a case had a password set, silently dropping evidence — contradicting the design intent (US-121-125) that write-only ingestion continues while locked.

## Changes

- Add  to  in  (alongside )
- Update the gate test to verify  is exempted when a password is set
- Add a regression test in  that sets a case password and verifies push still returns 202

## Test plan

- [x] 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.10 [39m[90m/home/hasamba/Projects/DFIR-Companion[39m

 [32m✓[39m companion/tests/analysis/caseLockGate.test.ts [2m([22m[2m8 tests[22m[2m)[22m[33m 1135[2mms[22m[39m
     [33m[2m✓[22m[39m rejects a cookie signed under the previous (pre-change) password [33m 351[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m8 passed[39m[22m[90m (8)[39m
[2m   Start at [22m 17:58:49
[2m   Duration [22m 2.65s[2m (transform 328ms, setup 0ms, import 862ms, tests 1.13s, environment 0ms)[22m — 8 passed
- [x] 
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.10 [39m[90m/home/hasamba/Projects/DFIR-Companion[39m

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m403s when no push token is configured anywhere
[22m[39m2026-07-24T14:59:11.783Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m403s when no push token is configured anywhere
[22m[39m2026-07-24T14:59:11.820Z INFO  [req] POST /cases/c1/push -> 403

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m401s when a token is configured but the wrong key is presented
[22m[39m2026-07-24T14:59:11.865Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m401s when a token is configured but the wrong key is presented
[22m[39m2026-07-24T14:59:11.887Z INFO  [req] POST /cases/c1/push -> 401

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m401s when no key is presented against a configured token
[22m[39m2026-07-24T14:59:11.922Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m401s when no key is presented against a configured token
[22m[39m2026-07-24T14:59:11.937Z INFO  [req] POST /cases/c1/push -> 401

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a payload with the global token and imports it into the timeline
[22m[39m2026-07-24T14:59:11.997Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a payload with the global token and imports it into the timeline
[22m[39m2026-07-24T14:59:12.016Z INFO  [push] case c1: received "siem-webhook" → thor

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a payload with the global token and imports it into the timeline
[22m[39m2026-07-24T14:59:12.031Z INFO  [req] POST /cases/c1/push -> 202

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a Bearer token too
[22m[39m2026-07-24T14:59:12.151Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a Bearer token too
[22m[39m2026-07-24T14:59:12.177Z INFO  [push] case c1: received "push" → thor

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a Bearer token too
[22m[39m2026-07-24T14:59:12.177Z INFO  [req] POST /cases/c1/push -> 202

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a raw artifact-map body whole
[22m[39m2026-07-24T14:59:12.216Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a raw artifact-map body whole
[22m[39m2026-07-24T14:59:12.229Z INFO  [push] case c1: received "push" → velociraptor

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts a raw artifact-map body whole
[22m[39m2026-07-24T14:59:12.231Z INFO  [req] POST /cases/c1/push -> 202

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mauthorizes with a per-case token generated via the API
[22m[39m2026-07-24T14:59:12.323Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mauthorizes with a per-case token generated via the API
[22m[39m2026-07-24T14:59:12.347Z INFO  [req] POST /cases/c1/push-token/generate -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mauthorizes with a per-case token generated via the API
[22m[39m2026-07-24T14:59:12.352Z INFO  [req] POST /cases/c1/push -> 401

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mauthorizes with a per-case token generated via the API
[22m[39m2026-07-24T14:59:12.355Z INFO  [push] case c1: received "push" → thor

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mauthorizes with a per-case token generated via the API
[22m[39m2026-07-24T14:59:12.356Z INFO  [req] POST /cases/c1/push -> 202

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mGET /cases/:id/push-token reports config + push URL; DELETE clears it
[22m[39m2026-07-24T14:59:12.365Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mGET /cases/:id/push-token reports config + push URL; DELETE clears it
[22m[39m2026-07-24T14:59:12.369Z INFO  [req] POST /cases/c1/push-token/generate -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mGET /cases/:id/push-token reports config + push URL; DELETE clears it
[22m[39m2026-07-24T14:59:12.374Z INFO  [req] GET /cases/c1/push-token -> 200

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mGET /cases/:id/push-token reports config + push URL; DELETE clears it
[22m[39m2026-07-24T14:59:12.376Z INFO  [req] DELETE /cases/c1/push-token -> 204

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2mGET /cases/:id/push-token reports config + push URL; DELETE clears it
[22m[39m2026-07-24T14:59:12.383Z INFO  [req] GET /cases/c1/push-token -> 200

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m404s an unknown case (even with a valid token)
[22m[39m2026-07-24T14:59:12.435Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m404s an unknown case (even with a valid token)
[22m[39m2026-07-24T14:59:12.439Z INFO  [req] POST /cases/nope/push -> 404

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m400s an undetectable payload
[22m[39m2026-07-24T14:59:12.455Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2m400s an undetectable payload
[22m[39m2026-07-24T14:59:12.463Z INFO  [req] POST /cases/c1/push -> 400

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts push to a password-protected (locked) case with a valid push token
[22m[39m2026-07-24T14:59:12.492Z INFO  [req] POST /cases -> 201

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts push to a password-protected (locked) case with a valid push token
[22m[39m2026-07-24T14:59:12.596Z INFO  [req] POST /cases/c1/password -> 200

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts push to a password-protected (locked) case with a valid push token
[22m[39m2026-07-24T14:59:12.611Z INFO  [push] case c1: received "siem" → thor

[90mstdout[2m | companion/tests/server/pushRoute.test.ts[2m > [22m[2mPOST /cases/:id/push — generic push ingest[2m > [22m[2maccepts push to a password-protected (locked) case with a valid push token
[22m[39m2026-07-24T14:59:12.615Z INFO  [req] POST /cases/c1/push -> 202

 [32m✓[39m companion/tests/server/pushRoute.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 1100[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m11 passed[39m[22m[90m (11)[39m
[2m   Start at [22m 17:58:56
[2m   Duration [22m 16.24s[2m (transform 11.33s, setup 0ms, import 14.59s, tests 1.10s, environment 0ms)[22m — 11 passed (including new locked-case push test)
- [x] 
[41m                                                                               [0m
[41m[37m                This is not the tsc command you are looking for                [0m
[41m                                                                               [0m

To get access to the TypeScript compiler, [34mtsc[0m, from the command line either:

- Use [1mnpm install typescript[0m to first add TypeScript to your project [1mbefore[0m using npx
- Use [1myarn[0m to avoid accidentally running code from un-installed packages — clean