### PR TITLE
fix(enrich): honor explicit 0 in DFIR_ENRICH_* env vars + treat corrupt enrich-control.json as never-set

### DIFF
--- a/companion/src/enrichment/enrichControl.ts
+++ b/companion/src/enrichment/enrichControl.ts
@@ -40,12 +40,18 @@ export class EnrichControlStore {
     return join(this.cases.stateDir(caseId), "enrich-control.json");
   }
 
-  // Returns the raw stored control (possibly legacy-shaped), or null when never set.
+  // Returns the raw stored control (possibly legacy-shaped), or null when never set OR when the
+  // file is corrupt/unreadable (empty, truncated, hand-edited, a crash mid-write). A corrupt
+  // control previously threw JSON.parse's SyntaxError out of load, propagating to the lock gate
+  // and the enrichment engine — GET /cases/:id/enrich-control returned 500 and enrichment
+  // silently errored for that case with no recovery. Treat a corrupt file as "never set" (null)
+  // so the case degrades to the OPSEC-safe local-only default and the analyst can re-save (#6).
   async load(caseId: string): Promise<RawControl | null> {
     try {
       return JSON.parse(await readFile(this.path(caseId), "utf8")) as RawControl;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      if (err instanceof SyntaxError) return null;   // corrupt/unreadable → fall back to default
       throw err;
     }
   }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2989,6 +2989,17 @@ function isEnvFlag(value: string | undefined): boolean {
   return /^(1|true|yes|on)$/i.test(value ?? "");
 }
 
