### PR TITLE
fix(ai): parse Gemini usageMetadata so AI cost card shows real token counts

### DIFF
--- a/companion/src/providers/gemini.ts
+++ b/companion/src/providers/gemini.ts
@@ -56,9 +56,22 @@ export class GeminiProvider implements AIProvider {
       const body = await res.text().catch(() => "");
       throw new ProviderError(httpErrorMessage("Gemini", res.status, body), httpErrorKind(res.status));
     }
-    const json = (await res.json()) as { candidates?: { content?: { parts?: { text?: string }[] } }[] };
+    const json = (await res.json()) as {
+      candidates?: { content?: { parts?: { text?: string }[] } }[];
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number; cachedContentTokenCount?: number };
+    };
     const text = json.candidates?.[0]?.content?.parts?.[0]?.text;
     if (!text) throw new ProviderError("Gemini returned no content", "other");
-    return { rawText: text };
+    // Google's Generative Language response includes usageMetadata (promptTokenCount,
+    // candidatesTokenCount, cachedContentTokenCount). Parse it so the Diagnostics "AI cost — this
+    // case" card shows real token counts for Gemini instead of always 0/0 (bug #3). Google does
+    // not report a dollar cost, so costUSD is omitted (matching the other providers).
+    const u = json.usageMetadata;
+    const usage = u && {
+      ...(u.promptTokenCount !== undefined ? { inputTokens: u.promptTokenCount } : {}),
+      ...(u.candidatesTokenCount !== undefined ? { outputTokens: u.candidatesTokenCount } : {}),
+      ...(u.cachedContentTokenCount !== undefined ? { cacheReadTokens: u.cachedContentTokenCount } : {}),
+    };
+    return { rawText: text, ...(usage ? { usage } : {}) };
   }
 }

--- a/companion/tests/providers/gemini.test.ts
+++ b/companion/tests/providers/gemini.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { GeminiProvider } from "../../src/providers/gemini.js";
-import { ProviderError } from "../../src/providers/provider.js";
+import { ProviderError, type AnalyzeResult } from "../../src/providers/provider.js";
 
 describe("GeminiProvider — base URL validation (#246)", () => {
   // validateBaseUrl() has its own unit tests (urlValidation.test.ts); these confirm it's actually
@@ -17,5 +17,39 @@ describe("GeminiProvider — base URL validation (#246)", () => {
 
   it("allows https:// to any host, including the provider default", () => {
     expect(() => new GeminiProvider({ apiKey: "k", model: "gemini-1.5-pro" })).not.toThrow();
+  });
+});
+
+describe("GeminiProvider — usageMetadata parsing (#3)", () => {
+  it("reports input/output/cacheRead tokens from usageMetadata so the AI cost card is not always 0/0", async () => {
+    const fakeResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }],
+        usageMetadata: { promptTokenCount: 42, candidatesTokenCount: 7, cachedContentTokenCount: 3 },
+      }),
+      text: async () => "",
+    };
+    const provider = new GeminiProvider({ apiKey: "k", model: "gemini-2.5-pro", fetchFn: async () => fakeResponse as unknown as Response });
+    const result: AnalyzeResult = await provider.analyze({ systemPrompt: "s", userPrompt: "x", images: [] });
+    expect(result.usage).toBeDefined();
+    expect(result.usage!.inputTokens).toBe(42);
+    expect(result.usage!.outputTokens).toBe(7);
+    expect(result.usage!.cacheReadTokens).toBe(3);
+    // Google does not report a dollar cost.
+    expect(result.usage!.costUSD).toBeUndefined();
+  });
+
+  it("omits usage when usageMetadata is absent (no regression)", async () => {
+    const fakeResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }] }),
+      text: async () => "",
+    };
+    const provider = new GeminiProvider({ apiKey: "k", model: "gemini-2.5-pro", fetchFn: async () => fakeResponse as unknown as Response });
+    const result = await provider.analyze({ systemPrompt: "s", userPrompt: "x", images: [] });
+    expect(result.usage).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Bug (MEDIUM — diagnostics silently zero for Gemini)
`GeminiProvider.analyze` read only `candidates[0].content.parts[0].text` and returned no `usage`. Google's response includes `usageMetadata` (`promptTokenCount`, `candidatesTokenCount`, `cachedContentTokenCount`), but the code never read it. The Diagnostics 'AI cost — this case' card showed `calls:N, costUSD:0, inputTokens:0, outputTokens:0` for a case synthesized with Gemini — the feature built to show per-case spend was silently zero for an entire supported provider.

## Fix
Declare `usageMetadata` on the response type, parse it into `ProviderUsage` (`inputTokens`=`promptTokenCount`, `outputTokens`=`candidatesTokenCount`, `cacheReadTokens`=`cachedContentTokenCount`). Google does not report a dollar cost, so `costUSD` is omitted.

## Verification
- `tsc --noEmit` clean.
- 5 gemini tests pass (+2 new usage-parsing tests with a fake `fetchFn`).

Found by end-to-end QA AI-pipeline subagent.