### PR TITLE
docs(custody): use the Companion's real port in the custody API example (#231)

### DIFF
--- a/mkdocs-docs/reference/chain-of-custody.md
+++ b/mkdocs-docs/reference/chain-of-custody.md
@@ -31,7 +31,7 @@ Report, STIX, IRIS and ClickUp exports carry conclusions rather than evidence, s
 Evidence the Companion never stored itself — a mounted disk image, output from an external tool, or a physical handover — is recorded through the API:
 
 ```bash
-curl -X POST http://localhost:3000/cases/INC-1/custody \
+curl -X POST http://127.0.0.1:4773/cases/INC-1/custody \
   -H 'content-type: application/json' \
   -d '{"artifactPath":"/mnt/evidence/laptop.dd","collectedBy":"alice","source":"seized 2026-07-28","event":"collected"}'
 ```


### PR DESCRIPTION
The manual-recording example in `reference/chain-of-custody.md` said `localhost:3000`. The Companion's default port is **4773** (`DEFAULT_PORT` in `server.ts`), and every other docs page writes it as `http://127.0.0.1:4773`.

So the one command on that page a reader would copy-paste was the one that couldn't work. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)