+// Parse a numeric env var, honoring an explicit "0". `Number(x) || undefined` would discard 0
+// (falsy) and silently fall back to the hardcoded default — an operator who set
+// DFIR_ENRICH_RETRIES=0 to disable 429 retry still got 2 retries. Returns undefined for
+// unset/empty/non-finite so downstream `?? default` keeps working.
+function numEnv(key: string): number | undefined {
+  const v = process.env[key];
+  if (v === undefined || v === "") return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 // Build the DFIR-IRIS push client from env (DFIR_IRIS_URL + DFIR_IRIS_KEY). Returns
 // undefined when not configured, which hides the dashboard's "Push to IRIS" button.
 // TLS trust for a self-hosted IRIS honors DFIR_IRIS_CA / DFIR_IRIS_INSECURE.
@@ -3673,17 +3684,21 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     enrichProviderDelayMs: buildEnrichProviderDelayMap(),
     // #78: ± jitter on the inter-call wait, and bounded retry-with-backoff on a 429 (honouring
     // Retry-After) instead of a single rate-limit hit aborting the lookup.
-    enrichJitterMs: Number(process.env.DFIR_ENRICH_JITTER_MS) || undefined,
-    enrichRetries: Number(process.env.DFIR_ENRICH_RETRIES) || undefined,
-    enrichRetryBackoffMs: Number(process.env.DFIR_ENRICH_RETRY_BACKOFF_MS) || undefined,
-    enrichMaxIocs: Number(process.env.DFIR_ENRICH_MAX) || undefined,
+    // NOTE: parse with `numEnv` (not `Number(x) || undefined`) so an explicit "0" is honored —
+    // `Number("0") || undefined` is `undefined` (0 is falsy), which silently fell back to the
+    // hardcoded default. An operator who set DFIR_ENRICH_RETRIES=0 to disable 429 retry still
+    // got 2 retries (#5). The poller's `=== "0"` special-case is now unified here too.
+    enrichJitterMs: numEnv("DFIR_ENRICH_JITTER_MS"),
+    enrichRetries: numEnv("DFIR_ENRICH_RETRIES"),
+    enrichRetryBackoffMs: numEnv("DFIR_ENRICH_RETRY_BACKOFF_MS"),
+    enrichMaxIocs: numEnv("DFIR_ENRICH_MAX"),
     customerExposureProviders: buildCustomerExposureProviders(),
-    customerExposureDelayMs: Number(process.env.DFIR_EXPOSURE_DELAY_MS) || undefined,
+    customerExposureDelayMs: numEnv("DFIR_EXPOSURE_DELAY_MS"),
     // Reachability gate: probe a self-hosted MISP/YETI before sending IOCs, cached this long
     // (default 60s in the cache). The poller re-checks down servers on the same cadence and
     // auto-resumes skipped cases on recovery — set DFIR_ENRICH_HEALTH_POLL_MS=0 to disable it.
-    enrichHealthTtlMs: Number(process.env.DFIR_ENRICH_HEALTH_TTL_MS) || undefined,
-    enrichHealthPollMs: process.env.DFIR_ENRICH_HEALTH_POLL_MS === "0" ? 0 : (Number(process.env.DFIR_ENRICH_HEALTH_POLL_MS) || 60_000),
+    enrichHealthTtlMs: numEnv("DFIR_ENRICH_HEALTH_TTL_MS"),
+    enrichHealthPollMs: numEnv("DFIR_ENRICH_HEALTH_POLL_MS") ?? 60_000,
     irisClient: buildIrisClient(),
     velociraptorClient,
     velociraptorClientStore,

--- a/companion/tests/enrichment/enrichControl.test.ts
+++ b/companion/tests/enrichment/enrichControl.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { resolveEnabledProviders } from "../../src/enrichment/enrichControl.js";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { EnrichControlStore, resolveEnabledProviders } from "../../src/enrichment/enrichControl.js";
 
 const configured = ["VirusTotal", "AbuseIPDB", "MISP", "YETI"];
 const local = ["MISP", "YETI"];
@@ -21,5 +25,29 @@ describe("resolveEnabledProviders", () => {
   it("migrates legacy { enabled } — true → all configured, false → none", () => {
     expect(resolveEnabledProviders({ enabled: true }, configured, local)).toEqual(configured);
     expect(resolveEnabledProviders({ enabled: false }, configured, local)).toEqual([]);
+  });
+});
+
+describe("EnrichControlStore.load — corrupt-file resilience (#6)", () => {
+  it("returns null for an empty/corrupt enrich-control.json instead of throwing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-enrichctrl-"));
+    const cases = new CaseStore(root);
+    await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const store = new EnrichControlStore(cases);
+    // Write a corrupt (empty) control file — a crash mid-write or a sync conflict.
+    await writeFile(join(cases.stateDir("c1"), "enrich-control.json"), "");
+    // load must NOT throw; it returns null so the case degrades to the default.
+    await expect(store.load("c1")).resolves.toBeNull();
+    // And resolveEnabledProviders(null, ...) gives the OPSEC-safe local-only default.
+    expect(resolveEnabledProviders(await store.load("c1"), configured, local)).toEqual(["MISP", "YETI"]);
+  });
+
+  it("returns null for a truncated/invalid-JSON control file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-enrichctrl-"));
+    const cases = new CaseStore(root);
+    await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const store = new EnrichControlStore(cases);
+    await writeFile(join(cases.stateDir("c1"), "enrich-control.json"), '{providers:["VirusTotal"');
+    await expect(store.load("c1")).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Bugs (MEDIUM #5 + MEDIUM #6)
**#5** — `DFIR_ENRICH_RETRIES=0` (and `MAX=0`, `BACKOFF=0`, `JITTER=0`, `DELAY=0`, `HEALTH_TTL=0`, `EXPOSURE_DELAY=0`) silently ignored. `Number(x) || undefined` discards 0 (falsy) → hardcoded default used. An operator who set `RETRIES=0` to disable 429 retry still got 2 retries. Add `numEnv()` helper returning 0 for "0"; unify all seven numeric enrichment env vars + the poller through it.

**#6** — `EnrichControlStore.load` only caught `ENOENT`; a corrupt/empty `enrich-control.json` (crash mid-write, sync conflict) threw `SyntaxError` → 500 on the enrichment panel + enrichment silently errored for that case with no recovery. Catch `SyntaxError` → return `null` (degrade to OPSEC-safe default, analyst can re-save).

## Verification
- `tsc --noEmit` clean.
- 147 enrichment tests pass (+2 new corrupt-file-resilience tests).

Found by end-to-end QA enrichment subagent.