### PR TITLE
fix(security): stop trusting the client Host header in the origin guard (F1, HIGH)

### DIFF
--- a/companion/src/http/originGuard.ts
+++ b/companion/src/http/originGuard.ts
@@ -14,8 +14,9 @@ import type { Request, RequestHandler, Response, NextFunction } from "express";
  *  1. NO `Origin` header — curl, the push-to-companion scripts, Velociraptor, MCP clients. Allowed.
  *     These are not the threat: a process that can already run on this machine does not need the
  *     companion's help to run more code, and blocking them breaks every documented scripted flow.
- *  2. A TRUSTED browser origin — the capture extension, the dashboard on loopback, the server's own
- *     host (so the hosted demo and reverse-proxy setups work), or an operator-configured origin.
+ *  2. A TRUSTED browser origin — the capture extension, the dashboard on loopback, or an
+ *     operator-configured origin (this is how a hosted demo or reverse-proxy deployment is trusted:
+ *     its public origin must be listed in DFIR_ALLOWED_ORIGINS, never inferred from the Host header).
  *     Allowed, and answered with that exact origin echoed back rather than a wildcard.
  *  3. Anything else — a real web page. Rejected with 403 before the route runs, and with no CORS or
  *     private-network headers, so the browser fails the preflight too.
@@ -41,10 +42,15 @@ export function parseAllowedOrigins(raw: string | undefined): string[] {
 /**
  * Is this browser origin allowed to talk to the companion?
  *
- * `host` is the server's own Host header, which makes same-origin work without configuration no
- * matter where the companion is deployed (loopback, the Railway demo, behind a reverse proxy).
+ * Trust is derived ONLY from the origin itself plus the operator's allow-list — never from the
+ * request's own `Host` header. `Host` is client-controlled, so blessing an origin merely because it
+ * equals the Host is a DNS-rebinding bypass (CWE-346): an attacker rebinds `evil.example` to
+ * 127.0.0.1 and sends `Origin: http://evil.example` with `Host: evil.example`; the two match and the
+ * gate would open. Loopback and configured origins are each recognised on their own merits below, so
+ * a deployment behind a public host or reverse proxy is trusted by listing its origin in
+ * DFIR_ALLOWED_ORIGINS, not by echoing back whatever Host the caller supplied.
  */
-export function isOriginAllowed(origin: string | undefined, host: string | undefined, extra: string[]): boolean {
+export function isOriginAllowed(origin: string | undefined, extra: string[]): boolean {
   if (!origin) return true; // non-browser caller — see group 1 above
 
   let url: URL;
@@ -57,7 +63,6 @@ export function isOriginAllowed(origin: string | undefined, host: string | undef
   if (EXTENSION_SCHEMES.has(url.protocol)) return true;
   // Compare parsed components, never substrings: `https://127.0.0.1.evil.example` contains a
   // trusted host as a prefix but is a completely different origin.
-  if (host && url.host.toLowerCase() === host.toLowerCase()) return true;
   if (LOOPBACK_HOSTNAMES.has(url.hostname.toLowerCase())) return true;
   return extra.includes(`${url.protocol}//${url.host}`);
 }
@@ -67,7 +72,7 @@ export function createOriginGuard(opts: { allowedOrigins?: string[] } = {}): Req
   const extra = opts.allowedOrigins ?? [];
   return (req: Request, res: Response, next: NextFunction): void => {
     const origin = req.headers.origin;
-    if (!isOriginAllowed(origin, req.headers.host, extra)) {
+    if (!isOriginAllowed(origin, extra)) {
       // 403 with no CORS headers: the page cannot read this response, and a preflight shaped like
       // this fails, so the browser never sends the real request either.
       res.status(403).json({

--- a/companion/src/live/wsGate.ts
+++ b/companion/src/live/wsGate.ts
@@ -43,7 +43,7 @@ const SAFE_CASE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 export async function authorizeWsUpgrade(req: WsUpgradeRequest, deps: WsUpgradeDeps): Promise<WsUpgradeDecision> {
   const { headers } = req;
 
-  if (!isOriginAllowed(headers.origin, headers.host, deps.allowedOrigins)) {
+  if (!isOriginAllowed(headers.origin, deps.allowedOrigins)) {
     return { ok: false, reason: `origin "${headers.origin}" is not allowed` };
   }
 

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -582,8 +582,9 @@ export interface AppOptions {
   // the server is actually ready. Tests can inject their own handler or leave it absent.
   onPreflightReady?: (run: () => Promise<PreflightReport>) => void;
   // Extra browser origins allowed to call the API, beyond the always-trusted set (the capture
-  // extension, loopback, and the server's own host). From DFIR_ALLOWED_ORIGINS — see
-  // src/http/originGuard.ts. Absent → only the built-in trusted origins.
+  // extension and loopback). From DFIR_ALLOWED_ORIGINS — see src/http/originGuard.ts. Absent → only
+  // the built-in trusted origins. A hosted/reverse-proxied deployment lists its own public origin
+  // here, since the guard no longer infers trust from the client-supplied Host header.
   allowedOrigins?: string[];
 }
 
@@ -3374,8 +3375,8 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     // from DFIR_TOOL_* env, so a tool is off until its binary is set — no gating client to build.
     toolRunner: spawnToolRunner(),
     customToolStore,
-    // Extra browser origins permitted past the origin guard (#211), beyond the extension, loopback,
-    // and this server's own host. Comma-separated, e.g. "https://soc.example.com".
+    // Extra browser origins permitted past the origin guard (#211), beyond the extension and
+    // loopback. Comma-separated, e.g. "https://soc.example.com".
     allowedOrigins: parseAllowedOrigins(process.env.DFIR_ALLOWED_ORIGINS),
     importUndoStore,
     onImportUndo: (caseId) => hub.broadcastTo(caseId, { type: "import_undo_changed" }),

--- a/companion/tests/http/originGuard.test.ts
+++ b/companion/tests/http/originGuard.test.ts
@@ -17,43 +17,53 @@ describe("isOriginAllowed", () => {
   it("allows a request with no Origin header at all (curl, scripts, Velociraptor pushes)", () => {
     // Non-browser clients never send Origin. They are not the threat this guard addresses —
     // any local process can already run code — and blocking them breaks every scripted push.
-    expect(isOriginAllowed(undefined, "127.0.0.1:4773", [])).toBe(true);
+    expect(isOriginAllowed(undefined, [])).toBe(true);
   });
 
   it("allows the capture extension's chrome-extension:// origin", () => {
     // Unpacked installs get a random extension id, so the scheme is what we can rely on.
-    expect(isOriginAllowed("chrome-extension://abcdefghijklmnopabcdefghijklmnop", "127.0.0.1:4773", [])).toBe(true);
-    expect(isOriginAllowed("moz-extension://11112222-3333-4444-5555-666677778888", "127.0.0.1:4773", [])).toBe(true);
+    expect(isOriginAllowed("chrome-extension://abcdefghijklmnopabcdefghijklmnop", [])).toBe(true);
+    expect(isOriginAllowed("moz-extension://11112222-3333-4444-5555-666677778888", [])).toBe(true);
   });
 
   it("allows the dashboard on loopback, on any port", () => {
-    expect(isOriginAllowed("http://127.0.0.1:4773", "127.0.0.1:4773", [])).toBe(true);
-    expect(isOriginAllowed("http://localhost:9999", "127.0.0.1:4773", [])).toBe(true);
-    expect(isOriginAllowed("http://[::1]:4773", "127.0.0.1:4773", [])).toBe(true);
+    expect(isOriginAllowed("http://127.0.0.1:4773", [])).toBe(true);
+    expect(isOriginAllowed("http://localhost:9999", [])).toBe(true);
+    expect(isOriginAllowed("http://[::1]:4773", [])).toBe(true);
   });
 
-  it("allows an origin that matches the server's own Host header (hosted demo, reverse proxy)", () => {
-    // The Railway demo serves the dashboard from a public https origin, not loopback.
-    expect(isOriginAllowed("https://demo.example.app", "demo.example.app", [])).toBe(true);
+  it("trusts a hosted/reverse-proxied origin only when it is explicitly configured, never via the Host header", () => {
+    // A public deployment (e.g. the Railway demo) serves the dashboard from a non-loopback https
+    // origin. It is trusted by listing that origin in DFIR_ALLOWED_ORIGINS — NOT by matching the
+    // request's own Host header, which is client-controlled and would open a DNS-rebinding hole.
+    expect(isOriginAllowed("https://demo.example.app", [])).toBe(false);
+    expect(isOriginAllowed("https://demo.example.app", ["https://demo.example.app"])).toBe(true);
+  });
+
+  it("rejects a rebound origin even though the attacker can make Origin and Host identical (CWE-346)", () => {
+    // DNS-rebinding: evil.example resolves to 127.0.0.1, so the victim's browser sends
+    // Origin: http://evil.example:4773 with a matching Host. The old Origin==Host branch trusted
+    // this; trust must now come only from the origin's own value, so it is refused.
+    expect(isOriginAllowed("http://evil.example:4773", [])).toBe(false);
   });
 
   it("allows an explicitly configured extra origin", () => {
-    expect(isOriginAllowed("https://soc.example.com", "127.0.0.1:4773", ["https://soc.example.com"])).toBe(true);
+    expect(isOriginAllowed("https://soc.example.com", ["https://soc.example.com"])).toBe(true);
   });
 
   it("rejects an arbitrary web page's origin", () => {
-    expect(isOriginAllowed("https://evil.example", "127.0.0.1:4773", [])).toBe(false);
-    expect(isOriginAllowed("http://evil.example", "127.0.0.1:4773", [])).toBe(false);
+    expect(isOriginAllowed("https://evil.example", [])).toBe(false);
+    expect(isOriginAllowed("http://evil.example", [])).toBe(false);
   });
 
   it("rejects an origin that merely embeds a trusted one as a substring", () => {
-    expect(isOriginAllowed("https://127.0.0.1.evil.example", "127.0.0.1:4773", [])).toBe(false);
-    expect(isOriginAllowed("https://localhost.evil.example", "127.0.0.1:4773", [])).toBe(false);
-    expect(isOriginAllowed("https://evil.example/#http://localhost", "127.0.0.1:4773", [])).toBe(false);
+    expect(isOriginAllowed("https://127.0.0.1.evil.example", [])).toBe(false);
+    expect(isOriginAllowed("https://localhost.evil.example", [])).toBe(false);
+    expect(isOriginAllowed("https://evil.example/#http://localhost", [])).toBe(false);
   });
 
   it("rejects the literal null origin used by sandboxed iframes and data: URLs", () => {
-    expect(isOriginAllowed("null", "127.0.0.1:4773", [])).toBe(false);
+    expect(isOriginAllowed("null", [])).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Security fix — F1 (HIGH): DNS-rebinding bypass of the origin guard

**CWE-346 · auth-bypass**

### Problem
`isOriginAllowed` in `companion/src/http/originGuard.ts` — the single browser-origin trust gate for every HTTP route and the `/ws` upgrade — granted access when the request's `Origin` host equaled `req.headers.host`. Both values are client-controlled, so an attacker can always make them match. Via DNS rebinding (`evil.example` → `127.0.0.1`), a page the victim merely visits sends `Origin` and `Host` as the same rebound name, passes the gate, and can reach the whole localhost API — including `POST /tools/custom` to register an arbitrary binary and `POST /cases/:id/tools/:toolId/run` to spawn it (local code execution).

### Fix
Remove the `host` parameter from `isOriginAllowed` and delete the `Origin == Host` trust branch, so trust derives only from the origin's own value plus the allow-list (loopback hostnames, extension schemes, and configured `DFIR_ALLOWED_ORIGINS`). The `Host` header no longer feeds the trust decision anywhere. Both callers (the HTTP middleware and the `/ws` upgrade) are updated to the new signature.

**Behaviour note:** a hosted / reverse-proxied deployment on a non-loopback host that previously relied on the automatic `Origin == Host` match must now list its public origin in `DFIR_ALLOWED_ORIGINS`. That is exactly the untrusted-`Host` path this fixes; loopback, extension, configured-origin, no-origin, and CORS behaviour are unchanged.

### Verification
Verified by a panel of agents (an independent reviewer that ran the tests, plus a fresh reviewer that adversarially attacked the diff). Tests: `originGuard`/`live` suites (34), `tsc --noEmit` clean, and the full companion suite (4780 tests) all pass. Not validated with a live exploit.

Files: `companion/src/http/originGuard.ts`, `companion/src/live/wsGate.ts`, `companion/src/server.ts`, `companion/tests/http/originGuard.test.ts`.

Generated by Claude Security (whole-repository scan at `d8f7fda6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
