### PR TITLE
feat(playbooks): incident-type auto-playbooks for ransomware/BEC/exfil templates (#236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Incident-type auto-playbooks** (#236) — the New case dialog's *Incident type* picker pre-configures a case for a recurring incident pattern: eight built-in types (ransomware, BEC, data exfiltration, intrusion, insider threat, cloud compromise, web-app intrusion, malware outbreak) seed type-specific key questions, priority-ordered next steps, and that incident's expected findings as open confirm/deny questions. Synthesis is told which type the case is so it prioritizes the relevant ATT&CK techniques — prompt context only, it never reaches the report. Types are editable JSON in `companion/data/incident-types/`, analysts can drop their own into an `incident-types/` folder beside the cases root, and re-picking a type merges rather than overwriting analyst edits.
+
 ### Fixed
 - **Correlation no longer merges one artifact across hosts** (#345) — the same binary hash or file path seen on two machines was collapsed into a single event, which erased the lateral-movement edge the evidence graph derives from it, left the surviving row holding one host's name and the other's timestamp, and could drop a host from the case entirely. The hash, path and exact-duplicate steps now correlate within a host (as the host+pid and command-line steps already did); an event with no recorded host still joins a host's group when the artifact was seen on exactly one. Note: timelines correlated by an earlier build stay merged — the fix applies as new evidence is correlated, and cannot un-merge what was already persisted.
 

--- a/companion/data/incident-types/bec.json
+++ b/companion/data/incident-types/bec.json
@@ -1,0 +1,77 @@
+{
+  "id": "bec",
+  "name": "BEC / Email Compromise",
+  "description": "Business Email Compromise — account takeover, mail-rule manipulation, wire fraud.",
+  "builtIn": true,
+  "recommendedImports": [
+    "m365",
+    "siem",
+    "chainsaw"
+  ],
+  "initialKeyQuestions": [
+    "Which mailboxes were compromised?",
+    "How was initial access achieved (phishing, password spray, OAuth grant)?",
+    "Were mail-forwarding rules or inbox rules created by the attacker?",
+    "Were financial transactions or wire transfers initiated?",
+    "What external IP addresses and user-agents accessed the account?",
+    "Was MFA present and, if so, how was it bypassed?",
+    "What data was accessed or exfiltrated from the mailbox?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Revoke all active sessions and reset the compromised account's password and MFA",
+      "rationale": "Terminates attacker's active access",
+      "pointer": "Entra ID → Revoke sessions, reset MFA, reset password"
+    },
+    {
+      "priority": "critical",
+      "action": "Export the Unified Audit Log (UAL) for all affected mailboxes (past 90 days)",
+      "rationale": "Primary evidence source for all mailbox and sign-in activity",
+      "pointer": "Microsoft Purview compliance portal → Audit search"
+    },
+    {
+      "priority": "high",
+      "action": "Review and immediately delete any attacker-created inbox rules",
+      "rationale": "Inbox rules hide replies and forward mail to attacker-controlled addresses",
+      "pointer": "Exchange Admin Center → mailbox rules"
+    },
+    {
+      "priority": "high",
+      "action": "Audit OAuth app grants and newly consented applications on the compromised account",
+      "rationale": "OAuth grants survive password resets and provide persistent mailbox access",
+      "pointer": "Entra ID → Enterprise Applications → User consent"
+    }
+  ],
+  "severityFloor": "Medium",
+  "huntPlatforms": [
+    "Microsoft 365",
+    "Entra ID / Azure AD"
+  ],
+  "recommendedImportOrder": [
+    "m365",
+    "entra-audit",
+    "siem",
+    "email-gateway"
+  ],
+  "huntBundles": [
+    "mailbox-rules",
+    "mfa-bypass",
+    "conditional-access",
+    "oauth-app-grants"
+  ],
+  "findingsSeeds": [
+    "Mailbox account takeover confirmed",
+    "Attacker-created inbox/forwarding rules",
+    "OAuth app grant persistence",
+    "MFA bypass mechanism",
+    "Wire transfer / payment fraud initiated",
+    "Mailbox data exfiltrated"
+  ],
+  "reportFraming": {
+    "template": "bec-executive",
+    "audience": "finance + legal + executive",
+    "summaryPrompt": "Summarize the BEC compromise, funds-at-risk, and recovery actions for finance and legal."
+  },
+  "synthesisHint": "This is a BEC case — prioritize T1566 Phishing (initial access), T1098 Account Manipulation (inbox rules / OAuth grants), T1078 Valid Accounts, and T1567 Exfiltration to Cloud Service."
+}

--- a/companion/data/incident-types/cloud-compromise.json
+++ b/companion/data/incident-types/cloud-compromise.json
@@ -1,0 +1,80 @@
+{
+  "id": "cloud-compromise",
+  "name": "Cloud Compromise",
+  "description": "Cloud account/tenant compromise — AWS/Azure/GCP, IAM abuse, key theft.",
+  "builtIn": true,
+  "recommendedImports": [
+    "aws",
+    "m365",
+    "siem",
+    "cloud-audit"
+  ],
+  "initialKeyQuestions": [
+    "Which cloud account/tenant was compromised?",
+    "How was initial access achieved (key leak, phishing, SSRF, misconfig)?",
+    "What IAM roles or permissions were abused?",
+    "Were new users, access keys, or roles created for persistence?",
+    "What resources were accessed, modified, or exfiltrated?",
+    "Were compute instances launched for cryptomining or pivoting?",
+    "Is the compromise still active?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Disable compromised credentials and revoke active sessions/tokens",
+      "rationale": "Terminates attacker's cloud access",
+      "pointer": "Cloud IAM: disable access keys, revoke sessions, rotate secrets"
+    },
+    {
+      "priority": "critical",
+      "action": "Quarantine or terminate unauthorized compute instances",
+      "rationale": "Stops cryptomining, C2 pivots, and ongoing cost accrual",
+      "pointer": "Cloud console / IaC: terminate unauthorized instances"
+    },
+    {
+      "priority": "high",
+      "action": "Pull full CloudTrail / Activity Log / Audit Log for the compromise window",
+      "rationale": "Cloud audit logs are the primary evidence source for IAM abuse",
+      "pointer": "AWS CloudTrail, Azure Activity Log, GCP Audit Logs"
+    },
+    {
+      "priority": "high",
+      "action": "Audit IAM for attacker-created users, keys, roles, and trust policies",
+      "rationale": "Persistence in the cloud is almost always new IAM principals",
+      "pointer": "IAM console + `aws iam list-entities` / `az role assignment list`"
+    }
+  ],
+  "severityFloor": "High",
+  "huntPlatforms": [
+    "AWS",
+    "Microsoft 365",
+    "Elastic SIEM"
+  ],
+  "recommendedImportOrder": [
+    "cloud-audit",
+    "aws",
+    "m365",
+    "siem",
+    "edr"
+  ],
+  "huntBundles": [
+    "iam-abuse",
+    "new-access-keys",
+    "unauthorized-instances",
+    "key-leak"
+  ],
+  "findingsSeeds": [
+    "Cloud account/tenant compromise confirmed",
+    "Initial access vector (key leak / phishing / SSRF / misconfig)",
+    "IAM roles/permissions abused",
+    "Persistence via new IAM principals",
+    "Resources accessed or exfiltrated",
+    "Unauthorized compute instances"
+  ],
+  "reportFraming": {
+    "template": "cloud-executive",
+    "audience": "cloud-ops + security + executive",
+    "summaryPrompt": "Summarize the cloud compromise, IAM abuse, and containment for cloud-ops and executive."
+  },
+  "synthesisHint": "This is a cloud-compromise case — prioritize T1078 Valid Accounts (cloud), T1098 Account Manipulation (new IAM principals), T1136 Create Account, and T1530 Data from Cloud Storage."
+}

--- a/companion/data/incident-types/data-exfiltration.json
+++ b/companion/data/incident-types/data-exfiltration.json
@@ -1,0 +1,81 @@
+{
+  "id": "data-exfiltration",
+  "name": "Data Exfiltration",
+  "description": "Confirmed or suspected data theft — staging, bulk transfer, cloud sync abuse.",
+  "builtIn": true,
+  "recommendedImports": [
+    "siem",
+    "network",
+    "kape",
+    "velociraptor",
+    "m365"
+  ],
+  "initialKeyQuestions": [
+    "What data was exfiltrated, and how much?",
+    "What channel was used (cloud sync, email, FTP, HTTPS, USB)?",
+    "When did the exfiltration occur, and from which host/account?",
+    "Was the data staged before transfer?",
+    "Is the exfiltration ongoing?",
+    "What user/account performed the transfer?",
+    "Are there indicators of an insider vs. external attacker?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Block the exfiltration channel and the account/host performing the transfer",
+      "rationale": "Stop ongoing data loss before scoping",
+      "pointer": "Firewall / proxy / cloud-sync policy"
+    },
+    {
+      "priority": "high",
+      "action": "Quantify exfiltrated data: volume, file types, and sensitivity classification",
+      "rationale": "Drives breach-notification obligations and downstream scope",
+      "pointer": "Proxy logs, CASB file-activity report, DLP alerts"
+    },
+    {
+      "priority": "high",
+      "action": "Identify the staging location and any archive/compression used before transfer",
+      "rationale": "Staging reveals intent and the full set of targeted data",
+      "pointer": "Endpoint triage: temp dirs, zip/rar/7z creation, recent files"
+    },
+    {
+      "priority": "medium",
+      "action": "Correlate exfiltration timing with user activity and access patterns",
+      "rationale": "Distinguishes insider from compromised-account exfiltration",
+      "pointer": "SIEM user-behavior analytics, badge/access logs"
+    }
+  ],
+  "severityFloor": "High",
+  "huntPlatforms": [
+    "Velociraptor",
+    "Security Onion",
+    "Microsoft 365"
+  ],
+  "recommendedImportOrder": [
+    "network",
+    "siem",
+    "edr",
+    "cloud-audit",
+    "m365"
+  ],
+  "huntBundles": [
+    "file-staging",
+    "cloud-sync",
+    "archive-creation",
+    "bulk-transfer"
+  ],
+  "findingsSeeds": [
+    "Exfiltration channel confirmed",
+    "Data volume and sensitivity scoped",
+    "Staging location identified",
+    "Account/host performing transfer attributed",
+    "Insider vs. external actor distinguished",
+    "Ongoing exfiltration stopped"
+  ],
+  "reportFraming": {
+    "template": "exfiltration-executive",
+    "audience": "legal + DPO + executive",
+    "summaryPrompt": "Summarize the exfiltrated data, notification obligations, and containment for legal and the DPO."
+  },
+  "synthesisHint": "This is a data-exfiltration case — prioritize T1567 Exfiltration to Cloud Service, T1048 Exfiltration Over Alternative Protocol, T1052 Exfiltration Over Physical Medium, and T1074 Data Staged."
+}

