### PR TITLE
fix(security): lock-gate diagnostics sizes and strip absolute paths from error responses (#250)

### DIFF
--- a/companion/src/analysis/diagnostics.ts
+++ b/companion/src/analysis/diagnostics.ts
@@ -211,14 +211,25 @@ export interface SizeReport {
   totalBytes: number;
   cases: CaseSize[]; // largest first
   largestFiles: Array<{ caseId: string; path: string; bytes: number }>; // largest first
+  lockedCases: number; // cases whose filenames were withheld because the case is locked (#250)
 }
 
 /**
  * Aggregate a flat list of scanned files into total bytes, per-case sizes (largest first),
  * and the top-N largest individual files. Pure — the recursive walk that produces the file
  * list lives in the route (compute-on-demand, so the default diagnostics load stays cheap).
+ *
+ * `withheldCaseIds` names cases that are password-protected and NOT unlocked for this caller: their
+ * bytes still count toward the totals (an aggregate, and the case ids are already public via
+ * GET /cases) but their per-file entries are dropped from `largestFiles`. Evidence FILENAMES are
+ * case content — victim names, malware names, the shape of the investigation — so they belong
+ * behind the same lock as the case itself (#250).
  */
-export function aggregateCaseSizes(files: readonly ScannedFile[], topN = 10): SizeReport {
+export function aggregateCaseSizes(
+  files: readonly ScannedFile[],
+  topN = 10,
+  withheldCaseIds: ReadonlySet<string> = new Set(),
+): SizeReport {
   const byCase = new Map<string, number>();
   let totalBytes = 0;
   for (const f of files) {
@@ -230,11 +241,14 @@ export function aggregateCaseSizes(files: readonly ScannedFile[], topN = 10): Si
     .map(([caseId, bytes]) => ({ caseId, bytes }))
     .sort((a, b) => b.bytes - a.bytes);
   const largestFiles = [...files]
-    .filter((f) => Number.isFinite(f.bytes) && f.bytes > 0)
+    .filter((f) => Number.isFinite(f.bytes) && f.bytes > 0 && !withheldCaseIds.has(f.caseId))
     .sort((a, b) => b.bytes - a.bytes)
     .slice(0, Math.max(0, topN))
     .map((f) => ({ caseId: f.caseId, path: f.path, bytes: f.bytes }));
-  return { totalBytes, cases, largestFiles };
+  // Count only cases that actually contributed bytes — a withheld id with nothing scanned under it
+  // would otherwise inflate the "n locked" note the dashboard shows.
+  const lockedCases = [...withheldCaseIds].filter((id) => byCase.has(id)).length;
+  return { totalBytes, cases, largestFiles, lockedCases };
 }
 
 // ── The full diagnostics report ─────────────────────────────────────────────────────────

--- a/companion/src/analysis/importerStore.ts
+++ b/companion/src/analysis/importerStore.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { atomicWrite } from "../storage/atomicWrite.js";
 import { parseImporterSpec, type ImporterSpec, type SpecParseError } from "./importerSpec.js";
+import { redactPaths } from "./redactPaths.js";
 import { buildImporter, type ExternalImporter } from "./declarativeImporter.js";
 
 export type ImporterPrecedence = "builtin-first" | "external-first";
@@ -40,7 +41,10 @@ export class ImporterStore {
       if (!file.endsWith(".json") || file === CONFIG_FILE) continue;
       let raw: unknown;
       try { raw = JSON.parse(await readFile(join(this.dir, file), "utf8")); }
-      catch (err) { errors.push({ file, errors: [{ path: "(file)", message: `not valid JSON: ${(err as Error).message}` }] }); continue; }
+      // /diagnostics ships these load errors to the client, so the message is redacted here (#250).
+      // A JSON.parse error carries no path, but the readFile in the same try can fail with an ENOENT
+      // or EACCES that quotes the spec's absolute path — `file` above is deliberately a bare name.
+      catch (err) { errors.push({ file, errors: [{ path: "(file)", message: `not valid JSON: ${redactPaths((err as Error).message, [this.dir])}` }] }); continue; }
       const parsed = parseImporterSpec(raw);
       if (!parsed.ok) { errors.push({ file, errors: parsed.errors }); continue; }
       if (importers.has(parsed.spec.id)) { errors.push({ file, errors: [{ path: "id", message: `duplicate id "${parsed.spec.id}"` }] }); continue; }

--- a/companion/src/analysis/redactPaths.ts
+++ b/companion/src/analysis/redactPaths.ts
@@ -1,0 +1,91 @@
+import { homedir, tmpdir } from "node:os";
+
+/**
+ * Strip absolute filesystem paths out of strings bound for an HTTP client (#250).
+ *
+ * Node's fs errors embed the whole path — `ENOENT: no such file or directory, open
+ * '/home/alice/cases/INC-1/imports/0001_alerts.json'` — and the route `catch` blocks return
+ * `err.message` verbatim. On an unauthenticated localhost API that hands any caller the cases-root
+ * location, the operator's username, and the install layout: reconnaissance for a file-targeting
+ * attack (symlink, env injection). Removing `casesRoot` from /diagnostics accomplishes nothing while
+ * the first failed import prints it back out.
+ *
+ * Only the CLIENT-facing copy is redacted. `serverLogger` keeps the raw message, so an operator
+ * debugging from the console or the log file loses no fidelity — see the callers in server.ts.
+ */
+
+const PLACEHOLDER = "<path>";
+
+/** Path characters: up to whitespace, a quote, or a separator. Deliberately narrow, so a path at
+ * the end of a sentence doesn't swallow the trailing prose along with it. */
+const SEG = String.raw`[^\s/\\:*?"'<>|]+`;
+
+/** Schemes copied through untouched: a provider error legitimately carries its endpoint, and
+ * `ai.baseUrl` is already a deliberate diagnostics field, so flattening it to <path> would make
+ * those errors unactionable. `file:` is deliberately absent — that is a filesystem path in a
+ * scheme's clothing and gets redacted like any other. */
+const URL_RE = /\b(?!file:)[a-z][a-z0-9+.-]*:\/\/[^\s'"<>]+/gi;
+
+/**
+ * First segment of an absolute POSIX path that is plausibly a FILESYSTEM path. Without this
+ * allowlist a message naming an HTTP route ("expected /cases/:id/import") flattens to <path> and
+ * stops being actionable — routes and filesystem paths are both slash-delimited absolutes, and
+ * only the leading segment tells them apart.
+ */
+const FS_TOP_LEVEL = [
+  "home", "Users", "root", "var", "tmp", "opt", "srv", "mnt", "media", "etc", "usr",
+  "private", "data", "app", "Volumes", "Applications", "Library", "System", "proc", "dev", "run",
+];
+
+const POSIX_FS_PATH_RE = new RegExp(String.raw`/(?:${FS_TOP_LEVEL.join("|")})(?:/${SEG})*/?`, "g");
+
+/** `C:\dir\file` and UNC `\\host\share\file`. Both require at least one segment, so a bare "C:" in
+ * prose is left alone. */
+const WINDOWS_FS_PATH_RE = new RegExp(String.raw`(?:[A-Za-z]:\\|\\\\)${SEG}(?:\\${SEG})*\\?`, "g");
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Known roots on THIS machine, longest first so a nested root wins over its parent. Relative and
+ * single-character roots are dropped — replacing "/" globally would shred every message. */
+function knownRoots(extraRoots: readonly string[]): string[] {
+  return [...extraRoots, homedir(), tmpdir(), process.cwd()]
+    .filter((r) => typeof r === "string" && r.length > 1 && (r.startsWith("/") || /^[A-Za-z]:[\\/]/.test(r)))
+    .sort((a, b) => b.length - a.length);
+}
+
+function redactOutsideUrls(text: string, roots: readonly string[]): string {
+  let out = text;
+  // Configured roots first: they catch an installation living somewhere FS_TOP_LEVEL doesn't
+  // know about (a DFIR_CASES_ROOT of /evidence/cases, say).
+  for (const root of roots) {
+    out = out.replace(new RegExp(`${escapeRegExp(root)}(?:[/\\\\]${SEG})*[/\\\\]?`, "g"), PLACEHOLDER);
+  }
+  return out.replace(WINDOWS_FS_PATH_RE, PLACEHOLDER).replace(POSIX_FS_PATH_RE, PLACEHOLDER);
+}
+
+/**
+ * Replace absolute filesystem paths in `text` with `<path>`, leaving http(s)-style URLs intact.
+ * `extraRoots` adds machine-specific roots to redact wholesale — pass `store.casesRoot`.
+ */
+export function redactPaths(text: string, extraRoots: readonly string[] = []): string {
+  if (!text) return text;
+  const roots = knownRoots(extraRoots);
+  // Walk the string so a URL's own path segments are never mistaken for a filesystem path: copy
+  // each protected URL through verbatim and redact only the gaps between them.
+  let out = "";
+  let last = 0;
+  for (const m of text.matchAll(URL_RE)) {
+    const at = m.index ?? 0;
+    out += redactOutsideUrls(text.slice(last, at), roots);
+    out += m[0];
+    last = at + m[0].length;
+  }
+  return out + redactOutsideUrls(text.slice(last), roots);
+}
+
+/** `redactPaths` over an unknown thrown value — the shape every `catch` block here deals with. */
+export function redactedErrorMessage(err: unknown, extraRoots: readonly string[] = []): string {
+  return redactPaths((err as Error)?.message ?? String(err), extraRoots);
+}

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -271,18 +271,27 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
   // Per-case sizes + top-N largest evidence files. SEPARATE from /diagnostics because it walks the
   // whole cases tree (compute-on-demand, behind the dashboard's "Compute sizes" button) so the
   // default diagnostics load stays cheap. Bounded to DFIR_DIAG_MAX_FILES files (default 100k).
+  //
+  // This route spans ALL cases, so it cannot sit behind the /cases/:id lock gate — there is no single
+  // id to gate on. It enforces the same rule per case instead: a password-protected case that this
+  // caller has not unlocked contributes its bytes but not its filenames (#250). An unprotected case
+  // is as open here as it already is at /cases/:id/*, which is the app's existing security model.
   app.get("/diagnostics/sizes", async (req: Request, res: Response) => {
     try {
       const topN = Math.min(50, Math.max(1, Number(req.query.top) || 10));
       const budget = { n: Number(process.env.DFIR_DIAG_MAX_FILES) || 100_000 };
       const cases = await store.listCases();
       const files: ScannedFile[] = [];
+      const withheld = new Set<string>();
       for (const c of cases) {
         if (budget.n <= 0) break;
+        // listCases returns the raw meta (password included) — read the salt straight off it rather
+        // than re-reading each case.json just to learn whether it is locked.
+        if (c.password && !ctx.readUnlockState(req, c.caseId, c.password.salt).unlocked) withheld.add(c.caseId);
         const dir = store.caseDir(c.caseId);
         await walkCaseFiles(dir, dir, c.caseId, files, budget);
       }
-      const report = aggregateCaseSizes(files, topN);
+      const report = aggregateCaseSizes(files, topN, withheld);
       return res.status(200).json({ ...report, truncated: budget.n <= 0, scannedFiles: files.length });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -191,6 +191,7 @@ import { NotionExportStore } from "./integrations/notion/notionExportStore.js";
 import { ClickUpClient } from "./integrations/clickup/clickupClient.js";
 import { ClickUpExportStore } from "./integrations/clickup/clickupExportStore.js";
 import type { ImporterFailure, AiError, ImporterRunStat } from "./analysis/diagnostics.js";
+import { redactPaths, redactedErrorMessage } from "./analysis/redactPaths.js";
 import type { PreflightReport } from "./analysis/preflight.js";
 import { NotificationConfigStore } from "./analysis/notificationStore.js";
 import { seedDemoCase } from "./analysis/seedDemoCase.js";
@@ -618,13 +619,17 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   const DIAG_RING = 50;
   const recentImportFailures: ImporterFailure[] = [];
   const recentAiErrors: AiError[] = [];
+  // Both rings are served to the client by /diagnostics (JSON report AND the copy-to-clipboard text
+  // blob), so the message is redacted on the way IN — one choke point instead of two on the way out.
+  // The raw message still reaches serverLogger at each call site, so the console keeps full paths.
+  const redactErr = (err: unknown): string => redactedErrorMessage(err, [store.casesRoot]);
   function recordImportFailure(caseId: string, kind: string, filename: string, err: unknown): void {
-    recentImportFailures.unshift({ at: new Date().toISOString(), caseId, kind, filename, error: (err as Error)?.message ?? String(err) });
+    recentImportFailures.unshift({ at: new Date().toISOString(), caseId, kind, filename, error: redactErr(err) });
     if (recentImportFailures.length > DIAG_RING) recentImportFailures.length = DIAG_RING;
   }
   function recordAiError(caseId: string, phase: string, err: unknown): void {
     const kind = err instanceof ProviderError ? err.kind : "other";
-    recentAiErrors.unshift({ at: new Date().toISOString(), caseId, phase, kind, detail: (err as Error)?.message ?? String(err) });
+    recentAiErrors.unshift({ at: new Date().toISOString(), caseId, phase, kind, detail: redactErr(err) });
     if (recentAiErrors.length > DIAG_RING) recentAiErrors.length = DIAG_RING;
   }
   // Per-importer health (#84): last run's outcome per custom (declarative) importer id. Keyed by
@@ -695,6 +700,30 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       return res.status(400).json({ error: "request body is not valid JSON" });
     }
     return next(err);
+  });
+
+  // ── Absolute-path redaction on every error response (#250) ───────────────────────────
+  // ~60 route catch blocks end in `res.status(500).json({ error: (err as Error).message })`, and
+  // Node's fs errors carry the full path, so each one is a potential cases-root disclosure. Wrapping
+  // res.json here is the single choke point that covers all of them — including routes added later
+  // and the terminal error handler at the bottom of this file — with no per-handler opt-in, the same
+  // reasoning as the caseIdGate/caseLockGate mounts below.
+  //
+  // ONLY the `error` field is rewritten. Ordinary fields legitimately carry filesystem paths that
+  // the operator asked for: /settings/env round-trips DFIR_CASES_ROOT into the Settings form, and
+  // the size report's per-file paths are case-relative, not absolute. Redacting those would break
+  // features to no benefit. Request logging is untouched, so the console still shows real paths.
+  app.use((_req: Request, res: Response, next: NextFunction) => {
+    const sendJson = res.json.bind(res);
+    res.json = ((body: unknown) => {
+      if (body && typeof body === "object" && typeof (body as { error?: unknown }).error === "string") {
+        // Spread rather than mutate: the caller's object literal is not ours to rewrite, and
+        // overwriting an existing key preserves its position in the response.
+        return sendJson({ ...body, error: redactPaths((body as { error: string }).error, [store.casesRoot]) });
+      }
+      return sendJson(body);
+    }) as typeof res.json;
+    next();
   });
 
   // ── Case id validation ────────────────────────────────────────────────────────────────
@@ -1143,7 +1172,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
           recordImporterRun(kind, { lastStatus: "ok", ...parsed, lastError: null });
         },
       }).catch((err) => {
-        recordImporterRun(kind, { lastStatus: "error", total: parsed?.total ?? 0, kept: parsed?.kept ?? 0, dropped: parsed?.dropped ?? 0, lastError: (err as Error)?.message ?? String(err) });
+        recordImporterRun(kind, { lastStatus: "error", total: parsed?.total ?? 0, kept: parsed?.kept ?? 0, dropped: parsed?.dropped ?? 0, lastError: redactErr(err) });
         throw err;
       });
     }

--- a/companion/tests/analysis/redactPaths.test.ts
+++ b/companion/tests/analysis/redactPaths.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { homedir, tmpdir } from "node:os";
+import { redactPaths, redactedErrorMessage } from "../../src/analysis/redactPaths.js";
+
+describe("redactPaths", () => {
+  it("redacts the absolute path out of a Node fs error", () => {
+    const msg = "ENOENT: no such file or directory, open '/home/alice/cases/INC-1/imports/0001_alerts.json'";
+    const out = redactPaths(msg);
+    expect(out).not.toContain("/home/alice");
+    expect(out).not.toContain("INC-1");
+    expect(out).toBe("ENOENT: no such file or directory, open '<path>'");
+  });
+
+  it("redacts a configured cases root that no top-level allowlist would catch", () => {
+    const out = redactPaths("failed to write /evidence/store/INC-9/state.json", ["/evidence/store"]);
+    expect(out).toBe("failed to write <path>");
+  });
+
+  it("redacts this machine's home and tmp directories", () => {
+    expect(redactPaths(`spill at ${homedir()}/notes.txt`)).toBe("spill at <path>");
+    expect(redactPaths(`temp at ${tmpdir()}/dfir-x/y.bin`)).toBe("temp at <path>");
+  });
+
+  it("redacts Windows drive and UNC paths", () => {
+    expect(redactPaths("cannot read C:\\Users\\bob\\cases\\INC-1\\a.json")).toBe("cannot read <path>");
+    expect(redactPaths("cannot read \\\\fileserver\\eviershare\\a.json")).toBe("cannot read <path>");
+  });
+
+  it("leaves an http(s) endpoint intact so provider errors stay actionable", () => {
+    const msg = "401 from https://api.openai.com/v1/chat/completions — check the key";
+    expect(redactPaths(msg)).toBe(msg);
+  });
+
+  it("redacts a file:// URL — that is a filesystem path wearing a scheme", () => {
+    expect(redactPaths("cannot load file:///home/alice/cases/x.json")).not.toContain("alice");
+  });
+
+  it("redacts a path that sits next to a URL without eating the URL", () => {
+    const out = redactPaths("POST https://api.example.com/v1/x failed writing /var/lib/dfir/a.json");
+    expect(out).toContain("https://api.example.com/v1/x");
+    expect(out).not.toContain("/var/lib/dfir");
+  });
+
+  it("leaves route-shaped absolutes alone — they are not filesystem paths", () => {
+    // The whole point of the top-level allowlist: an error naming a route must stay readable.
+    expect(redactPaths("expected /cases/:id/import")).toBe("expected /cases/:id/import");
+    expect(redactPaths("unknown endpoint /diagnostics/sizes")).toBe("unknown endpoint /diagnostics/sizes");
+  });
+
+  it("leaves ordinary prose and fractions alone", () => {
+    expect(redactPaths("kept 50/50 of the rows and/or dropped them")).toBe("kept 50/50 of the rows and/or dropped them");
+    expect(redactPaths("bad JSON at row 3")).toBe("bad JSON at row 3");
+  });
+
+  it("does not choke on empty or non-Error throwables", () => {
+    expect(redactPaths("")).toBe("");
+    expect(redactedErrorMessage(new Error("/home/alice/x/y.json is bad"))).toBe("<path> is bad");
+    expect(redactedErrorMessage("plain string throw")).toBe("plain string throw");
+    expect(redactedErrorMessage(undefined)).toBe("undefined");
+  });
+});

--- a/companion/tests/server/diagnostics.test.ts
+++ b/companion/tests/server/diagnostics.test.ts
@@ -1,12 +1,40 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import request from "supertest";
 import { CaseStore } from "../../src/storage/caseStore.js";
-import { createApp, setServerLogger } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { createApp, setServerLogger, buildRuntimePipeline } from "../../src/server.js";
 import { createConsoleLogger } from "../../src/logging/logger.js";
 import { ProviderError, type AIProvider } from "../../src/providers/provider.js";
+
+// One Chainsaw/Sigma detection — enough for resolveImportKind to classify the file as "chainsaw"
+// (a deterministic importer, no AI call) so an import-file request reaches the evidence copy.
+const CHAINSAW_HUNT = [
+  {
+    group: "Sigma",
+    kind: "individual",
+    document: {
+      kind: "evtx",
+      path: "Sysmon.evtx",
+      data: {
+        Event: {
+          System: {
+            Provider: { "#attributes": { Name: "Microsoft-Windows-Sysmon" } },
+            EventID: 1,
+            Channel: "Microsoft-Windows-Sysmon/Operational",
+            Computer: "WIN-DC01.corp.local",
+            TimeCreated: { "#attributes": { SystemTime: "2023-01-02T10:00:00.000Z" } },
+          },
+          EventData: { UtcTime: "2023-01-02 10:00:00.000", Image: "C:\\Windows\\System32\\cmd.exe", CommandLine: "cmd.exe /c whoami" },
+        },
+      },
+    },
+    rule: { name: "Suspicious Command", level: "high", tags: ["attack.execution"] },
+    timestamp: "2023-01-02T10:00:00.000Z",
+  },
+];
 
 let store: CaseStore;
 let root: string;
@@ -101,6 +129,104 @@ describe("GET /diagnostics/sizes", () => {
     expect(c.bytes).toBeGreaterThanOrEqual(1234);
     expect(res.body.largestFiles.length).toBeGreaterThan(0);
     expect(res.body.truncated).toBe(false);
+    expect(res.body.lockedCases).toBe(0);
+  });
+
+  // #250: this route spans every case, so it cannot sit behind the /cases/:id lock gate. It must
+  // enforce the same rule itself — evidence FILENAMES are case content, not metadata.
+  it("withholds a locked case's filenames but still counts its bytes", async () => {
+    await store.createCase({ caseId: "open-c", name: "O", investigator: "x", aiProvider: null });
+    await store.saveImport("open-c", "0001_open_evidence.json", "x".repeat(2000));
+    await store.createCase({ caseId: "locked-c", name: "L", investigator: "x", aiProvider: null });
+    await store.saveImport("locked-c", "0001_victim_acme_breach.json", "y".repeat(3000));
+    const app = createApp(store, {});
+    await request(app).post("/cases/locked-c/password").send({ newPassword: "correct horse" });
+
+    // Fresh, cookie-less client: the case is locked for it.
+    const res = await request(app).get("/diagnostics/sizes?top=50");
+    expect(res.status).toBe(200);
+    expect(res.body.lockedCases).toBe(1);
+    // Bytes and the case id still show — both are aggregates, and GET /cases already lists ids.
+    const locked = res.body.cases.find((x: { caseId: string }) => x.caseId === "locked-c");
+    expect(locked.bytes).toBeGreaterThanOrEqual(3000);
+    // The filename must not appear anywhere in the payload.
+    expect(JSON.stringify(res.body)).not.toContain("victim_acme_breach");
+    const paths = res.body.largestFiles.map((f: { caseId: string }) => f.caseId);
+    expect(paths).toContain("open-c");
+    expect(paths).not.toContain("locked-c");
+  });
+
+  it("lists a locked case's filenames again once the caller unlocks it", async () => {
+    await store.createCase({ caseId: "locked-c", name: "L", investigator: "x", aiProvider: null });
+    await store.saveImport("locked-c", "0001_victim_acme_breach.json", "y".repeat(3000));
+    const app = createApp(store, {});
+    const agent = request.agent(app);
+    await agent.post("/cases/locked-c/password").send({ newPassword: "correct horse" });
+    await agent.post("/cases/locked-c/unlock").send({ password: "correct horse" });
+
+    const res = await agent.get("/diagnostics/sizes?top=50");
+    expect(res.status).toBe(200);
+    expect(res.body.lockedCases).toBe(0);
+    expect(JSON.stringify(res.body)).toContain("victim_acme_breach");
+  });
+});
+
+// #250: ~60 route catch blocks return err.message verbatim, and Node's fs errors embed the absolute
+// path — so removing casesRoot from /diagnostics buys nothing if the next failed read prints it back.
+// Covered once, centrally, by the res.json wrapper in createApp.
+describe("absolute paths in error responses", () => {
+  it("redacts the absolute path out of a failed server-side import-file read", async () => {
+    await store.createCase({ caseId: "c1", name: "C", investigator: "x", aiProvider: null });
+    const stateStore = new StateStore(store);
+    const pipeline = buildRuntimePipeline({
+      provider: undefined, synthesisProvider: undefined, stateStore, store,
+      imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+    });
+    const app = createApp(store, { pipeline, stateStore });
+
+    // A path that does not exist, under the cases root itself — ENOENT will quote it in full.
+    const missing = join(root, "c1", "imports", "definitely_not_here.json");
+    const res = await request(app).post("/cases/c1/import-file").send({ path: missing });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cannot read file/i);
+    // The reason for the failure survives; the filesystem layout does not.
+    expect(res.body.error).toContain("ENOENT");
+    expect(res.body.error).not.toContain(root);
+    expect(res.body.error).toContain("<path>");
+  });
+
+  // The other half of the leak: /diagnostics replays the import-failure ring, so a path that reached
+  // the ring is served to every later caller even though the failing request is long gone.
+  it("keeps the absolute path out of the diagnostics failure ring, JSON and text alike", async () => {
+    await store.createCase({ caseId: "c1", name: "C", investigator: "x", aiProvider: null });
+    const stateStore = new StateStore(store);
+    const pipeline = buildRuntimePipeline({
+      provider: undefined, synthesisProvider: undefined, stateStore, store,
+      imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+    });
+    const app = createApp(store, { pipeline, stateStore });
+
+    // Provoke a real EEXIST out of the evidence copy: nextImportSeq counts audit-log lines, not
+    // files, so pre-creating the destination leaves the sequence at 1 and the COPYFILE_EXCL copy
+    // collides. Its message quotes BOTH absolute paths — source and the one under the cases root.
+    const src = join(await mkdtemp(join(tmpdir(), "dfir-diag-src-")), "hunt.json");
+    await writeFile(src, JSON.stringify(CHAINSAW_HUNT), "utf8");
+    await store.saveImport("c1", "0001_hunt.json", "already here");
+
+    const failed = await request(app).post("/cases/c1/import-file").send({ path: src });
+    expect(failed.status).toBe(500);
+    expect(failed.body.error).not.toContain(root);
+
+    // Now the ring: the report AND the copy-to-clipboard blob must both be clean.
+    const diag = await request(app).get("/diagnostics");
+    expect(diag.status).toBe(200);
+    const failures = diag.body.report.importers.recentFailures;
+    expect(failures.length).toBeGreaterThan(0);
+    expect(failures[0].error).toContain("EEXIST");
+    expect(failures[0].error).toContain("<path>");
+    expect(JSON.stringify(diag.body.report)).not.toContain(root);
+    expect(diag.body.text).not.toContain(root);
   });
 });
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -20333,9 +20333,12 @@
             <span style="color:#9aa4b2;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(f.caseId)}/${esc(f.path)}</span>
             <span>${diagFmtBytes(f.bytes)}</span></div>`).join("") || `<div style="color:#9aa4b2">none</div>`;
         const trunc = j.truncated ? ` <span style="color:#ffb05a">(scan truncated at ${j.scannedFiles} files)</span>` : "";
+        // Locked cases still count toward the byte totals but withhold their filenames, so say so —
+        // otherwise a short "Largest files" list on a passworded install just looks broken.
+        const locked = j.lockedCases ? ` <span style="font-weight:400">— hidden for ${j.lockedCases} locked case(s)</span>` : "";
         target.innerHTML = diagCard("Case sizes — total " + diagFmtBytes(j.totalBytes) + trunc,
           `<div style="font-weight:600;color:#9aa4b2;margin:2px 0">By case</div>${cases}
