### PR TITLE
fix(ws): attach error handler, ping/reaper, and guard send() so dead/half-open peers no longer crash the server

### DIFF
--- a/companion/src/live/hub.ts
+++ b/companion/src/live/hub.ts
@@ -4,6 +4,12 @@ export interface SocketLike {
   readyState: number;
   OPEN: number;
   send(data: string): void;
+  /** Optional ping/pong/terminate — present on real `ws.WebSocket`s, absent on test fakes. */
+  ping?(data?: unknown): void;
+  pong?(data?: unknown): void;
+  terminate?(): void;
+  on?(event: "pong", listener: () => void): unknown;
+  isAlive?: boolean;
 }
 
 export class LiveHub {
@@ -17,6 +23,26 @@ export class LiveHub {
 
   unsubscribe(caseId: string, socket: SocketLike): void {
     this.subs.get(caseId)?.delete(socket);
+    if (this.subs.get(caseId)?.size === 0) this.subs.delete(caseId);
+  }
+
+  /** For the ping/reaper: every socket that has not ponged since the last sweep is dead. */
+  sweepReaper(): void {
+    for (const set of this.subs.values()) {
+      for (const socket of set) {
+        if (socket.isAlive === false) {
+          socket.terminate?.();
+          set.delete(socket);
+          continue;
+        }
+        socket.isAlive = false;
+        try { socket.ping?.(); } catch { set.delete(socket); }
+      }
+      if (set.size === 0) {
+        const caseId = [...this.subs.entries()].find(([, s]) => s === set)?.[0];
+        if (caseId) this.subs.delete(caseId);
+      }
+    }
   }
 
   broadcast(state: InvestigationState): void {
@@ -29,8 +55,14 @@ export class LiveHub {
     if (!set) return;
     const data = JSON.stringify(message);
     for (const socket of set) {
-      if (socket.readyState === socket.OPEN) socket.send(data);
-      else set.delete(socket);
+      if (socket.readyState !== socket.OPEN) { set.delete(socket); continue; }
+      try {
+        socket.send(data);
+      } catch {
+        // send to a just-dead peer throws on ws; contain it instead of crashing the process.
+        set.delete(socket);
+        socket.terminate?.();
+      }
     }
   }
 
@@ -41,8 +73,13 @@ export class LiveHub {
     const data = JSON.stringify(message);
     for (const set of this.subs.values()) {
       for (const socket of set) {
-        if (socket.readyState === socket.OPEN) socket.send(data);
-        else set.delete(socket);
+        if (socket.readyState !== socket.OPEN) { set.delete(socket); continue; }
+        try {
+          socket.send(data);
+        } catch {
+          set.delete(socket);
+          socket.terminate?.();
+        }
       }
     }
   }

--- a/companion/src/live/hub.ts
+++ b/companion/src/live/hub.ts
@@ -28,7 +28,7 @@ export class LiveHub {
 
   /** For the ping/reaper: every socket that has not ponged since the last sweep is dead. */
   sweepReaper(): void {
-    for (const set of this.subs.values()) {
+    for (const [caseId, set] of this.subs) {
       for (const socket of set) {
         if (socket.isAlive === false) {
           socket.terminate?.();
@@ -36,12 +36,16 @@ export class LiveHub {
           continue;
         }
         socket.isAlive = false;
-        try { socket.ping?.(); } catch { set.delete(socket); }
+        // A ping to an already-dead peer throws; that socket is gone, so close it out the same
+        // way the broadcast paths do rather than dropping the reference and leaking the handle.
+        try {
+          socket.ping?.();
+        } catch {
+          set.delete(socket);
+          socket.terminate?.();
+        }
       }
-      if (set.size === 0) {
-        const caseId = [...this.subs.entries()].find(([, s]) => s === set)?.[0];
-        if (caseId) this.subs.delete(caseId);
-      }
+      if (set.size === 0) this.subs.delete(caseId);
     }
   }
 

--- a/companion/src/live/wsGate.ts
+++ b/companion/src/live/wsGate.ts
@@ -98,6 +98,9 @@ export function attachLiveSocket(server: Server, hub: LiveHub, deps: WsUpgradeDe
   const reaper = setInterval(() => hub.sweepReaper(), REAPER_INTERVAL_MS);
   // Don't keep the process alive just for the reaper (tests rely on the event loop emptying).
   if (typeof reaper.unref === "function") reaper.unref();
+  // Stop sweeping once this server is closed, so a test (or a /settings/reload) that attaches a
+  // second WebSocketServer doesn't leave the first one's timer pinging a hub nobody serves.
+  wss.on("close", () => clearInterval(reaper));
 
   server.on("upgrade", (req, socket, head) => {
     // Only claim our own path; anything else is left for another handler to answer (or to time out).

--- a/companion/src/live/wsGate.ts
+++ b/companion/src/live/wsGate.ts
@@ -88,6 +88,17 @@ export async function authorizeWsUpgrade(req: WsUpgradeRequest, deps: WsUpgradeD
 export function attachLiveSocket(server: Server, hub: LiveHub, deps: WsUpgradeDeps): WebSocketServer {
   const wss = new WebSocketServer({ noServer: true });
 
+  // Ping/reaper: every 30s, mark each socket dead (isAlive=false), ping it, and let the pong
+  // handler flip it back alive. On the NEXT sweep, anything still dead is terminated and dropped
+  // from the hub. Without this a client that vanishes without a close frame (laptop sleep, NAT
+  // timeout, Wi-Fi loss — common for a localhost dashboard left open) lingers in `hub.subs`
+  // forever (memory leak) and the next broadcast's `send()` to the half-open socket throws an
+  // unhandled 'error' on the WebSocket (no error listener was attached) → process crash.
+  const REAPER_INTERVAL_MS = 30_000;
+  const reaper = setInterval(() => hub.sweepReaper(), REAPER_INTERVAL_MS);
+  // Don't keep the process alive just for the reaper (tests rely on the event loop emptying).
+  if (typeof reaper.unref === "function") reaper.unref();
+
   server.on("upgrade", (req, socket, head) => {
     // Only claim our own path; anything else is left for another handler to answer (or to time out).
     const path = new URL(req.url ?? "", "http://localhost").pathname;
@@ -103,8 +114,20 @@ export function attachLiveSocket(server: Server, hub: LiveHub, deps: WsUpgradeDe
         }
         const { caseId } = decision;
         wss.handleUpgrade(req, socket, head, (ws) => {
-          hub.subscribe(caseId, ws as unknown as SocketLike);
-          ws.on("close", () => hub.unsubscribe(caseId, ws as unknown as SocketLike));
+          const sock = ws as unknown as SocketLike;
+          // Track liveness for the ping/reaper: pong flips isAlive back to true.
+          sock.isAlive = true;
+          // ws attaches no default 'error' handler; an unhandled 'error' event (a send to a
+          // half-open peer, a protocol/RST error) would throw "Unhandled 'error' event" and
+          // kill the process. Contain it: log + drop from the hub so we stop broadcasting to it.
+          ws.on("error", () => {
+            try { ws.terminate(); } catch { /* already gone */ }
+            hub.unsubscribe(caseId, sock);
+          });
+          // pong handler: mark alive so the next reaper sweep doesn't terminate us.
+          ws.on("pong", () => { sock.isAlive = true; });
+          hub.subscribe(caseId, sock);
+          ws.on("close", () => hub.unsubscribe(caseId, sock));
           wss.emit("connection", ws, req);
         });
       })

--- a/companion/tests/live/hub.test.ts
+++ b/companion/tests/live/hub.test.ts
@@ -60,4 +60,53 @@ describe("LiveHub", () => {
     expect(JSON.parse(b.sent[0]).caseId).toBe("c1");
     expect(closed.sent).toHaveLength(0);
   });
+
+  it("broadcastTo contains a send() that throws (half-open peer) instead of crashing", () => {
+    const hub = new LiveHub();
+    const dead = fakeSocket();
+    dead.send = () => { throw new Error("not open"); };
+    const alive = fakeSocket();
+    let terminated = false;
+    dead.terminate = () => { terminated = true; };
+    hub.subscribe("c1", dead);
+    hub.subscribe("c1", alive);
+    expect(() => hub.broadcastTo("c1", { type: "state" })).not.toThrow();
+    expect(alive.sent).toHaveLength(1);
+    expect(terminated).toBe(true);
+  });
+
+  it("sweepReaper terminates sockets that never ponged since the last sweep", () => {
+    const hub = new LiveHub();
+    let terminated = false;
+    let pinged = false;
+    const s = fakeSocket();
+    s.isAlive = true;
+    s.ping = () => { pinged = true; };
+    s.terminate = () => { terminated = true; };
+    hub.subscribe("c1", s);
+    // First sweep: flip isAlive=false and ping.
+    hub.sweepReaper();
+    expect(pinged).toBe(true);
+    expect(terminated).toBe(false);
+    // Second sweep (no pong happened in between): isAlive still false → terminate + drop.
+    hub.sweepReaper();
+    expect(terminated).toBe(true);
+    // The dead socket is dropped from the hub; a subsequent broadcast is a no-op.
+    expect(() => hub.broadcastTo("c1", { type: "state" })).not.toThrow();
+    expect(s.sent).toHaveLength(0);
+  });
+
+  it("sweepReaper keeps a socket that ponged between sweeps", () => {
+    const hub = new LiveHub();
+    let terminated = false;
+    const s = fakeSocket();
+    s.isAlive = true;
+    s.ping = () => {};
+    s.terminate = () => { terminated = true; };
+    hub.subscribe("c1", s);
+    hub.sweepReaper();      // isAlive=false, ping sent
+    s.isAlive = true;       // pong handler fired
+    hub.sweepReaper();      // still alive → ping again, no terminate
+    expect(terminated).toBe(false);
+  });
 });


### PR DESCRIPTION
## Bug (HIGH — server crash on dead peer)
After admitting a `/ws` socket, only `ws.on('close')` was attached. No `ws.on('error')` (ws attaches no default no-op), no ping/pong, no idle reaper. A client that vanished without a close frame (laptop sleep, NAT timeout, Wi-Fi loss) lingered in `hub.subs` forever (memory leak), and the next broadcast's `socket.send()` to the half-open peer emitted an unhandled `'error'` event → process crash.

## Fix
- `ws.on('error')`: terminate + unsubscribe.
- Ping/reaper every 30s (unref'd): mark `isAlive=false`, ping, pong handler flips it back; next sweep terminates anything still false.
- Guard `broadcastTo`/`broadcastAll` `send()` in try/catch: a send to a just-dead peer throws on ws; contain it (drop + terminate) instead of crashing.
- Clean up empty case sets on unsubscribe.

## Verification
- `tsc --noEmit` clean.
- 23 live tests pass (was 20; +3 new: send-throw containment, reaper terminates dead socket, reaper keeps socket that ponged).

Found by end-to-end QA stress subagent.