### PR TITLE
feat(war-room): two-way slash-command bot for Slack/Teams/Telegram (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,26 +913,29 @@ of switching to the dashboard for every question:
 
 Each platform turns on when you set its secret:
 
-| Platform | Endpoint | Enable with |
+| Platform | How commands arrive | Enable with |
 |---|---|---|
+| Telegram | **Long polling — no inbound URL** | `DFIR_TELEGRAM_POLL=on` + `DFIR_TELEGRAM_BOT_TOKEN` |
 | Slack | `POST /integrations/slack/command` | `DFIR_SLACK_SIGNING_SECRET` (Basic Information → Signing Secret) |
 | MS Teams | `POST /integrations/teams/command` | `DFIR_TEAMS_TOKEN` (shared secret in the `Authorization` header) |
 | Telegram | `POST /integrations/telegram/command` | `DFIR_TELEGRAM_SECRET_TOKEN` (the `secret_token` you pass to `setWebhook`) |
 
-Telegram setup — create the bot with [@BotFather](https://t.me/BotFather), then register the webhook
-**with a secret** (without one, anyone who learns the URL could drive your cases, so the endpoint
-refuses to run until it is set):
+**Telegram needs no tunnel.** Create the bot with [@BotFather](https://t.me/BotFather), set two
+variables, restart, and message it:
 
 ```bash
-curl -F url=https://dfir.example.com/integrations/telegram/command -F secret_token=$DFIR_TELEGRAM_SECRET_TOKEN https://api.telegram.org/bot<TOKEN>/setWebhook
+DFIR_TELEGRAM_POLL=on
+DFIR_TELEGRAM_BOT_TOKEN=123456789:AAF...
 ```
 
-`DFIR_TELEGRAM_BOT_TOKEN` is needed as well, for `ask`/`hunt`/`synthesize` — those answers arrive
-long after the 3-second webhook reply, so they go back through the Bot API.
+The companion calls Telegram and asks for new commands, so nothing about the machine is reachable
+from the internet — the same outbound direction the notifier already uses. A bot can't do both:
+clear any existing webhook with `.../deleteWebhook` first.
 
-> **These are inbound webhooks**, so the chat platform reaches this companion from the internet via
-> your tunnel or reverse proxy — and that hostname **must** be in `DFIR_ALLOWED_HOSTS`, or the
-> DNS-rebinding guard turns the request away before the bot sees it.
+> **Slack and Teams are inbound webhooks**, so the platform reaches this companion from the internet
+> via your tunnel or reverse proxy — and that hostname **must** be in `DFIR_ALLOWED_HOSTS`, or the
+> DNS-rebinding guard turns the request away before the bot sees it. Telegram can also run this way
+> (`DFIR_TELEGRAM_SECRET_TOKEN` + `setWebhook`) if the companion is already reachable.
 
 > **OPSEC** — anyone who can post in the channel can pull case content. Password-protected cases are
 > refused over chat entirely (a chat message carries no unlock). Set `DFIR_*_ACTION_USERS` to keep

--- a/README.md
+++ b/README.md
@@ -913,9 +913,17 @@ of switching to the dashboard for every question:
 
 Each platform turns on when you set its secret:
 
+**No tunnel needed** — the companion opens the connection outbound:
+
 | Platform | How commands arrive | Enable with |
 |---|---|---|
-| Telegram | **Long polling — no inbound URL** | `DFIR_TELEGRAM_POLL=on` + `DFIR_TELEGRAM_BOT_TOKEN` |
+| Slack | **Socket Mode — outbound WebSocket** | `DFIR_SLACK_SOCKET_MODE=on` + `DFIR_SLACK_APP_TOKEN` (`xapp-…`, `connections:write`) |
+| Telegram | **Long polling** | `DFIR_TELEGRAM_POLL=on` + `DFIR_TELEGRAM_BOT_TOKEN` |
+
+Or as inbound webhooks, which need a public address:
+
+| Platform | Endpoint | Enable with |
+|---|---|---|
 | Slack | `POST /integrations/slack/command` | `DFIR_SLACK_SIGNING_SECRET` (Basic Information → Signing Secret) |
 | MS Teams | `POST /integrations/teams/command` | `DFIR_TEAMS_TOKEN` (shared secret in the `Authorization` header) |
 | Telegram | `POST /integrations/telegram/command` | `DFIR_TELEGRAM_SECRET_TOKEN` (the `secret_token` you pass to `setWebhook`) |
@@ -932,10 +940,12 @@ The companion calls Telegram and asks for new commands, so nothing about the mac
 from the internet — the same outbound direction the notifier already uses. A bot can't do both:
 clear any existing webhook with `.../deleteWebhook` first.
 
-> **Slack and Teams are inbound webhooks**, so the platform reaches this companion from the internet
-> via your tunnel or reverse proxy — and that hostname **must** be in `DFIR_ALLOWED_HOSTS`, or the
-> DNS-rebinding guard turns the request away before the bot sees it. Telegram can also run this way
-> (`DFIR_TELEGRAM_SECRET_TOKEN` + `setWebhook`) if the companion is already reachable.
+**Slack Socket Mode** is the same idea: enable Socket Mode on the app, mint an app-level token
+(`xapp-…`, scope `connections:write`), and the companion dials out to Slack — no Request URL.
+
+> **Webhook mode reaches this companion from the internet** via your tunnel or reverse proxy — and
+> that hostname **must** be in `DFIR_ALLOWED_HOSTS`, or the DNS-rebinding guard turns the request
+> away before the bot sees it. **MS Teams has no outbound option**, so it always needs this.
 
 > **OPSEC** — anyone who can post in the channel can pull case content. Password-protected cases are
 > refused over chat entirely (a chat message carries no unlock). Set `DFIR_*_ACTION_USERS` to keep

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ All importers are **deterministic (no AI call)**, read the artifact's own timest
 - **Notion export** — managed page block; your notes outside it untouched
 - **ClickUp export** — Response Playbook as tasks; re-push updates in place
 - **Notifications** — Slack/MS Teams/Mattermost/Discord/Telegram/SMTP for findings/playbook/milestones; per-channel threshold + toggles
+- **War-room slash-command bot** — two-way Slack/Teams/Telegram: `/dfir findings`, `/dfir iocs malicious`, `/dfir ask …` from the incident channel; bind a channel to a case, allowlist who can spend AI budget (#235)
 - **Report templates** — global branded layouts (accent, header/footer, section order); pick per case. A section disabled here skips its AI generation (executive summary, narrative) to save tokens (#168)
 - **Mobile companion** — read-only PWA (`/mobile`) for findings/timeline/IOCs with verdicts; offline app-shell
 - **Presentation / timeline-replay mode** — read-only, step-through slide deck (`/cases/:id/present`) for handoff briefings & executive walkthroughs: big cards, keyboard nav, auto-advance, severity filter, report-template branding; export a self-contained offline HTML deck (#177)
@@ -892,6 +893,61 @@ The token is stored in `notifications/config.json` (beside `cases/`) and is **ne
 | `DFIR_PUBLIC_URL` | `http://<host>:<port>` | Public base URL used to deep-link a notification back to the case (set when reached via a hostname/proxy) |
 | `DFIR_NOTIFY_CA` | — | PEM CA bundle for a self-hosted webhook host (e.g. Mattermost) |
 | `DFIR_NOTIFY_INSECURE` | — | `=1` to skip TLS verification for the webhook host (lab only) |
+
+### War-room slash-command bot (optional)
+
+Notifications push *out*; this is the way back *in*. Run the case from the incident channel instead
+of switching to the dashboard for every question:
+
+```
+/dfir bind IR-2026-014          bind this channel to a case — every later command can omit the id
+/dfir status                    events, findings, IOCs, open questions
+/dfir findings                  top 5 by severity
+/dfir finding f3                one finding card
+/dfir iocs malicious            IOCs filtered by verdict (flagged | malicious)
+/dfir ask what was the initial access vector?     grounded AI answer (posted when ready)
+/dfir synthesize                trigger a re-synthesis
+/dfir hunt T1059.001            note a technique to hunt (deploy it from the dashboard)
+/dfir unbind                    clear the binding
+```
+
+Each platform turns on when you set its secret:
+
+| Platform | Endpoint | Enable with |
+|---|---|---|
+| Slack | `POST /integrations/slack/command` | `DFIR_SLACK_SIGNING_SECRET` (Basic Information → Signing Secret) |
+| MS Teams | `POST /integrations/teams/command` | `DFIR_TEAMS_TOKEN` (shared secret in the `Authorization` header) |
+| Telegram | `POST /integrations/telegram/command` | `DFIR_TELEGRAM_SECRET_TOKEN` (the `secret_token` you pass to `setWebhook`) |
+
+Telegram setup — create the bot with [@BotFather](https://t.me/BotFather), then register the webhook
+**with a secret** (without one, anyone who learns the URL could drive your cases, so the endpoint
+refuses to run until it is set):
+
+```bash
+curl -F url=https://dfir.example.com/integrations/telegram/command -F secret_token=$DFIR_TELEGRAM_SECRET_TOKEN https://api.telegram.org/bot<TOKEN>/setWebhook
+```
+
+`DFIR_TELEGRAM_BOT_TOKEN` is needed as well, for `ask`/`hunt`/`synthesize` — those answers arrive
+long after the 3-second webhook reply, so they go back through the Bot API.
+
+> **These are inbound webhooks**, so the chat platform reaches this companion from the internet via
+> your tunnel or reverse proxy — and that hostname **must** be in `DFIR_ALLOWED_HOSTS`, or the
+> DNS-rebinding guard turns the request away before the bot sees it.
+
+> **OPSEC** — anyone who can post in the channel can pull case content. Password-protected cases are
+> refused over chat entirely (a chat message carries no unlock). Set `DFIR_*_ACTION_USERS` to keep
+> AI spend, re-synthesis and re-binding to named responders; doing so also confines everyone else to
+> the channel's bound case.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `DFIR_SLACK_ACTION_USERS` | _(unset = open)_ | Comma-separated Slack user ids allowed to run `ask`/`hunt`/`synthesize`/`bind` |
+| `DFIR_TEAMS_ACTION_USERS` | _(unset = open)_ | Same, for Teams |
+| `DFIR_TELEGRAM_ACTION_USERS` | _(unset = open)_ | Same, for Telegram (numeric user ids) |
+| `DFIR_SLACK_RESPONSE_HOSTS` | `hooks.slack.com` | Extra hosts an async result may be delivered to (self-hosted Slack-compatible server) |
+| `DFIR_TEAMS_RESPONSE_HOSTS` | `*.webhook.office.com`, `*.logic.azure.com`, `*.office.com` | Same, for Teams |
+| `DFIR_TELEGRAM_BOT_TOKEN` | — | @BotFather token, used to deliver async results |
+| `DFIR_TELEGRAM_API_BASE` | `https://api.telegram.org` | Bot API base URL override |
 
 ### Analysis tuning
 

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -51,6 +51,14 @@ DFIR_MAX_BODY_MB=256
 # Callers that send no Origin at all (curl, scripts, Velociraptor pushes) are unaffected.
 # DFIR_ALLOWED_ORIGINS=https://soc.example.com
 
+# Extra HOSTNAMES this companion answers to (comma-separated). Separate from the origin list above:
+# this is the DNS-rebinding guard, which refuses any request whose Host header names something we
+# don't recognise. Loopback and bare IP literals are always accepted, so localhost/LAN/Docker need
+# nothing here. You need this when the companion is reached under a NAME — a reverse proxy, a PaaS,
+# or the tunnel that carries the war-room slash-command bot's webhooks (see section 8 below).
+# DFIR_ALLOWED_HOSTS=dfir.example.com
+# DFIR_ALLOWED_HOST_SUFFIXES=.example.com
+
 
 # ══════════════════════════════════════════════════════════════════════════════
 # 2. AI PROVIDERS
@@ -585,6 +593,44 @@ DFIR_SYNTH_ADVERSARY_HINTS=off
 #                                  # http://<host>:<port>) — set when reached via hostname/proxy
 # DFIR_NOTIFY_CA=
 # DFIR_NOTIFY_INSECURE=
+
+# War-room slash-command bot (#235) — TWO-WAY chat, the inbound counterpart to the notifications
+# above. Run `/dfir findings`, `/dfir iocs malicious`, `/dfir ask <question>` from the incident
+# channel instead of switching to the dashboard. `/dfir bind <caseId>` ties a channel to a case so
+# every later command can omit the caseId. Enabled per platform by setting that platform's secret;
+# with none set, no platform authenticates and the bot answers nobody.
+#
+# ⚠ These are INBOUND webhooks, so the chat platform has to reach this companion from the internet
+#   (a tunnel or reverse proxy) — and the hostname it arrives under MUST be listed in
+#   DFIR_ALLOWED_HOSTS (section 1) or the DNS-rebinding guard refuses it before the bot ever runs.
+# ⚠ OPSEC: the same third-party exposure as notifications, but read-on-demand — anyone who can post
+#   in the channel can pull case content. Password-protected cases are refused over chat entirely.
+#
+# Slack — create a slash command pointing at POST /integrations/slack/command; the signing secret is
+# under "Basic Information". Requests are HMAC-verified with a 5-minute replay window.
+# DFIR_SLACK_SIGNING_SECRET=       # Slack app signing secret (enables the Slack endpoint)
+# DFIR_SLACK_ACTION_USERS=         # comma-separated Slack user ids allowed to run ask/hunt/
+#                                  # synthesize/bind. UNSET = open to everyone in the channel; once
+#                                  # set, everyone else is also confined to the channel's bound case
+# DFIR_SLACK_RESPONSE_HOSTS=       # extra hosts we may POST an async result to (default
+#                                  # hooks.slack.com) — for a self-hosted Slack-compatible server
+#
+# Teams — webhook-based slash commands POST to /integrations/teams/command with a bearer token.
+# DFIR_TEAMS_TOKEN=                # shared secret checked against the Authorization header
+# DFIR_TEAMS_ACTION_USERS=
+# DFIR_TEAMS_RESPONSE_HOSTS=       # default *.webhook.office.com, *.logic.azure.com, *.office.com
+#
+# Telegram — create a bot via @BotFather, then point its webhook at this companion WITH a secret:
+#   curl -F url=https://dfir.example.com/integrations/telegram/command \
+#        -F secret_token=<DFIR_TELEGRAM_SECRET_TOKEN> \
+#        https://api.telegram.org/bot<token>/setWebhook
+# Telegram echoes that secret back on every update; without it anyone who learns the URL could post
+# commands, so an unset secret refuses the endpoint outright.
+# DFIR_TELEGRAM_SECRET_TOKEN=      # setWebhook secret_token (enables the Telegram endpoint)
+# DFIR_TELEGRAM_BOT_TOKEN=         # @BotFather token — needed to deliver ask/hunt/synthesize
+#                                  # results, which arrive too late for the webhook reply
+# DFIR_TELEGRAM_ACTION_USERS=      # comma-separated numeric Telegram user ids
+# DFIR_TELEGRAM_API_BASE=          # override the Bot API base (default https://api.telegram.org)
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -620,15 +620,25 @@ DFIR_SYNTH_ADVERSARY_HINTS=off
 # DFIR_TEAMS_ACTION_USERS=
 # DFIR_TEAMS_RESPONSE_HOSTS=       # default *.webhook.office.com, *.logic.azure.com, *.office.com
 #
-# Telegram — create a bot via @BotFather, then point its webhook at this companion WITH a secret:
+# Telegram — TWO options. POLLING is the one to prefer on a workstation: the companion calls
+# Telegram and asks for new commands, so no tunnel, no DFIR_ALLOWED_HOSTS entry and no webhook
+# registration are needed, and nothing about this machine is reachable from the internet. Create a
+# bot via @BotFather, set these two, restart, and message the bot:
+# DFIR_TELEGRAM_POLL=on            # =on to receive commands by long polling (no inbound URL)
+# DFIR_TELEGRAM_BOT_TOKEN=         # @BotFather token. Required for polling; in webhook mode it
+#                                  # delivers ask/hunt/synthesize results, which arrive too late
+#                                  # for the webhook reply
+#
+# Or WEBHOOK, if this companion is already reachable. Point the bot at it WITH a secret:
 #   curl -F url=https://dfir.example.com/integrations/telegram/command \
 #        -F secret_token=<DFIR_TELEGRAM_SECRET_TOKEN> \
 #        https://api.telegram.org/bot<token>/setWebhook
 # Telegram echoes that secret back on every update; without it anyone who learns the URL could post
 # commands, so an unset secret refuses the endpoint outright.
 # DFIR_TELEGRAM_SECRET_TOKEN=      # setWebhook secret_token (enables the Telegram endpoint)
-# DFIR_TELEGRAM_BOT_TOKEN=         # @BotFather token — needed to deliver ask/hunt/synthesize
-#                                  # results, which arrive too late for the webhook reply
+#
+# A bot cannot do both: Telegram refuses getUpdates while a webhook is registered, and refuses a
+# second poller for the same bot. Clear an old webhook with .../deleteWebhook before polling.
 # DFIR_TELEGRAM_ACTION_USERS=      # comma-separated numeric Telegram user ids
 # DFIR_TELEGRAM_API_BASE=          # override the Bot API base (default https://api.telegram.org)
 

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -606,8 +606,17 @@ DFIR_SYNTH_ADVERSARY_HINTS=off
 # ⚠ OPSEC: the same third-party exposure as notifications, but read-on-demand — anyone who can post
 #   in the channel can pull case content. Password-protected cases are refused over chat entirely.
 #
-# Slack — create a slash command pointing at POST /integrations/slack/command; the signing secret is
-# under "Basic Information". Requests are HMAC-verified with a 5-minute replay window.
+# Slack — TWO options. SOCKET MODE needs no tunnel: the companion opens an outbound WebSocket to
+# Slack and commands arrive down it, so there is no Request URL to register. Enable Socket Mode in
+# the app settings, create an app-level token (xapp-…) with the connections:write scope, add the
+# /dfir slash command, install to the workspace, then:
+# DFIR_SLACK_SOCKET_MODE=on        # =on to receive commands over an outbound WebSocket
+# DFIR_SLACK_APP_TOKEN=            # app-level token, "xapp-…", scope connections:write. NOT a bot
+#                                  # token (xoxb-…) — that is rejected with invalid_auth
+#
+# Or WEBHOOK: point a slash command at POST /integrations/slack/command; the signing secret is under
+# "Basic Information". Requests are HMAC-verified with a 5-minute replay window. Unused in socket
+# mode, where the app-level token authenticates the connection instead.
 # DFIR_SLACK_SIGNING_SECRET=       # Slack app signing secret (enables the Slack endpoint)
 # DFIR_SLACK_ACTION_USERS=         # comma-separated Slack user ids allowed to run ask/hunt/
 #                                  # synthesize/bind. UNSET = open to everyone in the channel; once

--- a/companion/src/analysis/slackSocketMode.ts
+++ b/companion/src/analysis/slackSocketMode.ts
@@ -1,0 +1,209 @@
+import WebSocket from "ws";
+import type { Logger } from "../logging/logger.js";
+
+// Slack Socket Mode transport for the war-room slash-command bot (#235). The Slack counterpart to
+// Telegram's long polling: the Companion opens an outbound WebSocket to Slack and commands arrive
+// down it, so no tunnel, no public hostname, no DFIR_ALLOWED_HOSTS entry, and no Request URL to
+// re-register whenever a quick tunnel changes its name.
+//
+// The handshake: POST apps.connections.open with an app-level token (xapp-…, scope
+// connections:write) returns a single-use wss:// URL. Slack then pushes an envelope per command,
+// each carrying an envelope_id that MUST be acked — the ack payload is the reply the analyst sees,
+// exactly like the HTTP response body. Slack also asks us to reconnect periodically (a `disconnect`
+// frame), which is routine rather than an error: it hands out a fresh URL each time.
+//
+// Note Socket Mode replaces request signing entirely. There is no HTTP request to sign, and the
+// app-level token is what authenticates us to Slack — DFIR_SLACK_SIGNING_SECRET is a webhook-mode
+// concern and plays no part here.
+
+export interface SlackEnvelope {
+  envelope_id?: string;
+  type?: string;
+  payload?: SlackCommandPayload;
+  accepts_response_payload?: boolean;
+  reason?: string;
+}
+
+export interface SlackCommandPayload {
+  command?: string;
+  text?: string;
+  channel_id?: string;
+  user_id?: string;
+  response_url?: string;
+}
+
+/** The slice of a WebSocket this transport uses, so tests can supply a fake. */
+export interface SocketLike {
+  on(event: string, cb: (arg?: unknown) => void): void;
+  send(data: string): void;
+  close(): void;
+}
+
+export interface SlackSocketModeOptions {
+  appToken: string;
+  /** Handle one command. Returns the reply body Slack should show, or undefined to ack silently. */
+  onCommand: (payload: SlackCommandPayload) => Promise<unknown>;
+  log: Logger;
+  apiBase?: string;
+  fetchFn?: typeof fetch;
+  socketFactory?: (url: string) => SocketLike;
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+const MIN_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 60_000;
+
+export class SlackSocketMode {
+  private readonly opts: SlackSocketModeOptions;
+  private readonly fetchFn: typeof fetch;
+  private readonly socketFactory: (url: string) => SocketLike;
+  private readonly sleepFn: (ms: number) => Promise<void>;
+  private stopped = false;
+  private socket: SocketLike | undefined;
+  private loop: Promise<void> | undefined;
+  private backoffMs = MIN_BACKOFF_MS;
+  /** Settles the in-flight pump(). stop() calls this directly rather than waiting for the socket to
+   *  emit "close" — a half-open or wedged socket would otherwise hang shutdown indefinitely. */
+  private endCurrentSocket: (() => void) | undefined;
+
+  constructor(options: SlackSocketModeOptions) {
+    this.opts = options;
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.socketFactory = options.socketFactory ?? ((url) => new WebSocket(url) as unknown as SocketLike);
+    this.sleepFn = options.sleepFn ?? ((ms) => new Promise((r) => setTimeout(r, ms).unref?.()));
+  }
+
+  start(): void {
+    if (this.loop) return;
+    this.opts.log.info("[slack] socket mode: connecting (no inbound URL needed)");
+    this.loop = this.run();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    try {
+      this.socket?.close();
+    } catch { /* already gone */ }
+    this.endCurrentSocket?.(); // don't wait on a "close" event that may never come
+    await this.loop?.catch(() => {});
+    this.loop = undefined;
+  }
+
+  private async run(): Promise<void> {
+    while (!this.stopped) {
+      try {
+        const url = await this.openConnection();
+        await this.pump(url); // resolves when Slack asks us to reconnect, or the socket drops
+        this.backoffMs = MIN_BACKOFF_MS;
+      } catch (err) {
+        if (this.stopped) return;
+        await this.handleFailure(err as Error);
+      }
+    }
+  }
+
+  /** Trade the app-level token for a single-use wss:// URL. */
+  private async openConnection(): Promise<string> {
+    const base = (this.opts.apiBase ?? "https://slack.com/api").replace(/\/+$/, "");
+    const res = await this.fetchFn(`${base}/apps.connections.open`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.opts.appToken}`,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+    const body = (await res.json().catch(() => ({}))) as { ok?: boolean; url?: string; error?: string };
+    if (!body.ok || !body.url) throw new SlackSocketError(body.error ?? `HTTP ${res.status}`);
+    return body.url;
+  }
+
+  /** Run one socket to completion. Resolves on a clean reconnect request or a drop; rejects only
+   *  on a socket-level error, which the caller turns into a backoff. */
+  private pump(url: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      let socket: SocketLike;
+      try {
+        socket = this.socketFactory(url);
+      } catch (err) {
+        reject(err as Error);
+        return;
+      }
+      this.socket = socket;
+      let settled = false;
+      const done = (err?: Error): void => {
+        if (settled) return;
+        settled = true;
+        this.socket = undefined;
+        this.endCurrentSocket = undefined;
+        try { socket.close(); } catch { /* already closing */ }
+        if (err) reject(err); else resolve();
+      };
+      this.endCurrentSocket = () => done();
+
+      socket.on("open", () => this.opts.log.info("[slack] socket mode: connected"));
+      socket.on("close", () => done());
+      socket.on("error", (err) => done(err instanceof Error ? err : new Error(String(err))));
+      socket.on("message", (data) => {
+        void this.onMessage(socket, data)
+          .then((reconnect) => { if (reconnect) done(); })
+          .catch((err) => this.opts.log.warn(`[slack] socket message failed: ${(err as Error).message}`));
+      });
+    });
+  }
+
+  /** Handle one frame. Resolves true when Slack has asked us to reconnect. */
+  private async onMessage(socket: SocketLike, data: unknown): Promise<boolean> {
+    let frame: SlackEnvelope;
+    try {
+      frame = JSON.parse(typeof data === "string" ? data : String(data)) as SlackEnvelope;
+    } catch {
+      return false; // not JSON — nothing we can act on
+    }
+
+    if (frame.type === "hello") {
+      this.backoffMs = MIN_BACKOFF_MS;
+      return false;
+    }
+    // Routine: Slack rotates connections and warns before closing one. Not an error.
+    if (frame.type === "disconnect") {
+      this.opts.log.info(`[slack] socket mode: reconnecting (${frame.reason ?? "requested"})`);
+      return true;
+    }
+
+    if (!frame.envelope_id) return false;
+    // Ack EVERY envelope, including kinds we don't act on — an unacked envelope is redelivered.
+    let payload: unknown;
+    if (frame.type === "slash_commands" && frame.payload) {
+      payload = await this.opts.onCommand(frame.payload).catch((err) => {
+        this.opts.log.warn(`[slack] command failed: ${(err as Error).message}`);
+        return undefined;
+      });
+    }
+    const ack: Record<string, unknown> = { envelope_id: frame.envelope_id };
+    if (payload !== undefined && frame.accepts_response_payload !== false) ack.payload = payload;
+    socket.send(JSON.stringify(ack));
+    return false;
+  }
+
+  private async handleFailure(err: Error): Promise<void> {
+    const message = err.message;
+    if (message === "invalid_auth" || message === "not_authed" || message === "token_expired") {
+      this.opts.log.error(
+        `[slack] socket mode: ${message} — DFIR_SLACK_APP_TOKEN must be an app-level token ` +
+          `(starts "xapp-") with the connections:write scope, from Settings → Basic Information → App-Level Tokens.`,
+      );
+    } else {
+      this.opts.log.warn(`[slack] socket mode: ${message}; retrying in ${Math.round(this.backoffMs / 1000)}s`);
+    }
+    await this.sleepFn(this.backoffMs);
+    this.backoffMs = Math.min(this.backoffMs * 2, MAX_BACKOFF_MS);
+  }
+}
+
+export class SlackSocketError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SlackSocketError";
+  }
+}

--- a/companion/src/analysis/slashCommand.ts
+++ b/companion/src/analysis/slashCommand.ts
@@ -1,22 +1,23 @@
-import type { Finding, InvestigationState, IOC, Severity } from "./stateTypes.js";
+import type { Finding, InvestigationState, Severity } from "./stateTypes.js";
 
-// Two-way war-room slash-command bot (#235). IR happens in a Slack/Teams war room; this module
-// is the PURE core — the command parser + the read-only command formatters that turn case state
-// into a slash-command response card. The route (routes/slashCommand.ts) owns the inbound
-// webhook handler (HMAC auth + rate limiting), the async response_url posting, and per-channel
-// case binding; this module is deterministic and unit-tested with no I/O.
+// Two-way war-room slash-command bot (#235). IR happens in a Slack/Teams/Telegram war room; this
+// module is the PURE core — the command parser, the caseId resolver, the read-only command
+// formatters that turn case state into a slash-command response card, and the access-control
+// predicates. The route (routes/slashCommand.ts) owns the inbound webhook handler (auth + rate
+// limiting), the async result delivery, and per-channel case binding; this module is deterministic
+// and unit-tested with no I/O.
 //
 // Slash commands supported (the issue's full set):
-//   /dfir ask <caseId> <question>          → async (AI call) — the route handles this; here it's a parse result
-//   /dfir findings <caseId>                → top 5 findings (severity + confidence + MITRE)
-//   /dfir finding <caseId> <id>            → a single finding card
-//   /dfir iocs <caseId> [flagged|malicious]→ top IOCs with verdicts
-//   /dfir hunt <caseId> <technique>        → async (deploy) — the route handles this
-//   /dfir status <caseId>                  → case stats (events, findings, last synthesis, open hypotheses)
-//   /dfir synthesize <caseId>              → async (re-synthesis) — the route handles this
+//   /dfir ask [caseId] <question>          → async (AI call) — the route handles this
+//   /dfir findings [caseId]                → top 5 findings (severity + confidence + MITRE)
+//   /dfir finding [caseId] <id>            → a single finding card
+//   /dfir iocs [caseId] [flagged|malicious]→ top IOCs with verdicts
+//   /dfir hunt [caseId] <technique>        → async (hand-off to the dashboard's hunt panel)
+//   /dfir status [caseId]                  → case stats (events, findings, IOCs, questions)
+//   /dfir synthesize [caseId]              → async (re-synthesis)
 //   /dfir bind <caseId>                    → bind this channel to a default case
 //   /dfir unbind                           → clear the channel binding
-//   /dfir help                              → usage
+//   /dfir help                             → usage
 
 export type SlashCommandName =
   | "ask"
@@ -32,10 +33,11 @@ export type SlashCommandName =
 
 export interface ParsedSlashCommand {
   name: SlashCommandName;
-  caseId?: string;       // absent when the command doesn't take one (help, unbind) or when the
-                         // channel is expected to supply a bound default (the route fills it)
-  arg?: string;          // the question / technique / finding id / ioc filter
-  iocFilter?: "flagged" | "malicious";
+  // Everything after the command word, already split. The caseId CANNOT be picked out here: with a
+  // bound channel `/dfir ask what was the initial access vector?` has no caseId at all, and "what"
+  // is a syntactically valid caseId — only the route knows which case ids exist. resolveCommand()
+  // makes that call once the route has looked the first token up.
+  tokens: string[];
   raw: string;
 }
 
@@ -52,56 +54,97 @@ export const SLASH_COMMAND_NAMES: readonly SlashCommandName[] = [
   "help",
 ];
 
-// Parse a slash-command text string into a structured command. Tolerant of extra whitespace and
-// of a leading "/dfir" (Slack sends the bare args; Teams sometimes includes the trigger word).
-// Returns { name: "help", raw } for an empty/unrecognized input so the route always has something
-// to respond with.
+// Parse a slash-command text string into a command name + its argument tokens. Tolerant of extra
+// whitespace, of a leading "/" (Telegram sends the slash; Slack strips it), of the "/dfir" trigger
+// word (some clients echo it back), and of Telegram's "@BotName" suffix on the command word
+// (`/findings@DfirBot c1`, `/dfir@DfirBot findings c1`). Returns { name: "help" } for an
+// empty/unrecognized input so the route always has something to respond with.
 export function parseSlashCommand(text: string): ParsedSlashCommand {
   const raw = (text ?? "").trim();
-  if (!raw) return { name: "help", raw: "" };
-  // Strip a leading "/dfir" if present (some clients echo the trigger word back).
-  const stripped = raw.startsWith("/dfir ") ? raw.slice("/dfir ".length) : raw;
-  const parts = stripped.split(/\s+/);
-  const name = parts[0]?.toLowerCase() as SlashCommandName;
-  if (!SLASH_COMMAND_NAMES.includes(name)) return { name: "help", raw };
-  const rest = parts.slice(1);
+  if (!raw) return { name: "help", tokens: [], raw: "" };
+  const parts = (raw.startsWith("/") ? raw.slice(1) : raw).split(/\s+/).filter(Boolean);
+  // Telegram appends "@BotName" to the command word when several bots share a group chat.
+  if (parts[0]) parts[0] = parts[0].split("@")[0];
+  // Drop the trigger word when the client echoes it ("/dfir findings c1").
+  if (parts[0]?.toLowerCase() === "dfir") parts.shift();
 
-  switch (name) {
-    case "help":
-    case "unbind":
-      return { name, raw };
-    case "bind":
-      return { name, caseId: rest[0], raw };
-    case "status":
-    case "synthesize":
-      return { name, caseId: rest[0], raw };
-    case "findings":
-      return { name, caseId: rest[0], raw };
-    case "iocs": {
-      const caseId = rest[0];
-      const filter = rest[1];
-      return {
-        name,
-        caseId,
-        iocFilter: filter === "flagged" || filter === "malicious" ? filter : undefined,
-        raw,
-      };
-    }
-    case "finding":
-    case "hunt":
-    case "ask": {
-      const caseId = rest[0];
-      const arg = rest.slice(1).join(" ");
-      return { name, caseId, arg, raw };
-    }
-    default:
-      return { name: "help", raw };
+  const name = parts[0]?.toLowerCase() as SlashCommandName;
+  if (!SLASH_COMMAND_NAMES.includes(name)) return { name: "help", tokens: [], raw };
+  return { name, tokens: parts.slice(1), raw };
+}
+
+// ── caseId resolution ───────────────────────────────────────────────────────────────────
+
+export interface ChannelBinding {
+  caseId: string;
+  boundAt: string;
+}
+
+export interface ResolvedSlashCommand {
+  name: SlashCommandName;
+  caseId: string;                            // "" when the command takes none / none could be found
+  arg: string;                               // the question / technique / finding id
+  iocFilter?: "flagged" | "malicious";
+  usedBinding: boolean;                      // true when the caseId came from the channel binding
+  raw: string;
+}
+
+/**
+ * Turn a parsed command into a resolved one: decide whether the first token is the caseId or part
+ * of the argument, and fall back to the channel's bound case when it isn't.
+ *
+ * `firstTokenIsKnownCase` is the route's answer to "does a case with this id actually exist?" —
+ * the one fact this module cannot know. Without it the parser has to guess positionally, and it
+ * guesses wrong for every command that takes an argument: with a bound channel `/dfir iocs
+ * malicious` silently queried a case called "malicious", and `/dfir ask what happened` a case
+ * called "what". Both ids pass isValidCaseId, so nothing errored — the analyst just got an answer
+ * about the wrong (empty) case.
+ *
+ * `bind` is deliberately exempt: its argument names the case to bind TO, so falling back to the
+ * current binding would silently re-bind the channel to the case it is already bound to.
+ */
+export function resolveCommand(
+  cmd: ParsedSlashCommand,
+  binding: ChannelBinding | undefined,
+  firstTokenIsKnownCase: boolean,
+): ResolvedSlashCommand {
+  const { name, tokens, raw } = cmd;
+  const base = { name, arg: "", usedBinding: false, raw };
+
+  if (name === "help" || name === "unbind") return { ...base, caseId: "" };
+  if (name === "bind") return { ...base, caseId: (tokens[0] ?? "").trim() };
+
+  let caseId: string;
+  let rest: string[];
+  let usedBinding = false;
+  if (tokens.length > 0 && firstTokenIsKnownCase) {
+    caseId = tokens[0];
+    rest = tokens.slice(1);
+  } else if (binding?.caseId) {
+    caseId = binding.caseId;
+    rest = tokens;
+    usedBinding = true;
+  } else {
+    // No binding and the first token isn't a case we know: keep treating it as the caseId so the
+    // error message names what the analyst actually typed.
+    caseId = (tokens[0] ?? "").trim();
+    rest = tokens.slice(1);
   }
+
+  const filter = rest[0];
+  return {
+    name,
+    caseId,
+    arg: rest.join(" "),
+    iocFilter: name === "iocs" && (filter === "flagged" || filter === "malicious") ? filter : undefined,
+    usedBinding,
+    raw,
+  };
 }
 
 // ── Read-only command formatters ────────────────────────────────────────────────────────
-// Each returns a { title, lines } card the route formats per-channel (Slack Block Kit / Teams
-// MessageCard) and posts to response_url. Pure functions of InvestigationState.
+// Each returns a { title, lines } card the route wraps in the platform's response envelope.
+// Pure functions of InvestigationState.
 
 export interface SlashCommandResponse {
   title: string;
@@ -131,8 +174,12 @@ export function formatFindingsCommand(state: InvestigationState, limit = 5): Sla
 }
 
 export function formatFindingCommand(state: InvestigationState, findingId: string): SlashCommandResponse {
-  const f = state.findings.find((x) => x.id === findingId || x.semanticKey === findingId);
-  if (!f) return { title: `Finding ${findingId} not found`, lines: [`Case ${state.caseId} has no finding with id/semanticKey "${findingId}".`] };
+  const wanted = findingId.trim();
+  if (!wanted) {
+    return { title: "Which finding?", lines: ["Usage: /dfir finding <id> — run /dfir findings to list them."] };
+  }
+  const f = state.findings.find((x) => x.id === wanted || x.semanticKey === wanted);
+  if (!f) return { title: `Finding ${wanted} not found`, lines: [`Case ${state.caseId} has no finding with id/semanticKey "${wanted}".`] };
   const lines = [
     `Severity: ${f.severity}${f.confidence !== undefined ? ` (confidence ${f.confidence}%)` : ""}`,
     `Status: ${f.status}`,
@@ -189,10 +236,10 @@ export function formatHelpCommand(): SlashCommandResponse {
     lines: [
       "/dfir status [caseId] — case stats",
       "/dfir findings [caseId] — top 5 findings",
-      "/dfir finding <caseId|bound> <id> — a single finding card",
+      "/dfir finding [caseId] <id> — a single finding card",
       "/dfir iocs [caseId] [flagged|malicious] — top IOCs",
-      "/dfir ask <caseId|bound> <question> — ask the AI (async)",
-      "/dfir hunt <caseId|bound> <technique> — deploy a VQL hunt (async)",
+      "/dfir ask [caseId] <question> — ask the AI (async)",
+      "/dfir hunt [caseId] <technique> — note a technique to hunt; deploy it from the dashboard",
       "/dfir synthesize [caseId] — trigger re-synthesis (async)",
       "/dfir bind <caseId> — bind this channel to a default case",
       "/dfir unbind — clear the channel binding",
@@ -201,47 +248,67 @@ export function formatHelpCommand(): SlashCommandResponse {
   };
 }
 
-// Per-channel case binding store: a channel can bind to a default case so subsequent commands
-// omit the caseId. Stored in the notification config dir (a global, channel-level concern, not
-// per-case) — the route module owns the persistence; this is just the shape.
-export interface ChannelBinding {
-  caseId: string;
-  boundAt: string;
-}
+// ── Access control ──────────────────────────────────────────────────────────────────────
+// Two separate axes that the first cut of this bot conflated:
+//
+//   PRIVILEGED — needs the operator's user-id allowlist. Spending AI budget (ask), triggering a
+//   re-synthesis, filing a hunt, and REPOINTING THE CHANNEL AT A DIFFERENT CASE (bind). bind is in
+//   here because it decides which case everyone else in the room can read.
+//
+//   ASYNC — takes longer than the 3s a chat platform waits, so the route ACKs and delivers the
+//   result out of band. Nothing to do with permissions.
 
-// Resolve the caseId for a parsed command: prefer the explicit caseId, fall back to the channel's
-// bound default. Returns "" when neither is present (the route responds with a usage hint).
-export function resolveCaseId(cmd: ParsedSlashCommand, binding: ChannelBinding | undefined): string {
-  if (cmd.caseId && cmd.caseId.trim()) return cmd.caseId.trim();
-  return binding?.caseId ?? "";
-}
-
-// Access control: a command kind is allowed for a user when the user is in the action allowlist
-// (for action commands: hunt, synthesize, ask) OR when no allowlist is configured (open access,
-// the default). Read-only commands (findings, finding, iocs, status, help, bind, unbind) are
-// always allowed.
 export const READ_ONLY_COMMANDS: readonly SlashCommandName[] = [
   "findings",
   "finding",
   "iocs",
   "status",
   "help",
-  "bind",
   "unbind",
 ];
 
-export const ACTION_COMMANDS: readonly SlashCommandName[] = ["ask", "hunt", "synthesize"];
+export const PRIVILEGED_COMMANDS: readonly SlashCommandName[] = ["ask", "hunt", "synthesize", "bind"];
 
-export function isActionCommand(name: SlashCommandName): boolean {
-  return ACTION_COMMANDS.includes(name);
+export const ASYNC_COMMANDS: readonly SlashCommandName[] = ["ask", "hunt", "synthesize"];
+
+export function isPrivilegedCommand(name: SlashCommandName): boolean {
+  return PRIVILEGED_COMMANDS.includes(name);
 }
 
+export function isAsyncCommand(name: SlashCommandName): boolean {
+  return ASYNC_COMMANDS.includes(name);
+}
+
+/** Is `userId` allowed to run this command? Privileged commands require the allowlist; when no
+ *  allowlist is configured access is open (the default for a localhost tool). */
 export function isAllowed(
   name: SlashCommandName,
   userId: string,
   actionAllowlist: readonly string[] | undefined,
 ): boolean {
-  if (!isActionCommand(name)) return true;
+  if (!isPrivilegedCommand(name)) return true;
   if (!actionAllowlist || actionAllowlist.length === 0) return true; // open access when unconfigured
   return actionAllowlist.includes(userId);
+}
+
+/**
+ * Is `userId` allowed to read THIS case from THIS channel? Read-only commands take an explicit
+ * caseId, so without this an ordinary chat member could read any case on the server just by naming
+ * it. Policy: an operator who has configured an allowlist gets those responders full reach, and
+ * confines everyone else to the case the channel is bound to. With no allowlist configured the
+ * bot stays open, matching the rest of this localhost-first tool.
+ *
+ * Note this is about which case a chat member may READ. Password-protected cases are refused over
+ * chat outright (the route checks) — a chat message carries no unlock.
+ */
+export function isCaseAccessAllowed(input: {
+  userId: string;
+  caseId: string;
+  boundCaseId: string | undefined;
+  actionAllowlist: readonly string[] | undefined;
+}): boolean {
+  const { userId, caseId, boundCaseId, actionAllowlist } = input;
+  if (!actionAllowlist || actionAllowlist.length === 0) return true;
+  if (actionAllowlist.includes(userId)) return true;
+  return !!boundCaseId && caseId === boundCaseId;
 }

--- a/companion/src/analysis/slashCommand.ts
+++ b/companion/src/analysis/slashCommand.ts
@@ -1,0 +1,247 @@
+import type { Finding, InvestigationState, IOC, Severity } from "./stateTypes.js";
+
+// Two-way war-room slash-command bot (#235). IR happens in a Slack/Teams war room; this module
+// is the PURE core — the command parser + the read-only command formatters that turn case state
+// into a slash-command response card. The route (routes/slashCommand.ts) owns the inbound
+// webhook handler (HMAC auth + rate limiting), the async response_url posting, and per-channel
+// case binding; this module is deterministic and unit-tested with no I/O.
+//
+// Slash commands supported (the issue's full set):
+//   /dfir ask <caseId> <question>          → async (AI call) — the route handles this; here it's a parse result
+//   /dfir findings <caseId>                → top 5 findings (severity + confidence + MITRE)
+//   /dfir finding <caseId> <id>            → a single finding card
+//   /dfir iocs <caseId> [flagged|malicious]→ top IOCs with verdicts
+//   /dfir hunt <caseId> <technique>        → async (deploy) — the route handles this
+//   /dfir status <caseId>                  → case stats (events, findings, last synthesis, open hypotheses)
+//   /dfir synthesize <caseId>              → async (re-synthesis) — the route handles this
+//   /dfir bind <caseId>                    → bind this channel to a default case
+//   /dfir unbind                           → clear the channel binding
+//   /dfir help                              → usage
+
+export type SlashCommandName =
+  | "ask"
+  | "findings"
+  | "finding"
+  | "iocs"
+  | "hunt"
+  | "status"
+  | "synthesize"
+  | "bind"
+  | "unbind"
+  | "help";
+
+export interface ParsedSlashCommand {
+  name: SlashCommandName;
+  caseId?: string;       // absent when the command doesn't take one (help, unbind) or when the
+                         // channel is expected to supply a bound default (the route fills it)
+  arg?: string;          // the question / technique / finding id / ioc filter
+  iocFilter?: "flagged" | "malicious";
+  raw: string;
+}
+
+export const SLASH_COMMAND_NAMES: readonly SlashCommandName[] = [
+  "ask",
+  "findings",
+  "finding",
+  "iocs",
+  "hunt",
+  "status",
+  "synthesize",
+  "bind",
+  "unbind",
+  "help",
+];
+
+// Parse a slash-command text string into a structured command. Tolerant of extra whitespace and
+// of a leading "/dfir" (Slack sends the bare args; Teams sometimes includes the trigger word).
+// Returns { name: "help", raw } for an empty/unrecognized input so the route always has something
+// to respond with.
+export function parseSlashCommand(text: string): ParsedSlashCommand {
+  const raw = (text ?? "").trim();
+  if (!raw) return { name: "help", raw: "" };
+  // Strip a leading "/dfir" if present (some clients echo the trigger word back).
+  const stripped = raw.startsWith("/dfir ") ? raw.slice("/dfir ".length) : raw;
+  const parts = stripped.split(/\s+/);
+  const name = parts[0]?.toLowerCase() as SlashCommandName;
+  if (!SLASH_COMMAND_NAMES.includes(name)) return { name: "help", raw };
+  const rest = parts.slice(1);
+
+  switch (name) {
+    case "help":
+    case "unbind":
+      return { name, raw };
+    case "bind":
+      return { name, caseId: rest[0], raw };
+    case "status":
+    case "synthesize":
+      return { name, caseId: rest[0], raw };
+    case "findings":
+      return { name, caseId: rest[0], raw };
+    case "iocs": {
+      const caseId = rest[0];
+      const filter = rest[1];
+      return {
+        name,
+        caseId,
+        iocFilter: filter === "flagged" || filter === "malicious" ? filter : undefined,
+        raw,
+      };
+    }
+    case "finding":
+    case "hunt":
+    case "ask": {
+      const caseId = rest[0];
+      const arg = rest.slice(1).join(" ");
+      return { name, caseId, arg, raw };
+    }
+    default:
+      return { name: "help", raw };
+  }
+}
+
+// ── Read-only command formatters ────────────────────────────────────────────────────────
+// Each returns a { title, lines } card the route formats per-channel (Slack Block Kit / Teams
+// MessageCard) and posts to response_url. Pure functions of InvestigationState.
+
+export interface SlashCommandResponse {
+  title: string;
+  lines: string[];
+}
+
+const SEVERITY_ORDER: Record<Severity, number> = { Critical: 5, High: 4, Medium: 3, Low: 2, Info: 1 };
+
+function topFindings(state: InvestigationState, limit: number): Finding[] {
+  return [...state.findings]
+    .filter((f) => f.status !== "dismissed")
+    .sort((a, b) => (SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity]) || (b.confidence ?? 0) - (a.confidence ?? 0))
+    .slice(0, limit);
+}
+
+export function formatFindingsCommand(state: InvestigationState, limit = 5): SlashCommandResponse {
+  const top = topFindings(state, limit);
+  if (top.length === 0) {
+    return { title: `Top findings for ${state.caseId}`, lines: ["No findings yet — run a synthesis first."] };
+  }
+  const lines = top.map((f) => {
+    const conf = f.confidence !== undefined ? ` conf ${f.confidence}%` : "";
+    const mitre = f.mitreTechniques.length ? ` [${f.mitreTechniques.join(", ")}]` : "";
+    return `${f.severity} · ${f.id}${conf}${mitre} — ${f.title}`;
+  });
+  return { title: `Top ${top.length} finding(s) for ${state.caseId}`, lines };
+}
+
+export function formatFindingCommand(state: InvestigationState, findingId: string): SlashCommandResponse {
+  const f = state.findings.find((x) => x.id === findingId || x.semanticKey === findingId);
+  if (!f) return { title: `Finding ${findingId} not found`, lines: [`Case ${state.caseId} has no finding with id/semanticKey "${findingId}".`] };
+  const lines = [
+    `Severity: ${f.severity}${f.confidence !== undefined ? ` (confidence ${f.confidence}%)` : ""}`,
+    `Status: ${f.status}`,
+    `MITRE: ${f.mitreTechniques.length ? f.mitreTechniques.join(", ") : "—"}`,
+    `Related IOCs: ${f.relatedIocs.length || "none"}`,
+    `Description: ${f.description}`,
+    `First seen: ${f.firstSeen}`,
+  ];
+  return { title: `${f.id}: ${f.title}`, lines };
+}
+
+export function formatIocsCommand(
+  state: InvestigationState,
+  filter: "flagged" | "malicious" | undefined,
+  limit = 10,
+): SlashCommandResponse {
+  let iocs = state.iocs;
+  if (filter === "malicious") {
+    iocs = iocs.filter((ioc) => (ioc.enrichments ?? []).some((e) => e.verdict === "malicious"));
+  } else if (filter === "flagged") {
+    iocs = iocs.filter((ioc) => (ioc.enrichments ?? []).some((e) => e.verdict === "malicious" || e.verdict === "suspicious"));
+  }
+  if (iocs.length === 0) {
+    return { title: `IOCs for ${state.caseId}${filter ? ` (${filter})` : ""}`, lines: ["No IOCs match this filter."] };
+  }
+  const top = iocs.slice(0, limit);
+  const lines = top.map((ioc) => {
+    const verdicts = (ioc.enrichments ?? []).map((e) => `${e.source}:${e.verdict}`).join(", ");
+    return `${ioc.type} · ${ioc.value}${verdicts ? ` — ${verdicts}` : ""}`;
+  });
+  return { title: `${iocs.length} IOC(s)${filter ? ` (${filter})` : ""} — showing top ${top.length} for ${state.caseId}`, lines };
+}
+
+export function formatStatusCommand(state: InvestigationState): SlashCommandResponse {
+  const openFindings = state.findings.filter((f) => f.status === "open").length;
+  const confirmed = state.findings.filter((f) => f.status === "confirmed").length;
+  const maliciousIocs = state.iocs.filter((ioc) => (ioc.enrichments ?? []).some((e) => e.verdict === "malicious")).length;
+  const openHypotheses = (state as { hypotheses?: unknown[] }).hypotheses;
+  const lines = [
+    `Events: ${state.forensicTimeline.length}`,
+    `Findings: ${state.findings.length} (${openFindings} open, ${confirmed} confirmed)`,
+    `IOCs: ${state.iocs.length} (${maliciousIocs} malicious)`,
+    `Key questions: ${state.keyQuestions.length}`,
+    `Next steps: ${state.nextSteps.length}`,
+    `Last updated: ${state.updatedAt}`,
+    ...(Array.isArray(openHypotheses) ? [`Open hypotheses: ${openHypotheses.length}`] : []),
+  ];
+  return { title: `Status for ${state.caseId}`, lines };
+}
+
+export function formatHelpCommand(): SlashCommandResponse {
+  return {
+    title: "DFIR Companion slash commands",
+    lines: [
+      "/dfir status [caseId] — case stats",
+      "/dfir findings [caseId] — top 5 findings",
+      "/dfir finding <caseId|bound> <id> — a single finding card",
+      "/dfir iocs [caseId] [flagged|malicious] — top IOCs",
+      "/dfir ask <caseId|bound> <question> — ask the AI (async)",
+      "/dfir hunt <caseId|bound> <technique> — deploy a VQL hunt (async)",
+      "/dfir synthesize [caseId] — trigger re-synthesis (async)",
+      "/dfir bind <caseId> — bind this channel to a default case",
+      "/dfir unbind — clear the channel binding",
+      "When a channel is bound, the caseId can be omitted from any command.",
+    ],
+  };
+}
+
+// Per-channel case binding store: a channel can bind to a default case so subsequent commands
+// omit the caseId. Stored in the notification config dir (a global, channel-level concern, not
+// per-case) — the route module owns the persistence; this is just the shape.
+export interface ChannelBinding {
+  caseId: string;
+  boundAt: string;
+}
+
+// Resolve the caseId for a parsed command: prefer the explicit caseId, fall back to the channel's
+// bound default. Returns "" when neither is present (the route responds with a usage hint).
+export function resolveCaseId(cmd: ParsedSlashCommand, binding: ChannelBinding | undefined): string {
+  if (cmd.caseId && cmd.caseId.trim()) return cmd.caseId.trim();
+  return binding?.caseId ?? "";
+}
+
+// Access control: a command kind is allowed for a user when the user is in the action allowlist
+// (for action commands: hunt, synthesize, ask) OR when no allowlist is configured (open access,
+// the default). Read-only commands (findings, finding, iocs, status, help, bind, unbind) are
+// always allowed.
+export const READ_ONLY_COMMANDS: readonly SlashCommandName[] = [
+  "findings",
+  "finding",
+  "iocs",
+  "status",
+  "help",
+  "bind",
+  "unbind",
+];
+
+export const ACTION_COMMANDS: readonly SlashCommandName[] = ["ask", "hunt", "synthesize"];
+
+export function isActionCommand(name: SlashCommandName): boolean {
+  return ACTION_COMMANDS.includes(name);
+}
+
+export function isAllowed(
+  name: SlashCommandName,
+  userId: string,
+  actionAllowlist: readonly string[] | undefined,
+): boolean {
+  if (!isActionCommand(name)) return true;
+  if (!actionAllowlist || actionAllowlist.length === 0) return true; // open access when unconfigured
+  return actionAllowlist.includes(userId);
+}

--- a/companion/src/analysis/slashCommand.ts
+++ b/companion/src/analysis/slashCommand.ts
@@ -89,6 +89,13 @@ export interface ResolvedSlashCommand {
   raw: string;
 }
 
+// Commands whose argument is free text, so a leading token could plausibly be either the caseId or
+// the first word of the argument. Everything else takes no argument at all (status, findings,
+// synthesize) or one drawn from a closed vocabulary (iocs), and can be disambiguated outright.
+const FREEFORM_ARG_COMMANDS: readonly SlashCommandName[] = ["ask", "hunt", "finding"];
+
+const IOC_FILTERS = new Set(["flagged", "malicious"]);
+
 /**
  * Turn a parsed command into a resolved one: decide whether the first token is the caseId or part
  * of the argument, and fall back to the channel's bound case when it isn't.
@@ -100,8 +107,14 @@ export interface ResolvedSlashCommand {
  * called "what". Both ids pass isValidCaseId, so nothing errored — the analyst just got an answer
  * about the wrong (empty) case.
  *
- * `bind` is deliberately exempt: its argument names the case to bind TO, so falling back to the
- * current binding would silently re-bind the channel to the case it is already bound to.
+ * That existence check is only needed where the ambiguity is REAL. `/dfir status typo-case` has no
+ * argument for the token to belong to, so it is a caseId whether or not that case exists — falling
+ * back to the binding there would answer about the bound case and quietly hide the typo. Same for
+ * `/dfir iocs <x>`, where a filter can only be "flagged" or "malicious". Only ask/hunt/finding
+ * genuinely need the tiebreak.
+ *
+ * `bind` is exempt from the fallback entirely: its argument names the case to bind TO, so falling
+ * back to the current binding would silently re-bind the channel to the case it is already on.
  */
 export function resolveCommand(
   cmd: ParsedSlashCommand,
@@ -114,11 +127,19 @@ export function resolveCommand(
   if (name === "help" || name === "unbind") return { ...base, caseId: "" };
   if (name === "bind") return { ...base, caseId: (tokens[0] ?? "").trim() };
 
+  // Does the first token name the case, whether or not that case turns out to exist?
+  const first = tokens[0];
+  const firstIsCaseId =
+    first !== undefined &&
+    (FREEFORM_ARG_COMMANDS.includes(name)
+      ? firstTokenIsKnownCase           // ambiguous — only a real case id wins
+      : name !== "iocs" || !IOC_FILTERS.has(first)); // unambiguous — anything but a filter word
+
   let caseId: string;
   let rest: string[];
   let usedBinding = false;
-  if (tokens.length > 0 && firstTokenIsKnownCase) {
-    caseId = tokens[0];
+  if (firstIsCaseId) {
+    caseId = (first ?? "").trim();
     rest = tokens.slice(1);
   } else if (binding?.caseId) {
     caseId = binding.caseId;
@@ -127,7 +148,7 @@ export function resolveCommand(
   } else {
     // No binding and the first token isn't a case we know: keep treating it as the caseId so the
     // error message names what the analyst actually typed.
-    caseId = (tokens[0] ?? "").trim();
+    caseId = (first ?? "").trim();
     rest = tokens.slice(1);
   }
 

--- a/companion/src/analysis/slashCommandAuth.ts
+++ b/companion/src/analysis/slashCommandAuth.ts
@@ -1,14 +1,20 @@
-import { createHmac, timingSafeEqual as cryptoTimingSafeEqual } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { timingSafeEqual } from "./pushAuth.js";
 
-// HMAC signature verification for inbound slash-command webhooks (#235). Slack signs each
-// request with `v0:<timestamp>:<rawBody>` under the app's signing secret; the verifier
-// recomputes the HMAC and compares it to the `X-Slack-Signature` header in constant time.
-// Teams incoming webhooks (the webhook-based variant, not the Bot Framework) use a simpler
-// shared-secret bearer token in the Authorization header.
+// Inbound authentication for the war-room slash-command bot (#235), plus the outbound allowlist
+// for where a result may be delivered. Pure + I/O-free so every decision is unit-tested in
+// isolation.
 //
-// Pure + I/O-free so the verification decision is unit-tested in isolation. A 5-minute replay
-// window guards against a captured request being replayed later (Slack's own recommendation).
+//   Slack    — signs each request with `v0:<timestamp>:<rawBody>` under the app's signing secret.
+//              We recompute the HMAC and compare it to `X-Slack-Signature` in constant time. A
+//              5-minute replay window (Slack's own recommendation) bounds a captured request.
+//   Teams    — webhook-based slash commands (not the Bot Framework) carry a shared-secret bearer
+//              token in the Authorization header.
+//   Telegram — setWebhook takes a `secret_token`, which Telegram then sends back on every update
+//              in `X-Telegram-Bot-Api-Secret-Token`. Same shared-secret shape as Teams.
+//
+// All three compares go through pushAuth's timingSafeEqual, which is length-safe (it always costs
+// a full pass) — so a wrong secret leaks neither its length nor its prefix through response timing.
 
 export interface SlackSignatureInput {
   signingSecret: string;
@@ -37,13 +43,12 @@ export function verifySlackSignature(input: SlackSignatureInput): SignatureVerif
 
   const base = `v0:${input.timestamp}:${input.rawBody}`;
   const expected = "v0=" + createHmac("sha256", secret).update(base).digest("hex");
-  if (!constantTimeEqual(input.signature, expected)) return { ok: false, error: "signature mismatch" };
+  if (!timingSafeEqual(input.signature, expected)) return { ok: false, error: "signature mismatch" };
   return { ok: true };
 }
 
 // Teams webhook-based slash commands carry a bearer token the operator configures in the Teams
-// channel's webhook connector. Compare in constant time so a wrong token doesn't leak length/prefix.
-// Accepts both "Bearer <token>" and a bare "<token>" presentation.
+// channel's webhook connector. Accepts both "Bearer <token>" and a bare "<token>" presentation.
 export function verifyTeamsToken(presented: string | undefined, expected: string | undefined): SignatureVerifyResult {
   const want = String(expected ?? "").trim();
   if (!want) return { ok: false, error: "no Teams token configured" };
@@ -53,12 +58,51 @@ export function verifyTeamsToken(presented: string | undefined, expected: string
   return { ok: true };
 }
 
-// Constant-time buffer compare for the hex HMAC strings.
-function constantTimeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
+// Telegram echoes back the `secret_token` given to setWebhook in the
+// X-Telegram-Bot-Api-Secret-Token header. Without it, anyone who learns the webhook URL can post
+// updates — so an unconfigured secret refuses the request rather than running open.
+export function verifyTelegramSecret(presented: string | undefined, expected: string | undefined): SignatureVerifyResult {
+  const want = String(expected ?? "").trim();
+  if (!want) return { ok: false, error: "no Telegram webhook secret configured" };
+  if (!presented) return { ok: false, error: "missing X-Telegram-Bot-Api-Secret-Token header" };
+  if (!timingSafeEqual(String(presented).trim(), want)) return { ok: false, error: "secret token mismatch" };
+  return { ok: true };
+}
+
+// ── Outbound delivery allowlist ─────────────────────────────────────────────────────────
+// Slack and Teams tell us where to deliver an async result via a `response_url` in the request
+// body. That is a server-side fetch to a caller-supplied URL, so it is pinned to the hosts those
+// platforms actually deliver on. Self-hosted Slack-compatible servers (the Mattermost setup
+// DFIR_NOTIFY_CA already exists for) name themselves via DFIR_SLACK_RESPONSE_HOSTS /
+// DFIR_TEAMS_RESPONSE_HOSTS. A leading "." means "this host and any subdomain of it".
+
+export const DEFAULT_RESPONSE_HOSTS: Record<"slack" | "teams", readonly string[]> = {
+  slack: ["hooks.slack.com"],
+  // Classic connectors, Power Automate workflow URLs, and the Graph-hosted variant.
+  teams: [".webhook.office.com", ".logic.azure.com", ".office.com"],
+};
+
+/** Does `url` point somewhere we are willing to POST a case result to? https only. */
+export function isAllowedResponseUrl(
+  platform: "slack" | "teams",
+  url: string,
+  extraHosts: readonly string[] = [],
+): boolean {
+  let parsed: URL;
   try {
-    return cryptoTimingSafeEqual(Buffer.from(a), Buffer.from(b));
+    parsed = new URL(url);
   } catch {
     return false;
   }
+  if (parsed.protocol !== "https:") return false;
+  const host = parsed.hostname.toLowerCase();
+  return [...DEFAULT_RESPONSE_HOSTS[platform], ...extraHosts]
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean)
+    .some((allowed) => (allowed.startsWith(".") ? host === allowed.slice(1) || host.endsWith(allowed) : host === allowed));
+}
+
+/** Parse a comma-separated env var into a trimmed, non-empty list. */
+export function parseHostList(value: string | undefined): string[] {
+  return (value ?? "").split(",").map((s) => s.trim()).filter(Boolean);
 }

--- a/companion/src/analysis/slashCommandAuth.ts
+++ b/companion/src/analysis/slashCommandAuth.ts
@@ -1,0 +1,64 @@
+import { createHmac, timingSafeEqual as cryptoTimingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "./pushAuth.js";
+
+// HMAC signature verification for inbound slash-command webhooks (#235). Slack signs each
+// request with `v0:<timestamp>:<rawBody>` under the app's signing secret; the verifier
+// recomputes the HMAC and compares it to the `X-Slack-Signature` header in constant time.
+// Teams incoming webhooks (the webhook-based variant, not the Bot Framework) use a simpler
+// shared-secret bearer token in the Authorization header.
+//
+// Pure + I/O-free so the verification decision is unit-tested in isolation. A 5-minute replay
+// window guards against a captured request being replayed later (Slack's own recommendation).
+
+export interface SlackSignatureInput {
+  signingSecret: string;
+  timestamp: string;        // the X-Slack-Request-Timestamp header
+  rawBody: string;          // the raw request body (string)
+  signature: string;        // the X-Slack-Signature header (starts with "v0=")
+  now?: () => number;       // injectable clock (seconds since epoch) for tests
+  maxAgeSeconds?: number;   // default 300 (5 min)
+}
+
+export interface SignatureVerifyResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function verifySlackSignature(input: SlackSignatureInput): SignatureVerifyResult {
+  const secret = String(input.signingSecret ?? "").trim();
+  if (!secret) return { ok: false, error: "no Slack signing secret configured" };
+  if (!input.signature || !input.timestamp) return { ok: false, error: "missing signature/timestamp headers" };
+
+  const now = input.now ?? (() => Math.floor(Date.now() / 1000));
+  const maxAge = input.maxAgeSeconds ?? 300;
+  const ts = Number.parseInt(input.timestamp, 10);
+  if (!Number.isFinite(ts)) return { ok: false, error: "invalid timestamp" };
+  if (Math.abs(now() - ts) > maxAge) return { ok: false, error: "request timestamp outside the replay window" };
+
+  const base = `v0:${input.timestamp}:${input.rawBody}`;
+  const expected = "v0=" + createHmac("sha256", secret).update(base).digest("hex");
+  if (!constantTimeEqual(input.signature, expected)) return { ok: false, error: "signature mismatch" };
+  return { ok: true };
+}
+
+// Teams webhook-based slash commands carry a bearer token the operator configures in the Teams
+// channel's webhook connector. Compare in constant time so a wrong token doesn't leak length/prefix.
+// Accepts both "Bearer <token>" and a bare "<token>" presentation.
+export function verifyTeamsToken(presented: string | undefined, expected: string | undefined): SignatureVerifyResult {
+  const want = String(expected ?? "").trim();
+  if (!want) return { ok: false, error: "no Teams token configured" };
+  if (!presented) return { ok: false, error: "missing Authorization header" };
+  const presentedToken = String(presented).replace(/^Bearer\s+/i, "").trim();
+  if (!timingSafeEqual(presentedToken, want)) return { ok: false, error: "token mismatch" };
+  return { ok: true };
+}
+
+// Constant-time buffer compare for the hex HMAC strings.
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return cryptoTimingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}

--- a/companion/src/analysis/slashCommandStore.ts
+++ b/companion/src/analysis/slashCommandStore.ts
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+import { atomicWrite } from "../storage/atomicWrite.js";
+
+// Per-channel case binding store for the war-room slash-command bot (#235). A channel can bind
+// to a default case (`/dfir bind <caseId>`) so subsequent commands omit the caseId. Stored in a
+// GLOBAL JSON file beside the notification config (a channel-level concern, not per-case) —
+// mirrors NotificationConfigStore's location rationale. Returns sensible defaults when absent /
+// unreadable. Keyed by `<platform>:<channelId>` so a Slack channel and a Teams channel with the
+// same numeric id don't collide.
+
+const bindingSchema = z.object({
+  caseId: z.string(),
+  boundAt: z.string(),
+});
+
+const bindingsFileSchema = z.record(z.string(), bindingSchema).catch({});
+
+export type ChannelBindingMap = Record<string, { caseId: string; boundAt: string }>;
+
+export class SlashCommandChannelStore {
+  constructor(private readonly file: string) {}
+
+  async loadAll(): Promise<ChannelBindingMap> {
+    try {
+      return bindingsFileSchema.parse(JSON.parse(await readFile(this.file, "utf8")));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+      throw err;
+    }
+  }
+
+  async get(key: string): Promise<{ caseId: string; boundAt: string } | undefined> {
+    return (await this.loadAll())[key];
+  }
+
+  async bind(key: string, caseId: string, at: string = new Date().toISOString()): Promise<{ caseId: string; boundAt: string }> {
+    const all = await this.loadAll();
+    const next = { ...all, [key]: { caseId, boundAt: at } };
+    await atomicWrite(this.file, JSON.stringify(next, null, 2));
+    return next[key];
+  }
+
+  async unbind(key: string): Promise<boolean> {
+    const all = await this.loadAll();
+    if (!(key in all)) return false;
+    const next = { ...all };
+    delete next[key];
+    await atomicWrite(this.file, JSON.stringify(next, null, 2));
+    return true;
+  }
+}
+
+// Build the binding key from the inbound payload's platform + channel id.
+export function bindingKey(platform: "slack" | "teams", channelId: string): string {
+  return `${platform}:${channelId}`;
+}

--- a/companion/src/analysis/slashCommandStore.ts
+++ b/companion/src/analysis/slashCommandStore.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { readFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
 import { z } from "zod";
 import { atomicWrite } from "../storage/atomicWrite.js";
 
@@ -34,10 +35,19 @@ export class SlashCommandChannelStore {
     return (await this.loadAll())[key];
   }
 
+  // Create the parent directory before writing, exactly as NotificationConfigStore does: this file
+  // lives in the notifications/ dir beside cases/, which does not exist until something writes
+  // there — so on a fresh install the very first `/dfir bind` is the thing that creates it.
+  private async write(map: ChannelBindingMap): Promise<void> {
+    const dir = dirname(this.file);
+    if (dir) await mkdir(dir, { recursive: true });
+    await atomicWrite(this.file, JSON.stringify(map, null, 2));
+  }
+
   async bind(key: string, caseId: string, at: string = new Date().toISOString()): Promise<{ caseId: string; boundAt: string }> {
     const all = await this.loadAll();
     const next = { ...all, [key]: { caseId, boundAt: at } };
-    await atomicWrite(this.file, JSON.stringify(next, null, 2));
+    await this.write(next);
     return next[key];
   }
 
@@ -46,7 +56,7 @@ export class SlashCommandChannelStore {
     if (!(key in all)) return false;
     const next = { ...all };
     delete next[key];
-    await atomicWrite(this.file, JSON.stringify(next, null, 2));
+    await this.write(next);
     return true;
   }
 }

--- a/companion/src/analysis/slashCommandStore.ts
+++ b/companion/src/analysis/slashCommandStore.ts
@@ -51,7 +51,10 @@ export class SlashCommandChannelStore {
   }
 }
 
+/** The chat platforms the war-room bot speaks to. */
+export type ChatPlatform = "slack" | "teams" | "telegram";
+
 // Build the binding key from the inbound payload's platform + channel id.
-export function bindingKey(platform: "slack" | "teams", channelId: string): string {
+export function bindingKey(platform: ChatPlatform, channelId: string): string {
   return `${platform}:${channelId}`;
 }

--- a/companion/src/analysis/telegramPoller.ts
+++ b/companion/src/analysis/telegramPoller.ts
@@ -60,7 +60,15 @@ export class TelegramPoller {
   private backoffMs = MIN_BACKOFF_MS;
 
   constructor(options: TelegramPollerOptions) {
-    this.opts = { apiBase: "https://api.telegram.org", pollTimeoutSeconds: 50, ...options };
+    // Defaults go AFTER the spread and resolve with ??. Spreading options over a defaults object
+    // instead lets an explicitly-passed `apiBase: undefined` overwrite the default with undefined —
+    // which is exactly what the caller does when the env override is unset, and it broke every poll
+    // with "Cannot read properties of undefined". Tests that simply omit the key never see it.
+    this.opts = {
+      ...options,
+      apiBase: options.apiBase ?? "https://api.telegram.org",
+      pollTimeoutSeconds: options.pollTimeoutSeconds ?? 50,
+    };
     this.fetchFn = options.fetchFn ?? fetch;
     this.sleepFn = options.sleepFn ?? ((ms) => new Promise((r) => setTimeout(r, ms).unref?.()));
   }

--- a/companion/src/analysis/telegramPoller.ts
+++ b/companion/src/analysis/telegramPoller.ts
@@ -1,0 +1,185 @@
+import type { Logger } from "../logging/logger.js";
+
+// Telegram long-poll transport for the war-room slash-command bot (#235).
+//
+// The webhook routes need the Companion to be REACHABLE — a tunnel or reverse proxy, a hostname in
+// DFIR_ALLOWED_HOSTS, and a setWebhook registration to redo every time that hostname changes. For a
+// tool that is meant to run on a locked-down analyst workstation that is a lot of exposure and
+// ceremony, so Telegram (alone among the three platforms) offers the other direction: getUpdates.
+//
+// The Companion calls Telegram and Telegram holds the connection open until an update arrives or
+// the timeout expires — so replies stay near-instant without polling in a tight loop, and nothing
+// about the machine is reachable from the internet. Same outbound direction the notifier already
+// uses.
+//
+// Telegram refuses getUpdates while a webhook is registered for that bot, and refuses a second
+// concurrent poller for the same bot; both surface as HTTP 409 and are reported with the fix
+// rather than retried blindly.
+
+export interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+  edited_message?: TelegramMessage;
+  channel_post?: TelegramMessage;
+}
+
+export interface TelegramMessage {
+  chat?: { id?: number | string };
+  from?: { id?: number | string };
+  text?: string;
+  caption?: string;
+}
+
+export interface TelegramPollerOptions {
+  botToken: string;
+  /** Handle one update. Rejections are logged and the loop continues — one bad command must not
+   *  stop the bot. */
+  onUpdate: (update: TelegramUpdate) => Promise<void>;
+  log: Logger;
+  apiBase?: string;
+  /** How long Telegram holds an idle connection open, in seconds (default 50). */
+  pollTimeoutSeconds?: number;
+  fetchFn?: typeof fetch;
+  /** Injected in tests so backoff doesn't really sleep. */
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+const MIN_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 60_000;
+
+export class TelegramPoller {
+  private readonly opts: Required<Pick<TelegramPollerOptions, "apiBase" | "pollTimeoutSeconds">> & TelegramPollerOptions;
+  private readonly fetchFn: typeof fetch;
+  private readonly sleepFn: (ms: number) => Promise<void>;
+  private stopped = false;
+  private controller: AbortController | undefined;
+  private loop: Promise<void> | undefined;
+  /** Telegram's cursor: the next update_id we have NOT processed. Sending it back is what marks
+   *  everything before it as delivered — without it Telegram replays the same commands forever. */
+  private offset: number | undefined;
+  private backoffMs = MIN_BACKOFF_MS;
+
+  constructor(options: TelegramPollerOptions) {
+    this.opts = { apiBase: "https://api.telegram.org", pollTimeoutSeconds: 50, ...options };
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.sleepFn = options.sleepFn ?? ((ms) => new Promise((r) => setTimeout(r, ms).unref?.()));
+  }
+
+  /** Begin polling. Returns immediately; the loop runs until stop(). */
+  start(): void {
+    if (this.loop) return;
+    this.opts.log.info(`[telegram] long-polling for commands (no inbound URL needed)`);
+    this.loop = this.run();
+  }
+
+  /** Stop polling and wait for the in-flight request to unwind. */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.controller?.abort();
+    await this.loop?.catch(() => {});
+    this.loop = undefined;
+  }
+
+  private async run(): Promise<void> {
+    while (!this.stopped) {
+      try {
+        const updates = await this.getUpdates();
+        this.backoffMs = MIN_BACKOFF_MS; // a good round clears any accumulated backoff
+        for (const update of updates) {
+          if (this.stopped) return;
+          // Advance the cursor BEFORE handling: a command that throws must not be redelivered on
+          // the next poll, or one malformed message becomes an infinite loop.
+          this.offset = update.update_id + 1;
+          try {
+            await this.opts.onUpdate(update);
+          } catch (err) {
+            this.opts.log.warn(`[telegram] command failed: ${(err as Error).message}`);
+          }
+        }
+      } catch (err) {
+        if (this.stopped) return;
+        await this.handleFailure(err as Error);
+      }
+    }
+  }
+
+  private async getUpdates(): Promise<TelegramUpdate[]> {
+    this.controller = new AbortController();
+    // Give the request longer than Telegram's own hold, so the timeout that fires is theirs.
+    const timer = setTimeout(() => this.controller?.abort(), (this.opts.pollTimeoutSeconds + 15) * 1_000);
+    timer.unref?.();
+    try {
+      const url =
+        `${this.opts.apiBase.replace(/\/+$/, "")}/bot${this.opts.botToken}/getUpdates` +
+        `?timeout=${this.opts.pollTimeoutSeconds}` +
+        `&allowed_updates=${encodeURIComponent(JSON.stringify(["message", "channel_post"]))}` +
+        (this.offset === undefined ? "" : `&offset=${this.offset}`);
+      const res = await this.fetchFn(url, { signal: this.controller.signal });
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        result?: TelegramUpdate[];
+        description?: string;
+      };
+      if (!res.ok || body.ok === false) {
+        throw new TelegramApiError(res.status, body.description ?? `HTTP ${res.status}`);
+      }
+      return Array.isArray(body.result) ? body.result : [];
+    } finally {
+      clearTimeout(timer);
+      this.controller = undefined;
+    }
+  }
+
+  /** Back off after a failed round, saying something actionable for the failures that are
+   *  configuration rather than weather. */
+  private async handleFailure(err: Error): Promise<void> {
+    if (err instanceof TelegramApiError && err.status === 409) {
+      // The two ways a bot ends up with a second consumer. Neither resolves by waiting, so say what
+      // to do rather than letting an unexplained 409 scroll past every minute.
+      this.opts.log.error(
+        `[telegram] ${err.message} — a webhook is registered for this bot, or another poller is ` +
+          `running. Clear the webhook (deleteWebhook) or stop the other instance; polling and ` +
+          `webhooks cannot both be active on one bot.`,
+      );
+    } else if (err instanceof TelegramApiError && err.status === 401) {
+      this.opts.log.error(`[telegram] ${err.message} — DFIR_TELEGRAM_BOT_TOKEN is wrong or revoked.`);
+    } else {
+      this.opts.log.warn(`[telegram] poll failed (${err.message}); retrying in ${Math.round(this.backoffMs / 1000)}s`);
+    }
+    await this.sleepFn(this.backoffMs);
+    this.backoffMs = Math.min(this.backoffMs * 2, MAX_BACKOFF_MS);
+  }
+}
+
+export class TelegramApiError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+    this.name = "TelegramApiError";
+  }
+}
+
+/** Send a chat message through the Bot API. Used for poller replies, where there is no webhook
+ *  response to piggyback on. Best-effort: a delivery failure is logged, never thrown at the
+ *  command that produced it. */
+export async function sendTelegramMessage(input: {
+  botToken: string;
+  chatId: string;
+  text: string;
+  apiBase?: string;
+  fetchFn?: typeof fetch;
+  log: Logger;
+}): Promise<void> {
+  const base = (input.apiBase ?? "https://api.telegram.org").replace(/\/+$/, "");
+  const doFetch = input.fetchFn ?? fetch;
+  try {
+    const res = await doFetch(`${base}/bot${input.botToken}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: input.chatId, text: input.text }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) input.log.warn(`[telegram] sendMessage returned ${res.status}`);
+  } catch (err) {
+    input.log.warn(`[telegram] sendMessage failed: ${(err as Error).message}`);
+  }
+}

--- a/companion/src/routes/slashCommand.ts
+++ b/companion/src/routes/slashCommand.ts
@@ -26,6 +26,7 @@ import {
 } from "../analysis/slashCommandAuth.js";
 import { getAiLimiter } from "../http/rateLimiter.js";
 import { TelegramPoller, sendTelegramMessage, type TelegramUpdate } from "../analysis/telegramPoller.js";
+import { SlackSocketMode, type SlackCommandPayload } from "../analysis/slackSocketMode.js";
 import { isValidCaseId } from "../storage/caseStore.js";
 import type { RouteContext } from "./context.js";
 
@@ -201,6 +202,7 @@ export function startTelegramPolling(ctx: RouteContext): TelegramPoller | undefi
     return undefined;
   }
   const apiBase = (process.env.DFIR_TELEGRAM_API_BASE ?? "").trim() || undefined;
+  const limiter = getAiLimiter();
 
   const poller = new TelegramPoller({
     botToken,
@@ -211,6 +213,17 @@ export function startTelegramPolling(ctx: RouteContext): TelegramPoller | undefi
       const chatId = String(message.chat?.id ?? "");
       const text = String(message.text ?? message.caption ?? "");
       if (!chatId || !text.trim()) return; // a join notice, a photo with no caption — nothing to run
+
+      // Same per-channel cap as the webhook route. Polled commands are authenticated by
+      // construction, but a runaway script in one chat can still burn the AI budget.
+      if (!limiter.tryAcquire(`telegram:${chatId}`)) {
+        await sendTelegramMessage({
+          botToken, apiBase, chatId,
+          text: "Rate limit exceeded — try again in a minute.",
+          log: ctx.serverLogger,
+        });
+        return;
+      }
 
       const result = await dispatchSlashCommand({
         platform: "telegram",
@@ -234,6 +247,59 @@ export function startTelegramPolling(ctx: RouteContext): TelegramPoller | undefi
   });
   poller.start();
   return poller;
+}
+
+/**
+ * Start Slack Socket Mode, so Slack commands work with no inbound URL — the Slack counterpart to
+ * Telegram polling. The Companion opens an outbound WebSocket and commands arrive down it, so
+ * there is no Request URL to register and no tunnel hostname to keep in DFIR_ALLOWED_HOSTS.
+ *
+ * Returns the connection so the caller can stop it, or undefined when it isn't configured. Socket
+ * Mode and a Request URL are alternatives, not complements: an app configured for Socket Mode
+ * stops delivering over HTTP, and DFIR_SLACK_SIGNING_SECRET is unused here — the app-level token
+ * is what authenticates the connection.
+ */
+export function startSlackSocketMode(ctx: RouteContext): SlackSocketMode | undefined {
+  const { options } = ctx;
+  const channelStore = options.slashCommandChannelStore;
+  const appToken = (process.env.DFIR_SLACK_APP_TOKEN ?? "").trim();
+  if (!channelStore) return undefined;
+  if (!appToken) {
+    ctx.serverLogger.warn("[slack] socket mode requested but DFIR_SLACK_APP_TOKEN is not set — not starting");
+    return undefined;
+  }
+  const limiter = getAiLimiter();
+
+  const socket = new SlackSocketMode({
+    appToken,
+    apiBase: (process.env.DFIR_SLACK_API_BASE ?? "").trim() || undefined,
+    log: ctx.serverLogger,
+    onCommand: async (payload: SlackCommandPayload) => {
+      const channelId = String(payload.channel_id ?? "");
+      // Same per-channel cap as the webhook route: the request is authenticated by construction
+      // here, but a runaway script in one war room can still burn the AI budget.
+      if (!limiter.tryAcquire(`slack:${channelId}`)) {
+        return { response_type: "ephemeral", text: "Rate limit exceeded — try again in a minute." };
+      }
+      const result = await dispatchSlashCommand({
+        platform: "slack",
+        channelId,
+        userId: String(payload.user_id ?? ""),
+        responseUrl: String(payload.response_url ?? ""),
+        text: String(payload.text ?? ""),
+        actionAllowlist: parseHostList(process.env.DFIR_SLACK_ACTION_USERS),
+        channelStore,
+        ctx,
+      });
+      if (result.background) void result.background();
+      return {
+        response_type: result.ephemeral ? "ephemeral" : "in_channel",
+        text: renderText(result.reply),
+      };
+    },
+  });
+  socket.start();
+  return socket;
 }
 
 /** Dispatch a webhook-delivered command and write the answer in the platform's envelope. Any

--- a/companion/src/routes/slashCommand.ts
+++ b/companion/src/routes/slashCommand.ts
@@ -25,6 +25,7 @@ import {
   parseHostList,
 } from "../analysis/slashCommandAuth.js";
 import { getAiLimiter } from "../http/rateLimiter.js";
+import { TelegramPoller, sendTelegramMessage, type TelegramUpdate } from "../analysis/telegramPoller.js";
 import { isValidCaseId } from "../storage/caseStore.js";
 import type { RouteContext } from "./context.js";
 
@@ -109,7 +110,7 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
       return void res.status(429).json({ error: "rate limit exceeded — try again in a minute" });
     }
 
-    await dispatchCommand(res, {
+    await answer(res, {
       platform: "slack",
       channelId,
       userId: String(body.user_id ?? ""),
@@ -137,7 +138,7 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
       return void res.status(429).json({ error: "rate limit exceeded — try again in a minute" });
     }
 
-    await dispatchCommand(res, {
+    await answer(res, {
       platform: "teams",
       channelId,
       userId: String(body.from?.id ?? body.userId ?? ""),
@@ -168,7 +169,7 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
       return void res.status(429).json({ error: "rate limit exceeded — try again in a minute" });
     }
 
-    await dispatchCommand(res, {
+    await answer(res, {
       platform: "telegram",
       channelId,
       userId: String(message.from?.id ?? ""),
@@ -181,7 +182,70 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
   });
 }
 
-interface DispatchInput {
+/**
+ * Start the Telegram long-poll transport, so Telegram commands work with no inbound URL at all —
+ * no tunnel, no DFIR_ALLOWED_HOSTS entry, no setWebhook to redo whenever the hostname changes. The
+ * Companion calls Telegram instead of being called; see analysis/telegramPoller.ts.
+ *
+ * Returns the poller so the caller can stop it, or undefined when polling is not configured. The
+ * webhook route stays registered either way, but a bot cannot serve both at once — Telegram
+ * refuses getUpdates while a webhook is registered, which the poller reports with the fix.
+ */
+export function startTelegramPolling(ctx: RouteContext): TelegramPoller | undefined {
+  const { options } = ctx;
+  const channelStore = options.slashCommandChannelStore;
+  const botToken = (process.env.DFIR_TELEGRAM_BOT_TOKEN ?? "").trim();
+  if (!channelStore) return undefined;
+  if (!botToken) {
+    ctx.serverLogger.warn("[telegram] polling requested but DFIR_TELEGRAM_BOT_TOKEN is not set — not starting");
+    return undefined;
+  }
+  const apiBase = (process.env.DFIR_TELEGRAM_API_BASE ?? "").trim() || undefined;
+
+  const poller = new TelegramPoller({
+    botToken,
+    apiBase,
+    log: ctx.serverLogger,
+    onUpdate: async (update: TelegramUpdate) => {
+      const message = update.message ?? update.edited_message ?? update.channel_post ?? {};
+      const chatId = String(message.chat?.id ?? "");
+      const text = String(message.text ?? message.caption ?? "");
+      if (!chatId || !text.trim()) return; // a join notice, a photo with no caption — nothing to run
+
+      const result = await dispatchSlashCommand({
+        platform: "telegram",
+        channelId: chatId,
+        userId: String(message.from?.id ?? ""),
+        responseUrl: "", // polled commands deliver through the Bot API, same as async results
+        text,
+        actionAllowlist: parseHostList(process.env.DFIR_TELEGRAM_ACTION_USERS),
+        channelStore,
+        ctx,
+      });
+      await sendTelegramMessage({
+        botToken,
+        apiBase,
+        chatId,
+        text: renderText(result.reply),
+        log: ctx.serverLogger,
+      });
+      if (result.background) void result.background();
+    },
+  });
+  poller.start();
+  return poller;
+}
+
+/** Dispatch a webhook-delivered command and write the answer in the platform's envelope. Any
+ *  follow-up work starts only after the answer is on its way, so the platform's ~3s budget is
+ *  spent on the ACK and not on an AI call. */
+async function answer(res: Response, input: DispatchInput): Promise<void> {
+  const result = await dispatchSlashCommand(input);
+  res.status(200).json(chatResponse(input, result.reply, result.ephemeral));
+  if (result.background) void result.background();
+}
+
+export interface DispatchInput {
   platform: ChatPlatform;
   channelId: string;
   userId: string;
@@ -192,12 +256,27 @@ interface DispatchInput {
   ctx: RouteContext;
 }
 
-async function dispatchCommand(res: Response, input: DispatchInput): Promise<void> {
+/** What a dispatched command produced: the card to answer with, and — for the async commands —
+ *  the work to run once that answer is on its way. */
+export interface DispatchResult {
+  reply: SlashCommandResponse;
+  ephemeral: boolean;
+  background?: () => Promise<void>;
+}
+
+/**
+ * Run one slash command and say what to answer with. Deliberately knows nothing about HTTP: the
+ * webhook routes wrap the result in the platform's envelope, and the Telegram poller
+ * (analysis/telegramPoller.ts) sends the same result through the Bot API, having never received
+ * an HTTP request at all.
+ */
+export async function dispatchSlashCommand(input: DispatchInput): Promise<DispatchResult> {
   const { platform, channelId, userId, text, actionAllowlist, channelStore, ctx } = input;
   const { options, store } = ctx;
-  const reply = (r: SlashCommandResponse | string, ephemeral = true): void => {
-    res.status(200).json(chatResponse(input, typeof r === "string" ? { title: r, lines: [] } : r, ephemeral));
-  };
+  const reply = (r: SlashCommandResponse | string, ephemeral = true): DispatchResult => ({
+    reply: typeof r === "string" ? { title: r, lines: [] } : r,
+    ephemeral,
+  });
   const audit = (caseId: string, entry: Parameters<typeof logActivity>[3]): void => {
     void logActivity(options.activityLogStore, options.onActivity, caseId, { actor: `${platform}:${userId}`, ...entry });
   };
@@ -295,19 +374,21 @@ async function dispatchCommand(res: Response, input: DispatchInput): Promise<voi
 
   // Async commands: ACK immediately, then run and deliver the result out of band.
   if (isAsyncCommand(cmd.name)) {
-    reply(`Working on /dfir ${cmd.name} for case ${cmd.caseId}…`);
-    void runActionCommand(cmd, input).catch((err) => {
-      audit(cmd.caseId, {
-        category: "collaboration",
-        action: "slash-command-error",
-        detail: `/dfir ${cmd.name} failed: ${(err as Error).message}`,
-        outcome: "error",
-      });
-    });
-    return;
+    return {
+      ...reply(`Working on /dfir ${cmd.name} for case ${cmd.caseId}…`),
+      background: () =>
+        runActionCommand(cmd, input).catch((err) => {
+          audit(cmd.caseId, {
+            category: "collaboration",
+            action: "slash-command-error",
+            detail: `/dfir ${cmd.name} failed: ${(err as Error).message}`,
+            outcome: "error",
+          });
+        }),
+    };
   }
 
-  reply(formatHelpCommand());
+  return reply(formatHelpCommand());
 }
 
 /** Refuse a case the bot must not serve: one that doesn't exist, or one behind a password (chat
@@ -406,7 +487,8 @@ async function runActionCommand(cmd: ResolvedSlashCommand, input: DispatchInput)
 
 // ── Platform envelopes + delivery ───────────────────────────────────────────────────────
 
-function renderText(r: SlashCommandResponse): string {
+/** Flatten a card into the plain text every platform renders. */
+export function renderText(r: SlashCommandResponse): string {
   const body = r.lines.filter(Boolean).map((l) => `• ${l}`).join("\n");
   return `${r.title}${body ? `\n${body}` : ""}`;
 }

--- a/companion/src/routes/slashCommand.ts
+++ b/companion/src/routes/slashCommand.ts
@@ -1,0 +1,330 @@
+import express, { type Express, type Request, type Response } from "express";
+import { logActivity } from "../analysis/activityLog.js";
+import {
+  parseSlashCommand,
+  formatFindingsCommand,
+  formatFindingCommand,
+  formatIocsCommand,
+  formatStatusCommand,
+  formatHelpCommand,
+  resolveCaseId,
+  isAllowed,
+  isActionCommand,
+  READ_ONLY_COMMANDS,
+  type SlashCommandResponse,
+} from "../analysis/slashCommand.js";
+import { SlashCommandChannelStore, bindingKey } from "../analysis/slashCommandStore.js";
+import { verifySlackSignature, verifyTeamsToken } from "../analysis/slashCommandAuth.js";
+import { getAiLimiter } from "../http/rateLimiter.js";
+import { isValidCaseId } from "../storage/caseStore.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Two-way war-room slash-command bot (#235). Receives Slack/Teams slash commands, authenticates
+ * them (Slack HMAC signing secret / Teams bearer token), rate-limits per channel, and dispatches:
+ *   - read-only commands (findings, finding, iocs, status, help, bind, unbind) respond synchronously.
+ *   - action commands (ask, synthesize) ACK immediately with "working…" and post the result to the
+ *     request's response_url when ready (Slack/Teams expect a response within 3s; AI calls take
+ *     longer). `hunt` is supported as a route ACK + activity-log entry; full hunt deployment goes
+ *     through the dashboard (the velociraptor hunt-deploy surface is too rich for a slash command).
+ *
+ * Per-channel case binding: `/dfir bind <caseId>` lets a channel omit the caseId from subsequent
+ * commands. Access control: action commands are restricted to a configured user-id allowlist
+ * (DFIR_SLACK_ACTION_USERS / DFIR_TEAMS_ACTION_USERS, comma-separated); read-only commands are
+ * always allowed. When no allowlist is configured, access is open (the default for a localhost
+ * tool).
+ *
+ * Routes:
+ *   - POST /integrations/slack/command
+ *   - POST /integrations/teams/command
+ */
+export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): void {
+  const { options } = ctx;
+  const channelStore = options.slashCommandChannelStore;
+  if (!channelStore) return; // not configured — no bot
+
+  // Slack sends application/x-www-form-urlencoded; capture the raw body for HMAC verification via
+  // the parser's `verify` hook (called before parsing with the raw buffer).
+  app.use(
+    "/integrations/slack/command",
+    express.urlencoded({
+      extended: true,
+      limit: "1mb",
+      verify: (req: Request, _res: Response, buf: Buffer) => {
+        (req as Request & { rawBody?: string }).rawBody = buf.toString("utf8");
+      },
+    }),
+  );
+
+  const limiter = getAiLimiter();
+  const actionUsers = (): string[] =>
+    (process.env.DFIR_SLACK_ACTION_USERS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+
+  // ── Slack ───────────────────────────────────────────────────────────────────────────────
+  app.post("/integrations/slack/command", async (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    const channelId = String(body.channel_id ?? "");
+    const userId = String(body.user_id ?? "");
+    const responseUrl = String(body.response_url ?? "");
+    const text = String(body.text ?? "");
+    const rawBody = (req as Request & { rawBody?: string }).rawBody ?? "";
+
+    // Rate limit per channel (keyed by "slack:<channelId>") so a runaway script in one war room
+    // can't burn the server's AI budget.
+    const limitKey = `slack:${channelId}`;
+    if (!limiter.tryAcquire(limitKey)) {
+      return res.status(429).json({ response_type: "ephemeral", text: "Rate limit exceeded — try again in a minute." });
+    }
+
+    const signingSecret = (process.env.DFIR_SLACK_SIGNING_SECRET ?? "").trim();
+    const sig = verifySlackSignature({
+      signingSecret,
+      timestamp: String(req.headers["x-slack-request-timestamp"] ?? ""),
+      rawBody,
+      signature: String(req.headers["x-slack-signature"] ?? ""),
+    });
+    if (!sig.ok) {
+      return res.status(401).json({ error: sig.error ?? "unauthorized" });
+    }
+
+    await dispatchCommand(req, res, {
+      platform: "slack",
+      channelId,
+      userId,
+      responseUrl,
+      text,
+      actionAllowlist: actionUsers(),
+      channelStore,
+      ctx,
+    });
+  });
+
+  // ── Teams ───────────────────────────────────────────────────────────────────────────────
+  // Teams webhook-based slash commands POST a JSON body with a bearer token in the Authorization
+  // header. No raw-body HMAC needed.
+  app.post("/integrations/teams/command", async (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    const channelId = String(body.channel?.id ?? body.channelId ?? "");
+    const userId = String(body.from?.id ?? body.userId ?? "");
+    const responseUrl = String(body.responseUrl ?? "");
+    const text = String(body.text ?? body.command ?? "");
+
+    const limitKey = `teams:${channelId}`;
+    if (!limiter.tryAcquire(limitKey)) {
+      return res.status(429).json({ response_type: "ephemeral", text: "Rate limit exceeded — try again in a minute." });
+    }
+
+    const expectedToken = (process.env.DFIR_TEAMS_TOKEN ?? "").trim();
+    const presented = String(req.headers["authorization"] ?? "").replace(/^Bearer\s+/i, "");
+    const tok = verifyTeamsToken(presented || undefined, expectedToken);
+    if (!tok.ok) {
+      return res.status(401).json({ error: tok.error ?? "unauthorized" });
+    }
+
+    const teamsActionUsers = (process.env.DFIR_TEAMS_ACTION_USERS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+    await dispatchCommand(req, res, {
+      platform: "teams",
+      channelId,
+      userId,
+      responseUrl,
+      text,
+      actionAllowlist: teamsActionUsers,
+      channelStore,
+      ctx,
+    });
+  });
+}
+
+interface DispatchInput {
+  platform: "slack" | "teams";
+  channelId: string;
+  userId: string;
+  responseUrl: string;
+  text: string;
+  actionAllowlist: readonly string[];
+  channelStore: SlashCommandChannelStore;
+  ctx: RouteContext;
+}
+
+async function dispatchCommand(_req: Request, res: Response, input: DispatchInput): Promise<void> {
+  const { platform, channelId, userId, responseUrl, text, actionAllowlist, channelStore, ctx } = input;
+  const { options } = ctx;
+  const cmd = parseSlashCommand(text);
+  const bindKey = bindingKey(platform, channelId);
+  const binding = await channelStore.get(bindKey).catch(() => undefined);
+
+  // bind/unbind are handled inline (no caseId needed for unbind; bind takes the caseId arg).
+  if (cmd.name === "unbind") {
+    await channelStore.unbind(bindKey).catch(() => false);
+    res.status(200).json({ response_type: "ephemeral", text: "Channel case binding cleared." });
+    return;
+  }
+  if (cmd.name === "help") {
+    const r = formatHelpCommand();
+    res.status(200).json(toSlackResponse(r, true));
+    return;
+  }
+
+  // Access control: action commands require the user to be in the allowlist.
+  if (!isAllowed(cmd.name, userId, actionAllowlist)) {
+    res.status(403).json({ response_type: "ephemeral", text: `User ${userId} is not permitted to run /dfir ${cmd.name}.` });
+    return;
+  }
+
+  if (cmd.name === "bind") {
+    const caseId = cmd.caseId?.trim() ?? "";
+    if (!caseId || !isValidCaseId(caseId)) {
+      res.status(400).json({ response_type: "ephemeral", text: "Usage: /dfir bind <caseId>" });
+      return;
+    }
+    await channelStore.bind(bindKey, caseId);
+    res.status(200).json({ response_type: "ephemeral", text: `Channel bound to case ${caseId}.` });
+    return;
+  }
+
+  // Resolve the caseId (explicit arg → channel binding → empty).
+  const caseId = resolveCaseId(cmd, binding);
+  if (!caseId || !isValidCaseId(caseId)) {
+    const hint = binding ? `This channel is bound to case "${binding.caseId}".` : "Bind this channel first with `/dfir bind <caseId>`.";
+    res.status(400).json({ response_type: "ephemeral", text: `A valid caseId is required. ${hint}` });
+    return;
+  }
+  if (!options.stateStore) {
+    res.status(501).json({ response_type: "ephemeral", text: "State store not configured." });
+    return;
+  }
+
+  // Read-only commands respond synchronously.
+  if (READ_ONLY_COMMANDS.includes(cmd.name)) {
+    try {
+      const state = await options.stateStore.load(caseId);
+      let r: SlashCommandResponse;
+      switch (cmd.name) {
+        case "findings":
+          r = formatFindingsCommand(state);
+          break;
+        case "finding":
+          r = formatFindingCommand(state, cmd.arg ?? "");
+          break;
+        case "iocs":
+          r = formatIocsCommand(state, cmd.iocFilter);
+          break;
+        case "status":
+          r = formatStatusCommand(state);
+          break;
+        default:
+          r = formatHelpCommand();
+      }
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "collaboration",
+        action: "slash-command",
+        detail: `/dfir ${cmd.name} (user ${userId}, ${platform} channel ${channelId})`,
+      });
+      res.status(200).json(toSlackResponse(r, false));
+      return;
+    } catch (err) {
+      res.status(500).json({ response_type: "ephemeral", text: `Error loading case ${caseId}: ${(err as Error).message}` });
+      return;
+    }
+  }
+
+  // Action commands: ACK immediately, then run async and post the result to response_url.
+  if (isActionCommand(cmd.name)) {
+    if (!responseUrl) {
+      res.status(202).json({ response_type: "ephemeral", text: `Working on /dfir ${cmd.name}… (no response_url — result will appear in the activity log.)` });
+      return;
+    }
+    res.status(202).json({ response_type: "ephemeral", text: `Working on /dfir ${cmd.name} for case ${caseId}…` });
+    void runActionCommand(cmd.name, caseId, cmd.arg ?? "", responseUrl, input).catch((err) => {
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "collaboration",
+        action: "slash-command-error",
+        detail: `/dfir ${cmd.name} failed: ${(err as Error).message}`,
+      });
+    });
+    return;
+  }
+
+  // Unreachable (parseSlashCommand only returns known names), but keep a safe fallback.
+  res.status(200).json(toSlackResponse(formatHelpCommand(), true));
+}
+
+async function runActionCommand(
+  name: string,
+  caseId: string,
+  arg: string,
+  responseUrl: string,
+  input: DispatchInput,
+): Promise<void> {
+  const { options } = input.ctx;
+  if (name === "synthesize") {
+    input.ctx.resynthesizeInBackground(caseId);
+    logActivity(options.activityLogStore, options.onActivity, caseId, {
+      category: "ai",
+      action: "slash-command-synthesize",
+      detail: `/dfir synthesize triggered by user ${input.userId}`,
+    });
+    await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: `Re-synthesis started for case ${caseId}. The diff summary will appear in the dashboard and activity log when done.` });
+    return;
+  }
+  if (name === "ask") {
+    if (!arg.trim()) {
+      await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: "Usage: /dfir ask <question>" });
+      return;
+    }
+    if (!options.pipeline) {
+      await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: "AI pipeline not configured." });
+      return;
+    }
+    try {
+      const answer = await options.pipeline.ask(caseId, arg);
+      const lines = [answer.answer || "(no answer)", ...(answer.pointer ? [`Next: ${answer.pointer}`] : [])];
+      await postToResponseUrl(responseUrl, toSlackResponse({ title: `Q: ${arg}`, lines }, false));
+      logActivity(options.activityLogStore, options.onActivity, caseId, {
+        category: "ai",
+        action: "slash-command-ask",
+        detail: `/dfir ask "${arg.slice(0, 120)}" → ${answer.status}`,
+      });
+    } catch (err) {
+      await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: `AI ask failed: ${(err as Error).message}` });
+    }
+    return;
+  }
+  if (name === "hunt") {
+    // Hunt deployment via the bot is ACK-only — the velociraptor hunt-deploy surface (per-client
+    // targeting, artifact selection, bundle resolution) is too rich for a slash command. The
+    // dashboard's hunt panel is the deploy surface; the bot surfaces the technique to hunt.
+    await postToResponseUrl(responseUrl, {
+      response_type: "ephemeral",
+      text: `Hunt technique "${arg || "(none specified)"}" noted for case ${caseId}. Deploy the hunt from the dashboard's Velociraptor hunt panel.`,
+    });
+    logActivity(options.activityLogStore, options.onActivity, caseId, {
+      category: "hunt",
+      action: "slash-command-hunt",
+      detail: `/dfir hunt ${arg} (user ${input.userId}) — deploy via dashboard`,
+    });
+    return;
+  }
+}
+
+function toSlackResponse(r: SlashCommandResponse, ephemeral: boolean): { response_type: string; text: string } {
+  const body = r.lines.filter(Boolean).map((l) => `• ${l}`).join("\n");
+  return {
+    response_type: ephemeral ? "ephemeral" : "in_channel",
+    text: `${r.title}${body ? `\n${body}` : ""}`,
+  };
+}
+
+async function postToResponseUrl(url: string, payload: unknown): Promise<void> {
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch {
+    // best-effort — a failure to post the async result is logged via the action-command catch.
+  }
+}

