### PR TITLE
feat(collection-plan): incident-type guided evidence collection (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Collection plan** (#347) — the incident type's evidence checklist as a dashboard panel: what to collect for this kind of incident, in order, each item ticking itself off once matching evidence is in the case, whichever tool produced it. *Have it* records evidence held outside the tool and *N/A* retires a step this environment can't satisfy, so the plan stops nagging. Replaces the unused hunt-bundle and report-framing fields shipped with #236, which named Velociraptor bundles and report templates that do not exist.
 - **Incident-type auto-playbooks** (#236) — the New case dialog's *Incident type* picker pre-configures a case for a recurring incident pattern: eight built-in types (ransomware, BEC, data exfiltration, intrusion, insider threat, cloud compromise, web-app intrusion, malware outbreak) seed type-specific key questions, priority-ordered next steps, and that incident's expected findings as open confirm/deny questions. Synthesis is told which type the case is so it prioritizes the relevant ATT&CK techniques — prompt context only, it never reaches the report. Types are editable JSON in `companion/data/incident-types/`, analysts can drop their own into an `incident-types/` folder beside the cases root, and re-picking a type merges rather than overwriting analyst edits.
 
 ### Fixed

--- a/companion/data/incident-types/bec.json
+++ b/companion/data/incident-types/bec.json
@@ -50,15 +50,9 @@
   ],
   "recommendedImportOrder": [
     "m365",
-    "entra-audit",
+    "identity",
     "siem",
-    "email-gateway"
-  ],
-  "huntBundles": [
-    "mailbox-rules",
-    "mfa-bypass",
-    "conditional-access",
-    "oauth-app-grants"
+    "network"
   ],
   "findingsSeeds": [
     "Mailbox account takeover confirmed",
@@ -68,10 +62,5 @@
     "Wire transfer / payment fraud initiated",
     "Mailbox data exfiltrated"
   ],
-  "reportFraming": {
-    "template": "bec-executive",
-    "audience": "finance + legal + executive",
-    "summaryPrompt": "Summarize the BEC compromise, funds-at-risk, and recovery actions for finance and legal."
-  },
   "synthesisHint": "This is a BEC case — prioritize T1566 Phishing (initial access), T1098 Account Manipulation (inbox rules / OAuth grants), T1078 Valid Accounts, and T1567 Exfiltration to Cloud Service."
 }

--- a/companion/data/incident-types/cloud-compromise.json
+++ b/companion/data/incident-types/cloud-compromise.json
@@ -52,16 +52,10 @@
   ],
   "recommendedImportOrder": [
     "cloud-audit",
-    "aws",
+    "identity",
     "m365",
     "siem",
     "edr"
-  ],
-  "huntBundles": [
-    "iam-abuse",
-    "new-access-keys",
-    "unauthorized-instances",
-    "key-leak"
   ],
   "findingsSeeds": [
     "Cloud account/tenant compromise confirmed",
@@ -71,10 +65,5 @@
     "Resources accessed or exfiltrated",
     "Unauthorized compute instances"
   ],
-  "reportFraming": {
-    "template": "cloud-executive",
-    "audience": "cloud-ops + security + executive",
-    "summaryPrompt": "Summarize the cloud compromise, IAM abuse, and containment for cloud-ops and executive."
-  },
   "synthesisHint": "This is a cloud-compromise case — prioritize T1078 Valid Accounts (cloud), T1098 Account Manipulation (new IAM principals), T1136 Create Account, and T1530 Data from Cloud Storage."
 }

--- a/companion/data/incident-types/data-exfiltration.json
+++ b/companion/data/incident-types/data-exfiltration.json
@@ -56,13 +56,8 @@
     "siem",
     "edr",
     "cloud-audit",
-    "m365"
-  ],
-  "huntBundles": [
-    "file-staging",
-    "cloud-sync",
-    "archive-creation",
-    "bulk-transfer"
+    "m365",
+    "endpoint-triage"
   ],
   "findingsSeeds": [
     "Exfiltration channel confirmed",
@@ -72,10 +67,5 @@
     "Insider vs. external actor distinguished",
     "Ongoing exfiltration stopped"
   ],
-  "reportFraming": {
-    "template": "exfiltration-executive",
-    "audience": "legal + DPO + executive",
-    "summaryPrompt": "Summarize the exfiltrated data, notification obligations, and containment for legal and the DPO."
-  },
   "synthesisHint": "This is a data-exfiltration case — prioritize T1567 Exfiltration to Cloud Service, T1048 Exfiltration Over Alternative Protocol, T1052 Exfiltration Over Physical Medium, and T1074 Data Staged."
 }

--- a/companion/data/incident-types/insider-threat.json
+++ b/companion/data/incident-types/insider-threat.json
@@ -53,16 +53,11 @@
   ],
   "recommendedImportOrder": [
     "siem",
-    "edr",
+    "endpoint-triage",
+    "super-timeline",
     "m365",
     "cloud-audit",
-    "badge-access"
-  ],
-  "huntBundles": [
-    "usb-devices",
-    "file-access",
-    "cloud-sync",
-    "email-exfil"
+    "physical-access"
   ],
   "findingsSeeds": [
     "Subject identified and scoped",
@@ -72,10 +67,5 @@
     "Post-resignation access",
     "Credential / account sharing"
   ],
-  "reportFraming": {
-    "template": "insider-executive",
-    "audience": "HR + legal + executive",
-    "summaryPrompt": "Summarize the insider activity, policy violations, and evidence for HR and legal."
-  },
   "synthesisHint": "This is an insider-threat case — prioritize T1052 Exfiltration Over Physical Medium (USB), T1567 Exfiltration to Cloud Service, T1078 Valid Accounts (the insider's own), and T1056 Input Capture."
 }

--- a/companion/data/incident-types/intrusion.json
+++ b/companion/data/incident-types/intrusion.json
@@ -54,15 +54,9 @@
   "recommendedImportOrder": [
     "network",
     "edr",
-    "windows-evtx",
-    "siem",
-    "velociraptor"
-  ],
-  "huntBundles": [
-    "persistence",
-    "lateral-movement",
-    "c2-callback",
-    "credential-theft"
+    "windows-event-logs",
+    "endpoint-triage",
+    "siem"
   ],
   "findingsSeeds": [
     "Initial access vector confirmed",
@@ -72,10 +66,5 @@
     "Privilege escalation observed",
     "Attacker objective determined"
   ],
-  "reportFraming": {
-    "template": "intrusion-executive",
-    "audience": "IR team + IT operations + executive",
-    "summaryPrompt": "Summarize the intrusion scope, patient zero, and containment status for the IR team and executive."
-  },
   "synthesisHint": "This is a network intrusion case — prioritize TA0001 Initial Access, TA0003 Persistence, TA0008 Lateral Movement, and TA0011 Command and Control."
 }

--- a/companion/data/incident-types/malware-outbreak.json
+++ b/companion/data/incident-types/malware-outbreak.json
@@ -52,16 +52,11 @@
   ],
   "recommendedImportOrder": [
     "edr",
-    "windows-evtx",
-    "velociraptor",
+    "memory",
+    "sandbox",
+    "windows-event-logs",
     "network",
-    "sandbox"
-  ],
-  "huntBundles": [
-    "binary-hash",
-    "c2-callback",
-    "persistence",
-    "dropped-files"
+    "threat-scan"
   ],
   "findingsSeeds": [
     "Malware family identified",
@@ -71,10 +66,5 @@
     "Persistence mechanisms catalogued",
     "Credential theft / lateral movement observed"
   ],
-  "reportFraming": {
-    "template": "malware-executive",
-    "audience": "IR team + IT operations + executive",
-    "summaryPrompt": "Summarize the malware outbreak, scope, and containment for the IR team and executive."
-  },
   "synthesisHint": "This is a malware-outbreak case — prioritize TA0002 Execution, TA0003 Persistence, TA0011 Command and Control, and T1105 Ingress Tool Transfer."
 }

--- a/companion/data/incident-types/ransomware.json
+++ b/companion/data/incident-types/ransomware.json
@@ -52,16 +52,11 @@
   ],
   "recommendedImportOrder": [
     "edr",
-    "windows-evtx",
-    "velociraptor",
+    "memory",
+    "windows-event-logs",
+    "endpoint-triage",
     "network",
     "siem"
-  ],
-  "huntBundles": [
-    "vss-delete",
-    "mimikatz",
-    "lateral-movement",
-    "ransomware-note"
   ],
   "findingsSeeds": [
     "Initial access vector confirmed",
@@ -71,10 +66,5 @@
     "Persistence mechanism established",
     "Double-extortion leak-site listing"
   ],
-  "reportFraming": {
-    "template": "ransomware-executive",
-    "audience": "board + insurer + legal",
-    "summaryPrompt": "Summarize the ransomware impact, scope, and notification obligations for the board and insurer."
-  },
   "synthesisHint": "This is a ransomware case — prioritize T1486 Data Encrypted for Impact, T1490 Inhibit System Recovery (VSS deletion), T1021 Remote Services / lateral movement, and T1567 Exfiltration to Cloud Service (double extortion)."
 }

--- a/companion/data/incident-types/web-app-intrusion.json
+++ b/companion/data/incident-types/web-app-intrusion.json
@@ -53,14 +53,8 @@
     "web-logs",
     "network",
     "edr",
-    "siem",
-    "waf"
-  ],
-  "huntBundles": [
-    "webshell",
-    "suspicious-children",
-    "c2-callback",
-    "data-staging"
+    "windows-event-logs",
+    "siem"
   ],
   "findingsSeeds": [
     "Exploitation technique confirmed (SQLi/RCE/upload/SSRF)",
@@ -70,10 +64,5 @@
     "Data accessed or exfiltrated",
     "Vulnerability patched / system isolated"
   ],
-  "reportFraming": {
-    "template": "webapp-executive",
-    "audience": "app-team + security + executive",
-    "summaryPrompt": "Summarize the web-app intrusion, exploited vulnerability, and remediation for the app team and executive."
-  },
   "synthesisHint": "This is a web-app-intrusion case — prioritize T1190 Exploit Public-Facing Application, T1505.003 Server Software Component: Web Shell, T1059 Command and Scripting Interpreter, and T1071 Application Layer Protocol (C2)."
 }

--- a/companion/src/analysis/collectionPlan.ts
+++ b/companion/src/analysis/collectionPlan.ts
@@ -1,0 +1,109 @@
+import type { ForensicEvent } from "./stateTypes.js";
+
+// Guided evidence collection per incident type (#347). Steps name EVIDENCE, not tools: an analyst
+// knows they need Windows event logs before they know which importer produces them, and a
+// tool-named step would sit unticked because they used the other tool that yields the same evidence.
+//
+// `satisfiedBy` lists the event source labels that count. Labels come from two places and BOTH must
+// be covered or a step under-ticks:
+//   1. importer literals  — a fixed label the importer stamps ("MemProcFS", "Entra ID", ...)
+//   2. detectTool()       — CSV/log/SIEM imports derive the label from the filename, yielding
+//                           vendor names ("SentinelOne", "Splunk", ...)
+// Missing (2) would leave the EDR step blind to Defender, SentinelOne, Carbon Black and Cortex XDR
+// — the ones an analyst is most likely to actually have. collectionPlanVocabulary.test.ts pins
+// every label against the real importers so an invented one fails the build.
+//
+// Pure and deterministic — no I/O, no AI.
+
+export interface CollectionStepDef {
+  id: string;
+  label: string;
+  // Empty = this evidence cannot be imported by this tool; the step is still worth doing, and
+  // renders as "collect outside DFIR Companion" rather than nagging forever.
+  satisfiedBy: readonly string[];
+}
+
+export const COLLECTION_STEPS: readonly CollectionStepDef[] = [
+  { id: "edr", label: "EDR telemetry", satisfiedBy: ["EDR (ECAR)", "CrowdStrike Falcon", "SentinelOne", "Carbon Black", "Cortex XDR", "Microsoft Defender", "Wazuh", "Falco"] },
+  { id: "windows-event-logs", label: "Windows event logs", satisfiedBy: ["Chainsaw", "Hayabusa", "EVTX", "Sysmon", "Windows Event Log"] },
+  { id: "endpoint-triage", label: "Endpoint triage artifacts", satisfiedBy: ["Velociraptor", "KAPE", "Autopsy", "Cyber Triage", "MFT", "UsnJrnl", "Prefetch", "Amcache", "ShimCache", "LNK", "JumpLists", "Shellbags", "RecycleBin", "SRUM"] },
+  { id: "memory", label: "Memory image", satisfiedBy: ["MemProcFS", "Volatility", "Rekall", "VolWeb"] },
+  { id: "network", label: "Network traffic / IDS", satisfiedBy: ["Zeek", "Suricata", "Snort", "Security Onion", "Cisco ASA", "Arkime", "Wireshark"] },
+  { id: "web-logs", label: "Web server access logs", satisfiedBy: ["Web Access Log"] },
+  { id: "m365", label: "Microsoft 365 / mailbox audit", satisfiedBy: ["Microsoft 365", "Email"] },
+  { id: "identity", label: "Identity sign-in logs", satisfiedBy: ["Entra ID"] },
+  { id: "cloud-audit", label: "Cloud control-plane audit", satisfiedBy: ["AWS CloudTrail", "Azure Activity", "GCP Audit", "Kubernetes Audit"] },
+  { id: "siem", label: "SIEM / aggregated logs", satisfiedBy: ["SIEM", "SIEM import", "Splunk", "Elastic", "Microsoft Sentinel", "QRadar", "Graylog", "Syslog", "journald", "auditd", "osquery", "sysdig"] },
+  { id: "sandbox", label: "Malware sandbox report", satisfiedBy: ["CAPEv2", "Falcon Sandbox"] },
+  { id: "super-timeline", label: "Super-timeline", satisfiedBy: ["Plaso", "Timesketch"] },
+  { id: "threat-scan", label: "Threat / YARA scan", satisfiedBy: ["THOR", "YARA", "VirusTotal", "Nessus"] },
+  { id: "physical-access", label: "Physical access records", satisfiedBy: [] },
+];
+
+const BY_ID = new Map<string, CollectionStepDef>(COLLECTION_STEPS.map((s) => [s.id, s]));
+
+export function getCollectionStep(id: string): CollectionStepDef | undefined {
+  return BY_ID.get(id);
+}
+
+export interface CollectionOverride {
+  state: "collected" | "na";
+  reason: string;
+}
+
+export type CollectionStepState =
+  | "collected"           // derived: matching evidence is in the case
+  | "outstanding"         // derived: not yet collected
+  | "external"            // nothing can import this; collect it outside the tool
+  | "override-collected"  // analyst asserted they have it
+  | "override-na";        // analyst asserted it does not apply here
+
+export interface CollectionStep {
+  id: string;
+  label: string;
+  satisfiedBy: readonly string[];
+  state: CollectionStepState;
+  reason: string;         // the analyst's override reason ("" when derived)
+}
+
+export interface CollectionPlan {
+  steps: CollectionStep[];
+  nextStepId: string;     // the first step still worth collecting ("" when none)
+  collected: number;
+  total: number;          // excludes external and n/a steps — they are not collectable here
+}
+
+// Build the plan for one case. `stepIds` is the incident type's declared order; unknown ids are
+// dropped rather than rendered as blank rows (a typo in a custom type's JSON must not reach the UI).
+export function buildCollectionPlan(
+  stepIds: readonly string[],
+  events: readonly ForensicEvent[],
+  overrides: Readonly<Record<string, CollectionOverride>>,
+): CollectionPlan {
+  // One pass over the timeline; every other panel already holds it in memory.
+  const present = new Set<string>();
+  for (const e of events) for (const s of e.sources ?? []) present.add(s);
+
+  const steps: CollectionStep[] = [];
+  for (const id of stepIds) {
+    const def = BY_ID.get(id);
+    if (!def) continue;
+    const override = overrides[id];
+    const state: CollectionStepState = override
+      ? (override.state === "collected" ? "override-collected" : "override-na")
+      : def.satisfiedBy.length === 0
+        ? "external"
+        : def.satisfiedBy.some((s) => present.has(s))
+          ? "collected"
+          : "outstanding";
+    steps.push({ id: def.id, label: def.label, satisfiedBy: def.satisfiedBy, state, reason: override?.reason ?? "" });
+  }
+
+  const countable = steps.filter((s) => s.state !== "external" && s.state !== "override-na");
+  return {
+    steps,
+    nextStepId: steps.find((s) => s.state === "outstanding")?.id ?? "",
+    collected: countable.filter((s) => s.state === "collected" || s.state === "override-collected").length,
+    total: countable.length,
+  };
+}

