### PR TITLE
test: fix three flaky tests at the root, not by raising timeouts

### DIFF
--- a/companion/tests/analysis/loadTest.test.ts
+++ b/companion/tests/analysis/loadTest.test.ts
@@ -258,16 +258,27 @@ function buildSyntheticState(eventCount: number, iocCount: number): Investigatio
 
 interface Measurement { ms: number; result: unknown }
 
-// Best of N runs. Contention and GC can only ever ADD time, so the minimum is the closest
-// estimate of the code's own cost and — unlike a single sample — one scheduler stall can't
-// skew it.
+// Best of N runs, measured in CPU time rather than wall clock.
+//
+// Wall clock counts every millisecond this process spends descheduled while some other test
+// worker holds the core, so under a loaded machine it reports the machine's contention, not the
+// code's cost. Best-of-N was meant to absorb that, and does when a stall is occasional — but it
+// only helps if SOME sample runs clean, and the full-size run is GROWTH_FACTOR times longer than
+// the baseline, so under sustained load it is proportionally likelier that every one of its
+// samples is hit while the short baseline escapes. That asymmetry inflates the ratio and fails
+// the assertion for reasons that have nothing to do with the code under test.
+//
+// process.cpuUsage() counts only cycles actually burned on this process's behalf, so time spent
+// waiting for a core simply isn't counted. Every measured fn here is synchronous, so nothing else
+// in this worker can run inside the window and contribute. Same minimum-of-N, honest clock.
 function bestOf(fn: () => unknown, repeats: number): Measurement {
   let ms = Infinity;
   let result: unknown;
   for (let i = 0; i < repeats; i++) {
-    const t0 = performance.now();
+    const start = process.cpuUsage();
     result = fn();
-    const elapsed = performance.now() - t0;
+    const { user, system } = process.cpuUsage(start);
+    const elapsed = (user + system) / 1000;   // microseconds → milliseconds
     if (elapsed < ms) ms = elapsed;
   }
   return { ms, result };

--- a/companion/tests/server/backupManager.test.ts
+++ b/companion/tests/server/backupManager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import request from "supertest";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { JobManager } from "../../src/analysis/jobManager.js";
@@ -52,6 +52,43 @@ describe("resolveBackupConfig", () => {
 });
 
 // ── BackupManager with real temp dirs ────────────────────────────────────────
+
+/**
+ * A minimal in-memory stand-in for the fs calls BackupManager makes, for the one test whose cost
+ * is dominated by disk churn rather than by what it asserts. Deliberately faithful on the two
+ * behaviours the manager actually depends on: readFile raises ENOENT for a missing snapshot file
+ * (createBackup skips those), and readdir lists only the immediate children of a directory.
+ */
+function memoryFs(): Required<BackupManagerDeps> {
+  const files = new Map<string, string>();
+  const enoent = (path: string): NodeJS.ErrnoException =>
+    Object.assign(new Error(`ENOENT: no such file or directory, open '${path}'`), { code: "ENOENT" });
+  return {
+    mkdir: async () => undefined,
+    atomicWrite: async (path, content) => { files.set(path, content); },
+    readFile: async (path) => {
+      const content = files.get(path);
+      if (content === undefined) throw enoent(path);
+      return content;
+    },
+    readdir: async (dir) => {
+      const prefix = dir.endsWith(sep) ? dir : dir + sep;
+      const names = new Set<string>();
+      for (const path of files.keys()) {
+        if (!path.startsWith(prefix)) continue;
+        const rest = path.slice(prefix.length);
+        if (!rest.includes(sep)) names.add(rest);   // immediate children only
+      }
+      return [...names];
+    },
+    stat: async (path) => {
+      const content = files.get(path);
+      if (content === undefined) throw enoent(path);
+      return { size: Buffer.byteLength(content, "utf8"), mtimeMs: 0 };
+    },
+    unlink: async (path) => { files.delete(path); },
+  };
+}
 
 async function makeManager(config: Partial<BackupConfig> = {}): Promise<{ mgr: BackupManager; store: CaseStore; root: string }> {
   const root = await mkdtemp(join(tmpdir(), "dfir-backup-"));
@@ -201,8 +238,14 @@ describe("BackupManager.pruneBackups", () => {
     const cfg = resolveBackupConfig({ DFIR_STATE_BACKUP_RETAIN: "0", DFIR_STATE_BACKUP_PRE_SYNTH_RETAIN: "0" });
     const root = await mkdtemp(join(tmpdir(), "dfir-backup-"));
     const store = new CaseStore(root);
-    const mgr = new BackupManager(store, cfg);
-    const caseId = await makeCase(store);
+    // In-memory fs for this one case. What is under test is the PRUNE ARITHMETIC over 105
+    // backups — that an unlimited request still caps at RETAIN_FALLBACK_CAP — and none of that
+    // is about disk semantics (the real-fs path is covered by every other test in this file).
+    // Done against the real filesystem it costs ~4s of write+readdir+stat churn on an idle
+    // machine, which left no headroom inside the 15s budget once other suites competed for the
+    // disk, and the test timed out. The deps seam exists exactly for this.
+    const mgr = new BackupManager(store, cfg, memoryFs());
+    const caseId = "unlimited-retain-case";
 
     for (let i = 0; i < RETAIN_FALLBACK_CAP + 5; i++) {
       const hh = String(Math.floor(i / 60)).padStart(2, "0");

--- a/companion/tests/server/dropFolderSymlink.test.ts
+++ b/companion/tests/server/dropFolderSymlink.test.ts
@@ -72,17 +72,30 @@ async function runDropSweep(caseId: string, dropDir: string, seedSecretLinks: (d
     // A normal, legitimately-dropped file alongside it — proves the guard doesn't over-block.
     await writeFile(join(caseDropDir, "evidence.json"), VELO_EVIDENCE, "utf8");
 
+    // The poller needs two 2s cycles (seen, then imported), so several seconds pass here even on
+    // an idle machine. Wait against a wall-clock DEADLINE rather than a fixed iteration count: a
+    // loaded machine should get the same amount of time, not the same number of 50ms tries.
+    const deadline = Date.now() + 20_000;
+    const settle = (): Promise<unknown> => new Promise((r) => setTimeout(r, 50));
+
     let jobs: { kind: string; label?: string }[] = [];
-    for (let i = 0; i < 200 && !jobs.some((j) => j.kind === "import"); i++) {
-      await new Promise((r) => setTimeout(r, 50));
+    while (Date.now() < deadline && !jobs.some((j) => j.kind === "import")) {
+      await settle();
       jobs = jobManager.list(caseId);
     }
     expect(jobs.some((j) => j.kind === "import")).toBe(true);
-    // Give the sweep a moment past job completion to finish writing state/moving files.
-    await new Promise((r) => setTimeout(r, 200));
 
-    const state = await stateStore.load(caseId);
-    const haystack = JSON.stringify(state);
+    // Then wait for the CONDITION the assertions actually need — the legitimate detection having
+    // landed in state — rather than sleeping a fixed 200ms past job creation and hoping the write
+    // finished. The job appearing is not the same event as the state being written, so under load
+    // that sleep could expire early and the failure surfaced as a baffling content assertion
+    // ("Bad" missing) rather than as the timing problem it was.
+    let haystack = "";
+    while (Date.now() < deadline) {
+      haystack = JSON.stringify(await stateStore.load(caseId));
+      if (haystack.includes("Bad")) break;
+      await settle();
+    }
     return { caseDropDir, haystack };
   } finally {
     if (prevPoll === undefined) delete process.env.DFIR_DROP_POLL_S;
@@ -101,7 +114,7 @@ describe("drop-folder auto-importer — symlink/hardlink rejection (#243)", () =
     // it was dropped — never moved to _processed/ or _failed/.
     const remaining = await readdir(caseDropDir);
     expect(remaining).toContain("innocuous.json");
-  }, 15000);
+  }, 30_000);
 
   it("never reads a hardlink's target content into the case, but still imports a normal file", async () => {
     const { caseDropDir, haystack } = await runDropSweep("c2", "drop", async (dropDir, secretFile) => {
@@ -111,5 +124,5 @@ describe("drop-folder auto-importer — symlink/hardlink rejection (#243)", () =
     expect(haystack).toContain("Bad");
     const remaining = await readdir(caseDropDir);
     expect(remaining).toContain("innocuous2.json");
-  }, 15000);
+  }, 30_000);
 });


### PR DESCRIPTION
Follow-up to the security PRs, where these kept producing ambiguous red builds. They failed intermittently with a **different set each run** — the signature of load sensitivity, not a shared bug. Three tests, three genuinely different root causes.

## 1. `backupManager` — "still prunes when the operator asks for unlimited retention"

Creates 105 backups against the real filesystem, and every `createBackup` also prunes, which `readdir`s and `stat`s the whole directory. **Measured 4.0s on an idle machine**, leaving no headroom inside the 15s budget once other suites competed for the disk.

What it asserts is prune *arithmetic* — that an unlimited request still caps at `RETAIN_FALLBACK_CAP`. None of that is about disk semantics, so it now runs against the `BackupManagerDeps` seam (already imported by this file, never used). Real-fs coverage is unchanged: every other test in the file still uses a temp dir.

File went from timing out to **3.2s**.

## 2. `loadTest` — "scales sub-quadratically" (×2)

Measured **wall clock**, which counts every millisecond the process spends descheduled while another worker holds the core.

Best-of-N was meant to absorb that, and does for an occasional stall — but it only helps if *some* sample runs clean, and the full-size run is 8× longer than the baseline, so under sustained load its samples are proportionally likelier to **all** be hit while the short baseline escapes. That asymmetry inflates the ratio by itself.

Now measured with `process.cpuUsage()`, which counts only cycles actually burned on this process's behalf. Every measured fn here is synchronous, so nothing else in the worker can contribute.

**Verified by running both versions under an identical 16-CPU-hog load on 8 cores:**

| | baseline | full | ratio | verdict |
|---|---|---|---|---|
| Wall clock | 5.1ms | 325.5ms | **63.7×** | ❌ fails (limit 32) |
| CPU time | 13.8ms | 96.9ms | **7.0×** | ✅ passes |

The mechanism is visible in the numbers: the contended baseline came out at **5.1ms — faster than its own idle measurement** — while the long run absorbed the contention. Idle ratios are unchanged.

## 3. `dropFolderSymlink`

The poller needs two 2s cycles, and the test's own wait budget (200 × 50ms = 10s) nearly equalled its 15s timeout.

It also slept a fixed 200ms after the import job appeared, then read state. But **the job appearing is not the same event as the state being written**, so under load that sleep expired early and the failure surfaced as a baffling content assertion (`"Bad"` missing) rather than the timing problem it actually was.

Both waits are now deadline-based and poll for the real condition. The 15s → 30s bump is a *consequence* of the 20s internal deadline, not the fix.

## What I deliberately did not do

**Raise timeouts and move on.** That would leave `backupManager` burning 4s of I/O it doesn't need and `loadTest` still measuring the machine rather than the code — both would flake again on a busier CI box. Only one timeout changed, and only as a knock-on of making that test's waiting deadline-based.

## Verification

- All three pass under **16 CPU hogs on 8 cores** (3× oversubscription) — the condition that broke them
- Full companion suite: **421 files / 5107 tests, zero failures** — against 1 and then 4 shifting failures on this same machine beforehand
- `tsc --noEmit` clean

## One follow-up worth knowing

`loadTest`'s ratios shift slightly under CPU-time measurement (`correlateEvents` now reads 7–10× rather than the 12.8–14.4× recorded in the file's comment). The `GROWTH_LIMIT = 32` headroom is unaffected, but that comment now describes wall-clock figures the code no longer produces. I left it rather than rewrite documented baselines off a handful of local runs — worth updating once CI has produced a few.

🤖 Generated with [Claude Code](https://claude.com/claude-code)