### PR TITLE
chore(ci): retire the interactive-report internal-hostname allowlist

### DIFF
--- a/.betterleaks-config.toml
+++ b/.betterleaks-config.toml
@@ -32,23 +32,6 @@ regexes = [
   '''(?i)\b(?:docker|m|s|hash|misp|api)\.internal\b''',
 ]
 
-# Superseded fixture hostnames in the interactive-report confidentiality test. The test asserts that
-# analyst-private state never reaches the embedded blob, and its first version used `velo.internal`
-# and `corp.internal` as the sample values. The working tree now uses example.com instead, so these
-# appear in NO current file — but `betterleaks git .` scans every reachable commit's patch, so the
-# original patch in 9286c2d3 keeps matching. Scoped to that one test path and that one rule, so a
-# genuinely-new internal FQDN anywhere else still fails the scan.
-#
-# Delete this block only when 9286c2d3 is no longer reachable (e.g. after a squash-merge to master).
-[[allowlists]]
-description = "Superseded internal-hostname fixtures in interactiveHtml.test.ts patch history"
-targetRules = ["internal-hostname"]
-paths = ['''companion/tests/reports/interactiveHtml\.test\.ts''']
-regexTarget = "line"
-regexes = [
-  '''(?i)\b(?:velo|corp)\.internal\b''',
-]
-
 # The token/key rules stay ON, but their only matches here are deliberate FAKE fixtures — a Stripe
 # TEST-mode key with "Fake" in the name, the canonical AWS docs example key, a fake JWT, and a false
 # match on Windows Event-ID tradecraft prose. Allowlist those exact fixtures; a real leaked key still fails.


### PR DESCRIPTION
Removes the `internal-hostname` allowlist block added in #284, now that the commit it covered is gone.

## Why it existed

The confidentiality test in #284 originally used `velo.internal` and `corp.internal` as fixture values. The fixture was corrected to `example.com` in the same PR, but `betterleaks git .` scans every reachable commit's patch, so the original spelling survived in `9286c2d3` and kept failing the scan. The block was scoped to that one rule and one path, and annotated to be deleted once that commit was no longer reachable.

## Why it can go now

#284 squash-merged as `25d1571c` and its branch is deleted, so `9286c2d3` is unreachable.

Verified against a fresh clone of master rather than assumed:

- `git cat-file -e 9286c2d3^{commit}` — object not present
- `betterleaks 1.6.1 git . --config .betterleaks-config.toml --exit-code 1` with this block removed — `no leaks found`, exit 0

(Running the same scan in a working copy that still has the old branch checked out locally *does* report the two findings, which is the reachability point exactly.)

## Why bother

`internal-hostname` is deliberately left enabled in this repo to catch a genuinely-new internal FQDN. Leaving the carve-out in place would have kept a permanent hole for two hostnames that no longer appear anywhere in the tree or in master's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)