### PR TITLE
feat(custody): show the chain of custody in the dashboard (#231)

### DIFF
--- a/companion/src/analysis/dashboardViews.ts
+++ b/companion/src/analysis/dashboardViews.ts
@@ -79,6 +79,7 @@ export const DASHBOARD_SECTION_IDS: readonly string[] = [
   "sec-notebook",
   "sec-inv-log",
   "sec-activity",
+  "sec-custody",
   "sec-case-details",
 ];
 
@@ -123,6 +124,7 @@ export const BUILT_IN_DASHBOARD_VIEWS: readonly DashboardView[] = [
       "sec-source-trust",
       "sec-hypotheses",
       "sec-notebook",
+      "sec-custody",
       "sec-case-details",
     ],
     defaultSort: "time",
@@ -206,6 +208,7 @@ export const BUILT_IN_DASHBOARD_VIEWS: readonly DashboardView[] = [
       "sec-questions",
       "sec-uncertainties",
       "sec-compliance",
+      "sec-custody",
       "sec-case-details",
     ],
     defaultSort: "severity",
@@ -243,6 +246,7 @@ export const BUILT_IN_DASHBOARD_VIEWS: readonly DashboardView[] = [
       "sec-source-trust",
       "sec-notebook",
       "sec-activity",
+      "sec-custody",
     ],
     defaultSort: "time",
     reportTemplateId: "technical-detailed",

--- a/companion/tests/analysis/dashboardViews.test.ts
+++ b/companion/tests/analysis/dashboardViews.test.ts
@@ -88,6 +88,7 @@ describe("dashboardViews — seed integrity", () => {
       "sec-source-trust",
       "sec-hypotheses",
       "sec-notebook",
+      "sec-custody",
       "sec-case-details",
     ]);
   });

--- a/companion/tests/server/dashboardCustodySection.test.ts
+++ b/companion/tests/server/dashboardCustodySection.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// The dashboard is a single hand-written HTML file with inline JS and no DOM test harness in this
+// repo, so behaviour cannot be asserted here. What CAN be asserted is the wiring — the three
+// mistakes that make a new section silently dead: markup with no loader, a loader never called on
+// case open, or a section missing from the visibility registry so it can never be toggled.
+// This is a smoke test for those, not a substitute for looking at the page.
+
+let html: string;
+
+beforeAll(async () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  html = await readFile(join(here, "..", "..", "..", "public", "dashboard.html"), "utf8");
+});
+
+describe("Chain of Custody dashboard section (#231)", () => {
+  it("has its own section element", () => {
+    expect(html).toContain('<section id="sec-custody"');
+    expect(html).toContain('id="custodyPanel"');
+  });
+
+  it("is registered in the section-visibility list, so it can be hidden like any other", () => {
+    expect(html).toMatch(/\{\s*id:\s*"sec-custody",\s*label:\s*"Chain of Custody"\s*\}/);
+  });
+
+  it("loads its records when a case is opened", () => {
+    expect(html).toContain("loadCustody(caseId);");
+    expect(html).toContain("/custody`");
+  });
+
+  it("offers verification and the signed manifest", () => {
+    expect(html).toContain('id="custodyVerifyBtn"');
+    expect(html).toContain('id="custodyManifestLink"');
+    expect(html).toContain("/custody/verify`");
+    expect(html).toContain("/custody/manifest`");
+  });
+
+  it("escapes every custody field it renders, since paths and sources are attacker-influenced", () => {
+    // A capture's source is a page URL and an artifact path carries a filename — both reach this
+    // panel from outside, so neither may be interpolated raw.
+    const panel = html.slice(html.indexOf("function renderCustody()"), html.indexOf("function loadCustody("));
+    expect(panel).not.toMatch(/\$\{r\.(source|collectedBy|trigger|event|sha256)\}/);
+    expect(panel).not.toMatch(/\$\{(path|name)\}/);
+    expect(panel).toContain("esc(r.source)");
+    expect(panel).toContain("escAttr(path)");
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4952,6 +4952,15 @@
       </div>
       <div id="activityLogPanel">—</div>
     </section>
+    <section id="sec-custody" style="grid-column: 1 / -1"><h2>Chain of Custody<span class="ev-sub">every stored artifact, its hash, and each event that touched it &mdash; the appendix that ships in the report</span></h2>
+      <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:8px">
+        <button id="custodyVerifyBtn" type="button" title="Re-hash every artifact in this case now and re-walk the custody log">&#128274; Verify now</button>
+        <button id="custodyRefreshBtn" type="button" title="Reload the custody records">&#8635; Refresh</button>
+        <a id="custodyManifestLink" href="#" target="_blank" rel="noopener" title="Download the signed custody manifest for this case">&#11015; Signed manifest</a>
+        <span id="custodyVerifyMsg" class="manual-msg"></span>
+      </div>
+      <div id="custodyPanel">&mdash;</div>
+    </section>
     <section id="sec-case-details" style="grid-column: 1 / -1" class="collapsed">
       <h2>Case Details (for the generated report)</h2>
       <div id="reportMeta">
@@ -13833,6 +13842,113 @@
       });
     })();
 