-           <div style="font-weight:600;color:#9aa4b2;margin:8px 0 2px">Largest files</div>${files}`);
+           <div style="font-weight:600;color:#9aa4b2;margin:8px 0 2px">Largest files${locked}</div>${files}`);
       }).catch(e => { target.innerHTML = `<div style="color:#ff9f9f">Size scan failed: ${esc(e.message)}</div>`; })
         .finally(() => { if (btn) btn.disabled = false; });
     }


### PR DESCRIPTION
## Summary

Fixes #250. [#266](https://github.com/hasamba/DFIR-Companion/pull/266) removed `casesRoot` from `/diagnostics`; the other two leaks in that report stayed open, and either one gives back what `casesRoot` gave.

## 1. `/diagnostics/sizes` handed out an evidence-filename listing

`largestFiles[]` carried per-file paths across every case, unauthenticated — the more informative of the two leaks. Filenames are case content (victim names, malware names, the shape of the investigation), so they now sit behind the same lock as the case itself.

The route spans all cases, so it cannot mount under the `/cases/:id` lock gate — there is no single id to gate on. It applies the rule per case instead: a password-protected case the caller has not unlocked contributes its **bytes** but not its **filenames**, and the response reports `lockedCases` so the dashboard can say what it withheld.

Case ids and byte totals still show — both are aggregates, and `GET /cases` already lists ids. An unprotected case is as open here as it already is at `/cases/:id/*`: the existing security model, not a new hole.

