### PR TITLE
fix(extension): require Firefox 128 so pageHook always lands in the MAIN world

### DIFF
--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -3,7 +3,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "dfir-companion@example.com",
-      "strict_min_version": "121.0"
+      "strict_min_version": "128.0"
     }
   },
   "name": "DFIR Companion — Evidence Capture & Push",

--- a/extension/src/browser.ts
+++ b/extension/src/browser.ts
@@ -22,7 +22,13 @@ function globals(): ExtensionGlobals {
   return globalThis as ExtensionGlobals;
 }
 
-/** True on runtimes that expose the promise-based `browser` namespace (Firefox, Safari). */
+/**
+ * True on runtimes that expose the promise-based `browser` namespace (Firefox, Safari).
+ *
+ * Reach for this only where the two runtimes genuinely diverge in BEHAVIOUR, not in API surface —
+ * a growing pile of branches here is the sign the shim is being used to paper over something that
+ * belongs in the manifest or in a capability check.
+ */
 export function isFirefox(): boolean {
   return typeof globals().browser !== "undefined";
 }
@@ -46,17 +52,6 @@ export const browserApi: typeof chrome = new Proxy({} as typeof chrome, {
     return prop in resolveApi();
   },
 });
-
-// Firefox only gained `world: "MAIN"` for scripting.executeScript in Firefox 128; manifest-firefox
-// .json still admits 121, so the MAIN world is requested on Chrome only. Where it is omitted the
-// hook lands in the isolated world and never sees the page's own fetch — the content script's
-// DOM-scrape fallback (artifactCapture.ts) is what actually carries those pages.
-export function executeScriptTarget(tabId: number, files: string[]): Promise<void> {
-  return browserApi.scripting
-    .executeScript({
-      target: { tabId },
-      files,
-      ...(isFirefox() ? {} : { world: "MAIN" as const }),
-    })
-    .then(() => undefined);
-}
+// NOTE: scripting.executeScript needs no shim. Firefox gained `world: "MAIN"` in 128 and
+// manifest-firefox.json requires it (strict_min_version), so both runtimes take the same call —
+// see injectHook() in serviceWorker.ts.

--- a/extension/src/serviceWorker.ts
+++ b/extension/src/serviceWorker.ts
@@ -3,7 +3,7 @@ import { CaptureQueue } from "./captureQueue.js";
 import { CaptureController } from "./captureController.js";
 import { setActionIcon } from "./actionIcon.js";
 import { buildArtifactFilename } from "./adapters/artifactName.js";
-import { browserApi, executeScriptTarget } from "./browser.js";
+import { browserApi } from "./browser.js";
 import {
   DEFAULT_SETTINGS, type ContextPushResultMessage, type ContextTableResult,
   type GetContextTableMessage, type PushArtifactMessage, type PushArtifactResult,
@@ -76,10 +76,19 @@ async function captureActiveTab(trigger: TriggerType): Promise<void> {
 // known DFIR console (#102). executeScript into world "MAIN" bypasses the page's CSP (a <script src>
 // tag would be blocked by the strict CSPs these consoles ship). Idempotent — the hook guards against
 // double install. Best-effort: a restricted/blocked page just falls back to DOM-scrape.
+//
+// MAIN is requested unconditionally: Chrome has always supported it and Firefox has since 128,
+// which manifest-firefox.json requires. It must not silently degrade to the isolated world — there
+// the hook would wrap the content script's own `fetch`, which no page script ever calls, so it
+// would install, report ready, and then capture nothing at all.
 async function injectHook(tabId: number | undefined): Promise<void> {
   if (typeof tabId !== "number") return;
   try {
-    await executeScriptTarget(tabId, ["pageHook.js"]);
+    await browserApi.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      files: ["pageHook.js"],
+    });
   } catch { /* page not injectable — the content script's DOM-scrape fallback still works */ }
 }
 