+    // ── Chain of Custody (#231) ───────────────────────────────────────────────────────────
+    // Every artifact this case has stored, grouped with the full sequence of events that touched
+    // it. Grouped by artifact rather than shown as a flat log because the question an analyst has
+    // is "what happened to THIS piece of evidence" — the same reasoning as the report appendix.
+    // Verification state is filled in by "Verify now" (a re-hash of every artifact, which is far
+    // too heavy to run just because a panel rendered).
+    let custodyRecords = [];
+    let custodyFailedPaths = new Set();
+    let custodyVerifiedAt = null;
+
+    function custodyGroupByArtifact(records) {
+      const byPath = new Map();
+      for (const r of records) {
+        const chain = byPath.get(r.artifactPath);
+        if (chain) chain.push(r); else byPath.set(r.artifactPath, [r]);
+      }
+      return byPath;
+    }
+
+    function renderCustody() {
+      const el = document.getElementById("custodyPanel");
+      if (!el) return;
+      if (!custodyRecords.length) {
+        el.innerHTML = "<div style='color:var(--c-9aa4b2);font-size:12px'>No custody records for this case yet. Artifacts are recorded automatically as screenshots and imports are stored.</div>";
+        return;
+      }
+      const byPath = custodyGroupByArtifact(custodyRecords);
+      const rows = [];
+      byPath.forEach((chain, path) => {
+        const name = path.split(/[\\/]/).pop() || path;
+        const last = chain[chain.length - 1];
+        const failed = custodyFailedPaths.has(path);
+        const state = failed
+          ? "<span style='color:#e5484d;font-weight:600' title='This artifact no longer matches its recorded hash, or is missing'>&#9888; FAILED</span>"
+          : (custodyVerifiedAt ? "<span style='color:#46a758' title='Re-hashed and matching'>&#10003; verified</span>" : "<span style='color:var(--c-9aa4b2)'>&mdash;</span>");
+        const events = chain.map(r => `<tr style="border-bottom:1px solid var(--c-2a2f3a)">
+            <td style="padding:3px 8px;white-space:nowrap;color:var(--c-9aa4b2)">${esc(String(r.seq ?? ""))}</td>
+            <td style="padding:3px 8px;white-space:nowrap">${esc(r.event || "collected")}</td>
+            <td style="padding:3px 8px;white-space:nowrap;color:var(--c-9aa4b2)" title="${escAttr(r.collectedAt)}">${activityTimeAgo(r.collectedAt)}</td>
+            <td style="padding:3px 8px;white-space:nowrap">${esc(r.collectedBy)}</td>
+            <td style="padding:3px 8px">${esc(r.source)}</td>
+            <td style="padding:3px 8px;white-space:nowrap;color:var(--c-9aa4b2)">${esc(r.trigger)}</td>
+          </tr>`).join("");
+        rows.push(`<details style="border-bottom:1px solid var(--c-2a2f3a)">
+          <summary style="padding:5px 8px;cursor:pointer;display:grid;grid-template-columns:1fr auto auto auto;gap:10px;align-items:center;font-size:12px">
+            <span title="${escAttr(path)}">${esc(name)}</span>
+            <span style="color:var(--c-9aa4b2)">${chain.length} event(s)</span>
+            <code style="color:var(--c-9aa4b2);font-size:11px" title="${escAttr(last.sha256)}">${esc(String(last.sha256).slice(0, 12))}&hellip;</code>
+            <span>${state}</span>
+          </summary>
+          <div style="padding:4px 8px 10px">
+            <div style="font-size:11px;color:var(--c-9aa4b2);margin-bottom:4px">${esc(path)}</div>
+            <table style="width:100%;font-size:12px;border-collapse:collapse">
+              <tr style="color:var(--c-9aa4b2)"><td style="padding:3px 8px">#</td><td style="padding:3px 8px">Event</td><td style="padding:3px 8px">When</td><td style="padding:3px 8px">By</td><td style="padding:3px 8px">Source</td><td style="padding:3px 8px">Trigger</td></tr>
+              ${events}
+            </table>
+          </div>
+        </details>`);
+      });
+      el.innerHTML = `<div style="font-size:12px;color:var(--c-9aa4b2);margin-bottom:6px">${byPath.size} artifact(s), ${custodyRecords.length} recorded event(s).</div>` + rows.join("");
+    }
+
+    function loadCustody(caseId) {
+      fetch(`/cases/${caseId}/custody`)
+        .then(r => r.ok ? r.json() : { records: [] })
+        .then(d => { custodyRecords = d.records || []; renderCustody(); })
+        .catch(() => {});
+      const link = document.getElementById("custodyManifestLink");
+      if (link) link.href = `/cases/${caseId}/custody/manifest`;
+    }
+
+    (function initCustodyButtons() {
+      const verifyBtn = document.getElementById("custodyVerifyBtn");
+      const refreshBtn = document.getElementById("custodyRefreshBtn");
+      const msg = document.getElementById("custodyVerifyMsg");
+      if (refreshBtn) refreshBtn.addEventListener("click", () => {
+        const caseId = document.getElementById("caseId").value.trim();
+        if (caseId) loadCustody(caseId);
+      });
+      if (!verifyBtn) return;
+      verifyBtn.addEventListener("click", () => {
+        const caseId = document.getElementById("caseId").value.trim();
+        if (!caseId) return;
+        verifyBtn.disabled = true;
+        if (msg) msg.textContent = "Re-hashing evidence…";
+        // The synchronous verify endpoint: it re-reads every artifact, so it can take a while on a
+        // case holding disk images. The button stays disabled until it answers.
+        fetch(`/cases/${caseId}/custody/verify`)
+          .then(r => r.ok ? r.json() : null)
+          .then(d => {
+            if (!d) { if (msg) msg.textContent = "Verification unavailable."; return; }
+            custodyFailedPaths = new Set((d.mismatches || []).map(m => m.artifactPath));
+            custodyVerifiedAt = new Date().toISOString();
+            const breaks = (d.chainBreaks || []).length;
+            if (msg) {
+              msg.textContent = d.ok
+                ? "All artifacts verified, custody log intact."
+                : `${custodyFailedPaths.size} artifact(s) failed${breaks ? `, ${breaks} custody-log chain break(s)` : ""}.`;
+              msg.style.color = d.ok ? "#46a758" : "#e5484d";
+            }
+            renderCustody();
+          })
+          .catch(() => { if (msg) msg.textContent = "Verification failed to run."; })
+          .finally(() => { verifyBtn.disabled = false; });
+      });
+    })();
+
     // ── Hunting Profile (#157) ────────────────────────────────────────────────────────────
     // The per-case hunt feedback loop, surfaced read-only: every hunt deployed in this case (fleet /
     // playbook / technique / bundle) with whether it found new evidence. Auto-loaded on case open and
