### PR TITLE
fix(security): redact casesRoot in diagnostics and remove pushTokenGlobal from /health (#250)

### DIFF
--- a/companion/src/analysis/diagnostics.ts
+++ b/companion/src/analysis/diagnostics.ts
@@ -284,7 +284,7 @@ export function buildDiagnosticsText(r: DiagnosticsReport): string {
   lines.push("=== DFIR Companion — Diagnostics ===");
   lines.push(`generated:   ${r.generatedAt}`);
   lines.push(`uptime:      ${formatAge(r.uptimeMs)}`);
-  lines.push(`cases root:  ${r.casesRoot}`);
+  lines.push(`cases root:  <redacted>`);  // never expose the absolute path — reconnaissance surface
   lines.push("");
   lines.push("-- Disk --");
   lines.push(

--- a/companion/src/analysis/diagnostics.ts
+++ b/companion/src/analysis/diagnostics.ts
@@ -251,10 +251,12 @@ export interface DiskDiagnostics extends DiskStats {
   thresholds: DiskWarnThresholds;
 }
 
+// NOTE: deliberately carries NO casesRoot / absolute filesystem path (#250). /diagnostics is an
+// unauthenticated route, so the cases-root path would be free reconnaissance for any file-targeting
+// attack. The operator configured DFIR_CASES_ROOT and already knows it; the client never needs it.
 export interface DiagnosticsReport {
   generatedAt: string; // ISO-8601
   uptimeMs: number;
-  casesRoot: string;
   disk: DiskDiagnostics;
   cases: { count: number; open: number; closed: number; archived: number };
   queue: QueueDiagnostics;
@@ -284,7 +286,6 @@ export function buildDiagnosticsText(r: DiagnosticsReport): string {
   lines.push("=== DFIR Companion — Diagnostics ===");
   lines.push(`generated:   ${r.generatedAt}`);
   lines.push(`uptime:      ${formatAge(r.uptimeMs)}`);
-  lines.push(`cases root:  <redacted>`);  // never expose the absolute path — reconnaissance surface
   lines.push("");
   lines.push("-- Disk --");
   lines.push(

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -230,7 +230,6 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
       const report: DiagnosticsReport = {
         generatedAt: new Date(now).toISOString(),
         uptimeMs: now - appStartedAt,
-        casesRoot: "<redacted>",  // never expose the absolute filesystem path — reconnaissance surface
         disk,
         cases: { count: cases.length, open, closed: cases.length - open - archived, archived },
         queue: {

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -81,7 +81,7 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
     const irisClient = ctx.irisClient();
     const dropWatchEnabled = ctx.dropWatchEnabled();
     const importerRegistry = ctx.importerRegistry();
-    res.status(200).json({ ok: true, service: "dfir-companion", aiEnabled: hasAiProvider(), synthesisEnabled: !!options.pipeline?.hasSynthesisProvider(), enrichEnabled: (options.enrichmentProviders?.length ?? 0) > 0, customerExposureEnabled: (options.customerExposureProviders?.length ?? 0) > 0, velociraptorEnabled: !!options.velociraptorClient, irisEnabled: !!irisClient, timesketchEnabled: !!options.timesketchClient, notionEnabled: !!options.notionClient, clickupEnabled: !!options.clickupClient, notificationsEnabled: !!options.notificationStore, notifyEmailEnabled: !!options.notifyEmailEnabled, pushEnabled: !!options.pushTokenStore || !!(options.pushToken && options.pushToken.trim()), pushTokenGlobal: !!(options.pushToken && options.pushToken.trim()), huntPlatforms: options.huntPlatforms ?? [...HUNT_PLATFORMS], logLevel: serverLogger.getLevel(), kevEnabled: !!options.kevStore, secondOpinionEnabled: !!options.secondOpinionEnabled, dropEnabled: dropWatchEnabled && !!options.dropStatusStore, toolsEnabled: !!options.toolRunner, customImporters: importerRegistry.importers.size, updateCheckLocked: resolveUpdateMode(options.updateCheckEnv, undefined).locked, geoMapTileUrl: process.env.DFIR_GEOMAP_TILE_URL || "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" });
+    res.status(200).json({ ok: true, service: "dfir-companion", aiEnabled: hasAiProvider(), synthesisEnabled: !!options.pipeline?.hasSynthesisProvider(), enrichEnabled: (options.enrichmentProviders?.length ?? 0) > 0, customerExposureEnabled: (options.customerExposureProviders?.length ?? 0) > 0, velociraptorEnabled: !!options.velociraptorClient, irisEnabled: !!irisClient, timesketchEnabled: !!options.timesketchClient, notionEnabled: !!options.notionClient, clickupEnabled: !!options.clickupClient, notificationsEnabled: !!options.notificationStore, notifyEmailEnabled: !!options.notifyEmailEnabled, pushEnabled: !!options.pushTokenStore || !!(options.pushToken && options.pushToken.trim()), huntPlatforms: options.huntPlatforms ?? [...HUNT_PLATFORMS], logLevel: serverLogger.getLevel(), kevEnabled: !!options.kevStore, secondOpinionEnabled: !!options.secondOpinionEnabled, dropEnabled: dropWatchEnabled && !!options.dropStatusStore, toolsEnabled: !!options.toolRunner, customImporters: importerRegistry.importers.size, updateCheckLocked: resolveUpdateMode(options.updateCheckEnv, undefined).locked, geoMapTileUrl: process.env.DFIR_GEOMAP_TILE_URL || "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" });
   });
 
   // ── Update check (opt-in "newer release available" notice; NEVER downloads) ──────────────
@@ -230,7 +230,7 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
       const report: DiagnosticsReport = {
         generatedAt: new Date(now).toISOString(),
         uptimeMs: now - appStartedAt,
-        casesRoot: store.casesRoot,
+        casesRoot: "<redacted>",  // never expose the absolute filesystem path — reconnaissance surface
         disk,
         cases: { count: cases.length, open, closed: cases.length - open - archived, archived },
         queue: {

--- a/companion/tests/analysis/diagnostics.test.ts
+++ b/companion/tests/analysis/diagnostics.test.ts
@@ -164,7 +164,6 @@ function sampleReport(): DiagnosticsReport {
   return {
     generatedAt: "2026-06-17T00:00:00.000Z",
     uptimeMs: 3 * 60 * 60 * 1000,
-    casesRoot: "/data/cases",
     disk: {
       totalBytes: 1024 * 1024 * 1024 * 1024,
       freeBytes: 512 * 1024 * 1024 * 1024,

--- a/companion/tests/server/diagnostics.test.ts
+++ b/companion/tests/server/diagnostics.test.ts
@@ -72,6 +72,20 @@ describe("GET /diagnostics", () => {
       delete process.env.DFIR_AI_KEY;
     }
   });
+
+  // #250: /diagnostics is unauthenticated, so the absolute cases-root path must never reach the
+  // client — it is free reconnaissance for a file-targeting attack (symlink, env injection).
+  // Asserted against the whole payload, not a named field, so reintroducing the path under ANY
+  // key (or interpolated into the text blob) fails here.
+  it("NEVER leaks the absolute cases-root path into the diagnostics payload", async () => {
+    const app = createApp(store, {});
+    const res = await request(app).get("/diagnostics");
+    expect(res.status).toBe(200);
+    expect(res.body.report).not.toHaveProperty("casesRoot");
+    expect(JSON.stringify(res.body)).not.toContain(root);
+    expect(res.body.text).not.toContain(root);
+    expect(res.body.text).not.toContain("cases root");
+  });
 });
 
 describe("GET /diagnostics/sizes", () => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -20149,7 +20149,6 @@
         diagRow("Free", `${diagFmtBytes(d.freeBytes)} of ${diagFmtBytes(d.totalBytes)}`),
         diagRow("Used", `${(d.usedPct || 0).toFixed(1)}%`, lvlColor),
         diagRow("Status", esc(d.level), lvlColor),
-        diagRow("Cases root", `<code>${esc(report.casesRoot)}</code>`),
       ].join(""));
       const cs = report.cases;
       const cases = diagCard("Cases", diagRow("Total", `${cs.count} (${cs.open} open, ${cs.closed} closed)`));


### PR DESCRIPTION
## Summary

Fixes #250

`GET /diagnostics` exposed `store.casesRoot` (the absolute filesystem path to the cases directory) — reconnaissance surface for any file-targeting attack (symlink, env injection). `GET /health` exposed `pushTokenGlobal` — useful for an attacker triaging which endpoints to target.

## Changes

- **`/diagnostics`**: redact `casesRoot` to `"<redacted>"` in both the JSON report and the text builder. The operator already knows the path (they configured it); the client doesn't need it.
- **`/health`**: remove `pushTokenGlobal` from the response. `pushEnabled` is sufficient for the dashboard.

## Test plan

- [x] `npx vitest run tests/server/diagnostics.test.ts` — 8 passed
- [x] `npx tsc --noEmit` — clean