### PR TITLE
fix(ai): recover synthesis responses with fenced block + control char (#2) or first-object string truncation (#4)

### DIFF
--- a/companion/src/analysis/extractJson.ts
+++ b/companion/src/analysis/extractJson.ts
@@ -57,9 +57,9 @@ export function repairTruncatedJson(s: string): string {
     // behavior returned the input unchanged, leaving an unterminated string; neededClosers() can
     // only emit structural closers (it never closes an open string), so JSON.parse failed on
     // "Unterminated string" and the whole response was thrown away. Recover a partial-but-valid
-    // object: cut back to the last complete key-value boundary (a comma at the object's top
-    // level, tracked via string state), close any open string, drop a dangling comma, then append
-    // the structural closers. A partial findings array (even []) is still useful — the
+    // object: close the open string (keeping the partial value), or — when that still doesn't
+    // parse, e.g. truncation landed inside a KEY or right after a ':' — cut back to the last
+    // complete key-value boundary. A partial findings array (even []) is still useful — the
     // deterministic high-severity backfill fills the truncated finding.
     return repairInsideFirstObject(s);
   }
@@ -67,15 +67,49 @@ export function repairTruncatedJson(s: string): string {
   return prefix + neededClosers(prefix);
 }
 
-// Cut back to the last top-level comma (or the opening brace if none), close an open string,
-// drop a dangling comma, and append structural closers. Used only when lastBrace === -1.
+// Repair a truncation that landed inside the FIRST object (no complete '}' anywhere). Used only
+// when lastBrace === -1.
+//
+// Two candidate repairs, tried most-informative first and validated by an actual JSON.parse —
+// closing the string and cutting back are BOTH wrong in the other's case, so picking blindly
+// produces invalid JSON. (Doing both at once, as an earlier version did, is wrong in every case
+// where a cut happened: `{"a":1,"b":"oops` cut to `{"a":1` then given a stray closing quote
+// became `{"a":1"}`, which parses nowhere.)
+//
+//  A. Close the open string in place — keeps the partial value, which is the common truncation
+//     (max_tokens mid-description). Fails when the cut landed inside a KEY, or right after a ':'.
+//  B. Cut back to the last comma that was NOT inside a string, dropping the whole incomplete
+//     key-value pair. Structurally sound whenever A isn't, at the cost of that one pair.
+//
+// Neither is tried when it can't apply; if nothing parses we return B (or A) so the caller's
+// error message still describes real input.
 function repairInsideFirstObject(s: string): string {
-  // Find the last top-level comma (depth 0 inside the root object, not inside a nested array
-  // or string) — that's the boundary after the last COMPLETE key-value pair.
-  let depth = 0;
+  const { inStr, lastCommaOutsideString } = scanStringState(s);
+  const candidates: string[] = [];
+  if (inStr) candidates.push(closeAndBalance(s + '"'));
+  if (lastCommaOutsideString >= 0) candidates.push(closeAndBalance(s.slice(0, lastCommaOutsideString)));
+  candidates.push(closeAndBalance(s));
+  for (const c of candidates) {
+    try {
+      JSON.parse(c);
+      return c;
+    } catch { /* try the next candidate */ }
+  }
+  return candidates[candidates.length - 1];
+}
+
+// Drop a dangling separator, then append the closers needed to balance still-open structures.
+function closeAndBalance(s: string): string {
+  const prefix = s.replace(/,\s*$/, "");
+  return prefix + neededClosers(prefix);
+}
+
+// Whether the string ends mid-literal, and the index of the last comma that sat OUTSIDE any
+// string literal (-1 when there is none). Commas inside a string are content, not separators.
+function scanStringState(s: string): { inStr: boolean; lastCommaOutsideString: number } {
   let inStr = false;
   let esc = false;
-  let lastTopComma = -1;
+  let lastCommaOutsideString = -1;
   for (let i = 0; i < s.length; i++) {
     const c = s[i];
     if (inStr) {
@@ -85,18 +119,9 @@ function repairInsideFirstObject(s: string): string {
       continue;
     }
     if (c === '"') inStr = true;
-    else if (c === "{") depth++;
-    else if (c === "[") depth++;
-    else if (c === "}" || c === "]") depth--;
-    else if (c === "," && depth === 1) lastTopComma = i; // depth 1 = root object's direct children
+    else if (c === ",") lastCommaOutsideString = i;
   }
-  // Cut back to just after the last complete key-value (drop the dangling incomplete one).
-  let prefix = lastTopComma >= 0 ? s.slice(0, lastTopComma) : s;
-  // Close an open string (neededClosers won't, so do it here before structural closers).
-  if (inStr) prefix += '"';
-  // Drop a dangling comma / whitespace so the object doesn't end with a separator.
-  prefix = prefix.replace(/,\s*$/, "");
-  return prefix + neededClosers(prefix);
+  return { inStr, lastCommaOutsideString };
 }
 
 // JSON forbids raw control characters (U+0000–U+001F) inside string literals, but models

--- a/companion/src/analysis/extractJson.ts
+++ b/companion/src/analysis/extractJson.ts
@@ -51,8 +51,51 @@ function neededClosers(s: string): string {
 // deterministic high-severity backfill fills any finding the truncation dropped).
 export function repairTruncatedJson(s: string): string {
   const lastBrace = s.lastIndexOf("}");
-  if (lastBrace === -1) return s;
+  if (lastBrace === -1) {
+    // Truncation landed inside the FIRST (and only) object — no complete '}' exists yet. The
+    // usual case is the model hit max_tokens mid-description on the first finding. The previous
+    // behavior returned the input unchanged, leaving an unterminated string; neededClosers() can
+    // only emit structural closers (it never closes an open string), so JSON.parse failed on
+    // "Unterminated string" and the whole response was thrown away. Recover a partial-but-valid
+    // object: cut back to the last complete key-value boundary (a comma at the object's top
+    // level, tracked via string state), close any open string, drop a dangling comma, then append
+    // the structural closers. A partial findings array (even []) is still useful — the
+    // deterministic high-severity backfill fills the truncated finding.
+    return repairInsideFirstObject(s);
+  }
   const prefix = s.slice(0, lastBrace + 1).replace(/,\s*$/, "");
+  return prefix + neededClosers(prefix);
+}
+
+// Cut back to the last top-level comma (or the opening brace if none), close an open string,
+// drop a dangling comma, and append structural closers. Used only when lastBrace === -1.
+function repairInsideFirstObject(s: string): string {
+  // Find the last top-level comma (depth 0 inside the root object, not inside a nested array
+  // or string) — that's the boundary after the last COMPLETE key-value pair.
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  let lastTopComma = -1;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === "{") depth++;
+    else if (c === "[") depth++;
+    else if (c === "}" || c === "]") depth--;
+    else if (c === "," && depth === 1) lastTopComma = i; // depth 1 = root object's direct children
+  }
+  // Cut back to just after the last complete key-value (drop the dangling incomplete one).
+  let prefix = lastTopComma >= 0 ? s.slice(0, lastTopComma) : s;
+  // Close an open string (neededClosers won't, so do it here before structural closers).
+  if (inStr) prefix += '"';
+  // Drop a dangling comma / whitespace so the object doesn't end with a separator.
+  prefix = prefix.replace(/,\s*$/, "");
   return prefix + neededClosers(prefix);
 }
 
@@ -118,7 +161,20 @@ export function parseJsonLoose(raw: string): unknown {
     try {
       return JSON.parse(trimmed);
     } catch {
-      // fall through to fence/prose extraction below
+      // The strict parse failed. Before falling through to fence/prose extraction (which
+      // matches the FIRST ```json fence ANYWHERE and would slice the response down to a tiny
+      // inner snippet when a string value legitimately contains a fenced block), retry with
+      // control-char escaping on the WHOLE document. Models routinely emit a literal newline
+      // inside a long description instead of \n; JSON.parse rejects the whole response for it,
+      // and the fence extractor would grab an inner ```json snippet instead of the outer object.
+      // escapeControlCharsInStrings is string-literal-aware (tracks inStr/esc), so it's safe to
+      // run on the whole document — it only escapes raw control chars INSIDE string literals,
+      // preserving legal whitespace between tokens. (bug #2)
+      try {
+        return JSON.parse(escapeControlCharsInStrings(trimmed));
+      } catch {
+        // fall through to fence/prose extraction below
+      }
     }
   }
   const cleaned = extractJsonText(raw);

--- a/companion/tests/analysis/deepPassRun.test.ts
+++ b/companion/tests/analysis/deepPassRun.test.ts
@@ -182,7 +182,11 @@ describe("deepPass resilience", () => {
       if (/ONE SLICE/i.test(req.systemPrompt)) {
         this.observeCalls++;
         if (this.observeCalls <= this.failAttempts) {
-          return { rawText: '{"observations": [{"summary": "bad\ncontrol", ' };
+          // Prose with no JSON at all. The original fixture here was a control-char-plus-truncation
+          // response — parseJsonLoose now RECOVERS that shape (escape the control chars, close the
+          // open structure), which is the point of those repairs, so it no longer exercises the
+          // "batch failed" path. A refusal/prose reply has nothing to recover and still does.
+          return { rawText: "I'm unable to analyse this slice." };
         }
         return { rawText: OBSERVATIONS };
       }

--- a/companion/tests/analysis/extractJson.test.ts
+++ b/companion/tests/analysis/extractJson.test.ts
@@ -144,4 +144,30 @@ describe("repairTruncatedJson / parseJsonLoose", () => {
     expect(parsed.findings).toHaveLength(1);
     expect(parsed.findings[0].id).toBe("f1");
   });
+
+  // The repair has to pick between "close the open string" and "cut back to the last complete
+  // pair" — doing both at once emits a stray quote onto an already-cut prefix (`{"a":1` + `"` →
+  // `{"a":1"}`), which parses nowhere. Each of these lands on a different candidate; all must
+  // produce VALID JSON, never a plausible-looking string that JSON.parse still rejects.
+  it("#4: every no-'}' truncation shape repairs to valid JSON, whichever candidate wins", () => {
+    const shapes: [string, unknown][] = [
+      // Truncated inside a later key's VALUE, with an earlier complete pair → close the string.
+      ['{"a":1,"b":"unterminated', { a: 1, b: "unterminated" }],
+      // Truncated inside a nested ARRAY's string element → close the string, balance [ and {.
+      ['{"summary":"ok","findings":["a","b', { summary: "ok", findings: ["a", "b"] }],
+      // Truncated inside a KEY — closing the string leaves a key with no value, so cut instead.
+      ['{"a":1,"bcd', { a: 1 }],
+      // Truncated right after a ':' — nothing to close; cut back to the last complete pair.
+      ['{"a":1,"b":', { a: 1 }],
+      // Truncated on the separator after a complete pair — drop the dangling comma.
+      ['{"observations":[{"summary":"x"}, ', { observations: [{ summary: "x" }] }],
+      // Nothing but the opening brace.
+      ["{", {}],
+    ];
+    for (const [truncated, expected] of shapes) {
+      const repaired = repairTruncatedJson(truncated);
+      expect(() => JSON.parse(repaired), `repair of ${truncated} → ${repaired}`).not.toThrow();
+      expect(JSON.parse(repaired)).toEqual(expected);
+    }
+  });
 });

--- a/companion/tests/analysis/extractJson.test.ts
+++ b/companion/tests/analysis/extractJson.test.ts
@@ -105,4 +105,43 @@ describe("repairTruncatedJson / parseJsonLoose", () => {
     expect(parsed.findings[0].id).toBe("f1");
     expect(parsed.findings[0].description).toContain("powershell");
   });
+
+  it("#2: recovers the outer object when a string contains a fenced block AND a raw control char (direct parse fails)", () => {
+    // Direct JSON.parse fails on the raw \n inside the description. The previous code fell through
+    // to extractJsonText, which matched the INNER ```json fence and returned only the snippet —
+    // the whole synthesis (findings + summary) was silently lost. The fix retries
+    // escapeControlCharsInStrings on the trimmed text before fence extraction, recovering the
+    // outer object. (Inner JSON quotes are escaped, as a model emitting valid JSON inside a
+    // description string would do.)
+    const raw = '{"findings":[{"id":"f1","description":"cmd was:\n```json\\n{\\"cmd\\":\\"x\\"}\\n```\\ndone"}],"summary":"ok"}';
+    const parsed = parseJsonLoose(raw) as { findings: { id: string; description: string }[]; summary: string };
+    expect(parsed.findings).toHaveLength(1);
+    expect(parsed.findings[0].id).toBe("f1");
+    expect(parsed.summary).toBe("ok");
+    // The inner fenced snippet must NOT be what we get back.
+    expect(parsed).not.toEqual({ cmd: "x" });
+  });
+
+  it("#4: repairTruncatedJson recovers a partial object when truncation lands inside the first object's string (no '}' exists)", () => {
+    // Model hit max_tokens mid-description of the FIRST finding — no '}' exists yet. The previous
+    // behavior returned the input unchanged, leaving an unterminated string; JSON.parse failed on
+    // "Unterminated string" and the whole response was thrown away. The fix closes the open
+    // string and appends structural closers, recovering the finding's id + title (and a truncated
+    // description) — more useful than throwing the whole response away.
+    const truncated = '{"findings":[{"id":"f1","title":"Ransom","description":"Ransomware deployed at 10:20 on SRV-01 by js';
+    const repaired = repairTruncatedJson(truncated);
+    const parsed = JSON.parse(repaired) as { findings: { id: string; title: string; description: string }[] };
+    expect(parsed.findings).toHaveLength(1);
+    expect(parsed.findings[0].id).toBe("f1");
+    expect(parsed.findings[0].title).toBe("Ransom");
+    // The description was truncated mid-string; the repair closed the string, so it parses.
+    expect(parsed.findings[0].description).toContain("Ransomware deployed");
+  });
+
+  it("#4: parseJsonLoose recovers a partial result from a first-object-string truncation", () => {
+    const raw = '{"findings":[{"id":"f1","title":"Ransom","description":"Ransomware deployed at 10:20 on SRV-01 by js';
+    const parsed = parseJsonLoose(raw) as { findings: { id: string; title: string }[] };
+    expect(parsed.findings).toHaveLength(1);
+    expect(parsed.findings[0].id).toBe("f1");
+  });
 });


