### PR TITLE
fix(ingest): split Hayabusa Details on the broken bar only, not the ASCII pipe

### DIFF
--- a/companion/src/analysis/hayabusaImport.ts
+++ b/companion/src/analysis/hayabusaImport.ts
@@ -105,9 +105,14 @@ function hayaTime(s: string): string {
 
 // Parse a Hayabusa CSV `Details`/`ExtraFieldInfo` cell ("Proc: x ¦ CmdLine: y ¦ …") into a
 // field map. JSON timelines already give an object, handled separately.
+// The separator is the BROKEN BAR ¦ (U+00A6) — Hayabusa's actual field separator. The previous
+// regex `[¦|]` ALSO matched the ASCII pipe | (U+007C), a legitimate character in shell command
+// lines (e.g. `echo hello | grep foo`), so a detail value containing a pipe was over-split: the
+// tail became an orphan fragment with no `Key:` prefix and was silently dropped, truncating the
+// captured command line and any IOCs embedded in the lost tail (#27).
 function parseDetailCell(cell: string): Row {
   const out: Row = {};
-  for (const part of cell.split(/\s*[¦|]\s*/)) {
+  for (const part of cell.split(/\s*¦\s*/)) {
     const idx = part.indexOf(":");
     if (idx <= 0) continue;
     const k = part.slice(0, idx).trim();

--- a/companion/tests/analysis/hayabusaImport.test.ts
+++ b/companion/tests/analysis/hayabusaImport.test.ts
@@ -100,6 +100,18 @@ describe("parseHayabusaTimeline — csv-timeline", () => {
     expect(r.events).toHaveLength(1);
     expect(r.events[0].count).toBe(2);
   });
+
+  it("#27: preserves an ASCII pipe inside a Cmd value (doesn't split on |, only on ¦)", () => {
+    // A shell pipeline in a CmdLine value: `echo hello | grep foo`. The previous regex `[¦|]`
+    // split on the ASCII pipe too, truncating the command line and dropping IOCs in the tail.
+    const text = csvTimeline([
+      ["2021-12-12 09:00:00.000 +00:00", "WS02", "Sec", "1", "high", "Pipe Test", "Cmd: ls ¦ Args: echo hello | grep foo", "t1059"],
+    ]);
+    const r = parseHayabusaTimeline(text);
+    expect(r.events).toHaveLength(1);
+    // The full command line survives — the ASCII pipe is part of the value, not a separator.
+    expect(r.events[0].description).toContain("echo hello | grep foo");
+  });
 });
 
 // Velociraptor's `Windows.Hayabusa.Rules` artifact emits Hayabusa verdict rows in NDJSON with


### PR DESCRIPTION
## Bug (MEDIUM — silent command-line truncation + IOC loss)
`parseDetailCell` split the Hayabusa `Details`/`ExtraFieldInfo` cell on `/\s*[¦|]\s*/`, matching BOTH the broken bar `¦` (Hayabusa's actual separator) AND the ASCII pipe `|` (a legitimate character in shell command lines). A value containing a shell pipeline (`echo hello | grep foo`) was over-split at the ASCII pipe; the tail became an orphan with no `Key:` prefix and was silently dropped, truncating the captured command line and any IOCs in the lost tail.

## Fix
Split on `/\s*¦\s*/` (broken bar only). The module's own header comment already states the separator is the broken bar.

## Verification
- `tsc --noEmit` clean.
- 11 hayabusaImport tests pass (+1 new ASCII-pipe-in-Cmd-value test).

Found by end-to-end QA ingest subagent.