### PR TITLE
fix(notion): don't adopt a same-titled toggle when the remembered container is gone

### DIFF
--- a/companion/src/integrations/notion/notionPush.ts
+++ b/companion/src/integrations/notion/notionPush.ts
@@ -119,13 +119,12 @@ export async function pushCaseToNotion(
       const existing = await client.retrieveBlock(remembered.containerBlockId);
       if (existing && !existing.archived) containerBlockId = existing.id;
     }
-    // Defend a lost/replaced store: adopt a previous container recognizable by its title.
-    if (!containerBlockId) {
-      const adopted = (await client.listChildren(pageId)).find(
-        (b) => b.type === "toggle" && (b.plainText ?? "") === containerTitle && !b.archived,
-      );
-      if (adopted) containerBlockId = adopted.id;
-    }
+    // When the remembered container is gone (store lost/deleted, or a different page), do NOT
+    // adopt a same-titled toggle by name — that could be an analyst's own toggle with their own
+    // notes, and the export would archive its children and repurpose it as the Companion container
+    // (analyst content destruction). Instead, leave containerBlockId empty so a fresh toggle is
+    // created below, same as the first-export path. The remembered id is the only ownership marker
+    // the Companion has; title alone is not a strong enough signal.
   } else {
     const db = target.databaseId ?? options.databaseId;
     const parent = target.parentPageId ?? options.parentPageId;

--- a/companion/tests/integrations/notion.test.ts
+++ b/companion/tests/integrations/notion.test.ts
@@ -259,6 +259,25 @@ describe("pushCaseToNotion", () => {
     expect(res.containerBlockId).not.toBe(container);
   });
 
+  it("#31: does NOT adopt a same-titled analyst toggle when the remembered container is gone (creates a fresh one instead)", async () => {
+    // An analyst has a toggle titled with the Companion container title containing their own notes.
+    // The store is lost (fresh install, store cleared). The previous code adopted that toggle by
+    // title and archived its children. The fix creates a fresh toggle instead.
+    const m = new MockNotion();
+    m.seedPage("page-1");
+    const containerTitle = "🔍 DFIR Companion — Auto-generated";
+    const analystToggle = m.seedBlock("page-1", "toggle", containerTitle);
+    m.seedBlock(analystToggle, "paragraph", "analyst's own note 1");
+    m.seedBlock(analystToggle, "paragraph", "analyst's own note 2");
+    const store = new MemStore(); // empty — remembered container is gone
+    const res = await pushCaseToNotion(m, { caseName: "c1", state: sampleState() }, { mode: "existing", pageId: "page-1" }, { exportedAt: AT, sleep: noop }, store);
+    // A fresh container was created, NOT the analyst's toggle.
+    expect(res.containerBlockId).not.toBe(analystToggle);
+    // The analyst's toggle + its children were NOT archived.
+    expect(m.blocks.get(analystToggle)!.archived).toBe(false);
+    expect(m.blocks.get(analystToggle)!.children.length).toBe(2);
+  });
+
   it("batches content into ≤100-block appends", async () => {
     const m = new MockNotion();
     const store = new MemStore();


### PR DESCRIPTION
## Bug (MEDIUM — analyst content destruction)
When exporting to an EXISTING Notion page and the remembered container pointer was gone (store lost/deleted), the push adopted any non-archived top-level toggle whose `plainText` exactly equaled the container title. It then archived ALL of that toggle's children and appended Companion content. No ownership marker distinguished a Companion-created toggle from an analyst-created one — title alone. An analyst with a toggle titled `🔍 DFIR Companion — Auto-generated` containing their own notes had their content archived to trash.

## Fix
Remove title-based adoption. When the remembered `containerBlockId` is gone, leave it empty so a fresh toggle is created (same as first-export). The remembered id is the only ownership marker; title alone is not strong enough.

## Verification
- `tsc --noEmit` clean.
- 15 notion tests pass (+1 new: same-titled analyst toggle NOT adopted, children NOT archived, fresh container created).

Found by end-to-end QA integrations subagent.