### PR TITLE
fix(reports,privacy): neutralize newlines in Markdown table cells + tokenize victim org NAME in redacted export

### DIFF
--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -51,7 +51,13 @@ import {
 // human value nor derivable data exists, a clearly marked placeholder shows what to fill.
 
 function cellMd(value: string): string {
-  return value.replace(/\|/g, "\\|");
+  // Escape the pipe (GFM table cell separator) AND neutralize newlines. A \n or \r inside a GFM
+  // table cell ends the row; the text after the newline becomes spurious rows with empty trailing
+  // cells, corrupting the table structure. The corrupted Markdown flows to the HTML export (marked
+  // parses the broken table) and the DOCX export, producing broken tables in all three deliverables.
+  // Newlines reach here from report-meta free-text fields (revisions[].comments, distribution[].name,
+  // glossary entries) and from AI-generated descriptions that contain a literal newline (#12).
+  return value.replace(/\|/g, "\\|").replace(/[\r\n]+/g, " ");
 }
 
 const SEVERITY_ORDER: Record<Severity, number> = {

--- a/companion/src/reports/redactedExportBuilder.ts
+++ b/companion/src/reports/redactedExportBuilder.ts
@@ -35,6 +35,12 @@ export interface RedactedExportDeps {
   // Optional: the victim org's own domains/emails (analyst-entered for the exposure check). These
   // are PII and are merged into the anonymizer's known entities so they're tokenized everywhere.
   customerStore?: CustomerStore;
+  // Optional: report metadata (for the victim organization NAME). The anonymizer's detectors match
+  // structured indicators (IP/email/host/domain) but NOT a free-text org name, so without feeding
+  // it here as a custom OTHER entity the victim org name (e.g. "GlobalTech Industries") survived
+  // unredacted on the title page and throughout the report while the same org's DOMAINS were
+  // tokenized (#13). The org's domains come in via customerStore; the org NAME comes in here.
+  reportMetaStore?: { load(caseId: string): Promise<{ organization?: string }> };
   ocrRunner: OcrRunner;
   // Injectable for tests; default is the real sharp-backed redactor + fs readers.
   redactImage?: (buf: Buffer, opts: ScreenshotRedactOptions) => Promise<ScreenshotRedactResult>;
@@ -64,11 +70,22 @@ export async function buildRedactedExport(
   // domain in the exposure section is not otherwise in deriveKnownEntities) and their emails too.
   const targets = deps.customerStore ? await deps.customerStore.load(caseId) : { domains: [], emails: [] };
   const targetEmails: CustomEntity[] = targets.emails.map((value) => ({ value, category: "EMAIL" as const }));
+  // Victim organization NAME: the anonymizer's anonCustom does a word-boundary exact-match on every
+  // custom entity, so a multi-word org name is matched and tokenized wherever it appears. Without
+  // this, "GlobalTech Industries" survived unredacted while globaltech.com was tokenized (#13).
+  let orgEntity: CustomEntity[] = [];
+  if (deps.reportMetaStore) {
+    try {
+      const meta = await deps.reportMetaStore.load(caseId);
+      const org = meta.organization?.trim();
+      if (org) orgEntity = [{ value: org, category: "OTHER" as const }];
+    } catch { /* no meta or corrupt — skip; the org name stays as-is */ }
+  }
   const known: KnownEntities = {
     hosts: derived.hosts,
     accounts: derived.accounts,
     internalDomains: [...derived.internalDomains, ...targets.domains.map((d) => d.toLowerCase())],
-    custom: [...custom, ...disc.discovered, ...targetEmails],
+    custom: [...custom, ...disc.discovered, ...targetEmails, ...orgEntity],
     suppressed: disc.suppressed,
   };
   const policy = redactedExportPolicy();

--- a/companion/src/routes/anonymization.ts
+++ b/companion/src/routes/anonymization.ts
@@ -278,6 +278,9 @@ export function registerAnonymizationRoutes(app: Express, ctx: RouteContext): vo
           // Victim org domains/emails the analyst entered for the exposure check are PII too —
           // feed them to the anonymizer so they're tokenized even when absent from the timeline.
           customerStore: new CustomerStore(store),
+          // Victim org NAME: the anonymizer has no free-text detector, so feed meta.organization
+          // as a custom OTHER entity so it's tokenized to ANON_OTHER_n wherever it appears (#13).
+          reportMetaStore: options.reportMetaStore,
           ocrRunner: options.ocrRunner ?? new TesseractOcrRunner(),
         },
         req.params.id,

--- a/companion/tests/reports/markdown.test.ts
+++ b/companion/tests/reports/markdown.test.ts
@@ -346,6 +346,23 @@ describe("renderMarkdownReport", () => {
     expect(md).toContain("OS Credential Dumping \\| LSASS");
   });
 
+  it("#12: neutralizes newlines in table cells so a multi-line value doesn't break the table into spurious rows", () => {
+    // A multi-line revision comment reaches cellMd via the revisions table. The \n ends the GFM
+    // row; the text after becomes bogus extra rows with empty trailing cells. The fix collapses
+    // \r\n into a space so the row stays a single row.
+    const state = emptyState("c2");
+    const meta = emptyReportMeta();
+    meta.revisions = [{ version: "1.0", date: "2026-05-22", author: "Analyst", comments: "Initial\r\ndraft\nwith newlines" }];
+    const md = renderMarkdownReport(state, meta);
+    // The revisions row must be a single line; the newlines collapsed to a space.
+    const row = md.split("\n").find((l) => l.includes("Initial") && l.includes("draft"));
+    expect(row).toBeDefined();
+    expect(row!).toContain("Initial draft with newlines");
+    // No spurious extra rows from the newlines.
+    const bogus = md.split("\n").filter((l) => /^\| draft \|/.test(l) || /^\| with newlines/.test(l));
+    expect(bogus).toHaveLength(0);
+  });
+
   it("sorts findings by severity (Critical first)", () => {
     const state = emptyState("c1");
     const mk = (id: string, sev: "Critical" | "Low") => ({ id, severity: sev, title: id, description: "",

--- a/companion/tests/reports/redactedExportBuilder.test.ts
+++ b/companion/tests/reports/redactedExportBuilder.test.ts
@@ -115,6 +115,25 @@ describe("buildRedactedExport", () => {
     expect(paths).toEqual(["REDACTION-NOTES.txt", "export-manifest.json", "report/report.html", "report/report.md"]);
   });
 
+  it("#13: tokenizes the victim org NAME (from report-meta) as ANON_OTHER_n, not just its domains", async () => {
+    // The anonymizer has no free-text detector; the org name must be fed in as a custom OTHER
+    // entity. Without it, "GlobalTech Industries" survived unredacted while globaltech.com was
+    // tokenized to ANON_DOMAIN_n.
+    const d = deps({
+      reportMetaStore: { load: async () => ({ organization: "GlobalTech Industries" }) } as RedactedExportDeps["reportMetaStore"],
+      reportWriter: {
+        redactedReportContents: async (_caseId: string, redact: (s: string) => string) => ({
+          markdown: redact("Incident at GlobalTech Industries involving GlobalTech Industries servers"),
+          html: "<h1>r</h1>", findingsCsv: "f", iocsCsv: "i", timelineCsv: "t", forensicTimelineCsv: "ft", stateJson: "{}",
+        }),
+      },
+    });
+    const { zip } = await buildRedactedExport(d, "INC-1", DEFAULT_REDACTED_EXPORT_OPTIONS);
+    const md = new Map(readZip(zip).map((e) => [e.path, e.data])).get("report/report.md")!.toString("utf8");
+    expect(md).not.toContain("GlobalTech Industries");
+    expect(md).toContain("ANON_OTHER_1");
+  });
+
   it("ships an export-manifest.json with a correct sha256/bytes for every other file (#79)", async () => {
     const { zip } = await buildRedactedExport(deps(), "INC-1", DEFAULT_REDACTED_EXPORT_OPTIONS);
     const entries = readZip(zip);


### PR DESCRIPTION
## Bugs (MEDIUM #12 + MEDIUM #13)
**#12** — `cellMd` only escaped the pipe, not newlines. A `\n`/`\r` inside a GFM table cell ends the row; the text after became spurious rows, corrupting the table across MD/HTML/DOCX. Newlines reach here from report-meta free-text fields (revisions comments, distribution names) and AI descriptions. Fix: `cellMd` also `.replace(/[\r\n]+/g, " ")`.

**#13** — The anonymizer's `apply()` only matches structured indicators (IP/email/host/domain) — no free-text org name detector. `GlobalTech Industries` survived unredacted throughout the redacted export while the same org's domain (`globaltech.com`) was tokenized. Fix: feed `meta.organization` into the anonymizer's `known.custom` as an `OTHER` entity → tokenized to `ANON_OTHER_n` wherever it appears. Wired via a new optional `reportMetaStore` dep on `RedactedExportDeps`.

## Verification
- `tsc --noEmit` clean.
- 41 markdown + 6 redactedExportBuilder + 24 redacted-export tests pass (+2 new).

Found by end-to-end QA reports + case-lifecycle subagents.