### PR TITLE
fix(security): cover all AI-cost routes with the rate limiter + stop throttling non-AI undo/redo

### DIFF
--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -935,16 +935,43 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerTemplatesViewsRoutes(app, ctx);
   registerToolsRoutes(app, ctx);
 
-  // Rate-limit AI-cost-bearing routes (import triggers synthesis, synthesize is explicit) to
-  // prevent an attacker who knows a caseId from burning the operator's AI budget. 20 requests
-  // per minute per case — generous for a single analyst, blocks a script hammering the endpoint.
+  // Rate-limit AI-cost-bearing routes to prevent an attacker who knows a caseId from burning
+  // the operator's AI budget. 20 requests per minute per case — generous for a single analyst,
+  // blocks a script hammering the endpoint.
+  //
+  // Mounting per-exact-path (NOT as a prefix `app.use("/cases/:id/import", ...)`) — a prefix
+  // mount would also swallow the non-AI undo/redo/undo-stack routes under /import, throttling
+  // a pure read and locking the analyst out of their own import history (#23).
+  //
+  // Covers EVERY route that issues an LLM call (extract/synth/explain/ask/second-opinion/exec-
+  // summary/starred-report/view-summary/remediation-plan/hypothesis-review/narrative/memory/
+  // next-steps + the import triggers). The limiter key is the caseId, so a single attacker
+  // can't rotate endpoints to evade the cap (#25). The deep-pass/preview GET and the read-only
+  // GETs (synth-meta, ai-cost, hypotheses, ai-control, confidence-control, adversary-hints,
+  // starred-report) are NOT limited — they cost zero AI tokens.
   const aiLimiter = getAiLimiter();
