### PR TITLE
feat(custody): sign a chain-of-custody manifest into the report and the encrypted archive (#231)

### DIFF
--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -88,7 +88,15 @@ async function walkDir(dir: string, baseRel = ""): Promise<string[]> {
  * Build a `.dfircase` file: the whole case directory zipped, then AES-256-GCM encrypted with a
  * password-derived key. Throws if the case doesn't exist (no files under its directory).
  */
-export async function exportEncryptedCase(store: CaseStore, caseId: string, password: string): Promise<Buffer> {
+export async function exportEncryptedCase(
+  store: CaseStore,
+  caseId: string,
+  password: string,
+  // Files generated for the archive rather than read from the case dir — currently the signed
+  // chain-of-custody manifest (#231). Passed in rather than written into the case first, so
+  // exporting never mutates the case it is exporting.
+  extraEntries: ZipEntry[] = [],
+): Promise<Buffer> {
   if (!isValidCaseId(caseId)) throw new Error(`invalid case id "${caseId}"`);
   const caseDir = store.caseDir(caseId);
   const relPaths = (await walkDir(caseDir)).map((p) => p.replace(/\\/g, "/"));
@@ -108,6 +116,13 @@ export async function exportEncryptedCase(store: CaseStore, caseId: string, pass
     entries.push({ path: rel, data });
     manifestFiles.push({ path: rel, sha256: createHash("sha256").update(data).digest("hex"), bytes: data.length });
     totalBytes += data.length;
+  }
+  // Listed in archive-manifest.json alongside the case's own files, so a recipient checking the
+  // archive's checksums sees the generated entries too.
+  for (const entry of extraEntries) {
+    entries.push(entry);
+    manifestFiles.push({ path: entry.path, sha256: createHash("sha256").update(entry.data).digest("hex"), bytes: entry.data.length });
+    totalBytes += entry.data.length;
   }
   const manifest = {
     caseId,

--- a/companion/src/analysis/custody.ts
+++ b/companion/src/analysis/custody.ts
@@ -84,9 +84,29 @@ export interface CustodyChainBreak {
   reason: "prev-hash-mismatch" | "seq-out-of-order";
 }
 
+/** Where the custody chain currently ends. Signed into the manifest to pin the log's length. */
+export interface CustodyChainHead {
+  records: number;
+  headSeq: number | null;
+  /** Hash of the last stored line; "" when nothing has been recorded. */
+  headHash: string;
+}
+
 /** Hash of one stored line, exactly as it sits in the file — the unit the chain links together. */
 function hashLine(line: string): string {
   return createHash("sha256").update(line, "utf8").digest("hex");
+}
+
+/**
+ * artifactPath expressed relative to caseDir, or null when it lives outside. Shared by the store
+ * (which persists the relative form) and the manifest (which publishes it), so both answer
+ * "is this artifact inside the case?" the same way.
+ */
+export function toCaseRelative(caseDir: string, artifactPath: string): string | null {
+  const rel = relative(caseDir, artifactPath);
+  // "" is the case dir itself; ".." escapes it; an absolute result means a different root entirely.
+  if (!rel || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return null;
+  return rel;
 }
 
 export class CustodyStore {
@@ -119,10 +139,25 @@ export class CustodyStore {
    * relocation-proofing for free.
    */
   private caseRelative(caseId: string, artifactPath: string): string | null {
-    const rel = relative(this.cases.caseDir(caseId), artifactPath);
-    // "" is the case dir itself; ".." escapes it; an absolute result means a different root entirely.
-    if (!rel || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return null;
-    return rel;
+    return toCaseRelative(this.cases.caseDir(caseId), artifactPath);
+  }
+
+  /**
+   * Where the chain currently ends: how many records, the last seq, and the hash of the last stored
+   * line. Signing these into the manifest is what makes tail truncation detectable — lopping lines
+   * off the end otherwise leaves a shorter but perfectly valid chain (see verifyChain).
+   */
+  async chainHead(caseId: string): Promise<CustodyChainHead> {
+    const lines = await this.storedLines(caseId);
+    if (lines.length === 0) return { records: 0, headSeq: null, headHash: "" };
+    let headSeq: number | null = null;
+    try {
+      const tail = JSON.parse(lines[lines.length - 1]) as StoredCustodyRecord;
+      if (typeof tail.seq === "number") headSeq = tail.seq;
+    } catch {
+      // a malformed tail still has a hash, which is what the chain actually links
+    }
+    return { records: lines.length, headSeq, headHash: hashLine(lines[lines.length - 1]) };
   }
 
   async record(caseId: string, input: CustodyRecordInput): Promise<CustodyRecord> {

--- a/companion/src/analysis/custodyManifest.ts
+++ b/companion/src/analysis/custodyManifest.ts
@@ -1,0 +1,110 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { CaseStore } from "../storage/caseStore.js";
+import { toCaseRelative, type CustodyStore, type CustodyRecord, type CustodyChainBreak, type CustodyChainHead } from "./custody.js";
+import { getAppVersion } from "../version.js";
+
+/** Filename the manifest ships under, inside an export and in the case's reports dir. */
+export const CUSTODY_MANIFEST_FILENAME = "custody-manifest.json";
+
+export interface CustodyManifestArtifact {
+  /** Relative to the case dir when the artifact lives inside it, absolute otherwise. */
+  path: string;
+  /** Hash from the most recent record for this artifact — what it was last known to be. */
+  sha256: string;
+  /** Every custody event for this artifact, in log order. */
+  chain: CustodyRecord[];
+}
+
+export interface CustodyManifestSignature {
+  algorithm: "HMAC-SHA256";
+  value: string;
+}
+
+export interface CustodyManifest {
+  version: 1;
+  caseId: string;
+  generatedAt: string;
+  generatedBy: string;
+  chain: CustodyChainHead & { breaks: CustodyChainBreak[] };
+  artifacts: CustodyManifestArtifact[];
+  signature: CustodyManifestSignature;
+}
+
+/**
+ * Deterministic JSON: object keys sorted at every depth, arrays left in order. A signature over
+ * plain JSON.stringify would depend on key insertion order, so a manifest that had merely been
+ * parsed and re-serialized somewhere along the way could fail to verify while being untouched.
+ */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`;
+}
+
+function sign(unsigned: Omit<CustodyManifest, "signature">, secret: Buffer): string {
+  return createHmac("sha256", secret).update(canonicalize(unsigned), "utf8").digest("hex");
+}
+
+/**
+ * Build the signed chain-of-custody manifest for a case: every artifact with its full chain, plus
+ * where the log currently ends, HMAC'd with this installation's instance secret (#231).
+ *
+ * The signature is what makes tampering detectable without external PKI — an HSM-backed signature is
+ * a deployment concern and deliberately out of scope. It covers the chain head as well as the
+ * records, which is the point: verifyChain alone cannot see lines lopped off the end of the log,
+ * because what remains is still a valid chain. The manifest pins the length and the final hash.
+ */
+export async function buildCustodyManifest(
+  cases: CaseStore,
+  custody: CustodyStore,
+  caseId: string,
+  secret: Buffer,
+): Promise<CustodyManifest> {
+  const [records, head, breaks] = await Promise.all([
+    custody.load(caseId),
+    custody.chainHead(caseId),
+    custody.verifyChain(caseId),
+  ]);
+
+  const caseDir = cases.caseDir(caseId);
+  // Insertion order = first-seen order, so artifacts appear as they entered the case.
+  const byArtifact = new Map<string, CustodyRecord[]>();
+  for (const record of records) {
+    const existing = byArtifact.get(record.artifactPath);
+    if (existing) existing.push(record);
+    else byArtifact.set(record.artifactPath, [record]);
+  }
+
+  const artifacts: CustodyManifestArtifact[] = [...byArtifact].map(([artifactPath, chain]) => ({
+    path: toCaseRelative(caseDir, artifactPath) ?? artifactPath,
+    sha256: chain[chain.length - 1].sha256,
+    chain,
+  }));
+
+  const unsigned: Omit<CustodyManifest, "signature"> = {
+    version: 1,
+    caseId,
+    generatedAt: new Date().toISOString(),
+    generatedBy: getAppVersion(),
+    chain: { ...head, breaks },
+    artifacts,
+  };
+  return { ...unsigned, signature: { algorithm: "HMAC-SHA256", value: sign(unsigned, secret) } };
+}
+
+/**
+ * Recompute the manifest's HMAC and compare. False means the manifest was altered after signing, or
+ * was signed by a different installation — the two are indistinguishable from the manifest alone,
+ * which is the expected property of a shared-secret signature.
+ */
+export function verifyCustodyManifest(manifest: CustodyManifest, secret: Buffer): boolean {
+  const { signature, ...unsigned } = manifest;
+  if (!signature || signature.algorithm !== "HMAC-SHA256" || typeof signature.value !== "string") return false;
+  const expected = Buffer.from(sign(unsigned, secret), "hex");
+  const actual = Buffer.from(signature.value, "hex");
+  // Lengths differ on a malformed signature, where timingSafeEqual throws rather than returning false.
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -24,6 +24,7 @@ import { logActivity, ACTIVITY_CATEGORIES, type ActivityCategory } from "../anal
 import { buildManualEvent } from "../analysis/manualEntry.js";
 import { byEventTime } from "../analysis/forensicSort.js";
 import { parseImporterSpec } from "../analysis/importerSpec.js";
+import { buildCustodyManifest, CUSTODY_MANIFEST_FILENAME } from "../analysis/custodyManifest.js";
 import { getImporterPrompt } from "../analysis/pipeline.js";
 import { getEnvForSettings, updateEnv as updateEnvFile, reloadEnvPrefix, validateEnvUpdates } from "../settings/envManager.js";
 import { readPublicAsset } from "../serverAssets.js";
@@ -83,7 +84,7 @@ import type { RouteContext } from "./context.js";
  */
 export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): void {
   const {
-    store, options, serverLogger, hasAiProvider,
+    store, options, serverLogger, hasAiProvider, instanceSecret,
     dispatchNotify, ensureDropFolders, runStateExclusive, resynthesizeInBackground,
     syncPlaybook, reloadImporters,
   } = ctx;
@@ -469,7 +470,15 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       const meta = await store.getCaseMeta(id);
       if (meta?.status === "archived") return res.status(400).json({ error: `case ${id} is already archived` });
       const removeFromList = (req.body as { removeFromList?: unknown })?.removeFromList === true;
-      const archive = await exportEncryptedCase(store, id, password);
+      // The signed custody manifest travels inside the archive, so the recipient can verify the
+      // chain — including its length, which the log alone cannot vouch for (#231).
+      const custodyManifest = options.custodyStore
+        ? [{
+            path: CUSTODY_MANIFEST_FILENAME,
+            data: Buffer.from(JSON.stringify(await buildCustodyManifest(store, options.custodyStore, id, instanceSecret), null, 2), "utf8"),
+          }]
+        : [];
+      const archive = await exportEncryptedCase(store, id, password, custodyManifest);
       const filename = dfircaseFilename(id, meta?.name);
       // Same as the ZIP path: the evidence is leaving, so the chain records it (#231).
       await options.custodyStore?.recordExport(id, { exportedBy: meta?.investigator || "analyst", destination: `encrypted archive: ${filename}` });

--- a/companion/src/routes/custody.ts
+++ b/companion/src/routes/custody.ts
@@ -1,10 +1,24 @@
 import type { Express, Request, Response } from "express";
 import { hashFile, isCustodyEvent, CUSTODY_EVENTS } from "../analysis/custody.js";
+import { buildCustodyManifest } from "../analysis/custodyManifest.js";
 import { logActivity } from "../analysis/activityLog.js";
 import type { RouteContext } from "./context.js";
 
 export function registerCustodyRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options } = ctx;
+  const { store, options, instanceSecret } = ctx;
+
+  // The signed manifest for this case, on demand. Signed with the instance secret, so a manifest
+  // fetched here verifies on this installation and nowhere else — which is the point (#231).
+  app.get("/cases/:id/custody/manifest", async (req: Request, res: Response) => {
+    if (!options.custodyStore) return res.status(501).json({ error: "custody not configured" });
+    const caseId = req.params.id;
+    if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
+    try {
+      return res.status(200).json(await buildCustodyManifest(store, options.custodyStore, caseId, instanceSecret));
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
 
   app.get("/cases/:id/custody", async (req: Request, res: Response) => {
     if (!options.custodyStore) return res.status(501).json({ error: "custody not configured" });

--- a/companion/src/routes/reportsExport.ts
+++ b/companion/src/routes/reportsExport.ts
@@ -1,5 +1,5 @@
 import type { Express, Request, Response } from "express";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { injectPrintTrigger } from "../reports/html.js";
 import { logActivity } from "../analysis/activityLog.js";
@@ -7,6 +7,7 @@ import { milestoneEvent } from "../analysis/notifications.js";
 import { reloadEnvPrefix } from "../settings/envManager.js";
 import { fetchIrisCase } from "../integrations/iris/irisImportFetch.js";
 import { defaultIrisCaseName } from "../integrations/iris/irisExportStore.js";
+import { buildCustodyManifest, CUSTODY_MANIFEST_FILENAME } from "../analysis/custodyManifest.js";
 import type { RouteContext } from "./context.js";
 
 /**
@@ -54,7 +55,7 @@ import type { RouteContext } from "./context.js";
  * iris-import handler keeps its original logLine(...) calls verbatim.
  */
 export function registerReportsExportRoutes(app: Express, ctx: RouteContext): void {
-  const { store, options, dispatchNotify, resynthesizeInBackground } = ctx;
+  const { store, options, dispatchNotify, resynthesizeInBackground, instanceSecret } = ctx;
 
   // Module-private wrapper mirroring createApp's logLine (serverLogger.info), so the moved call
   // sites stay verbatim.
@@ -64,6 +65,14 @@ export function registerReportsExportRoutes(app: Express, ctx: RouteContext): vo
     if (!options.reportWriter) return res.status(501).json({ error: "report writer not configured" });
     try {
       const paths = await options.reportWriter.writeAll(req.params.id);
+      // The report is the court-facing deliverable, so the signed custody manifest is written
+      // beside it — a report whose evidence provenance cannot be checked is the gap #231 exists to
+      // close. Written after the report so a failed generation leaves no manifest claiming one.
+      if (options.custodyStore) {
+        const manifest = await buildCustodyManifest(store, options.custodyStore, req.params.id, instanceSecret);
+        await mkdir(store.reportsDir(req.params.id), { recursive: true });
+        await writeFile(join(store.reportsDir(req.params.id), CUSTODY_MANIFEST_FILENAME), JSON.stringify(manifest, null, 2), "utf8");
+      }
       dispatchNotify(milestoneEvent(req.params.id, "Report generated", ["The case report (Markdown + HTML) was (re)generated."], new Date().toISOString()));
       logActivity(options.activityLogStore, options.onActivity, req.params.id, {
         category: "export", action: "report-generated", detail: "report (Markdown + HTML) regenerated",

--- a/companion/tests/analysis/custodyManifest.test.ts
+++ b/companion/tests/analysis/custodyManifest.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, appendFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import { buildCustodyManifest, verifyCustodyManifest, type CustodyManifest } from "../../src/analysis/custodyManifest.js";
+
+let cases: CaseStore;
+let custody: CustodyStore;
+let one: string;
+let two: string;
+
+const SECRET = Buffer.from("a".repeat(64), "hex");
+const OTHER_SECRET = Buffer.from("b".repeat(64), "hex");
+const sha = (text: string) => createHash("sha256").update(text, "utf8").digest("hex");
+
+async function collect(path: string, text: string): Promise<void> {
+  await writeFile(path, text, "utf8");
+  await custody.record("c1", {
+    artifactPath: path, sha256: sha(text), collectedBy: "alice",
+    collectedAt: "2026-07-28T10:00:00.000Z", source: "host-a", trigger: "import", caseId: "c1",
+  });
+}
+
+const build = () => buildCustodyManifest(cases, custody, "c1", SECRET);
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-custodymanifest-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  custody = new CustodyStore(cases);
+  one = join(cases.importsDir("c1"), "one.csv");
+  two = join(cases.importsDir("c1"), "two.csv");
+});
+
+describe("buildCustodyManifest", () => {
+  it("groups every custody record under the artifact it belongs to", async () => {
+    await collect(one, "first\n");
+    await collect(two, "second\n");
+    await custody.recordExport("c1", { exportedBy: "alice", destination: "zip" });
+
+    const manifest = await build();
+
+    expect(manifest.artifacts).toHaveLength(2);
+    const first = manifest.artifacts.find((a) => a.path.endsWith("one.csv"));
+    expect(first?.chain.map((r) => r.event)).toEqual(["collected", "exported"]);
+  });
+
+  it("records artifact paths relative to the case dir, so the manifest travels with the case", async () => {
+    await collect(one, "first\n");
+
+    const manifest = await build();
+
+    expect(manifest.artifacts[0].path).toBe(join("imports", "one.csv"));
+  });
+
+  it("keeps an absolute path for evidence collected outside the case dir", async () => {
+    const external = join(await mkdtemp(join(tmpdir(), "dfir-manifest-ext-")), "image.dd");
+    await collect(external, "mounted\n");
+
+    const manifest = await build();
+
+    expect(manifest.artifacts[0].path).toBe(external);
+  });
+
+  it("records the chain head, which is what makes truncating the log detectable", async () => {
+    await collect(one, "first\n");
+    await collect(two, "second\n");
+    const lines = (await readFile(cases.custodyLogPath("c1"), "utf8")).split("\n").filter((l) => l.trim());
+
+    const manifest = await build();
+
+    expect(manifest.chain).toMatchObject({ records: 2, headSeq: 2, headHash: sha(lines[1]) });
+  });
+
+  it("reports chain breaks that already exist at signing time", async () => {
+    await collect(one, "first\n");
+    await collect(two, "second\n");
+    const [first, second] = (await readFile(cases.custodyLogPath("c1"), "utf8")).split("\n").filter((l) => l.trim());
+    const tampered = { ...(JSON.parse(first) as Record<string, unknown>), collectedBy: "mallory" };
+    await writeFile(cases.custodyLogPath("c1"), JSON.stringify(tampered) + "\n" + second + "\n", "utf8");
+
+    const manifest = await build();
+
+    expect(manifest.chain.breaks).toEqual([{ line: 2, seq: 2, reason: "prev-hash-mismatch" }]);
+  });
+
+  it("signs an empty case rather than refusing one", async () => {
+    const manifest = await build();
+
+    expect(manifest.artifacts).toEqual([]);
+    expect(manifest.chain).toMatchObject({ records: 0, headSeq: null, headHash: "" });
+    expect(verifyCustodyManifest(manifest, SECRET)).toBe(true);
+  });
+});
+
+describe("verifyCustodyManifest", () => {
+  it("verifies a manifest under the secret that signed it", async () => {
+    await collect(one, "first\n");
+
+    expect(verifyCustodyManifest(await build(), SECRET)).toBe(true);
+  });
+
+  it("rejects a manifest whose contents were edited after signing", async () => {
+    await collect(one, "first\n");
+    const manifest = await build();
+
+    manifest.artifacts[0].chain[0].collectedBy = "mallory";
+
+    expect(verifyCustodyManifest(manifest, SECRET)).toBe(false);
+  });
+
+  it("rejects a manifest whose recorded chain head was swapped", async () => {
+    await collect(one, "first\n");
+    const manifest = await build();
+
+    manifest.chain.headHash = sha("something else");
+
+    expect(verifyCustodyManifest(manifest, SECRET)).toBe(false);
+  });
+
+  it("rejects a manifest signed by a different instance", async () => {
+    await collect(one, "first\n");
+
+    expect(verifyCustodyManifest(await build(), OTHER_SECRET)).toBe(false);
+  });
+
+  it("rejects a manifest carrying no signature at all", async () => {
+    await collect(one, "first\n");
+    const manifest = await build();
+
+    expect(verifyCustodyManifest({ ...manifest, signature: undefined } as unknown as CustodyManifest, SECRET)).toBe(false);
+  });
+
+  it("verifies after a round trip through JSON, whatever order the keys come back in", async () => {
+    await collect(one, "first\n");
+    const manifest = await build();
+
+    const roundTripped = JSON.parse(JSON.stringify(manifest)) as Record<string, unknown>;
+    // Rebuild with the keys in reverse order — a signature over a naive JSON.stringify would break.
+    const reordered = Object.fromEntries(Object.entries(roundTripped).reverse()) as unknown as CustodyManifest;
+
+    expect(verifyCustodyManifest(reordered, SECRET)).toBe(true);
+  });
+});
+
+describe("CustodyStore.chainHead", () => {
+  it("reports an empty head before anything is recorded", async () => {
+    expect(await custody.chainHead("c1")).toEqual({ records: 0, headSeq: null, headHash: "" });
+  });
+
+  it("advances as records are appended", async () => {
+    await collect(one, "first\n");
+    await appendFile(cases.custodyLogPath("c1"), "\n", "utf8"); // blank lines are not records
+
+    const head = await custody.chainHead("c1");
+
+    expect(head).toMatchObject({ records: 1, headSeq: 1 });
+  });
+});

--- a/companion/tests/server/custodyManifestRoutes.test.ts
+++ b/companion/tests/server/custodyManifestRoutes.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import { loadOrCreateInstanceSecret } from "../../src/analysis/instanceSecret.js";
+import { verifyCustodyManifest, CUSTODY_MANIFEST_FILENAME, type CustodyManifest } from "../../src/analysis/custodyManifest.js";
+import { importEncryptedCase } from "../../src/analysis/caseExportArchive.js";
+import { ReportWriter } from "../../src/reports/reportWriter.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { createApp } from "../../src/server.js";
+
+let app: ReturnType<typeof createApp>;
+let cases: CaseStore;
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "dfir-custodymanifestroute-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  const stateStore = new StateStore(cases);
+  app = createApp(cases, { custodyStore: new CustodyStore(cases), stateStore, reportWriter: new ReportWriter(cases, stateStore) });
+  await cases.saveImport("c1", "0001_evidence.csv", "ts,message\n2026-01-01T00:00:00Z,hi\n");
+});
+
+describe("GET /cases/:id/custody/manifest", () => {
+  it("returns a manifest that verifies under this instance's secret", async () => {
+    const res = await request(app).get("/cases/c1/custody/manifest");
+
+    expect(res.status).toBe(200);
+    const manifest = res.body as CustodyManifest;
+    expect(manifest.caseId).toBe("c1");
+    expect(manifest.artifacts).toHaveLength(1);
+    expect(verifyCustodyManifest(manifest, loadOrCreateInstanceSecret(root))).toBe(true);
+  });
+
+  it("404s for a case that does not exist", async () => {
+    expect((await request(app).get("/cases/nope/custody/manifest")).status).toBe(404);
+  });
+
+  it("501s when no custody store is configured", async () => {
+    expect((await request(createApp(cases, {})).get("/cases/c1/custody/manifest")).status).toBe(501);
+  });
+});
+
+describe("custody manifest in the report", () => {
+  it("is written alongside the report when one is generated", async () => {
+    const res = await request(app).post("/cases/c1/report").send({});
+    expect(res.status).toBe(200);
+
+    const raw = await readFile(join(cases.reportsDir("c1"), CUSTODY_MANIFEST_FILENAME), "utf8");
+    expect(verifyCustodyManifest(JSON.parse(raw) as CustodyManifest, loadOrCreateInstanceSecret(root))).toBe(true);
+  });
+});
+
+function bufferRequest(req: request.Test): request.Test {
+  return req.buffer().parse((r, cb) => {
+    const chunks: Buffer[] = [];
+    r.on("data", (c: Buffer) => chunks.push(c));
+    r.on("end", () => cb(null, Buffer.concat(chunks)));
+  });
+}
+
+describe("custody manifest in the encrypted archive", () => {
+  it("ships inside the .dfircase so the recipient can verify the chain", async () => {
+    const res = await bufferRequest(
+      request(app).post("/cases/c1/export/encrypted").send({ password: "a-long-enough-password" }),
+    );
+    expect(res.status).toBe(200);
+
+    const target = await mkdtemp(join(tmpdir(), "dfir-manifest-import-"));
+    const into = new CaseStore(target);
+    await importEncryptedCase(into, res.body as Buffer, "a-long-enough-password", { targetCaseId: "c1" });
+
+    const raw = await readFile(join(into.caseDir("c1"), CUSTODY_MANIFEST_FILENAME), "utf8");
+    const manifest = JSON.parse(raw) as CustodyManifest;
+    expect(manifest.artifacts).toHaveLength(1);
+    // Signed by the EXPORTING instance, so it still verifies under that secret after travelling.
+    expect(verifyCustodyManifest(manifest, loadOrCreateInstanceSecret(root))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

`verifyChain()` (#351) proves no entry in `custody.jsonl` was *altered* — but not that entries still *exist*. Lopping lines off the end leaves a shorter chain that verifies perfectly. Nothing inside the log can close that gap, because the log is exactly what an attacker controls.

`custody-manifest.json` pins it from outside.

## What

Alongside every artifact and its full chain, the manifest records **where the chain ends** — record count, head `seq`, and the hash of the final stored line — and HMAC-SHA256s the whole thing with the instance secret already used to sign unlock cookies. A truncated log no longer matches the head its own manifest recorded.

- **`analysis/custodyManifest.ts`** — builds and verifies. The signature covers a **canonical** serialization (keys sorted at every depth), not plain `JSON.stringify`: a manifest that was merely parsed and re-serialized somewhere in transit must not fail to verify while being untouched.
- **`CustodyStore.chainHead()`** — reports where the log currently ends.
- **`toCaseRelative()`** — now shared between the store (which persists the relative form) and the manifest (which publishes it), so both answer "is this artifact inside the case?" identically.

Artifact paths are case-relative wherever possible, for the same reason the records are (#349): a manifest full of absolute paths from the exporting machine is noise to whoever receives it.

## Where it ships

| Surface | Behaviour |
|---|---|
| `GET /cases/:id/custody/manifest` | On demand, signed for this instance. |
| `POST /cases/:id/report` | Written beside the report — the court-facing deliverable. |
| `POST /cases/:id/export/encrypted` | Inside the `.dfircase`, listed in `archive-manifest.json`. |

`exportEncryptedCase` takes generated entries as a parameter rather than having them written into the case dir first, so **exporting never mutates the case it is exporting**.

## Out of scope

External PKI/HSM signing, per the issue. The shared secret detects tampering, which is what item 2 asks for. A consequence worth stating plainly: a manifest proves *this installation* signed it, and cannot prove *which* installation to someone who doesn't hold the secret. That is inherent to HMAC and is the documented trade.

## Verification

- `npm run typecheck` — clean
- `vitest run` — **470 files, 5814 tests passed**
- 19 new tests: signing, detection of edited records and a swapped chain head, a foreign secret, a missing signature, key-order independence, and the manifest surviving a round trip through an exported and re-imported archive.

## Scope

Closes item 2 of #231. Builds on #348, #349, #351. Items 3 (periodic verification job + Diagnostics) and 4 (report appendix) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
