### PR TITLE
fix(settings): stop Save posting every .env field, so one edit can succeed

### DIFF
--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -1030,6 +1030,9 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       }
       const rejected = validateEnvUpdates(updates as Record<string, string>);
       if (rejected.length > 0) {
+        // Log it: a rejected save is a real misconfiguration (a Settings field whose key was never
+        // allowlisted), and with the 400 shown only in a corner of the modal it left no trace at all.
+        errLine(`POST /settings/env rejected ${rejected.length} key(s) not on the writable allowlist: ${rejected.join(", ")}`);
         return res.status(400).json({ error: `rejected keys (not on the writable allowlist): ${rejected.join(", ")}` });
       }
       await updateEnvFile(updates as Record<string, string>);

--- a/companion/src/settings/envManager.ts
+++ b/companion/src/settings/envManager.ts
@@ -45,6 +45,15 @@ const WRITABLE_ENV_PREFIXES = [
   "DFIR_AI_DEBUG_USAGE", "DFIR_AI_VELO_", "DFIR_AI_SECOND_OPINION_",
   "DFIR_AI_CLAUDE_CODE_BIN", "DFIR_AI_CODEX_BIN", "DFIR_VISION_IMAGE_DETAIL",
   "DFIR_AI_", "DFIR_VISION_",
+  // Tuning knobs the Settings modal has always rendered as editable fields but the original
+  // allowlist (#240) never covered, so a save carrying them was rejected wholesale. All of them are
+  // limits, delays, and display options — none redirects case data, relaxes a security control, or
+  // changes where the server listens (those stay in DENIED_ENV_KEYS).
+  "TAGGER_", "DFIR_ENRICH_", "DFIR_EXPOSURE_", "DFIR_GEOMAP_", "DFIR_MOBILE_", "DFIR_PRESENT_",
+  "DFIR_VELO_HUNT_", "DFIR_VELO_MONITOR_", "DFIR_LOOKALIKE_", "DFIR_D3FEND_",
+  "DFIR_DEDUP", "DFIR_FLUSH_INTERVAL_MS", "DFIR_ATOMIC_WRITE_RETRIES", "DFIR_DISK_WARN_PCT",
+  "DFIR_IMPORTERS_DIR", "DFIR_MAX_PINNED_FINDINGS", "DFIR_LOG_MAX_TEMPLATES",
+  "DFIR_PUBLIC_URL", "DFIR_UPDATE_REPO", "DFIR_DIAG_MAX_FILES", "DFIR_JOBS_MAX",
 ];
 
 /** Validate that every key in `updates` is on the writable allowlist and not explicitly denied.

--- a/companion/tests/settings/settingsEnvFields.test.ts
+++ b/companion/tests/settings/settingsEnvFields.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+
+import { validateEnvUpdates } from "../../src/settings/envManager.js";
+
+/**
+ * The Settings modal and POST /settings/env share an implicit contract: every field the modal lets
+ * the analyst TYPE INTO must be on the server's writable allowlist. When the allowlist landed (#240)
+ * it was never reconciled against the 250-odd `env-*` fields the modal renders, so 49 of them were
+ * rejected — and because Save posted every field at once, the 400 killed the whole save. Changing a
+ * single Timesketch URL failed with a wall of unrelated key names.
+ *
+ * These tests pin both halves of the contract so adding a Settings field without allowlisting its
+ * key (or allowlisting a key that must stay read-only) fails here instead of in the analyst's face.
+ */
+
+const FIELD_TAG = /<(input|select|textarea)\b[^>]*\bid="env-([A-Za-z0-9_]+)"[^>]*>/g;
+
+interface EnvField { key: string; readOnly: boolean }
+
+async function envFields(): Promise<EnvField[]> {
+  const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+  const out: EnvField[] = [];
+  for (const m of html.matchAll(FIELD_TAG)) {
+    out.push({ key: m[2], readOnly: /\breadonly\b/i.test(m[0]) || /\bdisabled\b/i.test(m[0]) });
+  }
+  return out;
+}
+
+describe("Settings modal ⇄ POST /settings/env allowlist", () => {
+  it("renders every env-* field the modal reads", async () => {
+    const fields = await envFields();
+    // Sanity: the regex actually matched the modal, so an empty result can't pass the tests below.
+    expect(fields.length).toBeGreaterThan(200);
+    expect(fields.map(f => f.key)).toContain("DFIR_TIMESKETCH_URL");
+  });
+
+  it("accepts every editable field — no analyst can type into a key the server rejects", async () => {
+    const editable = (await envFields()).filter(f => !f.readOnly);
+    const updates = Object.fromEntries(editable.map(f => [f.key, "x"]));
+    expect(validateEnvUpdates(updates)).toEqual([]);
+  });
+
+  it("marks every non-writable field read-only rather than letting Save fail on it", async () => {
+    const readOnly = (await envFields()).filter(f => f.readOnly).map(f => f.key);
+    // The read-only fields exist precisely BECAUSE the server refuses them (bind host, port, cases
+    // root, log dir, anonymize default) — they stay visible so the analyst can read the live value.
+    const stillAccepted = readOnly.filter(k => validateEnvUpdates({ [k]: "x" }).length === 0);
+    expect(stillAccepted).toEqual([]);
+  });
+});
+
+describe("saveSettings()", () => {
+  it("posts only the keys the analyst actually changed", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    const fn = html.slice(html.indexOf("async function saveSettings()"), html.indexOf("function openSettingsModal()"));
+    // The diff against the loaded baseline must happen BEFORE the POST, not after it.
+    const diffAt = fn.indexOf("loadedEnvValues[key]");
+    const postAt = fn.indexOf('fetch("/settings/env"');
+    expect(diffAt).toBeGreaterThan(-1);
+    expect(postAt).toBeGreaterThan(diffAt);
+    // Read-only fields are skipped outright — they can never be part of an update.
+    expect(fn).toMatch(/readOnly|disabled/);
+  });
+
+  it("keeps a save error on screen instead of clearing it after a few seconds", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    const fn = html.slice(html.indexOf("async function saveSettings()"), html.indexOf("function openSettingsModal()"));
+    expect(fn).toMatch(/if \(ok\)\s*setTimeout\(/);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1516,7 +1516,9 @@
     .sec-selall button { font-size: 11px; padding: 2px 8px; background: var(--c-2a2f3a); border: none; border-radius: 4px; color: var(--c-9aa4b2); cursor: pointer; }
     .sec-selall button:hover { background: var(--c-353b47); color: var(--c-cbd3df); }
     .settings-footer { margin-top: 14px; display: flex; gap: 8px; align-items: center; border-top: 1px solid var(--c-2a2f3a); padding-top: 12px; flex-shrink: 0; }
-    .settings-msg { font-size: 11px; margin-left: 4px; }
+    /* Takes the footer's remaining width and wraps (scrolling past ~4 lines) — a save error can name
+       several .env keys, and as a single non-wrapping line it was clipped to the first few words. */
+    .settings-msg { font-size: 11px; margin-left: 4px; flex: 1; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; max-height: 4.6em; overflow-y: auto; }
     /* Global search + time-range filter row — revealed by the toolbar search icon, hidden by default.
        Sticky while open so it stays visible (e.g. over the Super-Timeline it also scopes) as the
        dashboard is scrolled; [hidden] still fully removes it when the toolbar icon closes it. */
@@ -2361,7 +2363,7 @@
           <div class="sfield"><label>Content tagger scope<span class="sfield-hint">TAGGER_SCOPE (forensic/super/both)</span></label><input id="env-TAGGER_SCOPE" placeholder="both" /></div>
         </div>
         <div class="sfield-row">
-          <div class="sfield"><label>Anonymize default<span class="sfield-hint">DFIR_ANONYMIZE (on/off)</span></label><input id="env-DFIR_ANONYMIZE" placeholder="on" /></div>
+          <div class="sfield"><label>Anonymize default<span class="sfield-hint">DFIR_ANONYMIZE (on/off) — <b>read-only here</b>: a security toggle the dashboard must not be able to flip. Edit <code>.env</code> and restart.</span></label><input id="env-DFIR_ANONYMIZE" placeholder="on" readonly /></div>
           <div class="sfield"><label>Screenshot flush interval (ms)<span class="sfield-hint">DFIR_FLUSH_INTERVAL_MS</span></label><input id="env-DFIR_FLUSH_INTERVAL_MS" placeholder="300000" /></div>
         </div>
         <div class="sfield-row">
@@ -2373,7 +2375,7 @@
           <div class="sfield"><label>OCR redaction debug dir<span class="sfield-hint">DFIR_OCR_DEBUG_DIR — also write each redacted screenshot copy here so you can eyeball the black boxes</span></label><input id="env-DFIR_OCR_DEBUG_DIR" placeholder="(off)" /></div>
         </div>
         <div class="sfield-row">
-          <div class="sfield"><label>Cases root<span class="sfield-hint">DFIR_CASES_ROOT</span></label><input id="env-DFIR_CASES_ROOT" placeholder="./cases" /></div>
+          <div class="sfield"><label>Cases root<span class="sfield-hint">DFIR_CASES_ROOT — <b>read-only here</b>: repointing it at runtime would redirect every case. Edit <code>.env</code> and restart.</span></label><input id="env-DFIR_CASES_ROOT" placeholder="./cases" readonly /></div>
           <div class="sfield"><label>Max body size (MB)<span class="sfield-hint">DFIR_MAX_BODY_MB</span></label><input id="env-DFIR_MAX_BODY_MB" placeholder="256" /></div>
         </div>
         <div class="sfield-row">
@@ -2390,11 +2392,11 @@
           <div class="sfield"><label>Disk-space warning threshold (%)<span class="sfield-hint">DFIR_DISK_WARN_PCT — "danger" usage % that triggers the orange disk-space banner; warning is 15 pp below, critical 10 pp above. Leave blank for defaults (70/85/95%). Set to 0 to disable the check</span></label><input id="env-DFIR_DISK_WARN_PCT" placeholder="85" /></div>
         </div>
         <div class="sfield-row">
-          <div class="sfield"><label>Log directory<span class="sfield-hint">DFIR_LOG_DIR — folder for the global session log; blank = <code>logs/</code> beside the cases root. Per-case logs always stay in the case folder</span></label><input id="env-DFIR_LOG_DIR" placeholder="(logs/ beside cases root)" /></div>
+          <div class="sfield"><label>Log directory<span class="sfield-hint">DFIR_LOG_DIR — folder for the global session log; blank = <code>logs/</code> beside the cases root. Per-case logs always stay in the case folder. <b>Read-only here</b> — edit <code>.env</code> and restart.</span></label><input id="env-DFIR_LOG_DIR" placeholder="(logs/ beside cases root)" readonly /></div>
         </div>
         <div class="sfield-row">
-          <div class="sfield"><label>Bind host<span class="sfield-hint">DFIR_HOST — keep 127.0.0.1 (localhost only) unless you know what you're doing</span></label><input id="env-DFIR_HOST" placeholder="127.0.0.1" /></div>
-          <div class="sfield"><label>Port<span class="sfield-hint">DFIR_PORT — the dashboard moves with it; reopen on the new port</span></label><input id="env-DFIR_PORT" placeholder="4773" /></div>
+          <div class="sfield"><label>Bind host<span class="sfield-hint">DFIR_HOST — keep 127.0.0.1 (localhost only) unless you know what you're doing. <b>Read-only here</b>: widening the bind address from a web page is exactly what the allowlist prevents. Edit <code>.env</code> and restart.</span></label><input id="env-DFIR_HOST" placeholder="127.0.0.1" readonly /></div>
+          <div class="sfield"><label>Port<span class="sfield-hint">DFIR_PORT — the dashboard moves with it; reopen on the new port. <b>Read-only here</b> — edit <code>.env</code> and restart.</span></label><input id="env-DFIR_PORT" placeholder="4773" readonly /></div>
         </div>
         <div class="sfield-row">
           <div class="sfield"><label>Custom importers dir<span class="sfield-hint">DFIR_IMPORTERS_DIR — folder of *.json declarative importer specs; blank = importers/ beside cases root</span></label><input id="env-DFIR_IMPORTERS_DIR" placeholder="(importers/ beside cases root)" /></div>
@@ -19088,16 +19090,28 @@
       applySectionsVis();
 
       // 3. Env vars → POST /settings/env
+      // ONLY the fields the analyst actually changed. Posting all ~250 of them (the original
+      // behaviour) meant one edit dragged every other key into the request, and the server's
+      // allowlist rejects a batch atomically — so changing a single Timesketch URL failed with a
+      // wall of unrelated key names, and no Settings save could ever succeed. Read-only fields are
+      // skipped outright: the server refuses them by design, they're rendered for reference only.
       const updates = {};
       document.querySelectorAll("[id^='env-']").forEach(el => {
         const key = el.id.replace(/^env-/, "");
+        if (el.readOnly || el.disabled) return;
+        let val;
         if (el.type === "password") {
-          if (el.value.trim()) updates[key] = el.value.trim();
+          // Secrets load blank behind a "(already set)" placeholder, so only a typed value is a change.
+          val = el.value.trim();
+          if (!val) return;
         } else if (el.tagName === "SELECT") {
-          if (el.value) updates[key] = el.value;
+          // A blank select is "leave whatever .env has" — it must not blank an existing key.
+          if (!el.value) return;
+          val = el.value;
         } else {
-          updates[key] = el.value.trim();
+          val = el.value.trim();
         }
+        if (val !== (loadedEnvValues[key] ?? "")) updates[key] = val;
       });
       const msg = document.getElementById("settingsSaveMsg");
       msg.textContent = "";
@@ -19114,7 +19128,7 @@
             // corrected MISP URL could sit on disk while the running server kept pushing to the old
             // one (#178). Now every integration group the save touched is applied live: /settings/reload
             // loads it into the environment AND rebuilds the clients it feeds, reporting them back.
-            const changed = Object.keys(updates).filter(k => updates[k] !== (loadedEnvValues[k] ?? ""));
+            const changed = Object.keys(updates);
             const rebuilt = await applySavedEnvGroups(changed);
             // The saved values are the new baseline, so saving twice without reopening the modal
             // doesn't rebuild the same clients again.
@@ -19123,14 +19137,11 @@
               msg.textContent = "✓ Saved and applied live: " + rebuilt.join(", ") +
                 " — AI model changes still need a server restart";
               msg.style.color = "#5fd470";
-            } else if (changed.length > 0) {
+            } else {
               // Changed something with no live client behind it (AI models, tool paths) — the honest
               // answer is still "restart", so don't claim more than the server actually did.
               msg.textContent = "✓ Saved — restart the server to apply server-side changes";
               msg.style.color = "#ffd93b";
-            } else {
-              msg.textContent = "✓ Saved";
-              msg.style.color = "#5fd470";
             }
           } else {
             const j = await r.json().catch(() => ({}));
@@ -19144,10 +19155,12 @@
           ok = false;
         }
       } else {
-        msg.textContent = "✓ Saved";
+        msg.textContent = "✓ No .env changes to save";
         msg.style.color = "#5fd470";
       }