-  app.use("/cases/:id/import", aiLimiter.middleware((req) => req.params.id));
-  app.use("/cases/:id/import-file", aiLimiter.middleware((req) => req.params.id));
-  app.use("/cases/:id/import-csv", aiLimiter.middleware((req) => req.params.id));
-  app.use("/cases/:id/import-log", aiLimiter.middleware((req) => req.params.id));
-  app.use("/cases/:id/synthesize", aiLimiter.middleware((req) => req.params.id));
-  app.use("/cases/:id/deep-pass", aiLimiter.middleware((req) => req.params.id));
+  const aiLimited = aiLimiter.middleware((req) => req.params.id);
+  // Static AI-cost POST routes (relative to /cases/:id).
+  const AI_LIMIT_PATHS = new Set([
+    "/import", "/import-file", "/import-csv", "/import-log",   // import triggers synthesis
+    "/synthesize", "/deep-pass",                                // explicit synthesis
+    "/second-opinion", "/second-opinion/apply", "/second-opinion/apply-all",  // 2nd LLM opinion
+    "/ask",                                                      // Ask-the-case GraphRAG
+    "/executive-summary", "/starred-report", "/view-summary", "/remediation-plan",  // report AI
+    "/hypothesis-review", "/narrative",                          // narrative + hypothesis AI
+    "/memory/next-steps",                                       // memory-forensics next-step AI
+  ]);
+  app.use("/cases/:id", (req: Request, res: Response, next: NextFunction) => {
+    if (req.method !== "POST") return next();
+    // Strip the /cases/:id/ prefix to compare against the static set.
+    const rel = req.path.replace(/^\/cases\/[^/]+\//, "/");
+    // /events/:eid/explain has a dynamic segment — match it explicitly.
+    const isExplain = /^\/events\/[^/]+\/explain$/.test(rel);
+    if (AI_LIMIT_PATHS.has(rel) || isExplain) {
+      return aiLimited(req, res, next);
+    }
+    next();
+  });
 
   registerImportRoutes(app, ctx);
   registerVelociraptorRoutes(app, ctx);

--- a/companion/tests/server/aiRateLimiterCoverage.test.ts
+++ b/companion/tests/server/aiRateLimiterCoverage.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { resetLimiters } from "../../src/http/rateLimiter.js";
+
+// The AI rate limiter (20 req/min per case) must cover EVERY AI-cost route and NOT throttle
+// the non-AI undo/redo/undo-stack routes under /import (which a prefix mount would swallow).
+// We assert shape (429 vs non-429) against a real createApp, not the limiter in isolation, so
+// the route-mounting wiring is what's tested. The case never exists, so AI-cost routes return
+// 404/500 — but a 429 means the limiter fired FIRST, which is what we want to detect.
+
+let app: ReturnType<typeof createApp>;
+
+beforeEach(async () => {
+  resetLimiters();
+  const root = await mkdtemp(join(tmpdir(), "dfir-ailimit-"));
+  const cases = new CaseStore(root);
+  app = createApp(cases, {});
+});
+
+async function fireManyPost(path: string, count: number, body?: unknown): Promise<number[]> {
+  const out: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const res = await request(app).post(path).send(body ?? {});
+    out.push(res.status);
+  }
+  return out;
+}
+
+async function fireManyGet(path: string, count: number): Promise<number[]> {
+  const out: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const res = await request(app).get(path);
+    out.push(res.status);
+  }
+  return out;
+}
+
+describe("AI rate limiter coverage", () => {
+  it("throttles POST /cases/:id/synthesize after 20 req/min (existing coverage, no regression)", async () => {
+    const statuses = await fireManyPost("/cases/nosuch/synthesize", 25);
+    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
+  });
+
+  it("throttles POST /cases/:id/second-opinion (previously unthrottled — bug #25)", async () => {
+    const statuses = await fireManyPost("/cases/nosuch/second-opinion", 25);
+    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
+  });
+
+  it("throttles POST /cases/:id/ask (previously unthrottled — bug #25)", async () => {
+    const statuses = await fireManyPost("/cases/nosuch/ask", 25);
+    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
+  });
+
+  it("throttles POST /cases/:id/executive-summary (previously unthrottled — bug #25)", async () => {
+    const statuses = await fireManyPost("/cases/nosuch/executive-summary", 25);
+    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
+  });
+
+  it("throttles POST /cases/:id/events/:eid/explain (dynamic segment, previously unthrottled — bug #25)", async () => {
+    const statuses = await fireManyPost("/cases/nosuch/events/ev1/explain", 25);
+    expect(statuses.filter((s) => s === 429).length).toBeGreaterThan(0);
+  });
+
+  it("does NOT throttle GET /cases/:id/import/undo-stack (non-AI read — prefix-mount bug #23)", async () => {
+    // 30 rapid GETs to the undo-stack read; none should be 429 (it costs zero AI tokens).
+    const statuses = await fireManyGet("/cases/nosuch/import/undo-stack", 30);
+    expect(statuses.filter((s) => s === 429).length).toBe(0);
+  });
+
+  it("does NOT throttle GET /cases/:id/synth-meta (read-only, zero AI cost)", async () => {
+    const statuses = await fireManyGet("/cases/nosuch/synth-meta", 30);
+    expect(statuses.filter((s) => s === 429).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Bugs (HIGH — #25 AI budget burn + #23 over-broad throttle)
The AI rate limiter (20 req/min per case) only covered `/synthesize`, `/deep-pass`, and four import routes. Every other AI-cost route (`/second-opinion`, `/ask`, `/executive-summary`, `/starred-report`, `/view-summary`, `/remediation-plan`, `/hypothesis-review`, `/narrative`, `/memory/next-steps`, `/events/:eid/explain`, second-opinion apply routes) issued real LLM calls with NO throttling. The over-broad prefix mount on `/import` also throttled the non-AI undo/redo/undo-stack routes.

## Fix
Replace the six prefix mounts with ONE precise mount on `/cases/:id` that limits only POST routes in a static AI-cost set plus the dynamic `/events/:eid/explain` path. Read-only GETs and undo/redo no longer throttled. Limiter key stays the caseId (can't rotate endpoints to evade the cap).

## Verification
- `tsc --noEmit` clean.
- 7 new tests pass (5 previously-unthrottled routes now 429 after 20; undo-stack + synth-meta GETs NOT throttled). 12 importUndo/explain/hypothesisReview/narrative tests still pass.

Found by end-to-end QA HTTP-routes subagent.