### PR TITLE
ci(security): scope the betterleaks push scan to master, matching trufflehog

### DIFF
--- a/.github/workflows/betterleaks-scan.yml
+++ b/.github/workflows/betterleaks-scan.yml
@@ -1,8 +1,20 @@
 name: Secret & PII Scan
 
+# push is scoped to master (not '**'), matching trufflehog-scan.yml and for the same reason.
+# `betterleaks git .` scans every commit reachable in the clone — which includes master's history —
+# but applies the config from the CHECKED-OUT tree. On a push to a feature branch that is the
+# branch's own .betterleaks-config.toml, so the moment master gains a fixture plus the allowlist
+# covering it (as fe8c831b did for the anonymizer's private-key tests), every branch cut before that
+# commit starts failing on a finding that is already allowlisted on master. The finding is real
+# history, the allowlist just hasn't reached the branch yet — a stale-base artifact, not a leak.
+#
+# pull_request covers feature branches correctly: actions/checkout resolves the MERGE commit, so the
+# config is always base+head and the allowlist is present. Master's own full history stays covered by
+# the push trigger here. This also halves the runs — every PR was scanned twice, once per event.
+
 on:
   push:
-    branches: ['**']
+    branches: [master]
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
## Summary

Every open PR currently shows a failing `betterleaks-scan` for a finding that is **already allowlisted on master**. Confirmed on #291, #282, #276 — all three branches predate the allowlist commit.

`betterleaks git .` scans every commit reachable in the clone — master's history included — but applies the config from the **checked-out tree**. On a push to a feature branch that is the branch's own `.betterleaks-config.toml`. So the moment master gains a fixture plus the allowlist covering it — `fe8c831b`, the anonymizer's private-key tests — every branch cut before that commit starts failing on a finding master already signed off. Stale base, not a leak, and it recurs every time a fixture+allowlist pair lands.

[trufflehog-scan.yml:8-13](https://github.com/hasamba/DFIR-Companion/blob/master/.github/workflows/trufflehog-scan.yml#L8-L13) already documents this exact failure mode — "would full-history-rescan (and re-surface any already-fixed/allowlisted finding) on every branch's first push" — and scopes its push trigger to master for it. betterleaks was never given the same treatment. This aligns them.

## Change

One line: `push: branches: ['**']` → `push: branches: [master]`, plus a comment recording why.

## No loss of coverage

- `pull_request` resolves the **merge** commit, so a branch scan always carries master's current config. Empirically why PR #266's `pull_request` scan passed while its `push` scan failed on the identical commit.
- Master's own full history stays covered by the push trigger here.
- Bonus: halves the runs — every PR was being scanned twice, once per event.

**Nothing is suppressed and no rule is relaxed.** `.betterleaks-config.toml` is untouched by this PR.

## Note on the existing red PRs

This does not clear them retroactively: push-event workflow selection uses the *pushed branch's* own workflow file, so each open PR clears when it rebases onto master. Their `pull_request` scans should pass on the next re-run regardless of this change, since master already carries the allowlist.

## Test plan

- [x] YAML validated by parsing (triggers, jobs, and steps all resolve as intended)
- [x] Master's scan verified green independently of this change — latest push run logs `no leaks found`
- [x] Allowlist audited, not extended: it is scoped to one rule (`private-key`) and one file, and the fixture body is `MIIEowIBAAKCAQEAnotarealkey`
- [ ] This PR's own checks: the `push` scan should NOT appear (branch carries the new trigger); the `pull_request` scan should run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)