--- a/companion/data/incident-types/insider-threat.json
+++ b/companion/data/incident-types/insider-threat.json
@@ -1,0 +1,81 @@
+{
+  "id": "insider-threat",
+  "name": "Insider Threat",
+  "description": "Malicious or negligent insider — data theft, sabotage, policy violation.",
+  "builtIn": true,
+  "recommendedImports": [
+    "siem",
+    "kape",
+    "plaso",
+    "m365",
+    "aws"
+  ],
+  "initialKeyQuestions": [
+    "Who is the subject of investigation and what is their role?",
+    "What data or systems did the subject access outside their normal scope?",
+    "Were large file copies, USB transfers, or cloud uploads observed?",
+    "Did the subject access systems after a resignation or termination notice?",
+    "Are there signs of data staging or collection before departure?",
+    "What communication channels (email, Teams, Slack) were used?",
+    "Was account or credentials sharing observed?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Preserve all relevant logs before the subject's access is revoked or systems are modified",
+      "rationale": "Evidence destruction risk is highest while the subject is active",
+      "pointer": "SIEM, DLP, proxy, badge-access, M365 UAL, endpoint logs"
+    },
+    {
+      "priority": "high",
+      "action": "Pull full DLP and data-loss alerts for the subject's accounts over the investigation window",
+      "rationale": "DLP alerts are the primary signal for data staging and exfiltration",
+      "pointer": "DLP console, Microsoft Purview, CASB file-activity report"
+    },
+    {
+      "priority": "high",
+      "action": "Collect endpoint forensic triage (KAPE or Plaso) from the subject's workstation",
+      "rationale": "Surfaces file access history, USB device connections, recent files",
+      "pointer": "KAPE targets: USB, LNK files, JumpLists, MFT, SRUM"
+    },
+    {
+      "priority": "medium",
+      "action": "Establish the subject's normal access baseline for the 3 months before the window",
+      "rationale": "Anomalous access is only meaningful relative to a baseline",
+      "pointer": "SIEM query: same user, same resource types, prior quarter"
+    }
+  ],
+  "severityFloor": "Medium",
+  "huntPlatforms": [
+    "Microsoft 365",
+    "Velociraptor",
+    "Elastic SIEM"
+  ],
+  "recommendedImportOrder": [
+    "siem",
+    "edr",
+    "m365",
+    "cloud-audit",
+    "badge-access"
+  ],
+  "huntBundles": [
+    "usb-devices",
+    "file-access",
+    "cloud-sync",
+    "email-exfil"
+  ],
+  "findingsSeeds": [
+    "Subject identified and scoped",
+    "Out-of-scope data access confirmed",
+    "USB / cloud / email exfiltration channel",
+    "Staging before departure",
+    "Post-resignation access",
+    "Credential / account sharing"
+  ],
+  "reportFraming": {
+    "template": "insider-executive",
+    "audience": "HR + legal + executive",
+    "summaryPrompt": "Summarize the insider activity, policy violations, and evidence for HR and legal."
+  },
+  "synthesisHint": "This is an insider-threat case — prioritize T1052 Exfiltration Over Physical Medium (USB), T1567 Exfiltration to Cloud Service, T1078 Valid Accounts (the insider's own), and T1056 Input Capture."
+}

--- a/companion/data/incident-types/intrusion.json
+++ b/companion/data/incident-types/intrusion.json
@@ -1,0 +1,81 @@
+{
+  "id": "intrusion",
+  "name": "Network Intrusion",
+  "description": "External attacker gained a foothold — initial access, persistence, lateral movement.",
+  "builtIn": true,
+  "recommendedImports": [
+    "network",
+    "siem",
+    "chainsaw",
+    "hayabusa",
+    "velociraptor"
+  ],
+  "initialKeyQuestions": [
+    "What was the initial access vector?",
+    "What persistence mechanisms were established?",
+    "Did the attacker move laterally, and to which hosts?",
+    "What privileges/accounts did the attacker obtain?",
+    "What C2 infrastructure was contacted?",
+    "What was the attacker's objective (data theft, persistence, staging)?",
+    "Is the attacker still active in the environment?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Isolate compromised hosts and block known C2 infrastructure",
+      "rationale": "Contain the foothold before scoping",
+      "pointer": "EDR isolation + firewall egress block"
+    },
+    {
+      "priority": "high",
+      "action": "Identify patient zero and the initial access vector",
+      "rationale": "Root-cause the entry to prevent re-entry and scope the investigation",
+      "pointer": "Web/proxy/email/SMB-share logs + EDR first-observed"
+    },
+    {
+      "priority": "high",
+      "action": "Map persistence across all touched hosts (services, scheduled tasks, registry, WMI)",
+      "rationale": "Persistence is what makes an intrusion durable across reboots",
+      "pointer": "Velociraptor Windows.Sysinternals.Autoruns / KAPE persistence targets"
+    },
+    {
+      "priority": "high",
+      "action": "Trace lateral movement from patient zero via RDP/SMB/WMI/WinRM",
+      "rationale": "Determines the full set of hosts to rebuild",
+      "pointer": "Windows Security 4624/4625/4688, Sysmon EID 3, 4624 logon type"
+    }
+  ],
+  "severityFloor": "High",
+  "huntPlatforms": [
+    "Velociraptor",
+    "Security Onion",
+    "Elastic SIEM"
+  ],
+  "recommendedImportOrder": [
+    "network",
+    "edr",
+    "windows-evtx",
+    "siem",
+    "velociraptor"
+  ],
+  "huntBundles": [
+    "persistence",
+    "lateral-movement",
+    "c2-callback",
+    "credential-theft"
+  ],
+  "findingsSeeds": [
+    "Initial access vector confirmed",
+    "Persistence mechanism identified",
+    "Lateral movement path mapped",
+    "C2 infrastructure attributed",
+    "Privilege escalation observed",
+    "Attacker objective determined"
+  ],
+  "reportFraming": {
+    "template": "intrusion-executive",
+    "audience": "IR team + IT operations + executive",
+    "summaryPrompt": "Summarize the intrusion scope, patient zero, and containment status for the IR team and executive."
+  },
+  "synthesisHint": "This is a network intrusion case — prioritize TA0001 Initial Access, TA0003 Persistence, TA0008 Lateral Movement, and TA0011 Command and Control."
+}

--- a/companion/data/incident-types/malware-outbreak.json
+++ b/companion/data/incident-types/malware-outbreak.json
@@ -1,0 +1,80 @@
+{
+  "id": "malware-outbreak",
+  "name": "Malware Outbreak",
+  "description": "Multi-host malware infection — trojan, RAT, info-stealer, cryptominer, or unknown family.",
+  "builtIn": true,
+  "recommendedImports": [
+    "thor",
+    "chainsaw",
+    "hayabusa",
+    "velociraptor",
+    "sandbox"
+  ],
+  "initialKeyQuestions": [
+    "What malware family or IOC triggered the alert?",
+    "What was the infection vector (email attachment, drive-by, USB)?",
+    "How many hosts are affected?",
+    "What C2 infrastructure (IP/domain/URL) was contacted?",
+    "What persistence mechanisms were established?",
+    "Was credential theft or lateral movement observed?",
+    "Is the malware still active or has the system been cleaned?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Isolate infected host(s) from the network to stop active C2 and lateral movement",
+      "rationale": "Live malware with an active C2 channel will download more payloads and spread",
+      "pointer": "EDR isolation console or network switch port shutdown"
+    },
+    {
+      "priority": "critical",
+      "action": "Capture a full memory dump of the infected host(s) before any remediation",
+      "rationale": "RAM contains decrypted payloads, in-memory C2 config, and credentials",
+      "pointer": "Velociraptor: Windows.Memory.Acquisition / winpmem"
+    },
+    {
+      "priority": "high",
+      "action": "Submit the malware sample to a sandbox and import the report",
+      "rationale": "Automated sandbox analysis surfaces behavior, network indicators, dropped files, MITRE mapping",
+      "pointer": "Collect sample via Velociraptor, submit to CAPEv2/Falcon, import JSON"
+    },
+    {
+      "priority": "high",
+      "action": "Hunt the fleet for the same binary hash and C2 IP/domain",
+      "rationale": "Malware commonly spreads or is deployed to multiple hosts before the initial detection",
+      "pointer": "Velociraptor fleet hunt: Windows.Search.FileFinder / Windows.Network.Netstat"
+    }
+  ],
+  "severityFloor": "High",
+  "huntPlatforms": [
+    "Velociraptor",
+    "Security Onion"
+  ],
+  "recommendedImportOrder": [
+    "edr",
+    "windows-evtx",
+    "velociraptor",
+    "network",
+    "sandbox"
+  ],
+  "huntBundles": [
+    "binary-hash",
+    "c2-callback",
+    "persistence",
+    "dropped-files"
+  ],
+  "findingsSeeds": [
+    "Malware family identified",
+    "Infection vector confirmed",
+    "Number of affected hosts scoped",
+    "C2 infrastructure attributed",
+    "Persistence mechanisms catalogued",
+    "Credential theft / lateral movement observed"
+  ],
+  "reportFraming": {
+    "template": "malware-executive",
+    "audience": "IR team + IT operations + executive",
+    "summaryPrompt": "Summarize the malware outbreak, scope, and containment for the IR team and executive."
+  },
+  "synthesisHint": "This is a malware-outbreak case — prioritize TA0002 Execution, TA0003 Persistence, TA0011 Command and Control, and T1105 Ingress Tool Transfer."
+}

--- a/companion/data/incident-types/ransomware.json
+++ b/companion/data/incident-types/ransomware.json
@@ -1,0 +1,80 @@
+{
+  "id": "ransomware",
+  "name": "Ransomware",
+  "description": "Ransomware encryption event — lateral movement, potential double-extortion leak site.",
+  "builtIn": true,
+  "recommendedImports": [
+    "chainsaw",
+    "hayabusa",
+    "thor",
+    "velociraptor",
+    "kape"
+  ],
+  "initialKeyQuestions": [
+    "What was the initial access vector?",
+    "When did encryption begin, and which hosts and shares were affected?",
+    "Was data exfiltrated before encryption (double-extortion)?",
+    "What ransom note or attacker-left IOC was found?",
+    "How did the attacker achieve lateral movement or privilege escalation?",
+    "How was persistence established?",
+    "Are backups intact and isolated from the network?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Isolate all affected hosts from the network immediately",
+      "rationale": "Prevent further encryption and lateral movement while preserving evidence",
+      "pointer": "Network switch ports or EDR isolation console"
+    },
+    {
+      "priority": "critical",
+      "action": "Preserve volatile memory (RAM dump) of patient zero before any remediation",
+      "rationale": "Memory may contain encryption keys, injected attacker tools, and credentials",
+      "pointer": "Velociraptor: Windows.Memory.Acquisition"
+    },
+    {
+      "priority": "high",
+      "action": "Collect Windows event logs (Security, System, Sysmon) from all affected hosts",
+      "rationale": "Identify initial access, lateral movement, and the encryption process chain",
+      "pointer": "KAPE triage or Velociraptor Windows.EventLogs.Evtx"
+    },
+    {
+      "priority": "high",
+      "action": "Check for data exfiltration indicators: large outbound transfers, rclone, MEGAsync",
+      "rationale": "Ransomware groups commonly exfiltrate before encrypting — determines notification obligations",
+      "pointer": "Zeek/Suricata logs, proxy logs, DLP alerts"
+    }
+  ],
+  "severityFloor": "High",
+  "huntPlatforms": [
+    "Velociraptor",
+    "Security Onion"
+  ],
+  "recommendedImportOrder": [
+    "edr",
+    "windows-evtx",
+    "velociraptor",
+    "network",
+    "siem"
+  ],
+  "huntBundles": [
+    "vss-delete",
+    "mimikatz",
+    "lateral-movement",
+    "ransomware-note"
+  ],
+  "findingsSeeds": [
+    "Initial access vector confirmed",
+    "VSS shadow copies deleted",
+    "Lateral movement to additional hosts",
+    "Data exfiltrated before encryption",
+    "Persistence mechanism established",
+    "Double-extortion leak-site listing"
+  ],
+  "reportFraming": {
+    "template": "ransomware-executive",
+    "audience": "board + insurer + legal",
+    "summaryPrompt": "Summarize the ransomware impact, scope, and notification obligations for the board and insurer."
+  },
+  "synthesisHint": "This is a ransomware case — prioritize T1486 Data Encrypted for Impact, T1490 Inhibit System Recovery (VSS deletion), T1021 Remote Services / lateral movement, and T1567 Exfiltration to Cloud Service (double extortion)."
+}

