### PR TITLE
feat(palette): command palette with fuzzy search (#238)

### DIFF
--- a/companion/src/analysis/commandPalette.ts
+++ b/companion/src/analysis/commandPalette.ts
@@ -1,0 +1,162 @@
+import type { InvestigationState } from "./stateTypes.js";
+
+export type PaletteCategory = "Navigation" | "Actions" | "Exports" | "Settings" | "Case";
+
+export interface PaletteAction {
+  id: string;
+  label: string;
+  keywords?: string[];
+  category: PaletteCategory;
+  run?: (caseId: string) => void;
+  available?: (caseState: InvestigationState) => boolean;
+}
+
+const CATEGORY_ORDER: PaletteCategory[] = ["Navigation", "Actions", "Exports", "Settings", "Case"];
+
+export function buildActionRegistry(): Record<PaletteCategory, PaletteAction[]> {
+  const registry: Record<PaletteCategory, PaletteAction[]> = {
+    Navigation: [],
+    Actions: [],
+    Exports: [],
+    Settings: [],
+    Case: [],
+  };
+
+  const navActions: PaletteAction[] = [
+    { id: "nav.findings", label: "Go to Findings", keywords: ["findings", "alerts"], category: "Navigation" },
+    { id: "nav.iocs", label: "Go to IOCs", keywords: ["ioc", "indicators"], category: "Navigation" },
+    { id: "nav.timeline", label: "Go to Timeline", keywords: ["timeline", "events"], category: "Navigation" },
+    { id: "nav.assetGraph", label: "Go to Asset Graph", keywords: ["asset", "graph"], category: "Navigation" },
+    { id: "nav.attackerPath", label: "Go to Attacker Path", keywords: ["attacker", "path", "narrative"], category: "Navigation" },
+    { id: "nav.questions", label: "Go to Key Questions", keywords: ["questions", "hypotheses"], category: "Navigation" },
+  ];
+
+  const actionActions: PaletteAction[] = [
+    { id: "act.import", label: "Import Evidence", keywords: ["import", "ingest", "upload"], category: "Actions" },
+    { id: "act.synthesize", label: "Re-run Synthesis", keywords: ["synthesize", "ai", "analysis"], category: "Actions", available: (s) => s.findings.length > 0 },
+    { id: "act.enrich", label: "Enrich IOCs", keywords: ["enrich", "threatintel", "lookup"], category: "Actions", available: (s) => s.iocs.length > 0 },
+    { id: "act.tag", label: "Run Tagger", keywords: ["tag", "tagger", "label"], category: "Actions" },
+    { id: "act.addFinding", label: "Add Finding", keywords: ["finding", "add", "manual"], category: "Actions" },
+    { id: "act.addIoc", label: "Add IOC", keywords: ["ioc", "add", "manual"], category: "Actions" },
+    { id: "act.addEvent", label: "Add Forensic Event", keywords: ["event", "manual", "timeline"], category: "Actions" },
+    { id: "act.mergeIocs", label: "Merge IOCs", keywords: ["merge", "ioc", "dedupe"], category: "Actions", available: (s) => s.iocs.length > 1 },
+  ];
+
+  const exportActions: PaletteAction[] = [
+    { id: "exp.report", label: "Generate Report", keywords: ["report", "pdf", "docx"], category: "Exports" },
+    { id: "exp.misp", label: "Export IOCs to MISP", keywords: ["misp", "ioc", "export"], category: "Exports", available: (s) => s.iocs.length > 0 },
+    { id: "exp.csv", label: "Export Findings to CSV", keywords: ["csv", "findings", "export"], category: "Exports", available: (s) => s.findings.length > 0 },
+    { id: "exp.stix", label: "Export STIX Bundle", keywords: ["stix", "bundle", "export"], category: "Exports" },
+    { id: "exp.thehive", label: "Push to TheHive", keywords: ["thehive", "export", "push"], category: "Exports" },
+  ];
+
+  const settingsActions: PaletteAction[] = [
+    { id: "set.ai", label: "Open AI Settings", keywords: ["ai", "settings", "provider"], category: "Settings" },
+    { id: "set.enrich", label: "Open Enrichment Settings", keywords: ["enrich", "settings", "provider"], category: "Settings" },
+    { id: "set.theme", label: "Toggle Theme", keywords: ["theme", "dark", "light"], category: "Settings" },
+    { id: "set.log", label: "Change Log Level", keywords: ["log", "level", "debug"], category: "Settings" },
+  ];
+
+  const caseActions: PaletteAction[] = [
+    { id: "case.new", label: "New Case", keywords: ["case", "new", "create"], category: "Case" },
+    { id: "case.switch", label: "Switch Case", keywords: ["case", "switch", "open"], category: "Case" },
+    { id: "case.archive", label: "Archive Case", keywords: ["case", "archive"], category: "Case" },
+    { id: "case.close", label: "Close Case", keywords: ["case", "close"], category: "Case" },
+  ];
+
+  registry.Navigation = navActions;
+  registry.Actions = actionActions;
+  registry.Exports = exportActions;
+  registry.Settings = settingsActions;
+  registry.Case = caseActions;
+  return registry;
+}
+
+export function allActions(registry: Record<PaletteCategory, PaletteAction[]>): PaletteAction[] {
+  return CATEGORY_ORDER.flatMap((c) => registry[c] ?? []);
+}
+
+const LOWER_A = 0x61;
+const LOWER_Z = 0x7a;
+
+function isAlpha(ch: string): boolean {
+  const c = ch.charCodeAt(0);
+  return c >= LOWER_A && c <= LOWER_Z;
+}
+
+function fuzzyScore(query: string, text: string): number {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  if (!q) return 1;
+  if (!t) return 0;
+  if (q === t) return 1000;
+  const words = t.split(/\s+/).filter(Boolean);
+  for (const w of words) {
+    if (w === q) return 800;
+  }
+  for (const w of words) {
+    if (w.startsWith(q)) return 600;
+  }
+  if (t.startsWith(q)) return 500;
+  const subIdx = t.indexOf(q);
+  if (subIdx >= 0) return 400 - Math.min(subIdx, 50);
+  let qi = 0;
+  let consec = 0;
+  let best = 0;
+  let cur = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      qi++;
+      consec++;
+      cur += 10 + consec * 5;
+      if (cur > best) best = cur;
+      if (isAlpha(t[ti]) && qi === q.length) break;
+    } else {
+      consec = 0;
+      cur = Math.max(0, cur - 1);
+    }
+  }
+  if (qi < q.length) return 0;
+  return Math.max(50, best);
+}
+
+export function fuzzyMatch(query: string, action: PaletteAction): number {
+  if (!query) return 1;
+  const labelScore = fuzzyScore(query, action.label);
+  const kwScore = (action.keywords ?? []).reduce((m, k) => Math.max(m, fuzzyScore(query, k)), 0);
+  return Math.max(labelScore, kwScore * 0.9);
+}
+
+export interface SearchResult {
+  action: PaletteAction;
+  score: number;
+}
+
+export function searchActions(query: string, actions: PaletteAction[]): SearchResult[] {
+  let categoryFilter: PaletteCategory | undefined;
+  let q = query.trim();
+  if (q.startsWith(">")) {
+    const rest = q.slice(1).trim();
+    const spaceIdx = rest.indexOf(" ");
+    const candidate = spaceIdx < 0 ? rest : rest.slice(0, spaceIdx);
+    const matched = CATEGORY_ORDER.find((c) => c.toLowerCase() === candidate.toLowerCase());
+    if (matched) {
+      categoryFilter = matched;
+      q = spaceIdx < 0 ? "" : rest.slice(spaceIdx + 1).trim();
+    }
+  }
+  const filtered = categoryFilter ? actions.filter((a) => a.category === categoryFilter) : actions;
+  const results: SearchResult[] = [];
+  for (const a of filtered) {
+    const score = fuzzyMatch(q, a);
+    if (score > 0) results.push({ action: a, score });
+  }
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const ca = CATEGORY_ORDER.indexOf(a.action.category);
+    const cb = CATEGORY_ORDER.indexOf(b.action.category);
+    if (ca !== cb) return ca - cb;
+    return a.action.label.localeCompare(b.action.label);
+  });
+  return results;
+}