--- a/companion/src/analysis/collectionPlanStore.ts
+++ b/companion/src/analysis/collectionPlanStore.ts
@@ -1,0 +1,69 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import type { CollectionOverride } from "./collectionPlan.js";
+
+// Per-case collection-plan overrides (#347), in state/collection-plan.json. A stateless wrapper
+// over CaseStore (mirrors IncidentTypeStore / ClockSkewStore). Only the analyst's assertions live
+// here — every derived state is recomputed from the timeline on read, so there is nothing to stale.
+
+const overrideSchema = z.object({
+  state: z.enum(["collected", "na"]),
+  reason: z.string().catch(""),
+});
+
+// A malformed entry is dropped, not defaulted: an override is an analyst assertion, and inventing
+// one would silently mark evidence collected that nobody vouched for.
+const recordSchema = z.object({
+  overrides: z.record(z.string(), overrideSchema.nullable().catch(null)).catch({}),
+});
+
+export type CollectionOverrides = Record<string, CollectionOverride>;
+
+export class CollectionPlanStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "collection-plan.json");
+  }
+
+  async load(caseId: string): Promise<CollectionOverrides> {
+    let raw: string;
+    try {
+      raw = await readFile(this.path(caseId), "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+      throw err;
+    }
+    try {
+      const parsed = recordSchema.parse(JSON.parse(raw));
+      const out: CollectionOverrides = {};
+      for (const [stepId, override] of Object.entries(parsed.overrides)) {
+        if (override) out[stepId] = override;
+      }
+      return out;
+    } catch {
+      // Corrupt file — the panel still renders from derived state.
+      return {};
+    }
+  }
+
+  private async save(caseId: string, overrides: CollectionOverrides): Promise<CollectionOverrides> {
+    await atomicWrite(this.path(caseId), JSON.stringify({ overrides }, null, 2));
+    return overrides;
+  }
+
+  async set(caseId: string, stepId: string, override: CollectionOverride): Promise<CollectionOverrides> {
+    const current = await this.load(caseId);
+    return this.save(caseId, { ...current, [stepId]: override });
+  }
+
+  async clear(caseId: string, stepId: string): Promise<CollectionOverrides> {
+    const current = await this.load(caseId);
+    if (!(stepId in current)) return current;
+    const { [stepId]: _removed, ...rest } = current;
+    return this.save(caseId, rest);
+  }
+}