--- a/companion/data/incident-types/web-app-intrusion.json
+++ b/companion/data/incident-types/web-app-intrusion.json
@@ -1,0 +1,79 @@
+{
+  "id": "web-app-intrusion",
+  "name": "Web App Intrusion",
+  "description": "Web application attack — SQLi, RCE, webshell, server compromise.",
+  "builtIn": true,
+  "recommendedImports": [
+    "network",
+    "siem",
+    "chainsaw",
+    "hayabusa"
+  ],
+  "initialKeyQuestions": [
+    "What web application or endpoint was targeted?",
+    "What was the attack technique (SQLi, RCE, file upload, SSRF)?",
+    "Was a webshell or backdoor installed?",
+    "What OS commands were executed by the web process?",
+    "Did the attacker pivot from the web server to internal systems?",
+    "What data was accessed or exfiltrated?",
+    "Has the vulnerability been patched or the system isolated?"
+  ],
+  "initialNextSteps": [
+    {
+      "priority": "critical",
+      "action": "Snapshot the compromised web server, then isolate it from the network",
+      "rationale": "Preserve evidence before isolation; prevent further exploitation",
+      "pointer": "VM snapshot or disk image first, then firewall/EDR isolation"
+    },
+    {
+      "priority": "critical",
+      "action": "Search for webshells across the web root and all upload/temp directories",
+      "rationale": "Webshells provide persistent backdoor access",
+      "pointer": "find /var/www -name '*.php' -newer <install_date> / Velociraptor Windows.Detection.Webshell"
+    },
+    {
+      "priority": "high",
+      "action": "Collect and archive web server access logs (Apache/Nginx/IIS/WAF) for the full attack window",
+      "rationale": "Access logs are the primary evidence source",
+      "pointer": "/var/log/apache2/access.log, IIS C:\\inetpub\\logs, WAF audit log"
+    },
+    {
+      "priority": "high",
+      "action": "Review OS process execution for suspicious child processes spawned by the web worker",
+      "rationale": "RCE/webshell activity appears as the web process spawning cmd/bash/python",
+      "pointer": "Sysmon EID 1, Auditd execve, Security EID 4688 filtered by ParentImage"
+    }
+  ],
+  "severityFloor": "Medium",
+  "huntPlatforms": [
+    "Security Onion",
+    "Elastic SIEM"
+  ],
+  "recommendedImportOrder": [
+    "web-logs",
+    "network",
+    "edr",
+    "siem",
+    "waf"
+  ],
+  "huntBundles": [
+    "webshell",
+    "suspicious-children",
+    "c2-callback",
+    "data-staging"
+  ],
+  "findingsSeeds": [
+    "Exploitation technique confirmed (SQLi/RCE/upload/SSRF)",
+    "Webshell or backdoor installed",
+    "OS commands executed by web process",
+    "Pivot from web server to internal systems",
+    "Data accessed or exfiltrated",
+    "Vulnerability patched / system isolated"
+  ],
+  "reportFraming": {
+    "template": "webapp-executive",
+    "audience": "app-team + security + executive",
+    "summaryPrompt": "Summarize the web-app intrusion, exploited vulnerability, and remediation for the app team and executive."
+  },
+  "synthesisHint": "This is a web-app-intrusion case — prioritize T1190 Exploit Public-Facing Application, T1505.003 Server Software Component: Web Shell, T1059 Command and Scripting Interpreter, and T1071 Application Layer Protocol (C2)."
+}

--- a/companion/src/analysis/incidentTypeStore.ts
+++ b/companion/src/analysis/incidentTypeStore.ts
@@ -1,0 +1,102 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import { parseIncidentType, type IncidentType } from "./incidentTypes.js";
+import { loadBuiltInIncidentTypes, getBuiltInIncidentType } from "./incidentTypesData.js";
+
+// Per-case chosen incident-type store (#236), in state/incident-type.json. A stateless wrapper over
+// CaseStore (mirrors SourceTrustStore / ClockSkewStore). Persists which incident type the analyst
+// picked for this case, so the synthesis prompt, a re-apply, and the dashboard can read it back,
+// plus the timestamp of the last apply.
+//
+// Custom (analyst-defined) incident types are loaded from a global data dir (mirroring
+// TemplateStore's custom-templates dir): each *.json is one IncidentType definition, validated on
+// read with the shared schema so a hand-edited file can't inject a malformed type into the apply
+// path. Built-in types come from the bundled library (incidentTypesData.ts) and always win a
+// name collision — a custom file cannot silently redefine "ransomware" out from under the analyst.
+
+export interface IncidentTypeRecord {
+  typeId: string;        // the chosen incident type id (built-in or custom)
+  appliedAt: string;     // ISO timestamp of the last apply
+}
+
+export const EMPTY_INCIDENT_TYPE_RECORD: IncidentTypeRecord = { typeId: "", appliedAt: "" };
+
+const incidentTypeRecordSchema = z.object({
+  typeId: z.string().catch(""),
+  appliedAt: z.string().catch(""),
+});
+
+export class IncidentTypeStore {
+  constructor(
+    private readonly cases: CaseStore,
+    private readonly customDir: string,
+  ) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "incident-type.json");
+  }
+
+  async loadRecord(caseId: string): Promise<IncidentTypeRecord> {
+    try {
+      return incidentTypeRecordSchema.parse(JSON.parse(await readFile(this.path(caseId), "utf8")));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return { ...EMPTY_INCIDENT_TYPE_RECORD };
+      // A corrupt record must not block synthesis or the dashboard — the analyst can re-pick a type,
+      // but they cannot recover a case whose every read throws.
+      if (err instanceof SyntaxError) return { ...EMPTY_INCIDENT_TYPE_RECORD };
+      throw err;
+    }
+  }
+
+  async saveRecord(caseId: string, typeId: string, at: string = new Date().toISOString()): Promise<IncidentTypeRecord> {
+    const record: IncidentTypeRecord = { typeId, appliedAt: at };
+    await atomicWrite(this.path(caseId), JSON.stringify(record, null, 2));
+    return record;
+  }
+
+  // The incident type currently chosen for a case, or null when none was picked (or the picked type
+  // has since been deleted). Convenience for the synthesis path, which wants the definition and does
+  // not care about the record.
+  async loadType(caseId: string): Promise<IncidentType | null> {
+    const record = await this.loadRecord(caseId);
+    return record.typeId ? await this.get(record.typeId) : null;
+  }
+
+  // List every available incident type: built-ins first, then custom types from the data dir.
+  async listAll(): Promise<IncidentType[]> {
+    return [...loadBuiltInIncidentTypes(), ...(await this.listCustom())];
+  }
+
+  async listCustom(): Promise<IncidentType[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.customDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+    const out: IncidentType[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue;
+      try {
+        const parsed = parseIncidentType(JSON.parse(await readFile(join(this.customDir, entry), "utf8")));
+        // A custom file never gets to claim builtIn (the flag drives "can't delete this" in the UI),
+        // and never gets to shadow a bundled id.
+        if (parsed && !getBuiltInIncidentType(parsed.id)) out.push({ ...parsed, builtIn: false });
+      } catch {
+        // skip malformed files — never crash the type listing over a bad custom definition
+      }
+    }
+    return out;
+  }
+
+  // Resolve a single incident type by id (built-in first, then custom).
+  async get(id: string): Promise<IncidentType | null> {
+    const builtin = getBuiltInIncidentType(id);
+    if (builtin) return builtin;
+    return (await this.listCustom()).find((t) => t.id === id) ?? null;
+  }
+}

--- a/companion/src/analysis/incidentTypes.ts
+++ b/companion/src/analysis/incidentTypes.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import type { InvestigationState, InvestigationQuestion, NextStep } from "./stateTypes.js";
+import {
+  buildInitialQuestions,
+  buildInitialNextSteps,
+  type CaseTemplate,
+} from "./templateStore.js";
+
+// Incident-type auto-playbooks (#236). A richer CaseTemplate: the template carries the GENERIC case
+// skeleton (questions, next steps, recommended imports, hunt platforms); an IncidentType extends it
+// with the per-type investigation GUIDANCE that auto-configures a case for a recurring incident
+// pattern (ransomware, BEC, exfil, …). Because IncidentType extends CaseTemplate, an incident type
+// IS a case template — the New Case dialog offers a single picker over both (the built-in template
+// ids ransomware/bec/insider-threat are the same incidents, only thinner).
+//
+// This module is PURE — no I/O, no AI. The built-in library lives in companion/data/incident-types/
+// as one JSON file per type (loaded by incidentTypesData.ts); per-case persistence of the chosen
+// type lives in incidentTypeStore.ts. Custom analyst-defined types flow through the same schema and
+// the same apply path, so there is exactly one validation and one mutation to reason about.
+//
+// Guidance fields and where they are consumed:
+//   - findingsSeeds          — pre-seeded confirm/deny key questions (consumed here, at apply).
+//   - synthesisHint          — one-line framing read by the synthesis prompt (pipeline.ts) from the
+//                              per-case record. NOT stored in state.lastSummary: that field is the
+//                              analyst-facing case summary and the report's executive-summary
+//                              fallback, so a prompt hint written there would print as the executive
+//                              summary of a forensic report.
+//   - recommendedImportOrder — ordered import checklist for the Import panel.  ─┐ defined and served
+//   - huntBundles            — pre-selected Velociraptor bundle ids.            ├─ over the API, not
+//   - reportFraming          — report template + exec-summary audience.        ─┘ yet consumed (#347).
+
+export type IncidentTypeId =
+  | "ransomware"
+  | "bec"
+  | "data-exfiltration"
+  | "intrusion"
+  | "insider-threat"
+  | "cloud-compromise"
+  | "web-app-intrusion"
+  | "malware-outbreak";
+
+// Presentation order for the built-in library — the loader reads a directory, whose entries arrive
+// alphabetically, but the pickers should lead with the incident types analysts meet most often.
+export const BUILT_IN_INCIDENT_TYPE_IDS: readonly IncidentTypeId[] = [
+  "ransomware",
+  "bec",
+  "data-exfiltration",
+  "intrusion",
+  "insider-threat",
+  "cloud-compromise",
+  "web-app-intrusion",
+  "malware-outbreak",
+];
+
+export interface IncidentTypeReportFraming {
+  template: string;          // report template id/name to pre-select
+  audience: string;          // executive-summary audience, e.g. "board + insurer"
+  summaryPrompt: string;     // a one-line framing prompt for the exec summary
+}
+
+// An incident type IS a case template plus the type-specific guidance fields.
+export interface IncidentType extends CaseTemplate {
+  recommendedImportOrder: string[];   // ordered importer labels, e.g. ["edr","dc-logs","network"]
+  huntBundles: string[];              // pre-selected Velociraptor bundle ids
+  findingsSeeds: string[];            // expected finding categories, pre-seeded as open questions
+  reportFraming: IncidentTypeReportFraming;
+  synthesisHint: string;              // one-line context for the synthesis prompt
+}
+
+const severitySchema = z.enum(["Critical", "High", "Medium", "Low", "Info"]);
+const prioritySchema = z.enum(["critical", "high", "medium", "low"]);
+
+// Validation for BOTH the bundled built-ins and analyst-authored custom types — a hand-edited file
+// must not be able to inject a malformed type into the apply path. `id` and `name` are required
+// (a type with neither is unusable and unpresentable); everything else degrades to an empty default
+// so one bad field doesn't discard an otherwise-good definition.
+export const incidentTypeSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().catch(""),
+  builtIn: z.boolean().catch(false),
+  recommendedImports: z.array(z.string()).catch([]),
+  initialKeyQuestions: z.array(z.string()).catch([]),
+  initialNextSteps: z.array(z.object({
+    action: z.string(),
+    priority: prioritySchema,
+    rationale: z.string().catch(""),
+    pointer: z.string().catch(""),
+  })).catch([]),
+  severityFloor: severitySchema.nullable().catch(null),
+  huntPlatforms: z.array(z.string()).catch([]),
+  recommendedImportOrder: z.array(z.string()).catch([]),
+  huntBundles: z.array(z.string()).catch([]),
+  findingsSeeds: z.array(z.string()).catch([]),
+  reportFraming: z.object({
+    template: z.string().catch(""),
+    audience: z.string().catch(""),
+    summaryPrompt: z.string().catch(""),
+  }).catch({ template: "", audience: "", summaryPrompt: "" }),
+  synthesisHint: z.string().catch(""),
+});
+
+// Parse one candidate definition, returning null rather than throwing — callers list a directory of
+// analyst-editable files and must never crash the whole listing over a single bad one.
+export function parseIncidentType(raw: unknown): IncidentType | null {
+  const parsed = incidentTypeSchema.safeParse(raw);
+  return parsed.success ? (parsed.data as IncidentType) : null;
+}
+
+// The prefix that marks a key question as seeded by an incident type rather than written by the
+// analyst — the dashboard badges these, and the analyst can dismiss one as N/A.
+export const TYPE_SEED_PREFIX = "[type-seed]";
+
+export interface ApplyIncidentTypeOptions {
+  now?: () => string;
+  // When true, REPLACES existing key questions / next steps with the type's. When false (default),
+  // MERGES — preserves analyst-added entries and only adds the type's seeds that aren't already
+  // present (matched by exact question/action text). Merge is the default everywhere, including at
+  // case creation: a template may already have seeded the fresh state, and discarding its questions
+  // silently loses what the analyst picked.
+  replace?: boolean;
+}
+
+export interface ApplyIncidentTypeResult {
+  state: InvestigationState;
+  questionsAdded: number;
+  nextStepsAdded: number;
+}
+
+// Apply an incident type's auto-configuration to an InvestigationState:
+//   - pre-populates key questions (the type's initialKeyQuestions)
+//   - pre-populates next steps (the type's initialNextSteps)
+//   - pre-seeds findingsSeeds as open confirm/deny key questions, so the analyst confirms or denies
+//     each expected finding category rather than starting from a blank slate
+//
+// Deliberately does NOT touch state.lastSummary — see the module header. The synthesis hint reaches
+// the AI from the per-case incident-type record, read by the synthesis prompt.
+//
+// Pure: returns a new state; never mutates the input. Does not persist (the caller does).
+export function applyIncidentTypeToState(
+  state: InvestigationState,
+  type: IncidentType,
+  opts: ApplyIncidentTypeOptions = {},
+): ApplyIncidentTypeResult {
+  const now = opts.now ?? (() => new Date().toISOString());
+  const replace = opts.replace ?? false;
+
+  const seedFindingsQuestions: InvestigationQuestion[] = type.findingsSeeds.map((label) => ({
+    id: randomUUID(),
+    question: `${TYPE_SEED_PREFIX} Confirm or deny: ${label}`,
+    status: "unknown" as const,
+    answer: "",
+    pointer: "",
+    pinned: true,
+  }));
+  const allSeedQuestions = [...buildInitialQuestions(type), ...seedFindingsQuestions];
+  const seedNextSteps: NextStep[] = buildInitialNextSteps(type);
+
+  let questions: InvestigationQuestion[];
+  let nextSteps: NextStep[];
+  let questionsAdded: number;
+  let nextStepsAdded: number;
+
+  if (replace) {
+    questions = allSeedQuestions;
+    nextSteps = seedNextSteps;
+    questionsAdded = allSeedQuestions.length;
+    nextStepsAdded = seedNextSteps.length;
+  } else {
+    const existingQ = new Set(state.keyQuestions.map((q) => q.question));
+    const newQ = allSeedQuestions.filter((q) => !existingQ.has(q.question));
+    questionsAdded = newQ.length;
+    questions = [...state.keyQuestions, ...newQ];
+
+    const existingSteps = new Set(state.nextSteps.map((s) => s.action));
+    const newSteps = seedNextSteps.filter((s) => !existingSteps.has(s.action));
+    nextStepsAdded = newSteps.length;
+    nextSteps = [...state.nextSteps, ...newSteps];
+  }
+
+  const next: InvestigationState = {
+    ...state,
+    keyQuestions: questions,
+    nextSteps,
+    updatedAt: now(),
+  };
+  return { state: next, questionsAdded, nextStepsAdded };
+}
+
+// Render the type's synthesis hint as a prompt block for the synthesis pass, so the AI prioritizes
+// the techniques that matter for this incident type. Returns "" for no type or an empty hint, so the
+// caller can concatenate it unconditionally and it costs nothing when unset.
+export function renderIncidentTypeBlock(type: IncidentType | null | undefined): string {
+  const hint = type?.synthesisHint?.trim();
+  if (!type || !hint) return "";
+  return `INCIDENT TYPE: ${type.name}. ${hint}\n\n`;
+}

