### PR TITLE
fix(state): say the whole case is unreadable past the ~512 MB ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Clearer error when a case's state file passes the ~512 MB load ceiling** — says the whole case is unreadable rather than just new imports, prints the absolute `state/backups/` path, and states the limit is permanent now that the SQLite-backed store (#237) is not planned.
+
 ## [0.33.0] - 2026-07-24
 
 ### Added

--- a/companion/src/analysis/stateStore.ts
+++ b/companion/src/analysis/stateStore.ts
@@ -50,12 +50,19 @@ export class StateStore {
       // A state file past the ~512 MB max string length can never be decoded again, so every
       // route that loads the case fails with an opaque RangeError and the case looks bricked.
       // Say so explicitly and name the recovery path (mirrors the 413 the import route returns
-      // for an oversized input file, so the two limits read as the same limit).
+      // for an oversized input file, so the two limits read as the same limit). This ceiling is
+      // permanent: the SQLite-backed store that would have lifted it (#237) was closed as not
+      // planned, so the message must not imply a bigger backend is coming.
       if (isTooLargeToDecode(err)) {
+        const backups = join(this.cases.stateDir(caseId), "backups");
         throw new Error(
-          `case "${caseId}" state file is too large to load: ${this.path(caseId)} exceeds the ~512 MB in-memory limit ` +
-            `(roughly 900K events). Restore an earlier, smaller snapshot from the case's state/backups/ dir, ` +
-            `or split the investigation across cases and re-import — no further imports into this case can be loaded.`,
+          `case "${caseId}" cannot be opened: its state file is too large to load. ` +
+            `${this.path(caseId)} has passed V8's ~512 MB max string length (roughly 900K events), so nothing in the ` +
+            `case is readable — timeline, findings, IOCs and reports are all unreachable, not just new imports. ` +
+            `This is a hard ceiling of the JSON state store and there is no larger-capacity backend, so the file ` +
+            `will not become loadable on its own. Recover by restoring the newest backup still under that size from ` +
+            `${backups}, then carry the investigation forward in a second case; re-importing into this one fails ` +
+            `the same way.`,
         );
       }
       throw err;


### PR DESCRIPTION
Follow-up to closing #237 as not planned.

`StateStore.load` told the analyst "no further imports into this case can be loaded" when `investigation.json` passed V8's ~512 MB max string length. That understates the failure: every route that loads the case throws, so the timeline, findings, IOCs and reports are all unreachable, not just new imports. An analyst reading the old text could reasonably think their existing work was still accessible.

## Changes
- Leads with "cannot be opened" and spells out that nothing in the case is readable.
- Prints the resolved `state/backups/` absolute path instead of naming it relatively, matching how the state file path is already printed.
- States the ceiling is permanent. With the SQLite-backed store (#237) closed as not planned, "split across cases" is the answer rather than a stopgap, so the message says the file will not become loadable on its own. The code comment records the #237 closure so the wording does not get softened back.

## Testing
- `npx tsc --noEmit` clean.
- `npx vitest run tests/analysis/stateStore.test.ts` 8/8 passing. The existing assertions on the message text (`too large to load`, `512 MB`, the case id, `backup`) all still match.
- Grepped for other references to the old wording; none outside the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)