### PR TITLE
docs(comments): make four spec references self-contained

### DIFF
--- a/companion/scripts/measure-synth-coverage.ts
+++ b/companion/scripts/measure-synth-coverage.ts
@@ -1,7 +1,12 @@
 // Measure how much of a real case's forensic timeline fits the synthesis prompt once detection bursts
-// are grouped. This is the decision input for tier 3 (the batched deep pass) in
-// docs/superpowers/specs/2026-07-21-forensic-timeline-ai-coverage-design.md: if the collapsed set fits
-// the cap on real imports, tier 3 is unnecessary and should be dropped.
+// are grouped.
+//
+// Why it exists: full AI coverage of the timeline was scoped as three tiers — (1) group bursts so a
+// repetitive detection costs one prompt row, (2) select what remains by severity and rarity, and
+// (3) a batched deep pass that runs synthesis over the timeline in chunks so nothing is unseen.
+// Tier 3 is much the most expensive, in tokens and in complexity. This script is the evidence for
+// whether it is needed at all: run it against real cases, and if the grouped timeline already fits
+// the prompt cap, tier 3 buys nothing and should be dropped rather than built.
 //
 // Usage (from companion/):  npx tsx scripts/measure-synth-coverage.ts <path-to-investigation.json>
 

--- a/companion/src/analysis/caseLockGate.ts
+++ b/companion/src/analysis/caseLockGate.ts
@@ -33,7 +33,9 @@ function lockPromptHtml(caseId: string): string {
  * once via `app.use('/cases/:id', createCaseLockGate(store, secret))`, as early as possible
  * (before ANY `/cases/:id/*` route is registered) — Express's prefix matching means it
  * covers every route registered after it, current or future, with no per-route changes.
- * See docs/superpowers/specs/2026-07-09-case-password-protection-design.md. */
+ *
+ * A per-route opt-in was rejected for exactly that reason: it leaves each new route one
+ * forgotten decorator away from serving a locked case's evidence unauthenticated. */
 export function createCaseLockGate(store: CaseStore, secret: Buffer) {
   return async function caseLockGate(req: Request, res: Response, next: NextFunction): Promise<void> {
     const caseId = req.params.id;

--- a/companion/src/analysis/forensicGate.ts
+++ b/companion/src/analysis/forensicGate.ts
@@ -2,7 +2,13 @@ import type { ForensicEvent, Severity } from "./stateTypes.js";
 
 // Info is the "don't know / not suspicious" floor; Low+ is a deliberate signal (source verdict or
 // one of our deterministic rules). The forensic timeline keeps Low+ and above; Info telemetry is
-// routed to the super-timeline only. See docs/superpowers/specs/2026-07-03-forensic-severity-gate-ioc-provenance-design.md.
+// routed to the super-timeline only.
+//
+// The consequence to hold on to: anything graded Info never reaches the forensic timeline, so the
+// AI cannot see it. A detection that matters must be graded above Info — which is what the
+// deterministic content tagger does at the route seam, promoting high-value telemetry AFTER import.
+// Gating Info out earlier, at merge time, was tried and reverted: it hid exactly the events the
+// tagger would have promoted.
 export const SEVERITY_RANK: Record<Severity, number> = { Info: 0, Low: 1, Medium: 2, High: 3, Critical: 4 };
 
 const VALID: readonly Severity[] = ["Info", "Low", "Medium", "High", "Critical"];

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -823,7 +823,8 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // ── Case password protection ─────────────────────────────────────────────────────────
   // Gates every /cases/:id/* route behind that case's password, when one is set. Mounted
   // here, before ANY /cases/:id/* route is registered, so it covers all of them via prefix
-  // matching. See docs/superpowers/specs/2026-07-09-case-password-protection-design.md.
+  // matching — a route added later is protected with no change to this file. See
+  // caseLockGate.ts for the gate itself.
   app.use("/cases/:id", createCaseLockGate(store, instanceSecret));
 
   // Bail out of read-only case routes whose client already gave up (#174). The dashboard's connect


### PR DESCRIPTION
Four source comments pointed at design specs under `docs/superpowers/specs/`. That path is excluded by `.gitignore` (line 64), so the files were never in the repo — following any of those references led nowhere for anyone but the author who had them locally.

The fix is not to commit the specs (they are deliberately untracked). Each comment now carries the context it was borrowing:

| File | What the comment now says on its own |
|---|---|
| `server.ts`, `caseLockGate.ts` | Why the lock gate is mounted by prefix rather than opted into per route — a forgotten decorator would serve a locked case's evidence unauthenticated |
| `forensicGate.ts` | That anything graded Info never reaches the forensic timeline, so the AI cannot see it; and that gating Info at merge time was tried and reverted because it pre-empted the content tagger |
| `measure-synth-coverage.ts` | What the three coverage tiers are, so the script's purpose — deciding whether the expensive tier 3 is needed at all — is legible without the spec |

No issue numbers cited: I could not identify them reliably from git history, and a wrong issue number is more misleading than none.

The `.gitignore` entry is untouched — keeping specs locally is still fine.

Comments only; no behaviour change. Build, typecheck and 5795 tests green.