## 2. Absolute paths reached the client via `err.message`

Node's fs errors quote the whole path and ~60 route `catch` blocks return `err.message` verbatim, so the first failed import printed the cases root straight back out. New `analysis/redactPaths.ts`, applied at four points:

- **One `res.json` wrapper** in `createApp` redacts the `error` field for every route at once — including routes added later and the terminal error handler, with no per-handler opt-in.
- **The two diagnostics rings + importer run stats** redact on the way *in*, so the JSON report and the copy-to-clipboard text blob are both covered at the source.
- **`importerStore.loadAll`** — found while auditing: `JSON.parse` carries no path, but the `readFile` beside it can fail EACCES quoting the spec's absolute path into a field the report ships.

Design calls worth reviewing:
- Only the `error` field is rewritten. `/settings/env` round-trips `DFIR_CASES_ROOT` into the Settings form and the size report's paths are case-relative — redacting ordinary fields would break features for nothing.
- `http(s)` URLs pass through (a provider error's endpoint is what makes it actionable; `ai.baseUrl` is already a deliberate field); `file://` does not.
- A top-level allowlist separates filesystem paths from routes, so `"expected /cases/:id/import"` stays readable instead of collapsing to `<path>`.
- **`serverLogger` is untouched** — console and log files keep full paths, so operator debugging loses no fidelity.

## Deliberately not changed

The rest of `/health`'s feature-flag map. It is not in the issue's fix list, and per the comment at `system.ts:80` it is the extension's intentionally-unauthenticated reachability check — trimming it breaks the dashboard for no security gain. Worth an explicit by-design decision rather than a silent removal.

## Test plan

- [x] 10 unit tests pin the redactor, including the negative cases (routes, fractions, URLs, non-`Error` throwables)
- [x] 4 integration tests: the lock gate both ways (withheld while locked, listed once unlocked) and both leak paths
- [x] The ring test provokes a genuine `COPYFILE_EXCL` EEXIST — `nextImportSeq` counts audit-log lines, not files, so pre-creating the destination collides — and asserts the served error still says `EEXIST` while carrying `<path>`. Positive assertions, so it cannot pass vacuously.
- [x] `npx tsc --noEmit` clean
- [x] Full suite: 411 files / 4935 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)