### PR TITLE
feat(custody): record chain of custody automatically for every stored artifact (#231)

### DIFF
--- a/companion/src/ingest/captureIngest.ts
+++ b/companion/src/ingest/captureIngest.ts
@@ -101,8 +101,14 @@ export async function ingestCapture(
     ? `${seq}_${tsSafe}_${titleSlug}.webp`
     : `${seq}_${tsSafe}.webp`;
 
-  // Evidence first: write the image before recording metadata.
-  await store.saveScreenshot(payload.caseId, screenshotFile, bytes);
+  // Evidence first: write the image before recording metadata. The provenance goes with the write
+  // because this is the only layer that still knows where the frame came from — the store below
+  // sees bytes and a filename, and custody wants the origin URL and what triggered the shot (#231).
+  await store.saveScreenshot(payload.caseId, screenshotFile, bytes, {
+    source: payload.url,
+    trigger: payload.triggerType,
+    collectedBy: "browser-extension",
+  });
 
   const metadata: CaptureMetadata = {
     caseId: payload.caseId,

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -989,6 +989,26 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerSessionSegmentationRoutes(app, ctx);
   registerFindingsRoutes(app, ctx);
   registerTaggerRoutes(app, ctx);
+  // Auto-record chain of custody for every artifact the companion stores (#231). Hooked onto the
+  // store rather than onto the ~25 saveImport call sites, so no import route — including ones added
+  // later — can quietly land evidence without a custody entry. POST /cases/:id/custody remains for
+  // evidence the companion never wrote itself (mounted images, external tool output).
+  if (options.custodyStore) {
+    const custody = options.custodyStore;
+    store.onArtifactStored(async (artifact) => {
+      await custody.record(artifact.caseId, {
+        artifactPath: artifact.path,
+        sha256: artifact.sha256,
+        // Only the capture path knows its collector and origin URL; an import is attributed to the
+        // companion itself, with the analyst's action already in the activity log.
+        collectedBy: artifact.provenance?.collectedBy ?? "companion",
+        collectedAt: new Date().toISOString(),
+        source: artifact.provenance?.source ?? "",
+        trigger: artifact.provenance?.trigger ?? artifact.kind,
+        caseId: artifact.caseId,
+      });
+    });
+  }
   registerCustodyRoutes(app, ctx);
   registerPlaybookHuntsRoutes(app, ctx);
   registerPlaybookMatchRoutes(app, ctx);

--- a/companion/src/storage/caseStore.ts
+++ b/companion/src/storage/caseStore.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile, appendFile, readFile, stat, readdir, rename, rm } from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import { existsSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import type { CaseMeta, CaptureMetadata, ImportMetadata } from "../types.js";
 import type { OcrIndex, OcrIndexEntry } from "../analysis/ocrSearch.js";
@@ -20,6 +21,24 @@ export function isValidCaseId(caseId: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(caseId) && !caseId.includes("..");
 }
 
+/** What the caller knows about where an artifact came from; only the capture path has all of it. */
+export interface ArtifactProvenance {
+  source?: string;
+  trigger?: string;
+  collectedBy?: string;
+}
+
+/** An artifact that has just been written to disk, announced to the artifact-stored listener. */
+export interface StoredArtifact {
+  caseId: string;
+  path: string;
+  sha256: string;
+  kind: "screenshot" | "import";
+  provenance?: ArtifactProvenance;
+}
+
+export type ArtifactStoredListener = (artifact: StoredArtifact) => void | Promise<void>;
+
 export class CaseStore {
   // Serializes evidence-sequence allocation per case+kind (#214). Reading "audit-log length + 1"
   // is a read-modify-write: two ingestions racing for the same case both read the same length and
@@ -38,9 +57,29 @@ export class CaseStore {
   // Serializes the OCR index read-modify-write per case (see putOcrEntry).
   private readonly ocrLock = new StateLock();
 
+  // Notified after every artifact write below, so chain-of-custody is recorded for ALL stored
+  // evidence rather than only where a caller remembered to ask (#231). It lives here, at the two
+  // methods that actually write evidence, because saveImport alone has 25 call sites — instrumenting
+  // them individually would guarantee a gap, and every future one would start life uncovered.
+  // Injected rather than imported so storage/ keeps knowing nothing about custody.
+  private artifactStoredListener: ArtifactStoredListener | null = null;
+
   constructor(private readonly root: string) {}
 
   get casesRoot(): string { return this.root; }
+
+  /** Register the (single) listener notified after each artifact write. */
+  onArtifactStored(listener: ArtifactStoredListener): void {
+    this.artifactStoredListener = listener;
+  }
+
+  // Called only AFTER the bytes are safely on disk, and deliberately not caught here: an artifact
+  // whose custody record silently failed to append is exactly the gap this feature exists to close,
+  // so it surfaces to the caller the same way saveScreenshot's `wx` collision does. The evidence
+  // itself is already written, so a raised error costs the caller its response, never the artifact.
+  private async announceArtifact(artifact: StoredArtifact): Promise<void> {
+    await this.artifactStoredListener?.(artifact);
+  }
 
   /** Reserve the next never-yet-used sequence number for this case+kind. */
   private reserveSequence(kind: "capture" | "import", caseId: string, countOnDisk: () => Promise<number>): Promise<number> {
@@ -207,9 +246,12 @@ export class CaseStore {
   // `wx` = create-exclusive: fail if the file exists rather than overwrite it (#214). Sequence
   // numbers are unique now, so a collision should be impossible — which is exactly why hitting one
   // must raise instead of destroying evidence that is already on disk.
-  async saveScreenshot(caseId: string, filename: string, bytes: Buffer): Promise<string> {
+  async saveScreenshot(caseId: string, filename: string, bytes: Buffer, provenance?: ArtifactProvenance): Promise<string> {
     const path = join(this.screenshotsDir(caseId), filename);
     await writeFile(path, bytes, { flag: "wx" });
+    // Hash the buffer we just wrote rather than re-reading the file: same bytes, no second pass
+    // over evidence that can run to hundreds of megabytes.
+    await this.announceArtifact({ caseId, path, sha256: createHash("sha256").update(bytes).digest("hex"), kind: "screenshot", provenance });
     return path;
   }
 
@@ -234,11 +276,13 @@ export class CaseStore {
 
   // Persist an uploaded CSV verbatim as evidence (mkdirs for cases created before
   // the imports/ dir existed). Returns the stored absolute path.
-  async saveImport(caseId: string, filename: string, text: string): Promise<string> {
+  async saveImport(caseId: string, filename: string, text: string, provenance?: ArtifactProvenance): Promise<string> {
     await mkdir(this.importsDir(caseId), { recursive: true });
     const path = join(this.importsDir(caseId), filename);
     // Create-exclusive, for the same reason as saveScreenshot above (#214).
     await writeFile(path, text, { encoding: "utf8", flag: "wx" });
+    // utf8 in, utf8 on disk — so this matches what a later re-read hashes during verification.
+    await this.announceArtifact({ caseId, path, sha256: createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex"), kind: "import", provenance });
     return path;
   }
 

--- a/companion/tests/server/custodyAutoRecord.test.ts
+++ b/companion/tests/server/custodyAutoRecord.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import request from "supertest";
+import sharp from "sharp";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import { _resetDedupCache } from "../../src/ingest/captureIngest.js";
+import { createApp } from "../../src/server.js";
+
+let app: ReturnType<typeof createApp>;
+let cases: CaseStore;
+
+async function pngBase64(): Promise<string> {
+  const buf = await sharp({ create: { width: 8, height: 8, channels: 3, background: { r: 1, g: 2, b: 3 } } }).png().toBuffer();
+  return buf.toString("base64");
+}
+
+beforeEach(async () => {
+  _resetDedupCache();
+  const root = await mkdtemp(join(tmpdir(), "dfir-custodyauto-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  app = createApp(cases, { custodyStore: new CustodyStore(cases) });
+});
+
+describe("automatic custody recording", () => {
+  it("records custody for a screenshot the extension pushes, with no analyst action", async () => {
+    const imageBase64 = await pngBase64();
+
+    const post = await request(app).post("/captures").send({
+      caseId: "c1",
+      timestamp: "2026-05-28T10:00:00.000Z",
+      url: "https://velociraptor.local/hunts",
+      tabTitle: "Hunts",
+      triggerType: "navigation",
+      imageBase64,
+    });
+    expect(post.status).toBe(201);
+
+    const { body } = await request(app).get("/cases/c1/custody");
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]).toMatchObject({
+      caseId: "c1",
+      sha256: createHash("sha256").update(Buffer.from(imageBase64, "base64")).digest("hex"),
+      collectedBy: "browser-extension",
+      source: "https://velociraptor.local/hunts",
+      trigger: "navigation",
+    });
+    expect(body.records[0].artifactPath).toContain(cases.screenshotsDir("c1"));
+    expect(body.records[0].collectedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("records custody for a stored import", async () => {
+    const text = "ts,message\n2026-01-01T00:00:00Z,hello\n";
+
+    const path = await cases.saveImport("c1", "0001_evidence.csv", text);
+
+    const { body } = await request(app).get("/cases/c1/custody");
+    expect(body.records).toHaveLength(1);
+    expect(body.records[0]).toMatchObject({
+      caseId: "c1",
+      artifactPath: path,
+      sha256: createHash("sha256").update(Buffer.from(text, "utf8")).digest("hex"),
+      collectedBy: "companion",
+      trigger: "import",
+    });
+  });
+
+  it("verifies clean, then flags the artifact once its bytes change on disk", async () => {
+    const path = await cases.saveImport("c1", "0001_evidence.csv", "original\n");
+
+    const clean = await request(app).get("/cases/c1/custody/verify");
+    expect(clean.body).toMatchObject({ ok: true, mismatches: [] });
+
+    await writeFile(path, "tampered\n", "utf8");
+
+    const dirty = await request(app).get("/cases/c1/custody/verify");
+    expect(dirty.body.ok).toBe(false);
+    expect(dirty.body.mismatches).toHaveLength(1);
+    expect(dirty.body.mismatches[0]).toMatchObject({ artifactPath: path, reason: "hash-mismatch" });
+  });
+
+  it("stores artifacts normally, and writes no custody log, when no custody store is configured", async () => {
+    // A store of its own: the app in beforeEach already attached a listener to `cases`.
+    const other = new CaseStore(await mkdtemp(join(tmpdir(), "dfir-custodyauto-bare-")));
+    await other.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    createApp(other, {});
+
+    await expect(other.saveImport("c1", "0001_evidence.csv", "data")).resolves.toBeTruthy();
+
+    await expect(readFile(join(other.metadataDir("c1"), "custody.jsonl"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/companion/tests/storage/artifactStoredHook.test.ts
+++ b/companion/tests/storage/artifactStoredHook.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { CaseStore, type StoredArtifact } from "../../src/storage/caseStore.js";
+
+let store: CaseStore;
+let seen: StoredArtifact[];
+
+const sha256 = (data: Buffer | string) => createHash("sha256").update(data).digest("hex");
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-artifacthook-"));
+  store = new CaseStore(root);
+  await store.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  seen = [];
+  store.onArtifactStored(async (artifact) => { seen.push(artifact); });
+});
+
+describe("CaseStore artifact-stored hook", () => {
+  it("notifies with the stored path and sha256 when a screenshot is saved", async () => {
+    const bytes = Buffer.from("not-really-an-image");
+
+    const path = await store.saveScreenshot("c1", "000001_shot.webp", bytes);
+
+    expect(seen).toEqual([
+      { caseId: "c1", path, sha256: sha256(bytes), kind: "screenshot", provenance: undefined },
+    ]);
+  });
+
+  it("passes the caller's provenance through to the listener", async () => {
+    const provenance = { source: "https://mail.example.com/inbox", trigger: "navigation", collectedBy: "extension" };
+
+    await store.saveScreenshot("c1", "000001_shot.webp", Buffer.from("x"), provenance);
+
+    expect(seen[0]?.provenance).toEqual(provenance);
+  });
+
+  it("notifies with the stored path and sha256 when an import is saved", async () => {
+    const text = "ts,message\n2026-01-01T00:00:00Z,hello\n";
+
+    const path = await store.saveImport("c1", "evidence.csv", text);
+
+    expect(seen).toEqual([
+      { caseId: "c1", path, sha256: sha256(Buffer.from(text, "utf8")), kind: "import", provenance: undefined },
+    ]);
+  });
+
+  it("does not notify when the write fails", async () => {
+    await store.saveImport("c1", "evidence.csv", "first");
+    // `wx` refuses to overwrite evidence already on disk (#214) — no artifact was stored, so
+    // custody must not gain a record claiming one was.
+    await expect(store.saveImport("c1", "evidence.csv", "second")).rejects.toThrow();
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it("surfaces a listener failure to the caller rather than dropping the record silently", async () => {
+    store.onArtifactStored(async () => { throw new Error("custody log is full"); });
+
+    await expect(store.saveImport("c1", "evidence.csv", "data")).rejects.toThrow("custody log is full");
+  });
+});


### PR DESCRIPTION
## Why

The `CustodyStore` and its three routes already existed, but nothing called them. An analyst had to `POST /cases/:id/custody` by hand for every artifact, so in practice `custody.jsonl` stayed empty — and the signed manifest, periodic verification and report appendix still open on #231 would all have been built over nothing.

## What

Auto-record is hooked onto `CaseStore`, not onto the call sites. `saveImport` alone has 25 callers and `saveScreenshot` one; instrumenting them individually would guarantee a gap, and every import route added later would start life uncovered. The listener fires after each evidence write, so no path can land an artifact without a custody entry.

- **`caseStore.ts`** — new `onArtifactStored()` plus the `StoredArtifact` / `ArtifactProvenance` types. `saveScreenshot` and `saveImport` hash the buffer they just wrote rather than re-reading the file: evidence here runs to hundreds of megabytes and the bytes are identical either way. Storage stays custody-agnostic — the listener is injected, never imported.
- **`server.ts`** — `createApp` registers the listener when `options.custodyStore` is present.
- **`captureIngest.ts`** — passes the frame's origin URL, its trigger type, and `browser-extension` as the collector. That layer is the last one that still knows them; `CaseStore` only sees bytes and a filename. Imports are attributed to the companion, with the analyst's action already in the activity log.

Manual `POST /cases/:id/custody` is untouched — it still covers evidence the companion never wrote itself (mounted images, external tool output).

## Design note

A listener failure **propagates** rather than being swallowed. A silently dropped custody record is exactly the gap this closes, so it fails loudly — matching the `wx` create-exclusive flag that already raises rather than quietly overwriting evidence (#214). The bytes are on disk before the hook runs, so a raised error costs the caller its response, never the artifact.

## Verification

- `npm run typecheck` — clean
- `vitest run` — **459 files, 5721 tests passed**
- New coverage: `tests/storage/artifactStoredHook.test.ts` (5) and `tests/server/custodyAutoRecord.test.ts` (4) — hash correctness, provenance pass-through, no record when the write fails, listener errors surfacing, an end-to-end extension capture, and tamper detection on an auto-recorded artifact.

## Known limitation (tracked separately)

`CustodyRecord.artifactPath` is absolute, and `caseDir()` relocates a case to `_archived/` when archived — so auto-recorded artifacts would then verify as `missing`. Fixing it needs a record-format change (relative for in-case artifacts, absolute preserved for externally-collected ones, backward-compatible reads), which is why it is not in this PR.

## Scope

Part of #231 — this is the auto-record half of item 1. The signed manifest, periodic verification job and report appendix remain open, as does the event-type + hash-chaining change that should land before the manifest is signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
