### PR TITLE
fix(state,privacy): serialize narrative/questions on StateLock + blank people-bearing report-meta in redacted export

### DIFF
--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -569,7 +569,22 @@ export class ReportWriter {
   async redactedReportContents(caseId: string, redact: (s: string) => string): Promise<RedactedReportContents> {
     const state = applyAnonDeep(await this.loadFilteredState(caseId), redact);
     const rawMeta = this.reportMeta ? await this.reportMeta.load(caseId) : emptyReportMeta();
-    const meta: ReportMeta = { ...applyAnonDeep(rawMeta, redact), companyLogo: rawMeta.companyLogo };
+    // The redacted export is meant for EXTERNAL parties. The anonymizer's apply() only tokenizes
+    // structured indicators (IP/email/host/domain/path/account/secret) — it has no detector for
+    // free-text PEOPLE names or the investigating firm's internal distribution list. Without
+    // stripping these, the redacted report shipped the victim org's CISO by name ("Chris Reynolds
+    // — CISO, GlobalTech Industries"), the VP Engineering, the case investigators, and the
+    // incident manager in cleartext (bug #18). These fields are firm-internal metadata, not case
+    // content an external party needs, so blank them in the redacted meta copy. The on-disk
+    // report (writeAll) keeps them; only the redacted export is affected.
+    const redactedMeta: ReportMeta = {
+      ...rawMeta,
+      investigators: [],
+      reviewer: "",
+      incidentManager: "",
+      distribution: [],
+    };
+    const meta: ReportMeta = { ...applyAnonDeep(redactedMeta, redact), companyLogo: rawMeta.companyLogo };
     const exposure = applyAnonDeep(await this.loadExposure(caseId), redact);
     const notebookEntries = applyAnonDeep(await this.loadNotebook(caseId), redact);
     const playbookTasks = applyAnonDeep(await this.loadPlaybook(caseId), redact);

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -569,13 +569,21 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
 
   // Save an analyst-edited narrative timeline. The analyst may edit the AI-generated narrative
   // before export; this persists the edit to state.narrativeTimeline until the next synthesis.
+  // Serialize the load→save on the per-case StateLock so this write can't race synthesis's locked
+  // persistLatest (which overwrites the whole state file) — without the lock whichever writer
+  // saves last silently destroys the other's data (analyst edit lost OR synthesis results lost).
   app.put("/cases/:id/narrative", async (req: Request, res: Response) => {
     if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
     const narrative = typeof req.body?.narrativeTimeline === "string" ? req.body.narrativeTimeline : "";
     try {
-      const state = await options.stateStore.load(req.params.id);
-      const updated = { ...state, narrativeTimeline: narrative };
-      await options.stateStore.save(updated);
+      const stateStore = options.stateStore;
+      const saved = await ctx.runStateExclusive(req.params.id, async () => {
+        const state = await stateStore.load(req.params.id);
+        const updated = { ...state, narrativeTimeline: narrative };
+        await stateStore.save(updated);
+        return updated;
+      });
+      options.onState?.(saved);
       return res.status(200).json({ narrativeTimeline: narrative });
     } catch (err) {
       return sendPipelineError(res, err);
@@ -605,6 +613,8 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
 
   // Add an analyst question to the case's open key questions (e.g. from Ask, when unknown).
   // It's pinned, so synthesis preserves it and answers it once the evidence supports it.
+  // Serialized on the per-case StateLock (same as PUT /narrative) so a concurrent synthesis's
+  // persistLatest can't overwrite the analyst's just-added question.
   app.post("/cases/:id/questions", async (req: Request, res: Response) => {
     if (!options.stateStore) return res.status(501).json({ error: "state store not configured" });
     const question = typeof req.body?.question === "string" ? req.body.question.trim() : "";
@@ -612,20 +622,24 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
     const statusIn = String(req.body?.status ?? "unknown");
     const status: QuestionStatus = statusIn === "answered" || statusIn === "partial" ? statusIn : "unknown";
     try {
-      const state = await options.stateStore.load(req.params.id);
-      const nums = state.keyQuestions.map((q) => Number(/^aq(\d+)$/.exec(q.id)?.[1])).filter((n) => !Number.isNaN(n));
-      const newQuestion: InvestigationQuestion = {
-        id: `aq${(nums.length ? Math.max(...nums) : 0) + 1}`,
-        question,
-        status,
-        answer: typeof req.body?.answer === "string" ? req.body.answer : "",
-        pointer: typeof req.body?.pointer === "string" ? req.body.pointer : "",
-        pinned: true,
-      };
-      const next = { ...state, keyQuestions: [...state.keyQuestions, newQuestion] };
-      await options.stateStore.save(next);
-      options.onState?.(next);
-      return res.status(201).json(newQuestion);
+      const stateStore = options.stateStore;
+      const result = await ctx.runStateExclusive(req.params.id, async () => {
+        const state = await stateStore.load(req.params.id);
+        const nums = state.keyQuestions.map((q) => Number(/^aq(\d+)$/.exec(q.id)?.[1])).filter((n) => !Number.isNaN(n));
+        const newQuestion: InvestigationQuestion = {
+          id: `aq${(nums.length ? Math.max(...nums) : 0) + 1}`,
+          question,
+          status,
+          answer: typeof req.body?.answer === "string" ? req.body.answer : "",
+          pointer: typeof req.body?.pointer === "string" ? req.body.pointer : "",
+          pinned: true,
+        };
+        const next = { ...state, keyQuestions: [...state.keyQuestions, newQuestion] };
+        await stateStore.save(next);
+        return { newQuestion, next };
+      });
+      options.onState?.(result.next);
+      return res.status(201).json(result.newQuestion);
     } catch (err) {
       return sendPipelineError(res, err);
     }

--- a/companion/tests/reports/reportWriter.test.ts
+++ b/companion/tests/reports/reportWriter.test.ts
@@ -212,4 +212,32 @@ describe("ReportWriter", () => {
     expect(geo.markers[0].falsePositive).toBe(true);
     expect(geo.markers[0].color).toBe("gray");
   });
+
+  it("redactedReportContents blanks people-bearing report-meta fields (distribution, investigators, reviewer, incidentManager — bug #18)", async () => {
+    const { ReportMetaStore } = await import("../../src/reports/reportMeta.js");
+    const reportMeta = new ReportMetaStore(caseStore);
+    await reportMeta.save("c1", {
+      organization: "GlobalTech Industries",
+      investigators: ["Demo Analyst", "Senior DFIR Analyst"],
+      reviewer: "IR Team Lead",
+      incidentManager: "Chris Reynolds",
+      distribution: [
+        { name: "Chris Reynolds", role: "CISO, GlobalTech Industries", method: "Encrypted email" },
+        { name: "Sarah Kim", role: "VP Engineering", method: "Encrypted email" },
+      ],
+    });
+    const writer = new ReportWriter(caseStore, stateStore, { reportMeta });
+    const redacted = await writer.redactedReportContents("c1", (s) => s); // identity redact — field-blanking is structural
+    // The people-bearing fields must NOT appear in the rendered redacted report.
+    const md = redacted.markdown;
+    expect(md).not.toContain("Chris Reynolds");
+    expect(md).not.toContain("Sarah Kim");
+    expect(md).not.toContain("Demo Analyst");
+    expect(md).not.toContain("IR Team Lead");
+    expect(md).not.toContain("CISO");
+    // The on-disk report-meta.json is untouched (the real report keeps them).
+    const onDisk = await reportMeta.load("c1");
+    expect(onDisk.investigators).toEqual(["Demo Analyst", "Senior DFIR Analyst"]);
+    expect(onDisk.distribution.length).toBe(2);
+  });
 });

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -1461,6 +1461,32 @@ describe("state and report routes", () => {
     expect(state.body.keyQuestions.some((q: { pinned?: boolean }) => q.pinned)).toBe(true);
   });
 
+  it("POST /cases/:id/questions keeps every concurrently-added question", async () => {
+    // Each add is a load → append → save. Run them concurrently without the per-case StateLock
+    // and they all read the same starting state, so the last save wins and the rest of the
+    // analyst's questions vanish — the same read-modify-write race a synthesis running alongside
+    // an add would lose to.
+    const root = await mkdtemp(join(tmpdir(), "dfir-questions-race-"));
+    const store = new CaseStore(root);
+    const stateStore = new StateStore(store);
+    // runStateExclusive is a no-op unless a StateLock is wired, so the lock has to be passed for
+    // this to test anything — startServer wires one.
+    const { StateLock } = await import("../src/analysis/stateLock.js");
+    const app = createApp(store, { stateStore, stateLock: new StateLock() });
+    await store.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+    await stateStore.save((await import("../src/analysis/stateTypes.js")).emptyState("c1"));
+
+    const adds = await Promise.all(Array.from({ length: 8 }, (_, i) =>
+      request(app).post("/cases/c1/questions").send({ question: `q${i}` })));
+    expect(adds.every((r) => r.status === 201)).toBe(true);
+
+    const state = await request(app).get("/cases/c1/state");
+    const questions = state.body.keyQuestions as { id: string; question: string }[];
+    expect(questions).toHaveLength(8);
+    expect(new Set(questions.map((q) => q.id)).size).toBe(8);          // no id collisions either
+    expect(new Set(questions.map((q) => q.question)).size).toBe(8);
+  });
+
   it("derives the asset ↔ IoC graph on demand", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-asset-graph-"));
     const store = new CaseStore(root);


### PR DESCRIPTION
## Bugs (HIGH #10 lost-update race + HIGH #18 PII leak)
**#10** — `PUT /narrative` and `POST /questions` did unlocked load→mutate→save on `investigation.json`, racing synthesis's locked `persistLatest` (lost update — analyst edit OR synthesis results silently destroyed). Wrap both in `ctx.runStateExclusive`.

**#18** — `redactedReportContents` passed full report-meta through `applyAnonDeep`, but the anonymizer only tokenizes structured indicators — free-text people names and the firm's distribution list survived. The redacted export shipped the victim CISO by name (`Chris Reynolds — CISO, GlobalTech Industries`), VP Engineering, investigators, and incident manager in cleartext. Blank `investigators`/`reviewer`/`incidentManager`/`distribution` in the redacted meta copy (firm-internal metadata, not case content). On-disk report-meta and canonical `writeAll` keep them; only the redacted export drops them.

## Verification
- `tsc --noEmit` clean.
- 92 server + 8 reportWriter tests pass (+1 new redacted-meta field-blanking test).

Found by end-to-end QA storage + case-lifecycle subagents.