### PR TITLE
fix(security): rate-limit brute-force on POST /captures too

### DIFF
--- a/companion/src/routes/captures.ts
+++ b/companion/src/routes/captures.ts
@@ -6,6 +6,7 @@ import { ingestCapture, CaseNotFoundError, InvalidImageError } from "../ingest/c
 import { searchOcrIndex, isOcrSearchEnabled } from "../analysis/ocrSearch.js";
 import { isValidCaseId } from "../storage/caseStore.js";
 import { parseCookieHeader, unlockCookieName, verifyUnlockToken, verifyCasePassword } from "../analysis/casePassword.js";
+import { getUnlockLimiter } from "../http/rateLimiter.js";
 import type { RouteContext } from "./context.js";
 
 // Content type for an evidence file served back to the dashboard. CSVs/text are
@@ -85,14 +86,35 @@ export function registerCaptureRoutes(app: Express, ctx: RouteContext): void {
         // analyst entered in the popup; the dashboard sends the unlock cookie. This prevents
         // a third party from injecting screenshots into a password-protected case.
         if (caseMeta?.password) {
+          // Rate-limit brute-force attempts on this second online-entry point too. /captures
+          // accepts a casePassword in the body and runs verifyCasePassword on it, so without
+          // this gate an attacker could hammer /captures thousands of times per hour with no
+          // lockout (the unlock limiter only covered POST /cases/:id/unlock). The scrypt KDF
+          // was kept weak (N=2^14) on the documented assumption that online attempts are
+          // rate-limited — so leaving /captures unthrottled defeated that assumption too.
+          const limiter = getUnlockLimiter();
+          const remaining = limiter.remainingLockout(rawCaseId);
+          if (remaining > 0) {
+            res.setHeader("Retry-After", String(Math.ceil(remaining / 1000)));
+            return res.status(429).json({ error: "too many failed attempts, try again later", retryAfterMs: remaining });
+          }
           const cookies = parseCookieHeader(req.headers.cookie);
           const token = cookies[unlockCookieName(rawCaseId)];
           const cookieOk = token && verifyUnlockToken(token, rawCaseId, caseMeta.password.salt, ctx.instanceSecret);
           const bodyPassword = typeof req.body?.casePassword === "string" ? req.body.casePassword : "";
           const passwordOk = bodyPassword && verifyCasePassword(bodyPassword, caseMeta.password);
           if (!cookieOk && !passwordOk) {
+            // Record the failure in the SHARED limiter so /captures and /unlock attempts count
+            // together toward lockout — an attacker can't rotate endpoints to reset the budget.
+            const lockout = limiter.recordFailure(rawCaseId);
+            if (lockout > 0) {
+              res.setHeader("Retry-After", String(Math.ceil(lockout / 1000)));
+              return res.status(429).json({ error: "too many failed attempts, locked out", retryAfterMs: lockout });
+            }
             return res.status(401).json({ error: "locked", caseId: rawCaseId });
           }
+          // A successful auth clears the limiter for this case (mirrors /unlock).
+          limiter.clear(rawCaseId);
         }
       }
       const metadata = await ingestCapture(store, req.body);

--- a/companion/tests/server/capturesLockGate.test.ts
+++ b/companion/tests/server/capturesLockGate.test.ts
@@ -7,6 +7,7 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp } from "../../src/server.js";
 import { _resetDedupCache } from "../../src/ingest/captureIngest.js";
 import { hashCasePassword } from "../../src/analysis/casePassword.js";
+import { resetLimiters } from "../../src/http/rateLimiter.js";
 
 // POST /captures is a top-level route (not under /cases/:id), so createCaseLockGate never covers
 // it (see tests/analysis/caseLockGate.test.ts) — the route carries its own password check instead
@@ -29,6 +30,7 @@ const CAPTURE_BODY = {
 
 beforeEach(async () => {
   _resetDedupCache();
+  resetLimiters();
   const root = await mkdtemp(join(tmpdir(), "dfir-captureslock-"));
   cases = new CaseStore(root);
   await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
@@ -75,5 +77,31 @@ describe("POST /captures — case-password gate", () => {
   it("400s an invalid caseId before ever touching the store", async () => {
     const res = await request(app).post("/captures").send({ ...CAPTURE_BODY, caseId: "../../etc/passwd" });
     expect(res.status).toBe(400);
+  });
+
+  it("rate-limits brute-force: 5 wrong passwords via /captures then 429 lockout", async () => {
+    await cases.updateCaseMeta("c1", { password: hashCasePassword("secret123") });
+    // Hammer /captures with wrong passwords (the previously-unthrottled second entry point).
+    let statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const res = await request(app).post("/captures").send({ ...CAPTURE_BODY, casePassword: `wrong${i}` });
+      statuses.push(res.status);
+    }
+    // First 5 are 401 (failures), 6th triggers the lockout → 429.
+    expect(statuses.filter((s) => s === 401).length).toBeLessThanOrEqual(5);
+    expect(statuses).toContain(429);
+    // After lockout, even the CORRECT password is rejected with 429 (lockout takes precedence).
+    const locked = await request(app).post("/captures").send({ ...CAPTURE_BODY, casePassword: "secret123" });
+    expect(locked.status).toBe(429);
+  });
+
+  it("shares the limiter with /unlock so /captures failures count toward /unlock lockout", async () => {
+    await cases.updateCaseMeta("c1", { password: hashCasePassword("secret123") });
+    // Burn attempts on /captures, then /unlock should already be locked out (shared counter).
+    for (let i = 0; i < 6; i++) {
+      await request(app).post("/captures").send({ ...CAPTURE_BODY, casePassword: `wrong${i}` });
+    }
+    const unlock = await request(app).post("/cases/c1/unlock").send({ password: "secret123" });
+    expect(unlock.status).toBe(429);
   });
 });


### PR DESCRIPTION
## Bug (HIGH — auth bypass)
`POST /captures` accepts a `casePassword` and runs `verifyCasePassword` on it — a second online-entry point for a locked case. The `AttemptLimiter` (5 failures → exponential lockout) was applied ONLY to `POST /cases/:id/unlock`, so `/captures` could be hammered thousands of times per hour with no lockout. The scrypt KDF was kept weak (N=2^14) on the assumption that online attempts are rate-limited — leaving `/captures` unthrottled defeated that assumption.

## Fix
Gate `POST /captures` on the SAME `getUnlockLimiter()` before `verifyCasePassword`. Record failures into the SHARED limiter (so `/captures` and `/unlock` attempts count together — an attacker can't rotate endpoints to reset the budget), clear on success, return 429 + Retry-After on lockout.

## Verification
- `tsc --noEmit` clean.
- 8 captures-lock-gate tests pass (+2 new: 5-wrong-then-429 lockout, shared-counter cross-endpoint lockout). 22 casePasswordRoutes tests still pass.

Found by end-to-end QA storage + stress subagents.