--- a/companion/src/routes/commandPalette.ts
+++ b/companion/src/routes/commandPalette.ts
@@ -1,0 +1,17 @@
+import type { Express, Request, Response } from "express";
+import type { RouteContext } from "./context.js";
+import { buildActionRegistry, allActions, searchActions } from "../analysis/commandPalette.js";
+
+export function registerCommandPaletteRoutes(app: Express, _ctx: RouteContext): void {
+  const registry = buildActionRegistry();
+
+  app.get("/command-palette/actions", (_req: Request, res: Response) => {
+    res.status(200).json({ actions: allActions(registry) });
+  });
+
+  app.get("/command-palette/search", (req: Request, res: Response) => {
+    const q = typeof req.query.q === "string" ? req.query.q : "";
+    const results = searchActions(q, allActions(registry));
+    res.status(200).json({ query: q, results: results.map((r) => ({ id: r.action.id, label: r.action.label, category: r.action.category, score: r.score })) });
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -31,6 +31,7 @@ import { registerPlaybookHuntsRoutes } from "./routes/playbookHunts.js";
 import { registerAiSynthesisRoutes } from "./routes/aiSynthesis.js";
 import { registerReportsExportRoutes } from "./routes/reportsExport.js";
 import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
+import { registerCommandPaletteRoutes } from "./routes/commandPalette.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
@@ -833,6 +834,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerAiSynthesisRoutes(app, ctx);
   registerReportsExportRoutes(app, ctx);
   registerReportVersionsRoutes(app, ctx);
+  registerCommandPaletteRoutes(app, ctx);
   // Case-password routes first (mirrors their original registration order, right after the case-lock gate),
   // then the case-core catch-all (lifecycle, archives, integration pushes, importers, jobs, settings, static
   // app shell). Both register before the terminal error handler at the end of createApp.

--- a/companion/tests/analysis/commandPalette.test.ts
+++ b/companion/tests/analysis/commandPalette.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildActionRegistry,
+  allActions,
+  fuzzyMatch,
+  searchActions,
+  type PaletteAction,
+} from "../../src/analysis/commandPalette.js";
+import { emptyState, type InvestigationState } from "../../src/analysis/stateTypes.js";
+
+function state(partial: Partial<InvestigationState> = {}): InvestigationState {
+  return { ...emptyState("c1"), ...partial };
+}
+
+const navFindings: PaletteAction = {
+  id: "nav.findings",
+  label: "Go to Findings",
+  keywords: ["findings", "alerts"],
+  category: "Navigation",
+};
+
+describe("commandPalette fuzzyMatch", () => {
+  it("scores an exact word match highest", () => {
+    expect(fuzzyMatch("findings", navFindings)).toBeGreaterThanOrEqual(800);
+  });
+
+  it("scores a prefix match above substring", () => {
+    const prefix = fuzzyMatch("find", navFindings);
+    const sub = fuzzyMatch("ings", navFindings);
+    expect(prefix).toBeGreaterThan(sub);
+    expect(prefix).toBeGreaterThanOrEqual(600);
+  });
+
+  it("scores a substring match above zero", () => {
+    const score = fuzzyMatch("ings", navFindings);
+    expect(score).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for no character overlap", () => {
+    expect(fuzzyMatch("zzz", navFindings)).toBe(0);
+  });
+});
+
+describe("commandPalette buildActionRegistry", () => {
+  it("groups actions under all five categories", () => {
+    const r = buildActionRegistry();
+    expect(Object.keys(r).sort()).toEqual(["Actions", "Case", "Exports", "Navigation", "Settings"]);
+    for (const cat of Object.keys(r) as Array<keyof typeof r>) {
+      expect(r[cat].length).toBeGreaterThan(0);
+    }
+    expect(allActions(r).length).toBeGreaterThan(10);
+  });
+});
+
+describe("commandPalette searchActions", () => {
+  const all = allActions(buildActionRegistry());
+
+  it("filters by category using the > prefix", () => {
+    const res = searchActions(">Exports", all);
+    expect(res.length).toBeGreaterThan(0);
+    expect(res.every((r) => r.action.category === "Exports")).toBe(true);
+  });
+
+  it("combines > category filter with a query term", () => {
+    const res = searchActions(">Actions synthesize", all);
+    expect(res.some((r) => r.action.id === "act.synthesize")).toBe(true);
+    expect(res.every((r) => r.action.category === "Actions")).toBe(true);
+  });
+
+  it("filters out unavailable actions when given case state", () => {
+    const synthesize = all.find((a) => a.id === "act.synthesize")!;
+    expect(synthesize.available?.(state())).toBe(false);
+    expect(synthesize.available?.(state({ findings: [{ id: "f1", severity: "High", title: "t", description: "d", relatedIocs: [], sourceScreenshots: [], mitreTechniques: [], firstSeen: "x", lastUpdated: "y", status: "open" }] }))).toBe(true);
+  });
+
+  it("ranks higher-scoring matches first", () => {
+    const res = searchActions("findings", all);
+    expect(res.length).toBeGreaterThan(1);
+    expect(res[0].score).toBeGreaterThanOrEqual(res[1].score);
+  });
+
+  it("returns empty for an unmatched query", () => {
+    expect(searchActions("zzzzznomatch", all)).toEqual([]);
+  });
+
+  it("treats an empty query as matching all (ranked by category order)", () => {
+    const res = searchActions("", all);
+    expect(res.length).toBe(all.length);
+    expect(res[0].action.category).toBe("Navigation");
+  });
+});


### PR DESCRIPTION
Implements issue #238: a Ctrl+P-style command palette with fuzzy search.

## Changes
- `companion/src/analysis/commandPalette.ts`: `PaletteAction` interface, `buildActionRegistry()` grouped by Navigation / Actions / Exports / Settings / Case, `fuzzyMatch` scorer (exact word > prefix > substring), `searchActions` with `>` category-filter syntax (VS Code style).
- `companion/src/routes/commandPalette.ts`: `GET /command-palette/actions` and `GET /command-palette/search?q=...`, registered in `server.ts`.
- `companion/tests/analysis/commandPalette.test.ts`: 11 tests covering exact/prefix/substring fuzzy match, category filter with `>`, action availability filtering, and ranking.

## Verification
- `npx tsc --noEmit` clean for these files (only pre-existing `clockSkew.ts` errors unrelated to this PR)
- `npx vitest run tests/analysis/commandPalette.test.ts` — 11 passed