### PR TITLE
feat(custody): make the log a verifiable chain of events, not a flat inventory (#231)

### DIFF
--- a/companion/src/analysis/custody.ts
+++ b/companion/src/analysis/custody.ts
@@ -3,6 +3,7 @@ import { createReadStream } from "node:fs";
 import { createHash } from "node:crypto";
 import { join, relative, isAbsolute, sep } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
+import { StateLock } from "./stateLock.js";
 
 // Evidence here is disk images, memory dumps and Plaso super-timelines — routinely 400 MB+, and
 // past V8's ~512 MB string ceiling. readFile() would OOM on exactly the artifacts custody matters
@@ -15,6 +16,17 @@ export async function hashFile(path: string): Promise<string> {
   return hash.digest("hex");
 }
 
+/**
+ * What happened to the artifact. A custody chain is a sequence of events, not a one-off inventory
+ * line — "collected" alone cannot answer who has since held or released the evidence.
+ */
+export const CUSTODY_EVENTS = ["collected", "accessed", "transferred", "exported"] as const;
+export type CustodyEvent = (typeof CUSTODY_EVENTS)[number];
+
+export function isCustodyEvent(value: unknown): value is CustodyEvent {
+  return typeof value === "string" && (CUSTODY_EVENTS as readonly string[]).includes(value);
+}
+
 export interface CustodyRecord {
   /** Always absolute, in both directions — see StoredCustodyRecord for how it is persisted. */
   artifactPath: string;
@@ -24,7 +36,19 @@ export interface CustodyRecord {
   source: string;
   trigger: string;
   caseId: string;
+  event: CustodyEvent;
+  /** Position in this case's custody chain. Strictly increasing; gaps are legal (see nextCustodySeq). */
+  seq: number;
+  /** SHA-256 of the preceding stored line; "" for the first record in the log. */
+  prevHash: string;
 }
+
+/**
+ * What a caller hands to record(). `seq` and `prevHash` are the chain's business and are assigned
+ * here, never accepted from outside — a caller that could pick its own would be able to forge a
+ * link. `event` defaults to "collected".
+ */
+export type CustodyRecordInput = Omit<CustodyRecord, "seq" | "prevHash" | "event"> & { event?: CustodyEvent };
 
 /**
  * How a record is written to custody.jsonl. An absolute path is only valid for as long as the case
@@ -52,11 +76,39 @@ export interface CustodyMismatch {
   reason: "hash-mismatch" | "missing";
 }
 
+/** A place where the log stopped being a chain: an entry was altered, removed, or replayed. */
+export interface CustodyChainBreak {
+  /** 1-indexed position in custody.jsonl, so the break is findable even if seq itself was forged. */
+  line: number;
+  seq: number | null;
+  reason: "prev-hash-mismatch" | "seq-out-of-order";
+}
+
+/** Hash of one stored line, exactly as it sits in the file — the unit the chain links together. */
+function hashLine(line: string): string {
+  return createHash("sha256").update(line, "utf8").digest("hex");
+}
+
 export class CustodyStore {
+  // Serializes the read-tail → append critical section per case. Two concurrent imports would
+  // otherwise both read the same tail line, compute the same prevHash, and fork the chain into two
+  // records claiming the same predecessor — which reads exactly like tampering afterwards.
+  private readonly appendLock = new StateLock();
+
   constructor(private readonly cases: CaseStore) {}
 
   private path(caseId: string): string {
-    return join(this.cases.metadataDir(caseId), "custody.jsonl");
+    return this.cases.custodyLogPath(caseId);
+  }
+
+  /** The stored lines of custody.jsonl, verbatim; [] when the log does not exist yet. */
+  private async storedLines(caseId: string): Promise<string[]> {
+    try {
+      return (await readFile(this.path(caseId), "utf8")).split("\n").filter((l) => l.trim().length > 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
   }
 
   /**
@@ -73,13 +125,77 @@ export class CustodyStore {
     return rel;
   }
 
-  async record(caseId: string, record: CustodyRecord): Promise<CustodyRecord> {
-    const rel = this.caseRelative(caseId, record.artifactPath);
-    const stored: StoredCustodyRecord = rel === null ? record : { ...record, artifactPath: rel, relativeTo: "case-dir" };
-    await mkdir(this.cases.metadataDir(caseId), { recursive: true });
-    await appendFile(this.path(caseId), JSON.stringify(stored) + "\n", "utf8");
-    // The caller gets back what it handed in — the relative form never leaves this class.
-    return record;
+  async record(caseId: string, input: CustodyRecordInput): Promise<CustodyRecord> {
+    return (await this.appendChained(caseId, [input]))[0];
+  }
+
+  /**
+   * Append a batch of records as one unbroken run of the chain, under a single lock acquisition.
+   * A batch shares the lock rather than looping over record() so that an export of a thousand
+   * artifacts costs one read of the log instead of a thousand reads of a log that keeps growing.
+   */
+  private async appendChained(caseId: string, inputs: CustodyRecordInput[]): Promise<CustodyRecord[]> {
+    if (inputs.length === 0) return [];
+    return this.appendLock.runExclusive(caseId, async () => {
+      const lines = await this.storedLines(caseId);
+      // The chain links STORED lines, not resolved ones: a case-relative path is what is actually on
+      // disk, so archiving the case (which rewrites no lines) leaves every link intact. Chaining the
+      // resolved absolute form would break the whole chain the moment the folder moved.
+      let prevHash = lines.length === 0 ? "" : hashLine(lines[lines.length - 1]);
+      const records: CustodyRecord[] = [];
+      const pending: string[] = [];
+
+      for (const input of inputs) {
+        const record: CustodyRecord = {
+          ...input,
+          event: isCustodyEvent(input.event) ? input.event : "collected",
+          seq: await this.cases.nextCustodySeq(caseId),
+          prevHash,
+        };
+        const rel = this.caseRelative(caseId, record.artifactPath);
+        const stored: StoredCustodyRecord = rel === null ? record : { ...record, artifactPath: rel, relativeTo: "case-dir" };
+        const line = JSON.stringify(stored);
+        // Each line in the batch links to the one before it, exactly as separate appends would.
+        prevHash = hashLine(line);
+        pending.push(line);
+        records.push(record);
+      }
+
+      await mkdir(this.cases.metadataDir(caseId), { recursive: true });
+      await appendFile(this.path(caseId), pending.join("\n") + "\n", "utf8");
+      // Callers get back the absolute form — the relative one never leaves this class.
+      return records;
+    });
+  }
+
+  /**
+   * Record that every artifact under custody left the instance — one `exported` event per artifact,
+   * because a per-artifact chain that omits "this left the building" is not a custody chain.
+   *
+   * Each artifact is re-hashed rather than reusing the hash on file: the export must state the bytes
+   * it actually carried out. An artifact that has since been deleted is skipped, since nothing about
+   * it left. Call this AFTER the export succeeds, so a failed export never logs one that happened.
+   */
+  async recordExport(caseId: string, opts: { exportedBy: string; destination: string }): Promise<CustodyRecord[]> {
+    const existing = await this.load(caseId);
+    const artifactPaths = [...new Set(existing.map((r) => r.artifactPath))];
+    const exportedAt = new Date().toISOString();
+    const inputs: CustodyRecordInput[] = [];
+
+    for (const artifactPath of artifactPaths) {
+      let sha256: string;
+      try {
+        sha256 = await hashFile(artifactPath);
+      } catch {
+        continue;
+      }
+      inputs.push({
+        artifactPath, sha256, caseId, event: "exported",
+        collectedBy: opts.exportedBy, collectedAt: exportedAt,
+        source: opts.destination, trigger: "export",
+      });
+    }
+    return this.appendChained(caseId, inputs);
   }
 
   async load(caseId: string): Promise<CustodyRecord[]> {
@@ -108,9 +224,54 @@ export class CustodyStore {
    * evidence and everything written before the marker existed.
    */
   private resolve(caseId: string, stored: StoredCustodyRecord): CustodyRecord {
-    if (stored.relativeTo !== "case-dir") return stored;
-    const { relativeTo: _relativeTo, ...record } = stored;
+    const { relativeTo, ...rest } = stored;
+    const record: CustodyRecord = {
+      ...rest,
+      // Records written before the chain existed have no event; they were all collections.
+      event: isCustodyEvent(stored.event) ? stored.event : "collected",
+    };
+    if (relativeTo !== "case-dir") return record;
     return { ...record, artifactPath: join(this.cases.caseDir(caseId), stored.artifactPath) };
+  }
+
+  /**
+   * Walk the log and report every place it stopped being a chain. Each line carries the hash of the
+   * line before it, so editing or deleting an entry is detectable at the FOLLOWING line — the one
+   * whose recorded predecessor no longer matches what is actually there.
+   *
+   * Two things are deliberately not breaks. Records that predate the chain carry no prevHash and are
+   * skipped rather than condemned; a chained record that follows one links onto it normally. And a
+   * jump in seq is fine — nextCustodySeq burns a number on a failed append by design, so gaps are
+   * expected. Only a seq that fails to ADVANCE is a break: that is a replay or a rewrite.
+   *
+   * What this cannot catch on its own is truncation of the tail — lopping off the last N lines leaves
+   * a perfectly valid shorter chain. Detecting that needs the head seq + hash recorded somewhere the
+   * log itself cannot reach, which is the signed manifest's job (#231 item 2).
+   */
+  async verifyChain(caseId: string): Promise<CustodyChainBreak[]> {
+    const lines = await this.storedLines(caseId);
+    const breaks: CustodyChainBreak[] = [];
+    let lastSeq: number | null = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      let stored: StoredCustodyRecord;
+      try {
+        stored = JSON.parse(lines[i]) as StoredCustodyRecord;
+      } catch {
+        continue; // matches load()'s tolerance of a malformed line
+      }
+      const seq = typeof stored.seq === "number" ? stored.seq : null;
+
+      if (typeof stored.prevHash === "string") {
+        const expected = i === 0 ? "" : hashLine(lines[i - 1]);
+        if (stored.prevHash !== expected) breaks.push({ line: i + 1, seq, reason: "prev-hash-mismatch" });
+      }
+      if (seq !== null && lastSeq !== null && seq <= lastSeq) {
+        breaks.push({ line: i + 1, seq, reason: "seq-out-of-order" });
+      }
+      if (seq !== null) lastSeq = seq;
+    }
+    return breaks;
   }
 
   async verifyIntegrity(caseId: string): Promise<CustodyMismatch[]> {

--- a/companion/src/routes/anonymization.ts
+++ b/companion/src/routes/anonymization.ts
@@ -286,6 +286,10 @@ export function registerAnonymizationRoutes(app: Express, ctx: RouteContext): vo
         req.params.id,
         exportOptions,
       );
+      // The package carries redacted derivatives rather than the originals, but the evidence still
+      // left the instance — so each artifact under custody gets an `exported` event naming the
+      // redacted package as its destination (#231).
+      await options.custodyStore?.recordExport(req.params.id, { exportedBy: "analyst", destination: "redacted export package" });
       res.type("application/zip");
       res.setHeader("Content-Disposition", `attachment; filename="${redactedExportFilename(req.params.id)}"`);
       res.setHeader("Cache-Control", "private, no-cache");

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -238,6 +238,11 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       logLine(`[archive] starting archive for case=${id}`);
       const result = await archiveCase(store.casesRoot, id, {}, meta.name, store.caseDir(id));
       logLine(`[archive] done case=${id} files=${result.manifest.totalFiles} bytes=${result.manifest.totalBytes} path=${result.archivePath}`);
+      // Evidence just left the instance, so every artifact under custody gets an `exported` event
+      // (#231). Recorded only after the archive exists — a failed export must never log one that
+      // happened — and before removeFromList, though either order works: custody paths are stored
+      // relative to the case dir, so the move to _archived/ does not disturb them.
+      await options.custodyStore?.recordExport(id, { exportedBy: meta.investigator || "analyst", destination: `zip archive: ${result.archivePath}` });
       let removedFromList = false;
       let removeFromListError: string | undefined;
       if (removeFromList) {
@@ -466,6 +471,8 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       const removeFromList = (req.body as { removeFromList?: unknown })?.removeFromList === true;
       const archive = await exportEncryptedCase(store, id, password);
       const filename = dfircaseFilename(id, meta?.name);
+      // Same as the ZIP path: the evidence is leaving, so the chain records it (#231).
+      await options.custodyStore?.recordExport(id, { exportedBy: meta?.investigator || "analyst", destination: `encrypted archive: ${filename}` });
       let removedFromList = false;
       if (removeFromList) {
         const outcome = await removeCaseFromActiveListBestEffort(id, "[export]");

--- a/companion/src/routes/custody.ts
+++ b/companion/src/routes/custody.ts
@@ -1,5 +1,5 @@
 import type { Express, Request, Response } from "express";
-import { hashFile } from "../analysis/custody.js";
+import { hashFile, isCustodyEvent, CUSTODY_EVENTS } from "../analysis/custody.js";
 import { logActivity } from "../analysis/activityLog.js";
 import type { RouteContext } from "./context.js";
 
@@ -38,6 +38,13 @@ export function registerCustodyRoutes(app: Express, ctx: RouteContext): void {
     const collectedBy = typeof req.body?.collectedBy === "string" ? req.body.collectedBy.trim() : "";
     const source = typeof req.body?.source === "string" ? req.body.source.trim() : "";
     const trigger = typeof req.body?.trigger === "string" ? req.body.trigger.trim() : "";
+    // An unrecognized event is rejected rather than quietly filed as a collection: this is the route
+    // an analyst uses to record a transfer or a release, and a custody chain that silently relabels
+    // what happened to the evidence is worse than one that refuses the entry.
+    const rawEvent = req.body?.event;
+    if (rawEvent !== undefined && !isCustodyEvent(rawEvent)) {
+      return res.status(400).json({ error: `event must be one of: ${CUSTODY_EVENTS.join(", ")}` });
+    }
     let sha256: string;
     try {
       sha256 = await hashFile(artifactPath);
@@ -53,6 +60,7 @@ export function registerCustodyRoutes(app: Express, ctx: RouteContext): void {
         source,
         trigger,
         caseId,
+        event: rawEvent,
       });
       logActivity(options.activityLogStore, options.onActivity, caseId, {
         category: "triage", action: "custody-record", actor: collectedBy || "analyst",
@@ -69,12 +77,22 @@ export function registerCustodyRoutes(app: Express, ctx: RouteContext): void {
     const caseId = req.params.id;
     if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
     try {
-      const mismatches = await options.custodyStore.verifyIntegrity(caseId);
+      // Two independent questions: did the EVIDENCE change (re-hash each artifact), and did the LOG
+      // change (walk the chain). Either alone misses a whole class of tampering — swapping a file
+      // leaves the chain intact, and rewriting who collected it leaves every hash intact.
+      const [mismatches, chainBreaks] = await Promise.all([
+        options.custodyStore.verifyIntegrity(caseId),
+        options.custodyStore.verifyChain(caseId),
+      ]);
+      const problems = [
+        mismatches.length ? `${mismatches.length} mismatch(es)` : "",
+        chainBreaks.length ? `${chainBreaks.length} chain break(s)` : "",
+      ].filter(Boolean);
       logActivity(options.activityLogStore, options.onActivity, caseId, {
         category: "triage", action: "custody-verify",
-        detail: mismatches.length === 0 ? "integrity verified — no mismatches" : `${mismatches.length} mismatch(es)`,
+        detail: problems.length === 0 ? "integrity verified — no mismatches, chain intact" : problems.join(", "),
       });
-      return res.status(200).json({ ok: mismatches.length === 0, mismatches });
+      return res.status(200).json({ ok: problems.length === 0, mismatches, chainBreaks });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/src/storage/caseStore.ts
+++ b/companion/src/storage/caseStore.ts
@@ -82,7 +82,7 @@ export class CaseStore {
   }
 
   /** Reserve the next never-yet-used sequence number for this case+kind. */
-  private reserveSequence(kind: "capture" | "import", caseId: string, countOnDisk: () => Promise<number>): Promise<number> {
+  private reserveSequence(kind: "capture" | "import" | "custody", caseId: string, countOnDisk: () => Promise<number>): Promise<number> {
     const key = `${kind}:${caseId}`;
     return this.seqLock.runExclusive(key, async () => {
       // Disk is authoritative across restarts (the map starts empty); the map is authoritative
@@ -123,6 +123,9 @@ export class CaseStore {
   }
   importsLogPath(caseId: string): string {
     return join(this.metadataDir(caseId), "imports.jsonl");
+  }
+  custodyLogPath(caseId: string): string {
+    return join(this.metadataDir(caseId), "custody.jsonl");
   }
   // Screenshot OCR full-text search index (#176). A sidecar — NOT captures.jsonl, which is
   // append-only — keyed by screenshotFile so a re-OCR replaces a row instead of duplicating it.
@@ -298,6 +301,13 @@ export class CaseStore {
     const updated = { ...existing, ...patch, caseId } as CaseMeta;
     await atomicWrite(this.caseMetaPath(caseId), JSON.stringify(updated, null, 2));
     return updated;
+  }
+
+  // Ordinal for the next chain-of-custody entry (#231). Same allocator as captures and imports, so a
+  // custody record that fails to append burns its number rather than letting the next one reuse it —
+  // gaps are the safe direction for provenance, reuse is not.
+  async nextCustodySeq(caseId: string): Promise<number> {
+    return this.reserveSequence("custody", caseId, () => this.countLogLines(this.custodyLogPath(caseId)));
   }
 
   async nextImportSeq(caseId: string): Promise<number> {

--- a/companion/tests/analysis/custodyChain.test.ts
+++ b/companion/tests/analysis/custodyChain.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, readFile, appendFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore, type CustodyRecordInput } from "../../src/analysis/custody.js";
+
+let store: CustodyStore;
+let cases: CaseStore;
+let casesRoot: string;
+let logPath: string;
+
+const sha = (text: string) => createHash("sha256").update(text, "utf8").digest("hex");
+const lines = async () => (await readFile(logPath, "utf8")).split("\n").filter((l) => l.trim());
+
+function input(over: Partial<CustodyRecordInput> = {}): CustodyRecordInput {
+  return {
+    artifactPath: join(cases.importsDir("c1"), "evidence.csv"),
+    sha256: "0".repeat(64),
+    collectedBy: "alice",
+    collectedAt: "2026-07-28T10:00:00.000Z",
+    source: "workstation-7",
+    trigger: "manual",
+    caseId: "c1",
+    ...over,
+  };
+}
+
+beforeEach(async () => {
+  casesRoot = await mkdtemp(join(tmpdir(), "dfir-custodychain-"));
+  cases = new CaseStore(casesRoot);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  store = new CustodyStore(cases);
+  logPath = join(casesRoot, "c1", "metadata", "custody.jsonl");
+});
+
+describe("custody event type", () => {
+  it("defaults to the collected event", async () => {
+    const record = await store.record("c1", input());
+
+    expect(record.event).toBe("collected");
+    expect((await store.load("c1"))[0].event).toBe("collected");
+  });
+
+  it("records the event the caller asks for", async () => {
+    const record = await store.record("c1", input({ event: "exported" }));
+
+    expect(record).toMatchObject({ event: "exported", seq: 1 });
+    expect((await store.load("c1"))[0].event).toBe("exported");
+  });
+
+  it("normalizes an unrecognized event to collected rather than logging it verbatim", async () => {
+    await store.record("c1", input({ event: "shredded" as never }));
+
+    expect((await store.load("c1"))[0].event).toBe("collected");
+  });
+
+  it("reads a legacy record with no event as collected", async () => {
+    const legacy = { ...input(), artifactPath: "/tmp/legacy.dd" };
+    await mkdir(join(casesRoot, "c1", "metadata"), { recursive: true });
+    await appendFile(logPath, JSON.stringify(legacy) + "\n", "utf8");
+
+    expect((await store.load("c1"))[0].event).toBe("collected");
+  });
+});
+
+describe("custody hash chain", () => {
+  it("starts the chain with an empty prevHash at seq 1", async () => {
+    const record = await store.record("c1", input());
+
+    expect(record).toMatchObject({ seq: 1, prevHash: "" });
+  });
+
+  it("links each record to the hash of the previous stored line", async () => {
+    await store.record("c1", input());
+    const second = await store.record("c1", input({ event: "exported" }));
+
+    const [first] = await lines();
+    expect(second.seq).toBe(2);
+    expect(second.prevHash).toBe(sha(first));
+  });
+
+  it("chains over the stored line, so the chain survives the case being archived", async () => {
+    await store.record("c1", input());
+    await store.record("c1", input({ event: "exported" }));
+
+    await cases.archiveCaseFolder("c1");
+
+    expect(await store.verifyChain("c1")).toEqual([]);
+  });
+
+  it("keeps one unbroken chain when records are appended concurrently", async () => {
+    await Promise.all(Array.from({ length: 12 }, () => store.record("c1", input())));
+
+    expect(await store.verifyChain("c1")).toEqual([]);
+    expect((await store.load("c1")).map((r) => r.seq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+});
+
+describe("CustodyStore.verifyChain", () => {
+  it("reports no breaks for an intact log", async () => {
+    await store.record("c1", input());
+    await store.record("c1", input());
+
+    expect(await store.verifyChain("c1")).toEqual([]);
+  });
+
+  it("reports no breaks when nothing has been recorded", async () => {
+    expect(await store.verifyChain("c1")).toEqual([]);
+  });
+
+  it("flags the following record when an entry is edited in place", async () => {
+    await store.record("c1", input());
+    await store.record("c1", input());
+    const [first, second] = await lines();
+    const tampered = JSON.parse(first) as Record<string, unknown>;
+    tampered.collectedBy = "mallory";
+
+    await writeFile(logPath, JSON.stringify(tampered) + "\n" + second + "\n", "utf8");
+
+    expect(await store.verifyChain("c1")).toEqual([
+      { line: 2, seq: 2, reason: "prev-hash-mismatch" },
+    ]);
+  });
+
+  it("flags the gap when a record is deleted from the middle", async () => {
+    await store.record("c1", input());
+    await store.record("c1", input());
+    await store.record("c1", input());
+    const [first, , third] = await lines();
+
+    await writeFile(logPath, first + "\n" + third + "\n", "utf8");
+
+    expect(await store.verifyChain("c1")).toEqual([
+      { line: 2, seq: 3, reason: "prev-hash-mismatch" },
+    ]);
+  });
+
+  it("flags a record whose seq does not advance", async () => {
+    await store.record("c1", input());
+    const [first] = await lines();
+    // Re-linked correctly but numbered backwards — a replayed record.
+    const replay = { ...(JSON.parse(first) as Record<string, unknown>), seq: 1, prevHash: sha(first) };
+
+    await appendFile(logPath, JSON.stringify(replay) + "\n", "utf8");
+
+    expect(await store.verifyChain("c1")).toEqual([
+      { line: 2, seq: 1, reason: "seq-out-of-order" },
+    ]);
+  });
+
+  it("allows a gap in seq, which a failed append leaves behind by design", async () => {
+    await store.record("c1", input());
+    const [first] = await lines();
+    const skipped = { ...(JSON.parse(first) as Record<string, unknown>), seq: 7, prevHash: sha(first) };
+
+    await appendFile(logPath, JSON.stringify(skipped) + "\n", "utf8");
+
+    expect(await store.verifyChain("c1")).toEqual([]);
+  });
+
+  it("does not flag legacy records that predate the chain", async () => {
+    const legacy = { ...input(), artifactPath: "/tmp/legacy.dd" };
+    await mkdir(join(casesRoot, "c1", "metadata"), { recursive: true });
+    await appendFile(logPath, JSON.stringify(legacy) + "\n", "utf8");
+
+    expect(await store.verifyChain("c1")).toEqual([]);
+  });
+
+  it("chains a new record onto a legacy tail, and verifies it", async () => {
+    const legacy = { ...input(), artifactPath: "/tmp/legacy.dd" };
+    await mkdir(join(casesRoot, "c1", "metadata"), { recursive: true });
+    await appendFile(logPath, JSON.stringify(legacy) + "\n", "utf8");
+
+    const next = await store.record("c1", input());
+
+    expect(next.prevHash).toBe(sha(JSON.stringify(legacy)));
+    expect(await store.verifyChain("c1")).toEqual([]);
+  });
+});

--- a/companion/tests/analysis/custodyExport.test.ts
+++ b/companion/tests/analysis/custodyExport.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+
+let store: CustodyStore;
+let cases: CaseStore;
+let one: string;
+let two: string;
+
+const sha = (text: string) => createHash("sha256").update(text, "utf8").digest("hex");
+
+async function collect(path: string, text: string): Promise<void> {
+  await writeFile(path, text, "utf8");
+  await store.record("c1", {
+    artifactPath: path, sha256: sha(text), collectedBy: "alice",
+    collectedAt: "2026-07-28T10:00:00.000Z", source: "host-a", trigger: "import", caseId: "c1",
+  });
+}
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-custodyexport-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  store = new CustodyStore(cases);
+  one = join(cases.importsDir("c1"), "one.csv");
+  two = join(cases.importsDir("c1"), "two.csv");
+});
+
+describe("CustodyStore.recordExport", () => {
+  it("appends one exported event per artifact under custody", async () => {
+    await collect(one, "first\n");
+    await collect(two, "second\n");
+
+    const written = await store.recordExport("c1", { exportedBy: "alice", destination: "encrypted archive" });
+
+    expect(written.map((r) => r.artifactPath).sort()).toEqual([one, two].sort());
+    expect(written.every((r) => r.event === "exported")).toBe(true);
+    expect(written.every((r) => r.source === "encrypted archive" && r.collectedBy === "alice")).toBe(true);
+  });
+
+  it("records one event per artifact however many prior records it has", async () => {
+    await collect(one, "first\n");
+    await store.record("c1", {
+      artifactPath: one, sha256: sha("first\n"), collectedBy: "bob",
+      collectedAt: "2026-07-28T11:00:00.000Z", source: "lab-3", trigger: "manual", caseId: "c1", event: "transferred",
+    });
+
+    const written = await store.recordExport("c1", { exportedBy: "alice", destination: "zip" });
+
+    expect(written).toHaveLength(1);
+  });
+
+  it("re-hashes each artifact so the export records what actually left", async () => {
+    await collect(one, "first\n");
+    // Legitimately rewritten after collection — the export must state the bytes it carried out,
+    // not the bytes recorded earlier.
+    await writeFile(one, "amended\n", "utf8");
+
+    const [record] = await store.recordExport("c1", { exportedBy: "alice", destination: "zip" });
+
+    expect(record.sha256).toBe(sha("amended\n"));
+  });
+
+  it("skips an artifact that is no longer on disk, since it left in nothing", async () => {
+    await collect(one, "first\n");
+    await collect(two, "second\n");
+    await rm(two);
+
+    const written = await store.recordExport("c1", { exportedBy: "alice", destination: "zip" });
+
+    expect(written.map((r) => r.artifactPath)).toEqual([one]);
+  });
+
+  it("writes nothing when the case has no custody records", async () => {
+    expect(await store.recordExport("c1", { exportedBy: "alice", destination: "zip" })).toEqual([]);
+    await expect(readFile(cases.custodyLogPath("c1"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("leaves the chain intact across the batch it appends", async () => {
+    await collect(one, "first\n");
+    await collect(two, "second\n");
+
+    await store.recordExport("c1", { exportedBy: "alice", destination: "zip" });
+
+    expect(await store.verifyChain("c1")).toEqual([]);
+    expect((await store.load("c1")).map((r) => r.seq)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/companion/tests/server/custodyChainRoutes.test.ts
+++ b/companion/tests/server/custodyChainRoutes.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import { createApp } from "../../src/server.js";
+
+let app: ReturnType<typeof createApp>;
+let cases: CaseStore;
+let artifactPath: string;
+let logPath: string;
+
+const recordIt = (body: Record<string, unknown> = {}) =>
+  request(app).post("/cases/c1/custody").send({ artifactPath, collectedBy: "alice", ...body });
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-custodychainroute-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  app = createApp(cases, { custodyStore: new CustodyStore(cases) });
+  artifactPath = join(cases.importsDir("c1"), "evidence.csv");
+  await writeFile(artifactPath, "hello world\n", "utf8");
+  logPath = cases.custodyLogPath("c1");
+});
+
+describe("POST /cases/:id/custody event", () => {
+  it("defaults to the collected event", async () => {
+    const res = await recordIt();
+
+    expect(res.status).toBe(201);
+    expect(res.body.record).toMatchObject({ event: "collected", seq: 1, prevHash: "" });
+  });
+
+  it("records a transfer the analyst reports", async () => {
+    const res = await recordIt({ event: "transferred", source: "handed to lab-3" });
+
+    expect(res.body.record.event).toBe("transferred");
+  });
+
+  it("400s on an event outside the known set rather than logging it", async () => {
+    const res = await recordIt({ event: "shredded" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/event/);
+    await expect(readFile(logPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("GET /cases/:id/custody/verify chain", () => {
+  it("reports an intact chain alongside the artifact hashes", async () => {
+    await recordIt();
+    await recordIt();
+
+    const res = await request(app).get("/cases/c1/custody/verify");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, mismatches: [], chainBreaks: [] });
+  });
+
+  it("reports not-ok when the log was edited even though every artifact still hashes clean", async () => {
+    await recordIt();
+    await recordIt();
+    const [first, second] = (await readFile(logPath, "utf8")).split("\n").filter((l) => l.trim());
+    const tampered = JSON.parse(first) as Record<string, unknown>;
+    tampered.collectedBy = "mallory";
+    await writeFile(logPath, JSON.stringify(tampered) + "\n" + second + "\n", "utf8");
+
+    const res = await request(app).get("/cases/c1/custody/verify");
+
+    // The artifact itself was never touched — only the record of who collected it.
+    expect(res.body.mismatches).toEqual([]);
+    expect(res.body.chainBreaks).toEqual([{ line: 2, seq: 2, reason: "prev-hash-mismatch" }]);
+    expect(res.body.ok).toBe(false);
+  });
+});

--- a/companion/tests/server/custodyExportEvents.test.ts
+++ b/companion/tests/server/custodyExportEvents.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import { createApp } from "../../src/server.js";
+
+let app: ReturnType<typeof createApp>;
+let cases: CaseStore;
+let artifactPath: string;
+
+const custodyRecords = async () => (await request(app).get("/cases/c1/custody")).body.records as Array<Record<string, unknown>>;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-custodyexportev-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  app = createApp(cases, { custodyStore: new CustodyStore(cases) });
+  // Goes through the auto-record hook, so the artifact is under custody as "collected".
+  artifactPath = await cases.saveImport("c1", "0001_evidence.csv", "ts,message\n2026-01-01T00:00:00Z,hi\n");
+});
+
+describe("exported custody events", () => {
+  it("records an export when the case is archived to a ZIP", async () => {
+    const res = await request(app).post("/cases/c1/archive").send({});
+    expect(res.status).toBe(200);
+
+    const records = await custodyRecords();
+    expect(records.map((r) => r.event)).toEqual(["collected", "exported"]);
+    expect(records[1]).toMatchObject({ artifactPath, event: "exported", trigger: "export" });
+  });
+
+  it("records an export when the case leaves as an encrypted archive", async () => {
+    const res = await request(app).post("/cases/c1/export/encrypted").send({ password: "a-long-enough-password" });
+    expect(res.status).toBe(200);
+
+    const records = await custodyRecords();
+    expect(records.map((r) => r.event)).toEqual(["collected", "exported"]);
+    expect(records[1]).toMatchObject({ artifactPath, event: "exported" });
+  });
+
+  it("leaves the chain intact after an export", async () => {
+    await request(app).post("/cases/c1/archive").send({});
+
+    const verify = await request(app).get("/cases/c1/custody/verify");
+    expect(verify.body).toMatchObject({ ok: true, chainBreaks: [] });
+  });
+
+  it("records no export when the archive fails", async () => {
+    const res = await request(app).post("/cases/nope/archive").send({});
+    expect(res.status).toBe(404);
+
+    expect((await custodyRecords()).map((r) => r.event)).toEqual(["collected"]);
+  });
+});


### PR DESCRIPTION
## Why

A custody record could only ever say *collected*, and `custody.jsonl` was a plain append-only file with nothing binding its lines together. An entry could be edited or removed and nothing would notice — so the signed manifest planned next (#231 item 2) would have proved only that the **manifest** was untampered, not the log it summarizes.

## What

Each record now carries three new fields:

| Field | Purpose |
|---|---|
| `event` | `collected` / `accessed` / `transferred` / `exported`. A chain of custody is a sequence of events; "collected" alone cannot say who has since held or released the evidence. |
| `seq` | Allocated by the same `reserveSequence()` that numbers captures and imports, so a record that fails to append burns its number rather than letting the next reuse it. |
| `prevHash` | SHA-256 of the preceding stored line. |

**The chain links stored lines, not resolved ones.** A case-relative path is what is actually on disk, so archiving a case (which rewrites no lines) leaves every link intact. Chaining the resolved absolute form would have broken the whole chain the moment the folder moved — undoing #349.

### `verifyChain()`

Walks the log and reports each break. Two things are deliberately *not* breaks:

- Records predating the chain carry no `prevHash` and are skipped rather than condemned. A chained record that follows one links onto it normally.
- A **gap** in `seq` is legal — a failed append burns a number by design. Only a `seq` that fails to *advance* is a break, since that is a replay or a rewrite.

Still undetectable from the log alone: truncation of the tail, which leaves a valid shorter chain. That needs the head seq + hash held somewhere the log cannot reach — the signed manifest's job.

### Routes

`GET /cases/:id/custody/verify` now answers two independent questions: did the **evidence** change (re-hash each artifact) and did the **log** change (walk the chain). Either alone misses a class of tampering — swapping a file leaves the chain intact, rewriting who collected it leaves every hash intact. The response gains `chainBreaks`, and `ok` reflects both.

`POST /cases/:id/custody` accepts an `event` and 400s on one outside the known set rather than silently filing it as a collection.

### Exported events

Appended per artifact from the three paths that actually carry evidence out — ZIP archive, encrypted archive, redacted package — recorded only **after** the export succeeds, with each artifact re-hashed so the record states the bytes that actually left. Report / STIX / Iris / ClickUp exports carry conclusions rather than evidence and are left to the activity log.

### Concurrency

Appends are serialized per case. Two concurrent imports would otherwise read the same tail, compute the same `prevHash`, and fork the chain into two records claiming one predecessor — indistinguishable from tampering afterwards. A batch shares one lock acquisition, so exporting a thousand artifacts costs one read of the log rather than a thousand reads of a log that keeps growing.

## Verification

- `npm run typecheck` — clean
- `vitest run` — **463 files, 5760 tests passed**
- 32 new tests covering chain linkage, tamper and mid-log deletion detection, replayed `seq`, legacy unchained records, concurrent appends, and each export path.

## Scope

Part of #231, and the prerequisite for item 2. Builds on #348 (auto-record) and #349 (relative paths). Items 2–4 — signed manifest, periodic verification job, report appendix — remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
