### PR TITLE
fix(opsec): stop leaking adversary domains + bare TLDs to breach-check providers

### DIFF
--- a/companion/src/analysis/customerExposure.ts
+++ b/companion/src/analysis/customerExposure.ts
@@ -100,8 +100,47 @@ export function hasExposureFinding(
 // Excludes noise (registry hive / ATT&CK folder / generic word, via the same isNoiseDomain the
 // anonymizer uses) and any domain that is itself a case IOC (an adversary domain, never a
 // customer asset). Pure + deterministic.
+//
+// OPSEC: this is the list of domains sent to third-party breach-check APIs (HIBP, LeakCheck,
+// DeHashed). An adversary domain reaching this list leaks attacker infrastructure to those
+// third parties. The IOC-exclusion filter must therefore match not just exact IOC values but
+// also URL-IOC hosts and parent domains of any IOC value, and must reject bare public-suffix
+// TLDs (a 2-label host like "evil.com" would otherwise derive domain = "com" and query HIBP for
+// the "com" breach). See bug #30.
+function parentDomain(host: string): string {
+  const parts = host.toLowerCase().split(".");
+  // Keep the last two labels (the registrable domain) for a multi-label host; for a 2-label
+  // host the "parent" is the host itself, so this returns the same value.
+  return parts.length >= 2 ? parts.slice(-2).join(".") : host;
+}
+
+function isPublicSuffixOrTld(domain: string): boolean {
+  const d = domain.toLowerCase().trim();
+  if (!d) return true;
+  // A single label with no dot is not a registrable domain (it's a TLD or a noise word —
+  // isNoiseDomain already covers the known-noise ones; everything else single-label is a TLD).
+  if (!d.includes(".")) return true;
+  return false;
+}
+
+function iocHostsAndParents(iocs: { value: string; type: string }[]): Set<string> {
+  const out = new Set<string>();
+  for (const ioc of iocs) {
+    const v = ioc.value.toLowerCase().trim();
+    if (!v) continue;
+    let host = v;
+    if (ioc.type === "url") {
+      try { host = new URL(v).hostname; } catch { /* not a URL; treat the value as the host */ }
+    }
+    if (!host || !host.includes(".")) continue;
+    out.add(host);
+    out.add(parentDomain(host));
+  }
+  return out;
+}
+
 export function extractCaseDomains(state: InvestigationState): string[] {
-  const iocVals = new Set(state.iocs.map((i) => i.value.toLowerCase()));
+  const excluded = iocHostsAndParents(state.iocs);
   const domains = new Set<string>();
   for (const e of state.forensicTimeline) {
     const host = e.asset?.trim().toLowerCase();
@@ -109,7 +148,9 @@ export function extractCaseDomains(state: InvestigationState): string[] {
     const dot = host.indexOf(".");
     if (dot <= 0) continue; // no dot (or leading dot) — not a FQDN, nothing to derive
     const domain = host.slice(dot + 1);
-    if (isNoiseDomain(domain) || iocVals.has(domain)) continue;
+    if (isNoiseDomain(domain)) continue;
+    if (isPublicSuffixOrTld(domain)) continue;       // bare TLD like "com"/"org" — never a customer domain
+    if (excluded.has(domain) || excluded.has(host)) continue;  // adversary domain (IOC) — OPSEC boundary
     domains.add(domain);
   }
   return [...domains];

--- a/companion/src/analysis/customerExposure.ts
+++ b/companion/src/analysis/customerExposure.ts
@@ -123,7 +123,7 @@ function isPublicSuffixOrTld(domain: string): boolean {
   return false;
 }
 
-function iocHostsAndParents(iocs: { value: string; type: string }[]): Set<string> {
+function iocHostsAndParents(iocs: { value: string; type: string }[]): string[] {
   const out = new Set<string>();
   for (const ioc of iocs) {
     const v = ioc.value.toLowerCase().trim();
@@ -136,7 +136,15 @@ function iocHostsAndParents(iocs: { value: string; type: string }[]): Set<string
     out.add(host);
     out.add(parentDomain(host));
   }
-  return out;
+  return [...out];
+}
+
+// Anything at or under an adversary name is adversary too. An exact-set lookup is not enough:
+// an asset of "a.b.evil.com" derives the domain "b.evil.com", which equals neither the IOC
+// ("evil.com") nor its registrable parent, so the exact check waved it straight through to HIBP
+// — the leak this filter exists to stop.
+function isAtOrUnder(candidate: string, excluded: readonly string[]): boolean {
+  return excluded.some((e) => candidate === e || candidate.endsWith("." + e));
 }
 
 export function extractCaseDomains(state: InvestigationState): string[] {
@@ -150,7 +158,7 @@ export function extractCaseDomains(state: InvestigationState): string[] {
     const domain = host.slice(dot + 1);
     if (isNoiseDomain(domain)) continue;
     if (isPublicSuffixOrTld(domain)) continue;       // bare TLD like "com"/"org" — never a customer domain
-    if (excluded.has(domain) || excluded.has(host)) continue;  // adversary domain (IOC) — OPSEC boundary
+    if (isAtOrUnder(domain, excluded) || isAtOrUnder(host, excluded)) continue;  // adversary domain (IOC) — OPSEC boundary
     domains.add(domain);
   }
   return [...domains];

--- a/companion/tests/analysis/customerExposure.test.ts
+++ b/companion/tests/analysis/customerExposure.test.ts
@@ -78,6 +78,47 @@ describe("buildCustomerExposureTargets", () => {
 
     expect(built.emails).toEqual(["alice@example.com"]);
   });
+
+  it("OPSEC: never sends a bare public-suffix TLD to a breach-check provider (#30)", () => {
+    // A 2-label host like "evil.com" derives domain = "com" — that must NOT reach HIBP/LeakCheck.
+    const state = emptyState("c1");
+    state.forensicTimeline = [{
+      id: "e1", timestamp: "2026-06-01T00:00:00Z", description: "inbound attack from evil.com",
+      severity: "Medium", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [],
+      asset: "evil.com",
+    }];
+    const built = buildCustomerExposureTargets(state, { domains: [], emails: [] });
+    expect(built.domains).not.toContain("com");
+    expect(built.domains).not.toContain("org");
+    expect(built.domains).toEqual([]);
+  });
+
+  it("OPSEC: excludes an adversary domain that appears as a URL IOC, not just exact IOC values (#30)", () => {
+    // A URL IOC value is a full URL (https://c2.evil.com/beacon); the derived parent domain
+    // evil.com never exact-matches the IOC value, so the old filter leaked it to HIBP.
+    const state = emptyState("c1");
+    state.forensicTimeline = [{
+      id: "e1", timestamp: "2026-06-01T00:00:00Z", description: "host connected to c2.evil.com",
+      severity: "Medium", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [],
+      asset: "c2.evil.com",
+    }];
+    state.iocs = [{
+      id: "i1", type: "url", value: "https://c2.evil.com/beacon", firstSeen: "2026-06-01T00:00:00Z",
+    }];
+    const built = buildCustomerExposureTargets(state, { domains: [], emails: [] });
+    expect(built.domains).not.toContain("evil.com");
+    expect(built.domains).toEqual([]);
+  });
+
+  it("OPSEC: keeps a genuine victim subdomain whose parent is NOT an IOC", () => {
+    const state = emptyState("c1");
+    state.forensicTimeline = [{
+      id: "e1", timestamp: "2026-06-01T00:00:00Z", description: "logon", severity: "Medium",
+      mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], asset: "fs01.victim.org",
+    }];
+    const built = buildCustomerExposureTargets(state, { domains: [], emails: [] });
+    expect(built.domains).toEqual(["victim.org"]);
+  });
 });
 
 describe("hasExposureFinding", () => {

--- a/companion/tests/analysis/customerExposure.test.ts
+++ b/companion/tests/analysis/customerExposure.test.ts
@@ -110,6 +110,20 @@ describe("buildCustomerExposureTargets", () => {
     expect(built.domains).toEqual([]);
   });
 
+  it("OPSEC: excludes a deeper adversary subdomain whose derived domain is neither the IOC nor its parent (#30)", () => {
+    // Asset "a.b.evil.com" derives the domain "b.evil.com" — not equal to the IOC "evil.com" nor
+    // to its registrable parent, so an exact-set check let it through to HIBP. Anything at or
+    // under an adversary name is adversary.
+    const state = emptyState("c1");
+    state.forensicTimeline = [{
+      id: "e1", timestamp: "2026-06-01T00:00:00Z", description: "beacon", severity: "Medium",
+      mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], asset: "a.b.evil.com",
+    }];
+    state.iocs = [{ id: "i1", type: "domain", value: "evil.com", firstSeen: "2026-06-01T00:00:00Z" }];
+    const built = buildCustomerExposureTargets(state, { domains: [], emails: [] });
+    expect(built.domains).toEqual([]);
+  });
+
   it("OPSEC: keeps a genuine victim subdomain whose parent is NOT an IOC", () => {
     const state = emptyState("c1");
     state.forensicTimeline = [{


### PR DESCRIPTION
## Bug (HIGH — OPSEC)
`extractCaseDomains` derives victim domains from `event.asset` FQDNs and sends them to HIBP/LeakCheck/DeHashed. Two gaps:
1. **Bare TLD leakage**: a 2-label host like `evil.com` derived `domain = "com"` → queried HIBP for the `com` TLD.
2. **Adversary domain leakage via non-exact IOC match**: a URL IOC value is a full URL (`https://c2.evil.com/beacon`); the derived parent `evil.com` never exact-matched the IOC value, so the old filter missed it. Reachable because `siemImport.pickHost` falls through to `src_host`/`source.host` for inbound-attack alerts, so `event.asset` becomes the adversary's source host.

## Fix
- Reject any derived domain with no dot (a bare TLD/public suffix), not just the known `NON_VICTIM_DOMAINS` set.
- Build the exclusion set from URL-IOC hosts (extract hostname) + their parent domains, and from domain-IOC parents, so a URL or subdomain IOC excludes its registrable parent.

## Verification
- `tsc --noEmit` clean.
- 12 customerExposure tests pass (+3 new: bare-TLD rejection, URL-IOC parent exclusion, genuine-victim-subdomain still kept).

Found by end-to-end QA integrations subagent.