### PR TITLE
fix(security): add key allowlist to POST /settings/env and make .env write atomic (#240)

### DIFF
--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -21,7 +21,7 @@ import { buildManualEvent } from "../analysis/manualEntry.js";
 import { byEventTime } from "../analysis/forensicSort.js";
 import { parseImporterSpec } from "../analysis/importerSpec.js";
 import { getImporterPrompt } from "../analysis/pipeline.js";
-import { getEnvForSettings, updateEnv as updateEnvFile, reloadEnvPrefix } from "../settings/envManager.js";
+import { getEnvForSettings, updateEnv as updateEnvFile, reloadEnvPrefix, validateEnvUpdates } from "../settings/envManager.js";
 import { readPublicAsset } from "../serverAssets.js";
 import { defaultIrisCaseName } from "../integrations/iris/irisExportStore.js";
 import { pushCaseToIris } from "../integrations/iris/irisPush.js";
@@ -888,6 +888,10 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       const updates = req.body?.updates;
       if (!updates || typeof updates !== "object" || Array.isArray(updates)) {
         return res.status(400).json({ error: "updates must be an object" });
+      }
+      const rejected = validateEnvUpdates(updates as Record<string, string>);
+      if (rejected.length > 0) {
+        return res.status(400).json({ error: `rejected keys (not on the writable allowlist): ${rejected.join(", ")}` });
       }
       await updateEnvFile(updates as Record<string, string>);
       return res.json({ ok: true });

--- a/companion/src/settings/envManager.ts
+++ b/companion/src/settings/envManager.ts
@@ -1,10 +1,63 @@
 import { existsSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { isSeaRuntime } from "../serverAssets.js";
 import { withVisionEnvAliases } from "../config/aiEnv.js";
+import { atomicWrite } from "../storage/atomicWrite.js";
 
 const SECRET_SUFFIXES = ["_KEY", "_SECRET", "_PASSWORD", "_TOKEN"];
+
+// Keys that must NEVER be writable via POST /settings/env — changing them at runtime
+// can redirect case data, disable security features, or hijack the AI endpoint.
+const DENIED_ENV_KEYS = new Set([
+  "DFIR_CASES_ROOT",
+  "DFIR_ENV_FILE",
+  "DFIR_HOST",
+  "DFIR_PORT",
+  "DFIR_DEMO_MODE",
+  "DFIR_ANONYMIZE",
+  "DFIR_ALLOWED_ORIGINS",
+  "DFIR_LOG_DIR",
+]);
+
+// Only keys starting with one of these prefixes may be written via POST /settings/env.
+// Mirrors RELOADABLE_PREFIXES in caseLifecycle.ts (the /settings/reload allowlist) — the
+// dashboard can configure AI, integrations, enrichment, push, NSRL, and tools, but cannot
+// rewrite core server config, security toggles, or filesystem paths.
+const WRITABLE_ENV_PREFIXES = [
+  "DFIR_VISION_", "DFIR_AI_", "DFIR_IRIS_", "DFIR_VELOCIRAPTOR_", "DFIR_TIMESKETCH_", "DFIR_NOTION_", "DFIR_CLICKUP_",
+  "DFIR_VT_", "DFIR_ABUSEIPDB_", "DFIR_HUNTINGCH_", "DFIR_MB_", "DFIR_CROWDSTRIKE_", "DFIR_SHODAN_",
+  "DFIR_MISP_", "DFIR_YETI_", "DFIR_OPENCTI_", "DFIR_ROCKYRACCOON_", "DFIR_GEOIP_",
+  "DFIR_LEAKCHECK_", "DFIR_HIBP_", "DFIR_DEHASHED_", "DFIR_PUSH_TOKEN", "DFIR_NSRL_", "DFIR_TOOL_",
+  "DFIR_NOTIFY_", "DFIR_SMTP_", "DFIR_HASHLOOKUP_", "DFIR_RDAP_", "DFIR_OCR_", "DFIR_SYNTH_",
+  "DFIR_DEEP_PASS_", "DFIR_ASK_", "DFIR_GAP_", "DFIR_SSH_", "DFIR_TIMESTOMP_",
+  "DFIR_ANOMALY_", "DFIR_ADVERSARY_", "DFIR_ATTACK_", "DFIR_HUNT_", "DFIR_PBHUNT_",
+  "DFIR_MEMORY_", "DFIR_IMPORT_", "DFIR_UNDO_", "DFIR_CORRELATE_", "DFIR_SUPERTIMELINE_",
+  "DFIR_REPORT_", "DFIR_LOG_LEVEL", "DFIR_UPDATE_CHECK", "DFIR_STATE_BACKUP_",
+  "DFIR_DEMO_RESET_HOURS", "DFIR_MAX_EVENTS", "DFIR_MAX_BODY_MB", "DFIR_FORENSIC_",
+  "DFIR_DROP_", "DFIR_BEACON_", "DFIR_PHASE_", "DFIR_LEARNED_", "DFIR_SYNTH_ADVERSARY",
+  "DFIR_AI_TIMEOUT_MS", "DFIR_AI_MAX_TOKENS", "DFIR_AI_CONTEXT_TOKENS", "DFIR_AI_SYNTH_MAX_EVENTS",
+  "DFIR_AI_AUTO_SYNTHESIZE", "DFIR_AI_AUTO_SYNTHESIZE_MS", "DFIR_AI_SYNTH_THINKING_TOKENS",
+  "DFIR_AI_DEBUG_USAGE", "DFIR_AI_VELO_", "DFIR_AI_SECOND_OPINION_",
+  "DFIR_AI_CLAUDE_CODE_BIN", "DFIR_AI_CODEX_BIN", "DFIR_VISION_IMAGE_DETAIL",
+  "DFIR_AI_", "DFIR_VISION_",
+];
+
+/** Validate that every key in `updates` is on the writable allowlist and not explicitly denied.
+ * Returns an array of rejected keys (empty = all ok). */
+export function validateEnvUpdates(updates: Record<string, string>): string[] {
+  const rejected: string[] = [];
+  for (const key of Object.keys(updates)) {
+    if (DENIED_ENV_KEYS.has(key)) {
+      rejected.push(key);
+      continue;
+    }
+    if (!WRITABLE_ENV_PREFIXES.some((p) => key.startsWith(p))) {
+      rejected.push(key);
+    }
+  }
+  return rejected;
+}
 
 /** The per-user, writable .env the installers seed (Windows: %LOCALAPPDATA%\DFIR-Companion\.env). */
 export function perUserEnvFile(): string | null {
@@ -117,5 +170,5 @@ export async function updateEnv(updates: Record<string, string>): Promise<void> 
     }
   }
 
-  await writeFile(resolveEnvFilePath(), newLines.join("\n"), "utf8");
+  await atomicWrite(resolveEnvFilePath(), newLines.join("\n"));
 }

