### PR TITLE
fix(security): skip a malformed cookie instead of crashing the lock gate with 500

### DIFF
--- a/companion/src/analysis/casePassword.ts
+++ b/companion/src/analysis/casePassword.ts
@@ -111,7 +111,18 @@ export function parseCookieHeader(header: string | undefined): Record<string, st
     if (eq === -1) continue;
     const name = part.slice(0, eq).trim();
     const value = part.slice(eq + 1).trim();
-    if (name) out[name] = decodeURIComponent(value);
+    if (!name) continue;
+    // A malformed percent-escape (e.g. %ZZ) throws URIError from decodeURIComponent. Previously
+    // that propagated out of the case-lock gate (parseCookieHeader sat outside its try/catch)
+    // and the /lock-status route, surfacing as a 500 + raw 'URIError: URI malformed' leak — and
+    // it fired on ANY cookie name (a malformed cookie from any other origin blocked all access
+    // to a password-protected case). Treat a malformed cookie as no cookie: skip it (the gate
+    // then falls back to its normal no-unlock-cookie path — 401 locked — instead of crashing).
+    try {
+      out[name] = decodeURIComponent(value);
+    } catch {
+      // URIError: malformed URI sequence — skip this cookie, keep the rest.
+    }
   }
   return out;
 }

--- a/companion/tests/analysis/casePassword.test.ts
+++ b/companion/tests/analysis/casePassword.test.ts
@@ -116,6 +116,14 @@ describe("parseCookieHeader", () => {
   it("URL-decodes values", () => {
     expect(parseCookieHeader("tok=" + encodeURIComponent("a.b/c"))).toEqual({ tok: "a.b/c" });
   });
+  it("skips a cookie with a malformed percent-escape instead of throwing (#24)", () => {
+    // A %ZZ throws URIError from decodeURIComponent; previously that propagated out of the
+    // case-lock gate as a 500 + raw 'URIError: URI malformed' leak, and fired on ANY cookie name
+    // (a malformed cookie from any other origin blocked all access to a password-protected case).
+    expect(() => parseCookieHeader("session_id=%ZZ")).not.toThrow();
+    // The malformed cookie is dropped; a well-formed sibling survives.
+    expect(parseCookieHeader("good=ok; bad=%ZZ; other=x")).toEqual({ good: "ok", other: "x" });
+  });
 });
 
 describe("unlockCookieName", () => {


### PR DESCRIPTION
## Bug (MEDIUM — soft DoS + error leak)
`parseCookieHeader` called `decodeURIComponent` unguarded. A malformed percent-escape (`%ZZ`) threw `URIError`, which propagated out of the case-lock gate (it sat outside its try/catch) and the `/lock-status` route → `500` + raw `URIError: URI malformed` leak. It fired on ANY cookie name — a malformed cookie from any other origin on `127.0.0.1` blocked all access to a password-protected case.

## Fix
Wrap `decodeURIComponent` in try/catch; on `URIError` skip that cookie and keep the rest. Fixes both the lock gate (`caseLockGate.ts:63`) and `readUnlockState` (`server.ts:805`) at the single source.

## Verification
- `tsc --noEmit` clean.
- 62 casePassword + routes + capturesLockGate + wsGate tests pass (+1 new malformed-cookie-skipped test).

Found by end-to-end QA HTTP-routes subagent.