### PR TITLE
fix(ingest): require the ShimCache discriminator in kapeSig so a generic CSV reaches the AI analyzer

### DIFF
--- a/companion/src/analysis/importDetect.ts
+++ b/companion/src/analysis/importDetect.ts
@@ -364,7 +364,12 @@ function velociraptorElasticCsvSig(h: Set<string>): boolean {
 }
 function kapeSig(h: Set<string>): boolean {
   return has(h, "executablename", "runcount") || has(h, "fullpath", "sha1") || has(h, "fullpath", "filekeylastwritetimestamp") ||
-    (h.has("path") && h.has("lastmodifiedtimeutc")) || has(h, "updatereasons", "updatetimestamp") ||
+    // ShimCache: require the executed/cacheentryposition discriminator the real ShimCache PROFILE
+    // match in kapeImport.ts needs. Without it, a generic CSV with just path + lastmodifiedtimeutc
+    // (common column names) was claimed as KAPE, dispatched to parseKapeCsv, found NO matching
+    // profile, and returned 0 events — silently dropping every row. It never reached the AI CSV
+    // analyzer (the `csv` fallback) because `kape` is a "confident" deterministic kind (#28).
+    (h.has("path") && h.has("lastmodifiedtimeutc") && (h.has("executed") || h.has("cacheentryposition"))) || has(h, "updatereasons", "updatetimestamp") ||
     (has(h, "parentpath", "filename") && (h.has("created0x10") || h.has("lastmodified0x10"))) ||
     has(h, "bytessent", "bytesreceived") || has(h, "deletedon", "filename") ||
     (h.has("absolutepath") && (h.has("lastinteracted") || h.has("firstinteracted"))) ||

--- a/companion/tests/analysis/importDetect.test.ts
+++ b/companion/tests/analysis/importDetect.test.ts
@@ -216,6 +216,16 @@ describe("detectImportKind — CSV formats", () => {
   it("kape: Amcache header", () => {
     expect(detectImportKind("am.csv", "ApplicationName,FullPath,SHA1,FileKeyLastWriteTimestamp\na,c:/x,abc,t")).toBe("kape");
   });
+  it("kape: ShimCache WITH the executed/cacheentryposition discriminator", () => {
+    expect(detectImportKind("shim.csv", "Path,LastModifiedTimeUTC,executed\nx,t,true")).toBe("kape");
+    expect(detectImportKind("shim2.csv", "Path,LastModifiedTimeUTC,cacheentryposition\nx,t,0")).toBe("kape");
+  });
+  it("#28: a generic CSV with only path + lastmodifiedtimeutc (no ShimCache discriminator) falls through to the AI CSV importer, not kape", () => {
+    // Previously kapeSig's loose ShimCache branch claimed it as kape; parseKapeCsv found no
+    // matching profile and returned 0 events — silently dropping every row. It must reach the AI
+    // CSV analyzer (the `csv` fallback) so its rows are actually extracted into the timeline.
+    expect(detectImportKind("generic.csv", "path,lastmodifiedtimeutc,extra\n/foo/bar,t,hello")).toBe("csv");
+  });
   it("plaso: dynamic header", () => {
     expect(detectImportKind("tl.csv", "datetime,timestamp_desc,source,message,parser\n2023-01-01T00:00:00+00:00,ctime,FILE,hi,filestat")).toBe("plaso");
   });


### PR DESCRIPTION
## Bug (MEDIUM — silent data loss)
`kapeSig`'s ShimCache branch was `(h.has("path") && h.has("lastmodifiedtimeutc"))` — but the real ShimCache profile match in `kapeImport.ts` additionally requires `executed` OR `cacheentryposition`. A generic CSV with only `path` + `lastmodifiedtimeutc` (common column names) was claimed as `kape`, dispatched to `parseKapeCsv`, found NO matching profile, returned 0 events — silently dropping every row. It never reached the AI CSV analyzer (the `csv` fallback) because `kape` is a confident deterministic kind that short-circuits.

## Fix
Add the `executed`/`cacheentryposition` discriminator to `kapeSig`'s ShimCache branch, mirroring the real profile. A generic CSV now falls through to `csv` and is AI-analyzed.

## Verification
- `tsc --noEmit` clean.
- 103 importDetect tests pass (+2 new: ShimCache WITH discriminator is `kape`, generic path+lastmodifiedtimeutc WITHOUT it is `csv`).

Found by end-to-end QA ingest subagent.