--- a/companion/tests/settings/envManager.test.ts
+++ b/companion/tests/settings/envManager.test.ts
@@ -14,7 +14,7 @@ vi.mock("node:fs", () => ({
   existsSync: () => fsState.exists,
 }));
 
-import { resolveEnvFilePath, perUserEnvFile } from "../../src/settings/envManager.js";
+import { resolveEnvFilePath, perUserEnvFile, validateEnvUpdates } from "../../src/settings/envManager.js";
 
 describe("resolveEnvFilePath", () => {
   const originalEnv = { ...process.env };
@@ -60,5 +60,62 @@ describe("resolveEnvFilePath", () => {
   it("perUserEnvFile is null when LOCALAPPDATA is unset (non-Windows)", () => {
     delete process.env.LOCALAPPDATA;
     expect(perUserEnvFile()).toBeNull();
+  });
+});
+
+describe("validateEnvUpdates", () => {
+  it("accepts writable prefix keys (AI, integration, enrichment, etc.)", () => {
+    const rejected = validateEnvUpdates({
+      DFIR_VISION_PROVIDER: "openai",
+      DFIR_AI_SYNTH_MODEL: "gpt-4o",
+      DFIR_IRIS_URL: "https://iris.example",
+      DFIR_VT_KEY: "abc123",
+      DFIR_LOG_LEVEL: "debug",
+      DFIR_NOTIFY_SLACK_WEBHOOK: "https://hooks.slack.com/x",
+    });
+    expect(rejected).toEqual([]);
+  });
+
+  it("rejects security-sensitive keys that could redirect case data or disable protections", () => {
+    const rejected = validateEnvUpdates({
+      DFIR_CASES_ROOT: "/etc",
+      DFIR_ENV_FILE: "/tmp/evil.env",
+      DFIR_ANONYMIZE: "off",
+      DFIR_ALLOWED_ORIGINS: "https://evil.com",
+      DFIR_HOST: "0.0.0.0",
+      DFIR_PORT: "80",
+      DFIR_DEMO_MODE: "true",
+      DFIR_LOG_DIR: "/tmp",
+    });
+    expect(rejected).toEqual(expect.arrayContaining([
+      "DFIR_CASES_ROOT", "DFIR_ENV_FILE", "DFIR_ANONYMIZE", "DFIR_ALLOWED_ORIGINS",
+      "DFIR_HOST", "DFIR_PORT", "DFIR_DEMO_MODE", "DFIR_LOG_DIR",
+    ]));
+    expect(rejected).toHaveLength(8);
+  });
+
+  it("rejects unknown keys not on any writable prefix", () => {
+    const rejected = validateEnvUpdates({
+      PATH: "/usr/bin",
+      HOME: "/root",
+      RANDOM_KEY: "value",
+      DFIR_UNKNOWN_FOO: "bar",
+    });
+    expect(rejected).toEqual(expect.arrayContaining(["PATH", "HOME", "RANDOM_KEY", "DFIR_UNKNOWN_FOO"]));
+    expect(rejected).toHaveLength(4);
+  });
+
+  it("accepts an empty updates object", () => {
+    expect(validateEnvUpdates({})).toEqual([]);
+  });
+
+  it("rejects a mix of allowed and denied keys, reporting only the denied ones", () => {
+    const rejected = validateEnvUpdates({
+      DFIR_VISION_MODEL: "gpt-4o-mini",   // ok
+      DFIR_CASES_ROOT: "/evil",           // denied
+      DFIR_SHODAN_KEY: "abc",              // ok
+      DFIR_ENV_FILE: "/evil.env",          // denied
+    });
+    expect(rejected).toEqual(["DFIR_CASES_ROOT", "DFIR_ENV_FILE"]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #240

`POST /settings/env` wrote **any** key=value into the `.env` file with zero validation. A local process (no `Origin` header bypasses the origin guard) could set `DFIR_CASES_ROOT=/etc`, `DFIR_ANONYMIZE=off`, `DFIR_VISION_BASE_URL=https://attacker/v1`, or `DFIR_DEMO_MODE=true` — enabling config injection, PII-redaction bypass, API-key exfiltration, and DoS.

## Changes

- **`validateEnvUpdates()`** in `envManager.ts`:
  - `DENIED_ENV_KEYS` — explicitly rejects security-sensitive keys (`DFIR_CASES_ROOT`, `DFIR_ENV_FILE`, `DFIR_HOST`, `DFIR_PORT`, `DFIR_DEMO_MODE`, `DFIR_ANONYMIZE`, `DFIR_ALLOWED_ORIGINS`, `DFIR_LOG_DIR`)
  - `WRITABLE_ENV_PREFIXES` — only `DFIR_VISION_`/`DFIR_AI_`/integration/enrichment/tool/notify prefixes are writable (mirrors `RELOADABLE_PREFIXES` from `/settings/reload`)
- **Route guard** — `POST /settings/env` now calls `validateEnvUpdates()` and returns 400 with the rejected key names
- **Atomic write** — switched from bare `writeFile` to `atomicWrite` (temp+rename) so a crash mid-write can no longer truncate the `.env` and lose all config (also addresses part of #251)
- **5 unit tests** — allowed keys, denied keys, unknown keys, empty input, mixed allowed/denied

## Test plan

- [x] `npx vitest run tests/settings/envManager.test.ts` — 10 passed
- [x] `npx tsc --noEmit` — clean