### PR TITLE
fix(correlate): scope artifact correlation to a host, restoring lateral movement (#345)

### DIFF
--- a/.betterleaks-config.toml
+++ b/.betterleaks-config.toml
@@ -27,7 +27,7 @@ targetRules = ["internal-hostname"]
 regexTarget = "line"
 regexes = [
   '''(?i)[\w.-]+\.corp\b''',
-  '''(?i)\b(?:windomain|storage|adatumlab|corp|velociraptor|globaltech|northstar-branch|ai|d|companion|windmill|dc|wiz-scope|lab|dfir-companion|acme|eval)\.local\b''',
+  '''(?i)\b(?:windomain|storage|adatumlab|corp|velociraptor|globaltech|northstar-branch|northstar|ai|d|companion|windmill|dc|wiz-scope|lab|dfir-companion|acme|eval)\.local\b''',
   '''(?i)\b(?:client01|other)\.lan\b''',
   '''(?i)\b(?:docker|m|s|hash|misp|api)\.internal\b''',
   # Presidio test fixtures. `presidio.local` is a deliberately unreachable URL in the client's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Correlation no longer merges one artifact across hosts** (#345) — the same binary hash or file path seen on two machines was collapsed into a single event, which erased the lateral-movement edge the evidence graph derives from it, left the surviving row holding one host's name and the other's timestamp, and could drop a host from the case entirely. The hash, path and exact-duplicate steps now correlate within a host (as the host+pid and command-line steps already did); an event with no recorded host still joins a host's group when the artifact was seen on exactly one. Note: timelines correlated by an earlier build stay merged — the fix applies as new evidence is correlated, and cannot un-merge what was already persisted.
+
 ### Added
 - **Clock-skew detection & cross-host timeline alignment** (#228) — measures each host's clock offset from artifacts two different tools recorded for the same event, flags hosts beyond 60s in Diagnostics → Host Clock Skew, and offers an "Align timelines" toggle that projects every host onto a common axis for the timeline, correlation windows, the evidence graph and the report. Offsets need several consistent anchors before they are trusted (a scattered host is shown but never aligned), analysts can override any host's offset by hand, and alignment never rewrites the case: each shifted row keeps and displays its recorded timestamp.
 

--- a/companion/src/analysis/clockSkew.ts
+++ b/companion/src/analysis/clockSkew.ts
@@ -204,10 +204,11 @@ export function detectClockSkew(groups: readonly ForensicEvent[][], opts: ClockS
  * Convenience wrapper that derives the correlation groups itself. Correct for a RAW (un-correlated)
  * timeline; on an already-correlated one it finds few anchors, because the merge that produced it
  * kept one timestamp per group. Callers holding the pre-merge events should prefer
- * `detectClockSkew(correlationGroups(events, opts), opts)`.
+ * `detectClockSkew(correlationGroups(events, { ...opts, crossHostArtifacts: true }), opts)` — the flag is
+ * required: without it correlate scopes each artifact to one host (#345) and no anchor ever spans two.
  */
 export function detectClockSkewFromTimeline(events: readonly ForensicEvent[], opts: ClockSkewOptions = {}): ClockSkewReport {
-  return detectClockSkew(correlationGroups(events, opts), opts);
+  return detectClockSkew(correlationGroups(events, { ...opts, crossHostArtifacts: true }), opts);
 }
 
 /**

--- a/companion/src/analysis/correlate.ts
+++ b/companion/src/analysis/correlate.ts
@@ -28,6 +28,11 @@ export interface CorrelateOptions {
   // minutes fast still correlates against the rest of the fleet — without touching the events
   // themselves, so what gets merged and persisted still carries the recorded time.
   epochOf?: (e: ForensicEvent) => number | undefined;
+  // Let the hash and path steps group an artifact ACROSS hosts (default false — see hostScopedGroups).
+  // Only clock-skew detection (#228) wants this: its anchors are, by definition, one artifact stamped
+  // by two different machines' clocks. Merging must never use it, or the lateral movement between
+  // those machines is collapsed into a single event (#345).
+  crossHostArtifacts?: boolean;
 }
 
 const SEV_RANK: Record<Severity, number> = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4 };
@@ -78,6 +83,40 @@ class DSU {
 
 function worse(a: Severity, b: Severity): Severity {
   return SEV_RANK[a] <= SEV_RANK[b] ? a : b;
+}
+
+// Match on the SHORT hostname: an EDR reports `FILE-BO-01` while the Windows log records the FQDN
+// `FILE-BO-01.northstar-branch.local` for the same host — keying on the full string would never match.
+// "" when the event has no recorded host.
+function shortHost(asset: string | undefined): string {
+  return (asset ?? "").split(".")[0].trim().toLowerCase();
+}
+
+// Split one artifact bucket (same hash, or same path) into the sets that may actually merge.
+//
+// A hash or a path identifies an ARTIFACT, not an event: the same binary dropped on two machines is
+// two facts, and the gap between them IS the lateral movement. Merging across hosts collapsed that
+// into one row — taking the timestamp from one host and the name from the other, and leaving the
+// evidence graph a single asset where its lateral_move rule needs two (#345). Steps 3 and 4 already
+// scope to a host (host+pid; host inside chainSignature); these two now do the same.
+//
+// Events with no recorded host are the exception. Attributing one to a host would be a guess, but
+// refusing to merge them at all would re-duplicate the AI-extracted rows that today gain their asset
+// from a structured sibling. So they group with each other, and join a real host only when the
+// artifact was seen on EXACTLY ONE — where there is nothing to be ambiguous about.
+function hostScopedGroups(indices: number[], evs: ForensicEvent[], crossHost: boolean): number[][] {
+  if (crossHost) return [indices];
+  const byHost = new Map<string, number[]>();
+  for (const i of indices) {
+    const key = shortHost(evs[i].asset);
+    (byHost.get(key) ?? byHost.set(key, []).get(key)!).push(i);
+  }
+  const unknown = byHost.get("") ?? [];
+  byHost.delete("");
+  const groups = [...byHost.values()];
+  if (groups.length === 1) { groups[0].push(...unknown); return groups; }   // unambiguous → attach
+  if (unknown.length) groups.push(unknown);
+  return groups;
 }
 
 // Path+time correlation (step 2) exists for CROSS-tool corroboration — the same file reported by two
@@ -184,18 +223,25 @@ function withSignature(e: ForensicEvent): ForensicEvent {
 function groupEvents(events: readonly ForensicEvent[], opts: CorrelateOptions): { evs: ForensicEvent[]; groups: number[][] } {
   const windowMs = (opts.windowSeconds ?? 2) * 1000;
   const timeOf = opts.epochOf ?? ((e: ForensicEvent) => epoch(e.timestamp));
+  const crossHostArtifacts = opts.crossHostArtifacts === true;
   const n = events.length;
   // Work over a copy with chainSignature populated so step 4 can key on it and every emitted
   // process-creation event carries the field (satisfying the importer-agnostic path).
   const evs = events.map(withSignature);
   const dsu = new DSU(n);
 
-  // 0) EXACT duplicates → union. Same event time + same description is the same
+  // 0) EXACT duplicates → union. Same event time + same description ON THE SAME HOST is the same
   // observation — this collapses re-imports of the SAME file (and any event type that
   // lacks a hash/path), so importing a report twice never doubles the timeline.
+  //
+  // The host is part of the key (#345): a fleet-wide sweep reports identical text at the identical
+  // second for every machine it hits, and those are as many findings as there are machines, not one.
+  // A re-import always carries the same asset, so dedup is unaffected. Unlike the artifact steps
+  // below this is never relaxed by crossHostArtifacts — two hosts' rows are not one observation, no
+  // matter who is asking.
   const byExact = new Map<string, number>();
   evs.forEach((e, i) => {
-    const k = `${e.timestamp} ${cleanDescription(e.description)}`;
+    const k = `${e.timestamp} ${cleanDescription(e.description)} ${shortHost(e.asset)}`;
     const prev = byExact.get(k);
     if (prev !== undefined) dsu.union(prev, i);
     else byExact.set(k, i);
@@ -206,7 +252,7 @@ function groupEvents(events: readonly ForensicEvent[], opts: CorrelateOptions): 
   //    they are two causal steps, not duplicates — and file_lineage edges can be derived.
   //    Events without an action (the common case) all share the "" bucket and correlate
   //    as before, so this is fully backward-compatible.
-  const byHash = new Map<string, number>(); // "hash:action" → first index with that pair
+  const byHash = new Map<string, number[]>(); // "hash:action" → every index with that pair
   evs.forEach((e, i) => {
     // Process-CREATION events (those carrying a `pid`) are correlated by host+pid in step 3, NOT by
     // image hash: a process's hash identifies the BINARY, not the activity, and an interpreter's image
@@ -218,11 +264,15 @@ function groupEvents(events: readonly ForensicEvent[], opts: CorrelateOptions): 
     if (e.pid !== undefined) return;
     for (const h of eventHashes(e)) {
       const key = `${h}:${e.action ?? ""}`;
-      const prev = byHash.get(key);
-      if (prev !== undefined) dsu.union(prev, i);
-      else byHash.set(key, i);
+      (byHash.get(key) ?? byHash.set(key, []).get(key)!).push(i);
     }
   });
+  for (const idxs of byHash.values()) {
+    if (idxs.length < 2) continue;
+    for (const group of hostScopedGroups(idxs, evs, crossHostArtifacts)) {
+      for (let k = 1; k < group.length; k++) dsu.union(group[0], group[k]);
+    }
+  }
 
   // 2) Same normalized path with timestamps within the window → union — but only when at least one
   //    side carries the path as a STRUCTURED field. Two free-text path mentions are too weak (a
@@ -235,15 +285,21 @@ function groupEvents(events: readonly ForensicEvent[], opts: CorrelateOptions): 
   });
   for (const entries of byPath.values()) {
     if (entries.length < 2) continue;
-    const dated = entries.map((x) => ({ i: x.i, structured: x.structured, t: timeOf(evs[x.i]) }))
-      .sort((a, b) => (a.t ?? Infinity) - (b.t ?? Infinity));
-    for (let k = 1; k < dated.length; k++) {
-      const a = dated[k - 1], b = dated[k];
-      if (!a.structured && !b.structured) continue; // both free-text → too weak to merge
-      if (!corroborates(evs[a.i], evs[b.i])) continue; // same tool sharing a container path → keep distinct
-      // Undated events on the same path correlate too (no time to disprove); dated ones
-      // must be within the window.
-      if (a.t === undefined || b.t === undefined || Math.abs(b.t - a.t) <= windowMs) dsu.union(a.i, b.i);
+    const structuredBy = new Map(entries.map((x) => [x.i, x.structured]));
+    // Same path on two machines is two files, not one (#345) — so pair within a host, exactly like
+    // the hash step above.
+    for (const group of hostScopedGroups(entries.map((x) => x.i), evs, crossHostArtifacts)) {
+      if (group.length < 2) continue;
+      const dated = group.map((i) => ({ i, structured: structuredBy.get(i) === true, t: timeOf(evs[i]) }))
+        .sort((a, b) => (a.t ?? Infinity) - (b.t ?? Infinity));
+      for (let k = 1; k < dated.length; k++) {
+        const a = dated[k - 1], b = dated[k];
+        if (!a.structured && !b.structured) continue; // both free-text → too weak to merge
+        if (!corroborates(evs[a.i], evs[b.i])) continue; // same tool sharing a container path → keep distinct
+        // Undated events on the same path correlate too (no time to disprove); dated ones
+        // must be within the window.
+        if (a.t === undefined || b.t === undefined || Math.abs(b.t - a.t) <= windowMs) dsu.union(a.i, b.i);
+      }
     }
   }
 
@@ -254,9 +310,6 @@ function groupEvents(events: readonly ForensicEvent[], opts: CorrelateOptions): 
   //    (one side carries a source the other lacks) so two creations from ONE tool that happen to reuse a
   //    pid never merge — only genuine cross-tool pairs do. Only process-creation events carry `pid`.
   const pidWindowMs = (opts.pidWindowSeconds ?? 120) * 1000;
-  // Match on the SHORT hostname: an EDR reports `FILE-BO-01` while the Windows log records the FQDN
-  // `FILE-BO-01.northstar-branch.local` for the same host — keying on the full string would never match.
-  const shortHost = (asset: string): string => asset.split(".")[0].trim().toLowerCase();
   const byPid = new Map<string, number[]>();
   evs.forEach((e, i) => {
     if (e.pid === undefined || !e.asset) return;

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -1753,7 +1753,7 @@ export class AnalysisPipeline {
     if (!store) return undefined;
     let record;
     try {
-      const report = detectClockSkew(correlationGroups(preMerge, opts), opts);
+      const report = detectClockSkew(correlationGroups(preMerge, { ...opts, crossHostArtifacts: true }), opts);
       record = await store.recordDetection(caseId, report);
     } catch {
       try { record = await store.load(caseId); } catch { return undefined; }

--- a/companion/src/routes/clockSkew.ts
+++ b/companion/src/routes/clockSkew.ts
@@ -44,7 +44,7 @@ export function registerClockSkewRoutes(app: Express, ctx: RouteContext): void {
     if (!options.clockSkewStore) return res.status(501).json({ error: "clock-skew store not configured" });
     try {
       const state = await options.stateStore.load(req.params.id);
-      const report = detectClockSkew(correlationGroups(state.forensicTimeline), thresholds);
+      const report = detectClockSkew(correlationGroups(state.forensicTimeline, { crossHostArtifacts: true }), thresholds);
       const record = await options.clockSkewStore.recordDetection(req.params.id, report, { replace: req.body?.replace === true });
       options.onClockSkew?.(req.params.id);
       return res.status(200).json({ ...record, thresholds, anchorGroups: report.anchorGroups, groupsExamined: report.groupsExamined });

--- a/companion/tests/analysis/clockSkew.test.ts
+++ b/companion/tests/analysis/clockSkew.test.ts
@@ -38,7 +38,9 @@ function anchorPair(i: number, host: string, hostSkewSec: number): ForensicEvent
   ];
 }
 
-const groupsOf = (events: ForensicEvent[]) => correlationGroups(events);
+// Anchors are cross-host by definition — one artifact stamped by two machines' clocks — so skew
+// detection asks correlate for the cross-host view that merging deliberately does not use (#345).
+const groupsOf = (events: ForensicEvent[]) => correlationGroups(events, { crossHostArtifacts: true });
 
 describe("detectClockSkew", () => {
   it("reports a zero offset when every host's anchors line up", () => {

--- a/companion/tests/analysis/correlate.test.ts
+++ b/companion/tests/analysis/correlate.test.ts
@@ -268,3 +268,83 @@ describe("correlateEvents", () => {
     expect(out[0].chainCheck?.observed).toBe(false);
   });
 });
+
+// #345 — a hash or a path identifies an ARTIFACT, not an event. Merging one across hosts collapsed
+// the lateral movement between them into a single row, took the timestamp from one machine and the
+// name from the other, and left the evidence graph one asset where its lateral_move rule needs two.
+describe("artifact correlation is scoped to a host (#345)", () => {
+  const SHA = "d".repeat(64);
+
+  it("keeps the same binary on two hosts as two events", () => {
+    const out = correlateEvents([
+      ev({ id: "a", description: "beacon.exe dropped", asset: "WS-01", sha256: SHA, sources: ["Velociraptor"], timestamp: "2026-05-20T14:00:00Z" }),
+      ev({ id: "b", description: "beacon.exe dropped", asset: "SRV-02", sha256: SHA, sources: ["THOR"], timestamp: "2026-05-20T14:40:00Z" }),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.map((e) => e.asset).sort()).toEqual(["SRV-02", "WS-01"]);
+    // Each keeps its OWN observation time — the 40-minute gap IS the lateral movement.
+    expect(out.find((e) => e.asset === "SRV-02")!.timestamp).toBe("2026-05-20T14:40:00Z");
+    expect(out.find((e) => e.asset === "WS-01")!.timestamp).toBe("2026-05-20T14:00:00Z");
+  });
+
+  it("still merges two tools reporting that binary on the SAME host", () => {
+    const out = correlateEvents([
+      ev({ id: "a", description: "beacon.exe dropped", asset: "WS-01", sha256: SHA, sources: ["Velociraptor"], timestamp: "2026-05-20T14:00:00Z" }),
+      ev({ id: "b", description: "Malware file found — beacon.exe", asset: "WS-01", sha256: SHA, sources: ["THOR"], timestamp: "2026-05-20T14:00:01Z" }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].sources).toEqual(expect.arrayContaining(["Velociraptor", "THOR"]));
+  });
+
+  it("treats an FQDN and a short hostname as the same host", () => {
+    const out = correlateEvents([
+      ev({ id: "a", asset: "FILE-BO-01", sha256: SHA, sources: ["Velociraptor"] }),
+      ev({ id: "b", asset: "FILE-BO-01.northstar-branch.local", sha256: SHA, sources: ["THOR"] }),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("adopts a host-less event when the artifact was seen on exactly one host", () => {
+    // The AI-extracted row carries no asset; the structured import does. One host ⇒ no ambiguity.
+    const out = correlateEvents([
+      ev({ id: "ai", description: `flagged file, sha256 ${SHA}`, sources: ["AI extraction"] }),
+      ev({ id: "imp", description: "Malware file found", asset: "WS-01", sha256: SHA, sources: ["THOR"] }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].asset).toBe("WS-01");
+  });
+
+  it("refuses to guess when the artifact spans two hosts", () => {
+    const out = correlateEvents([
+      ev({ id: "ai", description: `flagged file, sha256 ${SHA}`, sources: ["AI extraction"] }),
+      ev({ id: "w", description: "Malware file found", asset: "WS-01", sha256: SHA, sources: ["THOR"] }),
+      ev({ id: "s", description: "Malware file found", asset: "SRV-02", sha256: SHA, sources: ["THOR"] }),
+    ]);
+    expect(out).toHaveLength(3);
+    expect(out.find((e) => e.id === "ai")!.asset).toBeUndefined();
+  });
+
+  it("keeps the same path on two hosts as two events", () => {
+    const out = correlateEvents([
+      ev({ id: "a", description: "file written", asset: "WS-01", path: "c:\\windows\\temp\\evil.exe", sources: ["Velociraptor"], timestamp: "2026-05-20T14:00:00Z" }),
+      ev({ id: "b", description: "file written", asset: "SRV-02", path: "c:\\windows\\temp\\evil.exe", sources: ["THOR"], timestamp: "2026-05-20T14:00:01Z" }),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it("still merges the same path reported by two tools on one host", () => {
+    const out = correlateEvents([
+      ev({ id: "a", description: "file written", asset: "WS-01", path: "c:\\windows\\temp\\evil.exe", sources: ["Velociraptor"], timestamp: "2026-05-20T14:00:00Z" }),
+      ev({ id: "b", description: "file written", asset: "WS-01", path: "c:\\windows\\temp\\evil.exe", sources: ["THOR"], timestamp: "2026-05-20T14:00:01Z" }),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("host-less events still correlate with each other, as before", () => {
+    const out = correlateEvents([
+      ev({ id: "a", description: "flagged", sha256: SHA, sources: ["CSV import"] }),
+      ev({ id: "b", description: "Malware file found", sha256: SHA, sources: ["THOR"] }),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+});

--- a/companion/tests/analysis/crossHostLateral.test.ts
+++ b/companion/tests/analysis/crossHostLateral.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { correlateEvents } from "../../src/analysis/correlate.js";
+import { buildEvidenceGraph } from "../../src/analysis/evidenceGraph.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+// The failure #345 was filed for, end to end: correlation used to eat the lateral_move edge that
+// the evidence graph derives from one binary appearing on two hosts.
+const SHA = "a".repeat(64);
+function ev(id: string, timestamp: string, asset: string, source: string): ForensicEvent {
+  return {
+    id, timestamp, description: `beacon.exe dropped on ${asset}`, severity: "High",
+    mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [],
+    asset, sha256: SHA, sources: [source],
+  };
+}
+const raw = [
+  ev("e1", "2026-05-20T14:00:00Z", "WS-01", "Velociraptor"),
+  ev("e2", "2026-05-20T14:40:00Z", "SRV-02", "THOR"),
+];
+const lateral = (timeline: ForensicEvent[]) =>
+  buildEvidenceGraph({ ...emptyState("c1"), forensicTimeline: timeline })
+    .edges.filter((e) => e.type === "lateral_move");
+
+describe("cross-host lateral movement survives correlation (#345)", () => {
+  it("is present on the raw timeline", () => {
+    expect(lateral(raw)).toHaveLength(1);
+  });
+
+  it("is still present after correlation", () => {
+    const correlated = correlateEvents(raw);
+    expect(correlated).toHaveLength(2);
+    expect(lateral(correlated)).toHaveLength(1);
+    expect(lateral(correlated)[0].basis).toContain("SRV-02");
+    expect(lateral(correlated)[0].basis).toContain("WS-01");
+  });
+
+  it("keeps each host's own observation time, not one borrowed from the other", () => {
+    const byHost = new Map(correlateEvents(raw).map((e) => [e.asset, e.timestamp]));
+    expect(byHost.get("WS-01")).toBe("2026-05-20T14:00:00Z");
+    expect(byHost.get("SRV-02")).toBe("2026-05-20T14:40:00Z");
+  });
+
+  it("both hosts remain in the case's host set", () => {
+    expect(new Set(correlateEvents(raw).map((e) => e.asset))).toEqual(new Set(["WS-01", "SRV-02"]));
+  });
+});


### PR DESCRIPTION
Closes #345.

## The bug

A file hash or a path identifies an **artifact**, not an event. Correlation steps 0–2 keyed on it without the host, so the same binary on two machines became one event — and the gap between the two observations, which *is* the lateral movement, disappeared.

For one implant seen on WS-01 at 14:00 and SRV-02 at 14:40:

| | before | after |
| --- | --- | --- |
| events after `correlateEvents` | 1 | 2 |
| `lateral_move` edges in the evidence graph | 0 | 1 |
| surviving row | `asset=SRV-02, timestamp=14:00` | each host keeps its own time |

That surviving row is the part worth dwelling on: the host came from one observation and the timestamp from the other, so it described something that never happened — and it would print that way in a report. Which host survived was decided by severity, then source trust, then description length, none of which relate to the real subject. A host whose events all shared hashes with another could drop out of the case's host set entirely.

## The fix

Steps 3 (host+pid) and 4 (host inside `chainSignature`) were already host-scoped. The hash, path and exact-duplicate steps now match them, via one shared `hostScopedGroups` helper.

**Host-less events are not guessed at.** They group with each other, and join a real host only when the artifact was seen on exactly one — which keeps AI-extracted rows gaining their asset from a structured sibling, without inventing an attribution when the artifact spans two machines.

**Step 0 needed the same treatment.** A fleet-wide sweep writes identical text at the identical second on every machine it hits, and those are as many findings as there are machines, not one. A re-import always carries the same asset, so dedup is unaffected. This one is never relaxed — two hosts' rows are not one observation regardless of caller.

**Clock-skew detection (#228) needs the opposite grouping.** Its anchors are, by definition, one artifact stamped by two machines' clocks. So `correlationGroups` takes an explicit `crossHostArtifacts` flag that only skew passes. Without this, the feature merged in #287 would have silently stopped finding anchors — worth knowing about if either area is touched again.

## Caveat

This does **not** un-merge timelines a previous build already persisted. Correlation runs at synthesis and the result is written to state, so already-merged events stay merged; the fix applies as new evidence is correlated.

## Test plan

- [x] 12 new tests: 8 covering the scoping rules (two hosts stay separate; same host still merges; FQDN vs short name; host-less adoption and refusal; path variants), 4 end-to-end proving the `lateral_move` edge now survives correlation and each host keeps its own timestamp.
- [x] The 23 pre-existing correlation tests pass **unchanged** — they exercise host-less events, so they were never relying on cross-host merging.
- [x] `npx tsc --noEmit` clean.
- [x] Full suite: 5571 passing across 450 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)