### PR TITLE
feat(custody): add the Chain of Custody appendix to the report (#231)

### DIFF
--- a/companion/src/reports/html.ts
+++ b/companion/src/reports/html.ts
@@ -3,6 +3,7 @@ import type { InvestigationState } from "../analysis/stateTypes.js";
 import type { CustomerExposureSummary } from "../analysis/customerExposure.js";
 import { buildAssetGraph } from "../analysis/assetGraph.js";
 import { renderMarkdownReport } from "./markdown.js";
+import type { CustodyRecord } from "../analysis/custody.js";
 import { emptyReportMeta, type ReportMeta } from "./reportMeta.js";
 import { defaultReportTemplate, type ReportTemplate } from "./reportTemplate.js";
 import type { NotebookEntry } from "../analysis/notebookStore.js";
@@ -124,8 +125,8 @@ export function injectPrintTrigger(html: string): string {
   return idx === -1 ? html + PRINT_TRIGGER : html.slice(0, idx) + PRINT_TRIGGER + html.slice(idx);
 }
 
-export function renderHtmlReport(state: InvestigationState, meta: ReportMeta = emptyReportMeta(), exposure?: CustomerExposureSummary, assetGraph?: AssetGraph, notebookEntries?: NotebookEntry[], playbookTasks?: PlaybookTask[], template: ReportTemplate = defaultReportTemplate(), hypotheses?: Hypothesis[]): string {
-  const markdown = renderMarkdownReport(state, meta, exposure, assetGraph, notebookEntries, playbookTasks, template, undefined, hypotheses);
+export function renderHtmlReport(state: InvestigationState, meta: ReportMeta = emptyReportMeta(), exposure?: CustomerExposureSummary, assetGraph?: AssetGraph, notebookEntries?: NotebookEntry[], playbookTasks?: PlaybookTask[], template: ReportTemplate = defaultReportTemplate(), hypotheses?: Hypothesis[], custody?: CustodyRecord[]): string {
+  const markdown = renderMarkdownReport(state, meta, exposure, assetGraph, notebookEntries, playbookTasks, template, undefined, hypotheses, undefined, undefined, undefined, undefined, undefined, custody);
 
   const marked = new Marked({ gfm: true });
   // Escape any raw HTML tokens in the source instead of emitting them verbatim.

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -1,4 +1,5 @@
 import type { InvestigationState, Severity, ForensicEvent, Uncertainty } from "../analysis/stateTypes.js";
+import type { CustodyRecord } from "../analysis/custody.js";
 import { byEventTime } from "../analysis/forensicSort.js";
 import { emptyReportMeta, type ReportMeta, type ReportRevision } from "./reportMeta.js";
 import { deriveGlossary } from "./glossary.js";
@@ -1335,6 +1336,50 @@ function analystNotebook(entries: NotebookEntry[], lines: string[]): void {
   }
 }
 
+/**
+ * "Chain of Custody" appendix (#231 item 4): every artifact under custody, with its hash and the
+ * full sequence of events that touched it.
+ *
+ * Grouped by artifact rather than listed as a flat log, because the question a reader of the report
+ * actually has is "what happened to THIS piece of evidence" — a chronological dump of every event
+ * across every artifact answers it only after manual sorting.
+ *
+ * An empty case still renders the heading and says so. A court-facing deliverable that silently
+ * omits the section is indistinguishable from one where custody was never recorded at all.
+ */
+function chainOfCustodySection(custody: CustodyRecord[] | undefined, lines: string[]): void {
+  lines.push("## Appendix — Chain of Custody", "");
+  const records = custody ?? [];
+  if (records.length === 0) {
+    lines.push("No custody records were captured for this case.", "");
+    return;
+  }
+
+  // Insertion order = the order artifacts entered the case.
+  const byArtifact = new Map<string, CustodyRecord[]>();
+  for (const record of records) {
+    const existing = byArtifact.get(record.artifactPath);
+    if (existing) existing.push(record);
+    else byArtifact.set(record.artifactPath, [record]);
+  }
+
+  lines.push(`${byArtifact.size} artifact(s) under custody, ${records.length} recorded event(s).`, "");
+  for (const [artifactPath, chain] of byArtifact) {
+    const name = artifactPath.split(/[\\/]/).pop() || artifactPath;
+    lines.push(`### ${cellMd(name)}`, "");
+    lines.push(`- Path: \`${artifactPath}\``);
+    // The hash from the most recent event: what the artifact was last known to be.
+    lines.push(`- SHA-256: \`${chain[chain.length - 1].sha256}\``, "");
+    lines.push("| # | Event | When (UTC) | By | Source | Trigger |", "| --- | --- | --- | --- | --- | --- |");
+    for (const r of chain) {
+      lines.push(
+        `| ${r.seq ?? ""} | ${cellMd(r.event ?? "collected")} | ${cellMd(r.collectedAt)} | ${cellMd(r.collectedBy)} | ${cellMd(r.source)} | ${cellMd(r.trigger)} |`,
+      );
+    }
+    lines.push("");
+  }
+}
+
 export function renderMarkdownReport(
   state: InvestigationState,
   meta: ReportMeta = emptyReportMeta(),
@@ -1350,6 +1395,7 @@ export function renderMarkdownReport(
   lateralPaths?: LateralPath[],   // prebuilt with analyst dismissals applied; derived here when absent
   modelPerf?: ModelPerfSnapshot | null,  // #74: model-performance footnote (opt-in via DFIR_REPORT_MODEL_PERF)
   complianceControl?: ComplianceControl,  // #336: analyst-set discovery date + framework filter
+  custody?: CustodyRecord[],   // #231: per-artifact chain of custody for the appendix
 ): string {
   const lines: string[] = [];
   const ctx = buildBrandingContext(state, meta);
@@ -1401,6 +1447,7 @@ export function renderMarkdownReport(
     notebook: () => {
       if (notebookEntries && notebookEntries.length > 0) analystNotebook(notebookEntries, lines);
     },
+    chainOfCustody: () => chainOfCustodySection(custody, lines),
   };
 
   for (const key of orderedEnabledSections(template)) builders[key]();

--- a/companion/src/reports/reportTemplate.ts
+++ b/companion/src/reports/reportTemplate.ts
@@ -36,6 +36,7 @@ export const REPORT_SECTION_DEFS = [
   { key: "d3fend", label: "Mitigation & defensive countermeasures (ATT&CK + D3FEND)" },
   { key: "compliance", label: "Compliance Impact (control failures & notification obligations)" },
   { key: "notebook", label: "Analyst Notebook" },
+  { key: "chainOfCustody", label: "Chain of Custody (per-artifact custody chain)" },
 ] as const;
 
 export type ReportSectionKey = (typeof REPORT_SECTION_DEFS)[number]["key"];
@@ -187,6 +188,9 @@ export const BUILT_IN_REPORT_TEMPLATES: readonly ReportTemplate[] = [
       { key: "d3fend", enabled: false },
       { key: "compliance", enabled: true },
       { key: "notebook", enabled: false },
+      // Off for the same reason as sessions: a per-artifact custody table is operator detail, and
+      // this template exists to keep the client-facing brief short. The full report carries it.
+      { key: "chainOfCustody", enabled: false },
     ],
   }),
   normalizeReportTemplate({

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -6,6 +6,7 @@ import { NO_SCOPE, type ScopeStore } from "../analysis/scope.js";
 import { projectScope } from "../analysis/scopeProject.js";
 import { applyFalsePositive, filterFalsePositiveEvents, type FalsePositiveStore } from "../analysis/falsePositive.js";
 import { renderMarkdownReport } from "./markdown.js";
+import type { CustodyRecord, CustodyStore } from "../analysis/custody.js";
 import { renderHtmlReport } from "./html.js";
 import { renderDocxReport } from "./docx.js";
 import { emptyReportMeta, type ReportMetaStore } from "./reportMeta.js";
@@ -102,6 +103,7 @@ export interface ReportWriterOptions {
   reportVersions?: ReportVersionStore;   // #77 report versioning (diff & rollback)
   complianceControl?: ComplianceControlStore;   // #336 discovery date + framework filter
   clockSkew?: ClockSkewStore;   // #228 per-host clock offsets + the alignment toggle
+  custodyStore?: CustodyStore;   // #231 chain-of-custody appendix
 }
 
 export class ReportWriter {
@@ -121,6 +123,7 @@ export class ReportWriter {
   private readonly lateralPathDismissals?: LateralPathDismissStore;
   private readonly reportVersions?: ReportVersionStore;
   private readonly complianceControl?: ComplianceControlStore;
+  private readonly custodyStore?: CustodyStore;
 
   constructor(
     private readonly cases: CaseStore,
@@ -128,6 +131,7 @@ export class ReportWriter {
     opts: ReportWriterOptions = {},
   ) {
     this.scope = opts.scope;
+    this.custodyStore = opts.custodyStore;
     this.falsePositives = opts.falsePositives;
     this.reportMeta = opts.reportMeta;
     this.customerExposure = opts.customerExposure;
@@ -498,10 +502,11 @@ export class ReportWriter {
     lateralPaths?: LateralPath[],
     modelPerf?: ModelPerfSnapshot | null,
     complianceControl?: ComplianceControl,
+    custody?: CustodyRecord[],
   ): RedactedReportContents {
     return {
-      markdown: renderMarkdownReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths, modelPerf, complianceControl),
-      html: renderHtmlReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, hypotheses),
+      markdown: renderMarkdownReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths, modelPerf, complianceControl, custody),
+      html: renderHtmlReport(state, meta, exposure, graph, notebookEntries, playbookTasks, template, hypotheses, custody),
       findingsCsv: findingsCsv(state),
       iocsCsv: iocsCsv(state),
       timelineCsv: timelineCsv(state),
@@ -537,7 +542,8 @@ export class ReportWriter {
     const lateralPaths = filterDismissedPaths(buildLateralPaths(state), await this.loadLateralPathDismissals(caseId));
     const modelPerf = await this.loadModelPerf(caseId);
     const complianceControl = this.complianceControl ? await this.complianceControl.load(caseId) : {};
-    const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths, modelPerf, complianceControl);
+    const custody = this.custodyStore ? await this.custodyStore.load(caseId) : undefined;
+    const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths, modelPerf, complianceControl, custody);
     await writeFile(paths.markdown, c.markdown, "utf8");
     await writeFile(paths.html, c.html, "utf8");
     await writeFile(paths.findingsCsv, c.findingsCsv, "utf8");
@@ -606,6 +612,10 @@ export class ReportWriter {
     );
     // The control carries no case data (a date and a framework list), so it needs no redaction.
     const complianceControl = this.complianceControl ? await this.complianceControl.load(caseId) : {};
-    return this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, undefined, lateralPaths, undefined, complianceControl);
+    // Custody records live in custody.jsonl, NOT in investigation.json, so they never passed
+    // through the applyAnonDeep(state) above. Redacting them here is what stops the appendix
+    // shipping real hostnames, analyst names and filesystem paths to an external party (#231).
+    const custody = this.custodyStore ? applyAnonDeep(await this.custodyStore.load(caseId), redact) : undefined;
+    return this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, undefined, lateralPaths, undefined, complianceControl, custody);
   }
 }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -3569,6 +3569,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
   const irisExportStore = new IrisExportStore(store);
   const lateralPathDismissStore = new LateralPathDismissStore(store);
   const reportWriter = new ReportWriterImpl(store, stateStore, {
+    custodyStore,
     scope: new ScopeStore(store),
     falsePositives: new FalsePositiveStore(store),
     reportMeta: reportMetaStore,

--- a/companion/tests/reports/chainOfCustodySection.test.ts
+++ b/companion/tests/reports/chainOfCustodySection.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { renderMarkdownReport } from "../../src/reports/markdown.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+import { emptyReportMeta } from "../../src/reports/reportMeta.js";
+import { normalizeReportTemplate, REPORT_SECTION_DEFS } from "../../src/reports/reportTemplate.js";
+import type { CustodyRecord } from "../../src/analysis/custody.js";
+
+// The "Chain of Custody" report appendix (#231 item 4). The custody store and its verification have
+// their own tests; what matters here is what a reader of the DOCUMENT sees — that each artifact is
+// listed with its hash and every event that touched it, and that an empty case does not leave a
+// bare heading behind in a court-facing deliverable.
+
+function record(over: Partial<CustodyRecord> = {}): CustodyRecord {
+  return {
+    artifactPath: "/cases/INC-1/imports/0001_evidence.csv",
+    sha256: "a".repeat(64),
+    collectedBy: "alice",
+    collectedAt: "2026-07-28T10:00:00.000Z",
+    source: "WORKSTATION-7",
+    trigger: "import",
+    caseId: "INC-1",
+    event: "collected",
+    seq: 1,
+    prevHash: "",
+    ...over,
+  };
+}
+
+// A template with ONLY the custody section, so assertions cannot match a neighbouring section.
+const custodyOnly = normalizeReportTemplate({
+  id: "t",
+  name: "custody only",
+  sections: REPORT_SECTION_DEFS.map((s) => ({ key: s.key, enabled: s.key === "chainOfCustody" })),
+});
+
+const render = (custody?: CustodyRecord[]): string =>
+  renderMarkdownReport(
+    emptyState("INC-1"), emptyReportMeta(), undefined, undefined, undefined, undefined,
+    custodyOnly, undefined, undefined, [], null, undefined, null, undefined, custody,
+  );
+
+describe("chain of custody appendix", () => {
+  it("is offered as a toggleable report section", () => {
+    expect(REPORT_SECTION_DEFS.map((s) => s.key)).toContain("chainOfCustody");
+  });
+
+  it("lists each artifact with its hash", () => {
+    const text = render([record()]);
+
+    expect(text).toContain("Chain of Custody");
+    expect(text).toContain("0001_evidence.csv");
+    expect(text).toContain("a".repeat(64));
+  });
+
+  it("lists every event that touched an artifact, in order", () => {
+    const text = render([
+      record(),
+      record({ event: "transferred", collectedBy: "bob", collectedAt: "2026-07-28T11:00:00.000Z", source: "lab-3", seq: 2 }),
+      record({ event: "exported", collectedBy: "alice", collectedAt: "2026-07-28T12:00:00.000Z", source: "encrypted archive", seq: 3 }),
+    ]);
+
+    expect(text.indexOf("collected")).toBeLessThan(text.indexOf("transferred"));
+    expect(text.indexOf("transferred")).toBeLessThan(text.indexOf("exported"));
+    expect(text).toContain("bob");
+    expect(text).toContain("lab-3");
+  });
+
+  it("groups events under the artifact they belong to", () => {
+    const text = render([
+      record(),
+      record({ artifactPath: "/cases/INC-1/screenshots/000001_shot.webp", sha256: "b".repeat(64), seq: 2 }),
+    ]);
+
+    expect(text).toContain("0001_evidence.csv");
+    expect(text).toContain("000001_shot.webp");
+    expect(text).toContain("b".repeat(64));
+  });
+
+  it("says so plainly when nothing was recorded, rather than leaving a bare heading", () => {
+    const text = render([]);
+
+    expect(text).toContain("Chain of Custody");
+    expect(text).toMatch(/no custody records/i);
+  });
+
+  it("renders nothing at all when the section is disabled", () => {
+    const withoutCustody = normalizeReportTemplate({
+      id: "t2",
+      name: "no custody",
+      sections: REPORT_SECTION_DEFS.map((s) => ({ key: s.key, enabled: s.key !== "chainOfCustody" })),
+    });
+
+    const text = renderMarkdownReport(
+      emptyState("INC-1"), emptyReportMeta(), undefined, undefined, undefined, undefined,
+      withoutCustody, undefined, undefined, [], null, undefined, null, undefined, [record()],
+    );
+
+    expect(text).not.toContain("Chain of Custody");
+  });
+
+  it("does not break a report rendered without any custody data at all", () => {
+    expect(() => render(undefined)).not.toThrow();
+  });
+});

--- a/companion/tests/reports/chainOfCustodyWriter.test.ts
+++ b/companion/tests/reports/chainOfCustodyWriter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import { ReportWriter } from "../../src/reports/reportWriter.js";
+
+let cases: CaseStore;
+let custody: CustodyStore;
+let writer: ReportWriter;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-custodyreport-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  custody = new CustodyStore(cases);
+  const state = new StateStore(cases);
+  writer = new ReportWriter(cases, state, { custodyStore: custody });
+
+  const artifactPath = join(cases.importsDir("c1"), "0001_evidence.csv");
+  await writeFile(artifactPath, "ts,message\n", "utf8");
+  await custody.record("c1", {
+    artifactPath, sha256: "a".repeat(64), collectedBy: "alice",
+    collectedAt: "2026-07-28T10:00:00.000Z", source: "WORKSTATION-7", trigger: "import", caseId: "c1",
+  });
+});
+
+describe("chain of custody in the generated report", () => {
+  it("appears in the written Markdown report", async () => {
+    await writer.writeAll("c1");
+
+    const md = await readFile(join(cases.reportsDir("c1"), "report.md"), "utf8");
+    expect(md).toContain("Chain of Custody");
+    expect(md).toContain("0001_evidence.csv");
+    expect(md).toContain("WORKSTATION-7");
+  });
+
+  it("appears in the HTML report too, since it renders from the same Markdown", async () => {
+    await writer.writeAll("c1");
+
+    const html = await readFile(join(cases.reportsDir("c1"), "report.html"), "utf8");
+    expect(html).toContain("Chain of Custody");
+    expect(html).toContain("0001_evidence.csv");
+  });
+});
+
+describe("chain of custody in the REDACTED export", () => {
+  // Custody records live in custody.jsonl, not in investigation.json — so they do NOT pass through
+  // applyAnonDeep(state) like everything else the redacted report renders. Without explicit
+  // redaction the appendix would ship the victim's hostnames and real filesystem paths to an
+  // external party, which is the exact leak the redacted export exists to prevent.
+  it("tokenizes the hostnames and paths in the custody appendix", async () => {
+    const redact = (s: string) =>
+      s.replace(/WORKSTATION-7/g, "ANON_HOST_1").replace(/0001_evidence\.csv/g, "ANON_PATH_1");
+
+    const { markdown } = await writer.redactedReportContents("c1", redact);
+
+    expect(markdown).toContain("Chain of Custody");
+    expect(markdown).toContain("ANON_HOST_1");
+    expect(markdown).not.toContain("WORKSTATION-7");
+    expect(markdown).not.toContain("0001_evidence.csv");
+  });
+});


### PR DESCRIPTION
## Why

The last piece of #231. The custody chain existed, was verified, and was signed — but never reached the deliverable an analyst actually hands over.

## What

A new `chainOfCustody` report section renders every artifact with its SHA-256 and the full sequence of events that touched it:

```
## Appendix — Chain of Custody

2 artifact(s) under custody, 4 recorded event(s).

### 0001_evidence.csv
- Path: `/cases/INC-1/imports/0001_evidence.csv`
- SHA-256: `a1b2…`

| # | Event | When (UTC) | By | Source | Trigger |
| --- | --- | --- | --- | --- | --- |
| 1 | collected | 2026-07-28T10:00:00.000Z | alice | WORKSTATION-7 | import |
| 3 | exported | 2026-07-28T12:00:00.000Z | alice | encrypted archive | export |
```

Grouped **by artifact** rather than as a flat log: the question a reader has is "what happened to *this* piece of evidence", and a chronological dump across every artifact answers it only after manual sorting.

An empty case still renders the heading and says no records were captured — a court-facing deliverable that silently omits the section is indistinguishable from one where custody was never recorded at all.

It is a normal template key, so it reorders and toggles like any other. Markdown is the single source of truth, so HTML and DOCX pick it up automatically. It is **off** in the Executive Brief built-in, for the same reason `sessions` is: a per-artifact custody table is operator detail and that template exists to stay short.

## The redaction trap this closes

Custody records live in `custody.jsonl`, **not** `investigation.json` — so they do *not* pass through the `applyAnonDeep(state)` that redacts everything else in the redacted export. Rendering the appendix without handling this would have shipped real hostnames, analyst names and filesystem paths to an external party: precisely the leak that export exists to prevent.

`redactedReportContents` now runs the records through `applyAnonDeep` before rendering, and a test asserts the raw hostname and filename are absent from the output.

**A consequence worth knowing:** the anonymizer tokenizes indiscriminately, so an artifact's SHA-256 is redacted along with its path. The redacted appendix therefore shows the *structure* of the chain rather than verifiable hashes. That's the safe direction — the unredacted report and the signed manifest are where hashes get checked — but it's a deliberate choice, not an oversight, and worth a second opinion if you'd rather hashes survive redaction.

## Verification

- `npm run typecheck` — clean
- `vitest run` — **474 files, 5846 tests passed**
- 10 new tests: per-artifact grouping, event ordering, the empty case, the disabled section, presence in the written Markdown and HTML, and the redaction guarantee.
- Also updates the Executive Brief's section list and the two built-in-template tests that enumerate it.

## Scope

Closes item 4 — the last of #231. Builds on #348, #349, #351, #353, #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
