### PR TITLE
fix(analysis): epoch ms (not ISO strings) for lastSeen/firstSeen + fall back display ts when endTimestamp unparseable

### DIFF
--- a/companion/src/analysis/burstDetect.ts
+++ b/companion/src/analysis/burstDetect.ts
@@ -68,19 +68,28 @@ function eventEndMs(e: ForensicEvent): number {
   return Number.isNaN(end) ? Date.parse(e.timestamp) : end;
 }
 
+// The display-string companion to eventEndMs: fall back to e.timestamp when endTimestamp is
+// absent OR unparseable. The plain `e.endTimestamp || e.timestamp` truthiness check kept an
+// unparseable-but-non-empty endTimestamp (e.g. "invalid-date") as the display value while the
+// numeric helper correctly fell back — so the gap/phase card rendered a garbage ISO string (#15).
+function eventEndTsStr(e: ForensicEvent): string {
+  const end = e.endTimestamp ? Date.parse(e.endTimestamp) : NaN;
+  return Number.isNaN(end) ? e.timestamp : e.endTimestamp!;
+}
+
 function summarizePhase(index: number, events: ForensicEvent[]): AttackPhase {
   const tactic = dominantTactic(events);
   const techniques = new Set<string>();
   let count = 0;
   let maxSeverity: Severity = "Info";
-  let endTs = events[0].endTimestamp || events[0].timestamp;
+  let endTs = eventEndTsStr(events[0]);
   let endMs = eventEndMs(events[0]);
   for (const e of events) {
     for (const t of e.mitreTechniques) techniques.add(t);
     count += e.count && e.count > 1 ? e.count : 1;
     maxSeverity = worse(maxSeverity, e.severity);
     const ms = eventEndMs(e);
-    if (ms > endMs) { endMs = ms; endTs = e.endTimestamp || e.timestamp; }
+    if (ms > endMs) { endMs = ms; endTs = eventEndTsStr(e); }
   }
   return {
     id: `phase-${index + 1}`,

--- a/companion/src/analysis/gapDetect.ts
+++ b/companion/src/analysis/gapDetect.ts
@@ -103,6 +103,16 @@ function endMs(e: ForensicEvent): number {
   return Number.isNaN(end) ? Date.parse(e.timestamp) : end;
 }
 
+// The display-string companion to endMs: fall back to e.timestamp when endTimestamp is absent OR
+// unparseable. The plain `e.endTimestamp || e.timestamp` truthiness check kept an unparseable-
+// but-non-empty endTimestamp (e.g. "invalid-date") as the display value while endMs correctly
+// fell back — so the gap card rendered a garbage ISO string for startTimestamp, and a Finding
+// built from it carried a non-ISO firstSeen (#15).
+function endTsStr(e: ForensicEvent): string {
+  const end = e.endTimestamp ? Date.parse(e.endTimestamp) : NaN;
+  return Number.isNaN(end) ? e.timestamp : e.endTimestamp!;
+}
+
 // An event's distinct named sources (the tools/imports that reported it). Events with no `sources`
 // (e.g. screenshot extraction, manual entry) still bound gaps on the full timeline, but they don't
 // belong to any named source's per-source stream.
@@ -256,7 +266,7 @@ export function detectTimelineGaps(events: readonly ForensicEvent[], opts: GapOp
   // activity so a long aggregated event doesn't open a false gap. A qualifying window between the
   // running end and the next event's start is a stretch where NOTHING logged → all sources silent.
   let prevEndMs = endMs(dated[0]);
-  let prevEndTs = dated[0].endTimestamp || dated[0].timestamp;
+  let prevEndTs = endTsStr(dated[0]);
   let prevId = dated[0].id;
   for (let i = 1; i < dated.length; i++) {
     const e = dated[i];
@@ -278,7 +288,7 @@ export function detectTimelineGaps(events: readonly ForensicEvent[], opts: GapOp
       });
     }
     const eEnd = endMs(e);
-    if (eEnd >= prevEndMs) { prevEndMs = eEnd; prevEndTs = e.endTimestamp || e.timestamp; prevId = e.id; }
+    if (eEnd >= prevEndMs) { prevEndMs = eEnd; prevEndTs = endTsStr(e); prevId = e.id; }
   }
 
   // Pass B — PARTIAL silence per source. Only meaningful with ≥2 named sources (with one source every
@@ -300,7 +310,7 @@ export function detectTimelineGaps(events: readonly ForensicEvent[], opts: GapOp
         const durationSeconds = Math.round((bStart - fromMs) / 1000);
         gaps.push({
           id: "",
-          startTimestamp: a.endTimestamp || a.timestamp,
+          startTimestamp: endTsStr(a),
           endTimestamp: b.timestamp,
           durationSeconds,
           durationLabel: formatDuration(durationSeconds),

--- a/companion/src/analysis/loginGraph.ts
+++ b/companion/src/analysis/loginGraph.ts
@@ -135,8 +135,13 @@ export function buildLoginGraph(events: readonly ForensicEvent[], maxEdges = DEF
 
     const key = `${acct.id}|${host.id}|${p.typeName}|${p.outcome}`;
     // Clamp: anomalous importer data can carry endTimestamp < timestamp; lastSeen must never precede firstSeen.
+    // Compare epoch ms, NOT lexicographic ISO strings — a higher-precision endTimestamp that is
+    // chronologically LATER (e.g. ...09:20:00.500Z) sorts BEFORE the shorter ...09:20:00Z because
+    // '.' (0x2E) < 'Z' (0x5A), so a string `>` would discard the genuinely-later time (#14).
     const end = e.endTimestamp ?? e.timestamp;
-    const last = end > e.timestamp ? end : e.timestamp;
+    const endMs = e.endTimestamp ? Date.parse(e.endTimestamp) : NaN;
+    const tsMs = Date.parse(e.timestamp);
+    const last = !Number.isNaN(endMs) && endMs > tsMs ? end : e.timestamp;
     const risky = p.logonType !== undefined && logonRisk(p.logonType, p.sourceIp ?? "").severity !== undefined;
     const edge = edges.get(key);
     if (!edge) {
@@ -145,11 +150,17 @@ export function buildLoginGraph(events: readonly ForensicEvent[], maxEdges = DEF
         count: n, firstSeen: e.timestamp, lastSeen: last, risk: risky ? "medium" : "none",
       });
     } else {
+      // Same epoch-based comparison for firstSeen/lastSeen merge (avoids the same string-sort bug).
+      const eFirstMs = Date.parse(edge.firstSeen);
+      const eLastMs = Date.parse(edge.lastSeen);
+      const firstSeen = !Number.isNaN(eFirstMs) && tsMs < eFirstMs ? e.timestamp : edge.firstSeen;
+      const lastMs = Date.parse(last);
+      const lastSeen = !Number.isNaN(lastMs) && !Number.isNaN(eLastMs) && lastMs > eLastMs ? last : edge.lastSeen;
       edges.set(key, {
         ...edge,
         count: edge.count + n,
-        firstSeen: e.timestamp < edge.firstSeen ? e.timestamp : edge.firstSeen,
-        lastSeen: last > edge.lastSeen ? last : edge.lastSeen,
+        firstSeen,
+        lastSeen,
         risk: risky ? "medium" : edge.risk,
       });
     }

--- a/companion/tests/analysis/gapDetect.test.ts
+++ b/companion/tests/analysis/gapDetect.test.ts
@@ -335,4 +335,18 @@ describe("gapEnvOptions", () => {
     delete process.env.DFIR_GAP_MAX_FINDINGS;
     delete process.env.DFIR_GAP_OUTLIER_SPAN;
   });
+
+  it("#15: a gap's startTimestamp falls back to e.timestamp when endTimestamp is unparseable (not garbage)", () => {
+    // The bounding event carries a non-empty-but-unparseable endTimestamp ("invalid-date"). The
+    // numeric endMs helper correctly fell back to e.timestamp for the DURATION, but the display
+    // string used `e.endTimestamp || e.timestamp` (truthiness) and kept "invalid-date" — rendering
+    // a garbage ISO on the gap card and a non-ISO firstSeen on the derived Finding.
+    const before = series("a", "EventLog", "2026-05-20T08:00:00Z", 60, 10); // dense, qualifies
+    // Replace the LAST before-event's endTimestamp with an unparseable value.
+    before[before.length - 1].endTimestamp = "invalid-date";
+    const after = series("b", "EventLog", "2026-05-20T10:09:00Z", 60, 5);
+    const gaps = detectTimelineGaps([...before, ...after]);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].startTimestamp).toBe("2026-05-20T08:09:00.000Z"); // fell back, not "invalid-date"
+  });
 });

