### PR TITLE
fix(custody): store in-case artifact paths relative to the case dir so verification survives a move (#231)

### DIFF
--- a/companion/src/analysis/custody.ts
+++ b/companion/src/analysis/custody.ts
@@ -1,7 +1,7 @@
 import { readFile, appendFile, mkdir } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { join, relative, isAbsolute, sep } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
 
 // Evidence here is disk images, memory dumps and Plaso super-timelines — routinely 400 MB+, and
@@ -16,6 +16,7 @@ export async function hashFile(path: string): Promise<string> {
 }
 
 export interface CustodyRecord {
+  /** Always absolute, in both directions — see StoredCustodyRecord for how it is persisted. */
   artifactPath: string;
   sha256: string;
   collectedBy: string;
@@ -23,6 +24,25 @@ export interface CustodyRecord {
   source: string;
   trigger: string;
   caseId: string;
+}
+
+/**
+ * How a record is written to custody.jsonl. An absolute path is only valid for as long as the case
+ * folder stays put, and it does not: archiving moves it to <root>/_archived/<caseId>, and the whole
+ * cases root moves on a DFIR_CASES_DIR change, a container remount or a restore from backup. Every
+ * artifact recorded before such a move would then verify as "missing" — the integrity check would
+ * cry tampering over evidence sitting intact one directory across.
+ *
+ * So an artifact that lives inside the case dir is stored relative to it and re-resolved through the
+ * (archive-aware) caseDir() on every read. Evidence collected from outside the case dir — mounted
+ * images, external tool output, the POST /cases/:id/custody case — has nothing to be relative TO, so
+ * it keeps its absolute path and omits the marker. Records written before this distinction existed
+ * also lack the marker, which is exactly right: they are absolute.
+ *
+ * This stays internal. Callers hand in and get back absolute paths, unchanged.
+ */
+interface StoredCustodyRecord extends CustodyRecord {
+  relativeTo?: "case-dir";
 }
 
 export interface CustodyMismatch {
@@ -39,9 +59,26 @@ export class CustodyStore {
     return join(this.cases.metadataDir(caseId), "custody.jsonl");
   }
 
+  /**
+   * Whether artifactPath lives inside the case dir, and if so where. Deliberately derived from the
+   * path rather than declared by the caller: an artifact the companion stored itself always lands
+   * inside the case dir and externally collected evidence generally does not, so the two are already
+   * distinguishable — and a manual record that does name an in-case file gets the same
+   * relocation-proofing for free.
+   */
+  private caseRelative(caseId: string, artifactPath: string): string | null {
+    const rel = relative(this.cases.caseDir(caseId), artifactPath);
+    // "" is the case dir itself; ".." escapes it; an absolute result means a different root entirely.
+    if (!rel || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return null;
+    return rel;
+  }
+
   async record(caseId: string, record: CustodyRecord): Promise<CustodyRecord> {
+    const rel = this.caseRelative(caseId, record.artifactPath);
+    const stored: StoredCustodyRecord = rel === null ? record : { ...record, artifactPath: rel, relativeTo: "case-dir" };
     await mkdir(this.cases.metadataDir(caseId), { recursive: true });
-    await appendFile(this.path(caseId), JSON.stringify(record) + "\n", "utf8");
+    await appendFile(this.path(caseId), JSON.stringify(stored) + "\n", "utf8");
+    // The caller gets back what it handed in — the relative form never leaves this class.
     return record;
   }
 
@@ -57,12 +94,23 @@ export class CustodyStore {
     for (const line of text.split("\n")) {
       if (!line.trim()) continue;
       try {
-        records.push(JSON.parse(line) as CustodyRecord);
+        records.push(this.resolve(caseId, JSON.parse(line) as StoredCustodyRecord));
       } catch {
         // skip a malformed line
       }
     }
     return records;
+  }
+
+  /**
+   * Rebuild the absolute path from wherever the case folder is NOW, so a record outlives an archive
+   * or a moved cases root. A record with no marker is already absolute — that covers both external
+   * evidence and everything written before the marker existed.
+   */
+  private resolve(caseId: string, stored: StoredCustodyRecord): CustodyRecord {
+    if (stored.relativeTo !== "case-dir") return stored;
+    const { relativeTo: _relativeTo, ...record } = stored;
+    return { ...record, artifactPath: join(this.cases.caseDir(caseId), stored.artifactPath) };
   }
 
   async verifyIntegrity(caseId: string): Promise<CustodyMismatch[]> {

--- a/companion/tests/analysis/custody.test.ts
+++ b/companion/tests/analysis/custody.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile, readFile, rename, mkdir, appendFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -86,6 +86,95 @@ describe("CustodyStore", () => {
     expect(mismatches).toHaveLength(1);
     expect(mismatches[0].reason).toBe("missing");
     expect(mismatches[0].actualSha256).toBeNull();
+  });
+
+  // The case folder moves: archiving relocates it under _archived/, and the whole cases root moves
+  // on a DFIR_CASES_DIR change, a container remount or a restore from backup. An artifact inside the
+  // case dir is stored relative to it and re-resolved through caseDir() at verification time, so the
+  // evidence stays verifiable wherever the folder ends up (#231 follow-up).
+  describe("when the case folder moves", () => {
+    const sha = createHash("sha256").update("hello world\n").digest("hex");
+    const recordArtifact = (): Promise<unknown> =>
+      store.record("c1", {
+        artifactPath, sha256: sha, collectedBy: "a", collectedAt: "t", source: "s", trigger: "m", caseId: "c1",
+      });
+
+    it("stores an in-case artifact as a path relative to the case dir", async () => {
+      await recordArtifact();
+      const line = await readFile(join(casesRoot, "c1", "metadata", "custody.jsonl"), "utf8");
+      const stored = JSON.parse(line.trim()) as { artifactPath: string; relativeTo?: string };
+      expect(stored.artifactPath).toBe(join("imports", "evidence.csv"));
+      expect(stored.relativeTo).toBe("case-dir");
+    });
+
+    it("load resolves a case-relative record back to an absolute path", async () => {
+      await recordArtifact();
+      const list = await store.load("c1");
+      expect(list[0].artifactPath).toBe(artifactPath);
+    });
+
+    it("verifyIntegrity stays clean after the case is archived", async () => {
+      await recordArtifact();
+      await cases.archiveCaseFolder("c1");
+      expect(await store.verifyIntegrity("c1")).toEqual([]);
+    });
+
+    it("verifyIntegrity stays clean after the cases root is moved", async () => {
+      await recordArtifact();
+      const movedRoot = join(await mkdtemp(join(tmpdir(), "dfir-custody-moved-")), "cases");
+      await rename(casesRoot, movedRoot);
+      const moved = new CustodyStore(new CaseStore(movedRoot));
+      expect(await moved.verifyIntegrity("c1")).toEqual([]);
+    });
+
+    it("still catches tampering after the case is archived", async () => {
+      await recordArtifact();
+      await cases.archiveCaseFolder("c1");
+      await writeFile(join(cases.importsDir("c1"), "evidence.csv"), "tampered\n", "utf8");
+      const mismatches = await store.verifyIntegrity("c1");
+      expect(mismatches).toHaveLength(1);
+      expect(mismatches[0].reason).toBe("hash-mismatch");
+      expect(mismatches[0].artifactPath).toBe(join(casesRoot, "_archived", "c1", "imports", "evidence.csv"));
+    });
+  });
+
+  // Evidence collected manually via POST /cases/:id/custody routinely lives outside the case dir —
+  // mounted images, external tool output. There is nothing to make it relative to, so it keeps being
+  // stored (and verified) as the absolute path it is.
+  describe("artifacts outside the case dir", () => {
+    let external: string;
+    let externalSha: string;
+
+    beforeEach(async () => {
+      external = join(await mkdtemp(join(tmpdir(), "dfir-custody-ext-")), "mounted-image.dd");
+      await writeFile(external, "external evidence\n", "utf8");
+      externalSha = createHash("sha256").update("external evidence\n").digest("hex");
+      await store.record("c1", {
+        artifactPath: external, sha256: externalSha, collectedBy: "a", collectedAt: "t", source: "s", trigger: "m", caseId: "c1",
+      });
+    });
+
+    it("stores the absolute path with no case-dir marker", async () => {
+      const line = await readFile(join(casesRoot, "c1", "metadata", "custody.jsonl"), "utf8");
+      const stored = JSON.parse(line.trim()) as { artifactPath: string; relativeTo?: string };
+      expect(stored.artifactPath).toBe(external);
+      expect(stored.relativeTo).toBeUndefined();
+    });
+
+    it("verifyIntegrity stays clean after the case is archived", async () => {
+      await cases.archiveCaseFolder("c1");
+      expect(await store.verifyIntegrity("c1")).toEqual([]);
+    });
+  });
+
+  // custody.jsonl files written before the relative-path change hold absolute paths and no marker.
+  it("reads a record written in the pre-existing absolute-path format", async () => {
+    const sha = createHash("sha256").update("hello world\n").digest("hex");
+    const legacy = { artifactPath, sha256: sha, collectedBy: "a", collectedAt: "t", source: "s", trigger: "m", caseId: "c1" };
+    await mkdir(join(casesRoot, "c1", "metadata"), { recursive: true });
+    await appendFile(join(casesRoot, "c1", "metadata", "custody.jsonl"), JSON.stringify(legacy) + "\n", "utf8");
+    expect((await store.load("c1"))[0].artifactPath).toBe(artifactPath);
+    expect(await store.verifyIntegrity("c1")).toEqual([]);
   });
 
   it("records multiple entries for the same case", async () => {


### PR DESCRIPTION
## The problem

`CustodyRecord.artifactPath` was written as an absolute path, and `CustodyStore.verifyIntegrity()` re-hashed that exact string. An absolute path is only valid while the case folder stays put — and it doesn't:

- `CaseStore.archiveCaseFolder()` moves the case from `<root>/<caseId>` to `<root>/_archived/<caseId>`
- the whole cases root moves on a `DFIR_CASES_DIR` change, a container remount, or a restore from backup

Every artifact recorded before such a move then verified as `reason: "missing"` — the integrity check crying tampering over evidence sitting intact one directory across.

This mattered little while `custody.jsonl` was populated by hand, but the #231 auto-record wiring writes a record for every stored screenshot and import, and those all live inside the case directory. Archiving a case would have reported the entire evidence set as missing.

**Root cause:** the resolved location was frozen into the record at write time, while `CaseStore.caseDir()` resolves it at read time.

## The fix

An artifact inside the case dir is stored relative to it and marked `relativeTo: "case-dir"`, then rejoined onto the archive-aware `caseDir()` on every read:

```jsonc
// in-case artifact — survives archiving and a moved root
{ "artifactPath": "imports/evidence.csv", "relativeTo": "case-dir", ... }
// externally collected evidence — unchanged
{ "artifactPath": "/mnt/images/disk.dd", ... }
```

Containment is derived from the path rather than declared by the caller: an artifact the companion stored itself always lands inside the case dir and externally collected evidence generally does not, so the two are already distinguishable — and a manual record that names an in-case file gets the same relocation-proofing for free.

`verifyIntegrity()` needed no change at all; it consumes `load()`, so fixing resolution there fixed verification.

## Compatibility

- **Evidence outside the case dir** — mounted images, external tool output, what `POST /cases/:id/custody` exists for — has nothing to be relative *to*, so it keeps its absolute path and omits the marker.
- **Records already on disk** also lack the marker, which is exactly right: they *are* absolute. `load()` reads them unchanged, so there is no migration.
- **The relative form never leaves the file.** `StoredCustodyRecord` is module-private and `CustodyRecord.artifactPath` is absolute in both directions, so `record()` returns what the caller handed in and `load()` / `verifyIntegrity()` hand back absolute paths. No consumer changes — `custodyRoutes.test.ts` passes untouched, including its assertion that `GET /cases/:id/custody` returns the absolute path of an in-case file.

One consequence worth knowing: the fix keys off *where the file is*, not who recorded it, so a manual POST naming a file inside the case dir is now stored relative too. Strictly better (it survives archiving), but the manual endpoint no longer guarantees an absolute path *on disk* — only a guaranteed absolute one back out of `load()`.

## Verification

`npm run typecheck` clean; `vitest run` — **457 files, 5720 tests passed**.

Seven new cases in `companion/tests/analysis/custody.test.ts`, written test-first and watched fail (archive and root-move both reported `"missing"` before the fix):

- an in-case artifact is stored as a path relative to the case dir
- `load()` resolves a case-relative record back to an absolute path
- **verify stays clean after `archiveCaseFolder()`**
- **verify stays clean after the cases root is moved**
- tampering is still caught after archive, at the resolved path — so the fix isn't silently permissive
- an external artifact stays absolute on disk and still verifies after archive
- a legacy absolute-format record still loads and verifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)