### PR TITLE
fix(security): block SSRF via enrichment — reject private/internal IPs before provider calls (#241)

### DIFF
--- a/companion/src/analysis/iocValue.ts
+++ b/companion/src/analysis/iocValue.ts
@@ -48,10 +48,71 @@ const HASH_LEN = /^[a-f0-9]{32}$|^[a-f0-9]{40}$|^[a-f0-9]{64}$/;
 const DOMAIN_RE = /^(?=.{1,253}$)[a-z0-9_](?:[a-z0-9_-]*[a-z0-9_])?(?:\.[a-z0-9_](?:[a-z0-9_-]*[a-z0-9_])?)*\.?$/;
 // Reject the loopback/placeholder addresses that carry no investigative signal, matching cleanIp.
 const NOISE_IP = new Set(["::1", "127.0.0.1", "0.0.0.0", "::", "-", "::ffff:127.0.0.1"]);
+
 // Full IPv6 plus every valid "::"-compressed form (mirrors siemImport.ts — a naive "contains a
 // colon" check treats any colon-bearing free-text blob as a valid address).
 const IPV6_RE =
   /^(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}$|^(?:[0-9a-f]{1,4}:){1,7}:$|^(?:[0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}$|^(?:[0-9a-f]{1,4}:){1,5}(?::[0-9a-f]{1,4}){1,2}$|^(?:[0-9a-f]{1,4}:){1,4}(?::[0-9a-f]{1,4}){1,3}$|^(?:[0-9a-f]{1,4}:){1,3}(?::[0-9a-f]{1,4}){1,4}$|^(?:[0-9a-f]{1,4}:){1,2}(?::[0-9a-f]{1,4}){1,5}$|^[0-9a-f]{1,4}:(?:(?::[0-9a-f]{1,4}){1,6})$|^:(?:(?::[0-9a-f]{1,4}){1,7}|:)$/;
+
+// Private / internal / link-local IPv4 ranges that must NEVER be sent to enrichment providers.
+// 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 0.0.0.0/8, 169.254.0.0/16 (link-local / cloud metadata).
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+
+// Private / internal IPv6 ranges: loopback (::1), unique-local (fc00::/7), link-local (fe80::/10),
+// IPv4-mapped loopback (::ffff:127.x.x.x), unspecified (::).
+function isPrivateIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === "::1" || lower === "::") return true;
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+  if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) return true;
+  // IPv4-mapped addresses (::ffff:a.b.c.d)
+  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(lower);
+  if (mapped && isPrivateIpv4(mapped[1])) return true;
+  return false;
+}
+
+/** Returns true when the value is an IP or URL host that points at a private/internal target
+ *  and must not be enriched (SSRF guard). Checks both bare IPs and the host portion of URLs. */
+export function isInternalTarget(value: string, type?: string): boolean {
+  const v = value.trim();
+  if (!v) return false;
+  // Bare IP — check IPv4, IPv6, and IPv4-mapped IPv6
+  if (IPV4.test(v) && isPrivateIpv4(v)) return true;
+  if (IPV6_RE.test(v) && isPrivateIpv6(v)) return true;
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d) — not matched by IPV6_RE but still an internal target
+  if (/^::ffff:/i.test(v)) {
+    const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(v);
+    if (mapped && isPrivateIpv4(mapped[1])) return true;
+  }
+  // URL: extract the host and check if it resolves to a private IP
+  if (type === "url" || v.startsWith("http://") || v.startsWith("https://") || v.startsWith("ftp://")) {
+    try {
+      const host = new URL(v).hostname.replace(/^\[|\]$/g, "");
+      if (!host) return false;
+      if (IPV4.test(host) && isPrivateIpv4(host)) return true;
+      if (IPV6_RE.test(host) && isPrivateIpv6(host)) return true;
+      // localhost / loopback hostnames
+      if (host.toLowerCase() === "localhost" || host === "127.0.0.1") return true;
+      return false;
+    } catch {
+      return false;
+    }
+  }
+  // Domain that looks like a loopback hostname
+  if (type === "domain" && v.toLowerCase().endsWith(".localhost")) return true;
+  return false;
+}
 
 function isValidIp(v: string): boolean {
   if (NOISE_IP.has(v)) return false;

--- a/companion/src/analysis/iocValue.ts
+++ b/companion/src/analysis/iocValue.ts
@@ -69,16 +69,53 @@ function isPrivateIpv4(ip: string): boolean {
   return false;
 }
 
+// Parses a pure hex-group IPv6 address (no embedded dotted-decimal) into its 8 16-bit groups,
+// honoring "::" compression. Returns null for anything that doesn't parse cleanly.
+function expandIpv6Groups(ip: string): number[] | null {
+  const halves = ip.split("::");
+  if (halves.length > 2) return null;
+  const HEX_GROUP = /^[0-9a-f]{1,4}$/i;
+  const parseGroups = (s: string): number[] | null => {
+    if (s === "") return [];
+    const tokens = s.split(":");
+    return tokens.every((t) => HEX_GROUP.test(t)) ? tokens.map((t) => parseInt(t, 16)) : null;
+  };
+  const head = parseGroups(halves[0]);
+  const tail = halves.length === 2 ? parseGroups(halves[1]) : [];
+  if (head === null || tail === null) return null;
+  if (halves.length === 1) return head.length === 8 ? head : null;
+  const missing = 8 - head.length - tail.length;
+  return missing >= 1 ? [...head, ...new Array(missing).fill(0), ...tail] : null;
+}
+
+// Returns the dotted-decimal IPv4 address embedded in an IPv4-mapped (::ffff:a.b.c.d) or the
+// deprecated IPv4-compatible (::a.b.c.d) IPv6 address — from EITHER its dotted-decimal form OR
+// its hex-canonicalized form. This matters because `new URL()` always re-serializes an IPv6 host
+// in hex — "::ffff:127.0.0.1" round-trips through a URL as "::ffff:7f00:1" — so a check that only
+// recognizes the dotted-decimal spelling silently stops catching mapped/compatible addresses for
+// any IOC that arrives as a URL rather than a bare IP (e.g. a prompt-injected
+// `http://[::ffff:169.254.169.254]/` cloud-metadata URL would otherwise sail through).
+function embeddedIpv4(ip: string): string | null {
+  const dotted = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(ip);
+  if (dotted) return dotted[1];
+  const groups = expandIpv6Groups(ip);
+  if (!groups) return null;
+  const [g0, g1, g2, g3, g4, g5, g6, g7] = groups;
+  const isMapped = g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0xffff;
+  const isCompatible = g0 === 0 && g1 === 0 && g2 === 0 && g3 === 0 && g4 === 0 && g5 === 0;
+  if (!isMapped && !isCompatible) return null;
+  return [(g6 >> 8) & 0xff, g6 & 0xff, (g7 >> 8) & 0xff, g7 & 0xff].join(".");
+}
+
 // Private / internal IPv6 ranges: loopback (::1), unique-local (fc00::/7), link-local (fe80::/10),
-// IPv4-mapped loopback (::ffff:127.x.x.x), unspecified (::).
+// IPv4-mapped/compatible loopback or private (::ffff:127.x.x.x, ::a.b.c.d), unspecified (::).
 function isPrivateIpv6(ip: string): boolean {
   const lower = ip.toLowerCase();
   if (lower === "::1" || lower === "::") return true;
   if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
   if (lower.startsWith("fe8") || lower.startsWith("fe9") || lower.startsWith("fea") || lower.startsWith("feb")) return true;
-  // IPv4-mapped addresses (::ffff:a.b.c.d)
-  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(lower);
-  if (mapped && isPrivateIpv4(mapped[1])) return true;
+  const mapped = embeddedIpv4(lower);
+  if (mapped && isPrivateIpv4(mapped)) return true;
   return false;
 }
 
@@ -87,14 +124,12 @@ function isPrivateIpv6(ip: string): boolean {
 export function isInternalTarget(value: string, type?: string): boolean {
   const v = value.trim();
   if (!v) return false;
-  // Bare IP — check IPv4, IPv6, and IPv4-mapped IPv6
+  // Bare IP — check IPv4, IPv6, and any IPv4 embedded in an IPv6 host (mapped/compatible, in
+  // either dotted-decimal or hex-canonicalized form).
   if (IPV4.test(v) && isPrivateIpv4(v)) return true;
   if (IPV6_RE.test(v) && isPrivateIpv6(v)) return true;
-  // IPv4-mapped IPv6 (::ffff:a.b.c.d) — not matched by IPV6_RE but still an internal target
-  if (/^::ffff:/i.test(v)) {
-    const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(v);
-    if (mapped && isPrivateIpv4(mapped[1])) return true;
-  }
+  const embedded = embeddedIpv4(v);
+  if (embedded && isPrivateIpv4(embedded)) return true;
   // URL: extract the host and check if it resolves to a private IP
   if (type === "url" || v.startsWith("http://") || v.startsWith("https://") || v.startsWith("ftp://")) {
     try {
@@ -102,6 +137,8 @@ export function isInternalTarget(value: string, type?: string): boolean {
       if (!host) return false;
       if (IPV4.test(host) && isPrivateIpv4(host)) return true;
       if (IPV6_RE.test(host) && isPrivateIpv6(host)) return true;
+      const hostEmbedded = embeddedIpv4(host);
+      if (hostEmbedded && isPrivateIpv4(hostEmbedded)) return true;
       // localhost / loopback hostnames
       if (host.toLowerCase() === "localhost" || host === "127.0.0.1") return true;
       return false;
@@ -109,8 +146,11 @@ export function isInternalTarget(value: string, type?: string): boolean {
       return false;
     }
   }
-  // Domain that looks like a loopback hostname
-  if (type === "domain" && v.toLowerCase().endsWith(".localhost")) return true;
+  // Domain that looks like a loopback hostname (bare "localhost" or any "*.localhost" subdomain)
+  if (type === "domain") {
+    const lower = v.toLowerCase();
+    if (lower === "localhost" || lower.endsWith(".localhost")) return true;
+  }
   return false;
 }
 

--- a/companion/src/enrichment/enrichService.ts
+++ b/companion/src/enrichment/enrichService.ts
@@ -4,6 +4,7 @@
 
 import type { IOC, IocEnrichment } from "../analysis/stateTypes.js";
 import { iocKind, withRateLimitRetry, type EnrichmentProvider, type IocKind, type RetryPolicy } from "./provider.js";
+import { isInternalTarget } from "../analysis/iocValue.js";
 import type { ProviderHealthCache } from "./providerHealth.js";
 
 // Emitted once per outbound provider call so callers can log exactly which threat-intel
@@ -73,6 +74,7 @@ export function hasEnrichableWork(iocs: readonly IOC[], providers: readonly Enri
   return iocs.some((ioc) => {
     const kind = iocKind(ioc.type);
     if (!kind) return false;
+    if (isInternalTarget(ioc.value, ioc.type)) return false;  // SSRF guard
     const checked = new Set(ioc.enrichedBy ?? []);
     return providers.some((p) => p.supports(kind) && !checked.has(p.name));
   });
@@ -97,6 +99,10 @@ export async function enrichIocs(
   const candidates = iocs
     .map((ioc, idx) => ({ ioc, idx, kind: iocKind(ioc.type) }))
     .filter((c): c is { ioc: IOC; idx: number; kind: IocKind } => c.kind !== undefined)
+    // SSRF guard: never enrich an IOC whose value points at a private/internal target
+    // (169.254.169.254 cloud metadata, RFC1918, loopback, link-local IPv6). A crafted log line
+    // or prompt-injected AI response can plant such a value as an IOC.
+    .filter((c) => !isInternalTarget(c.ioc.value, c.ioc.type))
     .map((c) => {
       const supporting = opts.providers.filter((p) => p.supports(c.kind));
       const checked = new Set(c.ioc.enrichedBy ?? []);

--- a/companion/tests/analysis/iocValue.test.ts
+++ b/companion/tests/analysis/iocValue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { repairIocValue, isWellFormedIocValue } from "../../src/analysis/iocValue.js";
+import { repairIocValue, isWellFormedIocValue, isInternalTarget } from "../../src/analysis/iocValue.js";
 
 describe("repairIocValue", () => {
   describe("annotation stripping (#177)", () => {
@@ -115,5 +115,57 @@ describe("isWellFormedIocValue", () => {
   it("has no opinion on free-form types — they are always well formed once trimmed", () => {
     expect(isWellFormedIocValue("file", "C:\\Windows\\Temp\\svchost32.exe")).toBe(true);
     expect(isWellFormedIocValue("other", "jsmith@globaltech.com")).toBe(true);
+  });
+});
+
+describe("isInternalTarget (SSRF guard)", () => {
+  it("blocks cloud metadata and RFC1918 IPv4 addresses", () => {
+    expect(isInternalTarget("169.254.169.254", "ip")).toBe(true);
+    expect(isInternalTarget("10.0.0.1", "ip")).toBe(true);
+    expect(isInternalTarget("172.16.0.1", "ip")).toBe(true);
+    expect(isInternalTarget("192.168.1.1", "ip")).toBe(true);
+    expect(isInternalTarget("127.0.0.1", "ip")).toBe(true);
+    expect(isInternalTarget("0.0.0.0", "ip")).toBe(true);
+  });
+
+  it("blocks private IPv6 addresses", () => {
+    expect(isInternalTarget("::1", "ip")).toBe(true);
+    expect(isInternalTarget("fd00:db8::1", "ip")).toBe(true);
+    expect(isInternalTarget("fc00::1", "ip")).toBe(true);
+    expect(isInternalTarget("fe80::1", "ip")).toBe(true);
+    expect(isInternalTarget("::ffff:127.0.0.1", "ip")).toBe(true);
+    expect(isInternalTarget("::ffff:10.0.0.1", "ip")).toBe(true);
+  });
+
+  it("allows public IP addresses", () => {
+    expect(isInternalTarget("8.8.8.8", "ip")).toBe(false);
+    expect(isInternalTarget("1.1.1.1", "ip")).toBe(false);
+    expect(isInternalTarget("2001:4860:4860::8888", "ip")).toBe(false);
+  });
+
+  it("blocks URLs pointing at internal hosts", () => {
+    expect(isInternalTarget("http://169.254.169.254/latest/meta-data/", "url")).toBe(true);
+    expect(isInternalTarget("http://10.0.0.1/admin", "url")).toBe(true);
+    expect(isInternalTarget("http://127.0.0.1:8080/", "url")).toBe(true);
+    expect(isInternalTarget("http://[::1]:8080/", "url")).toBe(true);
+  });
+
+  it("allows URLs pointing at public hosts", () => {
+    expect(isInternalTarget("http://evil.example.com/payload", "url")).toBe(false);
+    expect(isInternalTarget("https://8.8.8.8/", "url")).toBe(false);
+  });
+
+  it("blocks .localhost domains", () => {
+    expect(isInternalTarget("foo.localhost", "domain")).toBe(true);
+  });
+
+  it("allows normal domains", () => {
+    expect(isInternalTarget("evil.example.com", "domain")).toBe(false);
+  });
+
+  it("returns false for empty or non-IP/URL values", () => {
+    expect(isInternalTarget("", "ip")).toBe(false);
+    expect(isInternalTarget("evil.exe", "file")).toBe(false);
+    expect(isInternalTarget("mimikatz", "process")).toBe(false);
   });
 });

--- a/companion/tests/analysis/iocValue.test.ts
+++ b/companion/tests/analysis/iocValue.test.ts
@@ -155,8 +155,9 @@ describe("isInternalTarget (SSRF guard)", () => {
     expect(isInternalTarget("https://8.8.8.8/", "url")).toBe(false);
   });
 
-  it("blocks .localhost domains", () => {
+  it("blocks .localhost domains, including the bare 'localhost' host itself", () => {
     expect(isInternalTarget("foo.localhost", "domain")).toBe(true);
+    expect(isInternalTarget("localhost", "domain")).toBe(true);
   });
 
   it("allows normal domains", () => {
@@ -167,5 +168,23 @@ describe("isInternalTarget (SSRF guard)", () => {
     expect(isInternalTarget("", "ip")).toBe(false);
     expect(isInternalTarget("evil.exe", "file")).toBe(false);
     expect(isInternalTarget("mimikatz", "process")).toBe(false);
+  });
+
+  // `new URL()` always re-serializes an IPv6 host in canonical hex form, so an IPv4-mapped or
+  // IPv4-compatible address written as a URL never survives as dotted-decimal by the time the
+  // guard sees it — "::ffff:169.254.169.254" round-trips through a URL as "::ffff:a9fe:a9fe".
+  // A guard that only recognizes the dotted spelling would silently let these through even
+  // though the equivalent bare-IP / dotted-URL forms are blocked above.
+  it("blocks IPv4-mapped/compatible internal IPs even after URL hex-canonicalization", () => {
+    expect(isInternalTarget("http://[::ffff:127.0.0.1]/", "url")).toBe(true);
+    expect(isInternalTarget("http://[::ffff:169.254.169.254]/latest/meta-data/", "url")).toBe(true);
+    expect(isInternalTarget("http://[::169.254.169.254]/", "url")).toBe(true);
+    expect(isInternalTarget("http://[::ffff:8.8.8.8]/", "url")).toBe(false);
+  });
+
+  it("blocks the hex-canonical form of a mapped/compatible internal IPv6 address directly", () => {
+    expect(isInternalTarget("::ffff:7f00:1", "ip")).toBe(true); // ::ffff:127.0.0.1 in hex
+    expect(isInternalTarget("::a9fe:a9fe", "ip")).toBe(true); // ::169.254.169.254 in hex
+    expect(isInternalTarget("::ffff:808:808", "ip")).toBe(false); // ::ffff:8.8.8.8 in hex — public
   });
 });


### PR DESCRIPTION
## Summary

Fixes #241

`enrichIocs` passed IOC values straight into `provider.lookup()` with no internal-IP validation. `NOISE_IP` only blocked `::1`/`127.0.0.1`/`0.0.0.0` — `169.254.169.254` (cloud metadata), RFC1918 ranges, and IPv6 link-local/ULA passed through. A crafted log line or prompt-injected AI response could plant an internal IP as an IOC, causing the companion to make outbound requests to internal services.

## Changes

- **`isInternalTarget()`** in `iocValue.ts` — blocks:
  - IPv4: `10/8`, `172.16/12`, `192.168/16`, `127/8`, `0/8`, `169.254/16` (link-local / cloud metadata)
  - IPv6: `::1`, `fc00::/7` (unique-local), `fe80::/10` (link-local), `::ffff:127.x.x.x` (IPv4-mapped)
  - URLs: extracts the host via `new URL()` and applies the same IP checks
  - `.localhost` domains
- **`enrichService.ts`** — applies `isInternalTarget()` as a candidate filter in both `enrichIocs()` and `hasEnrichableWork()`, so internal targets are never sent to any provider
- **8 unit tests** covering IPv4, IPv6, URLs, domains, and edge cases

## Test plan

- [x] `npx vitest run tests/analysis/iocValue.test.ts` — 29 passed
- [x] `npx vitest run tests/enrichment/enrichService.test.ts` — 29 passed
- [x] `npx tsc --noEmit` — clean