-      setTimeout(() => { if (msg) msg.textContent = ""; }, 5000);
+      // Only the success note self-clears. An error used to vanish after 5s too, which meant a long
+      // rejection message scrolled off before it could be read — errors now stay until the next save.
+      if (ok) setTimeout(() => { if (msg) msg.textContent = ""; }, 5000);
       return ok;
     }
 


### PR DESCRIPTION
## The bug

Changing a single Timesketch URL in Settings failed with:

> Error: rejected keys (not on the writable allowlist): TAGGER_AUTO, TAGGER_SCOPE, DFIR_ANONYMIZE, … (49 keys)

## Root cause

`saveSettings()` posted **every** `env-*` field in the Settings modal (~250 of them) on each Save, regardless of what the analyst touched. `POST /settings/env` validates a batch **atomically**, so one non-allowlisted key rejects the whole request.

49 of those fields were never reconciled against the writable allowlist when it landed in #240 — meaning the Settings modal's Save has been **completely broken since that commit**, for every field, not just Timesketch.

Two distinct groups:
- **44 tuning knobs** (`TAGGER_*`, `DFIR_ENRICH_*`, `DFIR_GEOMAP_*`, `DFIR_MOBILE_*`, limits/delays) — simply never allowlisted.
- **5 security-sensitive keys** (`DFIR_HOST`, `DFIR_PORT`, `DFIR_CASES_ROOT`, `DFIR_LOG_DIR`, `DFIR_ANONYMIZE`) — deliberately refused, yet still rendered as editable text boxes. The UI offered what the server forbids.

