### PR TITLE
feat(custody): re-verify all stored evidence on a schedule and surface it in Diagnostics (#231)

### DIFF
--- a/companion/src/analysis/custodyIntegrity.ts
+++ b/companion/src/analysis/custodyIntegrity.ts
@@ -1,0 +1,152 @@
+import type { CaseStore } from "../storage/caseStore.js";
+import type { CustodyStore, CustodyMismatch, CustodyChainBreak } from "./custody.js";
+
+/** Default sweep interval: once a day. Re-hashing every artifact is I/O-heavy, not a health ping. */
+export const DEFAULT_VERIFY_INTERVAL_MS = 86_400_000;
+
+export interface IntegrityConfig {
+  /** How often to re-verify all stored evidence (DFIR_CUSTODY_VERIFY_INTERVAL_MS). 0 = disabled. */
+  intervalMs: number;
+}
+
+export function resolveIntegrityConfig(env: NodeJS.ProcessEnv = process.env): IntegrityConfig {
+  const raw = env.DFIR_CUSTODY_VERIFY_INTERVAL_MS;
+  // Parsed explicitly rather than with `|| DEFAULT`, which would swallow a literal "0" — the one
+  // value an operator uses to turn the sweep OFF, and the one a fallback must not override.
+  const parsed = raw != null && raw !== "" ? Number(raw) : DEFAULT_VERIFY_INTERVAL_MS;
+  const intervalMs = Number.isFinite(parsed) ? Math.max(0, parsed) : DEFAULT_VERIFY_INTERVAL_MS;
+  return { intervalMs };
+}
+
+/** One case's verification result, only kept when something is actually wrong with it. */
+export interface CaseIntegrityProblem {
+  caseId: string;
+  mismatches: CustodyMismatch[];
+  chainBreaks: CustodyChainBreak[];
+}
+
+export interface IntegritySweep {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  casesChecked: number;
+  /** Distinct artifacts re-hashed across every case. */
+  artifacts: number;
+  /** Artifacts whose bytes no longer match, or that have gone missing. */
+  failedArtifacts: number;
+  /** Places where a custody log stopped being a chain. */
+  chainBreaks: number;
+  problemCases: CaseIntegrityProblem[];
+}
+
+/** What /diagnostics shows: the headline of the last sweep, without the per-record detail. */
+export interface EvidenceIntegrityStatus {
+  enabled: boolean;
+  intervalMs: number;
+  lastRunAt: string | null;
+  lastDurationMs: number | null;
+  artifacts: number;
+  failedArtifacts: number;
+  chainBreaks: number;
+  problemCaseIds: string[];
+}
+
+/**
+ * Periodic re-verification of all stored evidence (#231 item 3).
+ *
+ * A custody record asserts a hash at collection time; nothing re-checks it afterwards, so silent
+ * corruption — a failing disk, a botched restore, a deliberate swap — would surface only when
+ * someone happened to hit the verify endpoint, potentially long after it mattered. This sweeps
+ * every case on a schedule and raises an alert the moment the answer changes.
+ *
+ * Both questions are asked per case: did the EVIDENCE change (re-hash each artifact) and did the LOG
+ * change (walk the chain). Archived cases are included — archived evidence is still evidence.
+ *
+ * Deliberately timer-free. The interval lives in createApp beside the scheduled-backup timer, which
+ * keeps the scheduling in one place and leaves this class synchronously testable.
+ */
+export class EvidenceIntegrityMonitor {
+  private last: IntegritySweep | null = null;
+  private running = false;
+
+  constructor(
+    private readonly cases: CaseStore,
+    private readonly custody: CustodyStore,
+    private readonly config: IntegrityConfig,
+    private readonly onProblem?: (sweep: IntegritySweep) => void,
+  ) {}
+
+  status(): EvidenceIntegrityStatus {
+    return {
+      enabled: this.config.intervalMs > 0,
+      intervalMs: this.config.intervalMs,
+      lastRunAt: this.last?.finishedAt ?? null,
+      lastDurationMs: this.last?.durationMs ?? null,
+      artifacts: this.last?.artifacts ?? 0,
+      failedArtifacts: this.last?.failedArtifacts ?? 0,
+      chainBreaks: this.last?.chainBreaks ?? 0,
+      problemCaseIds: this.last?.problemCases.map((c) => c.caseId) ?? [],
+    };
+  }
+
+  /**
+   * Verify every case once. Returns the sweep and retains it as the reported status. A case that
+   * throws mid-sweep is skipped rather than abandoning the run — one unreadable case must not hide
+   * the verification state of every other one.
+   */
+  async runSweep(): Promise<IntegritySweep> {
+    const startedAt = new Date();
+    const metas = await this.cases.listCases().catch(() => []);
+    let artifacts = 0;
+    let failedArtifacts = 0;
+    let chainBreaks = 0;
+    const problemCases: CaseIntegrityProblem[] = [];
+
+    for (const meta of metas) {
+      try {
+        const records = await this.custody.load(meta.caseId);
+        artifacts += new Set(records.map((r) => r.artifactPath)).size;
+        const [mismatches, breaks] = await Promise.all([
+          this.custody.verifyIntegrity(meta.caseId),
+          this.custody.verifyChain(meta.caseId),
+        ]);
+        failedArtifacts += mismatches.length;
+        chainBreaks += breaks.length;
+        if (mismatches.length > 0 || breaks.length > 0) {
+          problemCases.push({ caseId: meta.caseId, mismatches, chainBreaks: breaks });
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    const finishedAt = new Date();
+    const sweep: IntegritySweep = {
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMs: finishedAt.getTime() - startedAt.getTime(),
+      casesChecked: metas.length,
+      artifacts,
+      failedArtifacts,
+      chainBreaks,
+      problemCases,
+    };
+    this.last = sweep;
+    if (problemCases.length > 0) this.onProblem?.(sweep);
+    return sweep;
+  }
+
+  /**
+   * Run a sweep unless one is already in flight. Re-hashing can outlast the interval on a large
+   * install, and overlapping sweeps would compete for the same disk and report over each other.
+   */
+  async runSweepIfIdle(): Promise<IntegritySweep | null> {
+    if (this.running) return null;
+    this.running = true;
+    try {
+      return await this.runSweep();
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/companion/src/analysis/diagnostics.ts
+++ b/companion/src/analysis/diagnostics.ts
@@ -7,6 +7,7 @@ import { isLocalAiProvider } from "./anonymize.js";
 import { visionEnv } from "../config/aiEnv.js";
 import type { DiskStats, DiskWarningLevel, DiskWarnThresholds } from "./diskWarn.js";
 import type { ImporterLoadError } from "./importerStore.js";
+import type { EvidenceIntegrityStatus } from "./custodyIntegrity.js";
 
 /** Human-readable byte size (binary units, 1 decimal place under 100). */
 export function formatBytes(bytes: number): string {
@@ -288,6 +289,8 @@ export interface DiagnosticsReport {
     totalBytes: number;
     retain: number;
   };
+  /** Result of the last periodic re-verification of stored evidence (#231). */
+  evidenceIntegrity: EvidenceIntegrityStatus;
 }
 
 /**
@@ -362,5 +365,28 @@ export function buildDiagnosticsText(r: DiagnosticsReport): string {
       lines.push(`    ${e.file}: ${e.errors.map((x) => `${x.path}: ${x.message}`).join("; ")}`);
     }
   }
+  lines.push("");
+  lines.push("-- Evidence integrity --");
+  lines.push(...evidenceIntegrityLines(r.evidenceIntegrity));
   return lines.join("\n");
+}
+
+/**
+ * The custody sweep's headline. A failure leads the line rather than trailing an all-clear, because
+ * this is the one section an operator scans for a reason to worry.
+ */
+function evidenceIntegrityLines(e: EvidenceIntegrityStatus): string[] {
+  if (!e.enabled) return ["  disabled (DFIR_CUSTODY_VERIFY_INTERVAL_MS=0)"];
+  if (!e.lastRunAt) return [`  not verified yet — next sweep within ${formatAge(e.intervalMs)}`];
+
+  const ago = formatAge(Date.now() - Date.parse(e.lastRunAt));
+  const lines: string[] = [];
+  if (e.failedArtifacts > 0) {
+    lines.push(`  last verified ${ago} ago — ${e.failedArtifacts} of ${e.artifacts} artifacts FAILED verification`);
+  } else {
+    lines.push(`  last verified ${ago} ago — all ${e.artifacts} artifacts OK`);
+  }
+  if (e.chainBreaks > 0) lines.push(`  ${e.chainBreaks} custody-log chain break(s)`);
+  if (e.problemCaseIds.length) lines.push(`  affected cases: ${e.problemCaseIds.join(", ")}`);
+  return lines;
 }

--- a/companion/src/routes/system.ts
+++ b/companion/src/routes/system.ts
@@ -262,6 +262,12 @@ export function registerSystemRoutes(app: Express, ctx: RouteContext): void {
               return { enabled: true, totalCount, totalBytes, retain: options.backupManager!.config.retain };
             })()
           : { enabled: false, totalCount: 0, totalBytes: 0, retain: 0 },
+        // Reported from the last completed sweep, never computed here: re-hashing every artifact
+        // is far too heavy for a route the dashboard polls (#231).
+        evidenceIntegrity: options.integrityMonitor?.status() ?? {
+          enabled: false, intervalMs: 0, lastRunAt: null, lastDurationMs: null,
+          artifacts: 0, failedArtifacts: 0, chainBreaks: 0, problemCaseIds: [],
+        },
       };
       return res.status(200).json({ report, text: buildDiagnosticsText(report) });
     } catch (err) {

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -129,6 +129,7 @@ import { TaggerStore } from "./analysis/taggerStore.js";
 import { autoTagNewEvents } from "./analysis/taggerAuto.js";
 import { ForensicGateControlStore } from "./analysis/forensicGateControl.js";
 import { CustodyStore } from "./analysis/custody.js";
+import { EvidenceIntegrityMonitor, resolveIntegrityConfig } from "./analysis/custodyIntegrity.js";
 import { demoteBelowSeverity, resolveForensicMinSeverity } from "./analysis/forensicGate.js";
 import { ConfidenceControlStore } from "./analysis/confidenceControl.js";
 import { ComplianceControlStore } from "./analysis/complianceControl.js";
@@ -255,6 +256,11 @@ export function getServerLogger(): Logger { return serverLogger; }
 function logLine(msg: string): void { serverLogger.info(msg); }
 function warnLine(msg: string): void { serverLogger.warn(msg); }
 
+// Delay before the first evidence-integrity sweep after boot. Long enough to stay out of the
+// startup path, short enough that Diagnostics reports a real answer rather than "not verified
+// yet" for a whole interval (#231).
+const INITIAL_INTEGRITY_SWEEP_DELAY_MS = 60_000;
+
 // Truncate a long indicator (e.g. a SHA-256) for a readable one-line log entry.
 function shortValue(value: string): string {
   return value.length > 24 ? `${value.slice(0, 24)}…` : value;
@@ -374,6 +380,7 @@ export interface AppOptions {
   forensicGateControlStore?: ForensicGateControlStore;
   onForensicGate?: (caseId: string) => void;
   custodyStore?: CustodyStore;
+  integrityMonitor?: EvidenceIntegrityMonitor;
   // Per-case minimum-confidence display preference (#226) — a machine/analyst preference, not
   // investigation data, mirroring forensicGateControlStore's shape. Purely a display filter: nothing
   // is removed from state, only the dashboard's findings list defaults to this floor.
@@ -3611,6 +3618,43 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     logLine(`[backup] automatic backups every ${backupConfig.intervalMs / 1000}s (retain ${backupConfig.retain})`);
   }
 
+  // Periodic evidence re-verification (#231 item 3). Scheduled here beside the backup timer rather
+  // than inside BackupManager: it reuses that scheduling PATTERN, but state backups and custody
+  // verification are unrelated concerns and folding one into the other would only couple them.
+  const integrityConfig = resolveIntegrityConfig(process.env);
+  const integrityMonitor = new EvidenceIntegrityMonitor(store, custodyStore, integrityConfig, (sweep) => {
+    const problems = [
+      sweep.failedArtifacts ? `${sweep.failedArtifacts} artifact(s) failed verification` : "",
+      sweep.chainBreaks ? `${sweep.chainBreaks} custody-log chain break(s)` : "",
+    ].filter(Boolean).join(", ");
+    warnLine(`[custody] EVIDENCE INTEGRITY ALERT — ${problems} across ${sweep.problemCases.length} case(s): ${sweep.problemCases.map((c) => c.caseId).join(", ")}`);
+    // One notification per affected case, so it lands in that case's feed where an analyst will
+    // see it rather than in a global channel nobody is watching. Fully guarded, like onSynth
+    // below: notifications are a side channel and must never break the sweep.
+    try {
+      for (const problem of sweep.problemCases) {
+        const url = `${dashboardBaseUrl}/dashboard?caseId=${encodeURIComponent(problem.caseId)}`;
+        const event = milestoneEvent(problem.caseId, "Evidence integrity check FAILED", [
+          `${problem.mismatches.length} artifact(s) failed verification, ${problem.chainBreaks.length} custody-log chain break(s).`,
+          ...problem.mismatches.slice(0, 5).map((m) => `${m.reason}: ${m.artifactPath}`),
+        ], sweep.finishedAt);
+        notifier.dispatch({ ...event, url }).catch((err) => logLine(`[notify] dispatch error: ${(err as Error).message}`));
+      }
+    } catch (err) {
+      logLine(`[custody] integrity alert dispatch error: ${(err as Error).message}`);
+    }
+  });
+  if (integrityConfig.intervalMs > 0) {
+    const integrityTimer = setInterval(() => { void integrityMonitor.runSweepIfIdle(); }, integrityConfig.intervalMs);
+    integrityTimer.unref();
+    // A first sweep shortly after boot, so Diagnostics reports a real answer instead of "not
+    // verified yet" for a whole interval. Delayed rather than inline: re-hashing every artifact
+    // must not sit in the startup path.
+    const firstSweep = setTimeout(() => { void integrityMonitor.runSweepIfIdle(); }, INITIAL_INTEGRITY_SWEEP_DELAY_MS);
+    firstSweep.unref();
+    logLine(`[custody] evidence integrity sweep every ${integrityConfig.intervalMs / 1000}s`);
+  }
+
   const provider = buildProvider();
   const synthesisProvider = buildSynthesisProvider();
   const velociraptorProvider = buildVelociraptorProvider();   // dedicated VQL-hunt model (#70)
@@ -3712,6 +3756,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     forensicGateControlStore,
     onForensicGate: (caseId) => hub.broadcastTo(caseId, { type: "forensic_gate_changed" }),
     custodyStore,
+    integrityMonitor,
     confidenceControlStore,
     onConfidenceControl: (caseId) => hub.broadcastTo(caseId, { type: "confidence_control_changed" }),
     complianceControlStore,

--- a/companion/tests/analysis/custodyIntegrity.test.ts
+++ b/companion/tests/analysis/custodyIntegrity.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import {
+  EvidenceIntegrityMonitor,
+  resolveIntegrityConfig,
+  type IntegritySweep,
+} from "../../src/analysis/custodyIntegrity.js";
+
+let cases: CaseStore;
+let custody: CustodyStore;
+let monitor: EvidenceIntegrityMonitor;
+let alerts: IntegritySweep[];
+
+const sha = (text: string) => createHash("sha256").update(text, "utf8").digest("hex");
+
+async function collect(caseId: string, name: string, text: string): Promise<string> {
+  const path = join(cases.importsDir(caseId), name);
+  await writeFile(path, text, "utf8");
+  await custody.record(caseId, {
+    artifactPath: path, sha256: sha(text), collectedBy: "alice",
+    collectedAt: "2026-07-28T10:00:00.000Z", source: "host-a", trigger: "import", caseId,
+  });
+  return path;
+}
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-integrity-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  await cases.createCase({ caseId: "c2", name: "n", investigator: "i", aiProvider: null });
+  custody = new CustodyStore(cases);
+  alerts = [];
+  monitor = new EvidenceIntegrityMonitor(cases, custody, { intervalMs: 86_400_000 }, (sweep) => { alerts.push(sweep); });
+});
+
+describe("resolveIntegrityConfig", () => {
+  it("verifies once a day by default", () => {
+    expect(resolveIntegrityConfig({}).intervalMs).toBe(86_400_000);
+  });
+
+  it("takes the operator's interval", () => {
+    expect(resolveIntegrityConfig({ DFIR_CUSTODY_VERIFY_INTERVAL_MS: "60000" }).intervalMs).toBe(60_000);
+  });
+
+  it("treats 0 as disabled rather than as 'run constantly'", () => {
+    expect(resolveIntegrityConfig({ DFIR_CUSTODY_VERIFY_INTERVAL_MS: "0" }).intervalMs).toBe(0);
+  });
+
+  it("falls back to the default on a non-numeric value", () => {
+    expect(resolveIntegrityConfig({ DFIR_CUSTODY_VERIFY_INTERVAL_MS: "soon" }).intervalMs).toBe(86_400_000);
+  });
+});
+
+describe("EvidenceIntegrityMonitor.runSweep", () => {
+  it("reports every artifact as verified when nothing has changed", async () => {
+    await collect("c1", "a.csv", "one\n");
+    await collect("c2", "b.csv", "two\n");
+
+    const sweep = await monitor.runSweep();
+
+    expect(sweep).toMatchObject({ casesChecked: 2, artifacts: 2, failedArtifacts: 0, chainBreaks: 0 });
+    expect(sweep.problemCases).toEqual([]);
+  });
+
+  it("counts an artifact whose bytes changed on disk", async () => {
+    const path = await collect("c1", "a.csv", "one\n");
+    await collect("c2", "b.csv", "two\n");
+    await writeFile(path, "tampered\n", "utf8");
+
+    const sweep = await monitor.runSweep();
+
+    expect(sweep).toMatchObject({ artifacts: 2, failedArtifacts: 1 });
+    expect(sweep.problemCases.map((c) => c.caseId)).toEqual(["c1"]);
+    expect(sweep.problemCases[0].mismatches[0]).toMatchObject({ artifactPath: path, reason: "hash-mismatch" });
+  });
+
+  it("counts a deleted artifact as failed", async () => {
+    const path = await collect("c1", "a.csv", "one\n");
+    await rm(path);
+
+    expect((await monitor.runSweep()).failedArtifacts).toBe(1);
+  });
+
+  it("counts a break in the custody log itself", async () => {
+    await collect("c1", "a.csv", "one\n");
+    await collect("c1", "b.csv", "two\n");
+    const [first, second] = (await readFile(cases.custodyLogPath("c1"), "utf8")).split("\n").filter((l) => l.trim());
+    const edited = { ...(JSON.parse(first) as Record<string, unknown>), collectedBy: "mallory" };
+    await writeFile(cases.custodyLogPath("c1"), JSON.stringify(edited) + "\n" + second + "\n", "utf8");
+
+    const sweep = await monitor.runSweep();
+
+    // The files themselves are untouched — only the record of them.
+    expect(sweep.failedArtifacts).toBe(0);
+    expect(sweep.chainBreaks).toBe(1);
+    expect(sweep.problemCases.map((c) => c.caseId)).toEqual(["c1"]);
+  });
+
+  it("counts cases with no custody log as checked but empty", async () => {
+    const sweep = await monitor.runSweep();
+
+    expect(sweep).toMatchObject({ casesChecked: 2, artifacts: 0, failedArtifacts: 0 });
+  });
+
+  it("verifies archived cases too, since archived evidence is still evidence", async () => {
+    const path = await collect("c1", "a.csv", "one\n");
+    await cases.archiveCaseFolder("c1");
+    await writeFile(path.replace(join(cases.casesRoot, "c1"), join(cases.casesRoot, "_archived", "c1")), "tampered\n", "utf8");
+
+    const sweep = await monitor.runSweep();
+
+    expect(sweep.failedArtifacts).toBe(1);
+  });
+});
+
+describe("EvidenceIntegrityMonitor alerting", () => {
+  it("alerts when a sweep finds a problem", async () => {
+    const path = await collect("c1", "a.csv", "one\n");
+    await writeFile(path, "tampered\n", "utf8");
+
+    await monitor.runSweep();
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].failedArtifacts).toBe(1);
+  });
+
+  it("stays quiet when everything verifies", async () => {
+    await collect("c1", "a.csv", "one\n");
+
+    await monitor.runSweep();
+
+    expect(alerts).toEqual([]);
+  });
+});
+
+describe("EvidenceIntegrityMonitor.status", () => {
+  it("reports never-run before the first sweep", () => {
+    expect(monitor.status()).toMatchObject({ enabled: true, lastRunAt: null, artifacts: 0, failedArtifacts: 0 });
+  });
+
+  it("reports the last sweep once one has run", async () => {
+    await collect("c1", "a.csv", "one\n");
+
+    await monitor.runSweep();
+
+    const status = monitor.status();
+    expect(status.lastRunAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(status).toMatchObject({ artifacts: 1, failedArtifacts: 0, chainBreaks: 0, problemCaseIds: [] });
+  });
+
+  it("names the cases that failed, so the operator knows where to look", async () => {
+    const path = await collect("c1", "a.csv", "one\n");
+    await writeFile(path, "tampered\n", "utf8");
+
+    await monitor.runSweep();
+
+    expect(monitor.status().problemCaseIds).toEqual(["c1"]);
+  });
+
+  it("reports itself disabled when the interval is 0", () => {
+    const off = new EvidenceIntegrityMonitor(cases, custody, { intervalMs: 0 });
+    expect(off.status().enabled).toBe(false);
+  });
+});
+
+describe("evidence integrity in GET /diagnostics", () => {
+  it("reports the monitor's last sweep, and defaults to disabled when none is wired", async () => {
+    const { createApp } = await import("../../src/server.js");
+    const app = createApp(cases, { custodyStore: custody, integrityMonitor: monitor });
+
+    await collect("c1", "a.csv", "one\n");
+    await monitor.runSweep();
+
+    const { default: request } = await import("supertest");
+    const res = await request(app).get("/diagnostics");
+    expect(res.status).toBe(200);
+    expect(res.body.report.evidenceIntegrity).toMatchObject({ enabled: true, artifacts: 1, failedArtifacts: 0 });
+    expect(res.body.text).toContain("-- Evidence integrity --");
+
+    const bare = await request(createApp(cases, {})).get("/diagnostics");
+    expect(bare.body.report.evidenceIntegrity).toMatchObject({ enabled: false, lastRunAt: null });
+  });
+});

--- a/companion/tests/analysis/diagnostics.test.ts
+++ b/companion/tests/analysis/diagnostics.test.ts
@@ -199,6 +199,10 @@ function sampleReport(): DiagnosticsReport {
       perImporter: [],
       loadErrors: [],
     },
+    evidenceIntegrity: {
+      enabled: true, intervalMs: 86_400_000, lastRunAt: null, lastDurationMs: null,
+      artifacts: 0, failedArtifacts: 0, chainBreaks: 0, problemCaseIds: [],
+    },
   };
 }
 

--- a/companion/tests/analysis/evidenceIntegrityDiagnostics.test.ts
+++ b/companion/tests/analysis/evidenceIntegrityDiagnostics.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { buildDiagnosticsText, type DiagnosticsReport } from "../../src/analysis/diagnostics.js";
+import type { EvidenceIntegrityStatus } from "../../src/analysis/custodyIntegrity.js";
+
+function report(evidenceIntegrity: EvidenceIntegrityStatus): DiagnosticsReport {
+  return {
+    generatedAt: "2026-07-28T12:00:00.000Z",
+    uptimeMs: 3_600_000,
+    disk: { freeBytes: 1, totalBytes: 2, usedPct: 50, level: "none", thresholds: { warnPct: 80, dangerPct: 90, criticalPct: 95 } },
+    cases: { count: 1, open: 1, closed: 0, archived: 0 },
+    queue: { bufferedCaptures: 0, casesBuffering: 0, oldestBufferedAgeMs: null, synthInFlight: 0, pendingAnalysisCases: 0 },
+    ai: { configured: false, recentErrors: [], errorCounts: {} } as unknown as DiagnosticsReport["ai"],
+    importers: {
+      attempts: { last24h: 0, last7d: 0, total: 0 },
+      recentFailures: [], customImporters: 0, perImporter: [], loadErrors: [],
+    },
+    backups: { enabled: true, totalCount: 0, totalBytes: 0, retain: 24 },
+    evidenceIntegrity,
+  };
+}
+
+const base: EvidenceIntegrityStatus = {
+  enabled: true, intervalMs: 86_400_000, lastRunAt: null, lastDurationMs: null,
+  artifacts: 0, failedArtifacts: 0, chainBreaks: 0, problemCaseIds: [],
+};
+
+describe("evidence integrity in the diagnostics text", () => {
+  it("says it has not run yet before the first sweep", () => {
+    const text = buildDiagnosticsText(report(base));
+
+    expect(text).toContain("-- Evidence integrity --");
+    expect(text).toContain("not verified yet");
+  });
+
+  it("reports an all-clear with the artifact count", () => {
+    const text = buildDiagnosticsText(report({
+      ...base, lastRunAt: "2026-07-28T10:00:00.000Z", lastDurationMs: 4200, artifacts: 1247,
+    }));
+
+    expect(text).toContain("all 1247 artifacts OK");
+  });
+
+  it("leads with the failure count when artifacts fail", () => {
+    const text = buildDiagnosticsText(report({
+      ...base, lastRunAt: "2026-07-28T10:00:00.000Z", artifacts: 1247,
+      failedArtifacts: 3, problemCaseIds: ["INC-1"],
+    }));
+
+    expect(text).toContain("3 of 1247 artifacts FAILED verification");
+    expect(text).toContain("INC-1");
+  });
+
+  it("reports a broken custody log even when every artifact hashes clean", () => {
+    const text = buildDiagnosticsText(report({
+      ...base, lastRunAt: "2026-07-28T10:00:00.000Z", artifacts: 5, chainBreaks: 2, problemCaseIds: ["INC-2"],
+    }));
+
+    expect(text).toContain("2 custody-log chain break(s)");
+  });
+
+  it("says so when the sweep is switched off", () => {
+    const text = buildDiagnosticsText(report({ ...base, enabled: false, intervalMs: 0 }));
+
+    expect(text).toContain("disabled");
+  });
+});


### PR DESCRIPTION
## Why

A custody record asserts a hash at collection time — and nothing re-checked it afterwards. Silent corruption (a failing disk, a botched restore, a deliberate swap) would surface only when someone happened to hit the verify endpoint, potentially long after it mattered.

## What

`EvidenceIntegrityMonitor` sweeps every case on a schedule — `DFIR_CUSTODY_VERIFY_INTERVAL_MS`, default **24h**, `0` disables — asking both questions per case: did the **evidence** change (re-hash each artifact) and did the **log** change (walk the chain). Archived cases are included; archived evidence is still evidence, and `listCases()` already covers both locations.

Failures raise a warn-level log line naming the affected cases, plus a notification **per case**, so the alert lands in the feed of the case it concerns rather than a global channel nobody is watching. Dispatch is guarded the same way `onSynth` is — notifications are a side channel and must never break the sweep.

## Diagnostics

`/diagnostics` gains an `evidenceIntegrity` section reporting the **last** sweep, never computing one — re-hashing every artifact is far too heavy for a route the dashboard polls.

```
-- Evidence integrity --
  last verified 2h ago — all 1247 artifacts OK
```

When something is wrong it leads with the failure rather than trailing an all-clear, since that's the line an operator scans for a reason to worry:

```
-- Evidence integrity --
  last verified 2h ago — 3 of 1247 artifacts FAILED verification
  2 custody-log chain break(s)
  affected cases: INC-1
```

## One deliberate deviation

The issue asked for this to *extend `backupManager.ts`'s scheduler*. It reuses the **pattern** — an unref'd `setInterval` beside the scheduled-backup timer — but not the class: state backups and custody verification are unrelated concerns, and folding one into the other would only couple them. The monitor itself is timer-free and synchronously testable.

Two scheduling details worth noting:
- `runSweepIfIdle()` drops an overlapping tick. Re-hashing can outlast the interval on a large install, and two sweeps would compete for the same disk and report over each other.
- A first sweep runs **60s after boot**, not inline — so Diagnostics reports a real answer instead of "not verified yet" for a whole interval, without putting a full re-hash in the startup path.

## Incidental fix

`sampleReport()` in `tests/analysis/diagnostics.test.ts` omitted the new field. That file is on `tsconfig.test.json`'s exclude list — the documented pre-existing debt register — so the omission was a **runtime** failure rather than a type error. Fixed at the fixture.

## Verification

- `npm run typecheck` — clean
- `vitest run` — **472 files, 5836 tests passed**
- 22 new tests: config parsing (including `0` = disabled and a non-numeric fallback), tampered / deleted / archived artifacts, chain breaks with clean files, alerting on problems and silence without them, status before and after a sweep, and the `/diagnostics` surface.

## Scope

Closes item 3 of #231. Builds on #348, #349, #351, #353. Only item 4 — the "Chain of Custody" report appendix — remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