--- a/companion/src/analysis/incidentTypesData.ts
+++ b/companion/src/analysis/incidentTypesData.ts
@@ -1,0 +1,109 @@
+// Loader for the bundled incident-type library (companion/data/incident-types/*.json, one file per
+// type) — issue #236.
+//
+// Isolated from the pure apply logic (incidentTypes.ts) so that module stays I/O-free and trivially
+// testable. The dataset is static, committed, analyst-editable data; there is NO runtime network
+// call. Read once and cached. Degrades gracefully: a missing directory or a corrupt file yields the
+// types that DID parse rather than crashing case creation — a bad hand-edit must never take the
+// New Case dialog down with it.
+//
+// Mirrors knownPlaybooksData.ts, including the SEA candidate-path handling (build-sea stages
+// companion/data/ next to the binary).
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  BUILT_IN_INCIDENT_TYPE_IDS,
+  parseIncidentType,
+  type IncidentType,
+} from "./incidentTypes.js";
+
+const DATA_SUBDIR = join("data", "incident-types");
+
+// Candidate locations, most-likely first: dev/tsc resolve relative to this module; the SEA EXE
+// ships data/ next to the binary.
+function candidateDirs(): string[] {
+  const dirs: string[] = [];
+  try {
+    dirs.push(fileURLToPath(new URL("../../data/incident-types/", import.meta.url)));
+  } catch {
+    // import.meta.url unavailable (some bundlers) — fall through to the execPath candidate.
+  }
+  try {
+    dirs.push(join(dirname(process.execPath), DATA_SUBDIR));
+  } catch {
+    // ignore
+  }
+  return dirs;
+}
+
+// Order by the canonical id list so the pickers lead with the most common incident types; any type
+// found on disk but absent from that list (an analyst dropped an extra file into the bundled dir)
+// keeps a stable alphabetical position at the end rather than disappearing.
+function inCanonicalOrder(types: IncidentType[]): IncidentType[] {
+  const rank = new Map<string, number>(BUILT_IN_INCIDENT_TYPE_IDS.map((id, i) => [id, i]));
+  const known = BUILT_IN_INCIDENT_TYPE_IDS.length;
+  return [...types].sort((a, b) => {
+    const ra = rank.get(a.id) ?? known;
+    const rb = rank.get(b.id) ?? known;
+    return ra !== rb ? ra - rb : a.id.localeCompare(b.id);
+  });
+}
+
+function readDir(dir: string): IncidentType[] {
+  const out: IncidentType[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith(".json")) continue;
+    try {
+      const parsed = parseIncidentType(JSON.parse(readFileSync(join(dir, entry), "utf8")));
+      // Force builtIn on anything read from the bundled dir — the flag is what tells the UI a type
+      // can't be deleted, and it must reflect where the file lives, not what the file claims.
+      if (parsed) out.push({ ...parsed, builtIn: true });
+    } catch {
+      // skip an unreadable/unparseable file — the rest of the library still loads
+    }
+  }
+  return out;
+}
+
+let cached: IncidentType[] | null = null;
+let warned = false;
+
+// The bundled incident-type library, loaded once and cached. Never throws — returns an empty list
+// (and warns once) if no candidate directory is readable, so callers degrade to "no built-in types"
+// rather than failing the request.
+export function loadBuiltInIncidentTypes(): readonly IncidentType[] {
+  if (cached) return cached;
+  for (const dir of candidateDirs()) {
+    try {
+      const types = readDir(dir);
+      if (types.length > 0) {
+        cached = inCanonicalOrder(types);
+        return cached;
+      }
+    } catch {
+      // try the next candidate
+    }
+  }
+  if (!warned) {
+    warned = true;
+    console.warn(
+      "[incident-types] data/incident-types/ not found or empty — built-in incident types unavailable.",
+    );
+  }
+  cached = [];
+  return cached;
+}
+
+// Resolve a built-in incident type by id. Returns undefined for an unknown id (custom types are
+// resolved by IncidentTypeStore, which falls back to its own on-disk list).
+export function getBuiltInIncidentType(id: string): IncidentType | undefined {
+  return loadBuiltInIncidentTypes().find((t) => t.id === id);
+}
+
+// Test-only: drop the cache so a test can point the loader at a fresh state.
+export function _resetIncidentTypesCache(): void {
+  cached = null;
+  warned = false;
+}

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -181,6 +181,8 @@ import {
 import { HUNT_PLATFORMS, type HuntPlatform } from "./huntPlatforms.js";
 import type { PlaybookTask } from "./playbook.js";
 import type { PlaybookStore } from "./playbookStore.js";
+import type { IncidentTypeStore } from "./incidentTypeStore.js";
+import { renderIncidentTypeBlock } from "./incidentTypes.js";
 import { renderPlaybookProgressBlock, renderRefutedHypothesesBlock, demoteCompletedNextSteps } from "./priorWork.js";
 import { flagContradictedAnswers } from "./answerContradiction.js";
 import { detectSatisfiedCollections, buildSatisfiedCollectionsBlock } from "./collectSatisfaction.js";
@@ -1643,6 +1645,10 @@ export interface PipelineOptions {
   // Per-case import-meta store. When set, synthesis + the evidence-gap panel flag a zero-yield AI
   // import (a source read as "clean" that actually dropped everything — investigation-guidance #10).
   importMetaStore?: ImportMetaStore;
+  // Per-case incident-type store (#236). When set, synthesis prepends the chosen type's one-line
+  // hint so the model prioritizes the techniques that matter for a ransomware / BEC / exfil case.
+  // Absent → no hint (CLI/tests).
+  incidentTypeStore?: IncidentTypeStore;
 }
 
 // Keep analyst-pinned questions across a synthesis. The model is told about them and may
@@ -5452,6 +5458,14 @@ export class AnalysisPipeline {
     const playbookTasks = this.opts.playbookStore ? await this.opts.playbookStore.load(caseId) : [];
     const playbookProgressBlock = renderPlaybookProgressBlock(playbookTasks);
 
+    // Incident-type framing (#236): the one-line hint for the type the analyst picked at case
+    // creation, so the model prioritizes ransomware / BEC / exfil techniques. A pure INPUT synthesis
+    // never rewrites, and cheap (one short line) — but changing the type must re-synthesize, so it
+    // joins the skip-if-unchanged hash below.
+    const incidentTypeBlock = renderIncidentTypeBlock(
+      this.opts.incidentTypeStore ? await this.opts.incidentTypeStore.loadType(caseId) : null,
+    );
+
     // Skip-if-unchanged: hash only the STABLE INPUTS to synthesis — the in-scope timeline,
     // the IOCs (value + intel verdicts), the scope, the legitimate markers, and (when opted
     // in) the notebook entries. NOT the findings / MITRE / threads / summary, which synthesis
@@ -5468,6 +5482,9 @@ export class AnalysisPipeline {
       // changes these strings, so an otherwise-identical timeline re-synthesizes to fold in the
       // new negative knowledge instead of skipping. Pure inputs — synthesis never rewrites them.
       pw: priorHuntsBlock + playbookProgressBlock + refutedHypothesesBlock,
+      // Re-picking the incident type reframes what the model should prioritize — an otherwise
+      // identical timeline must re-synthesize rather than skip.
+      it: incidentTypeBlock,
       // Deep-pass observations are a pure INPUT synthesis never rewrites, but they change what the
       // model can see — so a run carrying fresh ones must never be skipped as "inputs unchanged".
       ob: observationsBlock,
@@ -5590,7 +5607,7 @@ export class AnalysisPipeline {
       return `${ctx}[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}${groupTag}${prevTag ? ` ⟨${prevTag}⟩` : ""}`;
     };
     const synthOverhead = estimateTokens(getSynthesisPrompt())
-      + estimateTokens(scopeNote + contextBlock + graphBlock + beaconBlock + attackPhaseBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + satisfiedBlock + pinnedBlock + reanswerBlock + observationsBlock + existingFindings + openThreads + falsePositiveBlock + authorizedContextBlock + learnedPatternsBlock + (state.lastSummary || "")) + 400;
+      + estimateTokens(incidentTypeBlock + scopeNote + contextBlock + graphBlock + beaconBlock + attackPhaseBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + satisfiedBlock + pinnedBlock + reanswerBlock + observationsBlock + existingFindings + openThreads + falsePositiveBlock + authorizedContextBlock + learnedPatternsBlock + (state.lastSummary || "")) + 400;
     const fit = fitItemsToBudget(promptEvents, renderEvent, Math.max(0, inputTokenBudget() - synthOverhead));
     if (fit < promptEvents.length) { selection = selectSynthesisEventsAnnotated(collapsedEvents, fit, rarityOf); promptEvents = selection.events; }
 
@@ -5636,6 +5653,7 @@ export class AnalysisPipeline {
       ? " Rows prefixed \"~\" are SUPPORTING CONTEXT (pulled in to explain a nearby anchor), not primary findings — weight them as background."
       : "";
     const userPrompt =
+      incidentTypeBlock +
       scopeNote +
       contextBlock +
       graphBlock +

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -5,6 +5,7 @@ import { isValidCaseId } from "../storage/caseStore.js";
 import { withNonce } from "../http/securityHeaders.js";
 import { sanitizeCaseMeta } from "../analysis/casePassword.js";
 import { buildInitialQuestions, buildInitialNextSteps } from "../analysis/templateStore.js";
+import { applyIncidentTypeToState } from "../analysis/incidentTypes.js";
 import { milestoneEvent } from "../analysis/notifications.js";
 import { seedDemoCase } from "../analysis/seedDemoCase.js";
 import { archiveCase } from "../analysis/caseArchive.js";
@@ -105,9 +106,11 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
   // `npm run`-style tooling call it); the extension no longer creates cases. Rejects a
   // duplicate id so the form can't silently clobber an existing case's metadata/evidence.
   // Optional `templateId`: pre-populates key questions from the named template.
+  // Optional `incidentTypeId` (#236): additionally applies an incident type's auto-playbook —
+  // type-specific key questions, next steps, and expected-finding confirm/deny seeds.
   app.post("/cases", async (req: Request, res: Response) => {
     try {
-      const { caseId, name, investigator, aiProvider, templateId } = req.body ?? {};
+      const { caseId, name, investigator, aiProvider, templateId, incidentTypeId } = req.body ?? {};
       if (!caseId || !name) return res.status(400).json({ error: "caseId and name are required" });
       if (typeof caseId !== "string" || !isValidCaseId(caseId)) return res.status(400).json({ error: "caseId must use only letters, numbers, dots, dashes, or underscores, and may not contain path traversal" });
       if (await store.caseExists(caseId)) return res.status(409).json({ error: `case ${caseId} already exists` });
@@ -122,6 +125,22 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
           if (template.initialNextSteps?.length) state.nextSteps = buildInitialNextSteps(template);
           state.updatedAt = new Date().toISOString();
           await options.stateStore.save(state);
+        }
+      }
+      // Incident-type auto-configuration (#236): when an incident type is picked at creation, apply
+      // its key questions, next steps, and findings seeds to the fresh state, and persist the
+      // per-case chosen-type record (which the synthesis prompt reads for the type's hint).
+      //
+      // Runs AFTER the template apply and MERGES rather than replaces. The dashboard offers a single
+      // picker, so in practice only one of the two arrives — but an API caller may send both, and
+      // silently discarding the questions the template just seeded loses what it asked for.
+      if (incidentTypeId && options.incidentTypeStore && options.stateStore) {
+        const type = await options.incidentTypeStore.get(String(incidentTypeId));
+        if (type) {
+          const state = await options.stateStore.load(caseId);
+          const { state: next } = applyIncidentTypeToState(state, type);
+          await options.stateStore.save(next);
+          await options.incidentTypeStore.saveRecord(caseId, String(incidentTypeId));
         }
       }
       dispatchNotify(milestoneEvent(caseId, `Investigation opened: ${name}`, [`Investigator: ${investigator ?? "unknown"}`], new Date().toISOString()));

--- a/companion/src/routes/incidentTypes.ts
+++ b/companion/src/routes/incidentTypes.ts
@@ -1,0 +1,74 @@
+import type { Express, Request, Response } from "express";
+import { applyIncidentTypeToState } from "../analysis/incidentTypes.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Incident-type domain (#236): list/get the built-in + custom incident-type library, and apply a
+ * type to a case (auto-configures key questions, next steps, and expected-finding seeds).
+ *   - GET  /incident-types               — list every available incident type.
+ *   - GET  /incident-types/:id           — a single incident type definition.
+ *   - POST /cases/:id/incident-type      — set + apply an incident type to a case.
+ *   - GET  /cases/:id/incident-type      — the case's currently chosen incident type.
+ *
+ * The apply path mutates InvestigationState (keyQuestions, nextSteps) and persists both the new
+ * state and the per-case incident-type record — which is also where the synthesis prompt reads the
+ * type's hint from. Apply MERGES by default so a re-pick preserves analyst edits; { replace: true }
+ * is the "I picked the wrong type" escape hatch and overwrites.
+ *
+ * `:id` needs no isValidCaseId check: createApp mounts createCaseIdGate() on `/cases/:id`.
+ */
+export function registerIncidentTypeRoutes(app: Express, ctx: RouteContext): void {
+  const { options } = ctx;
+
+  app.get("/incident-types", async (_req: Request, res: Response) => {
+    if (!options.incidentTypeStore) return res.status(200).json([]);
+    try {
+      return res.status(200).json(await options.incidentTypeStore.listAll());
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.get("/incident-types/:id", async (req: Request, res: Response) => {
+    if (!options.incidentTypeStore) return res.status(404).json({ error: "incident-type store not configured" });
+    try {
+      const type = await options.incidentTypeStore.get(req.params.id);
+      if (!type) return res.status(404).json({ error: `incident type "${req.params.id}" not found` });
+      return res.status(200).json(type);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.get("/cases/:id/incident-type", async (req: Request, res: Response) => {
+    if (!options.incidentTypeStore) return res.status(501).json({ error: "incident-type store not configured" });
+    try {
+      const record = await options.incidentTypeStore.loadRecord(req.params.id);
+      const type = record.typeId ? await options.incidentTypeStore.get(record.typeId) : null;
+      return res.status(200).json({ record, type });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.post("/cases/:id/incident-type", async (req: Request, res: Response) => {
+    if (!options.incidentTypeStore) return res.status(501).json({ error: "incident-type store not configured" });
+    if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
+    const { typeId } = req.body ?? {};
+    if (typeof typeId !== "string" || !typeId.trim()) {
+      return res.status(400).json({ error: "typeId is required" });
+    }
+    const replace = req.body?.replace === true;
+    try {
+      const type = await options.incidentTypeStore.get(typeId);
+      if (!type) return res.status(404).json({ error: `incident type "${typeId}" not found` });
+      const state = await options.stateStore.load(req.params.id);
+      const { state: next, questionsAdded, nextStepsAdded } = applyIncidentTypeToState(state, type, { replace });
+      await options.stateStore.save(next);
+      const record = await options.incidentTypeStore.saveRecord(req.params.id, typeId);
+      return res.status(200).json({ record, type, questionsAdded, nextStepsAdded });
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -37,6 +37,7 @@ import { registerInteractiveReportRoutes } from "./routes/interactiveReport.js";
 import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
+import { registerIncidentTypeRoutes } from "./routes/incidentTypes.js";
 import { registerClockSkewRoutes } from "./routes/clockSkew.js";
 import { registerSlashCommandRoutes, startTelegramPolling, startSlackSocketMode } from "./routes/slashCommand.js";
 import { registerComplianceRoutes } from "./routes/compliance.js";
@@ -165,6 +166,7 @@ import {
 import { createSecurityHeaders } from "./http/securityHeaders.js";
 import { getAiLimiter } from "./http/rateLimiter.js";
 import { TemplateStore } from "./analysis/templateStore.js";
+import { IncidentTypeStore } from "./analysis/incidentTypeStore.js";
 import { diffTimeline, addedForensicEvents } from "./analysis/timelineDiff.js";
 import { diffIocs } from "./analysis/iocsDiff.js";
 import { ImportUndoStore, pushCheckpoint, undoMaxBytesFromEnv } from "./analysis/importUndo.js";
@@ -571,6 +573,10 @@ export interface AppOptions {
   rebuildTimesketchClient?: () => TimesketchClient | undefined;
   // Case templates: built-in + user-saved templates selectable at case creation.
   templateStore?: TemplateStore;
+  // Incident-type auto-playbooks (#236): the built-in + custom incident-type library plus the
+  // per-case chosen-type record. Applies a type's auto-configuration (key questions, next steps,
+  // expected-finding seeds) at case creation or on demand, and feeds the synthesis hint.
+  incidentTypeStore?: IncidentTypeStore;
   // MISP export: a configured client (when DFIR_MISP_URL/KEY are set) + push options
   // (distribution, analysis state, base URL for the event link).
   mispPushClient?: MispPushClient;
@@ -970,6 +976,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // app shell). Both register before the terminal error handler at the end of createApp.
   registerCasePasswordRoutes(app, ctx);
   registerCaseLifecycleRoutes(app, ctx);
+  registerIncidentTypeRoutes(app, ctx);
   registerClockSkewRoutes(app, ctx);
   registerCoachRoutes(app, ctx);
   registerComplianceRoutes(app, ctx);
@@ -3253,6 +3260,9 @@ export interface RuntimePipelineParams {
   // Clock-skew store (#228): synthesis measures per-host offsets from the PRE-merge timeline (the
   // correlation that follows collapses the anchors) and stores them here.
   clockSkewStore?: ClockSkewStore;
+  // Incident-type store (#236): synthesis reads the case's chosen type for its one-line hint.
+  // Passed in rather than built here — it needs the custom-types dir, not just the case store.
+  incidentTypeStore?: IncidentTypeStore;
   // Second LLM opinion (issue #116): a different model + its persistence store, plus the model
   // labels for the comparison header. Absent → the feature is disabled (route 501).
   secondOpinionProvider?: AnalyzeProvider;
@@ -3289,6 +3299,7 @@ export function buildRuntimePipeline(params: RuntimePipelineParams): AnalysisPip
     learnedPatternStore: new LearnedPatternStore(params.store), // #65 feed learned dismissal patterns into synthesis
     sourceTrustStore: new SourceTrustStore(params.store),   // #66 per-source trust weights for merge + confidence
     clockSkewStore: params.clockSkewStore,                  // #228 measure clock skew on the PRE-merge timeline
+    incidentTypeStore: params.incidentTypeStore,            // #236 frame synthesis with the case's incident type
     playbookStore: new PlaybookStore(params.store),         // #2 feed DONE/SKIPPED task status into synthesis
     importMetaStore: new ImportMetaStore(params.store),      // #10 flag a zero-yield AI import as a coverage gap
     aiControlStore: new AiControlStore(params.store),
@@ -3328,6 +3339,9 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     warnLine(`[state] ${caseId}: investigation.json save needed ${retries} rename retr${retries === 1 ? "y" : "ies"} — the state dir is contended (antivirus / search indexer / sync client). Consider excluding the cases root from real-time scanning, or raise DFIR_ATOMIC_WRITE_RETRIES.`),
   );
   const templateStore = new TemplateStore(join(dirname(casesRoot), "templates"));
+  // Incident-type auto-playbooks (#236): the built-in library ships in companion/data/incident-types/;
+  // this dir holds analyst-authored custom types (same drive-root-safe rationale as templates/bundles).
+  const incidentTypeStore = new IncidentTypeStore(store, join(dirname(casesRoot), "incident-types"));
   const artifactBundleStore = new ArtifactBundleStore(join(dirname(casesRoot), "bundles"));
   // Report templates are GLOBAL like case templates/bundles — a dedicated subdir beside cases/.
   const reportTemplateStore = new ReportTemplateStore(join(dirname(casesRoot), "report-templates"));
@@ -3544,7 +3558,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     : undefined;
   if (presidio) logLine(`[presidio] enabled — scanning masked AI prompts via ${presidioUrl} (minScore ${presidio.minScore})`);
   const wiredPipeline = buildRuntimePipeline({
-    provider, synthesisProvider, velociraptorProvider, stateStore, store, stateLock, onState: (s) => hub.broadcast(s), ocrRunner, logger, kevStore, clockSkewStore,
+    provider, synthesisProvider, velociraptorProvider, stateStore, store, stateLock, onState: (s) => hub.broadcast(s), ocrRunner, logger, kevStore, clockSkewStore, incidentTypeStore,
     presidio, presidioPendingStore: new PresidioPendingStore(store),
     secondOpinionProvider, secondOpinionStore, synthesisModelLabel, secondOpinionModelLabel,
     // After a real synthesis, page the matching channels for each new/escalated finding (#58).
@@ -3714,6 +3728,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     timesketchOptions: timesketchPushOptions(),
     rebuildTimesketchClient: buildTimesketchClient,
     templateStore,
+    incidentTypeStore,
     mispPushClient: buildMispPushClient(),
     mispPushOptions: mispPushOptions(),
     notionClient: buildNotionClient(),

--- a/companion/tests/analysis/incidentTypeSynthesis.test.ts
+++ b/companion/tests/analysis/incidentTypeSynthesis.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { IncidentTypeStore } from "../../src/analysis/incidentTypeStore.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+
+// The incident type's synthesis hint must reach the synthesis PROMPT (#236). It used to be stamped
+// onto state.lastSummary instead, which both printed it as the report's executive summary and let
+// the first synthesis overwrite it — so these tests pin the prompt, not the state.
+
+const SYNTH_DELTA = JSON.stringify({
+  findings: [], iocs: [], mitreTechniques: [], attackerPath: "p", summary: "s",
+  forensicEvents: [], threadsOpened: [], threadsClosed: [], timelineNote: "",
+});
+
+class CapturingProvider implements AIProvider {
+  readonly name = "capture";
+  readonly model = "capture-model";
+  lastReq?: AnalyzeRequest;
+  async analyze(req: AnalyzeRequest): Promise<AnalyzeResult> {
+    this.lastReq = req;
+    return { rawText: SYNTH_DELTA };
+  }
+}
+
+function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+  return {
+    timestamp: "2026-01-01T00:00:00Z", description: "", severity: "High",
+    mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], ...p,
+  };
+}
+
+async function makePipeline(opts: { withStore?: boolean } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "dfir-itype-synth-"));
+  const casesRoot = join(root, "cases");
+  const cases = new CaseStore(casesRoot);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  const stateStore = new StateStore(cases);
+  const state = emptyState("c1");
+  state.forensicTimeline = [ev({ id: "e1", description: "vssadmin delete shadows /all /quiet" })];
+  await stateStore.save(state);
+
+  const incidentTypeStore = new IncidentTypeStore(cases, join(root, "incident-types"));
+  const provider = new CapturingProvider();
+  const pipeline = new AnalysisPipeline({
+    provider, synthesisProvider: provider, stateStore,
+    imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+    ...(opts.withStore === false ? {} : { incidentTypeStore }),
+  });
+  return { pipeline, provider, stateStore, incidentTypeStore };
+}
+
+describe("incident-type synthesis hint (#236)", () => {
+  it("prepends the chosen type's hint to the synthesis prompt", async () => {
+    const { pipeline, provider, incidentTypeStore } = await makePipeline();
+    await incidentTypeStore.saveRecord("c1", "ransomware");
+
+    await pipeline.synthesize("c1", { force: true });
+
+    const prompt = provider.lastReq!.userPrompt;
+    expect(prompt).toContain("INCIDENT TYPE: Ransomware.");
+    expect(prompt).toContain("T1486");
+    // Framing belongs at the top, before the evidence it is meant to frame.
+    expect(prompt.indexOf("INCIDENT TYPE:")).toBeLessThan(prompt.indexOf("FORENSIC TIMELINE"));
+  });
+
+  it("sends no hint when the case has no incident type", async () => {
+    const { pipeline, provider } = await makePipeline();
+    await pipeline.synthesize("c1", { force: true });
+    expect(provider.lastReq!.userPrompt).not.toContain("INCIDENT TYPE:");
+  });
+
+  it("sends no hint when the store is not wired (CLI / tests)", async () => {
+    const { pipeline, provider } = await makePipeline({ withStore: false });
+    await pipeline.synthesize("c1", { force: true });
+    expect(provider.lastReq!.userPrompt).not.toContain("INCIDENT TYPE:");
+  });
+
+  it("survives synthesis — unlike the old lastSummary stamp, which the first run overwrote", async () => {
+    const { pipeline, provider, stateStore, incidentTypeStore } = await makePipeline();
+    await incidentTypeStore.saveRecord("c1", "ransomware");
+
+    await pipeline.synthesize("c1", { force: true });
+    // Synthesis wrote its own summary into lastSummary; the hint is unaffected because it never
+    // lived there.
+    expect((await stateStore.load("c1")).lastSummary).toBe("s");
+
+    await pipeline.synthesize("c1", { force: true });
+    expect(provider.lastReq!.userPrompt).toContain("INCIDENT TYPE: Ransomware.");
+  });
+
+  it("changing the incident type re-synthesizes instead of skipping as unchanged", async () => {
+    const { pipeline, provider, incidentTypeStore } = await makePipeline();
+    await incidentTypeStore.saveRecord("c1", "ransomware");
+    await pipeline.synthesize("c1", { force: true });
+
+    // No force this time: only the type changed, and that must be enough to invalidate the
+    // skip-if-unchanged hash.
+    await incidentTypeStore.saveRecord("c1", "bec");
+    await pipeline.synthesize("c1");
+    expect(provider.lastReq!.userPrompt).toContain("INCIDENT TYPE: BEC / Email Compromise.");
+  });
+});

--- a/companion/tests/analysis/incidentTypes.test.ts
+++ b/companion/tests/analysis/incidentTypes.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyIncidentTypeToState,
+  renderIncidentTypeBlock,
+  parseIncidentType,
+  BUILT_IN_INCIDENT_TYPE_IDS,
+  TYPE_SEED_PREFIX,
+  type IncidentType,
+} from "../../src/analysis/incidentTypes.js";
+import {
+  loadBuiltInIncidentTypes,
+  getBuiltInIncidentType,
+} from "../../src/analysis/incidentTypesData.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+
+const ransomware = getBuiltInIncidentType("ransomware")!;
+
+function customType(over: Partial<IncidentType> = {}): IncidentType {
+  return {
+    id: "org-ransomware-variant",
+    name: "Org Ransomware Variant",
+    description: "Org-specific ransomware variant",
+    builtIn: false,
+    recommendedImports: ["edr"],
+    initialKeyQuestions: ["What was the entry point?"],
+    initialNextSteps: [{ action: "Isolate host", priority: "critical", rationale: "contain", pointer: "EDR" }],
+    severityFloor: "High",
+    huntPlatforms: ["Velociraptor"],
+    recommendedImportOrder: ["edr"],
+    huntBundles: ["custom-bundle"],
+    findingsSeeds: ["Encryption observed"],
+    reportFraming: { template: "custom", audience: "exec", summaryPrompt: "summarize" },
+    synthesisHint: "Org-specific ransomware — prioritize encryption.",
+    ...over,
+  };
+}
+
+describe("built-in incident-type library (data/incident-types/*.json)", () => {
+  it("loads the eight built-in types from disk, in canonical order", () => {
+    expect(loadBuiltInIncidentTypes().map((t) => t.id)).toEqual([...BUILT_IN_INCIDENT_TYPE_IDS]);
+  });
+
+  it("every built-in carries the fields the pickers and the apply path read", () => {
+    for (const t of loadBuiltInIncidentTypes()) {
+      expect(t.builtIn).toBe(true);
+      expect(t.name.length).toBeGreaterThan(0);
+      expect(t.initialKeyQuestions.length).toBeGreaterThan(0);
+      expect(t.initialNextSteps.length).toBeGreaterThan(0);
+      expect(t.recommendedImportOrder.length).toBeGreaterThan(0);
+      expect(t.huntBundles.length).toBeGreaterThan(0);
+      expect(t.findingsSeeds.length).toBeGreaterThan(0);
+      expect(t.reportFraming.template.length).toBeGreaterThan(0);
+      expect(t.synthesisHint.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("getBuiltInIncidentType resolves by id and returns undefined for unknown", () => {
+    expect(getBuiltInIncidentType("ransomware")?.id).toBe("ransomware");
+    expect(getBuiltInIncidentType("nope")).toBeUndefined();
+  });
+
+  it("ransomware seeds VSS deletion and double-extortion; BEC seeds inbox rules and OAuth", () => {
+    expect(ransomware.findingsSeeds).toContain("VSS shadow copies deleted");
+    expect(ransomware.findingsSeeds).toContain("Double-extortion leak-site listing");
+    expect(ransomware.huntBundles).toContain("vss-delete");
+    expect(ransomware.synthesisHint).toContain("T1486");
+
+    const bec = getBuiltInIncidentType("bec")!;
+    expect(bec.findingsSeeds).toContain("Attacker-created inbox/forwarding rules");
+    expect(bec.findingsSeeds).toContain("OAuth app grant persistence");
+    expect(bec.huntBundles).toContain("mailbox-rules");
+  });
+});
+
+describe("parseIncidentType", () => {
+  it("rejects a definition with no id or no name rather than yielding an unusable type", () => {
+    expect(parseIncidentType({ name: "No id" })).toBeNull();
+    expect(parseIncidentType({ id: "no-name" })).toBeNull();
+    expect(parseIncidentType({ id: "", name: "empty id" })).toBeNull();
+  });
+
+  it("keeps a definition whose optional fields are malformed, defaulting just those", () => {
+    const parsed = parseIncidentType({
+      id: "minimal", name: "Minimal",
+      findingsSeeds: "not-an-array", huntBundles: 42, reportFraming: "nope",
+    });
+    expect(parsed?.id).toBe("minimal");
+    expect(parsed?.findingsSeeds).toEqual([]);
+    expect(parsed?.huntBundles).toEqual([]);
+    expect(parsed?.reportFraming).toEqual({ template: "", audience: "", summaryPrompt: "" });
+  });
+});
+
+describe("applyIncidentTypeToState", () => {
+  it("populates key questions and next steps on an empty state", () => {
+    const { state: next, questionsAdded, nextStepsAdded } = applyIncidentTypeToState(
+      emptyState("c1"), ransomware, { now: () => "2026-07-25T00:00:00Z" },
+    );
+    const expectedQuestions = ransomware.initialKeyQuestions.length + ransomware.findingsSeeds.length;
+    expect(questionsAdded).toBe(expectedQuestions);
+    expect(nextStepsAdded).toBe(ransomware.initialNextSteps.length);
+    expect(next.keyQuestions.length).toBe(expectedQuestions);
+    expect(next.nextSteps.length).toBe(ransomware.initialNextSteps.length);
+    expect(next.updatedAt).toBe("2026-07-25T00:00:00Z");
+  });
+
+  // The regression this whole module was reworked for: lastSummary is the analyst's case summary
+  // AND the report's executive-summary fallback. A prompt hint written there prints as the executive
+  // summary of a forensic report, and is then silently overwritten by the first AI synthesis.
+  it("never touches lastSummary — the synthesis hint must not reach the report", () => {
+    const { state: fromEmpty } = applyIncidentTypeToState(emptyState("c1"), ransomware);
+    expect(fromEmpty.lastSummary).toBe("");
+    expect(JSON.stringify(fromEmpty)).not.toContain("T1486");
+
+    const written = { ...emptyState("c1"), lastSummary: "Analyst wrote this summary." };
+    expect(applyIncidentTypeToState(written, ransomware).state.lastSummary).toBe("Analyst wrote this summary.");
+  });
+
+  it("seeds findings as pinned confirm/deny questions with a [type-seed] prefix", () => {
+    const { state: next } = applyIncidentTypeToState(emptyState("c1"), ransomware);
+    const seedQs = next.keyQuestions.filter((q) => q.question.startsWith(TYPE_SEED_PREFIX));
+    expect(seedQs.length).toBe(ransomware.findingsSeeds.length);
+    expect(seedQs.every((q) => q.status === "unknown" && q.pinned && q.answer === "")).toBe(true);
+    expect(new Set(seedQs.map((q) => q.id)).size).toBe(seedQs.length);   // ids are unique
+  });
+
+  it("merges by default — preserves analyst entries and skips seeds already present", () => {
+    const state = {
+      ...emptyState("c1"),
+      keyQuestions: [{ id: "q1", question: "Analyst's own question", status: "unknown" as const, answer: "", pointer: "", pinned: false }],
+      nextSteps: [{ id: "s1", priority: "high" as const, action: ransomware.initialNextSteps[0].action, rationale: "x", pointer: "y" }],
+    };
+    const { state: next, questionsAdded, nextStepsAdded } = applyIncidentTypeToState(state, ransomware);
+    expect(next.keyQuestions.some((q) => q.question === "Analyst's own question")).toBe(true);
+    expect(next.nextSteps.filter((s) => s.action === ransomware.initialNextSteps[0].action)).toHaveLength(1);
+    expect(questionsAdded).toBe(ransomware.initialKeyQuestions.length + ransomware.findingsSeeds.length);
+    expect(nextStepsAdded).toBe(ransomware.initialNextSteps.length - 1);
+  });
+
+  it("merging twice is idempotent — a re-apply adds nothing", () => {
+    const once = applyIncidentTypeToState(emptyState("c1"), ransomware).state;
+    const { state: twice, questionsAdded, nextStepsAdded } = applyIncidentTypeToState(once, ransomware);
+    expect(questionsAdded).toBe(0);
+    expect(nextStepsAdded).toBe(0);
+    expect(twice.keyQuestions.length).toBe(once.keyQuestions.length);
+    expect(twice.nextSteps.length).toBe(once.nextSteps.length);
+  });
+
+  it("replace mode overwrites existing questions and next steps", () => {
+    const state = {
+      ...emptyState("c1"),
+      keyQuestions: [{ id: "old", question: "old", status: "unknown" as const, answer: "", pointer: "", pinned: false }],
+      nextSteps: [{ id: "old", priority: "low" as const, action: "old action", rationale: "x", pointer: "y" }],
+    };
+    const { state: next } = applyIncidentTypeToState(state, ransomware, { replace: true });
+    expect(next.keyQuestions.some((q) => q.question === "old")).toBe(false);
+    expect(next.nextSteps.some((s) => s.action === "old action")).toBe(false);
+    expect(next.keyQuestions.length).toBe(ransomware.initialKeyQuestions.length + ransomware.findingsSeeds.length);
+  });
+
+  it("is pure — does not mutate the input state", () => {
+    const state = emptyState("c1");
+    const original = JSON.stringify(state);
+    applyIncidentTypeToState(state, ransomware);
+    expect(JSON.stringify(state)).toBe(original);
+  });
+
+  it("applies a custom (non-built-in) type through the same path", () => {
+    const { state: next } = applyIncidentTypeToState(emptyState("c1"), customType());
+    expect(next.keyQuestions.some((q) => q.question === "What was the entry point?")).toBe(true);
+    expect(next.keyQuestions.some((q) => q.question.includes("Encryption observed"))).toBe(true);
+  });
+});
+
+describe("renderIncidentTypeBlock", () => {
+  it("renders the type name and hint for the synthesis prompt", () => {
+    const block = renderIncidentTypeBlock(ransomware);
+    expect(block).toContain("INCIDENT TYPE: Ransomware.");
+    expect(block).toContain("T1486");
+    expect(block.endsWith("\n\n")).toBe(true);
+  });
+
+  it("is empty for no type or a blank hint, so callers can concatenate it unconditionally", () => {
+    expect(renderIncidentTypeBlock(null)).toBe("");
+    expect(renderIncidentTypeBlock(undefined)).toBe("");
+    expect(renderIncidentTypeBlock(customType({ synthesisHint: "   " }))).toBe("");
+  });
+});

--- a/companion/tests/server/incidentTypeRoutes.test.ts
+++ b/companion/tests/server/incidentTypeRoutes.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { TemplateStore } from "../../src/analysis/templateStore.js";
+import { IncidentTypeStore } from "../../src/analysis/incidentTypeStore.js";
+import { TYPE_SEED_PREFIX, type IncidentType } from "../../src/analysis/incidentTypes.js";
+import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+
+// Incident-type routes (#236). The custom-types dir sits beside the cases root, as it does at
+// runtime, so a test can drop a JSON definition in and exercise the analyst-authored path.
+async function makeApp(opts: { withStore?: boolean } = {}) {
+  const root = await mkdtemp(join(tmpdir(), "dfir-itype-"));
+  const casesRoot = join(root, "cases");
+  const customDir = join(root, "incident-types");
+  const store = new CaseStore(casesRoot);
+  const stateStore = new StateStore(store);
+  const incidentTypeStore = new IncidentTypeStore(store, customDir);
+  const app = createApp(store, {
+    stateStore, aiConfigured: false,
+    activityLogStore: new ActivityLogStore(store),
+    templateStore: new TemplateStore(join(root, "templates")),
+    ...(opts.withStore === false ? {} : { incidentTypeStore }),
+  });
+  const writeCustom = async (type: Partial<IncidentType> & { id: string }) => {
+    await mkdir(customDir, { recursive: true });
+    await writeFile(join(customDir, `${type.id}.json`), JSON.stringify(type), "utf8");
+  };
+  const writeRaw = async (file: string, body: string) => {
+    await mkdir(customDir, { recursive: true });
+    await writeFile(join(customDir, file), body, "utf8");
+  };
+  return { app, store, stateStore, incidentTypeStore, writeCustom, writeRaw };
+}
+
+const CUSTOM: Partial<IncidentType> & { id: string } = {
+  id: "org-cryptolocker",
+  name: "Org CryptoLocker",
+  description: "Org-specific variant",
+  initialKeyQuestions: ["Which share was hit first?"],
+  initialNextSteps: [{ action: "Isolate the file server", priority: "critical", rationale: "contain", pointer: "EDR" }],
+  findingsSeeds: ["Share encryption confirmed"],
+  synthesisHint: "Org variant — prioritize share encryption.",
+};
+
+describe("GET /incident-types", () => {
+  it("lists the built-in library", async () => {
+    const { app } = await makeApp();
+    const res = await request(app).get("/incident-types");
+    expect(res.status).toBe(200);
+    expect(res.body.map((t: IncidentType) => t.id)).toContain("ransomware");
+    expect(res.body).toHaveLength(8);
+    expect(res.body.every((t: IncidentType) => t.builtIn)).toBe(true);
+  });
+
+  it("appends custom types from the data dir, and skips malformed files", async () => {
+    const { app, writeCustom, writeRaw } = await makeApp();
+    await writeCustom(CUSTOM);
+    await writeRaw("broken.json", "{ not json");
+    await writeRaw("no-id.json", JSON.stringify({ name: "missing an id" }));
+    await writeRaw("notes.txt", "ignored — not a .json");
+
+    const res = await request(app).get("/incident-types");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(9);
+    const custom = res.body.find((t: IncidentType) => t.id === "org-cryptolocker");
+    expect(custom.builtIn).toBe(false);
+  });
+
+  it("a custom file cannot shadow a built-in id or claim builtIn", async () => {
+    const { app, writeCustom } = await makeApp();
+    await writeCustom({ id: "ransomware", name: "Impostor", builtIn: true, synthesisHint: "hijacked" });
+    const res = await request(app).get("/incident-types");
+    const ransomware = res.body.filter((t: IncidentType) => t.id === "ransomware");
+    expect(ransomware).toHaveLength(1);
+    expect(ransomware[0].name).toBe("Ransomware");
+  });
+
+  it("returns an empty list rather than an error when the store is not configured", async () => {
+    const { app } = await makeApp({ withStore: false });
+    const res = await request(app).get("/incident-types");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});
+
+describe("GET /incident-types/:id", () => {
+  it("returns a single definition, 404 for unknown", async () => {
+    const { app } = await makeApp();
+    const ok = await request(app).get("/incident-types/bec");
+    expect(ok.status).toBe(200);
+    expect(ok.body.name).toBe("BEC / Email Compromise");
+    expect((await request(app).get("/incident-types/nope")).status).toBe(404);
+  });
+});
+
+describe("POST /cases/:id/incident-type", () => {
+  async function withCase() {
+    const made = await makeApp();
+    await request(made.app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    return made;
+  }
+
+  it("applies the type, seeds confirm/deny questions, and records the choice", async () => {
+    const { app, stateStore, incidentTypeStore } = await withCase();
+    const res = await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    expect(res.status).toBe(200);
+    expect(res.body.questionsAdded).toBeGreaterThan(0);
+    expect(res.body.nextStepsAdded).toBeGreaterThan(0);
+    expect(res.body.record.typeId).toBe("ransomware");
+    expect(res.body.record.appliedAt).not.toBe("");
+
+    const state = await stateStore.load("c1");
+    expect(state.keyQuestions.some((q) => q.question.includes("Was data exfiltrated before encryption"))).toBe(true);
+    expect(state.keyQuestions.some((q) => q.question.startsWith(TYPE_SEED_PREFIX))).toBe(true);
+    // The hint reaches the AI from the record, never from the case summary (which reports print).
+    expect(state.lastSummary).toBe("");
+    expect((await incidentTypeStore.loadType("c1"))?.id).toBe("ransomware");
+  });
+
+  it("re-applying merges — analyst-written questions survive and seeds are not duplicated", async () => {
+    const { app, stateStore } = await withCase();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    const before = await stateStore.load("c1");
+    await stateStore.save({
+      ...before,
+      keyQuestions: [...before.keyQuestions, { id: "mine", question: "My own question", status: "unknown", answer: "", pointer: "", pinned: false }],
+    });
+
+    const res = await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    expect(res.body.questionsAdded).toBe(0);
+    const after = await stateStore.load("c1");
+    expect(after.keyQuestions.some((q) => q.question === "My own question")).toBe(true);
+    expect(after.keyQuestions.length).toBe(before.keyQuestions.length + 1);
+  });
+
+  it("replace: true overwrites, for an analyst who picked the wrong type", async () => {
+    const { app, stateStore } = await withCase();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "bec", replace: true });
+    const state = await stateStore.load("c1");
+    expect(state.keyQuestions.some((q) => q.question.includes("Which mailboxes were compromised"))).toBe(true);
+    expect(state.keyQuestions.some((q) => q.question.includes("Was data exfiltrated before encryption"))).toBe(false);
+  });
+
+  it("applies a custom type through the same path", async () => {
+    const { app, stateStore, writeCustom } = await withCase();
+    await writeCustom(CUSTOM);
+    const res = await request(app).post("/cases/c1/incident-type").send({ typeId: "org-cryptolocker" });
+    expect(res.status).toBe(200);
+    const state = await stateStore.load("c1");
+    expect(state.keyQuestions.some((q) => q.question === "Which share was hit first?")).toBe(true);
+    expect(state.nextSteps.some((s) => s.action === "Isolate the file server")).toBe(true);
+  });
+
+  it("rejects a missing or unknown typeId", async () => {
+    const { app } = await withCase();
+    expect((await request(app).post("/cases/c1/incident-type").send({})).status).toBe(400);
+    expect((await request(app).post("/cases/c1/incident-type").send({ typeId: "  " })).status).toBe(400);
+    expect((await request(app).post("/cases/c1/incident-type").send({ typeId: "nope" })).status).toBe(404);
+  });
+});
+
+describe("GET /cases/:id/incident-type", () => {
+  it("returns an empty record for a case that never picked one", async () => {
+    const { app } = await makeApp();
+    await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const res = await request(app).get("/cases/c1/incident-type");
+    expect(res.status).toBe(200);
+    expect(res.body.record.typeId).toBe("");
+    expect(res.body.type).toBeNull();
+  });
+
+  it("returns the chosen type after an apply", async () => {
+    const { app } = await makeApp();
+    await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "intrusion" });
+    const res = await request(app).get("/cases/c1/incident-type");
+    expect(res.body.record.typeId).toBe("intrusion");
+    expect(res.body.type.name).toBe("Network Intrusion");
+  });
+});
+
+describe("POST /cases with incidentTypeId", () => {
+  it("auto-configures the fresh case", async () => {
+    const { app, stateStore, incidentTypeStore } = await makeApp();
+    const res = await request(app).post("/cases").send({
+      caseId: "c1", name: "n", investigator: "i", aiProvider: null, incidentTypeId: "ransomware",
+    });
+    expect(res.status).toBe(201);
+    const state = await stateStore.load("c1");
+    expect(state.keyQuestions.length).toBeGreaterThan(0);
+    expect(state.nextSteps.length).toBeGreaterThan(0);
+    expect(state.lastSummary).toBe("");
+    expect((await incidentTypeStore.loadRecord("c1")).typeId).toBe("ransomware");
+  });
+
+  // The dashboard sends one or the other, but an API caller may send both — and the type used to
+  // replace the template's questions outright, silently losing what the caller asked for.
+  it("keeps the template's questions when a template AND a type are both supplied", async () => {
+    const { app, stateStore } = await makeApp();
+    await request(app).post("/cases").send({
+      caseId: "c1", name: "n", investigator: "i", aiProvider: null,
+      templateId: "web-intrusion", incidentTypeId: "ransomware",
+    });
+    const state = await stateStore.load("c1");
+    // From the web-intrusion template…
+    expect(state.keyQuestions.some((q) => q.question.includes("web application"))).toBe(true);
+    // …and from the ransomware incident type.
+    expect(state.keyQuestions.some((q) => q.question.includes("Was data exfiltrated before encryption"))).toBe(true);
+  });
+
+  it("creates the case normally when the incident type id is unknown", async () => {
+    const { app, incidentTypeStore } = await makeApp();
+    const res = await request(app).post("/cases").send({
+      caseId: "c1", name: "n", investigator: "i", aiProvider: null, incidentTypeId: "nope",
+    });
+    expect(res.status).toBe(201);
+    expect((await incidentTypeStore.loadRecord("c1")).typeId).toBe("");
+  });
+});

--- a/mkdocs-docs/reference/cases.md
+++ b/mkdocs-docs/reference/cases.md
@@ -6,6 +6,45 @@ Toolbar → **+ New case**. Fill in Case ID, name, and investigator.
 
 Cases live in the `cases/` folder (location configured by `DFIR_CASES_ROOT`).
 
+## Incident Types
+
+The **Incident type** dropdown on the New case dialog pre-configures the investigation for a
+recurring incident pattern, so the first thirty minutes are not spent rebuilding the same checklist
+under pressure. Eight types ship built in:
+
+| Type | Type |
+|---|---|
+| Ransomware | Insider Threat |
+| BEC / Email Compromise | Cloud Compromise |
+| Data Exfiltration | Web App Intrusion |
+| Network Intrusion | Malware Outbreak |
+
+Picking one seeds the case with:
+
+- **Key questions** tailored to the incident — a BEC case asks about inbox rules and OAuth grants; a
+  ransomware case asks about VSS deletion and double extortion.
+- **Recommended next steps**, priority-ordered, each with its rationale and where to look.
+- **Expected findings** as open *confirm or deny* questions, badged `[type-seed]`, so you work
+  through what this incident type usually involves instead of starting from a blank page. Dismiss any
+  that don't apply.
+- **AI framing** — synthesis is told which incident type this is, so it prioritizes the relevant
+  ATT&CK techniques. This is prompt context only; it never appears in your report.
+
+The dropdown also lists any **templates you saved yourself** (Case lifecycle → Save as template).
+
+!!! tip "Changing your mind"
+    Re-picking a type from the API (`POST /cases/<id>/incident-type`) *merges* — your own questions
+    and answers survive, and nothing is duplicated. Send `{"replace": true}` to start that case's
+    questions over from the new type.
+
+### Custom incident types
+
+Drop a `.json` file into the `incident-types/` folder beside your cases root and it appears in the
+dropdown, marked ★. Copy any built-in from `companion/data/incident-types/` as a starting point and
+edit the questions, next steps, and expected findings for how your organization actually runs that
+incident. A file with a broken definition is skipped rather than breaking the dropdown, and a custom
+file cannot override a built-in type of the same name.
+
 ## Switching Between Cases
 
 The case selector dropdown (top-left of dashboard) lists all cases, newest first. Select one to load it.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2073,9 +2073,9 @@
         <input id="ncName" placeholder="short description" style="width:100%; box-sizing:border-box; padding:5px; margin-top:3px;" /></label>
       <label style="display:block; font-size:12px; margin-bottom:8px;">Investigator
         <input id="ncInvestigator" placeholder="your name" style="width:100%; box-sizing:border-box; padding:5px; margin-top:3px;" /></label>
-      <label style="display:block; font-size:12px; margin-bottom:8px;">Template (optional)
+      <label style="display:block; font-size:12px; margin-bottom:8px;">Incident type (optional)
         <select id="ncTemplate" style="width:100%; box-sizing:border-box; padding:5px; margin-top:3px; background:var(--c-1e2330); color:var(--c-c9d1d9); border:1px solid #444;">
-          <option value="">No template — blank case</option>
+          <option value="">No incident type — blank case</option>
         </select></label>
       <div id="ncTemplateDesc" style="color:var(--c-9aa4b2); font-size:11px; margin:-4px 0 8px; padding:6px 8px; background:var(--c-1a1f2e); border-radius:4px; display:none;"></div>
       <div style="margin-top:10px; display:flex; gap:8px; align-items:center;">
@@ -16635,27 +16635,68 @@
       } catch { _cachedTemplates = []; }
       return _cachedTemplates;
     }
+    // Incident types (#236) are a strict superset of the five BUILT-IN case templates — same
+    // incidents, plus the expected-finding seeds and the synthesis hint. So the New Case dialog
+    // offers ONE picker: every incident type, then any template the analyst saved themselves.
+    // Listing the built-in templates too would show "Ransomware" twice, differing only in which one
+    // does more. Option values are prefixed so the create call knows which field to send.
+    let _cachedIncidentTypes = null;
+    async function loadIncidentTypes() {
+      if (_cachedIncidentTypes) return _cachedIncidentTypes;
+      try {
+        const r = await fetch("/incident-types");
+        _cachedIncidentTypes = r.ok ? await r.json() : [];
+      } catch { _cachedIncidentTypes = []; }
+      return _cachedIncidentTypes;
+    }
     async function populateTemplateSelect() {
       const sel = document.getElementById("ncTemplate");
-      const templates = await loadTemplates();
-      // Remove all options except the first ("No template")
+      const [types, templates] = await Promise.all([loadIncidentTypes(), loadTemplates()]);
+      // Remove all options except the first ("No incident type")
       while (sel.options.length > 1) sel.remove(1);
-      for (const t of templates) {
-        const opt = document.createElement("option");
-        opt.value = t.id;
-        opt.textContent = (t.builtIn ? "" : "★ ") + t.name;
-        sel.appendChild(opt);
+      const addGroup = (label, items, prefix) => {
+        if (!items.length) return;
+        const group = document.createElement("optgroup");
+        group.label = label;
+        for (const t of items) {
+          const opt = document.createElement("option");
+          opt.value = prefix + t.id;
+          opt.textContent = (t.builtIn ? "" : "★ ") + t.name;
+          group.appendChild(opt);
+        }
+        sel.appendChild(group);
+      };
+      addGroup("Incident types", types, "type:");
+      addGroup("Your saved templates", templates.filter(t => !t.builtIn), "tpl:");
+    }
+    // Resolve the picker's prefixed value back to { kind, def } against the right cache.
+    function selectedNewCasePlaybook() {
+      const raw = document.getElementById("ncTemplate").value || "";
+      if (raw.startsWith("type:")) {
+        const id = raw.slice(5);
+        return { kind: "type", id, def: (_cachedIncidentTypes || []).find(t => t.id === id) };
       }
+      if (raw.startsWith("tpl:")) {
+        const id = raw.slice(4);
+        return { kind: "tpl", id, def: (_cachedTemplates || []).find(t => t.id === id) };
+      }
+      return { kind: "", id: "", def: undefined };
     }
     function onTemplateSelectChange() {
-      const sel = document.getElementById("ncTemplate");
       const descEl = document.getElementById("ncTemplateDesc");
-      const templates = _cachedTemplates || [];
-      const t = templates.find(t => t.id === sel.value);
+      const { kind, def: t } = selectedNewCasePlaybook();
       if (t && t.description) {
         const hints = [];
-        if (t.recommendedImports?.length) hints.push("Imports: " + esc(t.recommendedImports.join(", ")));
+        // For an incident type, the import ORDER is the guidance ("EDR first, then DC logs") —
+        // show it instead of the unordered recommended-imports list a plain template carries.
+        const imports = kind === "type" && t.recommendedImportOrder?.length
+          ? { label: "Import order", value: t.recommendedImportOrder.join(" → ") }
+          : t.recommendedImports?.length
+            ? { label: "Imports", value: t.recommendedImports.join(", ") }
+            : null;
+        if (imports) hints.push(esc(imports.label) + ": " + esc(imports.value));
         if (t.huntPlatforms?.length) hints.push("Platforms: " + esc(t.huntPlatforms.join(", ")));
+        if (t.findingsSeeds?.length) hints.push(t.findingsSeeds.length + " expected findings to confirm/deny");
         const hintText = hints.length ? " · " + hints.join(" · ") : "";
         descEl.innerHTML = esc(t.description) + hintText;
         descEl.style.display = "block";
@@ -17070,14 +17111,18 @@
       const caseId = document.getElementById("ncCaseId").value.trim();
       const name = document.getElementById("ncName").value.trim();
       const investigator = document.getElementById("ncInvestigator").value.trim();
-      const templateId = document.getElementById("ncTemplate").value || undefined;
+      const picked = selectedNewCasePlaybook();
       const msg = document.getElementById("ncMsg");
       if (!caseId || !name) { msg.textContent = "case id and name are required"; return; }
       msg.textContent = "creating…";
       try {
         const res = await fetch("/cases", {
           method: "POST", headers: { "content-type": "application/json" },
-          body: JSON.stringify({ caseId, name, investigator: investigator || "unknown", aiProvider: null, templateId }),
+          body: JSON.stringify({
+            caseId, name, investigator: investigator || "unknown", aiProvider: null,
+            templateId: picked.kind === "tpl" ? picked.id : undefined,
+            incidentTypeId: picked.kind === "type" ? picked.id : undefined,
+          }),
         });
         if (res.status === 201) {
           closeNewCase();


### PR DESCRIPTION
## Summary

Implements #236: incident-type auto-playbooks. Eight built-in incident types (ransomware, BEC, data-exfiltration, intrusion, insider-threat, cloud-compromise, web-app-intrusion, malware-outbreak) auto-configure a case at creation with type-specific investigation guidance, so the first 30 minutes of a recurring incident type are codified and no standard step is missed under pressure.

## What the analyst gets

The New case dialog has an **Incident type** picker. Choosing one seeds the case with:

- **Key questions** tailored to the incident — BEC asks about inbox rules and OAuth grants; ransomware asks about VSS deletion and double extortion.
- **Recommended next steps**, priority-ordered, each with its rationale and where to look.
- **Expected findings** as open `[type-seed]` confirm/deny questions, so the analyst works a checklist instead of a blank page.
- **AI framing** — synthesis is told which incident type this is and prioritizes the relevant ATT&CK techniques.

Re-picking a type merges: analyst questions and answers survive, nothing is duplicated.

## Design notes

**The synthesis hint never touches the case summary.** It reaches the model from the per-case incident-type record, read by the synthesis prompt. An earlier revision stamped it onto `state.lastSummary` — which is the analyst-facing case summary *and* the report's executive-summary fallback, so the hint printed as the executive summary of a forensic report (and the first synthesis silently overwrote it anyway). The hint joins the skip-if-unchanged hash, so changing a case's type re-synthesizes.

**One picker, not two.** Incident types are a strict superset of the five built-in case templates — same ids (`ransomware`, `bec`, `insider-threat`), same questions, plus the seeds and the hint. Listing both showed "Ransomware" twice, differing only in which one did more. The dialog now lists incident types, then any template the analyst saved themselves. Built-in templates stay reachable via `/templates` for API compatibility.

**Apply merges, never discards.** A create call carrying both `templateId` and `incidentTypeId` keeps both sets of questions; the type used to replace the template's outright.

**Built-ins are editable JSON**, one file per type in `companion/data/incident-types/`, loaded and validated with the same schema as analyst-authored custom types. A malformed file is skipped rather than breaking the picker, and a custom file cannot shadow a built-in id or claim `builtIn`.

## Split out to a follow-up

`recommendedImportOrder`, `huntBundles`, and `reportFraming` are defined and served over the API but not yet consumed — each needs its own UI surface (Import panel checklist, hunt bundle pre-selection, report template pre-select). Tracked in #347 rather than merged half-wired. The import order is shown as a preview line under the picker.

## Changes

- **`companion/data/incident-types/*.json`** — the built-in library, 8 files.
- **`analysis/incidentTypes.ts`** — shared Zod schema, the pure `applyIncidentTypeToState` (merge/replace), and the synthesis-hint block renderer. No I/O.
- **`analysis/incidentTypesData.ts`** — cached loader for the bundled library, with SEA candidate-path handling; degrades to the types that did parse.
- **`analysis/incidentTypeStore.ts`** — per-case chosen-type record (`state/incident-type.json`) + the custom-type loader.
- **`routes/incidentTypes.ts`** — `GET /incident-types`, `GET /incident-types/:id`, `GET|POST /cases/:id/incident-type`.
- **`routes/caseLifecycle.ts`** — `POST /cases` accepts `incidentTypeId`.
- **`analysis/pipeline.ts`** — the incident-type block in the synthesis prompt + the skip hash.
- **`public/dashboard.html`** — the New Case picker.
- **`mkdocs-docs/reference/cases.md`**, **CHANGELOG.md** — docs.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 455 files / 5650 tests pass.
- [x] 31 new tests: library shape and canonical order, schema rejection/degradation, apply (empty / merge / idempotent re-apply / replace / purity / custom types), all four routes incl. malformed and shadowing custom files, the create path with template+type together, and the synthesis wiring (hint present, absent without a type, survives synthesis, re-picking invalidates the skip hash).
- [x] Manual: created a case from the picker on a live server — 13 key questions (7 type + 6 seeds), 4 next steps, `incident-type.json` recorded, `lastSummary` empty, and the generated report's executive summary is the normal "to be completed" placeholder rather than the prompt hint.

Closes #236