--- a/companion/src/analysis/dashboardViews.ts
+++ b/companion/src/analysis/dashboardViews.ts
@@ -49,6 +49,7 @@ export const DASHBOARD_SECTION_IDS: readonly string[] = [
   "sec-narrative",
   "sec-findings",
   "sec-next-steps",
+  "sec-collection-plan",
   "sec-deep-pass",
   "sec-timeline",
   "sec-kill-chain",
@@ -183,6 +184,7 @@ export const BUILT_IN_DASHBOARD_VIEWS: readonly DashboardView[] = [
       "sec-kill-chain",
       "sec-phases",
       "sec-next-steps",
+      "sec-collection-plan",
       "sec-iocs",
     ],
     defaultSort: "severity",
@@ -252,6 +254,7 @@ export const BUILT_IN_DASHBOARD_VIEWS: readonly DashboardView[] = [
     sections: [
       "sec-playbook",
       "sec-next-steps",
+      "sec-collection-plan",
       "sec-evidence-gaps",
       "sec-findings",
       "sec-hypotheses",

--- a/companion/src/analysis/incidentTypes.ts
+++ b/companion/src/analysis/incidentTypes.ts
@@ -26,9 +26,14 @@ import {
 //                              analyst-facing case summary and the report's executive-summary
 //                              fallback, so a prompt hint written there would print as the executive
 //                              summary of a forensic report.
-//   - recommendedImportOrder — ordered import checklist for the Import panel.  ─┐ defined and served
-//   - huntBundles            — pre-selected Velociraptor bundle ids.            ├─ over the API, not
-//   - reportFraming          — report template + exec-summary audience.        ─┘ yet consumed (#347).
+//   - recommendedImportOrder — the ordered collection-plan step ids for this incident type, read by
+//                              the Collection Plan panel (#347). Step ids come from
+//                              COLLECTION_STEPS in collectionPlan.ts and name EVIDENCE, not tools.
+//
+// #236 also shipped `huntBundles` and `reportFraming`. Both were removed in #347: their identifiers
+// referred to Velociraptor bundles and report templates that do not exist (27 and 8 invented ids
+// against 3 real of each), and nothing consumed them. Older custom-type files may still carry them;
+// the schema strips unknown keys, so those files keep loading.
 
 export type IncidentTypeId =
   | "ransomware"
@@ -53,18 +58,10 @@ export const BUILT_IN_INCIDENT_TYPE_IDS: readonly IncidentTypeId[] = [
   "malware-outbreak",
 ];
 
-export interface IncidentTypeReportFraming {
-  template: string;          // report template id/name to pre-select
-  audience: string;          // executive-summary audience, e.g. "board + insurer"
-  summaryPrompt: string;     // a one-line framing prompt for the exec summary
-}
-
 // An incident type IS a case template plus the type-specific guidance fields.
 export interface IncidentType extends CaseTemplate {
-  recommendedImportOrder: string[];   // ordered importer labels, e.g. ["edr","dc-logs","network"]
-  huntBundles: string[];              // pre-selected Velociraptor bundle ids
+  recommendedImportOrder: string[];   // ordered collection-plan step ids (#347)
   findingsSeeds: string[];            // expected finding categories, pre-seeded as open questions
-  reportFraming: IncidentTypeReportFraming;
   synthesisHint: string;              // one-line context for the synthesis prompt
 }
 
@@ -91,13 +88,7 @@ export const incidentTypeSchema = z.object({
   severityFloor: severitySchema.nullable().catch(null),
   huntPlatforms: z.array(z.string()).catch([]),
   recommendedImportOrder: z.array(z.string()).catch([]),
-  huntBundles: z.array(z.string()).catch([]),
   findingsSeeds: z.array(z.string()).catch([]),
-  reportFraming: z.object({
-    template: z.string().catch(""),
-    audience: z.string().catch(""),
-    summaryPrompt: z.string().catch(""),
-  }).catch({ template: "", audience: "", summaryPrompt: "" }),
   synthesisHint: z.string().catch(""),
 });
 

--- a/companion/src/routes/collectionPlan.ts
+++ b/companion/src/routes/collectionPlan.ts
@@ -1,0 +1,72 @@
+import type { Express, Request, Response } from "express";
+import { buildCollectionPlan, getCollectionStep, type CollectionPlan } from "../analysis/collectionPlan.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Collection-plan domain (#347): the case's incident type expressed as an ordered evidence
+ * checklist, each step derived from the evidence already in the case, with analyst overrides.
+ *   - GET    /cases/:id/collection-plan           — the built plan (null with no incident type).
+ *   - PUT    /cases/:id/collection-plan/:stepId   — assert collected / not-applicable.
+ *   - DELETE /cases/:id/collection-plan/:stepId   — return the step to automatic.
+ *
+ * `:id` needs no isValidCaseId check: createApp mounts createCaseIdGate() on `/cases/:id`.
+ */
+export function registerCollectionPlanRoutes(app: Express, ctx: RouteContext): void {
+  const { options } = ctx;
+
+  // Build the response shared by all three routes: the chosen type id plus its plan. Recomputed
+  // every time from the timeline — no derived state is ever persisted, so nothing can go stale.
+  async function plan(caseId: string): Promise<{ typeId: string; plan: CollectionPlan | null }> {
+    const type = options.incidentTypeStore ? await options.incidentTypeStore.loadType(caseId) : null;
+    if (!type) return { typeId: "", plan: null };
+    const state = await options.stateStore!.load(caseId);
+    const overrides = options.collectionPlanStore ? await options.collectionPlanStore.load(caseId) : {};
+    return { typeId: type.id, plan: buildCollectionPlan(type.recommendedImportOrder, state.forensicTimeline, overrides) };
+  }
+
+  function configured(res: Response): boolean {
+    if (!options.collectionPlanStore || !options.stateStore) {
+      res.status(501).json({ error: "collection-plan store not configured" });
+      return false;
+    }
+    return true;
+  }
+
+  app.get("/cases/:id/collection-plan", async (req: Request, res: Response) => {
+    if (!configured(res)) return;
+    try {
+      return res.status(200).json(await plan(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.put("/cases/:id/collection-plan/:stepId", async (req: Request, res: Response) => {
+    if (!configured(res)) return;
+    const { stepId } = req.params;
+    if (!getCollectionStep(stepId)) return res.status(404).json({ error: `unknown collection step "${stepId}"` });
+    const state = req.body?.state;
+    if (state !== "collected" && state !== "na") {
+      return res.status(400).json({ error: 'state must be "collected" or "na"' });
+    }
+    const reason = typeof req.body?.reason === "string" ? req.body.reason.slice(0, 500) : "";
+    try {
+      await options.collectionPlanStore!.set(req.params.id, stepId, { state, reason });
+      return res.status(200).json(await plan(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.delete("/cases/:id/collection-plan/:stepId", async (req: Request, res: Response) => {
+    if (!configured(res)) return;
+    const { stepId } = req.params;
+    if (!getCollectionStep(stepId)) return res.status(404).json({ error: `unknown collection step "${stepId}"` });
+    try {
+      await options.collectionPlanStore!.clear(req.params.id, stepId);
+      return res.status(200).json(await plan(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -39,6 +39,7 @@ import { registerReportVersionsRoutes } from "./routes/reportVersions.js";
 import { registerCasePasswordRoutes } from "./routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "./routes/caseLifecycle.js";
 import { registerIncidentTypeRoutes } from "./routes/incidentTypes.js";
+import { registerCollectionPlanRoutes } from "./routes/collectionPlan.js";
 import { registerClockSkewRoutes } from "./routes/clockSkew.js";
 import { registerSlashCommandRoutes, startTelegramPolling, startSlackSocketMode } from "./routes/slashCommand.js";
 import { registerComplianceRoutes } from "./routes/compliance.js";
@@ -168,6 +169,7 @@ import { createSecurityHeaders } from "./http/securityHeaders.js";
 import { getAiLimiter } from "./http/rateLimiter.js";
 import { TemplateStore } from "./analysis/templateStore.js";
 import { IncidentTypeStore } from "./analysis/incidentTypeStore.js";
+import { CollectionPlanStore } from "./analysis/collectionPlanStore.js";
 import { diffTimeline, addedForensicEvents } from "./analysis/timelineDiff.js";
 import { diffIocs } from "./analysis/iocsDiff.js";
 import { ImportUndoStore, pushCheckpoint, undoMaxBytesFromEnv } from "./analysis/importUndo.js";
@@ -578,6 +580,9 @@ export interface AppOptions {
   // per-case chosen-type record. Applies a type's auto-configuration (key questions, next steps,
   // expected-finding seeds) at case creation or on demand, and feeds the synthesis hint.
   incidentTypeStore?: IncidentTypeStore;
+  // Collection plan (#347): per-case analyst overrides for the incident type's evidence checklist.
+  // The plan itself is derived on read from the timeline — only the overrides are stored.
+  collectionPlanStore?: CollectionPlanStore;
   // MISP export: a configured client (when DFIR_MISP_URL/KEY are set) + push options
   // (distribution, analysis state, base URL for the event link).
   mispPushClient?: MispPushClient;
@@ -1005,6 +1010,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   registerCasePasswordRoutes(app, ctx);
   registerCaseLifecycleRoutes(app, ctx);
   registerIncidentTypeRoutes(app, ctx);
+  registerCollectionPlanRoutes(app, ctx);
   registerClockSkewRoutes(app, ctx);
   registerCoachRoutes(app, ctx);
   registerComplianceRoutes(app, ctx);
@@ -3391,6 +3397,8 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   // Incident-type auto-playbooks (#236): the built-in library ships in companion/data/incident-types/;
   // this dir holds analyst-authored custom types (same drive-root-safe rationale as templates/bundles).
   const incidentTypeStore = new IncidentTypeStore(store, join(dirname(casesRoot), "incident-types"));
+  // Collection plan (#347): per-case only — the plan is derived from the timeline, so nothing global.
+  const collectionPlanStore = new CollectionPlanStore(store);
   const artifactBundleStore = new ArtifactBundleStore(join(dirname(casesRoot), "bundles"));
   // Report templates are GLOBAL like case templates/bundles — a dedicated subdir beside cases/.
   const reportTemplateStore = new ReportTemplateStore(join(dirname(casesRoot), "report-templates"));
@@ -3782,6 +3790,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     rebuildTimesketchClient: buildTimesketchClient,
     templateStore,
     incidentTypeStore,
+    collectionPlanStore,
     mispPushClient: buildMispPushClient(),
     mispPushOptions: mispPushOptions(),
     notionClient: buildNotionClient(),

--- a/companion/tests/analysis/collectionPlan.test.ts
+++ b/companion/tests/analysis/collectionPlan.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  COLLECTION_STEPS,
+  getCollectionStep,
+  buildCollectionPlan,
+} from "../../src/analysis/collectionPlan.js";
+import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+function ev(sources: string[]): ForensicEvent {
+  return {
+    id: `e${sources.join("-")}`, timestamp: "2026-01-01T00:00:00Z", description: "",
+    severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], sources,
+  };
+}
+
+describe("collection step vocabulary", () => {
+  it("defines every step with a label and a satisfiedBy list", () => {
+    expect(COLLECTION_STEPS.length).toBeGreaterThan(0);
+    for (const s of COLLECTION_STEPS) {
+      expect(s.id).toMatch(/^[a-z0-9-]+$/);
+      expect(s.label.length).toBeGreaterThan(0);
+      expect(Array.isArray(s.satisfiedBy)).toBe(true);
+    }
+    expect(new Set(COLLECTION_STEPS.map((s) => s.id)).size).toBe(COLLECTION_STEPS.length);
+  });
+
+  it("resolves a step by id", () => {
+    expect(getCollectionStep("edr")?.label).toBe("EDR telemetry");
+    expect(getCollectionStep("nope")).toBeUndefined();
+  });
+
+  // "CSV import" / "Log import" mean "we could not tell what this was" — they must satisfy nothing.
+  it("never lets an unidentified import satisfy a step", () => {
+    const all = COLLECTION_STEPS.flatMap((s) => s.satisfiedBy);
+    expect(all).not.toContain("CSV import");
+    expect(all).not.toContain("Log import");
+  });
+});
+
+describe("buildCollectionPlan", () => {
+  it("marks a step collected when the timeline holds a matching source", () => {
+    const plan = buildCollectionPlan(["edr", "network"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.steps.find((s) => s.id === "edr")!.state).toBe("collected");
+    expect(plan.steps.find((s) => s.id === "network")!.state).toBe("outstanding");
+    expect(plan.collected).toBe(1);
+    expect(plan.total).toBe(2);
+  });
+
+  it("ticks a step from ANY of its satisfying sources, not just the first", () => {
+    for (const label of ["Chainsaw", "Hayabusa", "EVTX", "Sysmon", "Windows Event Log"]) {
+      const plan = buildCollectionPlan(["windows-event-logs"], [ev([label])], {});
+      expect(plan.steps[0].state, `${label} should satisfy windows-event-logs`).toBe("collected");
+    }
+  });
+
+  it("preserves the declared order and names the next outstanding step", () => {
+    const plan = buildCollectionPlan(["edr", "network", "siem"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.steps.map((s) => s.id)).toEqual(["edr", "network", "siem"]);
+    expect(plan.nextStepId).toBe("network");
+  });
+
+  it("reports no next step once everything is collected", () => {
+    const plan = buildCollectionPlan(["edr"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.nextStepId).toBe("");
+  });
+
+  // A step nothing can import is real work, but the tool must not nag about it.
+  it("marks a step with no satisfying sources as external and never as next", () => {
+    const plan = buildCollectionPlan(["physical-access", "network"], [], {});
+    expect(plan.steps.find((s) => s.id === "physical-access")!.state).toBe("external");
+    expect(plan.nextStepId).toBe("network");
+  });
+
+  it("excludes external steps from the collected/total counts", () => {
+    const plan = buildCollectionPlan(["physical-access", "edr"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.total).toBe(1);
+    expect(plan.collected).toBe(1);
+  });
+
+  it("lets an override beat the derived state in both directions", () => {
+    const collected = buildCollectionPlan(["network"], [], { network: { state: "collected", reason: "pcap on the SAN" } });
+    expect(collected.steps[0].state).toBe("override-collected");
+    expect(collected.steps[0].reason).toBe("pcap on the SAN");
+    expect(collected.collected).toBe(1);
+
+    const na = buildCollectionPlan(["edr"], [ev(["EDR (ECAR)"])], { edr: { state: "na", reason: "no EDR here" } });
+    expect(na.steps[0].state).toBe("override-na");
+    expect(na.collected).toBe(0);
+    expect(na.total).toBe(0);          // n/a leaves the denominator, like an external step
+  });
+
+  it("never proposes an overridden step as next", () => {
+    const plan = buildCollectionPlan(["network", "siem"], [], { network: { state: "na", reason: "" } });
+    expect(plan.nextStepId).toBe("siem");
+  });
+
+  it("ignores an unknown step id rather than rendering a blank row", () => {
+    const plan = buildCollectionPlan(["edr", "not-a-step"], [], {});
+    expect(plan.steps.map((s) => s.id)).toEqual(["edr"]);
+  });
+
+  it("is pure — does not mutate its inputs", () => {
+    const events = [ev(["EDR (ECAR)"])];
+    const overrides = { edr: { state: "na" as const, reason: "x" } };
+    const snapshot = JSON.stringify({ events, overrides });
+    buildCollectionPlan(["edr"], events, overrides);
+    expect(JSON.stringify({ events, overrides })).toBe(snapshot);
+  });
+});

--- a/companion/tests/analysis/collectionPlanStore.test.ts
+++ b/companion/tests/analysis/collectionPlanStore.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CollectionPlanStore } from "../../src/analysis/collectionPlanStore.js";
+
+async function makeStore() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-cplan-"));
+  const cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { cases, store: new CollectionPlanStore(cases) };
+}
+
+describe("CollectionPlanStore", () => {
+  it("returns no overrides for a case that has never set one", async () => {
+    const { store } = await makeStore();
+    expect(await store.load("c1")).toEqual({});
+  });
+
+  it("round-trips an override", async () => {
+    const { store } = await makeStore();
+    await store.set("c1", "edr", { state: "na", reason: "no EDR in this estate" });
+    expect(await store.load("c1")).toEqual({ edr: { state: "na", reason: "no EDR in this estate" } });
+  });
+
+  it("keeps overrides for other steps when setting one", async () => {
+    const { store } = await makeStore();
+    await store.set("c1", "edr", { state: "na", reason: "a" });
+    const after = await store.set("c1", "network", { state: "collected", reason: "b" });
+    expect(Object.keys(after).sort()).toEqual(["edr", "network"]);
+  });
+
+  it("clears one override without touching the others", async () => {
+    const { store } = await makeStore();
+    await store.set("c1", "edr", { state: "na", reason: "a" });
+    await store.set("c1", "network", { state: "collected", reason: "b" });
+    expect(await store.clear("c1", "edr")).toEqual({ network: { state: "collected", reason: "b" } });
+  });
+
+  it("clearing an override that was never set is a no-op, not an error", async () => {
+    const { store } = await makeStore();
+    expect(await store.clear("c1", "edr")).toEqual({});
+  });
+
+  // A corrupt file must not block the panel — the analyst can re-assert an override, but they
+  // cannot recover a case whose every read throws.
+  it("returns no overrides when the file is corrupt", async () => {
+    const { cases, store } = await makeStore();
+    const dir = cases.stateDir("c1");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "collection-plan.json"), "{ not json", "utf8");
+    expect(await store.load("c1")).toEqual({});
+  });
+
+  it("drops a malformed override rather than trusting it", async () => {
+    const { cases, store } = await makeStore();
+    const dir = cases.stateDir("c1");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "collection-plan.json"),
+      JSON.stringify({ overrides: { edr: { state: "banana", reason: "x" }, network: { state: "na", reason: "ok" } } }), "utf8");
+    expect(await store.load("c1")).toEqual({ network: { state: "na", reason: "ok" } });
+  });
+});

--- a/companion/tests/analysis/collectionPlanVocabulary.test.ts
+++ b/companion/tests/analysis/collectionPlanVocabulary.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { COLLECTION_STEPS } from "../../src/analysis/collectionPlan.js";
+import { detectTool } from "../../src/analysis/toolDetect.js";
+
+// #236 shipped 27 hunt-bundle ids and 8 report-template ids that referred to nothing. This test is
+// the guard against doing it again: every source label a collection step claims to be satisfied by
+// must be a label some importer actually stamps on an event, or a name detectTool() resolves.
+// A renamed or invented label fails the build instead of silently leaving a step that never ticks.
+
+const SRC = fileURLToPath(new URL("../../src/", import.meta.url));
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return walk(full);
+    return full.endsWith(".ts") ? [full] : [];
+  });
+}
+
+// Labels written as literals in the importers: `sources: ["X"]` or `const X_SOURCE = "Y"`.
+function importerLiterals(): Set<string> {
+  const found = new Set<string>();
+  for (const file of walk(SRC)) {
+    const text = readFileSync(file, "utf8");
+    for (const m of text.matchAll(/sources:\s*\["([^"]+)"\]/g)) found.add(m[1]);
+    for (const m of text.matchAll(/_SOURCE\s*=\s*"([^"]+)"/g)) found.add(m[1]);
+    for (const m of text.matchAll(/\?\?\s*"([A-Z][^"]+)"/g)) found.add(m[1]);
+  }
+  return found;
+}
+
+describe("collection-plan vocabulary is grounded in real importers", () => {
+  const literals = importerLiterals();
+
+  it("finds the importer source literals to check against", () => {
+    // Guards the guard: if the scrape breaks, every label would "pass" vacuously.
+    expect(literals.size).toBeGreaterThan(20);
+    expect(literals).toContain("MemProcFS");
+    expect(literals).toContain("Entra ID");
+  });
+
+  it("every satisfying label is a real importer literal or a detectTool name", () => {
+    const unknown: string[] = [];
+    for (const step of COLLECTION_STEPS) {
+      for (const label of step.satisfiedBy) {
+        // detectTool round-trips its own vendor names: its patterns match the name itself.
+        if (literals.has(label) || detectTool(label) === label) continue;
+        unknown.push(`${step.id} → "${label}"`);
+      }
+    }
+    expect(unknown, `labels no importer produces:\n${unknown.join("\n")}`).toEqual([]);
+  });
+
+  it("every step is either satisfiable or explicitly external", () => {
+    for (const step of COLLECTION_STEPS) {
+      const satisfiable = step.satisfiedBy.length > 0;
+      const external = step.id === "physical-access";
+      expect(satisfiable || external, `step "${step.id}" can never be satisfied`).toBe(true);
+    }
+  });
+});

--- a/companion/tests/analysis/dashboardViews.test.ts
+++ b/companion/tests/analysis/dashboardViews.test.ts
@@ -138,3 +138,16 @@ describe("dashboardViews — getDashboardView", () => {
     expect(getDashboardView("does-not-exist")).toBeUndefined();
   });
 });
+
+describe("sec-collection-plan registration (#347)", () => {
+  it("is a registered dashboard section", () => {
+    expect(DASHBOARD_SECTION_IDS).toContain("sec-collection-plan");
+  });
+
+  it("appears in the Triage and Hunt Prep profiles", () => {
+    for (const id of ["triage", "hunt-prep"]) {
+      const view = BUILT_IN_DASHBOARD_VIEWS.find((v) => v.id === id)!;
+      expect(view.sections, `${id} is missing sec-collection-plan`).toContain("sec-collection-plan");
+    }
+  });
+});

--- a/companion/tests/analysis/incidentTypePlans.test.ts
+++ b/companion/tests/analysis/incidentTypePlans.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { loadBuiltInIncidentTypes } from "../../src/analysis/incidentTypesData.js";
+import { getCollectionStep } from "../../src/analysis/collectionPlan.js";
+
+describe("incident-type collection plans", () => {
+  const types = loadBuiltInIncidentTypes();
+
+  it("every type declares a non-empty plan of DEFINED step ids", () => {
+    for (const t of types) {
+      expect(t.recommendedImportOrder.length, `${t.id} has no collection plan`).toBeGreaterThan(0);
+      for (const id of t.recommendedImportOrder) {
+        expect(getCollectionStep(id), `${t.id} references unknown step "${id}"`).toBeDefined();
+      }
+    }
+  });
+
+  it("no type repeats a step", () => {
+    for (const t of types) {
+      expect(new Set(t.recommendedImportOrder).size, `${t.id} repeats a step`).toBe(t.recommendedImportOrder.length);
+    }
+  });
+
+  it("matches the orders agreed in the design", () => {
+    const byId = new Map(types.map((t) => [t.id, t.recommendedImportOrder]));
+    expect(byId.get("ransomware")).toEqual(["edr", "memory", "windows-event-logs", "endpoint-triage", "network", "siem"]);
+    expect(byId.get("bec")).toEqual(["m365", "identity", "siem", "network"]);
+    expect(byId.get("data-exfiltration")).toEqual(["network", "siem", "edr", "cloud-audit", "m365", "endpoint-triage"]);
+    expect(byId.get("intrusion")).toEqual(["network", "edr", "windows-event-logs", "endpoint-triage", "siem"]);
+    expect(byId.get("insider-threat")).toEqual(["siem", "endpoint-triage", "super-timeline", "m365", "cloud-audit", "physical-access"]);
+    expect(byId.get("cloud-compromise")).toEqual(["cloud-audit", "identity", "m365", "siem", "edr"]);
+    expect(byId.get("web-app-intrusion")).toEqual(["web-logs", "network", "edr", "windows-event-logs", "siem"]);
+    expect(byId.get("malware-outbreak")).toEqual(["edr", "memory", "sandbox", "windows-event-logs", "network", "threat-scan"]);
+  });
+
+  it("no longer carries the fictional hunt-bundle and report-framing fields", () => {
+    for (const t of types) {
+      expect(t).not.toHaveProperty("huntBundles");
+      expect(t).not.toHaveProperty("reportFraming");
+    }
+  });
+
+  // An analyst's custom type written against the old shape must keep working.
+  it("ignores the removed fields rather than rejecting an older custom definition", async () => {
+    const { parseIncidentType } = await import("../../src/analysis/incidentTypes.js");
+    const parsed = parseIncidentType({
+      id: "legacy", name: "Legacy",
+      recommendedImportOrder: ["edr"],
+      huntBundles: ["vss-delete"],
+      reportFraming: { template: "ransomware-executive", audience: "board", summaryPrompt: "x" },
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed).not.toHaveProperty("huntBundles");
+    expect(parsed).not.toHaveProperty("reportFraming");
+  });
+});

--- a/companion/tests/analysis/incidentTypes.test.ts
+++ b/companion/tests/analysis/incidentTypes.test.ts
@@ -27,9 +27,7 @@ function customType(over: Partial<IncidentType> = {}): IncidentType {
     severityFloor: "High",
     huntPlatforms: ["Velociraptor"],
     recommendedImportOrder: ["edr"],
-    huntBundles: ["custom-bundle"],
     findingsSeeds: ["Encryption observed"],
-    reportFraming: { template: "custom", audience: "exec", summaryPrompt: "summarize" },
     synthesisHint: "Org-specific ransomware — prioritize encryption.",
     ...over,
   };
@@ -47,9 +45,7 @@ describe("built-in incident-type library (data/incident-types/*.json)", () => {
       expect(t.initialKeyQuestions.length).toBeGreaterThan(0);
       expect(t.initialNextSteps.length).toBeGreaterThan(0);
       expect(t.recommendedImportOrder.length).toBeGreaterThan(0);
-      expect(t.huntBundles.length).toBeGreaterThan(0);
       expect(t.findingsSeeds.length).toBeGreaterThan(0);
-      expect(t.reportFraming.template.length).toBeGreaterThan(0);
       expect(t.synthesisHint.length).toBeGreaterThan(0);
     }
   });
@@ -62,13 +58,11 @@ describe("built-in incident-type library (data/incident-types/*.json)", () => {
   it("ransomware seeds VSS deletion and double-extortion; BEC seeds inbox rules and OAuth", () => {
     expect(ransomware.findingsSeeds).toContain("VSS shadow copies deleted");
     expect(ransomware.findingsSeeds).toContain("Double-extortion leak-site listing");
-    expect(ransomware.huntBundles).toContain("vss-delete");
     expect(ransomware.synthesisHint).toContain("T1486");
 
     const bec = getBuiltInIncidentType("bec")!;
     expect(bec.findingsSeeds).toContain("Attacker-created inbox/forwarding rules");
     expect(bec.findingsSeeds).toContain("OAuth app grant persistence");
-    expect(bec.huntBundles).toContain("mailbox-rules");
   });
 });
 
@@ -82,12 +76,10 @@ describe("parseIncidentType", () => {
   it("keeps a definition whose optional fields are malformed, defaulting just those", () => {
     const parsed = parseIncidentType({
       id: "minimal", name: "Minimal",
-      findingsSeeds: "not-an-array", huntBundles: 42, reportFraming: "nope",
+      findingsSeeds: "not-an-array",
     });
     expect(parsed?.id).toBe("minimal");
     expect(parsed?.findingsSeeds).toEqual([]);
-    expect(parsed?.huntBundles).toEqual([]);
-    expect(parsed?.reportFraming).toEqual({ template: "", audience: "", summaryPrompt: "" });
   });
 });
 

--- a/companion/tests/server/collectionPlanRoutes.test.ts
+++ b/companion/tests/server/collectionPlanRoutes.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { IncidentTypeStore } from "../../src/analysis/incidentTypeStore.js";
+import { CollectionPlanStore } from "../../src/analysis/collectionPlanStore.js";
+import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+import type { ForensicEvent, InvestigationState } from "../../src/analysis/stateTypes.js";
+
+function ev(sources: string[]): ForensicEvent {
+  return {
+    id: `e-${sources[0]}`, timestamp: "2026-01-01T00:00:00Z", description: "", severity: "Info",
+    mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], sources,
+  };
+}
+
+async function makeApp() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-cplanroute-"));
+  const casesRoot = join(root, "cases");
+  const store = new CaseStore(casesRoot);
+  const stateStore = new StateStore(store);
+  const app = createApp(store, {
+    stateStore, aiConfigured: false,
+    activityLogStore: new ActivityLogStore(store),
+    incidentTypeStore: new IncidentTypeStore(store, join(root, "incident-types")),
+    collectionPlanStore: new CollectionPlanStore(store),
+  });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  const withEvents = async (events: ForensicEvent[]) => {
+    const s = await stateStore.load("c1");
+    await stateStore.save({ ...s, forensicTimeline: events } as InvestigationState);
+  };
+  return { app, stateStore, withEvents };
+}
+
+describe("GET /cases/:id/collection-plan", () => {
+  it("returns no plan for a case with no incident type", async () => {
+    const { app } = await makeApp();
+    const res = await request(app).get("/cases/c1/collection-plan");
+    expect(res.status).toBe(200);
+    expect(res.body.typeId).toBe("");
+    expect(res.body.plan).toBeNull();
+  });
+
+  it("returns the type's ordered plan, ticking what the case already holds", async () => {
+    const { app, withEvents } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    await withEvents([ev(["EDR (ECAR)"])]);
+
+    const res = await request(app).get("/cases/c1/collection-plan");
+    expect(res.status).toBe(200);
+    expect(res.body.typeId).toBe("ransomware");
+    expect(res.body.plan.steps.map((s: { id: string }) => s.id))
+      .toEqual(["edr", "memory", "windows-event-logs", "endpoint-triage", "network", "siem"]);
+    expect(res.body.plan.steps[0].state).toBe("collected");
+    expect(res.body.plan.nextStepId).toBe("memory");
+  });
+});
+
+describe("PUT/DELETE /cases/:id/collection-plan/:stepId", () => {
+  it("sets an override that beats the derived state", async () => {
+    const { app } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+
+    const res = await request(app).put("/cases/c1/collection-plan/edr").send({ state: "na", reason: "no EDR here" });
+    expect(res.status).toBe(200);
+    const step = res.body.plan.steps.find((s: { id: string }) => s.id === "edr");
+    expect(step.state).toBe("override-na");
+    expect(step.reason).toBe("no EDR here");
+    expect(res.body.plan.nextStepId).toBe("memory");
+  });
+
+  it("clears an override, returning the step to automatic", async () => {
+    const { app, withEvents } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    await withEvents([ev(["EDR (ECAR)"])]);
+    await request(app).put("/cases/c1/collection-plan/edr").send({ state: "na", reason: "x" });
+
+    const res = await request(app).delete("/cases/c1/collection-plan/edr");
+    expect(res.status).toBe(200);
+    expect(res.body.plan.steps.find((s: { id: string }) => s.id === "edr").state).toBe("collected");
+  });
+
+  it("rejects an unknown step id and an invalid state", async () => {
+    const { app } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    expect((await request(app).put("/cases/c1/collection-plan/nope").send({ state: "na" })).status).toBe(404);
+    expect((await request(app).put("/cases/c1/collection-plan/edr").send({ state: "banana" })).status).toBe(400);
+    expect((await request(app).put("/cases/c1/collection-plan/edr").send({})).status).toBe(400);
+  });
+});

--- a/mkdocs-docs/reference/cases.md
+++ b/mkdocs-docs/reference/cases.md
@@ -27,6 +27,11 @@ Picking one seeds the case with:
 - **Expected findings** as open *confirm or deny* questions, badged `[type-seed]`, so you work
   through what this incident type usually involves instead of starting from a blank page. Dismiss any
   that don't apply.
+- **A collection plan** — the evidence this incident type calls for, in order, shown in its own
+  dashboard panel. Each item ticks itself off once matching evidence is imported, whichever tool
+  produced it, so "Windows event logs" is satisfied by Chainsaw, Hayabusa, or raw event logs alike.
+  Mark an item *N/A* when your environment can't provide it (no EDR, no badge system) and it stops
+  being proposed.
 - **AI framing** — synthesis is told which incident type this is, so it prioritizes the relevant
   ATT&CK techniques. This is prompt context only; it never appears in your report.
 

--- a/mkdocs-docs/reference/dashboard.md
+++ b/mkdocs-docs/reference/dashboard.md
@@ -102,6 +102,25 @@ The same one-click collect directive also appears wherever a next step or key qu
 
 ---
 
+## Collection Plan
+
+Shown only for a case with an [incident type](cases.md#incident-types). Lists the evidence that type calls for, in collection order, and marks each one:
+
+| Mark | Meaning |
+|---|---|
+| ✔ | Collected — the case holds evidence from a matching source |
+| ○ | Outstanding; the next one is flagged **collect next** |
+| ↗ | Collect outside DFIR Companion — the tool cannot import this (e.g. building access records) |
+| — | Marked not applicable by an analyst |
+
+Derived from the evidence already imported, with no AI. A step names *evidence*, not a tool, so "Windows event logs" is satisfied whether it arrived via Chainsaw, Hayabusa, or raw event logs — the row lists what would satisfy it while it is still outstanding.
+
+**Have it** records evidence held outside the tool; **N/A** retires a step this environment can't satisfy (no EDR, no badge system); **Undo** returns a step to automatic. An override always beats the derived state and is remembered with the case.
+
+Distinct from [Evidence Gaps](#evidence-gaps) above: that panel is AI-derived from what the case can't yet answer, this one is a deterministic checklist fixed by the incident type.
+
+---
+
 ## Deep Pass
 
 A section (and toolbar button) between **Findings** and the **Forensic Timeline** for an analyst-triggered, batched AI pass that reads **every** graded event at or above a chosen severity floor — full coverage of a large, multi-host case a single synthesis prompt can't show.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4031,6 +4031,19 @@
     </section>
     <section id="sec-exec" style="grid-column: 1 / -1"><h2>Executive Summary<button id="genExecBtn" type="button" title="Generate a management-facing executive summary with AI (review before saving it to the report)" style="margin-left:8px;padding:2px 10px;font-size:11px;text-transform:none;letter-spacing:0;font-weight:400">✨ Generate</button><span id="genExecMsg" style="margin-left:8px;font-size:11px;font-weight:400;text-transform:none;letter-spacing:0;color:var(--c-9aa4b2)"></span></h2><div id="summary">—</div><div id="execGenResult"></div></section>
     <section id="sec-next-steps" style="grid-column: 1 / -1"><h2>Recommended Next Steps</h2><div id="nextSteps">—</div></section>
+    <!-- Collection plan (#347): the incident type's evidence checklist; hidden until a type is set. -->
+    <section id="sec-collection-plan" data-gate-open="" style="grid-column: 1 / -1; display:none"><h2>Collection Plan<span class="ev-sub">the evidence this incident type calls for, in order — ticked off from what the case already holds (derived, no AI)</span></h2><div id="collectionPlan">—</div></section>
+    <style>
+      #sec-collection-plan .cp-row{display:flex;align-items:baseline;gap:10px;padding:6px 8px;border-bottom:1px solid var(--c-232a33)}
+      #sec-collection-plan .cp-row:last-child{border-bottom:none}
+      #sec-collection-plan .cp-mark{width:16px;flex:0 0 16px;text-align:center}
+      #sec-collection-plan .cp-label{font-weight:600}
+      #sec-collection-plan .cp-next{color:var(--c-ffb454)}
+      #sec-collection-plan .cp-hint{color:var(--c-9aa4b2);font-size:11px}
+      #sec-collection-plan .cp-act{margin-left:auto;display:flex;gap:6px}
+      #sec-collection-plan .cp-act button{padding:1px 8px;font-size:11px;text-transform:none;letter-spacing:0;font-weight:400}
+      #sec-collection-plan .cp-done{color:var(--c-9aa4b2);font-size:12px;margin-bottom:8px}
+    </style>
     <section id="sec-attack-path" style="grid-column: 1 / -1"><h2>Attack Path</h2><div id="attackerPath">—</div></section>
     <section id="sec-narrative" style="grid-column: 1 / -1"><h2><span title="Takes the Attack Path and rewrites it into client-readable prose, on-demand, and lets a human polish the wording by hand before it goes in a report">Narrative Timeline</span><button id="genNarrativeBtn" type="button" title="Generate a prose narrative of the incident for stakeholders (saved automatically)" style="margin-left:8px;padding:2px 10px;font-size:11px;text-transform:none;letter-spacing:0;font-weight:400">✨ Generate</button><span id="genNarrativeMsg" style="margin-left:8px;font-size:11px;font-weight:400;text-transform:none;letter-spacing:0;color:var(--c-9aa4b2)"></span><button id="editNarrativeBtn" type="button" title="Edit the narrative before export" style="margin-left:8px;padding:2px 10px;font-size:11px;text-transform:none;letter-spacing:0;font-weight:400">✏ Edit</button></h2><div id="narrativeView">—</div><div id="narrativeEditWrap" style="display:none"><textarea id="narrativeText" style="width:100%;min-height:200px;background:var(--c-0d1117);color:var(--c-cdd9e5);border:1px solid var(--c-2f3741);border-radius:4px;padding:8px;font-family:inherit;font-size:13px;resize:vertical;box-sizing:border-box;margin-top:6px"></textarea><div style="margin-top:6px;display:flex;gap:6px"><button id="saveNarrativeBtn" type="button">Save</button><button id="cancelNarrativeBtn" type="button" style="background:var(--c-1c2330);border-color:var(--c-2f3741);color:var(--c-9aa4b2)">Cancel</button><span id="saveNarrativeMsg" style="align-self:center;font-size:11px;color:var(--c-9aa4b2)"></span></div></div></section>
     <section id="sec-findings" style="grid-column: 1 / -1"><h2>Findings<span id="findingsCount" title="Total findings in scope; updates in real time"></span><select class="corrob-sel" id="corrobFindings" title="Corroboration lens — show only findings backed by events from ≥N distinct tools (a lens; nothing is deleted)" data-stop-click><option value="0">⊕ any</option><option value="2">⊕ 2+ src</option><option value="3">⊕ 3+ src</option></select></h2><div id="pinnedStrip" class="pinned-strip"><div class="pinned-strip-head">📌 Pinned<span id="pinnedCount" style="color:var(--c-9aa4b2);font-size:12px;font-weight:normal"></span><span class="ev-sub" style="font-weight:400">the analyst-curated shortlist — pin a finding with 📌, drag to reorder, click to jump</span></div><div id="pinnedList" class="pinned-list"><div class="pinned-empty">No findings pinned yet — click 📌 on a finding to keep it here.</div></div></div><div id="synthMeta" class="synth-meta" style="display:none"></div><div id="secondOpinionPanel" class="so-panel" style="display:none"></div><div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;font-size:12px;color:var(--c-9aa4b2)"><label for="confFilter" title="Hide findings below this confidence level (0 = show all)">Min confidence:</label><input type="number" id="confFilter" min="0" max="100" value="0" style="width:56px;padding:3px 6px;font-size:12px" title="0–100; findings without a confidence score always shown"><span id="confFilterLabel" style="color:var(--c-9aa4b2)">% (0 = all)</span></div>
@@ -16063,10 +16076,84 @@
       }
     });
 
+    // Collection plan (#347). Derived server-side from the case timeline; this only renders it and
+    // posts the analyst's overrides. The section is data-gated: no incident type → no plan → stays
+    // hidden, because a generic collection plan would be guesswork.
+    const CP_MARK = {
+      collected: "✔", "override-collected": "✔", "override-na": "—", external: "↗", outstanding: "○",
+    };
+    // Step id → analyst-facing label, mirroring COLLECTION_STEPS server-side. Kept here so the New
+    // Case preview reads "EDR telemetry → Memory image" rather than raw ids.
+    const CP_LABELS = {
+      "edr": "EDR telemetry", "windows-event-logs": "Windows event logs",
+      "endpoint-triage": "Endpoint triage artifacts", "memory": "Memory image",
+      "network": "Network traffic / IDS", "web-logs": "Web server access logs",
+      "m365": "Microsoft 365 / mailbox audit", "identity": "Identity sign-in logs",
+      "cloud-audit": "Cloud control-plane audit", "siem": "SIEM / aggregated logs",
+      "sandbox": "Malware sandbox report", "super-timeline": "Super-timeline",
+      "threat-scan": "Threat / YARA scan", "physical-access": "Physical access records",
+    };
+    async function renderCollectionPlan() {
+      const caseId = document.getElementById("caseId").value.trim();
+      const sec = document.getElementById("sec-collection-plan");
+      const el = document.getElementById("collectionPlan");
+      if (!caseId) { sec.dataset.gateOpen = ""; applySectionsVis(); return; }
+      let data;
+      try {
+        const r = await fetch(`/cases/${encodeURIComponent(caseId)}/collection-plan`);
+        data = r.ok ? await r.json() : null;
+      } catch { data = null; }
+      if (!data || !data.plan) { sec.dataset.gateOpen = ""; applySectionsVis(); return; }
+
+      const p = data.plan;
+      const rows = p.steps.map(s => {
+        const isNext = s.id === p.nextStepId;
+        const hint = s.state === "external"
+          ? "collect outside DFIR Companion"
+          : s.reason ? esc(s.reason)
+          : s.state === "outstanding" ? "satisfied by: " + esc(s.satisfiedBy.join(", "))
+          : "";
+        const acts = s.state === "collected"
+          ? ""
+          : (s.state === "override-collected" || s.state === "override-na")
+            ? `<button data-cp-clear="${esc(s.id)}">Undo</button>`
+            : `<button data-cp-set="${esc(s.id)}" data-cp-state="collected">Have it</button>`
+              + `<button data-cp-set="${esc(s.id)}" data-cp-state="na">N/A</button>`;
+        return `<div class="cp-row"><span class="cp-mark">${CP_MARK[s.state] || "○"}</span>`
+          + `<span class="cp-label${isNext ? " cp-next" : ""}">${esc(s.label)}${isNext ? " — collect next" : ""}</span>`
+          + `<span class="cp-hint">${hint}</span><span class="cp-act">${acts}</span></div>`;
+      }).join("");
+      el.innerHTML = `<div class="cp-done">${p.collected} of ${p.total} collected</div>${rows}`;
+      sec.dataset.gateOpen = "1";
+      applySectionsVis();
+    }
+
+    document.getElementById("collectionPlan").addEventListener("click", async (e) => {
+      const setBtn = e.target.closest("[data-cp-set]");
+      const clearBtn = e.target.closest("[data-cp-clear]");
+      if (!setBtn && !clearBtn) return;
+      const caseId = document.getElementById("caseId").value.trim();
+      if (!caseId) return;
+      const stepId = setBtn ? setBtn.dataset.cpSet : clearBtn.dataset.cpClear;
+      const url = `/cases/${encodeURIComponent(caseId)}/collection-plan/${encodeURIComponent(stepId)}`;
+      try {
+        if (setBtn) {
+          const state = setBtn.dataset.cpState;
+          const reason = prompt(state === "na" ? "Why does this not apply?" : "Where is this evidence?") ?? "";
+          await fetch(url, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ state, reason }) });
+        } else {
+          await fetch(url, { method: "DELETE" });
+        }
+      } catch { /* transient — the next render re-reads the truth from the server */ }
+      renderCollectionPlan();
+    });
+
     function render(rawState) {
       // Ignore a state response/WS push for a case the analyst has already left (#174) — otherwise
       // a slow response for an abandoned case load can silently overwrite the case now on screen.
       if (rawState && rawState.caseId && activeCaseId && rawState.caseId !== activeCaseId) return;
+      // Independent of rawState — it reads the plan from the server, so it is fire-and-forget here.
+      renderCollectionPlan();
       // Keep the raw state so scope-preset clicks can re-project without a refetch.
       lastState = rawState;
       const state = projectScope(rawState);
@@ -16690,7 +16777,7 @@
         // For an incident type, the import ORDER is the guidance ("EDR first, then DC logs") —
         // show it instead of the unordered recommended-imports list a plain template carries.
         const imports = kind === "type" && t.recommendedImportOrder?.length
-          ? { label: "Import order", value: t.recommendedImportOrder.join(" → ") }
+          ? { label: "Collect in order", value: t.recommendedImportOrder.map(id => CP_LABELS[id] || id).join(" → ") }
           : t.recommendedImports?.length
             ? { label: "Imports", value: t.recommendedImports.join(", ") }
             : null;
@@ -19077,6 +19164,7 @@
       // action-tracking. Its data still feeds the Playbook, report, and exports; re-enable it
       // anytime from Settings → section visibility.
       { id: "sec-next-steps",   label: "Recommended Next Steps", defaultHidden: true },
+      { id: "sec-collection-plan", label: "Collection Plan" },
       { id: "sec-deep-pass",    label: "Deep Pass" },
       { id: "sec-timeline",     label: "Forensic Timeline" },
       { id: "sec-sessions",     label: "Attacker Sessions" },

--- a/specs/2026-07-28-collection-plan-design.md
+++ b/specs/2026-07-28-collection-plan-design.md
@@ -1,0 +1,240 @@
+# Collection plan — incident-type guided evidence collection (#347)
+
+**Status:** design, awaiting review
+**Issue:** #347 (follow-up to #236 / PR #289)
+**Date:** 2026-07-28
+
+---
+
+## 1. Problem
+
+Every incident type shipped in #236 carries three fields the product never reads:
+`recommendedImportOrder`, `huntBundles`, and `reportFraming`. #347 asked for all three to be
+given a surface.
+
+Investigation found their identifiers are almost entirely fictional — they were authored
+alongside the type definitions and never reconciled with the tool:
+
+| Field | Names used | Exists |
+|---|---|---|
+| `huntBundles` | 27 bundle ids | 3 bundles ship (`best-practice`, `super-timeline-triage`, `linux-triage`). **Zero match.** |
+| `reportFraming.template` | 8 template ids | 3 templates ship (`standard`, `executive-brief`, `technical-detailed`). **Zero match.** |
+| `recommendedImportOrder` | 14 evidence types | ~6 map to real importers; the rest name evidence the tool has no distinct notion of. |
+
+Pre-selecting hunt bundles is meaningless when only three exist and none are incident-specific.
+Report framing would mean mapping eight names onto three real templates — so nearly every incident
+type resolves to "Executive brief" — or authoring five new report templates, a far larger job than
+#347 implies.
+
+**Decision:** build the collection order only. Remove `huntBundles` and `reportFraming` from the
+type definitions in the same change, so no dead fields remain. Re-file them if and when the
+underlying bundles and templates exist.
+
+---
+
+## 2. Scope
+
+**In**
+
+- A *Collection plan* dashboard panel: the incident type's ordered evidence steps, each showing
+  as collected or outstanding, derived from the evidence already in the case.
+- Analyst overrides per step (force collected / not applicable) that persist with the case.
+- Rewriting all eight shipped types' collection plans in an evidence vocabulary grounded in the
+  tool's real source labels.
+- Deleting `huntBundles` and `reportFraming` from the schema, the definitions, and the API
+  response.
+
+**Out**
+
+- Per-case editing or reordering of steps. To change a plan, edit the type's JSON.
+- New importers. A step naming evidence the tool cannot ingest is handled (§5.3), not fixed.
+- Hunt bundles and report framing (see §1).
+- Auto-detecting the incident type from evidence — still out of scope, as in #236.
+
+---
+
+## 3. Evidence vocabulary
+
+Steps name **evidence, not tools**. An analyst knows they need Windows event logs before they know
+which importer produces them, and a tool-named step would sit unticked because they used the other
+tool that produces the same evidence.
+
+Each step declares the source labels that satisfy it. Event source labels come from two places,
+both of which must be covered or a step under-ticks:
+
+1. **Importer literals** — a fixed label the importer stamps (`MemProcFS`, `Entra ID`,
+   `Web Access Log`, …).
+2. **`detectTool()`** — CSV, log, and SIEM imports derive the label from the filename, yielding a
+   further 32 vendor names (`Splunk`, `SentinelOne`, `Carbon Black`, `KAPE`, …), with the
+   fallbacks `CSV import`, `Log import`, `SIEM import`, `Windows Event Log`.
+
+Missing the second source is how the `edr` step would have ticked only for ECAR and Falco while
+silently ignoring every Defender, SentinelOne, Carbon Black, and Cortex XDR import. Both sets are
+pinned by test (§7).
+
+| Step id | Analyst-facing label | Satisfied by |
+|---|---|---|
+| `edr` | EDR telemetry | `EDR (ECAR)`, `CrowdStrike Falcon`, `SentinelOne`, `Carbon Black`, `Cortex XDR`, `Microsoft Defender`, `Wazuh`, `Falco` |
+| `windows-event-logs` | Windows event logs | `Chainsaw`, `Hayabusa`, `EVTX`, `Sysmon`, `Windows Event Log` |
+| `endpoint-triage` | Endpoint triage artifacts | `Velociraptor`, `KAPE`, `Autopsy`, `Cyber Triage`, `MFT`, `UsnJrnl`, `Prefetch`, `Amcache`, `ShimCache`, `LNK`, `JumpLists`, `Shellbags`, `RecycleBin`, `SRUM` |
+| `memory` | Memory image | `MemProcFS`, `Volatility`, `Rekall`, `VolWeb` |
+| `network` | Network traffic / IDS | `Zeek`, `Suricata`, `Snort`, `Security Onion`, `Cisco ASA`, `Arkime`, `Wireshark` |
+| `web-logs` | Web server access logs | `Web Access Log` |
+| `m365` | Microsoft 365 / mailbox audit | `Microsoft 365`, `Email` |
+| `identity` | Identity sign-in logs | `Entra ID` |
+| `cloud-audit` | Cloud control-plane audit | `AWS CloudTrail`, `Azure Activity`, `GCP Audit`, `Kubernetes Audit` |
+| `siem` | SIEM / aggregated logs | `SIEM`, `SIEM import`, `Splunk`, `Elastic`, `Microsoft Sentinel`, `QRadar`, `Graylog`, `Syslog`, `journald`, `auditd`, `osquery`, `sysdig` |
+| `sandbox` | Malware sandbox report | `CAPEv2`, `Falcon Sandbox` |
+| `super-timeline` | Super-timeline | `Plaso`, `Timesketch` |
+| `threat-scan` | Threat / YARA scan | `THOR`, `YARA`, `VirusTotal`, `Nessus` |
+| `physical-access` | Physical access records | *(none — collected outside the tool, §5.3)* |
+
+`CSV import` and `Log import` are deliberately unmapped: they mean "we could not tell what this
+was", so they must not satisfy any step.
+
+A step with no satisfying labels is legitimate: physical badge records matter to an insider case
+even though this tool cannot ingest them.
+
+---
+
+## 4. Per-type collection plans
+
+Ordered. This is the IR content and the part most worth a practitioner's review.
+
+| Incident type | Collection plan |
+|---|---|
+| Ransomware | `edr` → `memory` → `windows-event-logs` → `endpoint-triage` → `network` → `siem` |
+| BEC / Email Compromise | `m365` → `identity` → `siem` → `network` |
+| Data Exfiltration | `network` → `siem` → `edr` → `cloud-audit` → `m365` → `endpoint-triage` |
+| Network Intrusion | `network` → `edr` → `windows-event-logs` → `endpoint-triage` → `siem` |
+| Insider Threat | `siem` → `endpoint-triage` → `super-timeline` → `m365` → `cloud-audit` → `physical-access` |
+| Cloud Compromise | `cloud-audit` → `identity` → `m365` → `siem` → `edr` |
+| Web App Intrusion | `web-logs` → `network` → `edr` → `windows-event-logs` → `siem` |
+| Malware Outbreak | `edr` → `memory` → `sandbox` → `windows-event-logs` → `network` → `threat-scan` |
+
+Rationale for the two orderings most likely to be argued:
+
+- **Ransomware puts memory second**, ahead of logs. Memory is the most perishable evidence and is
+  destroyed by the isolation and rebuild that follow; logs keep. The type's own next steps already
+  say "preserve volatile memory before any remediation".
+- **Insider threat leads with SIEM**, not endpoint. The subject is usually still active and the
+  first job is preserving centrally-held evidence before access is revoked and the endpoint changes.
+  It is also the only plan asking for a super-timeline: insider cases turn on file-access history
+  over a long dwell, which is what a Plaso timeline is for.
+
+---
+
+## 5. Behaviour
+
+### 5.1 Panel
+
+A `sec-collection-plan` panel listing the case's steps in order. Each row shows its label, its
+state, and — for an outstanding step — what would satisfy it, so "Windows event logs" tells the
+analyst that Chainsaw, Hayabusa, or raw EVTX all count.
+
+The next outstanding step is called out as the recommended next collection. That is the whole
+point of the feature: the answer to "what do I pull now".
+
+**A case with no incident type does not render the panel.** There is nothing to plan against, and
+a generic plan would be guesswork.
+
+### 5.2 State derivation
+
+A step is **collected** when the case's forensic timeline holds at least one event whose `sources`
+include any of the step's satisfying labels.
+
+Computed on read from the timeline — no new store, no bookkeeping, no import hook. Importing
+something ticks its step on the next load. This is deliberate: `ImportMetaStore` records only the
+*last* import, so it cannot answer "what has this case ever received", whereas the timeline can.
+
+The check is on `sources` only. It deliberately does **not** infer from event content: an event
+mentioning a mailbox is not evidence that the mailbox audit log was imported.
+
+### 5.3 Steps the tool cannot satisfy
+
+A step with no satisfying labels renders as **collect outside DFIR Companion**. It never
+auto-ticks, is never counted as outstanding for the "next step" callout, and never nags. It exists
+because the collection still matters to the investigation.
+
+### 5.4 Overrides
+
+Per step, the analyst may set:
+
+- **collected** — "we have this, it just didn't come in through the tool"
+- **not-applicable** — "this environment has no EDR"
+
+with an optional short reason. An override always beats the derived state. Clearing it returns the
+step to automatic. Overrides persist per case in `state/collection-plan.json`, alongside the
+existing incident-type record, and are shown as analyst-set so the derived and asserted states are
+never confused.
+
+---
+
+## 6. Structure
+
+New:
+
+- `companion/src/analysis/collectionPlan.ts` — pure. The evidence vocabulary (§3), and
+  `buildCollectionPlan(type, events, overrides)` returning the ordered steps with their states. No
+  I/O, no AI.
+- `companion/src/analysis/collectionPlanStore.ts` — per-case overrides; mirrors
+  `IncidentTypeStore`.
+- `companion/src/routes/collectionPlan.ts` — `GET /cases/:id/collection-plan` (the built plan),
+  `PUT /cases/:id/collection-plan/:stepId` (set an override), `DELETE` the same (clear it).
+
+Changed:
+
+- `companion/data/incident-types/*.json` — `recommendedImportOrder` rewritten to §4's step ids;
+  `huntBundles` and `reportFraming` removed.
+- `companion/src/analysis/incidentTypes.ts` — drop the two fields from the interface and schema.
+- `public/dashboard.html` — the panel.
+
+The New Case picker's preview line currently shows the raw import order. It will show the new
+evidence labels, which read better there anyway ("EDR telemetry → Memory image → …").
+
+### 6.1 Panel wiring (CLAUDE.md §8)
+
+Not optional, and the step most often missed:
+
+1. Register `sec-collection-plan` in `DASHBOARD_SECTION_IDS`.
+2. Add it to the section-visibility settings editor.
+3. Add it to the built-in view profiles — **Triage** and **Hunt-Prep** at minimum; Analyst spreads
+   the full list automatically.
+4. No report section — the collection plan is working state, not a report finding.
+
+---
+
+## 7. Testing
+
+- **Vocabulary is real** — every source label in §3 is asserted to exist in the importers. A label
+  that nothing stamps fails the build. This is the guard against repeating #236's mistake.
+- **Every step is satisfiable** — each step in §3 either has ≥1 real satisfying label or is
+  explicitly declared collect-outside-the-tool. A step that can never tick fails the build.
+- **Every type's plan references defined steps** — a typo'd step id in a JSON file fails the build.
+- Derivation: collected / outstanding / mixed timelines; a case with no events; a case with no
+  incident type (no plan).
+- Overrides: set, clear, override-beats-derived in both directions, persistence across load.
+- Routes: the three endpoints, unknown step id, case with no type.
+- Removal: the API response no longer carries `huntBundles` or `reportFraming`, and a custom type
+  JSON still containing them loads without error (they are ignored, not rejected — an analyst's
+  file written against the old shape must not break).
+
+---
+
+## 8. Failure modes
+
+| Risk | Handling |
+|---|---|
+| A step names evidence nothing produces, so it nags forever | Build-time test (§7) — cannot ship. |
+| A source label is renamed in an importer, silently breaking a step | The same test fails on rename. |
+| Analyst disagrees with a type's order | Edit the type's JSON; it is analyst-editable data, not code. |
+| Timeline is huge, derivation is slow | Single pass collecting distinct `sources`; the timeline is already fully in memory for every other panel. |
+| A custom type predates this change | Old fields ignored; a missing `recommendedImportOrder` yields no panel, not an error. |
+
+---
+
+## 9. Open question for review
+
+§4's orderings are my reading of the tradecraft, not yours. The ransomware and insider-threat
+orderings in particular encode judgment calls (§4) that a practitioner may want different. The step
+*vocabulary* (§3) is constrained by what the tool can see; the *order* is entirely yours to set.

--- a/specs/2026-07-28-collection-plan-implementation-plan.md
+++ b/specs/2026-07-28-collection-plan-implementation-plan.md
@@ -1,0 +1,1317 @@
+# Collection Plan Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each incident type a *Collection plan* panel — its ordered evidence steps, ticked off automatically from the evidence already in the case, with analyst overrides — and delete the two fictional fields (`huntBundles`, `reportFraming`) that #236 shipped unused.
+
+**Architecture:** A pure module owns the evidence vocabulary and derives each step's state from the case timeline's `sources` labels; a small per-case store holds analyst overrides; three routes expose the built plan and the overrides; a data-gated dashboard panel renders it. No AI, no new import hooks — the plan is recomputed on read from data already in memory.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Express 4, Zod, Vitest + Supertest, vanilla JS in `public/dashboard.html`.
+
+**Design spec:** `specs/2026-07-28-collection-plan-design.md`
+
+## Global Constraints
+
+- **Worktree:** `/home/hasamba/Projects/DFIR-347`, branch `feat/issue-347`. Never commit to `master`.
+- **Never touch `cases/`.**
+- Immutability — return new objects, never mutate inputs.
+- Files 200–400 lines typical, 800 max; functions under 50 lines.
+- Validate at boundaries; handle errors explicitly, never silently swallowed.
+- Imports use the `.js` extension even for `.ts` sources (ESM/NodeNext).
+- No attribution trailers in commits. Conventional commit types only.
+- Verify with the commands CI runs, in order: `npm run build`, `npm run typecheck`, `npm test`. **`tsc --noEmit` is not sufficient — it skips the tests.**
+- A step id is `[a-z-]+`. Analyst-facing labels are sentence case.
+
+---
+
+### Task 1: Evidence vocabulary and the pure plan builder
+
+**Files:**
+- Create: `companion/src/analysis/collectionPlan.ts`
+- Test: `companion/tests/analysis/collectionPlan.test.ts`
+
+**Interfaces:**
+- Consumes: `ForensicEvent` from `./stateTypes.js` (field used: `sources: string[]`).
+- Produces:
+  - `COLLECTION_STEPS: readonly CollectionStepDef[]` where
+    `CollectionStepDef = { id: string; label: string; satisfiedBy: readonly string[] }`
+  - `type CollectionStepState = "collected" | "outstanding" | "external" | "override-collected" | "override-na"`
+  - `type CollectionStep = { id: string; label: string; satisfiedBy: readonly string[]; state: CollectionStepState; reason: string }`
+  - `type CollectionPlan = { steps: CollectionStep[]; nextStepId: string; collected: number; total: number }`
+  - `getCollectionStep(id: string): CollectionStepDef | undefined`
+  - `buildCollectionPlan(stepIds: readonly string[], events: readonly ForensicEvent[], overrides: Readonly<Record<string, CollectionOverride>>): CollectionPlan`
+  - `type CollectionOverride = { state: "collected" | "na"; reason: string }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `companion/tests/analysis/collectionPlan.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  COLLECTION_STEPS,
+  getCollectionStep,
+  buildCollectionPlan,
+} from "../../src/analysis/collectionPlan.js";
+import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+function ev(sources: string[]): ForensicEvent {
+  return {
+    id: `e${sources.join("-")}`, timestamp: "2026-01-01T00:00:00Z", description: "",
+    severity: "Info", mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], sources,
+  };
+}
+
+describe("collection step vocabulary", () => {
+  it("defines every step with a label and a satisfiedBy list", () => {
+    expect(COLLECTION_STEPS.length).toBeGreaterThan(0);
+    for (const s of COLLECTION_STEPS) {
+      expect(s.id).toMatch(/^[a-z0-9-]+$/);
+      expect(s.label.length).toBeGreaterThan(0);
+      expect(Array.isArray(s.satisfiedBy)).toBe(true);
+    }
+    expect(new Set(COLLECTION_STEPS.map((s) => s.id)).size).toBe(COLLECTION_STEPS.length);
+  });
+
+  it("resolves a step by id", () => {
+    expect(getCollectionStep("edr")?.label).toBe("EDR telemetry");
+    expect(getCollectionStep("nope")).toBeUndefined();
+  });
+
+  // "CSV import" / "Log import" mean "we could not tell what this was" — they must satisfy nothing.
+  it("never lets an unidentified import satisfy a step", () => {
+    const all = COLLECTION_STEPS.flatMap((s) => s.satisfiedBy);
+    expect(all).not.toContain("CSV import");
+    expect(all).not.toContain("Log import");
+  });
+});
+
+describe("buildCollectionPlan", () => {
+  it("marks a step collected when the timeline holds a matching source", () => {
+    const plan = buildCollectionPlan(["edr", "network"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.steps.find((s) => s.id === "edr")!.state).toBe("collected");
+    expect(plan.steps.find((s) => s.id === "network")!.state).toBe("outstanding");
+    expect(plan.collected).toBe(1);
+    expect(plan.total).toBe(2);
+  });
+
+  it("ticks a step from ANY of its satisfying sources, not just the first", () => {
+    for (const label of ["Chainsaw", "Hayabusa", "EVTX", "Sysmon", "Windows Event Log"]) {
+      const plan = buildCollectionPlan(["windows-event-logs"], [ev([label])], {});
+      expect(plan.steps[0].state, `${label} should satisfy windows-event-logs`).toBe("collected");
+    }
+  });
+
+  it("preserves the declared order and names the next outstanding step", () => {
+    const plan = buildCollectionPlan(["edr", "network", "siem"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.steps.map((s) => s.id)).toEqual(["edr", "network", "siem"]);
+    expect(plan.nextStepId).toBe("network");
+  });
+
+  it("reports no next step once everything is collected", () => {
+    const plan = buildCollectionPlan(["edr"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.nextStepId).toBe("");
+  });
+
+  // A step nothing can import is real work, but the tool must not nag about it.
+  it("marks a step with no satisfying sources as external and never as next", () => {
+    const plan = buildCollectionPlan(["physical-access", "network"], [], {});
+    expect(plan.steps.find((s) => s.id === "physical-access")!.state).toBe("external");
+    expect(plan.nextStepId).toBe("network");
+  });
+
+  it("excludes external steps from the collected/total counts", () => {
+    const plan = buildCollectionPlan(["physical-access", "edr"], [ev(["EDR (ECAR)"])], {});
+    expect(plan.total).toBe(1);
+    expect(plan.collected).toBe(1);
+  });
+
+  it("lets an override beat the derived state in both directions", () => {
+    const collected = buildCollectionPlan(["network"], [], { network: { state: "collected", reason: "pcap on the SAN" } });
+    expect(collected.steps[0].state).toBe("override-collected");
+    expect(collected.steps[0].reason).toBe("pcap on the SAN");
+    expect(collected.collected).toBe(1);
+
+    const na = buildCollectionPlan(["edr"], [ev(["EDR (ECAR)"])], { edr: { state: "na", reason: "no EDR here" } });
+    expect(na.steps[0].state).toBe("override-na");
+    expect(na.collected).toBe(0);
+    expect(na.total).toBe(0);          // n/a leaves the denominator, like an external step
+  });
+
+  it("never proposes an overridden step as next", () => {
+    const plan = buildCollectionPlan(["network", "siem"], [], { network: { state: "na", reason: "" } });
+    expect(plan.nextStepId).toBe("siem");
+  });
+
+  it("ignores an unknown step id rather than rendering a blank row", () => {
+    const plan = buildCollectionPlan(["edr", "not-a-step"], [], {});
+    expect(plan.steps.map((s) => s.id)).toEqual(["edr"]);
+  });
+
+  it("is pure — does not mutate its inputs", () => {
+    const events = [ev(["EDR (ECAR)"])];
+    const overrides = { edr: { state: "na" as const, reason: "x" } };
+    const snapshot = JSON.stringify({ events, overrides });
+    buildCollectionPlan(["edr"], events, overrides);
+    expect(JSON.stringify({ events, overrides })).toBe(snapshot);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/collectionPlan.test.ts`
+Expected: FAIL — `Failed to resolve import ".../collectionPlan.js"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `companion/src/analysis/collectionPlan.ts`:
+
+```typescript
+import type { ForensicEvent } from "./stateTypes.js";
+
+// Guided evidence collection per incident type (#347). Steps name EVIDENCE, not tools: an analyst
+// knows they need Windows event logs before they know which importer produces them, and a
+// tool-named step would sit unticked because they used the other tool that yields the same evidence.
+//
+// `satisfiedBy` lists the event source labels that count. Labels come from two places and BOTH must
+// be covered or a step under-ticks:
+//   1. importer literals  — a fixed label the importer stamps ("MemProcFS", "Entra ID", ...)
+//   2. detectTool()       — CSV/log/SIEM imports derive the label from the filename, yielding
+//                           vendor names ("SentinelOne", "Splunk", ...)
+// Missing (2) would leave the EDR step blind to Defender, SentinelOne, Carbon Black and Cortex XDR
+// — the ones an analyst is most likely to actually have. collectionPlanVocabulary.test.ts pins
+// every label against the real importers so an invented one fails the build.
+//
+// Pure and deterministic — no I/O, no AI.
+
+export interface CollectionStepDef {
+  id: string;
+  label: string;
+  // Empty = this evidence cannot be imported by this tool; the step is still worth doing, and
+  // renders as "collect outside DFIR Companion" rather than nagging forever.
+  satisfiedBy: readonly string[];
+}
+
+export const COLLECTION_STEPS: readonly CollectionStepDef[] = [
+  { id: "edr", label: "EDR telemetry", satisfiedBy: ["EDR (ECAR)", "CrowdStrike Falcon", "SentinelOne", "Carbon Black", "Cortex XDR", "Microsoft Defender", "Wazuh", "Falco"] },
+  { id: "windows-event-logs", label: "Windows event logs", satisfiedBy: ["Chainsaw", "Hayabusa", "EVTX", "Sysmon", "Windows Event Log"] },
+  { id: "endpoint-triage", label: "Endpoint triage artifacts", satisfiedBy: ["Velociraptor", "KAPE", "Autopsy", "Cyber Triage", "MFT", "UsnJrnl", "Prefetch", "Amcache", "ShimCache", "LNK", "JumpLists", "Shellbags", "RecycleBin", "SRUM"] },
+  { id: "memory", label: "Memory image", satisfiedBy: ["MemProcFS", "Volatility", "Rekall", "VolWeb"] },
+  { id: "network", label: "Network traffic / IDS", satisfiedBy: ["Zeek", "Suricata", "Snort", "Security Onion", "Cisco ASA", "Arkime", "Wireshark"] },
+  { id: "web-logs", label: "Web server access logs", satisfiedBy: ["Web Access Log"] },
+  { id: "m365", label: "Microsoft 365 / mailbox audit", satisfiedBy: ["Microsoft 365", "Email"] },
+  { id: "identity", label: "Identity sign-in logs", satisfiedBy: ["Entra ID"] },
+  { id: "cloud-audit", label: "Cloud control-plane audit", satisfiedBy: ["AWS CloudTrail", "Azure Activity", "GCP Audit", "Kubernetes Audit"] },
+  { id: "siem", label: "SIEM / aggregated logs", satisfiedBy: ["SIEM", "SIEM import", "Splunk", "Elastic", "Microsoft Sentinel", "QRadar", "Graylog", "Syslog", "journald", "auditd", "osquery", "sysdig"] },
+  { id: "sandbox", label: "Malware sandbox report", satisfiedBy: ["CAPEv2", "Falcon Sandbox"] },
+  { id: "super-timeline", label: "Super-timeline", satisfiedBy: ["Plaso", "Timesketch"] },
+  { id: "threat-scan", label: "Threat / YARA scan", satisfiedBy: ["THOR", "YARA", "VirusTotal", "Nessus"] },
+  { id: "physical-access", label: "Physical access records", satisfiedBy: [] },
+];
+
+const BY_ID = new Map<string, CollectionStepDef>(COLLECTION_STEPS.map((s) => [s.id, s]));
+
+export function getCollectionStep(id: string): CollectionStepDef | undefined {
+  return BY_ID.get(id);
+}
+
+export interface CollectionOverride {
+  state: "collected" | "na";
+  reason: string;
+}
+
+export type CollectionStepState =
+  | "collected"           // derived: matching evidence is in the case
+  | "outstanding"         // derived: not yet collected
+  | "external"            // nothing can import this; collect it outside the tool
+  | "override-collected"  // analyst asserted they have it
+  | "override-na";        // analyst asserted it does not apply here
+
+export interface CollectionStep {
+  id: string;
+  label: string;
+  satisfiedBy: readonly string[];
+  state: CollectionStepState;
+  reason: string;         // the analyst's override reason ("" when derived)
+}
+
+export interface CollectionPlan {
+  steps: CollectionStep[];
+  nextStepId: string;     // the first step still worth collecting ("" when none)
+  collected: number;
+  total: number;          // excludes external and n/a steps — they are not collectable here
+}
+
+// Build the plan for one case. `stepIds` is the incident type's declared order; unknown ids are
+// dropped rather than rendered as blank rows (a typo in a custom type's JSON must not reach the UI).
+export function buildCollectionPlan(
+  stepIds: readonly string[],
+  events: readonly ForensicEvent[],
+  overrides: Readonly<Record<string, CollectionOverride>>,
+): CollectionPlan {
+  // One pass over the timeline; every other panel already holds it in memory.
+  const present = new Set<string>();
+  for (const e of events) for (const s of e.sources ?? []) present.add(s);
+
+  const steps: CollectionStep[] = [];
+  for (const id of stepIds) {
+    const def = BY_ID.get(id);
+    if (!def) continue;
+    const override = overrides[id];
+    const state: CollectionStepState = override
+      ? (override.state === "collected" ? "override-collected" : "override-na")
+      : def.satisfiedBy.length === 0
+        ? "external"
+        : def.satisfiedBy.some((s) => present.has(s))
+          ? "collected"
+          : "outstanding";
+    steps.push({ id: def.id, label: def.label, satisfiedBy: def.satisfiedBy, state, reason: override?.reason ?? "" });
+  }
+
+  const countable = steps.filter((s) => s.state !== "external" && s.state !== "override-na");
+  return {
+    steps,
+    nextStepId: steps.find((s) => s.state === "outstanding")?.id ?? "",
+    collected: countable.filter((s) => s.state === "collected" || s.state === "override-collected").length,
+    total: countable.length,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/collectionPlan.test.ts`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/hasamba/Projects/DFIR-347
+git add companion/src/analysis/collectionPlan.ts companion/tests/analysis/collectionPlan.test.ts
+git commit -m "feat(collection-plan): evidence vocabulary and pure plan builder (#347)"
+```
+
+---
+
+### Task 2: The vocabulary guard test
+
+This is the task that stops #347 repeating #236's mistake. It has no implementation — it asserts the vocabulary from Task 1 refers to labels the importers really stamp.
+
+**Files:**
+- Test: `companion/tests/analysis/collectionPlanVocabulary.test.ts`
+
+**Interfaces:**
+- Consumes: `COLLECTION_STEPS` from Task 1; `detectTool` from `../../src/analysis/toolDetect.js`.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the test**
+
+Create `companion/tests/analysis/collectionPlanVocabulary.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { COLLECTION_STEPS } from "../../src/analysis/collectionPlan.js";
+import { detectTool } from "../../src/analysis/toolDetect.js";
+
+// #236 shipped 27 hunt-bundle ids and 8 report-template ids that referred to nothing. This test is
+// the guard against doing it again: every source label a collection step claims to be satisfied by
+// must be a label some importer actually stamps on an event, or a name detectTool() resolves.
+// A renamed or invented label fails the build instead of silently leaving a step that never ticks.
+
+const SRC = fileURLToPath(new URL("../../src/", import.meta.url));
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return walk(full);
+    return full.endsWith(".ts") ? [full] : [];
+  });
+}
+
+// Labels written as literals in the importers: `sources: ["X"]` or `const X_SOURCE = "Y"`.
+function importerLiterals(): Set<string> {
+  const found = new Set<string>();
+  for (const file of walk(SRC)) {
+    const text = readFileSync(file, "utf8");
+    for (const m of text.matchAll(/sources:\s*\["([^"]+)"\]/g)) found.add(m[1]);
+    for (const m of text.matchAll(/_SOURCE\s*=\s*"([^"]+)"/g)) found.add(m[1]);
+    for (const m of text.matchAll(/\?\?\s*"([A-Z][^"]+)"/g)) found.add(m[1]);
+  }
+  return found;
+}
+
+describe("collection-plan vocabulary is grounded in real importers", () => {
+  const literals = importerLiterals();
+
+  it("finds the importer source literals to check against", () => {
+    // Guards the guard: if the scrape breaks, every label would "pass" vacuously.
+    expect(literals.size).toBeGreaterThan(20);
+    expect(literals).toContain("MemProcFS");
+    expect(literals).toContain("Entra ID");
+  });
+
+  it("every satisfying label is a real importer literal or a detectTool name", () => {
+    const unknown: string[] = [];
+    for (const step of COLLECTION_STEPS) {
+      for (const label of step.satisfiedBy) {
+        // detectTool round-trips its own vendor names: its patterns match the name itself.
+        if (literals.has(label) || detectTool(label) === label) continue;
+        unknown.push(`${step.id} → "${label}"`);
+      }
+    }
+    expect(unknown, `labels no importer produces:\n${unknown.join("\n")}`).toEqual([]);
+  });
+
+  it("every step is either satisfiable or explicitly external", () => {
+    for (const step of COLLECTION_STEPS) {
+      const satisfiable = step.satisfiedBy.length > 0;
+      const external = step.id === "physical-access";
+      expect(satisfiable || external, `step "${step.id}" can never be satisfied`).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it and verify it passes against Task 1's vocabulary**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/collectionPlanVocabulary.test.ts`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 3: Prove the guard actually catches an invented label**
+
+Temporarily add `"Definitely Not A Real Tool"` to the `edr` step's `satisfiedBy` in
+`companion/src/analysis/collectionPlan.ts`, then run the test again.
+Expected: FAIL, listing `edr → "Definitely Not A Real Tool"`.
+**Then remove the fake label** and re-run to confirm PASS. A guard that has never failed is not
+known to work.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/hasamba/Projects/DFIR-347
+git add companion/tests/analysis/collectionPlanVocabulary.test.ts
+git commit -m "test(collection-plan): pin the evidence vocabulary to real importer labels (#347)"
+```
+
+---
+
+### Task 3: Per-case overrides store
+
+**Files:**
+- Create: `companion/src/analysis/collectionPlanStore.ts`
+- Test: `companion/tests/analysis/collectionPlanStore.test.ts`
+
+**Interfaces:**
+- Consumes: `CollectionOverride` from Task 1; `CaseStore` from `../storage/caseStore.js`; `atomicWrite` from `../storage/atomicWrite.js`.
+- Produces:
+  - `class CollectionPlanStore` with `constructor(cases: CaseStore)`
+  - `load(caseId: string): Promise<Record<string, CollectionOverride>>`
+  - `set(caseId: string, stepId: string, override: CollectionOverride): Promise<Record<string, CollectionOverride>>`
+  - `clear(caseId: string, stepId: string): Promise<Record<string, CollectionOverride>>`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `companion/tests/analysis/collectionPlanStore.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CollectionPlanStore } from "../../src/analysis/collectionPlanStore.js";
+
+async function makeStore() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-cplan-"));
+  const cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { cases, store: new CollectionPlanStore(cases) };
+}
+
+describe("CollectionPlanStore", () => {
+  it("returns no overrides for a case that has never set one", async () => {
+    const { store } = await makeStore();
+    expect(await store.load("c1")).toEqual({});
+  });
+
+  it("round-trips an override", async () => {
+    const { store } = await makeStore();
+    await store.set("c1", "edr", { state: "na", reason: "no EDR in this estate" });
+    expect(await store.load("c1")).toEqual({ edr: { state: "na", reason: "no EDR in this estate" } });
+  });
+
+  it("keeps overrides for other steps when setting one", async () => {
+    const { store } = await makeStore();
+    await store.set("c1", "edr", { state: "na", reason: "a" });
+    const after = await store.set("c1", "network", { state: "collected", reason: "b" });
+    expect(Object.keys(after).sort()).toEqual(["edr", "network"]);
+  });
+
+  it("clears one override without touching the others", async () => {
+    const { store } = await makeStore();
+    await store.set("c1", "edr", { state: "na", reason: "a" });
+    await store.set("c1", "network", { state: "collected", reason: "b" });
+    expect(await store.clear("c1", "edr")).toEqual({ network: { state: "collected", reason: "b" } });
+  });
+
+  it("clearing an override that was never set is a no-op, not an error", async () => {
+    const { store } = await makeStore();
+    expect(await store.clear("c1", "edr")).toEqual({});
+  });
+
+  // A corrupt file must not block the panel — the analyst can re-assert an override, but they
+  // cannot recover a case whose every read throws.
+  it("returns no overrides when the file is corrupt", async () => {
+    const { cases, store } = await makeStore();
+    const dir = cases.stateDir("c1");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "collection-plan.json"), "{ not json", "utf8");
+    expect(await store.load("c1")).toEqual({});
+  });
+
+  it("drops a malformed override rather than trusting it", async () => {
+    const { cases, store } = await makeStore();
+    const dir = cases.stateDir("c1");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "collection-plan.json"),
+      JSON.stringify({ overrides: { edr: { state: "banana", reason: "x" }, network: { state: "na", reason: "ok" } } }), "utf8");
+    expect(await store.load("c1")).toEqual({ network: { state: "na", reason: "ok" } });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/collectionPlanStore.test.ts`
+Expected: FAIL — cannot resolve `collectionPlanStore.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `companion/src/analysis/collectionPlanStore.ts`:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import type { CollectionOverride } from "./collectionPlan.js";
+
+// Per-case collection-plan overrides (#347), in state/collection-plan.json. A stateless wrapper
+// over CaseStore (mirrors IncidentTypeStore / ClockSkewStore). Only the analyst's assertions live
+// here — every derived state is recomputed from the timeline on read, so there is nothing to stale.
+
+const overrideSchema = z.object({
+  state: z.enum(["collected", "na"]),
+  reason: z.string().catch(""),
+});
+
+// A malformed entry is dropped, not defaulted: an override is an analyst assertion, and inventing
+// one would silently mark evidence collected that nobody vouched for.
+const recordSchema = z.object({
+  overrides: z.record(z.string(), overrideSchema.nullable().catch(null)).catch({}),
+});
+
+export type CollectionOverrides = Record<string, CollectionOverride>;
+
+export class CollectionPlanStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "collection-plan.json");
+  }
+
+  async load(caseId: string): Promise<CollectionOverrides> {
+    let raw: string;
+    try {
+      raw = await readFile(this.path(caseId), "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+      throw err;
+    }
+    try {
+      const parsed = recordSchema.parse(JSON.parse(raw));
+      const out: CollectionOverrides = {};
+      for (const [stepId, override] of Object.entries(parsed.overrides)) {
+        if (override) out[stepId] = override;
+      }
+      return out;
+    } catch {
+      // Corrupt file — the panel still renders from derived state.
+      return {};
+    }
+  }
+
+  private async save(caseId: string, overrides: CollectionOverrides): Promise<CollectionOverrides> {
+    await atomicWrite(this.path(caseId), JSON.stringify({ overrides }, null, 2));
+    return overrides;
+  }
+
+  async set(caseId: string, stepId: string, override: CollectionOverride): Promise<CollectionOverrides> {
+    const current = await this.load(caseId);
+    return this.save(caseId, { ...current, [stepId]: override });
+  }
+
+  async clear(caseId: string, stepId: string): Promise<CollectionOverrides> {
+    const current = await this.load(caseId);
+    if (!(stepId in current)) return current;
+    const { [stepId]: _removed, ...rest } = current;
+    return this.save(caseId, rest);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/collectionPlanStore.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/hasamba/Projects/DFIR-347
+git add companion/src/analysis/collectionPlanStore.ts companion/tests/analysis/collectionPlanStore.test.ts
+git commit -m "feat(collection-plan): per-case analyst override store (#347)"
+```
+
+---
+
+### Task 4: Rewrite the incident types and drop the fictional fields
+
+**Files:**
+- Modify: `companion/data/incident-types/*.json` (all 8)
+- Modify: `companion/src/analysis/incidentTypes.ts`
+- Modify: `companion/tests/analysis/incidentTypes.test.ts`
+- Test: `companion/tests/analysis/incidentTypePlans.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `COLLECTION_STEPS` / `getCollectionStep` from Task 1.
+- Produces: `IncidentType` no longer carries `huntBundles`, `reportFraming`, or the
+  `IncidentTypeReportFraming` type. `recommendedImportOrder` now holds collection step ids.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `companion/tests/analysis/incidentTypePlans.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { loadBuiltInIncidentTypes } from "../../src/analysis/incidentTypesData.js";
+import { getCollectionStep } from "../../src/analysis/collectionPlan.js";
+
+describe("incident-type collection plans", () => {
+  const types = loadBuiltInIncidentTypes();
+
+  it("every type declares a non-empty plan of DEFINED step ids", () => {
+    for (const t of types) {
+      expect(t.recommendedImportOrder.length, `${t.id} has no collection plan`).toBeGreaterThan(0);
+      for (const id of t.recommendedImportOrder) {
+        expect(getCollectionStep(id), `${t.id} references unknown step "${id}"`).toBeDefined();
+      }
+    }
+  });
+
+  it("no type repeats a step", () => {
+    for (const t of types) {
+      expect(new Set(t.recommendedImportOrder).size, `${t.id} repeats a step`).toBe(t.recommendedImportOrder.length);
+    }
+  });
+
+  it("matches the orders agreed in the design", () => {
+    const byId = new Map(types.map((t) => [t.id, t.recommendedImportOrder]));
+    expect(byId.get("ransomware")).toEqual(["edr", "memory", "windows-event-logs", "endpoint-triage", "network", "siem"]);
+    expect(byId.get("bec")).toEqual(["m365", "identity", "siem", "network"]);
+    expect(byId.get("data-exfiltration")).toEqual(["network", "siem", "edr", "cloud-audit", "m365", "endpoint-triage"]);
+    expect(byId.get("intrusion")).toEqual(["network", "edr", "windows-event-logs", "endpoint-triage", "siem"]);
+    expect(byId.get("insider-threat")).toEqual(["siem", "endpoint-triage", "super-timeline", "m365", "cloud-audit", "physical-access"]);
+    expect(byId.get("cloud-compromise")).toEqual(["cloud-audit", "identity", "m365", "siem", "edr"]);
+    expect(byId.get("web-app-intrusion")).toEqual(["web-logs", "network", "edr", "windows-event-logs", "siem"]);
+    expect(byId.get("malware-outbreak")).toEqual(["edr", "memory", "sandbox", "windows-event-logs", "network", "threat-scan"]);
+  });
+
+  it("no longer carries the fictional hunt-bundle and report-framing fields", () => {
+    for (const t of types) {
+      expect(t).not.toHaveProperty("huntBundles");
+      expect(t).not.toHaveProperty("reportFraming");
+    }
+  });
+
+  // An analyst's custom type written against the old shape must keep working.
+  it("ignores the removed fields rather than rejecting an older custom definition", async () => {
+    const { parseIncidentType } = await import("../../src/analysis/incidentTypes.js");
+    const parsed = parseIncidentType({
+      id: "legacy", name: "Legacy",
+      recommendedImportOrder: ["edr"],
+      huntBundles: ["vss-delete"],
+      reportFraming: { template: "ransomware-executive", audience: "board", summaryPrompt: "x" },
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed).not.toHaveProperty("huntBundles");
+    expect(parsed).not.toHaveProperty("reportFraming");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/incidentTypePlans.test.ts`
+Expected: FAIL — the JSON still holds the old `recommendedImportOrder` values and both removed fields.
+
+- [ ] **Step 3: Strip the two fields from the type**
+
+In `companion/src/analysis/incidentTypes.ts`:
+
+1. Delete the `IncidentTypeReportFraming` interface.
+2. From `interface IncidentType`, delete the `huntBundles`, `findingsSeeds`-adjacent
+   `reportFraming` lines — keep `recommendedImportOrder` and `findingsSeeds`. The block becomes:
+
+```typescript
+export interface IncidentType extends CaseTemplate {
+  recommendedImportOrder: string[];   // ordered collection-plan step ids (#347)
+  findingsSeeds: string[];            // expected finding categories, pre-seeded as open questions
+  synthesisHint: string;              // one-line context for the synthesis prompt
+}
+```
+
+3. From `incidentTypeSchema`, delete the `huntBundles` and `reportFraming` entries. Zod strips
+   unknown keys by default, so an older custom file carrying them still parses and the extra keys
+   are dropped — which is what the last test above asserts.
+4. Update the module header comment: remove the "defined and served over the API, not yet
+   consumed (#347)" note and describe `recommendedImportOrder` as the collection plan.
+
+- [ ] **Step 4: Rewrite the eight JSON files**
+
+For each file in `companion/data/incident-types/`, delete the `huntBundles` and `reportFraming`
+keys and replace `recommendedImportOrder` with the agreed order:
+
+| File | `recommendedImportOrder` |
+|---|---|
+| `ransomware.json` | `["edr","memory","windows-event-logs","endpoint-triage","network","siem"]` |
+| `bec.json` | `["m365","identity","siem","network"]` |
+| `data-exfiltration.json` | `["network","siem","edr","cloud-audit","m365","endpoint-triage"]` |
+| `intrusion.json` | `["network","edr","windows-event-logs","endpoint-triage","siem"]` |
+| `insider-threat.json` | `["siem","endpoint-triage","super-timeline","m365","cloud-audit","physical-access"]` |
+| `cloud-compromise.json` | `["cloud-audit","identity","m365","siem","edr"]` |
+| `web-app-intrusion.json` | `["web-logs","network","edr","windows-event-logs","siem"]` |
+| `malware-outbreak.json` | `["edr","memory","sandbox","windows-event-logs","network","threat-scan"]` |
+
+Leave every other key (`initialKeyQuestions`, `initialNextSteps`, `findingsSeeds`,
+`synthesisHint`, …) untouched.
+
+- [ ] **Step 5: Update the existing incident-type test**
+
+In `companion/tests/analysis/incidentTypes.test.ts`:
+
+- In "every built-in carries the fields the pickers and the apply path read", delete the
+  `expect(t.huntBundles.length)...` and `expect(t.reportFraming.template.length)...` assertions.
+- In "ransomware seeds VSS deletion … BEC seeds inbox rules and OAuth", delete
+  `expect(ransomware.huntBundles).toContain("vss-delete")` and
+  `expect(bec.huntBundles).toContain("mailbox-rules")`. The findings-seed assertions stay.
+- In "keeps a definition whose optional fields are malformed", delete the `huntBundles` and
+  `reportFraming` inputs and their two assertions.
+- In the `customType()` helper, delete the `huntBundles` and `reportFraming` properties.
+
+- [ ] **Step 6: Run both test files to verify they pass**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/incidentTypePlans.test.ts tests/analysis/incidentTypes.test.ts`
+Expected: PASS — 5 tests in the new file, the existing file's tests all still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/hasamba/Projects/DFIR-347
+git add companion/data/incident-types companion/src/analysis/incidentTypes.ts \
+        companion/tests/analysis/incidentTypes.test.ts companion/tests/analysis/incidentTypePlans.test.ts
+git commit -m "feat(collection-plan): rewrite type plans in evidence terms, drop unused fields (#347)"
+```
+
+---
+
+### Task 5: Routes and server wiring
+
+**Files:**
+- Create: `companion/src/routes/collectionPlan.ts`
+- Modify: `companion/src/server.ts`
+- Test: `companion/tests/server/collectionPlanRoutes.test.ts`
+
+**Interfaces:**
+- Consumes: `buildCollectionPlan` (Task 1), `CollectionPlanStore` (Task 3), `IncidentTypeStore` (existing).
+- Produces:
+  - `registerCollectionPlanRoutes(app: Express, ctx: RouteContext): void`
+  - `AppOptions.collectionPlanStore?: CollectionPlanStore`
+  - `GET /cases/:id/collection-plan` → `{ typeId, plan }` (`plan` is `null` with no incident type)
+  - `PUT /cases/:id/collection-plan/:stepId` body `{ state: "collected"|"na", reason?: string }` → `{ typeId, plan }`
+  - `DELETE /cases/:id/collection-plan/:stepId` → `{ typeId, plan }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `companion/tests/server/collectionPlanRoutes.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { IncidentTypeStore } from "../../src/analysis/incidentTypeStore.js";
+import { CollectionPlanStore } from "../../src/analysis/collectionPlanStore.js";
+import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+import type { ForensicEvent, InvestigationState } from "../../src/analysis/stateTypes.js";
+
+function ev(sources: string[]): ForensicEvent {
+  return {
+    id: `e-${sources[0]}`, timestamp: "2026-01-01T00:00:00Z", description: "", severity: "Info",
+    mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [], sources,
+  };
+}
+
+async function makeApp() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-cplanroute-"));
+  const casesRoot = join(root, "cases");
+  const store = new CaseStore(casesRoot);
+  const stateStore = new StateStore(store);
+  const app = createApp(store, {
+    stateStore, aiConfigured: false,
+    activityLogStore: new ActivityLogStore(store),
+    incidentTypeStore: new IncidentTypeStore(store, join(root, "incident-types")),
+    collectionPlanStore: new CollectionPlanStore(store),
+  });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  const withEvents = async (events: ForensicEvent[]) => {
+    const s = await stateStore.load("c1");
+    await stateStore.save({ ...s, forensicTimeline: events } as InvestigationState);
+  };
+  return { app, stateStore, withEvents };
+}
+
+describe("GET /cases/:id/collection-plan", () => {
+  it("returns no plan for a case with no incident type", async () => {
+    const { app } = await makeApp();
+    const res = await request(app).get("/cases/c1/collection-plan");
+    expect(res.status).toBe(200);
+    expect(res.body.typeId).toBe("");
+    expect(res.body.plan).toBeNull();
+  });
+
+  it("returns the type's ordered plan, ticking what the case already holds", async () => {
+    const { app, withEvents } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    await withEvents([ev(["EDR (ECAR)"])]);
+
+    const res = await request(app).get("/cases/c1/collection-plan");
+    expect(res.status).toBe(200);
+    expect(res.body.typeId).toBe("ransomware");
+    expect(res.body.plan.steps.map((s: { id: string }) => s.id))
+      .toEqual(["edr", "memory", "windows-event-logs", "endpoint-triage", "network", "siem"]);
+    expect(res.body.plan.steps[0].state).toBe("collected");
+    expect(res.body.plan.nextStepId).toBe("memory");
+  });
+});
+
+describe("PUT/DELETE /cases/:id/collection-plan/:stepId", () => {
+  it("sets an override that beats the derived state", async () => {
+    const { app } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+
+    const res = await request(app).put("/cases/c1/collection-plan/edr").send({ state: "na", reason: "no EDR here" });
+    expect(res.status).toBe(200);
+    const step = res.body.plan.steps.find((s: { id: string }) => s.id === "edr");
+    expect(step.state).toBe("override-na");
+    expect(step.reason).toBe("no EDR here");
+    expect(res.body.plan.nextStepId).toBe("memory");
+  });
+
+  it("clears an override, returning the step to automatic", async () => {
+    const { app, withEvents } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    await withEvents([ev(["EDR (ECAR)"])]);
+    await request(app).put("/cases/c1/collection-plan/edr").send({ state: "na", reason: "x" });
+
+    const res = await request(app).delete("/cases/c1/collection-plan/edr");
+    expect(res.status).toBe(200);
+    expect(res.body.plan.steps.find((s: { id: string }) => s.id === "edr").state).toBe("collected");
+  });
+
+  it("rejects an unknown step id and an invalid state", async () => {
+    const { app } = await makeApp();
+    await request(app).post("/cases/c1/incident-type").send({ typeId: "ransomware" });
+    expect((await request(app).put("/cases/c1/collection-plan/nope").send({ state: "na" })).status).toBe(404);
+    expect((await request(app).put("/cases/c1/collection-plan/edr").send({ state: "banana" })).status).toBe(400);
+    expect((await request(app).put("/cases/c1/collection-plan/edr").send({})).status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/server/collectionPlanRoutes.test.ts`
+Expected: FAIL — cannot resolve `collectionPlanStore.js` in `server.ts` / routes not registered (404s).
+
+- [ ] **Step 3: Write the routes**
+
+Create `companion/src/routes/collectionPlan.ts`:
+
+```typescript
+import type { Express, Request, Response } from "express";
+import { buildCollectionPlan, getCollectionStep, type CollectionPlan } from "../analysis/collectionPlan.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Collection-plan domain (#347): the case's incident type expressed as an ordered evidence
+ * checklist, each step derived from the evidence already in the case, with analyst overrides.
+ *   - GET    /cases/:id/collection-plan           — the built plan (null with no incident type).
+ *   - PUT    /cases/:id/collection-plan/:stepId   — assert collected / not-applicable.
+ *   - DELETE /cases/:id/collection-plan/:stepId   — return the step to automatic.
+ *
+ * `:id` needs no isValidCaseId check: createApp mounts createCaseIdGate() on `/cases/:id`.
+ */
+export function registerCollectionPlanRoutes(app: Express, ctx: RouteContext): void {
+  const { options } = ctx;
+
+  // Build the response shared by all three routes: the chosen type id plus its plan. Recomputed
+  // every time from the timeline — no derived state is ever persisted, so nothing can go stale.
+  async function plan(caseId: string): Promise<{ typeId: string; plan: CollectionPlan | null }> {
+    const type = options.incidentTypeStore ? await options.incidentTypeStore.loadType(caseId) : null;
+    if (!type) return { typeId: "", plan: null };
+    const state = await options.stateStore!.load(caseId);
+    const overrides = options.collectionPlanStore ? await options.collectionPlanStore.load(caseId) : {};
+    return { typeId: type.id, plan: buildCollectionPlan(type.recommendedImportOrder, state.forensicTimeline, overrides) };
+  }
+
+  function configured(res: Response): boolean {
+    if (!options.collectionPlanStore || !options.stateStore) {
+      res.status(501).json({ error: "collection-plan store not configured" });
+      return false;
+    }
+    return true;
+  }
+
+  app.get("/cases/:id/collection-plan", async (req: Request, res: Response) => {
+    if (!configured(res)) return;
+    try {
+      return res.status(200).json(await plan(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.put("/cases/:id/collection-plan/:stepId", async (req: Request, res: Response) => {
+    if (!configured(res)) return;
+    const { stepId } = req.params;
+    if (!getCollectionStep(stepId)) return res.status(404).json({ error: `unknown collection step "${stepId}"` });
+    const state = req.body?.state;
+    if (state !== "collected" && state !== "na") {
+      return res.status(400).json({ error: 'state must be "collected" or "na"' });
+    }
+    const reason = typeof req.body?.reason === "string" ? req.body.reason.slice(0, 500) : "";
+    try {
+      await options.collectionPlanStore!.set(req.params.id, stepId, { state, reason });
+      return res.status(200).json(await plan(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  app.delete("/cases/:id/collection-plan/:stepId", async (req: Request, res: Response) => {
+    if (!configured(res)) return;
+    const { stepId } = req.params;
+    if (!getCollectionStep(stepId)) return res.status(404).json({ error: `unknown collection step "${stepId}"` });
+    try {
+      await options.collectionPlanStore!.clear(req.params.id, stepId);
+      return res.status(200).json(await plan(req.params.id));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}
+```
+
+- [ ] **Step 4: Wire it into the server**
+
+In `companion/src/server.ts`, four edits mirroring how `incidentTypeStore` is wired:
+
+1. Beside `import { registerIncidentTypeRoutes } from "./routes/incidentTypes.js";` add:
+
+```typescript
+import { registerCollectionPlanRoutes } from "./routes/collectionPlan.js";
+```
+
+2. Beside `import { IncidentTypeStore } from "./analysis/incidentTypeStore.js";` add:
+
+```typescript
+import { CollectionPlanStore } from "./analysis/collectionPlanStore.js";
+```
+
+3. In `AppOptions`, after the `incidentTypeStore?: IncidentTypeStore;` block, add:
+
+```typescript
+  // Collection plan (#347): per-case analyst overrides for the incident type's evidence checklist.
+  // The plan itself is derived on read from the timeline — only the overrides are stored.
+  collectionPlanStore?: CollectionPlanStore;
+```
+
+4. After `registerIncidentTypeRoutes(app, ctx);` add:
+
+```typescript
+  registerCollectionPlanRoutes(app, ctx);
+```
+
+5. In `startServer`, after the `const incidentTypeStore = ...` line add:
+
+```typescript
+  const collectionPlanStore = new CollectionPlanStore(store);
+```
+
+and add `collectionPlanStore,` to the options object passed to `createApp`, immediately after
+`incidentTypeStore,`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/server/collectionPlanRoutes.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/hasamba/Projects/DFIR-347
+git add companion/src/routes/collectionPlan.ts companion/src/server.ts companion/tests/server/collectionPlanRoutes.test.ts
+git commit -m "feat(collection-plan): routes for the plan and analyst overrides (#347)"
+```
+
+---
+
+### Task 6: Dashboard panel and section wiring
+
+**Files:**
+- Modify: `public/dashboard.html`
+- Modify: `companion/src/analysis/dashboardViews.ts`
+- Test: `companion/tests/analysis/dashboardViews.test.ts` — **this file already exists. Append a
+  new `describe` block to it; do not overwrite it.** It already asserts every profile references
+  only registered section ids, so adding the section to a profile without registering it fails there
+  too.
+
+**Interfaces:**
+- Consumes: `GET/PUT/DELETE /cases/:id/collection-plan` from Task 5.
+- Produces: section id `sec-collection-plan`, registered everywhere §8 of CLAUDE.md requires.
+
+- [ ] **Step 1: Write the failing test**
+
+Append this `describe` block to the end of the existing
+`companion/tests/analysis/dashboardViews.test.ts`. `BUILT_IN_DASHBOARD_VIEWS` and
+`DASHBOARD_SECTION_IDS` are already imported at the top of that file — do not re-import them.
+
+```typescript
+describe("sec-collection-plan registration (#347)", () => {
+  it("is a registered dashboard section", () => {
+    expect(DASHBOARD_SECTION_IDS).toContain("sec-collection-plan");
+  });
+
+  it("appears in the Triage and Hunt Prep profiles", () => {
+    for (const id of ["triage", "hunt-prep"]) {
+      const view = BUILT_IN_DASHBOARD_VIEWS.find((v) => v.id === id)!;
+      expect(view.sections, `${id} is missing sec-collection-plan`).toContain("sec-collection-plan");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/dashboardViews.test.ts`
+Expected: FAIL — `sec-collection-plan` is in neither list.
+
+- [ ] **Step 3: Register the section**
+
+In `companion/src/analysis/dashboardViews.ts`:
+
+1. Add `"sec-collection-plan",` to `DASHBOARD_SECTION_IDS`, immediately after `"sec-next-steps",`.
+2. In the `triage` view's `sections`, add `"sec-collection-plan",` immediately after `"sec-next-steps",`.
+3. In the `hunt-prep` view's `sections`, add `"sec-collection-plan",` immediately after `"sec-next-steps",`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd /home/hasamba/Projects/DFIR-347/companion && npx vitest run tests/analysis/dashboardViews.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Add the panel markup**
+
+In `public/dashboard.html`, immediately after the `sec-next-steps` section element, insert. Note
+`data-gate-open=""` — the section stays hidden until its render sets the attribute to `"1"`, which
+is how a case with no incident type shows nothing (the same mechanism `sec-mem-nextsteps` uses):
+
+```html
+    <!-- Collection plan (#347): the incident type's evidence checklist; hidden until a type is set. -->
+    <section id="sec-collection-plan" data-gate-open="" style="grid-column: 1 / -1; display:none"><h2>Collection Plan<span class="ev-sub">the evidence this incident type calls for, in order — ticked off from what the case already holds (derived, no AI)</span></h2><div id="collectionPlan">—</div></section>
+    <style>
+      #sec-collection-plan .cp-row{display:flex;align-items:baseline;gap:10px;padding:6px 8px;border-bottom:1px solid var(--c-232a33)}
+      #sec-collection-plan .cp-row:last-child{border-bottom:none}
+      #sec-collection-plan .cp-mark{width:16px;flex:0 0 16px;text-align:center}
+      #sec-collection-plan .cp-label{font-weight:600}
+      #sec-collection-plan .cp-next{color:var(--c-ffb454)}
+      #sec-collection-plan .cp-hint{color:var(--c-9aa4b2);font-size:11px}
+      #sec-collection-plan .cp-act{margin-left:auto;display:flex;gap:6px}
+      #sec-collection-plan .cp-act button{padding:1px 8px;font-size:11px;text-transform:none;letter-spacing:0;font-weight:400}
+      #sec-collection-plan .cp-done{color:var(--c-9aa4b2);font-size:12px;margin-bottom:8px}
+    </style>
+```
+
+- [ ] **Step 6: Add the render + interaction script**
+
+In `public/dashboard.html`, add these functions next to the other per-section renderers, and call
+`renderCollectionPlan()` from the same place other sections refresh after a state load:
+
+```javascript
+    // Collection plan (#347). Derived server-side from the case timeline; this only renders it and
+    // posts the analyst's overrides. The section is data-gated: no incident type → no plan → stays
+    // hidden, because a generic collection plan would be guesswork.
+    const CP_MARK = {
+      collected: "✔", "override-collected": "✔", "override-na": "—", external: "↗", outstanding: "○",
+    };
+    async function renderCollectionPlan() {
+      const caseId = document.getElementById("caseId").value.trim();
+      const sec = document.getElementById("sec-collection-plan");
+      const el = document.getElementById("collectionPlan");
+      if (!caseId) { sec.dataset.gateOpen = ""; applySectionsVis(); return; }
+      let data;
+      try {
+        const r = await fetch(`/cases/${encodeURIComponent(caseId)}/collection-plan`);
+        data = r.ok ? await r.json() : null;
+      } catch { data = null; }
+      if (!data || !data.plan) { sec.dataset.gateOpen = ""; applySectionsVis(); return; }
+
+      const p = data.plan;
+      const rows = p.steps.map(s => {
+        const isNext = s.id === p.nextStepId;
+        const hint = s.state === "external"
+          ? "collect outside DFIR Companion"
+          : s.reason ? esc(s.reason)
+          : s.state === "outstanding" ? "satisfied by: " + esc(s.satisfiedBy.join(", "))
+          : "";
+        const acts = s.state === "collected"
+          ? ""
+          : (s.state === "override-collected" || s.state === "override-na")
+            ? `<button data-cp-clear="${esc(s.id)}">Undo</button>`
+            : `<button data-cp-set="${esc(s.id)}" data-cp-state="collected">Have it</button>`
+              + `<button data-cp-set="${esc(s.id)}" data-cp-state="na">N/A</button>`;
+        return `<div class="cp-row"><span class="cp-mark">${CP_MARK[s.state] || "○"}</span>`
+          + `<span class="cp-label${isNext ? " cp-next" : ""}">${esc(s.label)}${isNext ? " — collect next" : ""}</span>`
+          + `<span class="cp-hint">${hint}</span><span class="cp-act">${acts}</span></div>`;
+      }).join("");
+      el.innerHTML = `<div class="cp-done">${p.collected} of ${p.total} collected</div>${rows}`;
+      sec.dataset.gateOpen = "1";
+      applySectionsVis();
+    }
+
+    document.getElementById("collectionPlan").addEventListener("click", async (e) => {
+      const setBtn = e.target.closest("[data-cp-set]");
+      const clearBtn = e.target.closest("[data-cp-clear]");
+      if (!setBtn && !clearBtn) return;
+      const caseId = document.getElementById("caseId").value.trim();
+      if (!caseId) return;
+      const stepId = setBtn ? setBtn.dataset.cpSet : clearBtn.dataset.cpClear;
+      const url = `/cases/${encodeURIComponent(caseId)}/collection-plan/${encodeURIComponent(stepId)}`;
+      try {
+        if (setBtn) {
+          const state = setBtn.dataset.cpState;
+          const reason = prompt(state === "na" ? "Why does this not apply?" : "Where is this evidence?") ?? "";
+          await fetch(url, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ state, reason }) });
+        } else {
+          await fetch(url, { method: "DELETE" });
+        }
+      } catch { /* transient — the next render re-reads the truth from the server */ }
+      renderCollectionPlan();
+    });
+```
+
+**Before writing this, confirm two names against the file:** `applySectionVisibility` and `esc`.
+Grep for them (`grep -n "function applySectionVisibility\|function esc(" public/dashboard.html`)
+and use the real names if they differ — the section-visibility function in particular is the one
+`isSectionDataOpen` feeds.
+
+- [ ] **Step 7: Register the section in the visibility editor**
+
+In `public/dashboard.html`, add to the `SECTION_DEFS` array (around line 19065), immediately after
+the `sec-next-steps` entry:
+
+```javascript
+      { id: "sec-collection-plan", label: "Collection Plan" },
+```
+
+- [ ] **Step 8: Verify live**
+
+```bash
+cp "/home/hasamba/Projects/DFIR-Companion/companion/.env" "/home/hasamba/Projects/DFIR-347/companion/.env"
+```
+
+```bash
+cd "/home/hasamba/Projects/DFIR-347/companion" && DFIR_PORT=4774 DFIR_CASES_ROOT=/tmp/dfir-347-test npm run dev
+```
+
+At http://127.0.0.1:4774/dashboard: create a case with incident type Ransomware; confirm the
+Collection Plan panel appears with six steps, all outstanding, "EDR telemetry — collect next", and
+"0 of 6 collected". Create a second case with no incident type and confirm the panel does **not**
+appear. Back on the first case, click **N/A** on EDR telemetry, give a reason, and confirm the row
+shows `—` with the reason and the next-step marker moves to Memory image. Click **Undo** and
+confirm it reverts.
+
+Then stop the server and clean up — the `.env` is a copy of the real config:
+
+```bash
+rm -f "/home/hasamba/Projects/DFIR-347/companion/.env" && rm -rf /tmp/dfir-347-test
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/hasamba/Projects/DFIR-347
+git add public/dashboard.html companion/src/analysis/dashboardViews.ts companion/tests/analysis/dashboardViews.test.ts
+git commit -m "feat(collection-plan): Collection Plan dashboard panel (#347)"
+```
+
+---
+
+### Task 7: Documentation and full verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `mkdocs-docs/reference/cases.md`
+- Modify: `mkdocs-docs/reference/dashboard.md`
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Under `## [Unreleased]`, in the existing `### Added` section, add one line:
+
+```markdown
+- **Collection plan** (#347) — the incident type's evidence checklist as a dashboard panel: what to collect for this kind of incident, in order, each item ticking itself off once matching evidence is in the case, with "we have it" / "not applicable" overrides for steps the tool can't see. Replaces the unused hunt-bundle and report-framing fields shipped with #236, which referenced bundles and report templates that do not exist.
+```
+
+- [ ] **Step 2: Update the incident-type manual page**
+
+In `mkdocs-docs/reference/cases.md`, in the "Picking one seeds the case with:" list, add a bullet
+after **Expected findings**:
+
+```markdown
+- **A collection plan** — the evidence this incident type calls for, in order, shown in its own
+  dashboard panel. Each item ticks itself off once matching evidence is imported, whichever tool
+  produced it, so "Windows event logs" is satisfied by Chainsaw, Hayabusa, or raw event logs alike.
+  Mark an item *N/A* when your environment can't provide it (no EDR, no badge system) and it stops
+  being proposed.
+```
+
+- [ ] **Step 3: Document the panel**
+
+In `mkdocs-docs/reference/dashboard.md`, add a section alongside the other panel descriptions:
+
+```markdown
+### Collection Plan
+
+Shown only for a case with an incident type. Lists the evidence that type calls for, in collection
+order, and marks each one:
+
+| Mark | Meaning |
+|---|---|
+| ✔ | Collected — the case holds evidence from a matching source |
+| ○ | Outstanding; the next one is flagged **collect next** |
+| ↗ | Collect outside DFIR Companion — the tool cannot import this (e.g. building access records) |
+| — | Marked not applicable by an analyst |
+
+Derived from the evidence already imported, with no AI. **Have it** records evidence held outside
+the tool; **N/A** retires a step this environment can't satisfy; **Undo** returns a step to
+automatic.
+```
+
+- [ ] **Step 4: Run the full CI sequence**
+
+```bash
+cd "/home/hasamba/Projects/DFIR-347/companion" && npm run build && npm run typecheck && npm test
+```
+
+Expected: build clean, typecheck clean, all tests pass. **All three are required** — `npm run build`
+alone type-checks only `src/`, so a test-only type error slips through.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+cd /home/hasamba/Projects/DFIR-347
+git add CHANGELOG.md mkdocs-docs/reference/cases.md mkdocs-docs/reference/dashboard.md
+git commit -m "docs(collection-plan): manual and changelog for the collection plan (#347)"
+git push -u origin feat/issue-347
+```
+
+- [ ] **Step 6: Open the PR**
+
+Before pushing, scan the diff for secrets, real hostnames, org domains, real names, or client
+codenames (CLAUDE.md §2 rule 5). Then:
+
+```bash
+cd /home/hasamba/Projects/DFIR-347 && gh pr create --base master --title "feat(collection-plan): incident-type guided evidence collection (#347)" --body "$(cat specs/2026-07-28-collection-plan-design.md | head -40)
+
+Closes #347"
+```
+
+Confirm all four CI checks pass before merging. `gh pr checks` exits non-zero when a check fails —
+read its output, do not rely on its exit code.
+
+---
+
+## Self-Review
+
+**Spec coverage**
+
+| Spec section | Task |
+|---|---|
+| §1 remove `huntBundles` / `reportFraming` | 4 |
+| §2 scope (no per-case step editing, no new importers) | respected throughout; no task adds either |
+| §3 evidence vocabulary + both label sources | 1, guarded by 2 |
+| §4 per-type plans | 4 (asserted verbatim) |
+| §5.1 panel, next-step callout, hidden with no type | 6 (`data-gate-open`) |
+| §5.2 derivation from `sources`, no new store | 1, 5 |
+| §5.3 external steps | 1 (`external` state), 6 (`↗` render) |
+| §5.4 overrides + persistence | 3, 5, 6 |
+| §6 file structure | 1, 3, 5 |
+| §6.1 panel wiring (4 points) | 6 — section ids, visibility editor, Triage + Hunt Prep; no report section, as specified |
+| §7 testing (7 groups) | 1, 2, 3, 4, 5, 6 |
+| §8 failure modes | 2 (invented/renamed label), 4 (typo'd step id), 1 (single pass), 4 (legacy custom type) |
+
+**Gap found and closed:** §6 says the New Case picker's preview line should show the new evidence
+labels. No task covered it. It is now Task 6 Step 6a below.
+
+- [ ] **Task 6, Step 6a: Update the New Case picker preview**
+
+In `public/dashboard.html`, `onTemplateSelectChange()` renders
+`t.recommendedImportOrder.join(" → ")`, which would now print step ids (`edr → memory`). Map them
+to labels first. Add near `renderCollectionPlan`:
+
+```javascript
+    // Step id → analyst-facing label, mirroring COLLECTION_STEPS server-side (#347). Kept here so
+    // the New Case preview reads "EDR telemetry → Memory image" rather than raw ids.
+    const CP_LABELS = {
+      "edr": "EDR telemetry", "windows-event-logs": "Windows event logs",
+      "endpoint-triage": "Endpoint triage artifacts", "memory": "Memory image",
+      "network": "Network traffic / IDS", "web-logs": "Web server access logs",
+      "m365": "Microsoft 365 / mailbox audit", "identity": "Identity sign-in logs",
+      "cloud-audit": "Cloud control-plane audit", "siem": "SIEM / aggregated logs",
+      "sandbox": "Malware sandbox report", "super-timeline": "Super-timeline",
+      "threat-scan": "Threat / YARA scan", "physical-access": "Physical access records",
+    };
+```
+
+and change the import-order branch of `onTemplateSelectChange()` to:
+
+```javascript
+        const imports = kind === "type" && t.recommendedImportOrder?.length
+          ? { label: "Collect in order", value: t.recommendedImportOrder.map(id => CP_LABELS[id] || id).join(" → ") }
+```
+
+**Placeholder scan:** no TBD/TODO; every code step carries real code; no "similar to Task N".
+
+**Type consistency:** `CollectionOverride`, `CollectionStepState`, `CollectionPlan`,
+`buildCollectionPlan`, `getCollectionStep`, `COLLECTION_STEPS`, `CollectionPlanStore.load/set/clear`
+are used identically in Tasks 1, 3, 5 and 6. The route response shape `{ typeId, plan }` matches
+between Task 5's implementation, its tests, and Task 6's renderer.


### PR DESCRIPTION
## Summary

Implements #347: the incident type's evidence checklist becomes a **Collection Plan** panel — what to collect for this kind of incident, in order, each item ticking itself off once matching evidence is in the case.

## What the analyst gets

A case with an incident type shows a Collection Plan panel:

```
0 of 6 collected
○  EDR telemetry — collect next    satisfied by: EDR (ECAR), CrowdStrike Falcon, SentinelOne, …
○  Memory image                    satisfied by: MemProcFS, Volatility, Rekall, VolWeb
○  Windows event logs              satisfied by: Chainsaw, Hayabusa, EVTX, Sysmon
…
```

- **Ticks itself off** from the evidence already imported — no AI, no bookkeeping, recomputed on every load.
- **Names evidence, not tools**, so "Windows event logs" is satisfied whether it arrived via Chainsaw, Hayabusa, or raw event logs. A tool-named step would sit unticked because the analyst used the other tool.
- **Have it / N/A** overrides for evidence held outside the tool or absent from the environment, with a reason. **Undo** returns a step to automatic.
- **Hidden entirely** for a case with no incident type — a generic collection plan would be guesswork.

## Scope: one of #347's three parts

#347 asked for `recommendedImportOrder`, `huntBundles`, and `reportFraming` to be given a surface. Investigation found the latter two name things that do not exist:

| Field | Names | Real |
|---|---|---|
| `huntBundles` | 27 bundle ids | 3 bundles ship. **Zero match.** |
| `reportFraming.template` | 8 template ids | 3 templates ship. **Zero match.** |

Both are **removed** rather than wired to nothing. Older custom-type files carrying them still load — the schema strips unknown keys. Re-file if the underlying bundles and templates ever exist.

## The guard against repeating that mistake

`collectionPlanVocabulary.test.ts` pins every source label a step claims to a label an importer really stamps, or a name `detectTool()` resolves. An invented or renamed label fails the build.

This caught a real bug while writing it: event source labels come from **two** places — importer literals *and* `detectTool()`'s filename-derived vendor names. Covering only the first would have left the EDR step blind to Defender, SentinelOne, Carbon Black, and Cortex XDR, the ones an analyst is most likely to have.

## Changes

- **`analysis/collectionPlan.ts`** — the evidence vocabulary (14 steps) and the pure plan builder. No I/O, no AI.
- **`analysis/collectionPlanStore.ts`** — per-case overrides in `state/collection-plan.json`.
- **`routes/collectionPlan.ts`** — `GET /cases/:id/collection-plan`, `PUT`/`DELETE` `…/:stepId`.
- **`data/incident-types/*.json`** — all 8 plans rewritten in evidence terms; the two fictional fields removed.
- **`public/dashboard.html`** — the panel, data-gated on the case having a type.
- Section wiring: `DASHBOARD_SECTION_IDS`, the visibility editor, and the Triage + Hunt Prep profiles.

## Test plan

- [x] `npm run build`, `npm run typecheck`, `npm test` — 462 files / 5747 tests pass.
- [x] 32 new tests: vocabulary, plan derivation (collected / outstanding / external / override / idempotent), the vocabulary guard, the store incl. corrupt and malformed files, all three routes, the 8 type plans asserted verbatim, section registration.
- [x] The guard test was **deliberately broken once** to prove it catches an invented label, then restored — a guard that has never failed is not known to work.
- [x] Manual on a live server: panel renders for a typed case and is absent for an untyped one; N/A → row shows `—` with the reason, count drops to 5, "collect next" moves to Memory image; Undo reverts. No console errors. New Case preview reads "SIEM / aggregated logs → Endpoint triage artifacts → …" rather than raw ids.

Closes #347