--- a/companion/tests/analysis/loginGraph.test.ts
+++ b/companion/tests/analysis/loginGraph.test.ts
@@ -205,3 +205,19 @@ describe("loginEdgeEvents", () => {
     expect(r.events[0]).toHaveProperty("description");
   });
 });
+
+describe("buildLoginGraph — epoch vs string timestamp comparison (#14)", () => {
+  it("lastSeen picks the chronologically-later endTimestamp even when it has higher fractional-second precision", () => {
+    // ...09:20:00Z (epoch X) vs ...09:20:00.500Z (epoch X+500ms). The '.' (0x2E) sorts before 'Z'
+    // (0x5A), so a lexicographic string `>` would DISCARD the genuinely-later .500Z time. The fix
+    // compares Date.parse epoch ms instead.
+    const rows = [
+      LOGON("CORP\\jdoe", "SRV-01", 1, { ts: "2026-06-10T09:20:00Z", endTs: "2026-06-10T09:20:00.500Z" }),
+      LOGON("CORP\\jdoe", "SRV-01", 1, { ts: "2026-06-10T09:20:00Z" }),
+    ];
+    const g = buildLoginGraph(rows);
+    expect(g.edges).toHaveLength(1);
+    // lastSeen must be the .500Z time (chronologically later), not the shorter Z time.
+    expect(g.edges[0].lastSeen).toBe("2026-06-10T09:20:00.500Z");
+  });
+});


### PR DESCRIPTION
## Bugs (MEDIUM #14 + MEDIUM #15)
**#14** — `loginGraph.ts` computed `lastSeen` with lexicographic ISO string comparison. `.` (0x2E) sorts before `Z` (0x5A), so a chronologically-later higher-precision `endTimestamp` (`...09:20:00.500Z`) was discarded vs the shorter `...09:20:00Z` — the edge's `lastSeen` recorded the earlier time, understating the span and misordering range queries. The `firstSeen`/`lastSeen` merge had the same bug. Fix: compare `Date.parse` epoch ms.

**#15** — `gapDetect.ts`/`burstDetect.ts` have a numeric `endMs()`/`eventEndMs()` that correctly falls back from an unparseable `endTimestamp` to `e.timestamp` for the DURATION, but the DISPLAY string used `e.endTimestamp || e.timestamp` (truthiness) — a non-empty-but-unparseable `endTimestamp` (`"invalid-date"`) was kept, rendering a garbage ISO on the gap/phase card and a non-ISO `firstSeen` on the derived Finding. Fix: add `endTsStr()`/`eventEndTsStr()` using the same validity test as the numeric helper; replace the four `||` sites.

## Verification
- `tsc --noEmit` clean.
- 49 loginGraph + gapDetect + burstDetect tests pass (+2 new).

Found by end-to-end QA deterministic-analysis subagent.