### PR DESCRIPTION
## Bugs (HIGH #2 silent data loss + MEDIUM #4 unrecoverable truncation)
**#2** — `parseJsonLoose`: when the trimmed text starts with `{`/`[` and `JSON.parse` fails, it fell through to `extractJsonText`, which matched the FIRST inner `json` fence ANYWHERE. A response whose description contained a raw newline (control char) AND a quoted fenced-json block (an attacker command) got sliced down to the tiny inner snippet — the whole synthesis (findings + summary) was silently lost and the call was still charged. Fix: retry `JSON.parse(escapeControlCharsInStrings(trimmed))` BEFORE fence extraction. The escape is string-literal-aware, so it's safe on the whole document.

**#4** — `repairTruncatedJson`: when `lastBrace === -1` (truncation landed inside the FIRST object's string, no complete `}` exists), it returned the input unchanged, leaving an unterminated string → `JSON.parse` failed on 'Unterminated string' → whole response thrown away. Fix: `repairInsideFirstObject` cuts back to the last top-level comma, closes the open string, drops a dangling comma, appends structural closers. Recovers the finding's id + title (and a truncated description).

## Verification
- `tsc --noEmit` clean.
- 19 extractJson tests pass (+3 new).

Found by end-to-end QA AI-pipeline subagent.