### PR TITLE
fix(security): make DFIR_NOTIFY_INSECURE respect the non-loopback TLS-MITM guard

### DIFF
--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2960,6 +2960,15 @@ const TLS_HOST_URL: Partial<Record<string, string | (() => string | undefined)>>
   SERVICENOW: () => process.env.DFIR_SERVICENOW_URL,
   NOTION: "https://api.notion.com",
   CLICKUP: "https://api.clickup.com/api/v2",
+  // NOTIFY webhooks are arbitrary external URLs (hooks.slack.com, outlook.office.com, a self-
+  // hosted Mattermost) only known at send time from NotificationConfigStore — there's no single
+  // env var to read at boot. DFIR_NOTIFY_INSECURE=1 used to silently bypass the non-loopback TLS-
+  // MITM guard for ALL of them (the guard defaulted to loopback when hostUrl was undefined). The
+  // minimal correct fix without a per-send-fetch refactor: when insecure is set, default hostUrl
+  // to a NON-loopback sentinel so the guard fires (and throws → caught → falls back to the
+  // verified global fetch) unless the operator also sets DFIR_TLS_ALLOW_INSECURE_EXTERNAL=true.
+  // When insecure is NOT set, no custom fetch is built at all, so the sentinel is never consulted.
+  NOTIFY: () => (isEnvFlag(process.env.DFIR_NOTIFY_INSECURE) ? "https://hooks.slack.com" : undefined),
 };
 function tlsFetchFor(name: "MISP" | "YETI" | "OPENCTI" | "IRIS" | "TIMESKETCH" | "NOTION" | "CLICKUP" | "NOTIFY" | "JIRA" | "SERVICENOW") {
   const hostSource = TLS_HOST_URL[name];

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2946,10 +2946,7 @@ export function buildVelociraptorProvider(): AnalyzeProvider | undefined {
 // DFIR_<NAME>_URL. NOTION and CLICKUP have no such env var — they're fixed SaaS hosts — so their
 // entries are the literal constants those clients themselves use, which correctly makes the guard
 // treat them as non-loopback (there's no legitimate reason to skip TLS verification against the
-// real api.notion.com/api.clickup.com). NOTIFY has no entry: it's one shared fetchFn reused across
-// whichever per-channel webhook URL a notification targets (stored in NotificationStore, not a
-// single env var at boot), so there's no single host to check here — DFIR_NOTIFY_INSECURE keeps
-// today's unguarded behavior until that's threaded through per-send instead of at construction.
+// real api.notion.com/api.clickup.com).
 const TLS_HOST_URL: Partial<Record<string, string | (() => string | undefined)>> = {
   MISP: () => process.env.DFIR_MISP_URL,
   YETI: () => process.env.DFIR_YETI_URL,
@@ -2962,15 +2959,19 @@ const TLS_HOST_URL: Partial<Record<string, string | (() => string | undefined)>>
   CLICKUP: "https://api.clickup.com/api/v2",
   // NOTIFY webhooks are arbitrary external URLs (hooks.slack.com, outlook.office.com, a self-
   // hosted Mattermost) only known at send time from NotificationConfigStore — there's no single
-  // env var to read at boot. DFIR_NOTIFY_INSECURE=1 used to silently bypass the non-loopback TLS-
-  // MITM guard for ALL of them (the guard defaulted to loopback when hostUrl was undefined). The
-  // minimal correct fix without a per-send-fetch refactor: when insecure is set, default hostUrl
-  // to a NON-loopback sentinel so the guard fires (and throws → caught → falls back to the
-  // verified global fetch) unless the operator also sets DFIR_TLS_ALLOW_INSECURE_EXTERNAL=true.
-  // When insecure is NOT set, no custom fetch is built at all, so the sentinel is never consulted.
-  NOTIFY: () => (isEnvFlag(process.env.DFIR_NOTIFY_INSECURE) ? "https://hooks.slack.com" : undefined),
+  // env var to read at boot. That is precisely why DFIR_NOTIFY_INSECURE=1 silently bypassed the
+  // non-loopback TLS-MITM guard for ALL of them: hostUrl was undefined and the guard defaults to
+  // "treat as loopback", i.e. allow. Since we can't know the host, assume the answer that fails
+  // closed — a sentinel that is definitively not loopback, so the guard fires and tlsFetchFor
+  // falls back to the verified global fetch unless the operator ALSO sets
+  // DFIR_TLS_ALLOW_INSECURE_EXTERNAL=true. hostUrl feeds nothing but isLoopbackUrl, so a reserved
+  // .invalid name (RFC 2606) is the honest spelling: it names no real host and can't be mistaken
+  // for one being verified. Only consulted when insecure is set — otherwise no custom fetch is
+  // built at all. Threading the real per-send URL through would let a loopback webhook keep
+  // using insecure on its own, which this deliberately no longer does.
+  NOTIFY: () => (isEnvFlag(process.env.DFIR_NOTIFY_INSECURE) ? "https://notify-webhook.invalid" : undefined),
 };
-function tlsFetchFor(name: "MISP" | "YETI" | "OPENCTI" | "IRIS" | "TIMESKETCH" | "NOTION" | "CLICKUP" | "NOTIFY" | "JIRA" | "SERVICENOW") {
+export function tlsFetchFor(name: "MISP" | "YETI" | "OPENCTI" | "IRIS" | "TIMESKETCH" | "NOTION" | "CLICKUP" | "NOTIFY" | "JIRA" | "SERVICENOW") {
   const hostSource = TLS_HOST_URL[name];
   const hostUrl = typeof hostSource === "function" ? hostSource() : hostSource;
   try {

--- a/companion/tests/server/tlsFetchForWiring.test.ts
+++ b/companion/tests/server/tlsFetchForWiring.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { buildEnrichmentProviders, setServerLogger, getServerLogger } from "../../src/server.js";
+import { buildEnrichmentProviders, tlsFetchFor, setServerLogger, getServerLogger } from "../../src/server.js";
 import type { Logger } from "../../src/logging/logger.js";
 
 // #246's insecureSkipVerify guard is unreachable from the real server unless tlsFetchFor() passes
@@ -7,7 +7,7 @@ import type { Logger } from "../../src/logging/logger.js";
 // (buildEnrichmentProviders, the same function server.ts calls at boot and on live reload), not
 // buildTlsFetch in isolation, so a regression in the wiring itself would fail here.
 
-const ENV_KEYS = ["DFIR_MISP_URL", "DFIR_MISP_KEY", "DFIR_MISP_INSECURE", "DFIR_TLS_ALLOW_INSECURE_EXTERNAL"];
+const ENV_KEYS = ["DFIR_MISP_URL", "DFIR_MISP_KEY", "DFIR_MISP_INSECURE", "DFIR_TLS_ALLOW_INSECURE_EXTERNAL", "DFIR_NOTIFY_INSECURE"];
 const saved: Record<string, string | undefined> = {};
 let originalLogger: Logger;
 
@@ -54,5 +54,31 @@ describe("tlsFetchFor wiring — insecureSkipVerify guard (#246)", () => {
     process.env.DFIR_MISP_URL = "https://misp.example.com";
     process.env.DFIR_MISP_KEY = "key123";
     expect(() => buildEnrichmentProviders()).not.toThrow();
+  });
+});
+
+// A notification webhook's host is only known at send time, so there is no env var for
+// tlsFetchFor to read — which meant hostUrl was undefined, the guard defaulted to "loopback",
+// and DFIR_NOTIFY_INSECURE turned off certificate verification for every Slack/Teams/Mattermost
+// webhook with nothing to stop it (#7).
+describe("tlsFetchFor(NOTIFY) — the guard must apply to webhooks too", () => {
+  it("refuses to skip verification on DFIR_NOTIFY_INSECURE alone, and says why", () => {
+    process.env.DFIR_NOTIFY_INSECURE = "1";
+    const warn = vi.fn();
+    setServerLogger({ ...originalLogger, warn });
+
+    // undefined = no custom TLS trust → createNotifier falls back to the verified global fetch.
+    expect(tlsFetchFor("NOTIFY")).toBeUndefined();
+    expect(warn.mock.calls.some(([m]) => /non-loopback/i.test(m as string))).toBe(true);
+  });
+
+  it("honours DFIR_NOTIFY_INSECURE once the operator also opts in to external insecure TLS", () => {
+    process.env.DFIR_NOTIFY_INSECURE = "1";
+    process.env.DFIR_TLS_ALLOW_INSECURE_EXTERNAL = "true";
+    expect(tlsFetchFor("NOTIFY")).toBeTypeOf("function");
+  });
+
+  it("builds no custom fetch at all when insecure is not requested", () => {
+    expect(tlsFetchFor("NOTIFY")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Bug (MED-HIGH — credential exposure to MITM)
`DFIR_NOTIFY_INSECURE=1` silently bypassed the non-loopback TLS-MITM guard for ALL notification webhooks. NOTIFY had no entry in `TLS_HOST_URL`, so `buildTlsFetch`'s loopback guard defaulted to `true` when `hostUrl` was `undefined` — the guard never fired. An on-path attacker could intercept the webhook request and harvest the webhook token/URL/payload (which includes case findings + deep-links). Every other integration was already protected; NOTIFY was the documented unfixed gap.

## Fix
Give NOTIFY a `hostUrl` function that returns a non-loopback sentinel (`https://hooks.slack.com`) WHEN insecure is set, so the guard fires (throws → caught → falls back to verified fetch) unless the operator also sets `DFIR_TLS_ALLOW_INSECURE_EXTERNAL=true`. When insecure is NOT set, no custom fetch is built. Per-send-host threading is a bigger refactor; this is the minimal correct fix closing the MITM gap today. A loopback self-hosted Mattermost with insecure + the override still works.

## Verification
- `tsc --noEmit` clean.
- 27 tlsFetch + notify + 4 tlsFetchForWiring tests still pass.

Found by end-to-end QA enrichment subagent.