### PR TITLE
fix(lifecycle): guard seed-demo force against an open/busy case + clear dir before re-seed

### DIFF
--- a/companion/src/analysis/seedDemoCase.ts
+++ b/companion/src/analysis/seedDemoCase.ts
@@ -1,7 +1,7 @@
 // Seed the rich demo case ("GlobalTech Industries — BEC & Ransomware Precursor, May 2026").
 // Shared between the CLI script (scripts/seed-demo-case.ts) and the POST /cases/seed-demo
 // server route, so EXE users who don't have tsx/Node can trigger it from the dashboard.
-import { writeFile, mkdir, appendFile, stat } from "node:fs/promises";
+import { writeFile, mkdir, appendFile, stat, rm } from "node:fs/promises";
 import { join } from "node:path";
 import type { ForensicEvent } from "./stateTypes.js";
 
@@ -57,6 +57,12 @@ export async function seedDemoCase(
       (err as NodeJS.ErrnoException).code = "EEXIST";
       throw err;
     }
+    // force: clear the existing case directory before re-seeding so orphan files (extra
+    // screenshots/imports the analyst added, custom state files) don't survive into the "fresh"
+    // demo case. Previously force overwrote only the demo's own files and left everything else,
+    // so the re-seeded demo shipped with stale evidence and a metadata/imports.jsonl that no longer
+    // matched the imports/ directory (#19). The route already refuses force on an OPEN/busy case.
+    await rm(caseDir, { recursive: true, force: true });
   }
 
   for (const sub of ["screenshots", "metadata", "state", "reports", "imports"]) {

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -141,6 +141,24 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
     try {
       const caseId = typeof req.body?.caseId === "string" ? req.body.caseId : undefined;
       const force  = req.body?.force === true;
+      // Guard against clobbering an in-progress case. force previously overwrote case.json +
+      // investigation.json for an OPEN case with a running synthesis/import job, destroying the
+      // analyst's findings/timeline mid-flight and leaving orphan files (the demo only writes its
+      // own captures/imports, so extra screenshots/imports survived as orphans). Refuse when the
+      // case exists and is open, or has a non-terminal job — mirroring /restore-backup's check.
+      if (force) {
+        const existing = caseId && await store.getCaseMeta(caseId).catch(() => null);
+        if (existing) {
+          const status = existing.status ?? "open";   // absent means open
+          if (status === "open") {
+            return res.status(409).json({ error: `case "${caseId}" is open — close it before force-seeding the demo over it (or delete it)` });
+          }
+          const busy = options.jobManager?.list(caseId).find((j) => !isTerminal(j.status));
+          if (busy) {
+            return res.status(409).json({ error: `a ${busy.kind}${busy.label ? ` (${busy.label})` : ""} job is in progress for this case — cancel it or wait, then seed`, jobId: busy.id, kind: busy.kind });
+          }
+        }
+      }
       const result = await seedDemoCase(store.casesRoot, { caseId, force });
       return res.status(201).json(result);
     } catch (err) {

--- a/companion/tests/server/caseLifecycleRoutes.test.ts
+++ b/companion/tests/server/caseLifecycleRoutes.test.ts
@@ -322,3 +322,29 @@ describe("POST /cases/:id/delete", () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe("POST /cases/seed-demo — force guard (#19)", () => {
+  it("refuses force:true on an OPEN case (doesn't clobber an in-progress investigation)", async () => {
+    const { app } = await harness();
+    await seedCase(app, "demoforce", "Active investigation");
+    // case is open by default
+    const res = await request(app).post("/cases/seed-demo").send({ caseId: "demoforce", force: true });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/open/i);
+  });
+
+  it("force:true on a CLOSED case re-seeds (clears the dir, no orphans)", async () => {
+    const { app, store } = await harness();
+    await seedCase(app, "democlosed", "Old case");
+    // Add an orphan file the demo wouldn't write.
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    await mkdir(join(store.casesRoot, "democlosed", "state"), { recursive: true });
+    await writeFile(join(store.casesRoot, "democlosed", "state", "custom.json"), '{"my":"state"}');
+    await request(app).patch("/cases/democlosed/status").send({ status: "closed" });
+    const res = await request(app).post("/cases/seed-demo").send({ caseId: "democlosed", force: true });
+    expect(res.status).toBe(201);
+    // The orphan is gone — the demo re-seeded into a cleared directory.
+    const { stat } = await import("node:fs/promises");
+    await expect(stat(join(store.casesRoot, "democlosed", "state", "custom.json"))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Bug (MEDIUM — data loss on an active case)
`POST /cases/seed-demo` with `force:true` overwrote `case.json` + `investigation.json` for an OPEN case with a running job, destroying findings/timeline mid-flight. It also left orphan files (extra screenshots/imports/custom state survived into the "fresh" demo, and `metadata/imports.jsonl` no longer matched the `imports/` directory).

## Fix
- **Route**: when `force` and the case exists, refuse 409 if status is open (absent means open) OR a non-terminal job is in flight (mirroring `/restore-backup`).
- **`seedDemoCase`**: in the `force` branch, `rm` the existing `caseDir` (recursive) before re-seeding so no orphans survive. The route guard ensures this only runs on a closed/idle case.

## Verification
- `tsc --noEmit` clean.
- 26 caseLifecycleRoutes tests pass (+2 new).

Found by end-to-end QA case-lifecycle subagent.