Three things hid it: the 400 was logged nowhere server-side, the message was clipped to one unwrapped 11px line, and it self-cleared after 5s.

## Changes

- `saveSettings()` diffs against the loaded baseline and posts **only changed keys**, skipping read-only fields.
- Allowlist the 44 tuning knobs. None redirects case data, relaxes a security control, or changes where the server listens — those stay in `DENIED_ENV_KEYS`.
- The 5 by-design-refused keys are now `readonly` with a hint to edit `.env` and restart. Still visible for reference, no longer a trap.
- Log a rejected save at ERROR server-side.
- The save message wraps and scrolls instead of clipping; errors persist until the next save, only success self-clears.
- New test cross-checks every editable modal field against `validateEnvUpdates`, so adding a Settings field without allowlisting its key fails in CI instead of in the analyst's face.

## Verification

Ran a real server against a scratch `.env` and saved through the actual dashboard button:

- Changing only the Timesketch URL → `✓ Saved and applied live: timesketch`, and `.env` shows only that key rewritten.
- `TAGGER_AUTO` / `DFIR_GEOMAP_MAX_MARKERS` / `DFIR_ENRICH_MAX` now save.
- `DFIR_HOST=0.0.0.0` is still refused, and now logs `ERROR POST /settings/env rejected 1 key(s)…`.

Full suite: **5188 tests / 428 files pass**. `tsc --noEmit` clean.

One gap: the CSS wrapping is verified structurally (`white-space: pre-wrap`, `scrollHeight > clientHeight`) but not visually — the test browser reported a zero-width viewport and screenshots would not composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)