### PR TITLE
fix(timesketch): don't delete an existing timeline on a zero-event push (silent data loss)

### DIFF
--- a/companion/src/integrations/timesketch/timesketchPush.ts
+++ b/companion/src/integrations/timesketch/timesketchPush.ts
@@ -87,23 +87,28 @@ async function pushEventsToTimesketch(
   // (non-fatal — if listing/deleting fails we still upload, but flag the possible duplication).
   // Matching by name is also what keeps the forensic and super-timeline pushes from clobbering
   // each other — they use different timelineName defaults within the same sketch.
+  // ONLY delete when we have events to replace it with — a zero-event push (all timestamps
+  // unparseable, or the source timeline is empty) must NOT destroy the existing timeline,
+  // otherwise a no-op re-push silently erases prior data with nothing to show for it.
   let replacedTimeline = false;
-  try {
-    for (const t of await client.listTimelines(sketch.id)) {
-      if (t.name === timelineName) {
-        await client.deleteTimeline(sketch.id, t.id);
-        replacedTimeline = true;
+  if (events.length) {
+    try {
+      for (const t of await client.listTimelines(sketch.id)) {
+        if (t.name === timelineName) {
+          await client.deleteTimeline(sketch.id, t.id);
+          replacedTimeline = true;
+        }
       }
+    } catch (err) {
+      warnings.push(`timeline cleanup: ${(err as Error).message} — a re-push may duplicate events`);
     }
-  } catch (err) {
-    warnings.push(`timeline cleanup: ${(err as Error).message} — a re-push may duplicate events`);
   }
 
   // 5. Upload (fatal on failure — the push has nothing else to do).
   if (events.length) {
     await client.uploadEvents(sketch.id, timelineName, jsonl);
   } else {
-    warnings.push("no events with a parseable timestamp to upload");
+    warnings.push("no events with a parseable timestamp to upload; existing timeline left untouched");
   }
 
   return {

--- a/companion/tests/integrations/timesketch.test.ts
+++ b/companion/tests/integrations/timesketch.test.ts
@@ -194,6 +194,22 @@ describe("pushCaseToTimesketch", () => {
     expect(m.uploads).toHaveLength(0);
     expect(res.warnings.some((w) => w.includes("no events with a parseable timestamp"))).toBe(true);
   });
+
+  it("does NOT delete an existing same-named timeline when there are no events to upload (data-loss guard)", async () => {
+    // A zero-event push (all timestamps unparseable, or the source timeline is empty) must be
+    // a no-op on the existing timeline, not a delete-without-replace. Previously the delete ran
+    // unconditionally before the upload guard, destroying prior data on a no-op re-push.
+    const m = new MockTimesketch();
+    m.sketches.push({ id: 42, name: "Case Beta" });
+    m.timelines.push({ id: 7, name: "DFIR-Companion Forensic Timeline" }); // prior data
+    const state = { ...emptyState("Case Beta"), forensicTimeline: [event({ timestamp: "bad", description: "x" })] };
+    const res = await pushCaseToTimesketch(m, { sketchName: "Case Beta", state });
+    expect(res.events).toBe(0);
+    expect(m.uploads).toHaveLength(0);
+    expect(m.deletedTimelines).not.toContain(7);          // prior timeline NOT deleted
+    expect(m.timelines.some((t) => t.id === 7)).toBe(true); // still present
+    expect(res.replacedTimeline).toBe(false);
+  });
 });
 
 describe("pushSuperTimelineToTimesketch", () => {


### PR DESCRIPTION
## Bug (HIGH — silent data loss in Timesketch)
A zero-event re-push (all timestamps unparseable, or the source timeline is empty) silently DELETED the existing same-named timeline and uploaded nothing. The deletion ran unconditionally before the `if (events.length)` upload guard.

## Fix
Only delete the existing same-named timeline when `events.length > 0`. A zero-event push is now a no-op on the existing timeline.

## Verification
- `tsc --noEmit` clean.
- 18 tests pass (+1 new data-loss-guard test asserting the prior timeline is NOT deleted and `replacedTimeline` is false).

Found by end-to-end QA integrations subagent.