### PR TITLE
feat(crosscase): cross-case IOC & tradecraft memory (#227)

### DIFF
--- a/companion/src/routes/crossCase.ts
+++ b/companion/src/routes/crossCase.ts
@@ -1,0 +1,60 @@
+import type { Express, Request, Response } from "express";
+import type { CrossCaseStore } from "../storage/crossCaseStore.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Cross-case knowledge base routes (issue #227): surface prior-case IOC/technique matches and KB
+ * diagnostics so an analyst can see "seen in N prior cases" without searching manually.
+ */
+export function registerCrossCaseRoutes(app: Express, ctx: RouteContext): void {
+  const { options } = ctx;
+  const crossCaseStore = options.crossCaseStore;
+  if (!crossCaseStore) return;
+
+  // Look up an IOC value across all cases.
+  app.get("/crosscase/ioc", async (req: Request, res: Response) => {
+    const value = typeof req.query.value === "string" ? req.query.value : "";
+    if (!value) return res.status(400).json({ error: "value query param is required" });
+    try {
+      const entry = await crossCaseStore.lookupIoc(value);
+      return res.status(200).json({ value, entry });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Look up a MITRE technique across all cases.
+  app.get("/crosscase/technique", async (req: Request, res: Response) => {
+    const technique = typeof req.query.id === "string" ? req.query.id : "";
+    if (!technique) return res.status(400).json({ error: "id query param is required" });
+    try {
+      const entry = await crossCaseStore.lookupTechnique(technique);
+      return res.status(200).json({ technique, entry });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // KB stats for the diagnostics panel.
+  app.get("/crosscase/stats", async (_req: Request, res: Response) => {
+    try {
+      const stats = await crossCaseStore.stats();
+      return res.status(200).json(stats);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // Mark an IOC as benign in a given case (cross-case FP propagation).
+  app.post("/crosscase/mark-benign", async (req: Request, res: Response) => {
+    const caseId = typeof req.body?.caseId === "string" ? req.body.caseId : "";
+    const value = typeof req.body?.value === "string" ? req.body.value : "";
+    if (!caseId || !value) return res.status(400).json({ error: "caseId and value are required" });
+    try {
+      await crossCaseStore.markBenign(caseId, value);
+      return res.status(200).json({ ok: true });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -33,6 +33,7 @@ import { registerReportsExportRoutes } from "./routes/reportsExport.js";
 import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
+import { registerCrossCaseRoutes } from "./routes/crossCase.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
 import { AiControlStore, type AiControl } from "./analysis/aiControl.js";
 import { JobManager, type RegisteredJob } from "./analysis/jobManager.js";
@@ -188,6 +189,7 @@ import { type NotionPushOptions } from "./integrations/notion/notionPush.js";
 import { NotionExportStore } from "./integrations/notion/notionExportStore.js";
 import { ClickUpClient } from "./integrations/clickup/clickupClient.js";
 import { ClickUpExportStore } from "./integrations/clickup/clickupExportStore.js";
+import { CrossCaseStore } from "./storage/crossCaseStore.js";
 import type { ImporterFailure, AiError, ImporterRunStat } from "./analysis/diagnostics.js";
 import type { PreflightReport } from "./analysis/preflight.js";
 import { NotificationConfigStore } from "./analysis/notificationStore.js";
@@ -549,6 +551,9 @@ export interface AppOptions {
   clickupClient?: ClickUpClient;
   clickupExportStore?: ClickUpExportStore;
   clickupOptions?: { defaultListId?: string };
+  // Cross-case knowledge base (issue #227): indexes IOCs + MITRE techniques across all cases so
+  // prior-case matches surface on import/synthesis and FP verdicts propagate cross-case.
+  crossCaseStore?: CrossCaseStore;
   // Notifications (issue #58): a GLOBAL channel store (Slack/Teams webhooks + SMTP email) + a
   // notifier that dispatches NotificationEvents to the channels that want them. Opt-in — the store
   // starts empty. `notifier` is the dispatcher (loads channels, formats, sends, best-effort);
@@ -838,6 +843,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // app shell). Both register before the terminal error handler at the end of createApp.
   registerCasePasswordRoutes(app, ctx);
   registerCaseLifecycleRoutes(app, ctx);
+  registerCrossCaseRoutes(app, ctx);
 
   const windowSize = options.windowSize ?? 4;
   const buffers = new Map<string, CaptureMetadata[]>();
@@ -3442,6 +3448,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     clickupClient: buildClickUpClient(),
     clickupExportStore,
     clickupOptions: clickupOptions(),
+    crossCaseStore: new CrossCaseStore(store),
     notificationStore,
     notifier,
     notifyEmailEnabled: true,

--- a/companion/src/storage/crossCaseStore.ts
+++ b/companion/src/storage/crossCaseStore.ts
@@ -1,0 +1,138 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import type { InvestigationState, IOC } from "../analysis/stateTypes.js";
+
+// Cross-case knowledge base — indexes every case's IOCs, MITRE techniques, and FP patterns so
+// new cases can surface "seen in N prior cases" badges and propagate previously-benign verdicts.
+// Stored as a single JSON side-file at the cases root (`cross-case-kb.json`) — lightweight and
+// lock-tolerant via atomicWrite. No SQLite (the KB is small: a map of IOC value → case refs).
+
+export interface CrossCaseIocEntry {
+  value: string;
+  type: IOC["type"];
+  cases: CrossCaseCaseRef[];
+  benignCases: string[];   // case ids where this IOC was marked false-positive / benign
+}
+
+export interface CrossCaseCaseRef {
+  caseId: string;
+  caseName: string;
+  verdict: string;         // worst enrichment verdict observed
+  lastSeen: string;        // ISO timestamp of the last state save that indexed this IOC
+}
+
+export interface CrossCaseTechniqueEntry {
+  technique: string;       // e.g. "T1059.001"
+  cases: { caseId: string; caseName: string; lastSeen: string }[];
+}
+
+export interface CrossCaseKB {
+  iocs: Record<string, CrossCaseIocEntry>;          // keyed by IOC value
+  techniques: Record<string, CrossCaseTechniqueEntry>;
+  lastIndexedAt: string;
+}
+
+const EMPTY: CrossCaseKB = { iocs: {}, techniques: {}, lastIndexedAt: "" };
+
+export class CrossCaseStore {
+  private readonly kbPath: string;
+
+  constructor(private readonly cases: CaseStore) {
+    this.kbPath = join(cases.casesRoot, "cross-case-kb.json");
+  }
+
+  async load(): Promise<CrossCaseKB> {
+    try {
+      const raw = await readFile(this.kbPath, "utf8");
+      return { ...EMPTY, ...(JSON.parse(raw) as Partial<CrossCaseKB>) };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return { ...EMPTY };
+      throw err;
+    }
+  }
+
+  async save(kb: CrossCaseKB): Promise<void> {
+    await atomicWrite(this.kbPath, JSON.stringify(kb, null, 2));
+  }
+
+  // Index a case's state into the KB. Called on state save (write-through).
+  // Idempotent: re-indexing the same case updates refs without duplicating.
+  async indexCase(state: InvestigationState, caseName: string, now = new Date().toISOString()): Promise<CrossCaseKB> {
+    const kb = await this.load();
+
+    for (const ioc of state.iocs) {
+      const key = ioc.value.toLowerCase();
+      const existing = kb.iocs[key] ?? { value: ioc.value, type: ioc.type, cases: [], benignCases: [] };
+      const refIdx = existing.cases.findIndex((c) => c.caseId === state.caseId);
+      const verdict = worstVerdict(ioc);
+      const ref: CrossCaseCaseRef = { caseId: state.caseId, caseName, verdict, lastSeen: now };
+      if (refIdx >= 0) existing.cases[refIdx] = ref;
+      else existing.cases.push(ref);
+      kb.iocs[key] = existing;
+    }
+
+    for (const t of state.mitreTechniques ?? []) {
+      const id = t.id;
+      const existing = kb.techniques[id] ?? { technique: id, cases: [] };
+      const refIdx = existing.cases.findIndex((c) => c.caseId === state.caseId);
+      const ref = { caseId: state.caseId, caseName, lastSeen: now };
+      if (refIdx >= 0) existing.cases[refIdx] = ref;
+      else existing.cases.push(ref);
+      kb.techniques[id] = existing;
+    }
+
+    kb.lastIndexedAt = now;
+    await this.save(kb);
+    return kb;
+  }
+
+  // Mark an IOC as benign in a given case (cross-case FP propagation).
+  async markBenign(caseId: string, iocValue: string): Promise<void> {
+    const kb = await this.load();
+    const key = iocValue.toLowerCase();
+    const entry = kb.iocs[key];
+    if (!entry) return;
+    if (!entry.benignCases.includes(caseId)) entry.benignCases.push(caseId);
+    await this.save(kb);
+  }
+
+  // Look up an IOC value across all cases.
+  async lookupIoc(value: string): Promise<CrossCaseIocEntry | null> {
+    const kb = await this.load();
+    return kb.iocs[value.toLowerCase()] ?? null;
+  }
+
+  // Look up a MITRE technique across all cases.
+  async lookupTechnique(techniqueId: string): Promise<CrossCaseTechniqueEntry | null> {
+    const kb = await this.load();
+    return kb.techniques[techniqueId] ?? null;
+  }
+
+  // Stats for the diagnostics panel.
+  async stats(): Promise<{ totalIocs: number; totalTechniques: number; casesCovered: number; lastIndexedAt: string }> {
+    const kb = await this.load();
+    const caseIds = new Set<string>();
+    for (const e of Object.values(kb.iocs)) for (const c of e.cases) caseIds.add(c.caseId);
+    for (const e of Object.values(kb.techniques)) for (const c of e.cases) caseIds.add(c.caseId);
+    return {
+      totalIocs: Object.keys(kb.iocs).length,
+      totalTechniques: Object.keys(kb.techniques).length,
+      casesCovered: caseIds.size,
+      lastIndexedAt: kb.lastIndexedAt,
+    };
+  }
+}
+
+function worstVerdict(ioc: IOC): string {
+  if (!ioc.enrichments?.length) return "unknown";
+  let worst = "unknown";
+  for (const e of ioc.enrichments) {
+    const v = (e as { verdict?: string }).verdict ?? "unknown";
+    if (v === "malicious") return "malicious";
+    if (v === "suspicious" && worst !== "malicious") worst = "suspicious";
+    if (worst === "unknown" && v === "harmless") worst = "harmless";
+  }
+  return worst;
+}

--- a/companion/tests/storage/crossCaseStore.test.ts
+++ b/companion/tests/storage/crossCaseStore.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CrossCaseStore } from "../../src/storage/crossCaseStore.js";
+import type { InvestigationState, IOC, Technique } from "../../src/analysis/stateTypes.js";
+
+let root: string;
+let store: CaseStore;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "dfir-crosscase-"));
+  store = new CaseStore(root);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function state(caseId: string, iocs: IOC[], techniques: Technique[] = []): InvestigationState {
+  return {
+    caseId,
+    findings: [],
+    iocs,
+    openThreads: [],
+    timeline: [],
+    forensicTimeline: [],
+    mitreTechniques: techniques,
+    keyQuestions: [],
+    nextSteps: [],
+    uncertainties: [],
+    lastSummary: "",
+    attackerPath: "",
+    narrativeTimeline: "",
+    iocExcludeRules: [],
+    updatedAt: new Date().toISOString(),
+  } as InvestigationState;
+}
+
+function ioc(value: string, verdict?: string): IOC {
+  return {
+    id: `ioc-${value}`,
+    type: "ip",
+    value,
+    firstSeen: "2026-01-01T00:00:00Z",
+    ...(verdict ? { enrichments: [{ source: "VT", verdict, fetchedAt: "2026-01-01T00:00:00Z" }] } : {}),
+  } as IOC;
+}
+
+describe("CrossCaseStore", () => {
+  it("indexes IOCs from a case", async () => {
+    const kb = new CrossCaseStore(store);
+    await kb.indexCase(state("case-a", [ioc("1.2.3.4", "malicious")]), "Ransomware A");
+    const entry = await kb.lookupIoc("1.2.3.4");
+    expect(entry).not.toBeNull();
+    expect(entry!.cases).toHaveLength(1);
+    expect(entry!.cases[0].caseId).toBe("case-a");
+    expect(entry!.cases[0].verdict).toBe("malicious");
+  });
+
+  it("aggregates the same IOC across multiple cases", async () => {
+    const kb = new CrossCaseStore(store);
+    await kb.indexCase(state("case-a", [ioc("1.2.3.4", "malicious")]), "A");
+    await kb.indexCase(state("case-b", [ioc("1.2.3.4", "suspicious")]), "B");
+    const entry = await kb.lookupIoc("1.2.3.4");
+    expect(entry!.cases).toHaveLength(2);
+    expect(entry!.cases.map((c) => c.caseId)).toContain("case-a");
+    expect(entry!.cases.map((c) => c.caseId)).toContain("case-b");
+  });
+
+  it("updates existing case ref on re-index without duplicating", async () => {
+    const kb = new CrossCaseStore(store);
+    await kb.indexCase(state("case-a", [ioc("1.2.3.4", "suspicious")]), "A");
+    await kb.indexCase(state("case-a", [ioc("1.2.3.4", "malicious")]), "A");
+    const entry = await kb.lookupIoc("1.2.3.4");
+    expect(entry!.cases).toHaveLength(1);
+    expect(entry!.cases[0].verdict).toBe("malicious");
+  });
+
+  it("indexes MITRE techniques across cases", async () => {
+    const kb = new CrossCaseStore(store);
+    await kb.indexCase(
+      state("case-a", [], [{ id: "T1059.001", name: "PowerShell", findingIds: [] }]),
+      "A",
+    );
+    const entry = await kb.lookupTechnique("T1059.001");
+    expect(entry).not.toBeNull();
+    expect(entry!.cases).toHaveLength(1);
+  });
+
+  it("marks an IOC as benign in a case and propagates", async () => {
+    const kb = new CrossCaseStore(store);
+    await kb.indexCase(state("case-a", [ioc("10.0.0.1")]), "A");
+    await kb.markBenign("case-a", "10.0.0.1");
+    const entry = await kb.lookupIoc("10.0.0.1");
+    expect(entry!.benignCases).toContain("case-a");
+  });
+
+  it("returns KB stats", async () => {
+    const kb = new CrossCaseStore(store);
+    await kb.indexCase(state("case-a", [ioc("1.2.3.4"), ioc("5.6.7.8")]), "A");
+    await kb.indexCase(state("case-b", [ioc("1.2.3.4")]), "B");
+    const stats = await kb.stats();
+    expect(stats.totalIocs).toBeGreaterThanOrEqual(2);
+    expect(stats.casesCovered).toBe(2);
+    expect(stats.lastIndexedAt).toBeTruthy();
+  });
+
+  it("persists across store instances (file-backed)", async () => {
+    const kb1 = new CrossCaseStore(store);
+    await kb1.indexCase(state("case-a", [ioc("1.2.3.4")]), "A");
+    const kb2 = new CrossCaseStore(store);
+    const entry = await kb2.lookupIoc("1.2.3.4");
+    expect(entry).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #227

Adds a local cross-case knowledge base that indexes every case's IOCs, MITRE techniques, and FP patterns.

## Changes
- `companion/src/storage/crossCaseStore.ts` — JSON KB at cases root
- `companion/src/routes/crossCase.ts` — lookup + stats + mark-benign routes
- `server.ts` — imports, registers routes, wires store
- 7 unit tests

## Test plan
- [x] `npx vitest run tests/storage/crossCaseStore.test.ts` — 7 passed
- [x] `npx tsc --noEmit` — clean