@@ -16544,6 +16660,7 @@
       history.replaceState(null, "", "?caseId=" + encodeURIComponent(caseId) + location.hash);   // keep #event=... (deep link) intact
       const stateLoadPromise = fetch(`/cases/${caseId}/state`, { signal: loadSignal }).then(r => r.json()).then(state => { render(state); jumpToEventFromHash(); }).catch(() => {});
       verifyCustodyOnOpen(caseId);
+      loadCustody(caseId);
       pollCount(caseId);
       loadAiToggle(caseId);
       loadEnrichToggle(caseId);
@@ -19208,6 +19325,7 @@
       { id: "sec-notebook",     label: "Analyst Notebook" },
       { id: "sec-inv-log",      label: "Investigation Log" },
       { id: "sec-activity",     label: "Activity Log" },
+      { id: "sec-custody",      label: "Chain of Custody" },
       { id: "sec-case-details", label: "Case Details" },
     ];
 


### PR DESCRIPTION
## Why

Everything built for #231 was reachable only through the API and one line in the Diagnostics text blob. An analyst who hadn't read the PRs could not tell the feature existed.

## What

A **Chain of Custody** section next to the Activity Log — the two are siblings: *what was done to this case* / *what happened to each piece of evidence*.

Each artifact is one collapsible row with its filename, event count, short hash and verification state; expanding shows the full chain. Grouped by artifact rather than as a flat log, matching the report appendix and for the same reason — the question is "what happened to *this* artifact", which a chronological dump answers only after manual sorting.