--- a/extension/tests/firefox.test.ts
+++ b/extension/tests/firefox.test.ts
@@ -12,7 +12,6 @@ describe("manifest-firefox.json", () => {
   it("has browser_specific_settings with a gecko id", () => {
     expect(firefoxManifest.browser_specific_settings).toBeDefined();
     expect(firefoxManifest.browser_specific_settings.gecko.id).toMatch(/.+@.+/);
-    expect(firefoxManifest.browser_specific_settings.gecko.strict_min_version).toMatch(/^\d/);
   });
 
   it("uses background.scripts instead of service_worker", () => {
@@ -33,6 +32,28 @@ describe("manifest-firefox.json", () => {
 
   it("keeps the same capture shortcut", () => {
     expect(firefoxManifest.commands["toggle-capture"].suggested_key.default).toBe("Ctrl+Shift+S");
+  });
+
+  // These two lock the MAIN-world precondition from both ends. injectHook() requests
+  // world: "MAIN" unconditionally, which is only safe because every Firefox that can install this
+  // add-on supports it (128+). Lower the floor and the injection silently degrades to the isolated
+  // world on older Firefox: the hook installs, wraps a `fetch` no page script calls, posts "ready",
+  // and captures nothing — no error anywhere, just an add-on that quietly stops intercepting.
+  it("requires Firefox 128+, where scripting.executeScript gained world: MAIN", () => {
+    const min = firefoxManifest.browser_specific_settings.gecko.strict_min_version;
+    expect(min).toMatch(/^\d+(\.\d+)*$/);
+    expect(Number.parseInt(min, 10)).toBeGreaterThanOrEqual(128);
+  });
+
+  it("injects pageHook into the MAIN world unconditionally", () => {
+    // Asserted against source: serviceWorker.ts registers listeners at import time, so it can't be
+    // imported here without standing up the whole extension environment.
+    const sw = readFileSync(resolve(__dirname, "../src/serviceWorker.ts"), "utf-8");
+    // Up to the closing brace at column 0, i.e. the end of the function.
+    const injectHook = /^async function injectHook[\s\S]*?^}/m.exec(sw)?.[0];
+    expect(injectHook, "injectHook not found in serviceWorker.ts").toBeDefined();
+    expect(injectHook).toContain('world: "MAIN"');
+    expect(injectHook).toContain('files: ["pageHook.js"]');
   });
 });
 
@@ -104,9 +125,12 @@ async function loadShim(globals: { chrome?: unknown; browser?: unknown }) {
   return import("../src/browser.js");
 }
 
+// A stand-in for whichever namespace the shim picks, recording what reached it. storage.local.get
+// is the vehicle simply because it's an ordinary promise-returning call — the shim is generic, so
+// any API would do.
 function fakeNamespace() {
-  const calls: Array<{ world?: string; target?: { tabId: number } }> = [];
-  const ns = { scripting: { executeScript: (a: unknown) => { calls.push(a as never); return Promise.resolve([]); } } };
+  const calls: string[] = [];
+  const ns = { storage: { local: { get: (key: string) => { calls.push(key); return Promise.resolve({}); } } } };
   return { ns, calls };
 }
 
@@ -122,39 +146,36 @@ describe("browser shim", () => {
     // no callback returns undefined, so `await chrome.storage.local.get(...)` yields undefined.
     const chromeNs = fakeNamespace();
     const browserNs = fakeNamespace();
-    const { executeScriptTarget, isFirefox } = await loadShim({ chrome: chromeNs.ns, browser: browserNs.ns });
+    const { browserApi, isFirefox } = await loadShim({ chrome: chromeNs.ns, browser: browserNs.ns });
 
     expect(isFirefox()).toBe(true);
-    await executeScriptTarget(42, ["pageHook.js"]);
+    await browserApi.storage.local.get("settings");
 
-    expect(browserNs.calls).toHaveLength(1);
-    expect(chromeNs.calls).toHaveLength(0);
-    expect(browserNs.calls[0].world).toBeUndefined(); // MAIN world needs Firefox 128+
+    expect(browserNs.calls).toEqual(["settings"]);
+    expect(chromeNs.calls).toEqual([]);
   });
 
-  it("falls back to `chrome` and requests the MAIN world (Chrome)", async () => {
+  it("falls back to `chrome` when that is all there is (Chrome)", async () => {
     const chromeNs = fakeNamespace();
-    const { executeScriptTarget, isFirefox } = await loadShim({ chrome: chromeNs.ns });
+    const { browserApi, isFirefox } = await loadShim({ chrome: chromeNs.ns });
 
     expect(isFirefox()).toBe(false);
-    await executeScriptTarget(43, ["pageHook.js"]);
+    await browserApi.storage.local.get("settings");
 
-    expect(chromeNs.calls).toHaveLength(1);
-    expect(chromeNs.calls[0].world).toBe("MAIN");
-    expect(chromeNs.calls[0].target).toEqual({ tabId: 43 });
+    expect(chromeNs.calls).toEqual(["settings"]);
   });
 
   it("resolves the namespace per access rather than freezing it at import", async () => {
     const first = fakeNamespace();
-    const { executeScriptTarget } = await loadShim({ chrome: first.ns });
-    await executeScriptTarget(1, ["pageHook.js"]);
+    const { browserApi } = await loadShim({ chrome: first.ns });
+    await browserApi.storage.local.get("one");
 
     const second = fakeNamespace();
     (globalThis as unknown as Record<string, unknown>).chrome = second.ns;
-    await executeScriptTarget(2, ["pageHook.js"]);
+    await browserApi.storage.local.get("two");
 
-    expect(first.calls).toHaveLength(1);
-    expect(second.calls).toHaveLength(1);
+    expect(first.calls).toEqual(["one"]);
+    expect(second.calls).toEqual(["two"]);
   });
 
   it("throws a clear error when neither namespace exists", async () => {


### PR DESCRIPTION
Follow-up to #275, which shipped the Firefox port with one deliberate gap.

## The problem

`manifest-firefox.json` admitted Firefox 121, so `world: "MAIN"` had to be omitted from the pageHook injection — Firefox only gained MAIN-world support for `scripting.executeScript` in [128](https://blog.mozilla.org/addons/2024/07/10/manifest-v3-updates-landed-in-firefox-128/). The shim's comment framed that as falling back to the DOM scrape, and the code read like a graceful degradation.

It wasn't one. Injection *succeeded* — into the isolated world, where the hook wraps the content script's own `fetch`, an object no page script ever calls. So on Firefox the hook installed, posted `dfir-companion-hook-ready`, the content script answered with the adapter's URL patterns, and then no capture ever arrived. `latest ?? scrapeVisibleTable()` quietly took over, so analysts got the visible DOM rows with none of the NDJSON or compressed-bfetch decoding that #102 was built for. No error, no warning, no log line.

A failed injection degrades safely. A successful injection into the wrong world does not, and that distinction is what the original comment missed.

## The fix

Raise `strict_min_version` to `128.0`. Every Firefox that can install the add-on then supports MAIN, so the injection is unconditional and byte-identical on both runtimes.

That makes `executeScriptTarget()` dead weight — it existed only to branch on this — so it's gone, and `injectHook()` is back to the plain `executeScript` call it was before the port. `isFirefox()` stays; `popup.ts` still needs it for the shortcuts page.

Firefox 128 is the current ESR (July 2024), so the floor isn't a real constraint for the analysts running this.

## Guards

Losing this is silent, so it's pinned from both ends: one test asserts `strict_min_version >= 128`, another asserts `injectHook` still requests `world: "MAIN"`. I verified each by reverting it independently — either one alone reproduces the quiet-no-capture bug.

The second reads `serviceWorker.ts` as source rather than importing it, since that module registers listeners at import time and can't be loaded without standing up the whole extension environment.

## Verification

- `npm run typecheck` — clean, exit 0
- `npm test` — 182 passed
- `npm run build` and `npm run build:firefox` — both succeed

Not verified: I have no Firefox to hand, so the MAIN-world injection is confirmed by docs and by the tests above, not by watching a capture land in a real profile. Worth one manual pass on a Velociraptor or Splunk console before the first AMO submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)