### PR TITLE
fix(security): add rate limiting to /unlock (brute-force) and AI-cost routes (DoS) (#244)

### DIFF
--- a/companion/src/http/rateLimiter.ts
+++ b/companion/src/http/rateLimiter.ts
@@ -1,0 +1,118 @@
+// Lightweight in-memory rate limiter — no external dependencies, suitable for a localhost tool.
+// Two modes:
+//   1. Per-key attempt limiter (e.g. brute-force protection on /unlock): tracks failed attempts
+//      per key (caseId), applies exponential backoff after N failures, and lockout for a cooldown.
+//   2. Sliding-window rate limiter (e.g. AI-cost DoS): caps total requests per window per key.
+
+import type { Request, Response, NextFunction } from "express";
+
+/** Per-key attempt tracker with exponential backoff + lockout. */
+export class AttemptLimiter {
+  private attempts = new Map<string, { count: number; lockedUntil: number }>();
+  private readonly maxAttempts: number;
+  private readonly lockoutMs: number;
+
+  /** @param maxAttempts  failed attempts before lockout kicks in (default 5)
+   *  @param lockoutMs    lockout duration after maxAttempts (default 30s, doubles each cycle up to 10min) */
+  constructor(maxAttempts = 5, lockoutMs = 30_000) {
+    this.maxAttempts = maxAttempts;
+    this.lockoutMs = lockoutMs;
+  }
+
+  /** Returns the remaining lockout time in ms, or 0 if not locked. */
+  remainingLockout(key: string, now = Date.now()): number {
+    const rec = this.attempts.get(key);
+    if (!rec || rec.lockedUntil <= now) return 0;
+    return rec.lockedUntil - now;
+  }
+
+  /** Record a failed attempt. Returns the lockout time in ms (0 = not yet locked). */
+  recordFailure(key: string, now = Date.now()): number {
+    const rec = this.attempts.get(key) ?? { count: 0, lockedUntil: 0 };
+    rec.count += 1;
+    if (rec.count >= this.maxAttempts) {
+      const lockout = Math.min(this.lockoutMs * Math.pow(2, Math.floor(rec.count / this.maxAttempts) - 1), 600_000);
+      rec.lockedUntil = now + lockout;
+      this.attempts.set(key, rec);
+      return lockout;
+    }
+    this.attempts.set(key, rec);
+    return 0;
+  }
+
+  /** Clear the attempt counter for a key (call on success). */
+  clear(key: string): void {
+    this.attempts.delete(key);
+  }
+
+  /** Express middleware factory: gates on a key extracted from the request. */
+  middleware(keyFn: (req: Request) => string) {
+    return (req: Request, res: Response, next: NextFunction): void => {
+      const key = keyFn(req);
+      const remaining = this.remainingLockout(key);
+      if (remaining > 0) {
+        res.setHeader("Retry-After", String(Math.ceil(remaining / 1000)));
+        res.status(429).json({ error: "too many attempts, try again later", retryAfterMs: remaining });
+        return;
+      }
+      next();
+    };
+  }
+}
+
+/** Sliding-window rate limiter: caps total requests per window per key. */
+export class SlidingWindowLimiter {
+  private counts = new Map<string, { windowStart: number; count: number }>();
+  private readonly maxRequests: number;
+  private readonly windowMs: number;
+
+  /** @param maxRequests  max requests per window
+   *  @param windowMs      window duration in ms */
+  constructor(maxRequests: number, windowMs: number) {
+    this.maxRequests = maxRequests;
+    this.windowMs = windowMs;
+  }
+
+  /** Returns true if the request is allowed (and counts it); false if rate-limited. */
+  tryAcquire(key: string, now = Date.now()): boolean {
+    const rec = this.counts.get(key);
+    if (!rec || rec.windowStart + this.windowMs <= now) {
+      this.counts.set(key, { windowStart: now, count: 1 });
+      return true;
+    }
+    rec.count += 1;
+    return rec.count <= this.maxRequests;
+  }
+
+  /** Express middleware factory: gates on a key extracted from the request. */
+  middleware(keyFn: (req: Request) => string) {
+    return (req: Request, res: Response, next: NextFunction): void => {
+      const key = keyFn(req);
+      if (!this.tryAcquire(key)) {
+        res.status(429).json({ error: "rate limit exceeded, slow down" });
+        return;
+      }
+      next();
+    };
+  }
+}
+
+// Module-level singletons, created once by the server.
+let _unlockLimiter: AttemptLimiter | null = null;
+let _aiLimiter: SlidingWindowLimiter | null = null;
+
+export function getUnlockLimiter(): AttemptLimiter {
+  if (!_unlockLimiter) _unlockLimiter = new AttemptLimiter(5, 30_000);
+  return _unlockLimiter;
+}
+
+export function getAiLimiter(): SlidingWindowLimiter {
+  if (!_aiLimiter) _aiLimiter = new SlidingWindowLimiter(20, 60_000);
+  return _aiLimiter;
+}
+
+/** Reset singletons (tests). */
+export function resetLimiters(): void {
+  _unlockLimiter = null;
+  _aiLimiter = null;
+}

--- a/companion/src/http/rateLimiter.ts
+++ b/companion/src/http/rateLimiter.ts
@@ -8,12 +8,14 @@ import type { Request, Response, NextFunction } from "express";
 
 /** Per-key attempt tracker with exponential backoff + lockout. */
 export class AttemptLimiter {
-  private attempts = new Map<string, { count: number; lockedUntil: number }>();
+  private attempts = new Map<string, { count: number; lockedUntil: number; cycles: number; lastSeen: number }>();
   private readonly maxAttempts: number;
   private readonly lockoutMs: number;
 
-  /** @param maxAttempts  failed attempts before lockout kicks in (default 5)
-   *  @param lockoutMs    lockout duration after maxAttempts (default 30s, doubles each cycle up to 10min) */
+  /** @param maxAttempts  failed attempts before the FIRST lockout kicks in (default 5). Every
+   *                      failure after that immediately re-locks (no free guesses in between),
+   *                      doubling the lockout each time.
+   *  @param lockoutMs    first lockout duration (default 30s, doubles each subsequent lockout up to 10min) */
   constructor(maxAttempts = 5, lockoutMs = 30_000) {
     this.maxAttempts = maxAttempts;
     this.lockoutMs = lockoutMs;
@@ -26,13 +28,23 @@ export class AttemptLimiter {
     return rec.lockedUntil - now;
   }
 
-  /** Record a failed attempt. Returns the lockout time in ms (0 = not yet locked). */
+  /** Record a failed attempt. Returns the lockout time in ms (0 = not yet locked).
+   *
+   *  Before the first lockout, `maxAttempts` failures are needed to trigger it (so a single
+   *  mistyped password doesn't lock anyone out). After that, `cycles` tracks how many times
+   *  this key has been locked out — every SINGLE further failure re-locks immediately (the
+   *  threshold drops to 1), and the lockout doubles each time, so an attacker who keeps waiting
+   *  out the lockout and retrying never gets a free burst of guesses between escalations. */
   recordFailure(key: string, now = Date.now()): number {
-    const rec = this.attempts.get(key) ?? { count: 0, lockedUntil: 0 };
+    const rec = this.attempts.get(key) ?? { count: 0, lockedUntil: 0, cycles: 0, lastSeen: now };
+    rec.lastSeen = now;
     rec.count += 1;
-    if (rec.count >= this.maxAttempts) {
-      const lockout = Math.min(this.lockoutMs * Math.pow(2, Math.floor(rec.count / this.maxAttempts) - 1), 600_000);
+    const threshold = rec.cycles === 0 ? this.maxAttempts : 1;
+    if (rec.count >= threshold) {
+      const lockout = Math.min(this.lockoutMs * Math.pow(2, rec.cycles), 600_000);
       rec.lockedUntil = now + lockout;
+      rec.cycles += 1;
+      rec.count = 0;
       this.attempts.set(key, rec);
       return lockout;
     }
@@ -43,6 +55,19 @@ export class AttemptLimiter {
   /** Clear the attempt counter for a key (call on success). */
   clear(key: string): void {
     this.attempts.delete(key);
+  }
+
+  /** Drop entries idle for longer than `maxIdleMs` (default 1h — well past the 10min lockout
+   *  cap, so an actively-escalating attacker's cycle count isn't lost mid-attack). Bounds memory
+   *  for a long-running process against a stream of distinct keys (garbage/enumerated caseIds
+   *  hitting this limiter cost nothing to try, since it runs before any caseId-existence check).
+   *  Returns the number of entries removed. */
+  sweep(now = Date.now(), maxIdleMs = 3_600_000): number {
+    let removed = 0;
+    for (const [key, rec] of this.attempts) {
+      if (now - rec.lastSeen > maxIdleMs) { this.attempts.delete(key); removed++; }
+    }
+    return removed;
   }
 
   /** Express middleware factory: gates on a key extracted from the request. */
@@ -84,6 +109,19 @@ export class SlidingWindowLimiter {
     return rec.count <= this.maxRequests;
   }
 
+  /** Drop windows that have already fully expired — nothing reads them again until the key
+   *  reappears, at which point tryAcquire starts a fresh window anyway. Bounds memory for a
+   *  long-running process against a stream of distinct keys (this limiter runs before any
+   *  caseId-existence check, so a garbage/enumerated caseId costs nothing to try). Returns the
+   *  number of entries removed. */
+  sweep(now = Date.now()): number {
+    let removed = 0;
+    for (const [key, rec] of this.counts) {
+      if (rec.windowStart + this.windowMs <= now) { this.counts.delete(key); removed++; }
+    }
+    return removed;
+  }
+
   /** Express middleware factory: gates on a key extracted from the request. */
   middleware(keyFn: (req: Request) => string) {
     return (req: Request, res: Response, next: NextFunction): void => {
@@ -97,22 +135,43 @@ export class SlidingWindowLimiter {
   }
 }
 
-// Module-level singletons, created once by the server.
+// Module-level singletons, created once by the server. Each gets its own periodic sweep so a
+// long-running process doesn't accumulate one Map entry per distinct (possibly garbage/attacker-
+// enumerated) key forever — see AttemptLimiter.sweep / SlidingWindowLimiter.sweep.
+const SWEEP_INTERVAL_MS = 5 * 60_000;
+
 let _unlockLimiter: AttemptLimiter | null = null;
 let _aiLimiter: SlidingWindowLimiter | null = null;
+let _unlockSweepTimer: NodeJS.Timeout | null = null;
+let _aiSweepTimer: NodeJS.Timeout | null = null;
 
 export function getUnlockLimiter(): AttemptLimiter {
-  if (!_unlockLimiter) _unlockLimiter = new AttemptLimiter(5, 30_000);
+  if (!_unlockLimiter) {
+    const limiter = new AttemptLimiter(5, 30_000);
+    _unlockLimiter = limiter;
+    _unlockSweepTimer = setInterval(() => limiter.sweep(), SWEEP_INTERVAL_MS);
+    _unlockSweepTimer.unref?.();
+  }
   return _unlockLimiter;
 }
 
 export function getAiLimiter(): SlidingWindowLimiter {
-  if (!_aiLimiter) _aiLimiter = new SlidingWindowLimiter(20, 60_000);
+  if (!_aiLimiter) {
+    const limiter = new SlidingWindowLimiter(20, 60_000);
+    _aiLimiter = limiter;
+    _aiSweepTimer = setInterval(() => limiter.sweep(), SWEEP_INTERVAL_MS);
+    _aiSweepTimer.unref?.();
+  }
   return _aiLimiter;
 }
 
-/** Reset singletons (tests). */
+/** Reset singletons (tests). Also clears each singleton's sweep timer so repeated
+ *  reset+get cycles in a test suite don't stack up abandoned intervals. */
 export function resetLimiters(): void {
+  if (_unlockSweepTimer) clearInterval(_unlockSweepTimer);
+  if (_aiSweepTimer) clearInterval(_aiSweepTimer);
+  _unlockSweepTimer = null;
+  _aiSweepTimer = null;
   _unlockLimiter = null;
   _aiLimiter = null;
 }

--- a/companion/src/routes/casePassword.ts
+++ b/companion/src/routes/casePassword.ts
@@ -8,6 +8,7 @@ import {
   unlockCookieName,
   MIN_CASE_PASSWORD_LENGTH,
 } from "../analysis/casePassword.js";
+import { getUnlockLimiter } from "../http/rateLimiter.js";
 import type { RouteContext } from "./context.js";
 
 // Cookie TTLs for a case-unlock token. Moved verbatim from createApp (they were used only by the
@@ -57,14 +58,27 @@ export function registerCasePasswordRoutes(app: Express, ctx: RouteContext): voi
     try {
       const { id } = req.params;
       if (!isValidCaseId(id)) return res.status(400).json({ error: "invalid caseId" });
+      // Rate-limit brute-force attempts: after 5 failures, lockout with exponential backoff.
+      const limiter = getUnlockLimiter();
+      const remaining = limiter.remainingLockout(id);
+      if (remaining > 0) {
+        res.setHeader("Retry-After", String(Math.ceil(remaining / 1000)));
+        return res.status(429).json({ error: "too many failed attempts, try again later", retryAfterMs: remaining });
+      }
       const meta = await store.getCaseMeta(id);
       if (!meta) return res.status(404).json({ error: `case ${id} not found` });
       if (!meta.password) return res.status(200).json({ ok: true }); // nothing to unlock
       const password = (req.body as { password?: unknown })?.password;
       const remember = (req.body as { remember?: unknown })?.remember === true;
       if (typeof password !== "string" || !verifyCasePassword(password, meta.password)) {
+        const lockout = limiter.recordFailure(id);
+        if (lockout > 0) {
+          res.setHeader("Retry-After", String(Math.ceil(lockout / 1000)));
+          return res.status(429).json({ error: "too many failed attempts, locked out", retryAfterMs: lockout });
+        }
         return res.status(401).json({ error: "incorrect password" });
       }
+      limiter.clear(id);
       const ttl = remember ? UNLOCK_TTL_REMEMBER_MS : UNLOCK_TTL_SESSION_MS;
       const token = signUnlockToken(id, meta.password.salt, instanceSecret, ttl, remember);
       const cookieOpts: CookieOptions = { httpOnly: true, sameSite: "strict", path: "/" };

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -143,6 +143,7 @@ import { spawnToolRunner, type ToolRunner } from "./integrations/tools/toolRunne
 import { runToolAgainstFile, resolveContainedPath } from "./integrations/tools/runToolImport.js";
 import { CustomToolStore, customToolToConfig, normalizeExt, type CustomTool } from "./integrations/tools/customToolStore.js";
 import { createOriginGuard, parseAllowedOrigins } from "./http/originGuard.js";
+import { getAiLimiter } from "./http/rateLimiter.js";
 import { TemplateStore } from "./analysis/templateStore.js";
 import { diffTimeline, addedForensicEvents } from "./analysis/timelineDiff.js";
 import { diffIocs } from "./analysis/iocsDiff.js";
@@ -821,6 +822,18 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerPushNotifyRoutes(app, ctx);
   registerTemplatesViewsRoutes(app, ctx);
   registerToolsRoutes(app, ctx);
+
+  // Rate-limit AI-cost-bearing routes (import triggers synthesis, synthesize is explicit) to
+  // prevent an attacker who knows a caseId from burning the operator's AI budget. 20 requests
+  // per minute per case — generous for a single analyst, blocks a script hammering the endpoint.
+  const aiLimiter = getAiLimiter();
+  app.use("/cases/:id/import", aiLimiter.middleware((req) => req.params.id));
+  app.use("/cases/:id/import-file", aiLimiter.middleware((req) => req.params.id));
+  app.use("/cases/:id/import-csv", aiLimiter.middleware((req) => req.params.id));
+  app.use("/cases/:id/import-log", aiLimiter.middleware((req) => req.params.id));
+  app.use("/cases/:id/synthesize", aiLimiter.middleware((req) => req.params.id));
+  app.use("/cases/:id/deep-pass", aiLimiter.middleware((req) => req.params.id));
+
   registerImportRoutes(app, ctx);
   registerVelociraptorRoutes(app, ctx);
   registerThreatIntelRoutes(app, ctx);

--- a/companion/tests/http/rateLimiter.test.ts
+++ b/companion/tests/http/rateLimiter.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { AttemptLimiter, SlidingWindowLimiter, resetLimiters, getUnlockLimiter, getAiLimiter } from "../../src/http/rateLimiter.js";
+
+describe("AttemptLimiter", () => {
+  let limiter: AttemptLimiter;
+
+  beforeEach(() => {
+    limiter = new AttemptLimiter(3, 1000); // 3 attempts, 1s lockout
+  });
+
+  it("allows attempts below the threshold", () => {
+    expect(limiter.remainingLockout("key1")).toBe(0);
+    limiter.recordFailure("key1");
+    limiter.recordFailure("key1");
+    expect(limiter.remainingLockout("key1")).toBe(0); // not locked yet (3 is the threshold)
+  });
+
+  it("locks out after maxAttempts failures with exponential backoff", () => {
+    limiter.recordFailure("key1");
+    limiter.recordFailure("key1");
+    const lockout = limiter.recordFailure("key1");
+    expect(lockout).toBeGreaterThanOrEqual(1000);
+    expect(limiter.remainingLockout("key1")).toBeGreaterThan(0);
+  });
+
+  it("doubles the lockout on each subsequent cycle", () => {
+    // First lockout: 1s
+    limiter.recordFailure("k"); limiter.recordFailure("k"); let lock = limiter.recordFailure("k");
+    expect(lock).toBeGreaterThanOrEqual(1000);
+    // Clear lockout by advancing time
+    const future = Date.now() + lock + 1;
+    // Second cycle: 2s
+    limiter.recordFailure("k", future); limiter.recordFailure("k", future); lock = limiter.recordFailure("k", future);
+    expect(lock).toBeGreaterThanOrEqual(2000);
+  });
+
+  it("caps lockout at 10 minutes", () => {
+    const lim = new AttemptLimiter(1, 600_000);
+    lim.recordFailure("k");
+    // After many cycles, the lockout should be capped at 600_000 (10min)
+    let now = Date.now();
+    for (let i = 0; i < 20; i++) {
+      const lock = lim.recordFailure("k", now);
+      now += lock + 1;
+    }
+    const finalLock = lim.recordFailure("k", now);
+    expect(finalLock).toBeLessThanOrEqual(600_000);
+  });
+
+  it("clears the counter on success", () => {
+    limiter.recordFailure("key1");
+    limiter.recordFailure("key1");
+    limiter.clear("key1");
+    // After clear, the next 2 failures should not lock (counter reset)
+    limiter.recordFailure("key1");
+    limiter.recordFailure("key1");
+    expect(limiter.remainingLockout("key1")).toBe(0);
+  });
+
+  it("tracks keys independently", () => {
+    limiter.recordFailure("a");
+    limiter.recordFailure("a");
+    limiter.recordFailure("a");
+    expect(limiter.remainingLockout("a")).toBeGreaterThan(0);
+    expect(limiter.remainingLockout("b")).toBe(0);
+  });
+});
+
+describe("SlidingWindowLimiter", () => {
+  it("allows requests up to the cap", () => {
+    const lim = new SlidingWindowLimiter(5, 10_000);
+    expect(lim.tryAcquire("k")).toBe(true);
+    expect(lim.tryAcquire("k")).toBe(true);
+    expect(lim.tryAcquire("k")).toBe(true);
+    expect(lim.tryAcquire("k")).toBe(true);
+    expect(lim.tryAcquire("k")).toBe(true);
+  });
+
+  it("rejects requests past the cap", () => {
+    const lim = new SlidingWindowLimiter(3, 10_000);
+    lim.tryAcquire("k"); lim.tryAcquire("k"); lim.tryAcquire("k");
+    expect(lim.tryAcquire("k")).toBe(false);
+  });
+
+  it("resets after the window expires", () => {
+    const lim = new SlidingWindowLimiter(2, 100);
+    const now = Date.now();
+    lim.tryAcquire("k", now); lim.tryAcquire("k", now);
+    expect(lim.tryAcquire("k", now)).toBe(false);
+    // After the window, it should reset
+    expect(lim.tryAcquire("k", now + 200)).toBe(true);
+  });
+
+  it("tracks keys independently", () => {
+    const lim = new SlidingWindowLimiter(1, 10_000);
+    expect(lim.tryAcquire("a")).toBe(true);
+    expect(lim.tryAcquire("a")).toBe(false);
+    expect(lim.tryAcquire("b")).toBe(true);
+  });
+});
+
+describe("limiter singletons", () => {
+  beforeEach(() => resetLimiters());
+
+  it("getUnlockLimiter returns a shared instance", () => {
+    const a = getUnlockLimiter();
+    const b = getUnlockLimiter();
+    expect(a).toBe(b);
+  });
+
+  it("getAiLimiter returns a shared instance", () => {
+    const a = getAiLimiter();
+    const b = getAiLimiter();
+    expect(a).toBe(b);
+  });
+
+  it("resetLimiters creates fresh instances", () => {
+    const a = getUnlockLimiter();
+    resetLimiters();
+    const b = getUnlockLimiter();
+    expect(a).not.toBe(b);
+  });
+});

--- a/companion/tests/http/rateLimiter.test.ts
+++ b/companion/tests/http/rateLimiter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { AttemptLimiter, SlidingWindowLimiter, resetLimiters, getUnlockLimiter, getAiLimiter } from "../../src/http/rateLimiter.js";
 
 describe("AttemptLimiter", () => {
@@ -23,15 +23,39 @@ describe("AttemptLimiter", () => {
     expect(limiter.remainingLockout("key1")).toBeGreaterThan(0);
   });
 
-  it("doubles the lockout on each subsequent cycle", () => {
-    // First lockout: 1s
-    limiter.recordFailure("k"); limiter.recordFailure("k"); let lock = limiter.recordFailure("k");
-    expect(lock).toBeGreaterThanOrEqual(1000);
-    // Clear lockout by advancing time
-    const future = Date.now() + lock + 1;
-    // Second cycle: 2s
-    limiter.recordFailure("k", future); limiter.recordFailure("k", future); lock = limiter.recordFailure("k", future);
-    expect(lock).toBeGreaterThanOrEqual(2000);
+  it("doubles the lockout on each SINGLE subsequent failure once already locked out once", () => {
+    // First lockout requires the full maxAttempts (3) failures: 1s
+    limiter.recordFailure("k"); limiter.recordFailure("k");
+    let lock = limiter.recordFailure("k");
+    expect(lock).toBe(1000);
+    // After the first lockout, a SINGLE further failure immediately re-locks — no free guesses —
+    // and doubles the duration each time. This is what the real /unlock route relies on: it only
+    // ever calls recordFailure once per real-world retry (it skips the call entirely while
+    // remainingLockout() is still positive), so the escalation must happen on failure #1 of each
+    // cycle, not require maxAttempts MORE failures to build back up.
+    lock = limiter.recordFailure("k", Date.now() + lock + 1);
+    expect(lock).toBe(2000);
+    lock = limiter.recordFailure("k", Date.now() + lock + 1);
+    expect(lock).toBe(4000);
+  });
+
+  it("matches the real /unlock route's call pattern: one recordFailure per wait-then-retry cycle", () => {
+    // Reproduces #244's actual wiring (casePassword.ts only calls recordFailure when NOT already
+    // locked — a locked request short-circuits to 429 before ever reaching it) to guard against
+    // the escalation silently degrading to "doubles every maxAttempts cumulative failures" again
+    // (which stayed flat at the FIRST lockout duration for `maxAttempts` real-world retries).
+    const lim = new AttemptLimiter(5, 30_000);
+    let now = 0;
+    const lockouts: number[] = [];
+    for (let i = 0; i < 15; i++) {
+      const remaining = lim.remainingLockout("c1", now);
+      if (remaining > 0) { now += remaining; continue; }
+      const lockout = lim.recordFailure("c1", now);
+      if (lockout > 0) lockouts.push(lockout);
+    }
+    // 5 failures to arm the first lockout, then every SINGLE further real attempt re-locks and
+    // doubles: 30s, 60s, 120s, 240s, 480s, 600s(capped)...
+    expect(lockouts.slice(0, 6)).toEqual([30_000, 60_000, 120_000, 240_000, 480_000, 600_000]);
   });
 
   it("caps lockout at 10 minutes", () => {
@@ -63,6 +87,35 @@ describe("AttemptLimiter", () => {
     limiter.recordFailure("a");
     expect(limiter.remainingLockout("a")).toBeGreaterThan(0);
     expect(limiter.remainingLockout("b")).toBe(0);
+  });
+
+  // #244 shipped with no key eviction at all: this limiter runs BEFORE any caseId-existence
+  // check (it gates /unlock itself), so a stream of distinct garbage/enumerated caseIds grows
+  // its Map forever on a long-running server. sweep() bounds that.
+  describe("sweep (memory bound against an unbounded key stream)", () => {
+    it("removes an entry that has been idle past maxIdleMs", () => {
+      limiter.recordFailure("stale-key", 0);
+      const removed = limiter.sweep(3_600_001, 3_600_000); // 1ms past the 1h default idle window
+      expect(removed).toBe(1);
+      expect(limiter.remainingLockout("stale-key", 3_600_001)).toBe(0);
+    });
+
+    it("keeps a recently-active entry, including one still mid-lockout", () => {
+      limiter.recordFailure("k", 0); limiter.recordFailure("k", 0);
+      limiter.recordFailure("k", 0); // 3rd failure, locks for 1000ms starting at t=0
+      const removed = limiter.sweep(500, 3_600_000); // mid-lockout, well within the idle window too
+      expect(removed).toBe(0);
+      expect(limiter.remainingLockout("k", 500)).toBeGreaterThan(0);
+    });
+
+    it("does not disturb unrelated keys", () => {
+      limiter.recordFailure("stale", 0);
+      limiter.recordFailure("fresh", 5_000_000);
+      limiter.sweep(5_000_000, 3_600_000); // "stale" is idle-expired, "fresh" was just touched
+      expect(limiter.remainingLockout("fresh", 5_000_000)).toBe(0); // still tracked, just not locked (1 failure)
+      limiter.recordFailure("fresh", 5_000_000);
+      expect(limiter.remainingLockout("fresh", 5_000_000)).toBe(0); // 2 failures total, not yet the 3-failure threshold
+    });
   });
 });
 
@@ -97,10 +150,34 @@ describe("SlidingWindowLimiter", () => {
     expect(lim.tryAcquire("a")).toBe(false);
     expect(lim.tryAcquire("b")).toBe(true);
   });
+
+  // #244 shipped with no key eviction: this limiter runs BEFORE any caseId-existence check (it
+  // gates /import et al. via a bare app.use), so a stream of distinct garbage/enumerated caseIds
+  // grows its Map forever on a long-running server. sweep() bounds that.
+  describe("sweep (memory bound against an unbounded key stream)", () => {
+    it("removes a window that has fully expired", () => {
+      const lim = new SlidingWindowLimiter(5, 1000);
+      lim.tryAcquire("stale", 0);
+      const removed = lim.sweep(1001); // 1ms past window end
+      expect(removed).toBe(1);
+    });
+
+    it("keeps a window still in progress", () => {
+      const lim = new SlidingWindowLimiter(5, 1000);
+      lim.tryAcquire("active", 0);
+      const removed = lim.sweep(500); // still within the window
+      expect(removed).toBe(0);
+      // proves it wasn't swept: the count is still tracked, not reset to a fresh window of 1
+      lim.tryAcquire("active", 500); lim.tryAcquire("active", 500);
+      lim.tryAcquire("active", 500); lim.tryAcquire("active", 500);
+      expect(lim.tryAcquire("active", 500)).toBe(false); // 6th request in the SAME window over cap 5
+    });
+  });
 });
 
 describe("limiter singletons", () => {
   beforeEach(() => resetLimiters());
+  afterEach(() => resetLimiters()); // release the sweep timers started by tests above
 
   it("getUnlockLimiter returns a shared instance", () => {
     const a = getUnlockLimiter();


### PR DESCRIPTION
## Summary

Fixes #244

No rate limiting existed anywhere in the codebase. `POST /cases/:id/unlock` had no attempt counter, lockout, or delay — `scryptSync` (~10 req/s) was the only throttle, and a weak dictionary password was reachable by brute force. Import and synthesize routes had no rate limit, so an attacker who knew a `caseId` could trigger unlimited paid AI synthesis calls.

## Changes

Two lightweight in-memory limiters (no external dependencies) in `src/http/rateLimiter.ts`:

1. **`AttemptLimiter`** — per-case exponential backoff on `/unlock`:
   - 5 failures → 30s lockout, doubling each cycle up to 10min
   - Returns `429` with `Retry-After` header
   - Cleared on successful unlock
2. **`SlidingWindowLimiter`** — per-case 20 req/min on `/import`, `/import-file`, `/import-csv`, `/import-log`, `/synthesize`, `/deep-pass`
   - Returns `429` when exceeded

Wiring:
- `casePassword.ts` — `getUnlockLimiter()` integrated into the `/unlock` handler
- `server.ts` — `getAiLimiter().middleware()` mounted before import/synthesis route registration

13 unit tests covering both limiters + singleton lifecycle.

## Test plan

- [x] `npx vitest run tests/http/rateLimiter.test.ts` — 13 passed
- [x] `npx vitest run tests/analysis/caseLockGate.test.ts` — 8 passed
- [x] `npx vitest run tests/server/pushRoute.test.ts` — 11 passed
- [x] `npx vitest run tests/server/ocrSearchRoute.test.ts` — 7 passed
- [x] `npx tsc --noEmit` — clean