### PR TITLE
docs(test): re-baseline loadTest's growth figures against CPU time

### DIFF
--- a/companion/tests/analysis/loadTest.test.ts
+++ b/companion/tests/analysis/loadTest.test.ts
@@ -10,13 +10,21 @@ import { emptyReportMeta } from "../../src/reports/reportMeta.js";
 // Performance / load test for issue #183: a synthetic 10k-event case exercising the hot
 // deterministic paths. No AI calls, no I/O, no network — pure in-memory benchmarking.
 //
-// These tests assert almost no absolute wall-clock budget. Under a full parallel
-// `vitest run` every worker competes for the same cores, and the same unchanged code
-// measures 2-3x slower than it does in isolation — so an absolute threshold either flakes
-// (renderMarkdownReport: ~3.5s alone, 5.5s contended, against a 5s budget) or is loosened
-// until it can no longer catch anything. Instead each hot path is timed against ITSELF at
-// two input sizes: contention inflates both measurements, so the growth RATIO stays stable
-// while still separating linear growth from a quadratic regression. See expectSubQuadratic.
+// These tests assert almost no absolute time budget. Under a full parallel `vitest run` every
+// worker competes for the same cores, and the same unchanged code measures 2-3x slower than it
+// does in isolation — so an absolute threshold either flakes (renderMarkdownReport: ~3.5s alone,
+// 5.5s contended, against a 5s budget) or is loosened until it can no longer catch anything.
+// Instead each hot path is timed against ITSELF at two input sizes, and only the growth RATIO is
+// asserted. See expectSubQuadratic.
+//
+// The ratio alone is NOT enough to make this robust, which cost a round of flakes to learn. The
+// original reasoning — "contention inflates both measurements, so the ratio stays stable" — is
+// wrong: the full-size run is GROWTH_FACTOR times longer than the baseline, so it is
+// proportionally likelier to be descheduled, and best-of-N only rescues a measurement if SOME
+// sample runs clean. Under sustained load the short baseline escaped while the long run did not,
+// and correlateEvents reported 63.7x against a limit of 32 — a pure artefact. bestOf therefore
+// measures process.cpuUsage(), not wall clock, so time spent waiting for a core is never counted
+// and the ratio reflects the code rather than the machine. Every figure below is CPU-time.
 //
 // Grow ONE dimension at a time. Scaling events, IOCs and findings together makes a path
 // that is merely linear in (events x iocs) look quadratic in events — renderMarkdownReport
@@ -285,14 +293,26 @@ function bestOf(fn: () => unknown, repeats: number): Measurement {
 }
 
 // How much slower the same code may get when its input grows GROWTH_FACTOR (8x) along one
-// dimension. Linear work costs 8x; a quadratic regression costs 64x. Measured today:
-// renderMarkdownReport 7.1x and filterEventsByScope ~8x (linear), buildSynthesisContext
-// 3.7-7.7x in IOC count (linear), correlateEvents 12.8-14.4x (~n^1.25, sort + windowed
-// scan). 32 leaves 2x of headroom over the slowest of those and sits 2x below quadratic.
+// dimension. Linear work costs 8x; a quadratic regression costs 64x.
+//
+// Measured in CPU time over 6 idle runs (ratio range, and how much of its own allowance the
+// WORST of those runs actually used — the allowance being baseline*GROWTH_LIMIT + FLOOR_MS):
+//   buildSynthesisContext  2.5-4.4x  in IOC count (linear)          worst run used 13%
+//   renderMarkdownReport   4.2-5.9x  (linear)                       worst run used 18%
+//   filterEventsByScope    7.7-13.7x (linear; ~1ms baseline, noisy) worst run used 20%
+//   correlateEvents        7.4-18.2x (~n^1.25, sort + windowed scan) worst run used 49%
+//
+// Read the ratio spread and the allowance column together. correlateEvents touching 18x looks
+// close to 32, but its high ratios come from runs where the BASELINE landed near 5ms, and there
+// FLOOR_MS dominates the limit — so the assertion still had 2.1x of room. Every path keeps at
+// least 2x, and 32 stays 2x below the 64x a genuinely quadratic path would cost.
 const GROWTH_LIMIT = 32;
-// Absolute slack, so a sub-millisecond baseline (where timer resolution dominates and the
-// ratio is meaningless) can't fail the assertion on noise alone. Any genuinely quadratic
-// path costs far more than this at 10k events, so it does not blunt the check.
+// Absolute slack (CPU-ms), so a very small baseline — where measurement resolution and JIT
+// variance dominate and the ratio stops meaning anything — can't fail the assertion on noise
+// alone. This carries more weight than it looks: it is what keeps the cheap paths, and
+// correlateEvents on its fastest-baseline runs, comfortably inside the limit even when their raw
+// ratio spikes. Any genuinely quadratic path costs far more than this at 10k events, so it does
+// not blunt the check.
 const FLOOR_MS = 25;
 
 interface Growth { baseline: Measurement; full: Measurement; label: string; dimension: string }


### PR DESCRIPTION
Closes the follow-up I flagged in #310. **Comment-only** — zero non-comment lines changed, verified mechanically.

#310 switched `bestOf` from wall clock to `process.cpuUsage()` but left the surrounding comments describing wall-clock measurements the code can no longer produce.

## Two things were actually wrong, not merely stale

**The header justified the whole approach with reasoning #310 disproved:**

> "contention inflates both measurements, so the growth RATIO stays stable"

That is precisely what failed. The full-size run is 8× longer than the baseline, so it is proportionally likelier to be descheduled, and best-of-N only rescues a measurement if *some* sample runs clean. The comment now says so, and records the number that made it concrete — correlateEvents reporting **63.7× under load against a limit of 32** — so the next person doesn't have to re-derive it from a flake.

**`GROWTH_LIMIT`'s recorded figures were wall-clock.** Re-measured over 6 idle runs:

| path | ratio range | worst run used |
|---|---|---|
| `buildSynthesisContext` | 2.5–4.4× | 13% of allowance |
| `renderMarkdownReport` | 4.2–5.9× | 18% |
| `filterEventsByScope` | 7.7–13.7× | 20% |
| `correlateEvents` | 7.4–18.2× | 49% |

## Why the table has a second column

The ratio spread alone reads alarmingly for `correlateEvents` — 18× against a limit of 32 looks like one bad run from failing. So the table also records how much of the *real* allowance (`baseline*GROWTH_LIMIT + FLOOR_MS`) each path's worst run actually consumed.

Those high ratios come from runs where the baseline landed near 5ms, and there `FLOOR_MS` dominates the limit — so the assertion still had **2.1× of room**. The documented "2× headroom" claim survives; it just isn't visible from the ratio alone. `FLOOR_MS`'s own comment now reflects that it carries real weight, rather than presenting itself as a minor guard against sub-millisecond noise.

## On the numbers

Ranges are what was observed, not rounded. The 6th run put `buildSynthesisContext` at 2.5×, below the 2.9× low bound the first 5 suggested — I widened the range to match rather than leave a figure my own next run contradicted.

`tsc --noEmit` clean; loadTest 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)