### PR TITLE
test(load): measure against a batch so a coarse CPU clock can't collapse the limit

### DIFF
--- a/companion/tests/analysis/loadTest.test.ts
+++ b/companion/tests/analysis/loadTest.test.ts
@@ -279,15 +279,49 @@ interface Measurement { ms: number; result: unknown }
 // process.cpuUsage() counts only cycles actually burned on this process's behalf, so time spent
 // waiting for a core simply isn't counted. Every measured fn here is synchronous, so nothing else
 // in this worker can run inside the window and contribute. Same minimum-of-N, honest clock.
+//
+// What that clock does NOT give is equal resolution everywhere. On Linux it is microsecond-grained,
+// but on Windows it advances in ~15.6ms scheduler ticks, so any run cheaper than one tick measures
+// as exactly 0. Three of the paths below cost 0.1-4.6 CPU-ms at baseline size, so on the Windows
+// release runner their baselines read 0 — and a 0 baseline collapses the allowance in
+// expectSubQuadratic() from baseline*GROWTH_LIMIT + FLOOR_MS to FLOOR_MS alone, several times
+// tighter than intended. That is what failed the release job during #366, on a path nobody had
+// touched: correlateEvents reported "0.0ms → 93.0ms" against a 25ms limit.
+//
+// So time a BATCH of calls and divide. The window then clears the tick and the per-call figure is
+// honest on every platform. Every figure in the table below is per-call CPU-time.
+const MIN_SAMPLE_MS = 50;   // ~3 Windows ticks, so quantization error is well under 1%.
+// Backstop against a path so cheap it could never fill a window. Reaching it needs a call under
+// ~0.01ms, and at that size the full-size run is under a millisecond too — orders of magnitude
+// inside FLOOR_MS — so the assertion still cannot fail on an unresolved measurement.
+const MAX_BATCH = 4096;
+
 function bestOf(fn: () => unknown, repeats: number): Measurement {
+  let batch = 1;
   let ms = Infinity;
   let result: unknown;
   for (let i = 0; i < repeats; i++) {
-    const start = process.cpuUsage();
-    result = fn();
-    const { user, system } = process.cpuUsage(start);
-    const elapsed = (user + system) / 1000;   // microseconds → milliseconds
-    if (elapsed < ms) ms = elapsed;
+    // Double the batch until one window clears MIN_SAMPLE_MS. Doubling rather than scaling a pilot
+    // estimate, because the reading being calibrated against is exactly the one that can come back
+    // 0 — there is nothing to divide by. Undersized windows are discarded rather than counted,
+    // since a reading below the clock's resolution is the very thing this avoids.
+    //
+    // `batch` lives outside the repeat loop, so this converges once and later repeats go straight
+    // through: the total cost is `repeats` honest windows plus one batch's worth of calibration.
+    // A path that already fills a window on its own — renderMarkdownReport at ~500ms — settles at
+    // batch 1 on its first sample and keeps it, so it is measured exactly as it was before.
+    for (;;) {
+      const start = process.cpuUsage();
+      for (let j = 0; j < batch; j++) result = fn();
+      const { user, system } = process.cpuUsage(start);
+      const elapsed = (user + system) / 1000;   // microseconds → milliseconds
+      if (elapsed >= MIN_SAMPLE_MS || batch >= MAX_BATCH) {
+        const perCall = elapsed / batch;
+        if (perCall < ms) ms = perCall;
+        break;
+      }
+      batch *= 2;
+    }
   }
   return { ms, result };
 }


### PR DESCRIPTION
The Windows leg of the release build failed on a path nobody had touched — [run 30445076058](https://github.com/hasamba/DFIR-Companion/actions/runs/30445076058), surfaced by the dry run for #366:

```
correlateEvents (1250→10000 events): 0.0ms → 93.0ms (n/a for 8x input)
— expected under 25.0ms: expected 93 to be less than 25
```

## The bug is the `0.0ms`

`bestOf` measures `process.cpuUsage()`. That counter is microsecond-grained on Linux but advances in ~15.6 ms scheduler ticks on Windows, so any run cheaper than a tick reads exactly 0. `expectSubQuadratic` then computes `baseline * GROWTH_LIMIT + FLOOR_MS`, which at baseline 0 collapses to a flat 25 ms budget for the full 10k-event run — several times tighter than the assertion was ever meant to be.

Not a regression in `correlateEvents`: the same test passes on the ubuntu CI leg, and 5,917 other tests passed alongside it.

It is systemic rather than a one-off. Measured on Linux, three of the five growth paths have sub-tick baselines:

| path | baseline | under a ~15.6 ms tick |
|---|---|---|
| `correlateEvents` | 4.6 ms | reads 0 → **fails** |
| `filterEventsByScope` | 0.7 ms | reads 0 → passes vacuously |
| `applyFalsePositive` | 0.1 ms | both sizes read 0 → vacuous |
| `buildSynthesisContext` | 19.1 ms | resolvable |
| `renderMarkdownReport` | 498 ms | resolvable |

So the Windows leg was asserting almost nothing about three of them.

## The fix

Make the measurement resolvable rather than suppressing the assertion: time a **batch** of calls and divide, doubling the batch until one window clears 50 ms. Doubling rather than scaling a pilot estimate, because the reading being calibrated against is precisely the one that can come back 0 — there is nothing to divide by. The batch is calibrated once per `bestOf` call and reused across its repeats; undersized windows are discarded rather than counted.

Skipping the assertion on a zero baseline was the alternative, and it is worse here: it would blind three of five paths on Windows rather than one.

Costs nothing where it isn't needed — a path that already fills a window settles at batch 1 on its first sample and keeps it, so `renderMarkdownReport` is measured exactly as before. Folding calibration into the measurement loop rather than running a separate pass matters for that: a standalone pass spends an extra full run of the most expensive path, which roughly doubled the file's runtime when I tried it first.

## Verification

Modelled the Windows tick locally by quantizing `process.cpuUsage` to 15.625 ms:

- **before, coarse clock** — `correlateEvents 0.0ms → 78.1ms, expected under 25.0ms` — fails, reproducing CI exactly; `filterEventsByScope` and `applyFalsePositive` both `0.0 → 0.0`
- **after, coarse clock** — 6/6 pass; `correlateEvents 5.9ms → 54.7ms (9.3x)`, `filterEventsByScope 0.7ms → 7.8ms (10.7x)` — meaningful for the first time

**Teeth intact**, which is the point of the test. With an `O(n²)` field comparison injected into `correlateEvents` it fails under *both* clocks — 75.3x against a 459 ms limit on the fine clock, 86.0x against 525 ms on the coarse one. A milder injection (~60 ms of added quadratic work) still passes at 18x, which is by design: `GROWTH_LIMIT` is 32 against the 64x a genuinely quadratic path costs.

Ratios across repeated runs stay inside the ranges the file's calibration table documents, so those figures still stand; they are per-call, and the comment now says so.

Full companion suite 478 files / 5921 tests passing; `npm run typecheck` and `npm run build` clean. File runtime 6.3s → ~10.5s.

## Why it mattered

`release` declares `needs: [windows-exe, linux-appimage, extension-zip]`, so a `windows-exe` failure skips it entirely and a tag publishes **no** release assets at all.

No CHANGELOG entry — test-only, matching #310 and #311 which changed this same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)