It also doubles as the listing of what a case actually holds, which the dashboard didn't have before.

Three controls: **Verify now** (the synchronous per-case re-hash, marking failed artifacts red inline), **Refresh**, and a link to the **signed manifest**. No new endpoints — `GET /custody`, `GET /custody/verify` and `GET /custody/manifest` already existed.

## The bug that running the app caught

Registering the section in `dashboard.html` alone was **not enough**. `applyViewLayout()` pins every section absent from a curated dashboard view to hidden, so the section was invisible under the default Analyst view — the feature would have shipped still undiscoverable. It's now in `DASHBOARD_SECTION_IDS` and in the Analyst, Report and Deep Dive views (Report especially, since the custody appendix is a report deliverable).

I would not have found this from unit tests.

## Verification — by running it

- Posted a real capture through `/captures`; the section rendered the artifact and its chain (`collected · browser-extension · https://velociraptor.local/hunts · navigation`).
- **Verify now** → "All artifacts verified, custody log intact", row marked ✓.
- Appended bytes to the stored `.webp` on disk, re-verified → **"1 artifact(s) failed"**, row marked ⚠ FAILED in red.
- Manifest link returns a signed manifest with a chain head.

Plus `npm run typecheck` clean and `vitest run` — **476 files, 5867 tests passed**.

## On the test I added

The dashboard is a single hand-written HTML file with inline JS and this repo has **no DOM test harness**, so behaviour can't be asserted in vitest. `tests/server/dashboardCustodySection.test.ts` is a smoke test for the three wiring mistakes that make a section silently dead — markup with no loader, a loader never called on connect, a section missing from the visibility registry — plus an assertion that every rendered custody field is escaped, since artifact paths and capture sources come from outside.

Being straight about it: **it was written after the markup, not before.** It can only assert on finished output, so it isn't TDD and shouldn't be read as such. I checked the escaping assertions actually fail on raw interpolation rather than passing vacuously.

## Scope

Closes the UI gap called out in the #231 closing summary. Docs and CHANGELOG coverage are still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
