### PR TITLE
fix(security): reject symlinks in drop folder to prevent host-file exfiltration (#243)

### DIFF
--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -8,7 +8,7 @@ import { config as loadDotenv } from "dotenv";
 import { join, basename, isAbsolute, resolve, dirname, relative, extname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
-import { writeFile, readFile, rm, readdir, stat, open, copyFile, mkdir, mkdtemp, rename } from "node:fs/promises";
+import { writeFile, readFile, rm, readdir, stat, lstat, open, copyFile, mkdir, mkdtemp, rename } from "node:fs/promises";
 import { ZodError } from "zod";
 import { CaseStore, isValidCaseId } from "./storage/caseStore.js";
 import { BackupManager, resolveBackupConfig } from "./storage/backupManager.js";
@@ -1390,6 +1390,8 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   }
 
   // Recursive walk of drop/, skipping the reserved subtrees + README + OS/sync junk (shouldIgnoreDropFile).
+  // Symlinks are rejected (lstat, not stat) to prevent a symlink-to-/etc/shadow from being read into
+  // the case as evidence — a Dropbox/OneDrive-synced cases/ root is exactly where this is realistic.
   async function listDropFiles(dropDir: string): Promise<DropFileStat[]> {
     const out: DropFileStat[] = [];
     const walk = async (dir: string): Promise<void> => {
@@ -1399,9 +1401,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
         const full = join(dir, e.name);
         const rel = relative(dropDir, full);
         if (shouldIgnoreDropFile(rel)) continue;
+        if (e.isSymbolicLink()) continue;   // never follow symlinks in the drop folder
         if (e.isDirectory()) { await walk(full); continue; }
         if (!e.isFile()) continue;
-        try { const st = await stat(full); out.push({ relpath: rel, size: st.size, mtimeMs: st.mtimeMs }); } catch { /* vanished mid-walk */ }
+        try { const st = await lstat(full); if (st.isSymbolicLink()) continue; out.push({ relpath: rel, size: st.size, mtimeMs: st.mtimeMs }); } catch { /* vanished mid-walk */ }
       }
     };
     await walk(dropDir);
@@ -1425,6 +1428,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     const dest = await uniqueDest(join(dropDir, ok ? DROP_PROCESSED : DROP_FAILED, relpath));
     await mkdir(dirname(dest), { recursive: true });
     try {
+      // Guard against a symlink swap (TOCTOU): rename follows symlinks on some platforms, and
+      // copyFile always does. Re-check before moving.
+      const lst = await lstat(src);
+      if (lst.isSymbolicLink()) throw new Error("symlink detected in drop folder — refused to move (security)");
       await rename(src, dest);
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code === "EXDEV") { await copyFile(src, dest); await rm(src, { force: true }); }
@@ -1459,6 +1466,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     const full = join(dropDir, file.relpath);
     const name = basename(file.relpath);
     try {
+      // TOCTOU guard: re-check that the path is not a symlink before reading. A file could have
+      // been replaced with a symlink between listDropFiles and this read.
+      const lst = await lstat(full);
+      if (lst.isSymbolicLink()) return { ok: false, reason: "symlink detected in drop folder — refused to read (security)" };
       // A raw file an external tool handles (built-in EVTX/PCAP, or any extension a CUSTOM tool claims)
       // — can't be read as text. Run the configured tool against the on-disk file (size-independent, so
       // checked BEFORE the oversize cap), or surface it as pending so the dashboard offers "Run/Configure

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -1392,6 +1392,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // Recursive walk of drop/, skipping the reserved subtrees + README + OS/sync junk (shouldIgnoreDropFile).
   // Symlinks are rejected (lstat, not stat) to prevent a symlink-to-/etc/shadow from being read into
   // the case as evidence — a Dropbox/OneDrive-synced cases/ root is exactly where this is realistic.
+  // Hardlinks are rejected too (nlink > 1): a hardlink is indistinguishable from a normal file via
+  // stat/lstat, but a legitimately-dropped file (synced, copied, or dragged in) is always nlink === 1
+  // — a multiply-linked path in the drop folder means some OTHER directory entry aliases the same
+  // inode, which is exactly the "read /etc/shadow via drop/" vector this whole guard exists for.
   async function listDropFiles(dropDir: string): Promise<DropFileStat[]> {
     const out: DropFileStat[] = [];
     const walk = async (dir: string): Promise<void> => {
@@ -1404,7 +1408,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
         if (e.isSymbolicLink()) continue;   // never follow symlinks in the drop folder
         if (e.isDirectory()) { await walk(full); continue; }
         if (!e.isFile()) continue;
-        try { const st = await lstat(full); if (st.isSymbolicLink()) continue; out.push({ relpath: rel, size: st.size, mtimeMs: st.mtimeMs }); } catch { /* vanished mid-walk */ }
+        try {
+          const st = await lstat(full);
+          if (st.isSymbolicLink() || st.nlink > 1) continue;
+          out.push({ relpath: rel, size: st.size, mtimeMs: st.mtimeMs });
+        } catch { /* vanished mid-walk */ }
       }
     };
     await walk(dropDir);
@@ -1429,9 +1437,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     await mkdir(dirname(dest), { recursive: true });
     try {
       // Guard against a symlink swap (TOCTOU): rename follows symlinks on some platforms, and
-      // copyFile always does. Re-check before moving.
+      // copyFile always does. Re-check before moving. Also refuse a hardlink (nlink > 1) — see
+      // listDropFiles for why that's just as much a host-file-exfiltration vector as a symlink.
       const lst = await lstat(src);
       if (lst.isSymbolicLink()) throw new Error("symlink detected in drop folder — refused to move (security)");
+      if (lst.nlink > 1) throw new Error("hardlink detected in drop folder — refused to move (security)");
       await rename(src, dest);
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code === "EXDEV") { await copyFile(src, dest); await rm(src, { force: true }); }
@@ -1467,9 +1477,12 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     const name = basename(file.relpath);
     try {
       // TOCTOU guard: re-check that the path is not a symlink before reading. A file could have
-      // been replaced with a symlink between listDropFiles and this read.
+      // been replaced with a symlink between listDropFiles and this read. Also refuse a hardlink
+      // (nlink > 1) — indistinguishable from a normal file via stat, but a legitimately-dropped
+      // file is always nlink === 1 (see listDropFiles).
       const lst = await lstat(full);
       if (lst.isSymbolicLink()) return { ok: false, reason: "symlink detected in drop folder — refused to read (security)" };
+      if (lst.nlink > 1) return { ok: false, reason: "hardlink detected in drop folder — refused to read (security)" };
       // A raw file an external tool handles (built-in EVTX/PCAP, or any extension a CUSTOM tool claims)
       // — can't be read as text. Run the configured tool against the on-disk file (size-independent, so
       // checked BEFORE the oversize cap), or surface it as pending so the dashboard offers "Run/Configure

--- a/companion/tests/server/dropFolderSymlink.test.ts
+++ b/companion/tests/server/dropFolderSymlink.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, symlink, link, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { JobManager } from "../../src/analysis/jobManager.js";
+import { DropStatusStore } from "../../src/analysis/dropStatus.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { MockProvider } from "../../src/providers/provider.js";
+import { createApp } from "../../src/server.js";
+
+// #243: the drop-folder auto-importer used stat() (follows symlinks) and had no nlink check
+// (a hardlink is indistinguishable from a normal file via stat), so a symlink or hardlink
+// planted in a case's drop/ folder — realistic since it's documented as a Dropbox/OneDrive-synced
+// inbox — could smuggle host files (/etc/shadow, .instance-secret, another case's case.json) into
+// the case as "imported evidence". These tests exercise the REAL drop-folder poller end to end
+// (not the private lstat helpers directly, since listDropFiles/processDropFile/moveDropFile are
+// closures inside createApp with no exported surface) and assert the secret content never reaches
+// the case, while a normal file dropped alongside it still imports correctly (no over-blocking).
+//
+// Verified against the pre-fix server.ts (before #259/this hardening): the hardlink test genuinely
+// fails without the nlink guard (the hardlinked file gets processed and moved to _failed/, proving
+// its content was read). The symlink "plant one and let the poller find it" case happened to be
+// accidentally safe even before this fix too — Dirent.isFile() already returns false for a symlink
+// dirent, so it was filtered before ever reaching stat() — but the REAL pre-fix symlink bug was a
+// narrower TOCTOU race (a file that reads as a normal file when first listed, then gets swapped to
+// a symlink before the read/move that follows once it's marked "ready"). That race isn't exercised
+// here — it would need to land squarely inside the drop poller's sub-second settle window — so the
+// symlink test below documents the now-deliberate (not incidental) guarantee at the listing stage,
+// while the processDropFile/moveDropFile lstat re-checks that close the TOCTOU window itself remain
+// unverified by an automated test.
+
+function findingPipeline(stateStore: StateStore): AnalysisPipeline {
+  return new AnalysisPipeline({
+    provider: new MockProvider("mock", JSON.stringify({
+      findings: [], iocs: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [],
+      timelineNote: "n", summary: "s",
+    })),
+    stateStore,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+}
+
+const VELO_EVIDENCE = JSON.stringify([{
+  _Source: "Windows.Detection.X", Detection: { Name: "Bad" },
+  EventTime: "2026-01-01T00:00:00Z", EntryPath: "c:\\x.exe",
+}]);
+
+async function runDropSweep(caseId: string, dropDir: string, seedSecretLinks: (dropDir: string, secretFile: string) => Promise<void>) {
+  const prevPoll = process.env.DFIR_DROP_POLL_S;
+  process.env.DFIR_DROP_POLL_S = "2"; // minimum settle: seen at poll 1, imported at poll 2
+  try {
+    const root = await mkdtemp(join(tmpdir(), "dfir-dropsymlink-"));
+    const store = new CaseStore(root);
+    const stateStore = new StateStore(store);
+    const jobManager = new JobManager();
+    const app = createApp(store, {
+      pipeline: findingPipeline(stateStore), stateStore, jobManager,
+      dropStatusStore: new DropStatusStore(store), // presence ARMS the drop-folder poller
+    });
+    await request(app).post("/cases").send({ caseId, name: "n", investigator: "i", aiProvider: "mock" });
+
+    const caseDropDir = join(store.caseDir(caseId), "drop");
+    await mkdir(caseDropDir, { recursive: true });
+    // A secret file OUTSIDE the drop folder, plus a symlink/hardlink to it planted INSIDE.
+    const secretDir = await mkdtemp(join(tmpdir(), "dfir-dropsymlink-secret-"));
+    const secretFile = join(secretDir, "shadow.txt");
+    await writeFile(secretFile, "TOPSECRET-HOST-FILE-CONTENTS-4f8a2b", "utf8");
+    await seedSecretLinks(caseDropDir, secretFile);
+    // A normal, legitimately-dropped file alongside it — proves the guard doesn't over-block.
+    await writeFile(join(caseDropDir, "evidence.json"), VELO_EVIDENCE, "utf8");
+
+    let jobs: { kind: string; label?: string }[] = [];
+    for (let i = 0; i < 200 && !jobs.some((j) => j.kind === "import"); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+      jobs = jobManager.list(caseId);
+    }
+    expect(jobs.some((j) => j.kind === "import")).toBe(true);
+    // Give the sweep a moment past job completion to finish writing state/moving files.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const state = await stateStore.load(caseId);
+    const haystack = JSON.stringify(state);
+    return { caseDropDir, haystack };
+  } finally {
+    if (prevPoll === undefined) delete process.env.DFIR_DROP_POLL_S;
+    else process.env.DFIR_DROP_POLL_S = prevPoll;
+  }
+}
+
+describe("drop-folder auto-importer — symlink/hardlink rejection (#243)", () => {
+  it("never reads a symlink's target content into the case, but still imports a normal file", async () => {
+    const { caseDropDir, haystack } = await runDropSweep("c1", "drop", async (dropDir, secretFile) => {
+      await symlink(secretFile, join(dropDir, "innocuous.json"));
+    });
+    expect(haystack).not.toContain("TOPSECRET-HOST-FILE-CONTENTS");
+    expect(haystack).toContain("Bad"); // the legit Velociraptor detection DID import
+    // The symlink itself is never even recognized by listDropFiles, so it's left exactly where
+    // it was dropped — never moved to _processed/ or _failed/.
+    const remaining = await readdir(caseDropDir);
+    expect(remaining).toContain("innocuous.json");
+  }, 15000);
+
+  it("never reads a hardlink's target content into the case, but still imports a normal file", async () => {
+    const { caseDropDir, haystack } = await runDropSweep("c2", "drop", async (dropDir, secretFile) => {
+      await link(secretFile, join(dropDir, "innocuous2.json"));
+    });
+    expect(haystack).not.toContain("TOPSECRET-HOST-FILE-CONTENTS");
+    expect(haystack).toContain("Bad");
+    const remaining = await readdir(caseDropDir);
+    expect(remaining).toContain("innocuous2.json");
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

Fixes #243

The drop folder walker used `Dirent.isFile()` (returns false for symlinks) and `stat()` (follows symlinks) with no `lstat`/`O_NOFOLLOW`/`readlink` checks anywhere. A TOCTOU race (file passes `isFile()` → replaced with a symlink before `readFile`) or a hardlink (passes `isFile()`) could cause the auto-importer to read `/etc/shadow`, `.instance-secret`, or another case's `case.json` — exfiltrating host files into the case as evidence.

## Changes

Three `lstat` guards:
1. **`listDropFiles`** — skip `Dirent.isSymbolicLink()` entries and use `lstat` (not `stat`) for size/mtime — never follows the link
2. **`processDropFile`** — re-check `lstat` before reading (TOCTOU guard between the walk and the read); returns an error if a symlink is detected
3. **`moveDropFile`** — re-check `lstat` before `rename`/`copyFile` (TOCTOU guard between the read and the move)

## Test plan

- [x] `npx vitest run tests/analysis/dropScan.test.ts` — 13 passed
- [x] `npx vitest run tests/analysis/dropLog.test.ts` — 16 passed
- [x] `npx tsc --noEmit` — clean