--- a/companion/src/routes/slashCommand.ts
+++ b/companion/src/routes/slashCommand.ts
@@ -1,42 +1,73 @@
 import express, { type Express, type Request, type Response } from "express";
 import { logActivity } from "../analysis/activityLog.js";
+import { redactPaths } from "../analysis/redactPaths.js";
 import {
   parseSlashCommand,
+  resolveCommand,
   formatFindingsCommand,
   formatFindingCommand,
   formatIocsCommand,
   formatStatusCommand,
   formatHelpCommand,
-  resolveCaseId,
   isAllowed,
-  isActionCommand,
+  isCaseAccessAllowed,
+  isAsyncCommand,
   READ_ONLY_COMMANDS,
+  type ResolvedSlashCommand,
   type SlashCommandResponse,
 } from "../analysis/slashCommand.js";
-import { SlashCommandChannelStore, bindingKey } from "../analysis/slashCommandStore.js";
-import { verifySlackSignature, verifyTeamsToken } from "../analysis/slashCommandAuth.js";
+import { SlashCommandChannelStore, bindingKey, type ChatPlatform } from "../analysis/slashCommandStore.js";
+import {
+  verifySlackSignature,
+  verifyTeamsToken,
+  verifyTelegramSecret,
+  isAllowedResponseUrl,
+  parseHostList,
+} from "../analysis/slashCommandAuth.js";
 import { getAiLimiter } from "../http/rateLimiter.js";
 import { isValidCaseId } from "../storage/caseStore.js";
 import type { RouteContext } from "./context.js";
 
 /**
- * Two-way war-room slash-command bot (#235). Receives Slack/Teams slash commands, authenticates
- * them (Slack HMAC signing secret / Teams bearer token), rate-limits per channel, and dispatches:
- *   - read-only commands (findings, finding, iocs, status, help, bind, unbind) respond synchronously.
- *   - action commands (ask, synthesize) ACK immediately with "working…" and post the result to the
- *     request's response_url when ready (Slack/Teams expect a response within 3s; AI calls take
- *     longer). `hunt` is supported as a route ACK + activity-log entry; full hunt deployment goes
- *     through the dashboard (the velociraptor hunt-deploy surface is too rich for a slash command).
+ * Two-way war-room slash-command bot (#235). Receives Slack / Teams / Telegram slash commands,
+ * authenticates them, rate-limits per channel, and dispatches:
+ *   - read-only commands (findings, finding, iocs, status, help, unbind) respond synchronously.
+ *   - async commands (ask, hunt, synthesize) ACK immediately with "working…" and deliver the
+ *     result out of band when ready (chat platforms want a response within ~3s; AI calls take
+ *     longer). `hunt` records the technique and points at the dashboard — the Velociraptor
+ *     hunt-deploy surface (per-client targeting, artifact selection) is too rich for a slash
+ *     command.
  *
  * Per-channel case binding: `/dfir bind <caseId>` lets a channel omit the caseId from subsequent
- * commands. Access control: action commands are restricted to a configured user-id allowlist
- * (DFIR_SLACK_ACTION_USERS / DFIR_TEAMS_ACTION_USERS, comma-separated); read-only commands are
- * always allowed. When no allowlist is configured, access is open (the default for a localhost
- * tool).
+ * commands.
+ *
+ * ── Access control ──────────────────────────────────────────────────────────────────────
+ * Privileged commands (ask, hunt, synthesize, and bind — it decides which case the whole room can
+ * read) are restricted to a configured user-id allowlist: DFIR_SLACK_ACTION_USERS /
+ * DFIR_TEAMS_ACTION_USERS / DFIR_TELEGRAM_ACTION_USERS, comma-separated. Once an allowlist IS
+ * configured, everyone else is also confined to the channel's bound case, so an ordinary chat
+ * member cannot read an unrelated case just by naming it. With no allowlist the bot is open,
+ * matching the rest of this localhost-first tool.
+ *
+ * Password-protected cases are refused over chat entirely: the case-password gate lives on
+ * `/cases/:id` and a chat message carries no unlock cookie, so serving a locked case's state from
+ * here would be a way around it.
+ *
+ * ── Status codes ────────────────────────────────────────────────────────────────────────
+ * Only pre-authentication failures use error statuses (401 unauthenticated, 429 rate-limited) —
+ * those replies are for an impostor, not a person. Everything after a request authenticates
+ * answers 200 with the message in the platform's own envelope, because all three platforms
+ * discard the body of a non-2xx reply and show the user a generic failure instead. Telegram in
+ * particular RETRIES a non-2xx webhook delivery, which would re-run the command.
  *
  * Routes:
  *   - POST /integrations/slack/command
  *   - POST /integrations/teams/command
+ *   - POST /integrations/telegram/command
+ *
+ * Note these endpoints are reached from the internet (via a tunnel or reverse proxy), so the
+ * hostname they arrive under must be named in DFIR_ALLOWED_HOSTS — the DNS-rebinding host guard
+ * (#280) rejects unknown Host headers before any route runs. See companion/.env.example.
  */
 export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): void {
   const { options } = ctx;
@@ -44,7 +75,8 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
   if (!channelStore) return; // not configured — no bot
 
   // Slack sends application/x-www-form-urlencoded; capture the raw body for HMAC verification via
-  // the parser's `verify` hook (called before parsing with the raw buffer).
+  // the parser's `verify` hook (called before parsing, with the raw buffer). Teams and Telegram
+  // send JSON, which the app-wide express.json() already handles.
   app.use(
     "/integrations/slack/command",
     express.urlencoded({
@@ -57,43 +89,33 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
   );
 
   const limiter = getAiLimiter();
-  const actionUsers = (): string[] =>
-    (process.env.DFIR_SLACK_ACTION_USERS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+  const envList = (name: string): string[] => parseHostList(process.env[name]);
 
   // ── Slack ───────────────────────────────────────────────────────────────────────────────
   app.post("/integrations/slack/command", async (req: Request, res: Response) => {
     const body = req.body ?? {};
     const channelId = String(body.channel_id ?? "");
-    const userId = String(body.user_id ?? "");
-    const responseUrl = String(body.response_url ?? "");
-    const text = String(body.text ?? "");
-    const rawBody = (req as Request & { rawBody?: string }).rawBody ?? "";
 
-    // Rate limit per channel (keyed by "slack:<channelId>") so a runaway script in one war room
-    // can't burn the server's AI budget.
-    const limitKey = `slack:${channelId}`;
-    if (!limiter.tryAcquire(limitKey)) {
-      return res.status(429).json({ response_type: "ephemeral", text: "Rate limit exceeded — try again in a minute." });
-    }
-
-    const signingSecret = (process.env.DFIR_SLACK_SIGNING_SECRET ?? "").trim();
+    // Authenticate BEFORE spending the channel's rate-limit budget: the key comes from the request
+    // body, so limiting first would let an unauthenticated caller burn a real war room's quota.
     const sig = verifySlackSignature({
-      signingSecret,
+      signingSecret: (process.env.DFIR_SLACK_SIGNING_SECRET ?? "").trim(),
       timestamp: String(req.headers["x-slack-request-timestamp"] ?? ""),
-      rawBody,
+      rawBody: (req as Request & { rawBody?: string }).rawBody ?? "",
       signature: String(req.headers["x-slack-signature"] ?? ""),
     });
-    if (!sig.ok) {
-      return res.status(401).json({ error: sig.error ?? "unauthorized" });
+    if (!sig.ok) return void res.status(401).json({ error: sig.error ?? "unauthorized" });
+    if (!limiter.tryAcquire(`slack:${channelId}`)) {
+      return void res.status(429).json({ error: "rate limit exceeded — try again in a minute" });
     }
 
-    await dispatchCommand(req, res, {
+    await dispatchCommand(res, {
       platform: "slack",
       channelId,
-      userId,
-      responseUrl,
-      text,
-      actionAllowlist: actionUsers(),
+      userId: String(body.user_id ?? ""),
+      responseUrl: String(body.response_url ?? ""),
+      text: String(body.text ?? ""),
+      actionAllowlist: envList("DFIR_SLACK_ACTION_USERS"),
       channelStore,
       ctx,
     });
@@ -105,30 +127,54 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
   app.post("/integrations/teams/command", async (req: Request, res: Response) => {
     const body = req.body ?? {};
     const channelId = String(body.channel?.id ?? body.channelId ?? "");
-    const userId = String(body.from?.id ?? body.userId ?? "");
-    const responseUrl = String(body.responseUrl ?? "");
-    const text = String(body.text ?? body.command ?? "");
 
-    const limitKey = `teams:${channelId}`;
-    if (!limiter.tryAcquire(limitKey)) {
-      return res.status(429).json({ response_type: "ephemeral", text: "Rate limit exceeded — try again in a minute." });
+    const tok = verifyTeamsToken(
+      String(req.headers["authorization"] ?? "") || undefined,
+      (process.env.DFIR_TEAMS_TOKEN ?? "").trim(),
+    );
+    if (!tok.ok) return void res.status(401).json({ error: tok.error ?? "unauthorized" });
+    if (!limiter.tryAcquire(`teams:${channelId}`)) {
+      return void res.status(429).json({ error: "rate limit exceeded — try again in a minute" });
     }
 
-    const expectedToken = (process.env.DFIR_TEAMS_TOKEN ?? "").trim();
-    const presented = String(req.headers["authorization"] ?? "").replace(/^Bearer\s+/i, "");
-    const tok = verifyTeamsToken(presented || undefined, expectedToken);
-    if (!tok.ok) {
-      return res.status(401).json({ error: tok.error ?? "unauthorized" });
-    }
-
-    const teamsActionUsers = (process.env.DFIR_TEAMS_ACTION_USERS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
-    await dispatchCommand(req, res, {
+    await dispatchCommand(res, {
       platform: "teams",
       channelId,
-      userId,
-      responseUrl,
-      text,
-      actionAllowlist: teamsActionUsers,
+      userId: String(body.from?.id ?? body.userId ?? ""),
+      responseUrl: String(body.responseUrl ?? ""),
+      text: String(body.text ?? body.command ?? ""),
+      actionAllowlist: envList("DFIR_TEAMS_ACTION_USERS"),
+      channelStore,
+      ctx,
+    });
+  });
+
+  // ── Telegram ────────────────────────────────────────────────────────────────────────────
+  // Telegram POSTs an Update object and authenticates with the secret_token given to setWebhook,
+  // echoed back in X-Telegram-Bot-Api-Secret-Token. There is no response_url: the synchronous
+  // reply carries a `method` field that Telegram executes, and async results go to the Bot API
+  // directly (see deliverAsyncResult).
+  app.post("/integrations/telegram/command", async (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    const message = body.message ?? body.edited_message ?? body.channel_post ?? {};
+    const channelId = String(message.chat?.id ?? "");
+
+    const tok = verifyTelegramSecret(
+      String(req.headers["x-telegram-bot-api-secret-token"] ?? "") || undefined,
+      (process.env.DFIR_TELEGRAM_SECRET_TOKEN ?? "").trim(),
+    );
+    if (!tok.ok) return void res.status(401).json({ error: tok.error ?? "unauthorized" });
+    if (!limiter.tryAcquire(`telegram:${channelId}`)) {
+      return void res.status(429).json({ error: "rate limit exceeded — try again in a minute" });
+    }
+
+    await dispatchCommand(res, {
+      platform: "telegram",
+      channelId,
+      userId: String(message.from?.id ?? ""),
+      responseUrl: "", // Telegram delivers through the Bot API, not a per-request URL
+      text: String(message.text ?? message.caption ?? ""),
+      actionAllowlist: envList("DFIR_TELEGRAM_ACTION_USERS"),
       channelStore,
       ctx,
     });
@@ -136,7 +182,7 @@ export function registerSlashCommandRoutes(app: Express, ctx: RouteContext): voi
 }
 
 interface DispatchInput {
-  platform: "slack" | "teams";
+  platform: ChatPlatform;
   channelId: string;
   userId: string;
   responseUrl: string;
@@ -146,185 +192,284 @@ interface DispatchInput {
   ctx: RouteContext;
 }
 
-async function dispatchCommand(_req: Request, res: Response, input: DispatchInput): Promise<void> {
-  const { platform, channelId, userId, responseUrl, text, actionAllowlist, channelStore, ctx } = input;
-  const { options } = ctx;
-  const cmd = parseSlashCommand(text);
+async function dispatchCommand(res: Response, input: DispatchInput): Promise<void> {
+  const { platform, channelId, userId, text, actionAllowlist, channelStore, ctx } = input;
+  const { options, store } = ctx;
+  const reply = (r: SlashCommandResponse | string, ephemeral = true): void => {
+    res.status(200).json(chatResponse(input, typeof r === "string" ? { title: r, lines: [] } : r, ephemeral));
+  };
+  const audit = (caseId: string, entry: Parameters<typeof logActivity>[3]): void => {
+    void logActivity(options.activityLogStore, options.onActivity, caseId, { actor: `${platform}:${userId}`, ...entry });
+  };
+
+  const parsed = parseSlashCommand(text);
   const bindKey = bindingKey(platform, channelId);
   const binding = await channelStore.get(bindKey).catch(() => undefined);
 
-  // bind/unbind are handled inline (no caseId needed for unbind; bind takes the caseId arg).
+  // Is the first token the name of a real case, or the first word of the argument? Only the store
+  // knows — see resolveCommand's docblock for why guessing positionally is wrong.
+  const firstToken = parsed.tokens[0];
+  const firstTokenIsKnownCase =
+    !!firstToken && isValidCaseId(firstToken) && (await store.caseExists(firstToken).catch(() => false));
+  const cmd = resolveCommand(parsed, binding, firstTokenIsKnownCase);
+
+  if (cmd.name === "help") return reply(formatHelpCommand());
+
   if (cmd.name === "unbind") {
+    const previous = binding?.caseId;
     await channelStore.unbind(bindKey).catch(() => false);
-    res.status(200).json({ response_type: "ephemeral", text: "Channel case binding cleared." });
-    return;
-  }
-  if (cmd.name === "help") {
-    const r = formatHelpCommand();
-    res.status(200).json(toSlackResponse(r, true));
-    return;
+    if (previous) {
+      audit(previous, {
+        category: "collaboration",
+        action: "slash-command-unbind",
+        detail: `${platform} channel ${channelId} unbound from case ${previous}`,
+      });
+    }
+    return reply(previous ? `Channel case binding cleared (was ${previous}).` : "This channel was not bound to a case.");
   }
 
-  // Access control: action commands require the user to be in the allowlist.
+  // Permission gate before anything touches case data. Audited against the resolved case when that
+  // case really exists, so a denial is visible in the case's own activity log.
   if (!isAllowed(cmd.name, userId, actionAllowlist)) {
-    res.status(403).json({ response_type: "ephemeral", text: `User ${userId} is not permitted to run /dfir ${cmd.name}.` });
-    return;
+    await auditDenial(input, cmd, `not permitted to run /dfir ${cmd.name}`);
+    return reply(`User ${userId || "(unknown)"} is not permitted to run /dfir ${cmd.name}.`);
   }
 
   if (cmd.name === "bind") {
-    const caseId = cmd.caseId?.trim() ?? "";
-    if (!caseId || !isValidCaseId(caseId)) {
-      res.status(400).json({ response_type: "ephemeral", text: "Usage: /dfir bind <caseId>" });
-      return;
-    }
-    await channelStore.bind(bindKey, caseId);
-    res.status(200).json({ response_type: "ephemeral", text: `Channel bound to case ${caseId}.` });
-    return;
+    if (!cmd.caseId || !isValidCaseId(cmd.caseId)) return reply("Usage: /dfir bind <caseId>");
+    const bindGuard = await guardCase(ctx, cmd.caseId);
+    if (bindGuard) return reply(bindGuard);
+    // An unreadable bindings file (hand-edited into invalid JSON) must answer the analyst, not
+    // reject into the terminal error handler with a bare 500 the chat client won't render.
+    const bound = await channelStore.bind(bindKey, cmd.caseId).then(() => true).catch(() => false);
+    if (!bound) return reply("Could not save the channel binding — check notifications/slash-command-bindings.json.");
+    audit(cmd.caseId, {
+      category: "collaboration",
+      action: "slash-command-bind",
+      detail: `${platform} channel ${channelId} bound to case ${cmd.caseId} by user ${userId}`,
+    });
+    return reply(`Channel bound to case ${cmd.caseId}.`);
   }
 
-  // Resolve the caseId (explicit arg → channel binding → empty).
-  const caseId = resolveCaseId(cmd, binding);
-  if (!caseId || !isValidCaseId(caseId)) {
-    const hint = binding ? `This channel is bound to case "${binding.caseId}".` : "Bind this channel first with `/dfir bind <caseId>`.";
-    res.status(400).json({ response_type: "ephemeral", text: `A valid caseId is required. ${hint}` });
-    return;
+  if (!cmd.caseId || !isValidCaseId(cmd.caseId)) {
+    const hint = binding
+      ? `This channel is bound to case "${binding.caseId}".`
+      : "Bind this channel first with `/dfir bind <caseId>`.";
+    return reply(`A valid caseId is required. ${hint}`);
   }
-  if (!options.stateStore) {
-    res.status(501).json({ response_type: "ephemeral", text: "State store not configured." });
-    return;
+  if (!isCaseAccessAllowed({ userId, caseId: cmd.caseId, boundCaseId: binding?.caseId, actionAllowlist })) {
+    await auditDenial(input, cmd, `not permitted to reach case ${cmd.caseId} from this channel`);
+    return reply(
+      `User ${userId || "(unknown)"} may only use this channel's bound case` +
+        `${binding ? ` (${binding.caseId})` : " — this channel has no binding"}.`,
+    );
   }
+  const guard = await guardCase(ctx, cmd.caseId);
+  if (guard) return reply(guard);
+  if (!options.stateStore) return reply("State store not configured.");
 
   // Read-only commands respond synchronously.
   if (READ_ONLY_COMMANDS.includes(cmd.name)) {
+    let r: SlashCommandResponse;
     try {
-      const state = await options.stateStore.load(caseId);
-      let r: SlashCommandResponse;
+      const state = await options.stateStore.load(cmd.caseId);
       switch (cmd.name) {
-        case "findings":
-          r = formatFindingsCommand(state);
-          break;
-        case "finding":
-          r = formatFindingCommand(state, cmd.arg ?? "");
-          break;
-        case "iocs":
-          r = formatIocsCommand(state, cmd.iocFilter);
-          break;
-        case "status":
-          r = formatStatusCommand(state);
-          break;
-        default:
-          r = formatHelpCommand();
+        case "findings": r = formatFindingsCommand(state); break;
+        case "finding":  r = formatFindingCommand(state, cmd.arg); break;
+        case "iocs":     r = formatIocsCommand(state, cmd.iocFilter); break;
+        case "status":   r = formatStatusCommand(state); break;
+        default:         r = formatHelpCommand();
       }
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
-        category: "collaboration",
-        action: "slash-command",
-        detail: `/dfir ${cmd.name} (user ${userId}, ${platform} channel ${channelId})`,
-      });
-      res.status(200).json(toSlackResponse(r, false));
-      return;
     } catch (err) {
-      res.status(500).json({ response_type: "ephemeral", text: `Error loading case ${caseId}: ${(err as Error).message}` });
-      return;
+      // Path-redacted: the app-wide res.json redaction only rewrites an `error` field, and this
+      // message goes out as chat `text` — an fs error carries the full cases-root path.
+      return reply(`Error loading case ${cmd.caseId}: ${redactPaths((err as Error).message, [store.casesRoot])}`);
     }
+    audit(cmd.caseId, {
+      category: "collaboration",
+      action: "slash-command",
+      detail: `/dfir ${cmd.name} (user ${userId}, ${platform} channel ${channelId})`,
+    });
+    return reply(r, false);
   }
 
-  // Action commands: ACK immediately, then run async and post the result to response_url.
-  if (isActionCommand(cmd.name)) {
-    if (!responseUrl) {
-      res.status(202).json({ response_type: "ephemeral", text: `Working on /dfir ${cmd.name}… (no response_url — result will appear in the activity log.)` });
-      return;
-    }
-    res.status(202).json({ response_type: "ephemeral", text: `Working on /dfir ${cmd.name} for case ${caseId}…` });
-    void runActionCommand(cmd.name, caseId, cmd.arg ?? "", responseUrl, input).catch((err) => {
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
+  // Async commands: ACK immediately, then run and deliver the result out of band.
+  if (isAsyncCommand(cmd.name)) {
+    reply(`Working on /dfir ${cmd.name} for case ${cmd.caseId}…`);
+    void runActionCommand(cmd, input).catch((err) => {
+      audit(cmd.caseId, {
         category: "collaboration",
         action: "slash-command-error",
         detail: `/dfir ${cmd.name} failed: ${(err as Error).message}`,
+        outcome: "error",
       });
     });
     return;
   }
 
-  // Unreachable (parseSlashCommand only returns known names), but keep a safe fallback.
-  res.status(200).json(toSlackResponse(formatHelpCommand(), true));
+  reply(formatHelpCommand());
 }
 
-async function runActionCommand(
-  name: string,
-  caseId: string,
-  arg: string,
-  responseUrl: string,
-  input: DispatchInput,
-): Promise<void> {
-  const { options } = input.ctx;
-  if (name === "synthesize") {
-    input.ctx.resynthesizeInBackground(caseId);
-    logActivity(options.activityLogStore, options.onActivity, caseId, {
+/** Refuse a case the bot must not serve: one that doesn't exist, or one behind a password (chat
+ *  carries no unlock — see the module docblock). Returns the message to send, or "" when fine. */
+async function guardCase(ctx: RouteContext, caseId: string): Promise<string> {
+  let meta;
+  try {
+    meta = await ctx.store.getCaseMeta(caseId);
+  } catch {
+    // Fail closed, exactly like the case-lock gate does on an unexpected metadata read failure.
+    return `Case ${caseId} could not be read.`;
+  }
+  if (!meta) return `No such case: ${caseId}.`;
+  if (meta.password) return `Case ${caseId} is password-protected and is not available over chat — use the dashboard.`;
+  return "";
+}
+
+async function auditDenial(input: DispatchInput, cmd: ResolvedSlashCommand, reason: string): Promise<void> {
+  const { ctx, platform, channelId, userId } = input;
+  // Only write into a case's log when that case actually exists — a denial naming a bogus id must
+  // not create a case directory.
+  if (!cmd.caseId || !isValidCaseId(cmd.caseId)) return;
+  if (!(await ctx.store.caseExists(cmd.caseId).catch(() => false))) return;
+  await logActivity(ctx.options.activityLogStore, ctx.options.onActivity, cmd.caseId, {
+    actor: `${platform}:${userId}`,
+    category: "collaboration",
+    action: "slash-command-denied",
+    detail: `/dfir ${cmd.name} from ${platform} channel ${channelId}: ${reason}`,
+    outcome: "error",
+  });
+}
+
+async function runActionCommand(cmd: ResolvedSlashCommand, input: DispatchInput): Promise<void> {
+  const { ctx, platform, userId } = input;
+  const { options } = ctx;
+  const audit = (entry: Parameters<typeof logActivity>[3]): void => {
+    void logActivity(options.activityLogStore, options.onActivity, cmd.caseId, { actor: `${platform}:${userId}`, ...entry });
+  };
+  const send = (r: SlashCommandResponse, ephemeral = true): Promise<void> => deliverAsyncResult(input, r, ephemeral);
+
+  if (cmd.name === "synthesize") {
+    ctx.resynthesizeInBackground(cmd.caseId);
+    audit({
       category: "ai",
       action: "slash-command-synthesize",
-      detail: `/dfir synthesize triggered by user ${input.userId}`,
+      detail: `/dfir synthesize triggered by user ${userId}`,
     });
-    await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: `Re-synthesis started for case ${caseId}. The diff summary will appear in the dashboard and activity log when done.` });
+    await send({
+      title: `Re-synthesis started for case ${cmd.caseId}.`,
+      lines: ["The diff summary will appear in the dashboard and activity log when it finishes."],
+    });
     return;
   }
-  if (name === "ask") {
-    if (!arg.trim()) {
-      await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: "Usage: /dfir ask <question>" });
-      return;
-    }
-    if (!options.pipeline) {
-      await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: "AI pipeline not configured." });
-      return;
-    }
+
+  if (cmd.name === "ask") {
+    if (!cmd.arg.trim()) return void (await send({ title: "Usage: /dfir ask <question>", lines: [] }));
+    if (!options.pipeline) return void (await send({ title: "AI pipeline not configured.", lines: [] }));
     try {
-      const answer = await options.pipeline.ask(caseId, arg);
-      const lines = [answer.answer || "(no answer)", ...(answer.pointer ? [`Next: ${answer.pointer}`] : [])];
-      await postToResponseUrl(responseUrl, toSlackResponse({ title: `Q: ${arg}`, lines }, false));
-      logActivity(options.activityLogStore, options.onActivity, caseId, {
+      const answer = await options.pipeline.ask(cmd.caseId, cmd.arg);
+      await send(
+        {
+          title: `Q: ${cmd.arg}`,
+          lines: [answer.answer || "(no answer)", ...(answer.pointer ? [`Next: ${answer.pointer}`] : [])],
+        },
+        false,
+      );
+      audit({
         category: "ai",
         action: "slash-command-ask",
-        detail: `/dfir ask "${arg.slice(0, 120)}" → ${answer.status}`,
+        detail: `/dfir ask "${cmd.arg.slice(0, 120)}" → ${answer.status}`,
       });
     } catch (err) {
-      await postToResponseUrl(responseUrl, { response_type: "ephemeral", text: `AI ask failed: ${(err as Error).message}` });
+      await send({ title: `AI ask failed: ${redactPaths((err as Error).message, [ctx.store.casesRoot])}`, lines: [] });
+      audit({
+        category: "ai",
+        action: "slash-command-ask",
+        detail: `/dfir ask "${cmd.arg.slice(0, 120)}" failed: ${(err as Error).message}`,
+        outcome: "error",
+      });
     }
     return;
   }
-  if (name === "hunt") {
-    // Hunt deployment via the bot is ACK-only — the velociraptor hunt-deploy surface (per-client
-    // targeting, artifact selection, bundle resolution) is too rich for a slash command. The
-    // dashboard's hunt panel is the deploy surface; the bot surfaces the technique to hunt.
-    await postToResponseUrl(responseUrl, {
-      response_type: "ephemeral",
-      text: `Hunt technique "${arg || "(none specified)"}" noted for case ${caseId}. Deploy the hunt from the dashboard's Velociraptor hunt panel.`,
+
+  if (cmd.name === "hunt") {
+    await send({
+      title: `Hunt technique "${cmd.arg || "(none specified)"}" noted for case ${cmd.caseId}.`,
+      lines: ["Deploy the hunt from the dashboard's Velociraptor hunt panel."],
     });
-    logActivity(options.activityLogStore, options.onActivity, caseId, {
+    audit({
       category: "hunt",
       action: "slash-command-hunt",
-      detail: `/dfir hunt ${arg} (user ${input.userId}) — deploy via dashboard`,
+      detail: `/dfir hunt ${cmd.arg} (user ${userId}) — deploy via dashboard`,
     });
-    return;
   }
 }
 
-function toSlackResponse(r: SlashCommandResponse, ephemeral: boolean): { response_type: string; text: string } {
+// ── Platform envelopes + delivery ───────────────────────────────────────────────────────
+
+function renderText(r: SlashCommandResponse): string {
   const body = r.lines.filter(Boolean).map((l) => `• ${l}`).join("\n");
-  return {
-    response_type: ephemeral ? "ephemeral" : "in_channel",
-    text: `${r.title}${body ? `\n${body}` : ""}`,
-  };
+  return `${r.title}${body ? `\n${body}` : ""}`;
 }
 
-async function postToResponseUrl(url: string, payload: unknown): Promise<void> {
-  if (!url) return;
+/** Wrap a card in the response envelope the platform expects for a synchronous reply. */
+function chatResponse(input: DispatchInput, r: SlashCommandResponse, ephemeral: boolean): unknown {
+  const text = renderText(r);
+  switch (input.platform) {
+    case "slack":
+      return { response_type: ephemeral ? "ephemeral" : "in_channel", text };
+    case "teams":
+      return { type: "message", text };
+    case "telegram":
+      // Telegram executes a Bot API method named in the webhook reply body — that is how you answer
+      // an update without a second HTTP call.
+      return { method: "sendMessage", chat_id: input.channelId, text };
+  }
+}
+
+/** Deliver a result that wasn't ready in time for the synchronous reply. */
+async function deliverAsyncResult(input: DispatchInput, r: SlashCommandResponse, ephemeral: boolean): Promise<void> {
+  const { ctx, platform } = input;
+  if (platform === "telegram") {
+    const token = (process.env.DFIR_TELEGRAM_BOT_TOKEN ?? "").trim();
+    if (!token) {
+      ctx.serverLogger.warn("[slash] telegram result dropped: DFIR_TELEGRAM_BOT_TOKEN is not set");
+      return;
+    }
+    const base = (process.env.DFIR_TELEGRAM_API_BASE ?? "https://api.telegram.org").replace(/\/+$/, "");
+    await postJson(input, `${base}/bot${token}/sendMessage`, { chat_id: input.channelId, text: renderText(r) });
+    return;
+  }
+
+  const url = input.responseUrl;
+  if (!url) {
+    ctx.serverLogger.warn(`[slash] ${platform} result dropped: the request carried no response_url`);
+    return;
+  }
+  const extraHosts = parseHostList(
+    platform === "slack" ? process.env.DFIR_SLACK_RESPONSE_HOSTS : process.env.DFIR_TEAMS_RESPONSE_HOSTS,
+  );
+  // The response_url is caller-supplied, so it is pinned to the hosts the platform delivers on
+  // before we make a server-side request to it.
+  if (!isAllowedResponseUrl(platform, url, extraHosts)) {
+    ctx.serverLogger.warn(
+      `[slash] refused to deliver to response_url "${url}" — not an allowed ${platform} host` +
+        ` (extend with DFIR_${platform.toUpperCase()}_RESPONSE_HOSTS)`,
+    );
+    return;
+  }
+  await postJson(input, url, chatResponse(input, r, ephemeral));
+}
+
+async function postJson(input: DispatchInput, url: string, payload: unknown): Promise<void> {
   try {
-    await fetch(url, {
+    const res = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(15_000),
     });
-  } catch {
-    // best-effort — a failure to post the async result is logged via the action-command catch.
+    if (!res.ok) input.ctx.serverLogger.warn(`[slash] result delivery to ${input.platform} returned ${res.status}`);
+  } catch (err) {
+    input.ctx.serverLogger.warn(`[slash] result delivery to ${input.platform} failed: ${(err as Error).message}`);
   }
 }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -35,6 +35,7 @@ import { registerInteractiveReportRoutes } from "./routes/interactiveReport.js";
 import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
+import { registerSlashCommandRoutes } from "./routes/slashCommand.js";
 import { registerComplianceRoutes } from "./routes/compliance.js";
 import { registerCoachRoutes } from "./routes/coach.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
@@ -212,6 +213,7 @@ import type { ImporterFailure, AiError, ImporterRunStat } from "./analysis/diagn
 import { redactPaths, redactedErrorMessage } from "./analysis/redactPaths.js";
 import type { PreflightReport } from "./analysis/preflight.js";
 import { NotificationConfigStore } from "./analysis/notificationStore.js";
+import { SlashCommandChannelStore } from "./analysis/slashCommandStore.js";
 import { seedDemoCase } from "./analysis/seedDemoCase.js";
 import {
   findingEventsFromDiff, milestoneEvent,
@@ -591,6 +593,9 @@ export interface AppOptions {
   // `notifyEmailEnabled` tells the dashboard whether an SMTP transport is wired (so it can hint).
   // `dashboardBaseUrl` deep-links notifications back to the case.
   notificationStore?: NotificationConfigStore;
+  // Per-channel case-binding store for the war-room slash-command bot (#235), in a global JSON
+  // file beside the notification config. Absent → the bot's routes are not registered at all.
+  slashCommandChannelStore?: SlashCommandChannelStore;
   notifier?: Notifier;
   notifyEmailEnabled?: boolean;
   dashboardBaseUrl?: string;
@@ -947,6 +952,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerCaseLifecycleRoutes(app, ctx);
   registerCoachRoutes(app, ctx);
   registerComplianceRoutes(app, ctx);
+  registerSlashCommandRoutes(app, ctx);
 
   const windowSize = options.windowSize ?? 4;
   const buffers = new Map<string, CaptureMetadata[]>();
@@ -3356,6 +3362,11 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   // notifier wired with a TLS-aware fetch (Slack/Teams webhooks, honoring DFIR_NOTIFY_CA/_INSECURE
   // for self-hosted Mattermost) and the built-in SMTP transport for email channels.
   const notificationStore = new NotificationConfigStore(join(dirname(casesRoot), "notifications", "config.json"));
+  // Per-channel case bindings for the war-room slash-command bot (#235) — a global file beside the
+  // notification config (a channel-level concern, not per-case).
+  const slashCommandChannelStore = new SlashCommandChannelStore(
+    join(dirname(casesRoot), "notifications", "slash-command-bindings.json"),
+  );
   const notifier = createNotifier({
     store: notificationStore,
     fetchFn: tlsFetchFor("NOTIFY") ?? fetch,
@@ -3667,6 +3678,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     servicenowExportStore: new ServiceNowExportStore(store),
     servicenowOptions: servicenowOptions(),
     notificationStore,
+    slashCommandChannelStore,
     notifier,
     notifyEmailEnabled: true,
     dashboardBaseUrl,

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -35,7 +35,7 @@ import { registerInteractiveReportRoutes } from "./routes/interactiveReport.js";
 import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
-import { registerSlashCommandRoutes } from "./routes/slashCommand.js";
+import { registerSlashCommandRoutes, startTelegramPolling } from "./routes/slashCommand.js";
 import { registerComplianceRoutes } from "./routes/compliance.js";
 import { registerCoachRoutes } from "./routes/coach.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
@@ -596,6 +596,10 @@ export interface AppOptions {
   // Per-channel case-binding store for the war-room slash-command bot (#235), in a global JSON
   // file beside the notification config. Absent → the bot's routes are not registered at all.
   slashCommandChannelStore?: SlashCommandChannelStore;
+  // Poll Telegram for commands instead of receiving them on a webhook, so no inbound URL is needed
+  // (#235). Gated on this flag rather than read straight from env, so createApp-only unit tests
+  // never start a network loop — same reasoning as the drop-folder watcher below.
+  telegramPolling?: boolean;
   notifier?: Notifier;
   notifyEmailEnabled?: boolean;
   dashboardBaseUrl?: string;
@@ -953,6 +957,9 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerCoachRoutes(app, ctx);
   registerComplianceRoutes(app, ctx);
   registerSlashCommandRoutes(app, ctx);
+  // Telegram long polling (#235): opt-in, and gated on the flag so createApp-only unit tests never
+  // reach the network. Exposed on app.locals so a host can stop it on shutdown.
+  if (options.telegramPolling) app.locals.telegramPoller = startTelegramPolling(ctx);
 
   const windowSize = options.windowSize ?? 4;
   const buffers = new Map<string, CaptureMetadata[]>();
@@ -3679,6 +3686,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     servicenowOptions: servicenowOptions(),
     notificationStore,
     slashCommandChannelStore,
+    telegramPolling: (process.env.DFIR_TELEGRAM_POLL ?? "").trim().toLowerCase() === "on",
     notifier,
     notifyEmailEnabled: true,
     dashboardBaseUrl,

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -35,7 +35,7 @@ import { registerInteractiveReportRoutes } from "./routes/interactiveReport.js";
 import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
-import { registerSlashCommandRoutes, startTelegramPolling } from "./routes/slashCommand.js";
+import { registerSlashCommandRoutes, startTelegramPolling, startSlackSocketMode } from "./routes/slashCommand.js";
 import { registerComplianceRoutes } from "./routes/compliance.js";
 import { registerCoachRoutes } from "./routes/coach.js";
 import { ingestCapture, CaseNotFoundError } from "./ingest/captureIngest.js";
@@ -600,6 +600,9 @@ export interface AppOptions {
   // (#235). Gated on this flag rather than read straight from env, so createApp-only unit tests
   // never start a network loop — same reasoning as the drop-folder watcher below.
   telegramPolling?: boolean;
+  // Receive Slack commands over an outbound WebSocket instead of a Request URL (#235). Same
+  // reasoning as telegramPolling above: gated on the flag so tests never open a socket.
+  slackSocketMode?: boolean;
   notifier?: Notifier;
   notifyEmailEnabled?: boolean;
   dashboardBaseUrl?: string;
@@ -957,9 +960,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerCoachRoutes(app, ctx);
   registerComplianceRoutes(app, ctx);
   registerSlashCommandRoutes(app, ctx);
-  // Telegram long polling (#235): opt-in, and gated on the flag so createApp-only unit tests never
-  // reach the network. Exposed on app.locals so a host can stop it on shutdown.
+  // Outbound-only command transports (#235) — neither needs an inbound URL. Opt-in, and gated on
+  // the flags so createApp-only unit tests never reach the network. Exposed on app.locals so a host
+  // can stop them on shutdown.
   if (options.telegramPolling) app.locals.telegramPoller = startTelegramPolling(ctx);
+  if (options.slackSocketMode) app.locals.slackSocketMode = startSlackSocketMode(ctx);
 
   const windowSize = options.windowSize ?? 4;
   const buffers = new Map<string, CaptureMetadata[]>();
@@ -3687,6 +3692,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     notificationStore,
     slashCommandChannelStore,
     telegramPolling: (process.env.DFIR_TELEGRAM_POLL ?? "").trim().toLowerCase() === "on",
+    slackSocketMode: (process.env.DFIR_SLACK_SOCKET_MODE ?? "").trim().toLowerCase() === "on",
     notifier,
     notifyEmailEnabled: true,
     dashboardBaseUrl,

--- a/companion/tests/analysis/slackSocketMode.test.ts
+++ b/companion/tests/analysis/slackSocketMode.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from "vitest";
+import { SlackSocketMode, type SocketLike, type SlackCommandPayload } from "../../src/analysis/slackSocketMode.js";
+import type { Logger } from "../../src/logging/logger.js";
+
+// Slack Socket Mode (#235): an outbound WebSocket instead of a Request URL, so Slack commands need
+// no tunnel and no public hostname. Slack pushes an envelope per command; each must be acked, and
+// the ack payload is what the analyst sees.
+
+const yieldingSleep = (record?: number[]) => async (ms: number) => {
+  record?.push(ms);
+  await new Promise((r) => setTimeout(r, 1));
+};
+
+function fakeLog(): Logger & { lines: string[] } {
+  const lines: string[] = [];
+  const push = (level: string) => (m: string) => { lines.push(`${level} ${m}`); };
+  return {
+    lines,
+    debug: push("debug"), info: push("info"), warn: push("warn"), error: push("error"),
+    getLevel: () => "info", setLevel: () => {}, close: async () => {},
+  } as unknown as Logger & { lines: string[] };
+}
+
+/** A controllable stand-in for the WebSocket, so a test can push frames at the transport. */
+class FakeSocket implements SocketLike {
+  readonly sent: string[] = [];
+  closed = false;
+  private handlers = new Map<string, (arg?: unknown) => void>();
+  on(event: string, cb: (arg?: unknown) => void): void { this.handlers.set(event, cb); }
+  send(data: string): void { this.sent.push(data); }
+  close(): void { this.closed = true; }
+  emit(event: string, arg?: unknown): void { this.handlers.get(event)?.(arg); }
+  deliver(frame: unknown): void { this.emit("message", JSON.stringify(frame)); }
+  acks(): Array<Record<string, unknown>> { return this.sent.map((s) => JSON.parse(s)); }
+}
+
+/** connections.open always succeeds; every socket it hands out is captured for the test. */
+function harness(opts: { onCommand?: (p: SlackCommandPayload) => Promise<unknown>; openBody?: unknown } = {}) {
+  const sockets: FakeSocket[] = [];
+  const log = fakeLog();
+  const opened: string[] = [];
+  const fetchFn = (async (url: string) => {
+    opened.push(String(url));
+    return new Response(JSON.stringify(opts.openBody ?? { ok: true, url: "wss://slack.test/link" }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const mode = new SlackSocketMode({
+    appToken: "xapp-1",
+    fetchFn,
+    log,
+    sleepFn: yieldingSleep(),
+    socketFactory: () => { const s = new FakeSocket(); sockets.push(s); return s; },
+    onCommand: opts.onCommand ?? (async () => ({ response_type: "in_channel", text: "ok" })),
+  });
+  return { mode, sockets, log, opened };
+}
+
+const commandEnvelope = (id: string, text: string) => ({
+  envelope_id: id,
+  type: "slash_commands",
+  accepts_response_payload: true,
+  payload: { command: "/dfir", text, channel_id: "C1", user_id: "U1", response_url: "https://hooks.slack.com/x" },
+});
+
+describe("SlackSocketMode", () => {
+  it("trades the app token for a socket URL", async () => {
+    const { mode, sockets, opened } = harness();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await mode.stop();
+    expect(opened[0]).toBe("https://slack.com/api/apps.connections.open");
+  });
+
+  it("dispatches a slash command and acks with the reply", async () => {
+    const seen: string[] = [];
+    const { mode, sockets } = harness({
+      onCommand: async (p) => { seen.push(p.text ?? ""); return { response_type: "in_channel", text: "Top 5 findings" }; },
+    });
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].deliver(commandEnvelope("env-1", "findings demo"));
+
+    await vi.waitFor(() => expect(sockets[0].sent).toHaveLength(1));
+    await mode.stop();
+    expect(seen).toEqual(["findings demo"]);
+    expect(sockets[0].acks()[0]).toEqual({
+      envelope_id: "env-1",
+      payload: { response_type: "in_channel", text: "Top 5 findings" },
+    });
+  });
+
+  // An unacked envelope is redelivered, so kinds we ignore still have to be acked.
+  it("acks an envelope it does not act on, with no payload", async () => {
+    const { mode, sockets } = harness();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].deliver({ envelope_id: "env-2", type: "events_api", payload: { event: {} } });
+
+    await vi.waitFor(() => expect(sockets[0].sent).toHaveLength(1));
+    await mode.stop();
+    expect(sockets[0].acks()[0]).toEqual({ envelope_id: "env-2" });
+  });
+
+  it("still acks when the command handler throws, so Slack does not redeliver it", async () => {
+    const { mode, sockets, log } = harness({ onCommand: async () => { throw new Error("dispatch exploded"); } });
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].deliver(commandEnvelope("env-3", "status"));
+
+    await vi.waitFor(() => expect(sockets[0].sent).toHaveLength(1));
+    await mode.stop();
+    expect(sockets[0].acks()[0]).toEqual({ envelope_id: "env-3" });
+    expect(log.lines.some((l) => l.includes("dispatch exploded"))).toBe(true);
+  });
+
+  // Slack rotates connections and warns first. Routine, not an error.
+  it("opens a fresh connection when Slack asks it to reconnect", async () => {
+    const { mode, sockets, opened, log } = harness();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].deliver({ type: "disconnect", reason: "refresh_requested" });
+
+    await vi.waitFor(() => expect(sockets.length).toBeGreaterThanOrEqual(2));
+    await mode.stop();
+    expect(opened.length).toBeGreaterThanOrEqual(2);
+    expect(log.lines.some((l) => l.includes("reconnecting"))).toBe(true);
+    expect(log.lines.some((l) => l.startsWith("warn"))).toBe(false); // a rotation is not a warning
+  });
+
+  it("reconnects after the socket drops", async () => {
+    const { mode, sockets } = harness();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].emit("close");
+    await vi.waitFor(() => expect(sockets.length).toBeGreaterThanOrEqual(2));
+    await mode.stop();
+  });
+
+  it("backs off when connections.open keeps failing", async () => {
+    const slept: number[] = [];
+    const log = fakeLog();
+    const fetchFn = (async () => new Response(JSON.stringify({ ok: false, error: "ratelimited" }), { status: 200 })) as unknown as typeof fetch;
+    const mode = new SlackSocketMode({
+      appToken: "xapp-1", fetchFn, log, sleepFn: yieldingSleep(slept),
+      socketFactory: () => new FakeSocket(),
+      onCommand: async () => undefined,
+    });
+    mode.start();
+    await vi.waitFor(() => expect(slept.length).toBeGreaterThanOrEqual(3));
+    await mode.stop();
+    expect(slept.slice(0, 3)).toEqual([1000, 2000, 4000]);
+  });
+
+  it("explains a bad app token rather than retrying quietly", async () => {
+    const log = fakeLog();
+    const fetchFn = (async () => new Response(JSON.stringify({ ok: false, error: "invalid_auth" }), { status: 200 })) as unknown as typeof fetch;
+    const mode = new SlackSocketMode({
+      appToken: "xoxb-wrong-kind", fetchFn, log, sleepFn: yieldingSleep(),
+      socketFactory: () => new FakeSocket(),
+      onCommand: async () => undefined,
+    });
+    mode.start();
+    await vi.waitFor(() => expect(log.lines.some((l) => l.startsWith("error"))).toBe(true));
+    await mode.stop();
+    const line = log.lines.find((l) => l.startsWith("error"))!;
+    expect(line).toMatch(/DFIR_SLACK_APP_TOKEN/);
+    expect(line).toMatch(/xapp-/);
+    expect(line).toMatch(/connections:write/);
+  });
+
+  it("ignores a frame that isn't JSON instead of dropping the connection", async () => {
+    const { mode, sockets } = harness();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    sockets[0].emit("message", "<not json>");
+    sockets[0].deliver(commandEnvelope("env-4", "status"));
+    await vi.waitFor(() => expect(sockets[0].sent).toHaveLength(1));
+    await mode.stop();
+    expect(sockets[0].acks()[0].envelope_id).toBe("env-4");
+  });
+
+  it("stop() closes the socket and stops reconnecting", async () => {
+    const { mode, sockets, opened } = harness();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await mode.stop();
+    const openCount = opened.length;
+    sockets[0].emit("close");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(opened.length).toBe(openCount);
+    expect(sockets[0].closed).toBe(true);
+  });
+
+  // stop() must not wait on a "close" event: a half-open or wedged socket never emits one, and
+  // shutdown would hang forever. FakeSocket.close() deliberately stays silent to prove it.
+  it("stop() returns even when the socket never emits close", async () => {
+    const { mode, sockets } = harness();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await expect(Promise.race([
+      mode.stop().then(() => "stopped"),
+      new Promise((r) => setTimeout(() => r("hung"), 2_000)),
+    ])).resolves.toBe("stopped");
+  });
+
+  it("start() twice does not open two connections", async () => {
+    const { mode, sockets } = harness();
+    mode.start();
+    mode.start();
+    await vi.waitFor(() => expect(sockets).toHaveLength(1));
+    await mode.stop();
+    expect(sockets).toHaveLength(1);
+  });
+});

--- a/companion/tests/analysis/slashCommand.test.ts
+++ b/companion/tests/analysis/slashCommand.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSlashCommand,
+  formatFindingsCommand,
+  formatFindingCommand,
+  formatIocsCommand,
+  formatStatusCommand,
+  formatHelpCommand,
+  resolveCaseId,
+  isAllowed,
+  isActionCommand,
+  READ_ONLY_COMMANDS,
+  ACTION_COMMANDS,
+  type ParsedSlashCommand,
+} from "../../src/analysis/slashCommand.js";
+import { verifySlackSignature, verifyTeamsToken } from "../../src/analysis/slashCommandAuth.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+import type { Finding, IOC, IocEnrichment, InvestigationState } from "../../src/analysis/stateTypes.js";
+
+describe("parseSlashCommand", () => {
+  it("returns help for empty input", () => {
+    expect(parseSlashCommand("").name).toBe("help");
+    expect(parseSlashCommand("   ").name).toBe("help");
+  });
+
+  it("returns help for an unrecognized command", () => {
+    expect(parseSlashCommand("/dfir frobnicate x").name).toBe("help");
+  });
+
+  it("parses /dfir findings <caseId>", () => {
+    const c = parseSlashCommand("/dfir findings case-42");
+    expect(c.name).toBe("findings");
+    expect(c.caseId).toBe("case-42");
+  });
+
+  it("parses /dfir finding <caseId> <id>", () => {
+    const c = parseSlashCommand("/dfir finding case-42 f3");
+    expect(c.name).toBe("finding");
+    expect(c.caseId).toBe("case-42");
+    expect(c.arg).toBe("f3");
+  });
+
+  it("parses /dfir iocs <caseId> [filter]", () => {
+    expect(parseSlashCommand("/dfir iocs case-1 malicious")).toEqual(expect.objectContaining({ name: "iocs", caseId: "case-1", iocFilter: "malicious" }));
+    expect(parseSlashCommand("/dfir iocs case-1 flagged")).toEqual(expect.objectContaining({ name: "iocs", caseId: "case-1", iocFilter: "flagged" }));
+    expect(parseSlashCommand("/dfir iocs case-1").iocFilter).toBeUndefined();
+  });
+
+  it("parses /dfir ask <caseId> <question> (multi-word question)", () => {
+    const c = parseSlashCommand("/dfir ask case-1 what was the initial access vector?");
+    expect(c.name).toBe("ask");
+    expect(c.caseId).toBe("case-1");
+    expect(c.arg).toBe("what was the initial access vector?");
+  });
+
+  it("parses /dfir hunt <caseId> <technique>", () => {
+    const c = parseSlashCommand("/dfir hunt case-1 T1059.001");
+    expect(c.name).toBe("hunt");
+    expect(c.arg).toBe("T1059.001");
+  });
+
+  it("parses status, synthesize (caseId only), bind, unbind, help", () => {
+    expect(parseSlashCommand("/dfir status c1")).toEqual(expect.objectContaining({ name: "status", caseId: "c1" }));
+    expect(parseSlashCommand("/dfir synthesize c1")).toEqual(expect.objectContaining({ name: "synthesize", caseId: "c1" }));
+    expect(parseSlashCommand("/dfir bind c1")).toEqual(expect.objectContaining({ name: "bind", caseId: "c1" }));
+    expect(parseSlashCommand("/dfir unbind").name).toBe("unbind");
+    expect(parseSlashCommand("/dfir help").name).toBe("help");
+  });
+
+  it("tolerates a bare command without the /dfir prefix", () => {
+    expect(parseSlashCommand("findings c1")).toEqual(expect.objectContaining({ name: "findings", caseId: "c1" }));
+  });
+});
+
+describe("command formatters", () => {
+  const finding = (id: string, severity: Finding["severity"], title: string, extra: Partial<Finding> = {}): Finding => ({
+    id,
+    severity,
+    title,
+    description: extra.description ?? "desc",
+    relatedIocs: extra.relatedIocs ?? [],
+    sourceScreenshots: [],
+    mitreTechniques: extra.mitreTechniques ?? [],
+    firstSeen: "2026-07-01T00:00:00Z",
+    lastUpdated: "2026-07-25T00:00:00Z",
+    status: extra.status ?? "open",
+    confidence: extra.confidence,
+    ...extra,
+  });
+
+  const ioc = (id: string, value: string, enrichments: IocEnrichment[] = []): IOC => ({
+    id, type: "ip", value, firstSeen: "2026-07-01T00:00:00Z", enrichments,
+  });
+
+  const state: InvestigationState = {
+    ...emptyState("case-1"),
+    findings: [
+      finding("f1", "Critical", "Ransomware encryption", { confidence: 90, mitreTechniques: ["T1486"] }),
+      finding("f2", "High", "Lateral movement", { confidence: 70, mitreTechniques: ["T1021"] }),
+      finding("f3", "Medium", "Suspicious PowerShell", { confidence: 55, status: "dismissed" }),
+    ],
+    iocs: [
+      ioc("i1", "5.6.7.8", [{ source: "VirusTotal", verdict: "malicious", fetchedAt: "2026-07-01T00:00:00Z", detections: 47, total: 60 }]),
+      ioc("i2", "evil.com", [{ source: "MISP", verdict: "suspicious", fetchedAt: "2026-07-01T00:00:00Z" }]),
+      ioc("i3", "clean.com", [{ source: "VirusTotal", verdict: "harmless", fetchedAt: "2026-07-01T00:00:00Z" }]),
+    ],
+  };
+
+  it("formatFindingsCommand returns top 5 by severity, excluding dismissed", () => {
+    const r = formatFindingsCommand(state);
+    expect(r.lines.length).toBe(2);
+    expect(r.lines[0]).toContain("Critical");
+    expect(r.lines[0]).toContain("f1");
+    expect(r.lines[0]).toContain("T1486");
+    expect(r.lines[1]).toContain("High");
+  });
+
+  it("formatFindingsCommand on an empty case tells the analyst to synthesize", () => {
+    const r = formatFindingsCommand(emptyState("c"));
+    expect(r.lines[0]).toMatch(/synthesis/i);
+  });
+
+  it("formatFindingCommand returns a single finding card by id", () => {
+    const r = formatFindingCommand(state, "f1");
+    expect(r.title).toContain("Ransomware encryption");
+    expect(r.lines.some((l) => l.includes("Critical"))).toBe(true);
+  });
+
+  it("formatFindingCommand reports a clear not-found for an unknown id", () => {
+    const r = formatFindingCommand(state, "f99");
+    expect(r.title).toMatch(/not found/);
+  });
+
+  it("formatIocsCommand with no filter lists all IOCs", () => {
+    const r = formatIocsCommand(state, undefined);
+    expect(r.lines.length).toBe(3);
+  });
+
+  it("formatIocsCommand malicious filter returns only malicious IOCs", () => {
+    const r = formatIocsCommand(state, "malicious");
+    expect(r.lines.length).toBe(1);
+    expect(r.lines[0]).toContain("5.6.7.8");
+  });
+
+  it("formatIocsCommand flagged filter returns malicious + suspicious", () => {
+    const r = formatIocsCommand(state, "flagged");
+    expect(r.lines.length).toBe(2);
+  });
+
+  it("formatStatusCommand reports event/finding/IOC counts", () => {
+    const r = formatStatusCommand(state);
+    expect(r.title).toContain("case-1");
+    expect(r.lines.some((l) => l.includes("Findings: 3"))).toBe(true);
+    expect(r.lines.some((l) => l.includes("IOCs: 3"))).toBe(true);
+  });
+
+  it("formatHelpCommand lists every command", () => {
+    const r = formatHelpCommand();
+    expect(r.lines.length).toBeGreaterThanOrEqual(9);
+    expect(r.lines.some((l) => l.includes("/dfir bind"))).toBe(true);
+  });
+});
+
+describe("resolveCaseId", () => {
+  it("prefers the explicit caseId over the channel binding", () => {
+    const cmd: ParsedSlashCommand = { name: "findings", caseId: "explicit", raw: "" };
+    expect(resolveCaseId(cmd, { caseId: "bound", boundAt: "" })).toBe("explicit");
+  });
+
+  it("falls back to the channel binding when no explicit caseId is given", () => {
+    const cmd: ParsedSlashCommand = { name: "status", caseId: undefined, raw: "" };
+    expect(resolveCaseId(cmd, { caseId: "bound", boundAt: "" })).toBe("bound");
+  });
+
+  it("returns empty when neither is present", () => {
+    const cmd: ParsedSlashCommand = { name: "status", caseId: undefined, raw: "" };
+    expect(resolveCaseId(cmd, undefined)).toBe("");
+  });
+});
+
+describe("access control", () => {
+  it("read-only commands are always allowed (no allowlist needed)", () => {
+    for (const name of READ_ONLY_COMMANDS) {
+      expect(isAllowed(name, "anyone", ["admin"])).toBe(true);
+      expect(isAllowed(name, "anyone", [])).toBe(true);
+      expect(isAllowed(name, "anyone", undefined)).toBe(true);
+    }
+  });
+
+  it("action commands are denied to a user not in the allowlist", () => {
+    for (const name of ACTION_COMMANDS) {
+      expect(isAllowed(name, "outsider", ["admin"])).toBe(false);
+    }
+  });
+
+  it("action commands are allowed to a user in the allowlist", () => {
+    for (const name of ACTION_COMMANDS) {
+      expect(isAllowed(name, "admin", ["admin"])).toBe(true);
+    }
+  });
+
+  it("action commands are open (allowed) when no allowlist is configured", () => {
+    for (const name of ACTION_COMMANDS) {
+      expect(isAllowed(name, "anyone", undefined)).toBe(true);
+      expect(isAllowed(name, "anyone", [])).toBe(true);
+    }
+  });
+
+  it("isActionCommand correctly classifies the three action commands", () => {
+    expect(isActionCommand("ask")).toBe(true);
+    expect(isActionCommand("hunt")).toBe(true);
+    expect(isActionCommand("synthesize")).toBe(true);
+    expect(isActionCommand("findings")).toBe(false);
+    expect(isActionCommand("status")).toBe(false);
+  });
+});
+
+describe("verifySlackSignature", () => {
+  const secret = "shhhh";
+  // The base string Slack signs is `v0:<timestamp>:<rawBody>`, HMAC-SHA256, hex, prefixed with "v0=".
+  // Compute a valid signature for a known body so we can verify the verifier accepts it.
+  const ts = "1700000000";
+  const rawBody = "token=abc&team_id=T1&channel_id=C1&user_id=U1&text=findings%20case-1&response_url=https%3A%2F%2Fhooks.slack.com%2Fx";
+  const validSig = "v0=" + hmacSha256Hex(secret, `v0:${ts}:${rawBody}`);
+
+  it("accepts a valid signature within the replay window", () => {
+    const r = verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody, signature: validSig, now: () => Number(ts) });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a tampered body (signature mismatch)", () => {
+    const r = verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody: rawBody + "tampered", signature: validSig, now: () => Number(ts) });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/mismatch/);
+  });
+
+  it("rejects a stale timestamp (outside the 5-minute replay window)", () => {
+    const stale = Number(ts) + 600; // 10 min later
+    const r = verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody, signature: validSig, now: () => stale });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/replay/);
+  });
+
+  it("rejects when no signing secret is configured", () => {
+    const r = verifySlackSignature({ signingSecret: "", timestamp: ts, rawBody, signature: validSig, now: () => Number(ts) });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("verifyTeamsToken", () => {
+  it("accepts a matching bearer token", () => {
+    const r = verifyTeamsToken("Bearer my-token", "my-token");
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a wrong token", () => {
+    const r = verifyTeamsToken("Bearer wrong", "my-token");
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/mismatch/);
+  });
+
+  it("rejects when no token is configured", () => {
+    const r = verifyTeamsToken("Bearer x", "");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a missing Authorization header", () => {
+    const r = verifyTeamsToken(undefined, "my-token");
+    expect(r.ok).toBe(false);
+  });
+});
+
+function hmacSha256Hex(secret: string, data: string): string {
+  // Use the same machinery the verifier does — node:crypto — so the test signature is correct.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createHmac } = require("node:crypto") as typeof import("node:crypto");
+  return createHmac("sha256", secret).update(data).digest("hex");
+}

--- a/companion/tests/analysis/slashCommand.test.ts
+++ b/companion/tests/analysis/slashCommand.test.ts
@@ -1,19 +1,29 @@
 import { describe, it, expect } from "vitest";
+import { createHmac } from "node:crypto";
 import {
   parseSlashCommand,
+  resolveCommand,
   formatFindingsCommand,
   formatFindingCommand,
   formatIocsCommand,
   formatStatusCommand,
   formatHelpCommand,
-  resolveCaseId,
   isAllowed,
-  isActionCommand,
+  isCaseAccessAllowed,
+  isPrivilegedCommand,
+  isAsyncCommand,
   READ_ONLY_COMMANDS,
-  ACTION_COMMANDS,
-  type ParsedSlashCommand,
+  PRIVILEGED_COMMANDS,
+  ASYNC_COMMANDS,
+  type ChannelBinding,
 } from "../../src/analysis/slashCommand.js";
-import { verifySlackSignature, verifyTeamsToken } from "../../src/analysis/slashCommandAuth.js";
+import {
+  verifySlackSignature,
+  verifyTeamsToken,
+  verifyTelegramSecret,
+  isAllowedResponseUrl,
+  parseHostList,
+} from "../../src/analysis/slashCommandAuth.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
 import type { Finding, IOC, IocEnrichment, InvestigationState } from "../../src/analysis/stateTypes.js";
 
@@ -27,48 +37,98 @@ describe("parseSlashCommand", () => {
     expect(parseSlashCommand("/dfir frobnicate x").name).toBe("help");
   });
 
-  it("parses /dfir findings <caseId>", () => {
-    const c = parseSlashCommand("/dfir findings case-42");
-    expect(c.name).toBe("findings");
-    expect(c.caseId).toBe("case-42");
+  it("splits the command word from its argument tokens", () => {
+    expect(parseSlashCommand("/dfir findings case-42")).toEqual(
+      expect.objectContaining({ name: "findings", tokens: ["case-42"] }),
+    );
+    expect(parseSlashCommand("/dfir finding case-42 f3")).toEqual(
+      expect.objectContaining({ name: "finding", tokens: ["case-42", "f3"] }),
+    );
+    expect(parseSlashCommand("/dfir ask case-1 what was the initial access vector?").tokens).toEqual([
+      "case-1", "what", "was", "the", "initial", "access", "vector?",
+    ]);
   });
 
-  it("parses /dfir finding <caseId> <id>", () => {
-    const c = parseSlashCommand("/dfir finding case-42 f3");
-    expect(c.name).toBe("finding");
-    expect(c.caseId).toBe("case-42");
-    expect(c.arg).toBe("f3");
+  it("tolerates a bare command, a leading slash, and the echoed trigger word", () => {
+    for (const text of ["findings c1", "/findings c1", "dfir findings c1", "/dfir findings c1"]) {
+      expect(parseSlashCommand(text), text).toEqual(expect.objectContaining({ name: "findings", tokens: ["c1"] }));
+    }
   });
 
-  it("parses /dfir iocs <caseId> [filter]", () => {
-    expect(parseSlashCommand("/dfir iocs case-1 malicious")).toEqual(expect.objectContaining({ name: "iocs", caseId: "case-1", iocFilter: "malicious" }));
-    expect(parseSlashCommand("/dfir iocs case-1 flagged")).toEqual(expect.objectContaining({ name: "iocs", caseId: "case-1", iocFilter: "flagged" }));
-    expect(parseSlashCommand("/dfir iocs case-1").iocFilter).toBeUndefined();
+  it("strips Telegram's @BotName suffix from the command word", () => {
+    expect(parseSlashCommand("/findings@DfirCompanionBot c1")).toEqual(
+      expect.objectContaining({ name: "findings", tokens: ["c1"] }),
+    );
+    expect(parseSlashCommand("/dfir@DfirCompanionBot findings c1")).toEqual(
+      expect.objectContaining({ name: "findings", tokens: ["c1"] }),
+    );
   });
 
-  it("parses /dfir ask <caseId> <question> (multi-word question)", () => {
-    const c = parseSlashCommand("/dfir ask case-1 what was the initial access vector?");
-    expect(c.name).toBe("ask");
-    expect(c.caseId).toBe("case-1");
-    expect(c.arg).toBe("what was the initial access vector?");
+  it("recognizes every command name", () => {
+    for (const name of ["ask", "findings", "finding", "iocs", "hunt", "status", "synthesize", "bind", "unbind", "help"]) {
+      expect(parseSlashCommand(`/dfir ${name} c1`).name, name).toBe(name);
+    }
+  });
+});
+
+describe("resolveCommand", () => {
+  const bound: ChannelBinding = { caseId: "case-42", boundAt: "2026-07-25T00:00:00Z" };
+  const parse = parseSlashCommand;
+
+  it("uses the first token as the caseId when it names a real case", () => {
+    const r = resolveCommand(parse("/dfir ask case-1 what happened?"), bound, true);
+    expect(r.caseId).toBe("case-1");
+    expect(r.arg).toBe("what happened?");
+    expect(r.usedBinding).toBe(false);
   });
 
-  it("parses /dfir hunt <caseId> <technique>", () => {
-    const c = parseSlashCommand("/dfir hunt case-1 T1059.001");
-    expect(c.name).toBe("hunt");
-    expect(c.arg).toBe("T1059.001");
+  // The bug this function exists for: positional parsing ate the first word of every argument.
+  // `/dfir ask what happened?` used to resolve to a case called "what" — which passes
+  // isValidCaseId, so nothing errored and the analyst got an answer about the wrong case.
+  it("falls back to the channel binding when the first token is NOT a case", () => {
+    const r = resolveCommand(parse("/dfir ask what was the initial access vector?"), bound, false);
+    expect(r.caseId).toBe("case-42");
+    expect(r.arg).toBe("what was the initial access vector?");
+    expect(r.usedBinding).toBe(true);
   });
 
-  it("parses status, synthesize (caseId only), bind, unbind, help", () => {
-    expect(parseSlashCommand("/dfir status c1")).toEqual(expect.objectContaining({ name: "status", caseId: "c1" }));
-    expect(parseSlashCommand("/dfir synthesize c1")).toEqual(expect.objectContaining({ name: "synthesize", caseId: "c1" }));
-    expect(parseSlashCommand("/dfir bind c1")).toEqual(expect.objectContaining({ name: "bind", caseId: "c1" }));
-    expect(parseSlashCommand("/dfir unbind").name).toBe("unbind");
-    expect(parseSlashCommand("/dfir help").name).toBe("help");
+  it("reads an ioc filter as a filter, not as a caseId, on a bound channel", () => {
+    const r = resolveCommand(parse("/dfir iocs malicious"), bound, false);
+    expect(r.caseId).toBe("case-42");
+    expect(r.iocFilter).toBe("malicious");
   });
 
-  it("tolerates a bare command without the /dfir prefix", () => {
-    expect(parseSlashCommand("findings c1")).toEqual(expect.objectContaining({ name: "findings", caseId: "c1" }));
+  it("keeps the ioc filter after an explicit caseId", () => {
+    const r = resolveCommand(parse("/dfir iocs case-1 flagged"), bound, true);
+    expect(r.caseId).toBe("case-1");
+    expect(r.iocFilter).toBe("flagged");
+  });
+
+  it("ignores a non-filter word instead of treating it as a filter", () => {
+    expect(resolveCommand(parse("/dfir iocs"), bound, false).iocFilter).toBeUndefined();
+    expect(resolveCommand(parse("/dfir iocs case-1"), bound, true).iocFilter).toBeUndefined();
+  });
+
+  it("passes a finding id through as the argument on a bound channel", () => {
+    const r = resolveCommand(parse("/dfir finding f1"), bound, false);
+    expect(r.caseId).toBe("case-42");
+    expect(r.arg).toBe("f1");
+  });
+
+  it("keeps the typed token as the caseId when there is no binding, so the error names it", () => {
+    const r = resolveCommand(parse("/dfir status nosuchcase"), undefined, false);
+    expect(r.caseId).toBe("nosuchcase");
+    expect(r.usedBinding).toBe(false);
+  });
+
+  it("never falls back to the binding for bind — that would re-bind to the current case", () => {
+    expect(resolveCommand(parse("/dfir bind case-7"), bound, false).caseId).toBe("case-7");
+    expect(resolveCommand(parse("/dfir bind"), bound, false).caseId).toBe("");
+  });
+
+  it("resolves no caseId for help and unbind", () => {
+    expect(resolveCommand(parse("/dfir help"), bound, false).caseId).toBe("");
+    expect(resolveCommand(parse("/dfir unbind"), bound, false).caseId).toBe("");
   });
 });
 
@@ -127,13 +187,15 @@ describe("command formatters", () => {
   });
 
   it("formatFindingCommand reports a clear not-found for an unknown id", () => {
-    const r = formatFindingCommand(state, "f99");
-    expect(r.title).toMatch(/not found/);
+    expect(formatFindingCommand(state, "f99").title).toMatch(/not found/);
+  });
+
+  it("formatFindingCommand asks for an id instead of reporting \"not found\" for a blank one", () => {
+    expect(formatFindingCommand(state, "").title).toMatch(/which finding/i);
   });
 
   it("formatIocsCommand with no filter lists all IOCs", () => {
-    const r = formatIocsCommand(state, undefined);
-    expect(r.lines.length).toBe(3);
+    expect(formatIocsCommand(state, undefined).lines.length).toBe(3);
   });
 
   it("formatIocsCommand malicious filter returns only malicious IOCs", () => {
@@ -143,8 +205,7 @@ describe("command formatters", () => {
   });
 
   it("formatIocsCommand flagged filter returns malicious + suspicious", () => {
-    const r = formatIocsCommand(state, "flagged");
-    expect(r.lines.length).toBe(2);
+    expect(formatIocsCommand(state, "flagged").lines.length).toBe(2);
   });
 
   it("formatStatusCommand reports event/finding/IOC counts", () => {
@@ -154,27 +215,11 @@ describe("command formatters", () => {
     expect(r.lines.some((l) => l.includes("IOCs: 3"))).toBe(true);
   });
 
-  it("formatHelpCommand lists every command", () => {
+  it("formatHelpCommand lists every command and does not promise hunt deployment", () => {
     const r = formatHelpCommand();
     expect(r.lines.length).toBeGreaterThanOrEqual(9);
     expect(r.lines.some((l) => l.includes("/dfir bind"))).toBe(true);
-  });
-});
-
-describe("resolveCaseId", () => {
-  it("prefers the explicit caseId over the channel binding", () => {
-    const cmd: ParsedSlashCommand = { name: "findings", caseId: "explicit", raw: "" };
-    expect(resolveCaseId(cmd, { caseId: "bound", boundAt: "" })).toBe("explicit");
-  });
-
-  it("falls back to the channel binding when no explicit caseId is given", () => {
-    const cmd: ParsedSlashCommand = { name: "status", caseId: undefined, raw: "" };
-    expect(resolveCaseId(cmd, { caseId: "bound", boundAt: "" })).toBe("bound");
-  });
-
-  it("returns empty when neither is present", () => {
-    const cmd: ParsedSlashCommand = { name: "status", caseId: undefined, raw: "" };
-    expect(resolveCaseId(cmd, undefined)).toBe("");
+    expect(r.lines.find((l) => l.startsWith("/dfir hunt"))).toMatch(/dashboard/);
   });
 });
 
@@ -187,45 +232,69 @@ describe("access control", () => {
     }
   });
 
-  it("action commands are denied to a user not in the allowlist", () => {
-    for (const name of ACTION_COMMANDS) {
-      expect(isAllowed(name, "outsider", ["admin"])).toBe(false);
+  it("privileged commands are denied to a user not in the allowlist", () => {
+    for (const name of PRIVILEGED_COMMANDS) {
+      expect(isAllowed(name, "outsider", ["admin"]), name).toBe(false);
     }
   });
 
-  it("action commands are allowed to a user in the allowlist", () => {
-    for (const name of ACTION_COMMANDS) {
-      expect(isAllowed(name, "admin", ["admin"])).toBe(true);
+  it("privileged commands are allowed to a user in the allowlist", () => {
+    for (const name of PRIVILEGED_COMMANDS) {
+      expect(isAllowed(name, "admin", ["admin"]), name).toBe(true);
     }
   });
 
-  it("action commands are open (allowed) when no allowlist is configured", () => {
-    for (const name of ACTION_COMMANDS) {
-      expect(isAllowed(name, "anyone", undefined)).toBe(true);
-      expect(isAllowed(name, "anyone", [])).toBe(true);
+  it("privileged commands are open when no allowlist is configured", () => {
+    for (const name of PRIVILEGED_COMMANDS) {
+      expect(isAllowed(name, "anyone", undefined), name).toBe(true);
+      expect(isAllowed(name, "anyone", []), name).toBe(true);
     }
   });
 
-  it("isActionCommand correctly classifies the three action commands", () => {
-    expect(isActionCommand("ask")).toBe(true);
-    expect(isActionCommand("hunt")).toBe(true);
-    expect(isActionCommand("synthesize")).toBe(true);
-    expect(isActionCommand("findings")).toBe(false);
-    expect(isActionCommand("status")).toBe(false);
+  // bind chooses which case the whole room can then read, so it is a privileged act — not the
+  // read-only one the first cut of this bot treated it as.
+  it("classifies bind as privileged but not async", () => {
+    expect(isPrivilegedCommand("bind")).toBe(true);
+    expect(isAsyncCommand("bind")).toBe(false);
+    expect(READ_ONLY_COMMANDS).not.toContain("bind");
+  });
+
+  it("classifies the async commands", () => {
+    expect(ASYNC_COMMANDS).toEqual(["ask", "hunt", "synthesize"]);
+    for (const name of ASYNC_COMMANDS) expect(isAsyncCommand(name), name).toBe(true);
+    expect(isAsyncCommand("findings")).toBe(false);
+    expect(isAsyncCommand("status")).toBe(false);
+  });
+});
+
+describe("isCaseAccessAllowed", () => {
+  it("is open when no allowlist is configured", () => {
+    expect(isCaseAccessAllowed({ userId: "u", caseId: "any", boundCaseId: "other", actionAllowlist: [] })).toBe(true);
+    expect(isCaseAccessAllowed({ userId: "u", caseId: "any", boundCaseId: undefined, actionAllowlist: undefined })).toBe(true);
+  });
+
+  it("lets an allowlisted responder reach any case", () => {
+    expect(isCaseAccessAllowed({ userId: "admin", caseId: "unrelated", boundCaseId: "c1", actionAllowlist: ["admin"] })).toBe(true);
+  });
+
+  // Without this, any chat member could read any case on the server just by naming it.
+  it("confines everyone else to the channel's bound case", () => {
+    const allowlist = ["admin"];
+    expect(isCaseAccessAllowed({ userId: "u", caseId: "c1", boundCaseId: "c1", actionAllowlist: allowlist })).toBe(true);
+    expect(isCaseAccessAllowed({ userId: "u", caseId: "secret", boundCaseId: "c1", actionAllowlist: allowlist })).toBe(false);
+    expect(isCaseAccessAllowed({ userId: "u", caseId: "c1", boundCaseId: undefined, actionAllowlist: allowlist })).toBe(false);
   });
 });
 
 describe("verifySlackSignature", () => {
   const secret = "shhhh";
-  // The base string Slack signs is `v0:<timestamp>:<rawBody>`, HMAC-SHA256, hex, prefixed with "v0=".
-  // Compute a valid signature for a known body so we can verify the verifier accepts it.
+  // The base string Slack signs is `v0:<timestamp>:<rawBody>`, HMAC-SHA256, hex, prefixed "v0=".
   const ts = "1700000000";
   const rawBody = "token=abc&team_id=T1&channel_id=C1&user_id=U1&text=findings%20case-1&response_url=https%3A%2F%2Fhooks.slack.com%2Fx";
-  const validSig = "v0=" + hmacSha256Hex(secret, `v0:${ts}:${rawBody}`);
+  const validSig = "v0=" + createHmac("sha256", secret).update(`v0:${ts}:${rawBody}`).digest("hex");
 
   it("accepts a valid signature within the replay window", () => {
-    const r = verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody, signature: validSig, now: () => Number(ts) });
-    expect(r.ok).toBe(true);
+    expect(verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody, signature: validSig, now: () => Number(ts) }).ok).toBe(true);
   });
 
   it("rejects a tampered body (signature mismatch)", () => {
@@ -235,22 +304,25 @@ describe("verifySlackSignature", () => {
   });
 
   it("rejects a stale timestamp (outside the 5-minute replay window)", () => {
-    const stale = Number(ts) + 600; // 10 min later
-    const r = verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody, signature: validSig, now: () => stale });
+    const r = verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody, signature: validSig, now: () => Number(ts) + 600 });
     expect(r.ok).toBe(false);
     expect(r.error).toMatch(/replay/);
   });
 
   it("rejects when no signing secret is configured", () => {
-    const r = verifySlackSignature({ signingSecret: "", timestamp: ts, rawBody, signature: validSig, now: () => Number(ts) });
+    expect(verifySlackSignature({ signingSecret: "", timestamp: ts, rawBody, signature: validSig, now: () => Number(ts) }).ok).toBe(false);
+  });
+
+  it("rejects a signature of the wrong length without throwing", () => {
+    const r = verifySlackSignature({ signingSecret: secret, timestamp: ts, rawBody, signature: "v0=short", now: () => Number(ts) });
     expect(r.ok).toBe(false);
   });
 });
 
 describe("verifyTeamsToken", () => {
   it("accepts a matching bearer token", () => {
-    const r = verifyTeamsToken("Bearer my-token", "my-token");
-    expect(r.ok).toBe(true);
+    expect(verifyTeamsToken("Bearer my-token", "my-token").ok).toBe(true);
+    expect(verifyTeamsToken("my-token", "my-token").ok).toBe(true);
   });
 
   it("rejects a wrong token", () => {
@@ -260,19 +332,63 @@ describe("verifyTeamsToken", () => {
   });
 
   it("rejects when no token is configured", () => {
-    const r = verifyTeamsToken("Bearer x", "");
-    expect(r.ok).toBe(false);
+    expect(verifyTeamsToken("Bearer x", "").ok).toBe(false);
   });
 
   it("rejects a missing Authorization header", () => {
-    const r = verifyTeamsToken(undefined, "my-token");
-    expect(r.ok).toBe(false);
+    expect(verifyTeamsToken(undefined, "my-token").ok).toBe(false);
   });
 });
 
-function hmacSha256Hex(secret: string, data: string): string {
-  // Use the same machinery the verifier does — node:crypto — so the test signature is correct.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { createHmac } = require("node:crypto") as typeof import("node:crypto");
-  return createHmac("sha256", secret).update(data).digest("hex");
-}
+describe("verifyTelegramSecret", () => {
+  it("accepts the secret Telegram echoes back from setWebhook", () => {
+    expect(verifyTelegramSecret("s3cret", "s3cret").ok).toBe(true);
+  });
+
+  it("rejects a wrong secret", () => {
+    expect(verifyTelegramSecret("nope", "s3cret").ok).toBe(false);
+  });
+
+  it("rejects a missing header", () => {
+    expect(verifyTelegramSecret(undefined, "s3cret").ok).toBe(false);
+  });
+
+  // Anyone who learns the webhook URL could otherwise post updates.
+  it("refuses to run open when no secret is configured", () => {
+    const r = verifyTelegramSecret("anything", "");
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no Telegram webhook secret/);
+  });
+});
+
+describe("isAllowedResponseUrl", () => {
+  it("accepts Slack's own delivery host", () => {
+    expect(isAllowedResponseUrl("slack", "https://hooks.slack.com/commands/T1/123/abc")).toBe(true);
+  });
+
+  it("accepts Teams delivery hosts, including subdomains", () => {
+    expect(isAllowedResponseUrl("teams", "https://outlook.webhook.office.com/webhookb2/x")).toBe(true);
+    expect(isAllowedResponseUrl("teams", "https://prod-1.westus.logic.azure.com/workflows/x")).toBe(true);
+  });
+
+  it("rejects an arbitrary host — the response_url is caller-supplied", () => {
+    expect(isAllowedResponseUrl("slack", "https://evil.example.com/collect")).toBe(false);
+    expect(isAllowedResponseUrl("slack", "http://169.254.169.254/latest/meta-data/")).toBe(false);
+    expect(isAllowedResponseUrl("slack", "https://hooks.slack.com.evil.example.com/x")).toBe(false);
+  });
+
+  it("rejects plaintext http and unparseable input", () => {
+    expect(isAllowedResponseUrl("slack", "http://hooks.slack.com/x")).toBe(false);
+    expect(isAllowedResponseUrl("slack", "not a url")).toBe(false);
+    expect(isAllowedResponseUrl("slack", "")).toBe(false);
+  });
+
+  it("honors an operator-configured extra host (self-hosted Mattermost)", () => {
+    expect(isAllowedResponseUrl("slack", "https://chat.corp.example/hooks/x", ["chat.corp.example"])).toBe(true);
+  });
+
+  it("parseHostList trims and drops empties", () => {
+    expect(parseHostList(" a.example , ,b.example ")).toEqual(["a.example", "b.example"]);
+    expect(parseHostList(undefined)).toEqual([]);
+  });
+});

--- a/companion/tests/analysis/slashCommand.test.ts
+++ b/companion/tests/analysis/slashCommand.test.ts
@@ -121,6 +121,30 @@ describe("resolveCommand", () => {
     expect(r.usedBinding).toBe(false);
   });
 
+  // status/findings/synthesize take no argument, so an unknown token is a caseId the analyst
+  // meant — answering about the bound case instead would quietly hide their typo.
+  it("does NOT fall back to the binding for an unknown caseId on an argument-less command", () => {
+    for (const cmd of ["status", "findings", "synthesize"]) {
+      const r = resolveCommand(parse(`/dfir ${cmd} nosuchcase`), bound, false);
+      expect(r.caseId, cmd).toBe("nosuchcase");
+      expect(r.usedBinding, cmd).toBe(false);
+    }
+  });
+
+  // iocs takes one argument from a closed vocabulary, so it is equally unambiguous.
+  it("treats a non-filter iocs token as a caseId rather than falling back", () => {
+    const r = resolveCommand(parse("/dfir iocs nosuchcase"), bound, false);
+    expect(r.caseId).toBe("nosuchcase");
+    expect(r.iocFilter).toBeUndefined();
+  });
+
+  it("only ask/hunt/finding need the does-this-case-exist tiebreak", () => {
+    // These three have free-text arguments, so an unknown token really is argument text.
+    expect(resolveCommand(parse("/dfir ask nosuchcase happened"), bound, false).caseId).toBe("case-42");
+    expect(resolveCommand(parse("/dfir hunt T1059.001"), bound, false).caseId).toBe("case-42");
+    expect(resolveCommand(parse("/dfir finding f1"), bound, false).caseId).toBe("case-42");
+  });
+
   it("never falls back to the binding for bind — that would re-bind to the current case", () => {
     expect(resolveCommand(parse("/dfir bind case-7"), bound, false).caseId).toBe("case-7");
     expect(resolveCommand(parse("/dfir bind"), bound, false).caseId).toBe("");

--- a/companion/tests/analysis/slashCommandStore.test.ts
+++ b/companion/tests/analysis/slashCommandStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SlashCommandChannelStore, bindingKey } from "../../src/analysis/slashCommandStore.js";
+
+let file: string;
+let store: SlashCommandChannelStore;
+
+beforeEach(async () => {
+  const dir = await mkdtemp(join(tmpdir(), "dfir-slashbind-"));
+  file = join(dir, "slash-command-bindings.json");
+  store = new SlashCommandChannelStore(file);
+});
+
+describe("SlashCommandChannelStore", () => {
+  it("reads as empty before anything is written", async () => {
+    expect(await store.loadAll()).toEqual({});
+    expect(await store.get("slack:C1")).toBeUndefined();
+  });
+
+  it("round-trips a binding", async () => {
+    const bound = await store.bind("slack:C1", "case-1", "2026-07-25T00:00:00Z");
+    expect(bound).toEqual({ caseId: "case-1", boundAt: "2026-07-25T00:00:00Z" });
+    expect(await store.get("slack:C1")).toEqual({ caseId: "case-1", boundAt: "2026-07-25T00:00:00Z" });
+  });
+
+  it("rebinding replaces only that channel's entry", async () => {
+    await store.bind("slack:C1", "case-1");
+    await store.bind("slack:C2", "case-2");
+    await store.bind("slack:C1", "case-9");
+    expect((await store.get("slack:C1"))?.caseId).toBe("case-9");
+    expect((await store.get("slack:C2"))?.caseId).toBe("case-2");
+  });
+
+  it("unbind removes the entry and reports whether there was one", async () => {
+    await store.bind("slack:C1", "case-1");
+    expect(await store.unbind("slack:C1")).toBe(true);
+    expect(await store.get("slack:C1")).toBeUndefined();
+    expect(await store.unbind("slack:C1")).toBe(false);
+  });
+
+  it("keys by platform so the same channel id on two platforms does not collide", async () => {
+    await store.bind(bindingKey("slack", "1001"), "case-slack");
+    await store.bind(bindingKey("teams", "1001"), "case-teams");
+    await store.bind(bindingKey("telegram", "1001"), "case-telegram");
+    expect((await store.get("slack:1001"))?.caseId).toBe("case-slack");
+    expect((await store.get("teams:1001"))?.caseId).toBe("case-teams");
+    expect((await store.get("telegram:1001"))?.caseId).toBe("case-telegram");
+  });
+
+  it("survives a corrupt file rather than throwing at the caller", async () => {
+    await writeFile(file, "{ not json", "utf8");
+    await expect(store.loadAll()).rejects.toThrow(); // malformed JSON surfaces...
+    await writeFile(file, JSON.stringify({ "slack:C1": { caseId: 42 } }), "utf8");
+    expect(await store.loadAll()).toEqual({}); // ...but a schema mismatch degrades to empty
+  });
+
+  it("writes readable JSON (an operator may need to edit it by hand)", async () => {
+    await store.bind("slack:C1", "case-1");
+    expect(JSON.parse(await readFile(file, "utf8"))).toHaveProperty("slack:C1.caseId", "case-1");
+  });
+});

--- a/companion/tests/analysis/slashCommandStore.test.ts
+++ b/companion/tests/analysis/slashCommandStore.test.ts
@@ -56,6 +56,16 @@ describe("SlashCommandChannelStore", () => {
     expect(await store.loadAll()).toEqual({}); // ...but a schema mismatch degrades to empty
   });
 
+  // On a fresh install the notifications/ dir beside cases/ does not exist yet, so the very first
+  // `/dfir bind` is what has to create it. Every other test here starts from an mkdtemp'd dir,
+  // which hid this.
+  it("creates the parent directory on first write", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dfir-slashbind-fresh-"));
+    const nested = new SlashCommandChannelStore(join(dir, "notifications", "slash-command-bindings.json"));
+    await expect(nested.bind("slack:C1", "case-1")).resolves.toMatchObject({ caseId: "case-1" });
+    expect(await nested.get("slack:C1")).toMatchObject({ caseId: "case-1" });
+  });
+
   it("writes readable JSON (an operator may need to edit it by hand)", async () => {
     await store.bind("slack:C1", "case-1");
     expect(JSON.parse(await readFile(file, "utf8"))).toHaveProperty("slack:C1.caseId", "case-1");

--- a/companion/tests/analysis/telegramPoller.test.ts
+++ b/companion/tests/analysis/telegramPoller.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi } from "vitest";
+import { TelegramPoller, sendTelegramMessage, type TelegramUpdate } from "../../src/analysis/telegramPoller.js";
+import type { Logger } from "../../src/logging/logger.js";
+
+// The long-poll transport (#235): the Companion calls Telegram rather than being called, so
+// Telegram commands need no tunnel, no DFIR_ALLOWED_HOSTS entry and no setWebhook.
+
+// Yield to the event loop on every retry. A sleep stub that resolves instantly turns the retry
+// loop into a tight spin that starves vi.waitFor — the real sleep is a setTimeout, so it always
+// yields.
+const yieldingSleep = (record?: number[]) => async (ms: number) => {
+  record?.push(ms);
+  await new Promise((r) => setTimeout(r, 1));
+};
+
+function fakeLog(): Logger & { lines: string[] } {
+  const lines: string[] = [];
+  const push = (level: string) => (m: string) => { lines.push(`${level} ${m}`); };
+  return {
+    lines,
+    debug: push("debug"), info: push("info"), warn: push("warn"), error: push("error"),
+    getLevel: () => "info", setLevel: () => {}, close: async () => {},
+  } as unknown as Logger & { lines: string[] };
+}
+
+const message = (id: number, text: string): TelegramUpdate => ({
+  update_id: id,
+  message: { chat: { id: -100 }, from: { id: 7 }, text },
+});
+
+/** A fetch stub that serves queued getUpdates rounds, then blocks so the loop parks. */
+function fetchServing(rounds: Array<{ status?: number; body: unknown }>) {
+  const urls: string[] = [];
+  const fn = async (url: string, init?: { signal?: AbortSignal }) => {
+    urls.push(String(url));
+    const next = rounds.shift();
+    if (!next) {
+      // Nothing left to serve: park until the poller aborts, mimicking Telegram holding the line.
+      await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    }
+    return new Response(JSON.stringify(next!.body), { status: next!.status ?? 200 });
+  };
+  return { fn: fn as unknown as typeof fetch, urls };
+}
+
+describe("TelegramPoller", () => {
+  it("delivers each update to the handler", async () => {
+    const seen: string[] = [];
+    const { fn } = fetchServing([{ body: { ok: true, result: [message(1, "/dfir status"), message(2, "/dfir findings")] } }]);
+    const poller = new TelegramPoller({
+      botToken: "T", fetchFn: fn, log: fakeLog(),
+      onUpdate: async (u) => { seen.push(u.message?.text ?? ""); },
+    });
+    poller.start();
+    await vi.waitFor(() => expect(seen).toHaveLength(2));
+    await poller.stop();
+    expect(seen).toEqual(["/dfir status", "/dfir findings"]);
+  });
+
+  // The offset is what marks updates delivered. Without it Telegram replays the same commands on
+  // every poll, forever.
+  it("advances the offset past the updates it has handled", async () => {
+    const { fn, urls } = fetchServing([
+      { body: { ok: true, result: [message(10, "/dfir status"), message(11, "/dfir help")] } },
+      { body: { ok: true, result: [] } },
+    ]);
+    const poller = new TelegramPoller({ botToken: "T", fetchFn: fn, log: fakeLog(), onUpdate: async () => {} });
+    poller.start();
+    await vi.waitFor(() => expect(urls.length).toBeGreaterThanOrEqual(2));
+    await poller.stop();
+    expect(urls[0]).not.toContain("offset=");   // first call has no cursor yet
+    expect(urls[1]).toContain("offset=12");     // 11 + 1
+  });
+
+  // One malformed command must not wedge the bot, and must not be redelivered forever.
+  it("keeps polling when a handler throws, and does not replay that update", async () => {
+    const { fn, urls } = fetchServing([
+      { body: { ok: true, result: [message(5, "/dfir boom")] } },
+      { body: { ok: true, result: [] } },
+    ]);
+    const log = fakeLog();
+    const poller = new TelegramPoller({
+      botToken: "T", fetchFn: fn, log,
+      onUpdate: async () => { throw new Error("handler exploded"); },
+    });
+    poller.start();
+    await vi.waitFor(() => expect(urls.length).toBeGreaterThanOrEqual(2));
+    await poller.stop();
+    expect(urls[1]).toContain("offset=6");
+    expect(log.lines.some((l) => l.includes("handler exploded"))).toBe(true);
+  });
+
+  it("requests only message updates, with a long-poll timeout", async () => {
+    const { fn, urls } = fetchServing([{ body: { ok: true, result: [] } }]);
+    const poller = new TelegramPoller({ botToken: "T", fetchFn: fn, log: fakeLog(), onUpdate: async () => {} });
+    poller.start();
+    await vi.waitFor(() => expect(urls.length).toBeGreaterThanOrEqual(1));
+    await poller.stop();
+    expect(urls[0]).toContain("/botT/getUpdates");
+    expect(urls[0]).toContain("timeout=50");
+    expect(urls[0]).toContain("message");
+  });
+
+  it("backs off after a failure and retries", async () => {
+    const slept: number[] = [];
+    const { fn, urls } = fetchServing([
+      { status: 500, body: { ok: false, description: "server error" } },
+      { body: { ok: true, result: [] } },
+    ]);
+    const poller = new TelegramPoller({
+      botToken: "T", fetchFn: fn, log: fakeLog(), onUpdate: async () => {},
+      sleepFn: yieldingSleep(slept),
+    });
+    poller.start();
+    await vi.waitFor(() => expect(urls.length).toBeGreaterThanOrEqual(2));
+    await poller.stop();
+    expect(slept[0]).toBe(1000);
+  });
+
+  it("escalates the backoff while failures continue", async () => {
+    const slept: number[] = [];
+    const fn = (async () => new Response(JSON.stringify({ ok: false, description: "nope" }), { status: 500 })) as unknown as typeof fetch;
+    const poller = new TelegramPoller({
+      botToken: "T", fetchFn: fn, log: fakeLog(), onUpdate: async () => {},
+      sleepFn: yieldingSleep(slept),
+    });
+    poller.start();
+    await vi.waitFor(() => expect(slept.length).toBeGreaterThanOrEqual(3));
+    await poller.stop();
+    expect(slept[1]).toBe(2000);
+    expect(slept[2]).toBe(4000);
+  });
+
+  // 409 means a webhook is registered, or a second poller is running. Neither fixes itself by
+  // waiting, so the log has to say what to do.
+  it("explains a 409 instead of retrying silently", async () => {
+    const log = fakeLog();
+    const fn = (async () =>
+      new Response(JSON.stringify({ ok: false, description: "Conflict: can't use getUpdates method while webhook is active" }), { status: 409 })) as unknown as typeof fetch;
+    const poller = new TelegramPoller({
+      botToken: "T", fetchFn: fn, log, onUpdate: async () => {}, sleepFn: yieldingSleep(),
+    });
+    poller.start();
+    await vi.waitFor(() => expect(log.lines.some((l) => l.startsWith("error"))).toBe(true));
+    await poller.stop();
+    const line = log.lines.find((l) => l.startsWith("error"))!;
+    expect(line).toMatch(/webhook/i);
+    expect(line).toMatch(/deleteWebhook/);
+  });
+
+  it("names a bad bot token rather than retrying quietly", async () => {
+    const log = fakeLog();
+    const fn = (async () => new Response(JSON.stringify({ ok: false, description: "Unauthorized" }), { status: 401 })) as unknown as typeof fetch;
+    const poller = new TelegramPoller({ botToken: "bad", fetchFn: fn, log, onUpdate: async () => {}, sleepFn: yieldingSleep() });
+    poller.start();
+    await vi.waitFor(() => expect(log.lines.some((l) => l.startsWith("error"))).toBe(true));
+    await poller.stop();
+    expect(log.lines.find((l) => l.startsWith("error"))).toMatch(/DFIR_TELEGRAM_BOT_TOKEN/);
+  });
+
+  it("stop() is idempotent and safe before any round completes", async () => {
+    const { fn } = fetchServing([]);
+    const poller = new TelegramPoller({ botToken: "T", fetchFn: fn, log: fakeLog(), onUpdate: async () => {} });
+    poller.start();
+    await poller.stop();
+    await expect(poller.stop()).resolves.toBeUndefined();
+  });
+
+  it("start() twice does not run two loops", async () => {
+    const { fn, urls } = fetchServing([{ body: { ok: true, result: [] } }]);
+    const poller = new TelegramPoller({ botToken: "T", fetchFn: fn, log: fakeLog(), onUpdate: async () => {} });
+    poller.start();
+    poller.start();
+    await vi.waitFor(() => expect(urls.length).toBeGreaterThanOrEqual(1));
+    await poller.stop();
+    expect(urls.length).toBeLessThanOrEqual(2); // one in-flight round, not two loops racing
+  });
+});
+
+describe("sendTelegramMessage", () => {
+  it("posts to the Bot API with the chat id and text", async () => {
+    const calls: Array<{ url: string; body: { chat_id: string; text: string } }> = [];
+    const fn = (async (url: string, init: { body: string }) => {
+      calls.push({ url: String(url), body: JSON.parse(init.body) });
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await sendTelegramMessage({ botToken: "T", chatId: "-100", text: "hello", fetchFn: fn, log: fakeLog() });
+    expect(calls[0].url).toBe("https://api.telegram.org/botT/sendMessage");
+    expect(calls[0].body).toEqual({ chat_id: "-100", text: "hello" });
+  });
+
+  it("logs rather than throws when delivery fails", async () => {
+    const log = fakeLog();
+    const fn = (async () => { throw new Error("network down"); }) as unknown as typeof fetch;
+    await expect(sendTelegramMessage({ botToken: "T", chatId: "-100", text: "x", fetchFn: fn, log })).resolves.toBeUndefined();
+    expect(log.lines.some((l) => l.includes("network down"))).toBe(true);
+  });
+
+  it("honours an API base override", async () => {
+    const urls: string[] = [];
+    const fn = (async (url: string) => { urls.push(String(url)); return new Response("ok", { status: 200 }); }) as unknown as typeof fetch;
+    await sendTelegramMessage({ botToken: "T", chatId: "1", text: "x", apiBase: "http://localhost:9099/", fetchFn: fn, log: fakeLog() });
+    expect(urls[0]).toBe("http://localhost:9099/botT/sendMessage");
+  });
+});

--- a/companion/tests/analysis/telegramPoller.test.ts
+++ b/companion/tests/analysis/telegramPoller.test.ts
@@ -92,6 +92,23 @@ describe("TelegramPoller", () => {
     expect(log.lines.some((l) => l.includes("handler exploded"))).toBe(true);
   });
 
+  // The caller passes `apiBase: undefined` whenever DFIR_TELEGRAM_API_BASE is unset. Spreading
+  // options over a defaults object let that undefined win, and every poll died on
+  // "Cannot read properties of undefined (reading 'replace')" — invisible to any test that simply
+  // omits the key, which is what all the others here do.
+  it("falls back to the public Bot API when apiBase is explicitly undefined", async () => {
+    const { fn, urls } = fetchServing([{ body: { ok: true, result: [] } }]);
+    const poller = new TelegramPoller({
+      botToken: "T", apiBase: undefined, pollTimeoutSeconds: undefined,
+      fetchFn: fn, log: fakeLog(), onUpdate: async () => {},
+    });
+    poller.start();
+    await vi.waitFor(() => expect(urls.length).toBeGreaterThanOrEqual(1));
+    await poller.stop();
+    expect(urls[0]).toContain("https://api.telegram.org/botT/getUpdates");
+    expect(urls[0]).toContain("timeout=50");
+  });
+
   it("requests only message updates, with a long-poll timeout", async () => {
     const { fn, urls } = fetchServing([{ body: { ok: true, result: [] } }]);
     const poller = new TelegramPoller({ botToken: "T", fetchFn: fn, log: fakeLog(), onUpdate: async () => {} });

--- a/companion/tests/server/slashCommandRoutes.test.ts
+++ b/companion/tests/server/slashCommandRoutes.test.ts
@@ -25,6 +25,7 @@ let activityLogStore: ActivityLogStore;
 let bindings: SlashCommandChannelStore;
 let app: ReturnType<typeof createApp>;
 let asked: Array<{ caseId: string; question: string }>;
+let delivered: Array<{ url: string; body: unknown }>;
 
 const fakePipeline = {
   ask: async (caseId: string, question: string) => {
@@ -43,6 +44,17 @@ beforeEach(async () => {
   activityLogStore = new ActivityLogStore(store);
   bindings = new SlashCommandChannelStore(join(bindDir, "slash-command-bindings.json"));
   asked = [];
+  delivered = [];
+
+  // Stub fetch for EVERY test, not just the delivery ones. An async command's result is posted to
+  // the request's response_url, so an unstubbed test that runs `ask` makes a real request to
+  // hooks.slack.com — network traffic from a unit test, flaky offline, and attributed to whichever
+  // test happens to be running when the warning lands. Individual tests override this to assert on
+  // the payload; this default just makes sure nothing escapes.
+  vi.stubGlobal("fetch", async (url: string, init: { body: string }) => {
+    delivered.push({ url, body: JSON.parse(init.body) });
+    return new Response("ok", { status: 200 });
+  });
 
   vi.stubEnv("DFIR_SLACK_SIGNING_SECRET", SLACK_SECRET);
   vi.stubEnv("DFIR_TEAMS_TOKEN", TEAMS_TOKEN);
@@ -318,49 +330,33 @@ describe("platform response envelopes", () => {
 // ── async delivery ──────────────────────────────────────────────────────────────────────
 
 describe("async command delivery", () => {
-  it("ACKs ask immediately and posts the answer to the Slack response_url", async () => {
-    const posts: Array<{ url: string; body: unknown }> = [];
-    vi.stubGlobal("fetch", async (url: string, init: { body: string }) => {
-      posts.push({ url, body: JSON.parse(init.body) });
-      return new Response("ok", { status: 200 });
-    });
+  const text = (i: number) => (delivered[i].body as { text: string }).text;
 
+  it("ACKs ask immediately and posts the answer to the Slack response_url", async () => {
     const ack = await slack("ask c1 what happened?");
     expect(ack.status).toBe(200);
     expect(ack.body.text).toMatch(/Working on \/dfir ask for case c1/);
 
-    await vi.waitFor(() => expect(posts).toHaveLength(1));
-    expect(posts[0].url).toBe("https://hooks.slack.com/commands/T1/1/x");
-    expect((posts[0].body as { text: string }).text).toMatch(/answer for c1/);
+    await vi.waitFor(() => expect(delivered).toHaveLength(1));
+    expect(delivered[0].url).toBe("https://hooks.slack.com/commands/T1/1/x");
+    expect(text(0)).toMatch(/answer for c1/);
   });
 
   // The response_url is caller-supplied; delivering to it unchecked is a server-side request to
   // wherever the caller points.
   it("refuses to deliver to a response_url outside the platform's hosts", async () => {
-    const posts: string[] = [];
-    vi.stubGlobal("fetch", async (url: string) => {
-      posts.push(url);
-      return new Response("ok", { status: 200 });
-    });
-
     await slack("ask c1 what happened?", { response_url: "https://evil.example.com/collect" });
     await vi.waitFor(() => expect(asked).toHaveLength(1));
-    expect(posts).toEqual([]);
+    expect(delivered).toEqual([]);
   });
 
   it("delivers a Telegram result through the Bot API", async () => {
-    const posts: Array<{ url: string; body: { chat_id: string; text: string } }> = [];
-    vi.stubGlobal("fetch", async (url: string, init: { body: string }) => {
-      posts.push({ url, body: JSON.parse(init.body) });
-      return new Response("ok", { status: 200 });
-    });
     vi.stubEnv("DFIR_TELEGRAM_BOT_TOKEN", "12345:ABC");
-
     await telegram("/ask c1 what happened?");
-    await vi.waitFor(() => expect(posts).toHaveLength(1));
-    expect(posts[0].url).toBe("https://api.telegram.org/bot12345:ABC/sendMessage");
-    expect(posts[0].body.chat_id).toBe("-100123");
-    expect(posts[0].body.text).toMatch(/answer for c1/);
+    await vi.waitFor(() => expect(delivered).toHaveLength(1));
+    expect(delivered[0].url).toBe("https://api.telegram.org/bot12345:ABC/sendMessage");
+    expect(delivered[0].body).toMatchObject({ chat_id: "-100123" });
+    expect(text(0)).toMatch(/answer for c1/);
   });
 
   it("drops a Telegram result rather than crashing when no bot token is configured", async () => {
@@ -368,18 +364,14 @@ describe("async command delivery", () => {
     const ack = await telegram("/ask c1 what happened?");
     expect(ack.status).toBe(200);
     await vi.waitFor(() => expect(asked).toHaveLength(1));
+    expect(delivered).toEqual([]);
   });
 
   it("hunt ACKs and hands off to the dashboard rather than claiming a deploy", async () => {
-    const posts: Array<{ text: string }> = [];
-    vi.stubGlobal("fetch", async (_url: string, init: { body: string }) => {
-      posts.push(JSON.parse(init.body));
-      return new Response("ok", { status: 200 });
-    });
     await slack("hunt c1 T1059.001");
-    await vi.waitFor(() => expect(posts).toHaveLength(1));
-    expect(posts[0].text).toMatch(/T1059\.001/);
-    expect(posts[0].text).toMatch(/dashboard/);
+    await vi.waitFor(() => expect(delivered).toHaveLength(1));
+    expect(text(0)).toMatch(/T1059\.001/);
+    expect(text(0)).toMatch(/dashboard/);
   });
 });
 

--- a/companion/tests/server/slashCommandRoutes.test.ts
+++ b/companion/tests/server/slashCommandRoutes.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHmac } from "node:crypto";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+import { SlashCommandChannelStore } from "../../src/analysis/slashCommandStore.js";
+import { resetLimiters } from "../../src/http/rateLimiter.js";
+import { createApp } from "../../src/server.js";
+
+// End-to-end coverage for the war-room slash-command bot's HTTP surface (#235): authentication,
+// rate limiting, the case guards, and the per-platform response envelopes. The pure parser and
+// formatters are covered in tests/analysis/slashCommand.test.ts.
+
+const SLACK_SECRET = "slack-signing-secret";
+const TEAMS_TOKEN = "teams-token";
+const TELEGRAM_SECRET = "telegram-secret";
+
+let store: CaseStore;
+let stateStore: StateStore;
+let activityLogStore: ActivityLogStore;
+let bindings: SlashCommandChannelStore;
+let app: ReturnType<typeof createApp>;
+let asked: Array<{ caseId: string; question: string }>;
+
+const fakePipeline = {
+  ask: async (caseId: string, question: string) => {
+    asked.push({ caseId, question });
+    return { answer: `answer for ${caseId}`, status: "answered", pointer: "collect the prefetch dir", relatedEventIds: [] };
+  },
+} as unknown as import("../../src/analysis/pipeline.js").AnalysisPipeline;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-slashroute-"));
+  const bindDir = await mkdtemp(join(tmpdir(), "dfir-slashbind-"));
+  store = new CaseStore(root);
+  await store.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  await store.createCase({ caseId: "c2", name: "n2", investigator: "i", aiProvider: null });
+  stateStore = new StateStore(store);
+  activityLogStore = new ActivityLogStore(store);
+  bindings = new SlashCommandChannelStore(join(bindDir, "slash-command-bindings.json"));
+  asked = [];
+
+  vi.stubEnv("DFIR_SLACK_SIGNING_SECRET", SLACK_SECRET);
+  vi.stubEnv("DFIR_TEAMS_TOKEN", TEAMS_TOKEN);
+  vi.stubEnv("DFIR_TELEGRAM_SECRET_TOKEN", TELEGRAM_SECRET);
+  vi.stubEnv("DFIR_SLACK_ACTION_USERS", "");
+  vi.stubEnv("DFIR_TELEGRAM_ACTION_USERS", "");
+
+  // Reset BEFORE createApp: the route captures the limiter singleton at registration time.
+  resetLimiters();
+  app = createApp(store, {
+    stateStore,
+    activityLogStore,
+    slashCommandChannelStore: bindings,
+    pipeline: fakePipeline,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+// ── request helpers ─────────────────────────────────────────────────────────────────────
+
+function slack(text: string, extra: Record<string, string> = {}) {
+  const raw = new URLSearchParams({
+    channel_id: "C1", user_id: "U1", text, response_url: "https://hooks.slack.com/commands/T1/1/x", ...extra,
+  }).toString();
+  const ts = String(Math.floor(Date.now() / 1000));
+  const sig = "v0=" + createHmac("sha256", SLACK_SECRET).update(`v0:${ts}:${raw}`).digest("hex");
+  return request(app)
+    .post("/integrations/slack/command")
+    .set("content-type", "application/x-www-form-urlencoded")
+    .set("x-slack-request-timestamp", ts)
+    .set("x-slack-signature", sig)
+    .send(raw);
+}
+
+function teams(text: string, extra: Record<string, unknown> = {}) {
+  return request(app)
+    .post("/integrations/teams/command")
+    .set("authorization", `Bearer ${TEAMS_TOKEN}`)
+    .send({ channel: { id: "T-CH" }, from: { id: "U1" }, text, responseUrl: "https://outlook.webhook.office.com/x", ...extra });
+}
+
+function telegram(text: string, extra: Record<string, unknown> = {}) {
+  return request(app)
+    .post("/integrations/telegram/command")
+    .set("x-telegram-bot-api-secret-token", TELEGRAM_SECRET)
+    .send({ update_id: 1, message: { chat: { id: -100123 }, from: { id: 555 }, text, ...extra } });
+}
+
+// ── authentication ──────────────────────────────────────────────────────────────────────
+
+describe("authentication", () => {
+  it("rejects a Slack request with a bad signature", async () => {
+    const res = await request(app)
+      .post("/integrations/slack/command")
+      .set("content-type", "application/x-www-form-urlencoded")
+      .set("x-slack-request-timestamp", String(Math.floor(Date.now() / 1000)))
+      .set("x-slack-signature", "v0=deadbeef")
+      .send("channel_id=C1&user_id=U1&text=status+c1");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a Slack request with no signature headers at all", async () => {
+    const res = await request(app)
+      .post("/integrations/slack/command")
+      .set("content-type", "application/x-www-form-urlencoded")
+      .send("channel_id=C1&user_id=U1&text=status+c1");
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts a correctly signed Slack request", async () => {
+    expect((await slack("status c1")).status).toBe(200);
+  });
+
+  it("rejects a Teams request with a wrong or missing bearer token", async () => {
+    expect((await request(app).post("/integrations/teams/command").set("authorization", "Bearer nope").send({ text: "status c1" })).status).toBe(401);
+    expect((await request(app).post("/integrations/teams/command").send({ text: "status c1" })).status).toBe(401);
+  });
+
+  it("rejects a Telegram update with a wrong or missing secret token", async () => {
+    expect((await request(app).post("/integrations/telegram/command").set("x-telegram-bot-api-secret-token", "nope").send({ message: { chat: { id: 1 }, text: "/status c1" } })).status).toBe(401);
+    expect((await request(app).post("/integrations/telegram/command").send({ message: { chat: { id: 1 }, text: "/status c1" } })).status).toBe(401);
+  });
+
+  it("refuses every platform when its secret is not configured", async () => {
+    vi.stubEnv("DFIR_SLACK_SIGNING_SECRET", "");
+    vi.stubEnv("DFIR_TEAMS_TOKEN", "");
+    vi.stubEnv("DFIR_TELEGRAM_SECRET_TOKEN", "");
+    expect((await slack("status c1")).status).toBe(401);
+    expect((await teams("status c1")).status).toBe(401);
+    expect((await telegram("/status c1")).status).toBe(401);
+  });
+});
+
+// ── rate limiting ───────────────────────────────────────────────────────────────────────
+
+describe("rate limiting", () => {
+  // The limit key comes from the request body, so limiting before authenticating would let an
+  // unauthenticated caller burn a real war room's quota.
+  it("does not spend the channel's budget on unauthenticated requests", async () => {
+    for (let i = 0; i < 30; i++) {
+      await request(app)
+        .post("/integrations/slack/command")
+        .set("content-type", "application/x-www-form-urlencoded")
+        .set("x-slack-signature", "v0=deadbeef")
+        .set("x-slack-request-timestamp", String(Math.floor(Date.now() / 1000)))
+        .send("channel_id=C1&user_id=U1&text=status+c1");
+    }
+    expect((await slack("status c1")).status).toBe(200);
+  });
+
+  it("rate-limits an authenticated channel past the window cap", async () => {
+    const codes: number[] = [];
+    for (let i = 0; i < 22; i++) codes.push((await slack("status c1")).status);
+    expect(codes.slice(0, 20).every((c) => c === 200)).toBe(true);
+    expect(codes.at(-1)).toBe(429);
+  });
+
+  it("limits each channel separately", async () => {
+    for (let i = 0; i < 21; i++) await slack("status c1");
+    expect((await slack("status c1", { channel_id: "C2" })).status).toBe(200);
+  });
+});
+
+// ── case guards ─────────────────────────────────────────────────────────────────────────
+
+describe("case guards", () => {
+  it("reports a missing case instead of a server error", async () => {
+    const res = await slack("status nosuchcase");
+    expect(res.status).toBe(200);
+    expect(res.body.text).toMatch(/No such case: nosuchcase/);
+  });
+
+  // The case-password gate lives on /cases/:id; this route reads state directly, so without an
+  // explicit check a locked case would be readable from chat with no unlock.
+  it("refuses a password-protected case", async () => {
+    await request(app).post("/cases/c1/password").send({ newPassword: "correct horse battery" });
+    const res = await slack("findings c1");
+    expect(res.status).toBe(200);
+    expect(res.body.text).toMatch(/password-protected/);
+    expect(res.body.text).not.toMatch(/finding/i);
+  });
+
+  it("refuses to bind a channel to a password-protected case", async () => {
+    await request(app).post("/cases/c1/password").send({ newPassword: "correct horse battery" });
+    const res = await slack("bind c1");
+    expect(res.body.text).toMatch(/password-protected/);
+    expect(await bindings.get("slack:C1")).toBeUndefined();
+  });
+
+  it("rejects a path-traversal caseId", async () => {
+    const res = await slack("status ../../etc");
+    expect(res.status).toBe(200);
+    expect(res.body.text).toMatch(/valid caseId is required|No such case/);
+  });
+});
+
+// ── binding + caseId resolution ─────────────────────────────────────────────────────────
+
+describe("binding and caseId resolution", () => {
+  it("binds, then answers commands with no caseId", async () => {
+    expect((await slack("bind c1")).body.text).toMatch(/bound to case c1/);
+    const res = await slack("status");
+    expect(res.body.text).toMatch(/Status for c1/);
+  });
+
+  // The bug this suite exists for: `ask` used to swallow the question's first word as the caseId.
+  it("keeps the whole question when a bound channel omits the caseId", async () => {
+    await slack("bind c1");
+    await slack("ask what was the initial access vector?");
+    await vi.waitFor(() => expect(asked).toHaveLength(1));
+    expect(asked[0]).toEqual({ caseId: "c1", question: "what was the initial access vector?" });
+  });
+
+  it("still honours an explicit caseId over the binding", async () => {
+    await slack("bind c1");
+    expect((await slack("status c2")).body.text).toMatch(/Status for c2/);
+  });
+
+  it("reads an ioc filter as a filter on a bound channel", async () => {
+    await slack("bind c1");
+    const res = await slack("iocs malicious");
+    expect(res.body.text).toMatch(/IOCs for c1 \(malicious\)|IOC\(s\) \(malicious\)/);
+  });
+
+  it("unbind clears the binding and says what it was", async () => {
+    await slack("bind c1");
+    expect((await slack("unbind")).body.text).toMatch(/cleared \(was c1\)/);
+    expect(await bindings.get("slack:C1")).toBeUndefined();
+    expect((await slack("unbind")).body.text).toMatch(/not bound/);
+  });
+
+  it("asks for a caseId when the channel has no binding", async () => {
+    expect((await slack("status")).body.text).toMatch(/valid caseId is required/);
+  });
+});
+
+// ── access control ──────────────────────────────────────────────────────────────────────
+
+describe("access control", () => {
+  it("denies a privileged command to a user outside the allowlist", async () => {
+    vi.stubEnv("DFIR_SLACK_ACTION_USERS", "admin");
+    const res = await slack("synthesize c1");
+    expect(res.status).toBe(200);
+    expect(res.body.text).toMatch(/not permitted/);
+  });
+
+  it("allows a privileged command to an allowlisted user", async () => {
+    vi.stubEnv("DFIR_SLACK_ACTION_USERS", "admin");
+    expect((await slack("bind c1", { user_id: "admin" })).body.text).toMatch(/bound to case c1/);
+  });
+
+  // Without this, any chat member could read any case on the server just by naming it.
+  it("confines a non-allowlisted user to the channel's bound case", async () => {
+    vi.stubEnv("DFIR_SLACK_ACTION_USERS", "admin");
+    await slack("bind c1", { user_id: "admin" });
+    expect((await slack("status c1")).body.text).toMatch(/Status for c1/);
+    expect((await slack("status c2")).body.text).toMatch(/may only use this channel's bound case/);
+  });
+
+  it("stays open when no allowlist is configured", async () => {
+    expect((await slack("status c2")).body.text).toMatch(/Status for c2/);
+    expect((await slack("bind c1")).body.text).toMatch(/bound to case c1/);
+  });
+});
+
+// ── platform envelopes ──────────────────────────────────────────────────────────────────
+
+describe("platform response envelopes", () => {
+  it("answers Slack with a response_type envelope", async () => {
+    const res = await slack("status c1");
+    expect(res.body).toMatchObject({ response_type: "in_channel" });
+    expect(res.body.text).toMatch(/Status for c1/);
+  });
+
+  it("answers Teams with a message envelope", async () => {
+    const res = await teams("status c1");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "message" });
+    expect(res.body.text).toMatch(/Status for c1/);
+  });
+
+  it("answers Telegram with a sendMessage method envelope addressed to the chat", async () => {
+    const res = await telegram("/status c1");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ method: "sendMessage", chat_id: "-100123" });
+    expect(res.body.text).toMatch(/Status for c1/);
+  });
+
+  it("understands Telegram's @BotName command suffix", async () => {
+    expect((await telegram("/status@DfirCompanionBot c1")).body.text).toMatch(/Status for c1/);
+  });
+
+  it("binds a Telegram chat independently of a Slack channel with the same id", async () => {
+    await telegram("/bind c1");
+    expect((await telegram("/status")).body.text).toMatch(/Status for c1/);
+    expect(await bindings.get("telegram:-100123")).toMatchObject({ caseId: "c1" });
+    expect(await bindings.get("slack:-100123")).toBeUndefined();
+  });
+
+  // Telegram retries a non-2xx webhook delivery, which would re-run the command; every
+  // post-authentication reply must therefore be a 200 carrying the message.
+  it("answers 200 even for a user-facing error", async () => {
+    const res = await telegram("/status nosuchcase");
+    expect(res.status).toBe(200);
+    expect(res.body.text).toMatch(/No such case/);
+  });
+});
+
+// ── async delivery ──────────────────────────────────────────────────────────────────────
+
+describe("async command delivery", () => {
+  it("ACKs ask immediately and posts the answer to the Slack response_url", async () => {
+    const posts: Array<{ url: string; body: unknown }> = [];
+    vi.stubGlobal("fetch", async (url: string, init: { body: string }) => {
+      posts.push({ url, body: JSON.parse(init.body) });
+      return new Response("ok", { status: 200 });
+    });
+
+    const ack = await slack("ask c1 what happened?");
+    expect(ack.status).toBe(200);
+    expect(ack.body.text).toMatch(/Working on \/dfir ask for case c1/);
+
+    await vi.waitFor(() => expect(posts).toHaveLength(1));
+    expect(posts[0].url).toBe("https://hooks.slack.com/commands/T1/1/x");
+    expect((posts[0].body as { text: string }).text).toMatch(/answer for c1/);
+  });
+
+  // The response_url is caller-supplied; delivering to it unchecked is a server-side request to
+  // wherever the caller points.
+  it("refuses to deliver to a response_url outside the platform's hosts", async () => {
+    const posts: string[] = [];
+    vi.stubGlobal("fetch", async (url: string) => {
+      posts.push(url);
+      return new Response("ok", { status: 200 });
+    });
+
+    await slack("ask c1 what happened?", { response_url: "https://evil.example.com/collect" });
+    await vi.waitFor(() => expect(asked).toHaveLength(1));
+    expect(posts).toEqual([]);
+  });
+
+  it("delivers a Telegram result through the Bot API", async () => {
+    const posts: Array<{ url: string; body: { chat_id: string; text: string } }> = [];
+    vi.stubGlobal("fetch", async (url: string, init: { body: string }) => {
+      posts.push({ url, body: JSON.parse(init.body) });
+      return new Response("ok", { status: 200 });
+    });
+    vi.stubEnv("DFIR_TELEGRAM_BOT_TOKEN", "12345:ABC");
+
+    await telegram("/ask c1 what happened?");
+    await vi.waitFor(() => expect(posts).toHaveLength(1));
+    expect(posts[0].url).toBe("https://api.telegram.org/bot12345:ABC/sendMessage");
+    expect(posts[0].body.chat_id).toBe("-100123");
+    expect(posts[0].body.text).toMatch(/answer for c1/);
+  });
+
+  it("drops a Telegram result rather than crashing when no bot token is configured", async () => {
+    vi.stubEnv("DFIR_TELEGRAM_BOT_TOKEN", "");
+    const ack = await telegram("/ask c1 what happened?");
+    expect(ack.status).toBe(200);
+    await vi.waitFor(() => expect(asked).toHaveLength(1));
+  });
+
+  it("hunt ACKs and hands off to the dashboard rather than claiming a deploy", async () => {
+    const posts: Array<{ text: string }> = [];
+    vi.stubGlobal("fetch", async (_url: string, init: { body: string }) => {
+      posts.push(JSON.parse(init.body));
+      return new Response("ok", { status: 200 });
+    });
+    await slack("hunt c1 T1059.001");
+    await vi.waitFor(() => expect(posts).toHaveLength(1));
+    expect(posts[0].text).toMatch(/T1059\.001/);
+    expect(posts[0].text).toMatch(/dashboard/);
+  });
+});
+
+// ── audit trail ─────────────────────────────────────────────────────────────────────────
+
+describe("activity log", () => {
+  // logActivity is fire-and-forget, so the entry can land just after the response.
+  const awaitAction = (caseId: string, action: string) =>
+    vi.waitFor(async () => {
+      const entry = (await activityLogStore.load(caseId)).find((e) => e.action === action);
+      expect(entry, `no "${action}" entry for ${caseId}`).toBeDefined();
+      return entry!;
+    });
+
+  it("logs a read-only command against the case", async () => {
+    await slack("findings c1");
+    const entry = await awaitAction("c1", "slash-command");
+    expect(entry.detail).toContain("/dfir findings");
+    expect(entry.actor).toBe("slack:U1");
+  });
+
+  it("logs bind and unbind", async () => {
+    await slack("bind c1");
+    await awaitAction("c1", "slash-command-bind");
+    await slack("unbind");
+    await awaitAction("c1", "slash-command-unbind");
+  });
+
+  it("logs a denied command as an error outcome", async () => {
+    vi.stubEnv("DFIR_SLACK_ACTION_USERS", "admin");
+    await slack("synthesize c1");
+    expect((await awaitAction("c1", "slash-command-denied")).outcome).toBe("error");
+  });
+
+  it("does not write a log entry for a case that does not exist", async () => {
+    vi.stubEnv("DFIR_SLACK_ACTION_USERS", "admin");
+    const res = await slack("synthesize nosuchcase");
+    expect(res.body.text).toMatch(/not permitted/);
+    await expect(activityLogStore.load("nosuchcase")).resolves.toEqual([]);
+  });
+});
+
+describe("registration", () => {
+  it("does not register the routes when no binding store is configured", async () => {
+    const bare = createApp(store, { stateStore });
+    expect((await request(bare).post("/integrations/slack/command").send({})).status).toBe(404);
+    expect((await request(bare).post("/integrations/telegram/command").send({})).status).toBe(404);
+  });
+});

--- a/mkdocs-docs/reference/integrations.md
+++ b/mkdocs-docs/reference/integrations.md
@@ -83,3 +83,9 @@ Push the Response Playbook as tasks to a ClickUp list.
 - **Re-push:** updates existing tasks (by saved task ID) instead of duplicating
 
 Toolbar → Export → Push playbook to ClickUp.
+
+---
+
+## War-Room Slash-Command Bot
+
+Two-way Slack / Teams / Telegram: run `/dfir findings`, `/dfir iocs malicious` or `/dfir ask <question>` from the incident channel. Needs an inbound URL (a tunnel) rather than just outbound access — see [War-Room Slash-Command Bot](war-room-bot.md).

--- a/mkdocs-docs/reference/settings.md
+++ b/mkdocs-docs/reference/settings.md
@@ -226,11 +226,12 @@ Inbound slash commands from Slack / Teams / Telegram — see [War-Room Slash-Com
 
 | Variable | Meaning |
 |---|---|
-| `DFIR_ALLOWED_HOSTS` | Hostnames the Companion answers to. **Required** — the tunnel/proxy hostname the platform delivers to must be listed, or requests are refused with 403 |
+| `DFIR_TELEGRAM_POLL` | `=on` to receive Telegram commands by long polling. **No tunnel, no inbound URL** — the preferred setup on a workstation. Needs only `DFIR_TELEGRAM_BOT_TOKEN` |
+| `DFIR_TELEGRAM_BOT_TOKEN` | @BotFather token. Required for polling; in webhook mode it delivers `ask`/`hunt`/`synthesize` results |
+| `DFIR_ALLOWED_HOSTS` | Hostnames the Companion answers to. **Required in webhook mode** — the tunnel/proxy hostname must be listed, or requests are refused with 403. Not used by polling |
 | `DFIR_SLACK_SIGNING_SECRET` | Slack app signing secret; enables `/integrations/slack/command` |
 | `DFIR_TEAMS_TOKEN` | Shared bearer token; enables `/integrations/teams/command` |
-| `DFIR_TELEGRAM_SECRET_TOKEN` | `setWebhook` secret; enables `/integrations/telegram/command` |
-| `DFIR_TELEGRAM_BOT_TOKEN` | @BotFather token — used to deliver `ask`/`hunt`/`synthesize` results |
+| `DFIR_TELEGRAM_SECRET_TOKEN` | `setWebhook` secret; enables `/integrations/telegram/command`. Webhook mode only |
 | `DFIR_SLACK_ACTION_USERS`<br>`DFIR_TEAMS_ACTION_USERS`<br>`DFIR_TELEGRAM_ACTION_USERS` | Comma-separated user ids allowed to run `ask`/`hunt`/`synthesize`/`bind`. Unset = open to the whole channel; once set, everyone else is confined to the channel's bound case |
 | `DFIR_SLACK_RESPONSE_HOSTS`<br>`DFIR_TEAMS_RESPONSE_HOSTS` | Extra hosts an async result may be delivered to, for a self-hosted Slack-compatible server. Defaults cover the platforms' own hosts |
 | `DFIR_TELEGRAM_API_BASE` | Bot API base URL override (default `https://api.telegram.org`) |

--- a/mkdocs-docs/reference/settings.md
+++ b/mkdocs-docs/reference/settings.md
@@ -220,6 +220,25 @@ Each channel has:
 
 ---
 
+## War-Room Bot
+
+Inbound slash commands from Slack / Teams / Telegram — see [War-Room Slash-Command Bot](war-room-bot.md) for setup. Configured entirely in `.env`; each platform switches on when its secret is set.
+
+| Variable | Meaning |
+|---|---|
+| `DFIR_ALLOWED_HOSTS` | Hostnames the Companion answers to. **Required** — the tunnel/proxy hostname the platform delivers to must be listed, or requests are refused with 403 |
+| `DFIR_SLACK_SIGNING_SECRET` | Slack app signing secret; enables `/integrations/slack/command` |
+| `DFIR_TEAMS_TOKEN` | Shared bearer token; enables `/integrations/teams/command` |
+| `DFIR_TELEGRAM_SECRET_TOKEN` | `setWebhook` secret; enables `/integrations/telegram/command` |
+| `DFIR_TELEGRAM_BOT_TOKEN` | @BotFather token — used to deliver `ask`/`hunt`/`synthesize` results |
+| `DFIR_SLACK_ACTION_USERS`<br>`DFIR_TEAMS_ACTION_USERS`<br>`DFIR_TELEGRAM_ACTION_USERS` | Comma-separated user ids allowed to run `ask`/`hunt`/`synthesize`/`bind`. Unset = open to the whole channel; once set, everyone else is confined to the channel's bound case |
+| `DFIR_SLACK_RESPONSE_HOSTS`<br>`DFIR_TEAMS_RESPONSE_HOSTS` | Extra hosts an async result may be delivered to, for a self-hosted Slack-compatible server. Defaults cover the platforms' own hosts |
+| `DFIR_TELEGRAM_API_BASE` | Bot API base URL override (default `https://api.telegram.org`) |
+
+Channel-to-case bindings are stored alongside the notification config, not in `.env`.
+
+---
+
 ## Updates
 
 Opt-in GitHub release check. Shows a dashboard banner when a newer version is available. Never auto-installs.

--- a/mkdocs-docs/reference/settings.md
+++ b/mkdocs-docs/reference/settings.md
@@ -226,10 +226,12 @@ Inbound slash commands from Slack / Teams / Telegram — see [War-Room Slash-Com
 
 | Variable | Meaning |
 |---|---|
-| `DFIR_TELEGRAM_POLL` | `=on` to receive Telegram commands by long polling. **No tunnel, no inbound URL** — the preferred setup on a workstation. Needs only `DFIR_TELEGRAM_BOT_TOKEN` |
+| `DFIR_SLACK_SOCKET_MODE` | `=on` to receive Slack commands over an outbound WebSocket. **No tunnel, no Request URL.** Needs `DFIR_SLACK_APP_TOKEN` |
+| `DFIR_SLACK_APP_TOKEN` | App-level token, `xapp-…`, scope `connections:write`. Not a bot token |
+| `DFIR_TELEGRAM_POLL` | `=on` to receive Telegram commands by long polling. **No tunnel, no inbound URL.** Needs only `DFIR_TELEGRAM_BOT_TOKEN` |
 | `DFIR_TELEGRAM_BOT_TOKEN` | @BotFather token. Required for polling; in webhook mode it delivers `ask`/`hunt`/`synthesize` results |
-| `DFIR_ALLOWED_HOSTS` | Hostnames the Companion answers to. **Required in webhook mode** — the tunnel/proxy hostname must be listed, or requests are refused with 403. Not used by polling |
-| `DFIR_SLACK_SIGNING_SECRET` | Slack app signing secret; enables `/integrations/slack/command` |
+| `DFIR_ALLOWED_HOSTS` | Hostnames the Companion answers to. **Required in webhook mode** — the tunnel/proxy hostname must be listed, or requests are refused with 403. Not used by Socket Mode or polling |
+| `DFIR_SLACK_SIGNING_SECRET` | Slack app signing secret; enables `/integrations/slack/command`. Webhook mode only |
 | `DFIR_TEAMS_TOKEN` | Shared bearer token; enables `/integrations/teams/command` |
 | `DFIR_TELEGRAM_SECRET_TOKEN` | `setWebhook` secret; enables `/integrations/telegram/command`. Webhook mode only |
 | `DFIR_SLACK_ACTION_USERS`<br>`DFIR_TEAMS_ACTION_USERS`<br>`DFIR_TELEGRAM_ACTION_USERS` | Comma-separated user ids allowed to run `ask`/`hunt`/`synthesize`/`bind`. Unset = open to the whole channel; once set, everyone else is confined to the channel's bound case |

--- a/mkdocs-docs/reference/war-room-bot.md
+++ b/mkdocs-docs/reference/war-room-bot.md
@@ -29,12 +29,18 @@ Once a channel is bound, every command can omit the case id. Name a case explici
 
 ---
 
-## You need a public URL
+## Two ways to receive commands
 
-The chat platform delivers commands to the Companion, so it has to be able to reach it. On a normal workstation install that means a tunnel.
+**Telegram can poll — start here if you can.** The Companion calls Telegram and asks for new commands, so nothing about your machine needs to be reachable. No tunnel, no `DFIR_ALLOWED_HOSTS`, no webhook registration to redo. Skip to [Telegram (polling)](#telegram-polling).
+
+**Slack and Teams must be delivered to** — and so must Telegram, if you'd rather use a webhook. The platform pushes each command to the Companion, which means it needs a public address. On a workstation install, that means a tunnel.
 
 !!! note "This is the opposite direction from notifications"
-    Outbound Telegram/Slack notifications work with no tunnel, because the Companion calls *them*. Commands arrive the other way, so they need an address the platform can reach.
+    Outbound Telegram/Slack notifications work with no tunnel, because the Companion calls *them*. Webhook commands arrive the other way, so they need an address the platform can reach. Polling puts Telegram back in the outbound direction.
+
+---
+
+## The tunnel (webhook mode only)
 
 Cloudflare's quick tunnel needs no account:
 
@@ -92,7 +98,42 @@ DFIR_TEAMS_TOKEN=<shared secret>
 
 ---
 
-## Telegram
+## Telegram (polling)
+
+The simplest setup of the three, and the one to prefer on a workstation: **no tunnel, no inbound URL, nothing exposed.**
+
+1. Message [@BotFather](https://t.me/BotFather) → `/newbot` → copy the token (`123456789:AAF…`).
+2. Add two lines to `.env`:
+
+```
+DFIR_TELEGRAM_POLL=on
+DFIR_TELEGRAM_BOT_TOKEN=123456789:AAF...
+```
+
+3. Restart. The log confirms it:
+
+```
+[telegram] long-polling for commands (no inbound URL needed)
+```
+
+Message the bot. That's the whole setup — `DFIR_ALLOWED_HOSTS`, `DFIR_TELEGRAM_SECRET_TOKEN` and `setWebhook` are all webhook-mode concerns and play no part here.
+
+Under the hood the Companion asks Telegram for new commands and Telegram holds the connection open until one arrives, so replies are near-instant without polling in a tight loop. If the connection drops it retries with a widening backoff, and one failing command never stops the loop.
+
+!!! warning "A bot does one or the other, not both"
+    Telegram refuses `getUpdates` while a webhook is registered for that bot, and refuses a second poller for the same bot. Either shows up as a `409` in the log with the fix spelled out. If you previously registered a webhook, clear it first:
+
+    ```bash
+    curl https://api.telegram.org/bot<TOKEN>/deleteWebhook
+    ```
+
+    Running the same bot from two Companion instances will have them fighting over updates — give each its own bot.
+
+---
+
+## Telegram (webhook)
+
+Use this only if you need it — a shared server that's already reachable, say. Polling is less setup and less exposure.
 
 1. Message [@BotFather](https://t.me/BotFather) → `/newbot` → copy the token (`123456789:AAF…`).
 2. Invent a long random string for the webhook secret.
@@ -186,6 +227,21 @@ If you see that, the whole chain works: tunnel → hostname guard → secret ver
 ---
 
 ## When it doesn't work
+
+### Polling mode
+
+Everything is in the Companion's own log, since there's no network path to misconfigure. Look for:
+
+| Log line | Cause |
+|---|---|
+| `[telegram] long-polling for commands` | Started fine — if commands still don't work, the bot you messaged isn't the token you configured |
+| *(nothing at all)* | `DFIR_TELEGRAM_POLL` isn't `on`, or the Companion wasn't restarted after setting it |
+| `polling requested but DFIR_TELEGRAM_BOT_TOKEN is not set` | Exactly that |
+| `409 … a webhook is registered for this bot` | Clear it with `deleteWebhook`, or stop the other poller |
+| `Unauthorized — DFIR_TELEGRAM_BOT_TOKEN is wrong or revoked` | Bad or revoked token |
+| `poll failed (…); retrying in Ns` | Network trouble; it recovers on its own |
+
+### Webhook mode
 
 Every setup failure looks the same from the chat window — nothing happens. Don't debug through the chat client; send the request yourself and read the status code:
 

--- a/mkdocs-docs/reference/war-room-bot.md
+++ b/mkdocs-docs/reference/war-room-bot.md
@@ -31,12 +31,18 @@ Once a channel is bound, every command can omit the case id. Name a case explici
 
 ## Two ways to receive commands
 
-**Telegram can poll — start here if you can.** The Companion calls Telegram and asks for new commands, so nothing about your machine needs to be reachable. No tunnel, no `DFIR_ALLOWED_HOSTS`, no webhook registration to redo. Skip to [Telegram (polling)](#telegram-polling).
+**Outbound — no tunnel needed.** The Companion opens the connection to the platform and commands arrive down it, so nothing about your machine is reachable from the internet and there's no address to register or keep current. Available for Slack ([Socket Mode](#slack-socket-mode)) and Telegram ([polling](#telegram-polling)). **Prefer this.**
 
-**Slack and Teams must be delivered to** — and so must Telegram, if you'd rather use a webhook. The platform pushes each command to the Companion, which means it needs a public address. On a workstation install, that means a tunnel.
+**Inbound webhooks.** The platform pushes each command to the Companion, which needs a public address — a tunnel or reverse proxy — plus its hostname in `DFIR_ALLOWED_HOSTS`. Required for Teams, optional for Slack and Telegram.
+
+| Platform | Outbound (no tunnel) | Inbound webhook |
+|---|---|---|
+| Slack | ✅ Socket Mode | ✅ Request URL |
+| Telegram | ✅ Long polling | ✅ `setWebhook` |
+| MS Teams | — | ✅ only option |
 
 !!! note "This is the opposite direction from notifications"
-    Outbound Telegram/Slack notifications work with no tunnel, because the Companion calls *them*. Webhook commands arrive the other way, so they need an address the platform can reach. Polling puts Telegram back in the outbound direction.
+    Outbound Telegram/Slack notifications work with no tunnel, because the Companion calls *them*. Webhook commands arrive the other way, so they need an address the platform can reach. Socket Mode and polling put commands back in the outbound direction too.
 
 ---
 
@@ -65,7 +71,41 @@ Hostname only — no `https://`, no path. Restart after changing it.
 
 ---
 
-## Slack
+## Slack (Socket Mode)
+
+No tunnel, no Request URL. The Companion opens an outbound WebSocket to Slack and commands arrive down it.
+
+1. [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → From scratch, pick your workspace.
+2. **Socket Mode** → toggle **Enable Socket Mode** on. Slack offers to create an app-level token — do that, give it the **`connections:write`** scope, and copy it (it starts `xapp-`).
+3. **Slash Commands** → **Create New Command** → Command `/dfir`. With Socket Mode on, Slack does not ask for a Request URL.
+4. **Install to Workspace**.
+5. Add to `.env`:
+
+```
+DFIR_SLACK_SOCKET_MODE=on
+DFIR_SLACK_APP_TOKEN=xapp-1-...
+```
+
+Restart. The log confirms it:
+
+```
+[slack] socket mode: connecting (no inbound URL needed)
+[slack] socket mode: connected
+```
+
+Slack rotates these connections periodically and warns first; the Companion reconnects on its own and logs it as routine. If the connection drops it retries with a widening backoff.
+
+!!! note "The signing secret isn't used here"
+    There is no HTTP request to sign — the app-level token authenticates the connection. `DFIR_SLACK_SIGNING_SECRET` is a webhook-mode setting.
+
+!!! warning "It must be an app-level token"
+    `xapp-…` from **Basic Information → App-Level Tokens**, with `connections:write`. A bot token (`xoxb-…`) will be rejected with `invalid_auth`, which the log calls out.
+
+---
+
+## Slack (webhook)
+
+Use this only if the Companion is already reachable at a stable address.
 
 1. [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → From scratch, pick your workspace.
 2. **Slash Commands** → **Create New Command**:
@@ -228,9 +268,22 @@ If you see that, the whole chain works: tunnel → hostname guard → secret ver
 
 ## When it doesn't work
 
-### Polling mode
+### Outbound modes (Socket Mode / polling)
 
-Everything is in the Companion's own log, since there's no network path to misconfigure. Look for:
+Everything is in the Companion's own log, since there's no network path to misconfigure.
+
+**Slack Socket Mode:**
+
+| Log line | Cause |
+|---|---|
+| `socket mode: connected` | Working — if commands still don't arrive, the slash command isn't installed, or you're in a workspace the app isn't in |
+| *(nothing at all)* | `DFIR_SLACK_SOCKET_MODE` isn't `on`, or the Companion wasn't restarted |
+| `socket mode requested but DFIR_SLACK_APP_TOKEN is not set` | Exactly that |
+| `invalid_auth — DFIR_SLACK_APP_TOKEN must be an app-level token` | You used a bot token (`xoxb-`); it needs `xapp-` with `connections:write` |
+| `socket mode: reconnecting (refresh_requested)` | Routine — Slack rotates connections |
+| `socket mode: …; retrying in Ns` | Network trouble; it recovers on its own |
+
+**Telegram polling:**
 
 | Log line | Cause |
 |---|---|

--- a/mkdocs-docs/reference/war-room-bot.md
+++ b/mkdocs-docs/reference/war-room-bot.md
@@ -187,15 +187,48 @@ If you see that, the whole chain works: tunnel → hostname guard → secret ver
 
 ## When it doesn't work
 
+Every setup failure looks the same from the chat window — nothing happens. Don't debug through the chat client; send the request yourself and read the status code:
+
+```bash
+curl -s -X POST https://<your-tunnel>/integrations/telegram/command -H "content-type: application/json" -d "{}"
+```
+
+That one call walks you down the chain, because each layer fails before the next one runs:
+
+| Response | Cause |
+|---|---|
+| `host "…" is not served by the DFIR companion` | Hostname missing from `DFIR_ALLOWED_HOSTS`, or the server was started before you set it |
+| `Cannot POST /integrations/telegram/command` | The route doesn't exist — this build predates the bot, or you're on the wrong branch |
+| `no Telegram webhook secret configured` | `DFIR_TELEGRAM_SECRET_TOKEN` is unset in the running process |
+| `missing X-Telegram-Bot-Api-Secret-Token header` | The route is live and authenticating — this is the healthy answer to an empty request |
+
+Fix them in that order. Clearing one only reveals the next, so a change that "does nothing" often did work.
+
+For Slack and Teams substitute their endpoint paths; the first two rows behave identically.
+
+!!! warning "Environment variables are read once, at startup"
+    Editing `.env` while the Companion is running changes nothing. Restart it. When in doubt, pass the variable inline — `DFIR_ALLOWED_HOSTS=… npm run dev` — which sidesteps any question of which `.env` is being read or whether a line got mangled.
+
+!!! note "The outbound Telegram notifier is a different thing"
+    If you already have Telegram alerts working, that's the notification channel, configured in the dashboard and stored in `notifications/config.json`. It shares nothing with the bot — it sets none of these variables and needs no tunnel, because it calls Telegram rather than being called.
+
+Once the request is reaching the bot, the rest are ordinary replies:
+
 | What you see | Cause |
 |---|---|
-| Platform reports **403**, nothing in the channel | Tunnel hostname missing from `DFIR_ALLOWED_HOSTS` |
-| Platform reports **401** | Wrong or unset signing secret / bearer token / Telegram secret token |
 | *"A valid caseId is required"* | Channel isn't bound — run `/dfir bind <caseId>` |
 | *"No such case: X"* | Case id typo, or the case doesn't exist on this instance |
 | *"…is password-protected and is not available over chat"* | Working as intended — use the dashboard |
 | *"may only use this channel's bound case"* | An allowlist is set and you aren't on it; you can only read the bound case |
 | *"Working on /dfir ask…"* then nothing | No AI provider configured, or the result couldn't be delivered — check the server log |
 | Rate-limited after ~20 commands a minute | Per-channel cap; wait a minute |
+
+Telegram also keeps its own record of what it saw, which is the fastest way to tell whether delivery is even being attempted:
+
+```bash
+curl https://api.telegram.org/bot<TOKEN>/getWebhookInfo
+```
+
+`last_error_message` carries the HTTP status the Companion returned, and `pending_update_count` tells you how many commands are queued waiting for you to fix it.
 
 Full variable list: [Settings Reference → War-Room Bot](settings.md#war-room-bot).

--- a/mkdocs-docs/reference/war-room-bot.md
+++ b/mkdocs-docs/reference/war-room-bot.md
@@ -1,0 +1,201 @@
+# War-Room Slash-Command Bot
+
+Run the case from your incident channel instead of switching to the dashboard for every question. Works with **Slack**, **Microsoft Teams** and **Telegram**.
+
+This is the inbound counterpart to [Notifications](../reference/settings.md): notifications push findings *out* to a channel; this lets the channel ask questions *back*.
+
+---
+
+## Commands
+
+```
+/dfir bind IR-2026-014       bind this channel to a case
+/dfir status                 events, findings, IOCs, open questions
+/dfir findings               top 5 by severity (dismissed excluded)
+/dfir finding f002           one finding card, by id
+/dfir iocs malicious         IOCs by verdict — flagged | malicious
+/dfir ask <question>         grounded AI answer, posted when ready
+/dfir synthesize             trigger a re-synthesis
+/dfir hunt T1059.001         note a technique to hunt
+/dfir unbind                 clear the binding
+/dfir help                   usage
+```
+
+Once a channel is bound, every command can omit the case id. Name a case explicitly at any time (`/dfir findings OTHER-CASE`) to override the binding for that one command.
+
+`status`, `findings`, `finding` and `iocs` answer immediately. `ask`, `synthesize` and `hunt` reply "working…" first and post the result when it's ready — chat platforms only wait about three seconds, and an AI answer takes longer.
+
+`hunt` records the technique against the case and points you at the dashboard; it does **not** launch the hunt. Deploying one needs per-client targeting and artifact selection, which is more than a chat line can carry — see [Threat Hunting](threat-hunting.md).
+
+---
+
+## You need a public URL
+
+The chat platform delivers commands to the Companion, so it has to be able to reach it. On a normal workstation install that means a tunnel.
+
+!!! note "This is the opposite direction from notifications"
+    Outbound Telegram/Slack notifications work with no tunnel, because the Companion calls *them*. Commands arrive the other way, so they need an address the platform can reach.
+
+Cloudflare's quick tunnel needs no account:
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:4773
+```
+
+It prints a hostname like `https://random-words-here.trycloudflare.com`. Leave it running — a quick tunnel gets a **new hostname every restart**, and you'll have to re-register the webhook when it changes. For anything beyond a one-off test, use a named Cloudflare tunnel or an `ngrok` reserved domain so the hostname is stable.
+
+### Allow the hostname
+
+The Companion refuses requests arriving under a hostname it doesn't recognise — that's the DNS-rebinding guard, and it runs before any route. Add your tunnel hostname to `.env`:
+
+```
+DFIR_ALLOWED_HOSTS=random-words-here.trycloudflare.com
+```
+
+Hostname only — no `https://`, no path. Restart after changing it.
+
+!!! warning "This is the most common setup failure"
+    If commands do nothing and the platform reports **403**, this is almost always why. The response body says which hostname was refused.
+
+---
+
+## Slack
+
+1. [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → From scratch, pick your workspace.
+2. **Slash Commands** → **Create New Command**:
+   - Command: `/dfir`
+   - Request URL: `https://<your-tunnel>/integrations/slack/command`
+3. **Install to Workspace**.
+4. **Basic Information** → copy the **Signing Secret** into `.env`:
+
+```
+DFIR_SLACK_SIGNING_SECRET=<signing secret>
+```
+
+Restart the Companion. Every request is HMAC-verified against that secret with a five-minute replay window, so an intercepted request can't be replayed later.
+
+---
+
+## Microsoft Teams
+
+Teams uses the webhook-based slash-command variant (not the Bot Framework). Point your channel's outgoing webhook at:
+
+```
+https://<your-tunnel>/integrations/teams/command
+```
+
+and set the shared secret it sends in the `Authorization` header:
+
+```
+DFIR_TEAMS_TOKEN=<shared secret>
+```
+
+---
+
+## Telegram
+
+1. Message [@BotFather](https://t.me/BotFather) → `/newbot` → copy the token (`123456789:AAF…`).
+2. Invent a long random string for the webhook secret.
+3. Add both to `.env`:
+
+```
+DFIR_TELEGRAM_SECRET_TOKEN=<long random string>
+DFIR_TELEGRAM_BOT_TOKEN=123456789:AAF...
+```
+
+4. Restart, then register the webhook:
+
+```bash
+curl -F url=https://<your-tunnel>/integrations/telegram/command -F secret_token=<long random string> https://api.telegram.org/bot<TOKEN>/setWebhook
+```
+
+Check it took:
+
+```bash
+curl https://api.telegram.org/bot<TOKEN>/getWebhookInfo
+```
+
+`last_error_message` should be absent. A **403** there means the hostname isn't in `DFIR_ALLOWED_HOSTS`.
+
+Both tokens are needed and they do different jobs: the **secret token** proves an incoming update really came from Telegram, and the **bot token** is how the Companion sends `ask`/`hunt`/`synthesize` results back, since those arrive too late for the webhook reply.
+
+!!! tip "Groups and command names"
+    In a group chat Telegram appends the bot's name to commands — `/status@YourBot`. The Companion handles that. Starting in a direct message with the bot avoids Telegram's group privacy rules while you're getting set up.
+
+!!! warning "One bot, one webhook"
+    Setting a webhook replaces any previous one for that bot. If you also use this bot for outbound notifications that's fine — but don't point two Companion instances at the same bot.
+
+---
+
+## Who is allowed to do what
+
+By default the bot is open: anyone who can post in the channel can run any command. That matches the rest of this localhost-first tool, but a war room usually has more people in it than you want spending AI budget.
+
+Name the responders who may run privileged commands:
+
+```
+DFIR_SLACK_ACTION_USERS=U012ABCDEF,U034GHIJKL
+DFIR_TEAMS_ACTION_USERS=...
+DFIR_TELEGRAM_ACTION_USERS=8675309,5551212
+```
+
+Comma-separated platform user ids (Telegram's are numeric — `getUpdates` or [@getidsbot](https://t.me/getidsbot) will tell you yours).
+
+Setting a list changes two things:
+
+- **`ask`, `hunt`, `synthesize` and `bind` become responder-only.** `bind` is on that list because it decides which case the whole room can read.
+- **Everyone else is confined to the channel's bound case.** Without this, any channel member could read any case on the server just by naming it.
+
+Reading a case (`status`, `findings`, `finding`, `iocs`) stays open to the channel either way.
+
+!!! warning "OPSEC"
+    Anyone who can post in the channel can pull case content — finding titles, IOC values, descriptions — into a third-party chat service. Treat a bound channel as a copy of the case. Password-protected cases are refused over chat entirely: a chat message carries no unlock, so the bot will not serve them at all.
+
+Every command is written to the case's activity log with the platform and user id that sent it, including refusals — so the audit trail shows who asked for what, and who was turned away.
+
+---
+
+## Try it with the demo case
+
+Seed a case with real findings to see something meaningful:
+
+```bash
+curl -X POST http://127.0.0.1:4773/cases/seed-demo -H "content-type: application/json" -d "{}"
+```
+
+Then from the channel:
+
+```
+/dfir bind demo
+/dfir findings
+```
+
+which answers:
+
+```
+Top 5 finding(s) for demo
+• Critical · f002 conf 99% [T1003.001] — Domain Administrator Credentials Compromised via Mimikatz
+• Critical · f001 conf 97% [T1071.001, T1105, T1055] — Active Cobalt Strike C2 Beacon — Persistent Backdoor
+• Critical · f009 conf 96% [T1190] — Internet-Facing WEB01 Exploited via CVE-2021-41773 + CVE-2021-44228
+• High · f003 conf 95% [T1566.001, T1204.002, T1059.001] — Spear-Phishing Email — Initial Access via Malicious Excel Macro
+• High · f004 conf 92% [T1021.002] — Lateral Movement via PsExec to DC01, FS01, and WEB01
+```
+
+If you see that, the whole chain works: tunnel → hostname guard → secret verification → binding → case read → reply.
+
+---
+
+## When it doesn't work
+
+| What you see | Cause |
+|---|---|
+| Platform reports **403**, nothing in the channel | Tunnel hostname missing from `DFIR_ALLOWED_HOSTS` |
+| Platform reports **401** | Wrong or unset signing secret / bearer token / Telegram secret token |
+| *"A valid caseId is required"* | Channel isn't bound — run `/dfir bind <caseId>` |
+| *"No such case: X"* | Case id typo, or the case doesn't exist on this instance |
+| *"…is password-protected and is not available over chat"* | Working as intended — use the dashboard |
+| *"may only use this channel's bound case"* | An allowlist is set and you aren't on it; you can only read the bound case |
+| *"Working on /dfir ask…"* then nothing | No AI provider configured, or the result couldn't be delivered — check the server log |
+| Rate-limited after ~20 commands a minute | Per-channel cap; wait a minute |
+
+Full variable list: [Settings Reference → War-Room Bot](settings.md#war-room-bot).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - Threat Hunting: reference/threat-hunting.md
     - Reports & Exports: reference/reports.md
     - Integrations: reference/integrations.md
+    - War-Room Slash-Command Bot: reference/war-room-bot.md
     - Live Monitoring & Push Ingest: reference/live-monitoring.md
     - Settings Reference: reference/settings.md
     - Advanced Features: reference/advanced.md


### PR DESCRIPTION
## Summary

Implements #235: a two-way war-room slash-command bot, so IR stays in the incident channel instead of forcing a context-switch to the dashboard for every query. Supports **Slack, MS Teams and Telegram**. Read-only commands answer synchronously; commands that spend AI budget ACK immediately and deliver the result out of band. A channel can bind to a case so every later command omits the caseId.

```
/dfir bind IR-2026-014       bind this channel to a case
/dfir status                 events, findings, IOCs, open questions
/dfir findings               top 5 by severity (dismissed excluded)
/dfir finding f3             one finding card (by id or semanticKey)
/dfir iocs malicious         IOCs by verdict (flagged | malicious)
/dfir ask what was the initial access vector?    grounded AI answer, posted when ready
/dfir synthesize             trigger a re-synthesis
/dfir hunt T1059.001         note a technique to hunt (deploy from the dashboard)
/dfir unbind                 clear the binding
/dfir help                   usage
```

## Setup

Two ways for commands to reach the Companion. **Outbound needs no tunnel** — the Companion opens the connection, so nothing about the machine is reachable from the internet:

| Platform | Outbound (no tunnel) | Inbound webhook |
|---|---|---|
| Slack | `DFIR_SLACK_SOCKET_MODE=on` + `DFIR_SLACK_APP_TOKEN` (`xapp-…`, `connections:write`) | `POST /integrations/slack/command` + `DFIR_SLACK_SIGNING_SECRET` |
| Telegram | `DFIR_TELEGRAM_POLL=on` + `DFIR_TELEGRAM_BOT_TOKEN` | `POST /integrations/telegram/command` + `DFIR_TELEGRAM_SECRET_TOKEN` |
| MS Teams | — no outbound option | `POST /integrations/teams/command` + `DFIR_TEAMS_TOKEN` |

⚠️ **Webhook mode** means the platform reaches the Companion from the internet via a tunnel or reverse proxy — and that hostname **must** be in `DFIR_ALLOWED_HOSTS`, or the DNS-rebinding host guard (#280) turns the request away before the bot ever runs. `DFIR_ALLOWED_HOSTS` had no entry in `.env.example` at all; this PR documents it. Outbound mode needs none of this.

Webhook requests are authenticated per platform: Slack by HMAC over `v0:<ts>:<rawBody>` with a 5-minute replay window, Teams by a bearer token, Telegram by the `secret_token` it echoes back from `setWebhook`. In outbound mode the platform token authenticates the connection instead, and the signing secret is unused.

## Access control

Two independent axes:

- **Privileged** (`ask`, `hunt`, `synthesize`, `bind`) — gated on `DFIR_{SLACK,TEAMS,TELEGRAM}_ACTION_USERS`. `bind` is in here because it decides which case the whole room can then read.
- **Async** (`ask`, `hunt`, `synthesize`) — ACK now, deliver later. Nothing to do with permissions.

Once an allowlist is configured, everyone *else* is also confined to the channel's bound case, so an ordinary chat member cannot read an unrelated case by naming it. With no allowlist the bot stays open, matching the rest of this localhost-first tool.

**Password-protected cases are refused over chat entirely.** The case-password gate lives on `/cases/:id`; this route reads state directly, and a chat message carries no unlock cookie, so serving a locked case here would be a way around it.

## Changes

- **`companion/src/analysis/slashCommand.ts`** — the pure core. Parsing is two-phase: `parseSlashCommand` splits the command word from its argument tokens (tolerating a bare form, a leading `/`, an echoed `/dfir`, and Telegram's `@BotName` suffix), and `resolveCommand` decides whether the first token is a caseId or the first word of the argument, given an existence check the route supplies. Read-only formatters (`findings`, `finding`, `iocs`, `status`, `help`). Access-control predicates `isAllowed` / `isCaseAccessAllowed` / `isPrivilegedCommand` / `isAsyncCommand`.
- **`companion/src/analysis/slashCommandAuth.ts`** — `verifySlackSignature`, `verifyTeamsToken`, `verifyTelegramSecret` (all constant-time via `pushAuth.timingSafeEqual`), plus `isAllowedResponseUrl`, the outbound delivery allowlist.
- **`companion/src/analysis/slashCommandStore.ts`** — `SlashCommandChannelStore`: per-channel bindings in a global JSON file beside the notification config, keyed `<platform>:<channelId>` so the same id on two platforms can't collide.
- **`companion/src/routes/slashCommand.ts`** — the three endpoints. Authenticate → rate-limit → resolve → permission → case guards → dispatch. Per-platform response envelopes (Slack `response_type`, Teams `message`, Telegram `{method: "sendMessage"}`), and per-platform async delivery (`response_url` for Slack/Teams, Bot API for Telegram).
- **`companion/src/server.ts`** — construct the binding store beside the notification config and register the routes.
- **README + `.env.example`** — full setup, the `DFIR_ALLOWED_HOSTS` requirement, OPSEC notes, and every new variable.

### Why some non-obvious choices

**Two-phase parsing.** The first cut picked the caseId positionally, which is wrong for every command that takes an argument: on a bound channel `/dfir ask what happened?` queried a case named `what`, and `/dfir iocs malicious` a case named `malicious`. Both pass `isValidCaseId`, so nothing errored — the analyst just got an answer about the wrong (empty) case. Only the store knows which ids are real, so that one fact is passed in and `resolveCommand` decides. `bind` is deliberately exempt: falling back to the binding would silently re-bind the channel to the case it is already on.

**Authenticate before rate-limiting.** The limit key comes from the request body, so limiting first let an unauthenticated caller burn a real war room's quota.

**`response_url` is pinned** to the hosts each platform actually delivers on (https only), because it is a caller-supplied URL we make a server-side request to. `DFIR_{SLACK,TEAMS}_RESPONSE_HOSTS` extends it for a self-hosted Slack-compatible server, matching the existing `DFIR_NOTIFY_CA` story.

**Everything after authentication answers HTTP 200**, with the message in the platform's envelope. Only 401/429 use error statuses. All three platforms discard the body of a non-2xx reply and show a generic failure instead, and Telegram *retries* it — which would re-run the command.

## Out of scope (per the issue)

- Natural-language bot conversation — slash commands only, explicit and auditable.
- MS Teams Bot Framework — this is the webhook-based variant; the Bot Framework can follow.
- Posting to DMs (channels only).
- Deploying hunts from chat. `hunt` records the technique and hands off; the Velociraptor deploy surface (per-client targeting, artifact selection, bundle resolution) is too rich for a slash command.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — **5263 tests / 428 files, all passing.**
- [x] 129 tests for the bot: 56 command core, 8 binding store, 39 route, 14 Telegram poller, 12 Slack Socket Mode.
- [x] Route coverage specifically: bad/missing/unconfigured secrets on all three platforms; that unauthenticated requests do not consume the rate limit; the per-channel window cap; missing case, password-protected case, path-traversal caseId; bind/unbind/rebind; bound-channel resolution for `ask` and `iocs`; allowlist denial and bound-case confinement; all three response envelopes; `response_url` allowlist enforcement; Telegram Bot API delivery; audit entries for command/bind/unbind/denial.
- [x] **Local end-to-end** — drove a running companion with curl on all three webhook endpoints: signed Slack commands, Teams bearer, Telegram updates including the `@BotName` suffix; bind → status/findings/iocs/finding → unbind on each; 401 on every bad secret; and a password-protected case refused over chat.
- [x] **Telegram webhook, against the real platform** — a live bot behind a cloudflared tunnel, registered via `setWebhook` with a secret token: `/dfir bind demo` then `/dfir findings` returned the demo case's findings in the chat.
- [x] **Telegram polling, against the real platform** — the same bot with the webhook deleted, `DFIR_TELEGRAM_POLL=on`, **no tunnel running and no `DFIR_ALLOWED_HOSTS`**: findings came back in the chat. This is the configuration a workstation install actually uses.
- [x] **Slack Socket Mode** — verified end to end over a real WebSocket against a stand-in Slack (connections.open → envelope → ack), and the URL/auth path against the real Bot API. Not yet run against Slack itself.
- [ ] **Slack (either transport) and Teams, against the real platforms** — not yet exercised.

### Bugs the live runs found that the tests did not

Each of these passed CI and failed in reality, which is worth recording:

1. **`/dfir bind` failed on a fresh install** — the bindings file's parent directory (`notifications/`) is created by whatever writes there first, and this store went straight to `atomicWrite`. Every store test started from an `mkdtemp`'d directory, so the parent always already existed.
2. **A typo'd caseId silently answered about the bound case** — the "is this token a caseId or argument text?" existence check was applied to commands that take no argument, where an unknown token is unambiguously a caseId.
3. **Telegram polling never built a URL** — the constructor spread caller options over a defaults object, and `apiBase: undefined` (passed whenever the env override is unset) overwrote the default instead of falling through. The unit tests omitted the key; the integration run set it. Nobody exercised the default.
4. **A shutdown hang in Slack Socket Mode** — `stop()` waited for a `close` event that a wedged socket never emits.

## Note on history

The branch was rebased onto master (it was 32 commits behind, and the host guard that gates these endpoints landed in that gap), so the push was a force-update from `2b3d84f2`. The pre-rebase version is in this PR's force-push history.
