### PR TITLE
fix(import): stop a forged __proto__ column from suppressing real Elastic fields

### DIFF
--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -74,6 +74,13 @@ type Row = Record<string, unknown>;
 // the DOTTED form ("__proto__.<x>") walks a step in before writing, so every segment must be checked.
 const DANGEROUS_SEGMENT = new Set(["__proto__", "constructor", "prototype"]);
 
+// Assign an OWN data property without invoking a setter. Plain `obj[key] = val` on the key
+// "__proto__" runs Object.prototype's prototype setter instead of storing anything, which hands an
+// attacker control of `obj`'s prototype; for every other key the observable result is identical.
+function safeSet(obj: Row, key: string, val: unknown): void {
+  Object.defineProperty(obj, key, { value: val, writable: true, enumerable: true, configurable: true });
+}
+
 // Expand dotted keys into nested objects: { "Detection.StringHit": x } → { Detection: { StringHit: x } }.
 // Collision-safe: a flat key is kept as-is when a needed branch already holds a leaf (or vice-versa).
 function unflattenDotted(row: Row): Row {
@@ -112,8 +119,8 @@ function normalizeElasticRow(row: Row): Row {
   const collapsed: Row = {};
   for (const [k, v] of Object.entries(row)) {
     const bare = k.replace(/\.(keyword|text|raw)$/i, "");
-    if (bare !== k) { if (!(bare in collapsed) && !(bare in row)) collapsed[bare] = v; }
-    else collapsed[k] = v;
+    if (bare !== k) { if (!(bare in collapsed) && !(bare in row)) safeSet(collapsed, bare, v); }
+    else safeSet(collapsed, k, v);
   }
   // 2) Un-flatten the remaining dotted keys to nested objects.
   const nested = unflattenDotted(collapsed);

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -225,6 +225,26 @@ describe("parseVelociraptorJson — prototype-pollution hardening (forged dotted
     expect(r.events[0].severity).toBe("High");             // "psexec" keyword — proves Detection.StringHit unflattened into the verdict
     expect(r.events[0].description).toContain("PsExec.exe");
   });
+
+  // The multi-field collapse in normalizeElasticRow runs BEFORE unflattenDotted and does its own
+  // bracket assignment plus `bare in collapsed` membership tests. A forged bare "__proto__" column
+  // carrying an object would set that accumulator's prototype, so every subsequent `in` test consults
+  // the attacker's object — silently discarding the real ".keyword" columns whose bare names it names.
+  it("a forged bare '__proto__' column cannot suppress a benign '.keyword' column via the collapse step", () => {
+    const row = JSON.parse(String.raw`{
+      "__proto__": { "Artifact": "attacker-suppressed", "EntryPath": "attacker-suppressed" },
+      "_index": "artifact_detectraptor_windows_detection_mft",
+      "@timestamp": "2026-05-07T16:03:56.000Z",
+      "Detection.StringHit": "PsExec.exe",
+      "Artifact.keyword": "DetectRaptor.Windows.Detection.MFT",
+      "EntryPath.keyword": "c:\\tools\\psexec.exe"
+    }`);
+    const r = parseVelociraptorJson(JSON.stringify([row]));
+    // The real Artifact/EntryPath values still reach the event — not dropped by a poisoned `in` test.
+    expect(r.events[0].description).toContain("DetectRaptor MFT detection:");
+    expect(r.events[0].description).toContain("PsExec.exe");
+    expect(r.events[0].description).not.toContain("attacker-suppressed");
+  });
 });
 
 // DetectRaptor-style "*.Detection.*" artifacts carry the verdict in a `Detection`/`RuleName`

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -10605,8 +10605,7 @@
         .then(result => {
           const section = (label, content, color) =>
             content ? `<div class="explain-section"><strong>${label}</strong><span style="color:${color || "var(--c-c9d1d9)"}">${esc(content)}</span></div>` : "";
-          const qhtml = (result.pivotQueries || []).map((q, i) => {
-            const uid = "exq" + i + "_" + Date.now();
+          const qhtml = (result.pivotQueries || []).map((q) => {
             return `<div class="hunt-card">`
               + `<div class="hunt-card-head"><span>${esc(q.platform || "query")}</span>`
               + `<button class="hunt-copy" data-q="${escAttr(q.query)}">Copy</button></div>`


### PR DESCRIPTION
Follow-up to #282, from reviewing it. Plus one dead-code removal spotted in #281.

## 1. The `normalizeElasticRow` collapse-step gap

`#282` guarded both `unflattenDotted` sinks, but the **multi-field collapse that runs before them** does its own bracket assignment:

```ts
if (bare !== k) { if (!(bare in collapsed) && !(bare in row)) collapsed[bare] = v; }
else collapsed[k] = v;
```

A page-forgeable row (`POST /cases/:id/import`) carrying a bare `"__proto__"` column whose value is an object sets `collapsed`'s prototype. Every subsequent `bare in collapsed` test then consults the attacker's object, so the real `.keyword` columns it names are silently dropped.

**This is a data-integrity bug, not a pollution bug.** #282 already stopped the global `Object.prototype` write. What remained is an attacker making genuine forensic fields disappear from an imported row — quieter, and worse in a DFIR tool, because evidence goes missing with no error surfaced.

### Test first

The test was written before the fix and failed for exactly this reason:

```
Expected: "DetectRaptor MFT detection:"
Received: "Velociraptor [detectraptor_windows_detection_mft] detection: PsExec.exe"
```

The forged column suppressed `Artifact.keyword`, so the event fell back to the index-derived label.

### Fix

Assign via `Object.defineProperty` (`safeSet`), mirroring the helper #282 added on the extension side. For every non-`__proto__` key the observable result is identical.

## 2. Dead `uid` in the explain panel

`public/dashboard.html` — assigned, never read. Its `map` index param existed only to build it, so that goes too. No behaviour change.

## Verification

- Companion suite: **418 files / 5070 tests pass**
- `tsc --noEmit` clean
- New test fails without the fix, passes with it

## Not done, deliberately

I started hardening the `in` membership tests to own-property checks, since `in` walks the prototype chain. I couldn't write an honest failing test: no legitimate Velociraptor or Elasticsearch column is named `constructor` or `valueOf`, and with `safeSet` in place the prototype can no longer be swapped — so it's cosmetic. I dropped the test rather than reshape an assertion to justify the change. Happy to do it as a labelled refactor if wanted.

Still outstanding from the #281/#282 reviews: **no CSP is served anywhere**, which is what made #281 critical rather than cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)