### PR TITLE
SO-CRATES API integration: analyze PCAP, binary, and EVTX imports, verdicts into the forensic timeline

### DIFF
--- a/companion/.env.example
+++ b/companion/.env.example
@@ -738,7 +738,8 @@ DFIR_SYNTH_ADVERSARY_HINTS=off
 # A raw import or drop ASKS first unless _AUTO_RUN=on. Apply changes without restart via the
 # "Reconnect" button (POST /tools/reconnect).
 #
-# Per tool, <ID> ∈ HAYABUSA | VELOCIRAPTOR_CLI | SURICATA | SNORT | YARA:
+# Per SPAWNED tool, <ID> ∈ HAYABUSA | VELOCIRAPTOR_CLI | SURICATA | SNORT | YARA
+# (SO-CRATES is an HTTP service — see its own block below):
 #   DFIR_TOOL_<ID>_BINARY          executable path (gates the tool on)
 #   DFIR_TOOL_<ID>_RUN_ARGS        args template (blank = built-in default)
 #   DFIR_TOOL_<ID>_RULES           rules path for <rules> (required for Snort/YARA)
@@ -755,6 +756,18 @@ DFIR_SYNTH_ADVERSARY_HINTS=off
 # DFIR_TOOL_SURICATA_BINARY=/usr/bin/suricata
 # DFIR_TOOL_YARA_BINARY=/usr/bin/yara
 # DFIR_TOOL_YARA_RULES=/opt/yara-rules/index.yar
+#
+# SO-CRATES is the one tool reached over HTTP instead of by spawning a binary, so it is gated on a
+# URL rather than a path and takes no RUN_ARGS / RULES / UPDATE_CMD. It analyzes a pcap with
+# Suricata, a log with Sigma, and anything else with YARA; only the DETECTIONS are imported.
+# Password-protected archives are unpacked by the Companion before upload — the SO-CRATES API can
+# only ever try "infected" and cannot open WinZip AES archives at all.
+# NOTE: SO-CRATES has NO authentication and binds 127.0.0.1 by default. A non-local URL means
+# unauthenticated evidence reachable by anyone who can route to it.
+#   DFIR_TOOL_SOCRATES_URL         service root (gates the tool on), e.g. http://localhost:8000
+#   DFIR_TOOL_SOCRATES_AUTO_RUN    opt-in; default OFF
+#   DFIR_TOOL_SOCRATES_TIMEOUT_MS=1200000   how long to wait for analysis (default 20 min)
+# DFIR_TOOL_SOCRATES_URL=http://localhost:8000
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/companion/src/analysis/dropLog.ts
+++ b/companion/src/analysis/dropLog.ts
@@ -10,17 +10,21 @@ import { join } from "node:path";
 /** The log file's basename inside `drop/`. Also added to dropScan.ts's IGNORED_BASENAMES. */
 export const DROP_LOG_FILE = "drop-log.txt";
 
-export type DropLogStatus = "IMPORTED" | "FAILED" | "PENDING";
+// SUBMITTED is distinct from IMPORTED on purpose: an ASYNCHRONOUS tool (SO-CRATES over HTTP) has only
+// been handed the file at that point. Its verdicts land minutes later, or the analysis fails — either
+// way a second line follows. Logging the handoff as IMPORTED would make this file claim an import that
+// had not happened, and would still claim it if the analysis later failed.
+export type DropLogStatus = "IMPORTED" | "SUBMITTED" | "FAILED" | "PENDING";
 
 export interface DropLogEntry {
   status: DropLogStatus;
   relpath: string;
-  /** Present for FAILED and PENDING; optional for IMPORTED (e.g. "via <tool>" when resolved from pending). */
+  /** Present for FAILED, PENDING and SUBMITTED; optional for IMPORTED (e.g. "via <tool>"). */
   reason?: string;
 }
 
-// "IMPORTED" is the longest status (8 chars); pad the others to match for column alignment.
-const STATUS_WIDTH = 8;
+// "SUBMITTED" is the longest status (9 chars); pad the others to match for column alignment.
+const STATUS_WIDTH = 9;
 
 // Collapse embedded newlines (and surrounding whitespace) to a single space so one logical event
 // never splits across multiple physical lines in drop-log.txt. Real Error messages (Node/Zod/parser)
@@ -52,6 +56,8 @@ export async function appendDropLog(dropDir: string, lines: readonly string[]): 
 export function buildSweepLogEntries(
   sweep: {
     imported: readonly string[];
+    /** Handed to an asynchronous tool; the outcome is appended later. Optional for older callers. */
+    submitted?: readonly { relpath: string; reason: string }[];
     failed: readonly { relpath: string; reason: string }[];
     pendingRawInputs: readonly { relpath: string; ext: string; configured: boolean }[];
   },
@@ -59,6 +65,7 @@ export function buildSweepLogEntries(
 ): { entries: DropLogEntry[]; nextLoggedPending: Set<string> } {
   const entries: DropLogEntry[] = [
     ...sweep.imported.map((relpath): DropLogEntry => ({ status: "IMPORTED", relpath })),
+    ...(sweep.submitted ?? []).map((s): DropLogEntry => ({ status: "SUBMITTED", relpath: s.relpath, reason: s.reason })),
     ...sweep.failed.map((f): DropLogEntry => ({ status: "FAILED", relpath: f.relpath, reason: f.reason })),
     ...sweep.pendingRawInputs
       .filter((p) => !loggedPending.has(p.relpath))

--- a/companion/src/analysis/dropScan.ts
+++ b/companion/src/analysis/dropScan.ts
@@ -11,6 +11,7 @@
 
 import { extname, basename } from "node:path";
 import { DROP_LOG_FILE } from "./dropLog.js";
+import { SOCRATES_EXTS } from "../integrations/tools/toolConfig.js";
 
 /** A drop-folder file as seen by one poll: its path relative to `drop/`, plus size + mtime. */
 export interface DropFileStat {
@@ -36,6 +37,34 @@ export const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif", ".b
 // Raw binary evidence the Companion can't parse natively — routed to the external-tool run path (#211),
 // never read as text. Kept in sync with the tool `extensions` in integrations/tools/toolConfig.ts.
 export const RAW_TOOL_EXTS = new Set([".evtx", ".evt", ".pcap", ".pcapng"]);
+
+// Text formats the Companion parses natively. The binary sniff must never override these — a .csv
+// with a stray NUL is still a CSV for the native importer, not a malware sample.
+const NATIVE_TEXT_EXTS = new Set([
+  ".csv", ".tsv", ".json", ".jsonl", ".ndjson", ".xml", ".log", ".txt", ".yaml", ".yml", ".md", ".html",
+]);
+
+// How much of a file to look at, and how much non-printable content marks it binary.
+const SNIFF_BYTES = 8192;
+const NON_PRINTABLE_RATIO = 0.3;
+
+/**
+ * Heuristic "is this a binary blob rather than text". A NUL byte is decisive; otherwise more than
+ * 30 percent non-printable bytes. Exists because malware samples routinely arrive extensionless or
+ * hash-named, and reading one as text produces silent garbage.
+ */
+export function looksBinary(sample: Buffer): boolean {
+  const view = sample.subarray(0, SNIFF_BYTES);
+  if (view.length === 0) return false;   // nothing to judge on
+  let nonPrintable = 0;
+  for (const b of view) {
+    if (b === 0) return true;
+    // Printable ASCII, common whitespace, or a high byte (assume UTF-8 continuation).
+    const printable = (b >= 0x20 && b < 0x7f) || b === 0x09 || b === 0x0a || b === 0x0d || b >= 0x80;
+    if (!printable) nonPrintable++;
+  }
+  return nonPrintable / view.length > NON_PRINTABLE_RATIO;
+}
 
 // Reserved subfolders the watcher writes to — never re-scanned (moving a file here *is* the dedup).
 export const DROP_PROCESSED = "_processed";
@@ -71,13 +100,21 @@ export function shouldIgnoreDropFile(relpath: string): boolean {
 }
 
 /**
- * Route a (non-ignored) drop file by extension: image → capture pipeline; raw binary (EVTX/PCAP) →
- * external-tool run path; else artifact import (read as text).
+ * Route a (non-ignored) drop file: image → capture pipeline; raw binary → external-tool run path;
+ * else artifact import (read as text).
+ *
+ * `sample` is the first bytes of the file when the caller has them. It only ever promotes an
+ * otherwise-unclaimed file to "raw-tool-input" — a known image or text extension always wins, so
+ * adding the sniff cannot re-route anything that worked before.
  */
-export function classifyDropFile(relpath: string): DropClass {
+export function classifyDropFile(relpath: string, sample?: Buffer): DropClass {
   const ext = extname(relpath).toLowerCase();
   if (IMAGE_EXTS.has(ext)) return "image";
   if (RAW_TOOL_EXTS.has(ext)) return "raw-tool-input";
+  if (SOCRATES_EXTS.includes(ext)) return "raw-tool-input";
+  if (ext === "" || !NATIVE_TEXT_EXTS.has(ext)) {
+    if (sample && looksBinary(sample)) return "raw-tool-input";
+  }
   return "artifact";
 }
 

--- a/companion/src/analysis/zipArchive.ts
+++ b/companion/src/analysis/zipArchive.ts
@@ -1,4 +1,7 @@
 import { deflateRawSync, inflateRawSync } from "node:zlib";
+import {
+  zipCryptoDecrypt, verifyZipCryptoCheckByte, parseAesExtra, aesDecrypt, ZipPasswordError,
+} from "./zipCrypto.js";
 
 // A tiny, dependency-free ZIP writer/reader. The redacted case export (#54) bundles the
 // anonymized report + screenshots into one shareable archive; rather than pull in a native
@@ -33,6 +36,9 @@ const SIG_LOCAL = 0x04034b50;
 const SIG_CENTRAL = 0x02014b50;
 const SIG_EOCD = 0x06054b50;
 const METHOD_DEFLATE = 8;
+const METHOD_AES = 99;          // WinZip AE-x; the real method lives in the 0x9901 extra field
+const FLAG_ENCRYPTED = 0x0001;  // general-purpose bit 0
+const ZIPCRYPTO_HEADER_LEN = 12;
 const VERSION = 20; // 2.0 — the minimum that supports DEFLATE
 const FLAG_UTF8 = 0x0800; // general-purpose bit 11: filenames are UTF-8
 // Fixed DOS time/date (1980-01-01 00:00:00) → reproducible archives, no Date dependency.
@@ -134,6 +140,8 @@ export interface ReadZipOptions {
   maxEntryBytes?: number;
   /** Override the total inflated-size cap (default {@link MAX_TOTAL_INFLATED}). Tests only. */
   maxTotalBytes?: number;
+  /** Password for encrypted entries. Ignored for unencrypted archives. Never logged or persisted. */
+  password?: string;
 }
 
 /**
@@ -165,6 +173,8 @@ export function readZip(archive: Buffer, opts: ReadZipOptions = {}): ZipEntry[] 
   for (let i = 0; i < total; i++) {
     if (archive.readUInt32LE(ptr) !== SIG_CENTRAL) throw new Error("corrupt ZIP: bad central header");
     const method = archive.readUInt16LE(ptr + 10);
+    const flag = archive.readUInt16LE(ptr + 8);
+    const modTime = archive.readUInt16LE(ptr + 12);
     const crc = archive.readUInt32LE(ptr + 16);
     const compSize = archive.readUInt32LE(ptr + 20);
     const nameLen = archive.readUInt16LE(ptr + 28);
@@ -172,14 +182,46 @@ export function readZip(archive: Buffer, opts: ReadZipOptions = {}): ZipEntry[] 
     const commentLen = archive.readUInt16LE(ptr + 32);
     const localOffset = archive.readUInt32LE(ptr + 42);
     const name = archive.toString("utf8", ptr + 46, ptr + 46 + nameLen);
+    const extra = archive.subarray(ptr + 46 + nameLen, ptr + 46 + nameLen + extraLen);
 
     // Jump to the local header to find the actual data start (its name/extra lengths may differ).
     const localNameLen = archive.readUInt16LE(localOffset + 26);
     const localExtraLen = archive.readUInt16LE(localOffset + 28);
     const dataStart = localOffset + 30 + localNameLen + localExtraLen;
-    const compressed = archive.subarray(dataStart, dataStart + compSize);
+    let compressed = archive.subarray(dataStart, dataStart + compSize);
+    const encrypted = (flag & FLAG_ENCRYPTED) !== 0;
+
+    // Effective compression method and CRC policy, both of which AES entries override.
+    let effectiveMethod = method;
+    let verifyCrc = true;
+
+    if (encrypted) {
+      const password = opts.password;
+      if (password === undefined || password === "") {
+        throw new ZipPasswordError(`zip entry "${name}" is encrypted — a password is required`, "password-required");
+      }
+      if (method === METHOD_AES) {
+        const params = parseAesExtra(extra);
+        if (!params) {
+          throw new ZipPasswordError(`zip entry "${name}" uses AES but has no readable AE header`, "unsupported-encryption");
+        }
+        const { plaintext } = aesDecrypt(compressed, password, params.strength);
+        compressed = plaintext;
+        effectiveMethod = params.actualMethod;
+        // AE-2 stores a zero CRC by design, so the usual integrity check would always fail.
+        // The HMAC already authenticated the data.
+        verifyCrc = params.aeVersion !== 2;
+      } else {
+        const decrypted = zipCryptoDecrypt(compressed, password);
+        if (!verifyZipCryptoCheckByte(decrypted.subarray(0, ZIPCRYPTO_HEADER_LEN), crc, modTime)) {
+          throw new ZipPasswordError(`wrong password for zip entry "${name}"`, "wrong-password");
+        }
+        compressed = decrypted.subarray(ZIPCRYPTO_HEADER_LEN);
+      }
+    }
+
     let data: Buffer;
-    if (method === METHOD_DEFLATE) {
+    if (effectiveMethod === METHOD_DEFLATE) {
       // Zip-bomb guard: cap the output DURING decompression via zlib's own maxOutputLength, not
       // after — inflateRawSync() otherwise fully materializes the decompressed output before
       // returning, so a check on the result's length only runs once the damage (allocating/OOMing
@@ -203,7 +245,7 @@ export function readZip(archive: Buffer, opts: ReadZipOptions = {}): ZipEntry[] 
 
     totalInflated += data.length;
 
-    if (crc32(data) !== crc) throw new Error(`corrupt ZIP: CRC mismatch for ${name}`);
+    if (verifyCrc && crc32(data) !== crc) throw new Error(`corrupt ZIP: CRC mismatch for ${name}`);
     entries.push({ path: name, data });
     ptr += 46 + nameLen + extraLen + commentLen;
   }

--- a/companion/src/analysis/zipCrypto.ts
+++ b/companion/src/analysis/zipCrypto.ts
@@ -6,6 +6,8 @@
 // never supported WinZip AES. An analyst-supplied password, or any 7-Zip archive, has to be opened
 // here instead.
 
+import { pbkdf2Sync, createCipheriv, createHmac, timingSafeEqual } from "node:crypto";
+
 // The CRC-32 table the cipher's key schedule needs. Rebuilt locally ON PURPOSE rather than imported
 // from zipArchive: zipArchive imports THIS module, so importing back would create a cycle whose
 // module-init order decides whether the table is populated when the cipher first runs. This module
@@ -63,4 +65,110 @@ export function zipCryptoDecrypt(data: Buffer, password: string): Buffer {
 export function verifyZipCryptoCheckByte(header: Buffer, crc: number, modTime: number): boolean {
   const checkByte = header[11];
   return checkByte === (crc >>> 24) || checkByte === ((modTime >> 8) & 0xff);
+}
+
+/**
+ * Why an encrypted entry could not be opened. Distinguishing these is the difference between
+ * "try another password" and "this archive can never be opened here", which is what the analyst
+ * actually needs to know.
+ *  - wrong-password:          this password is not it; another candidate may still work
+ *  - password-required:       encrypted, and no password was supplied at all
+ *  - unsupported-encryption:  malformed or unknown AE header; no password will ever work
+ */
+export type ZipPasswordFailure = "wrong-password" | "unsupported-encryption" | "password-required";
+
+export class ZipPasswordError extends Error {
+  constructor(message: string, readonly reason: ZipPasswordFailure) {
+    super(message);
+    this.name = "ZipPasswordError";
+  }
+}
+
+export interface AesParams {
+  aeVersion: number;       // 1 or 2; AE-2 zeroes the entry CRC, so callers must skip the CRC check
+  strength: 1 | 2 | 3;     // AES-128 / AES-192 / AES-256
+  actualMethod: number;    // the real compression method (0 stored, 8 deflate) hidden behind method 99
+}
+
+const AES_EXTRA_ID = 0x9901;
+const SALT_LEN: Record<number, number> = { 1: 8, 2: 12, 3: 16 };
+const KEY_LEN: Record<number, number> = { 1: 16, 2: 24, 3: 32 };
+const PW_VERIFY_LEN = 2;
+const MAC_LEN = 10;         // HMAC-SHA1 truncated to 80 bits
+const PBKDF2_ITERATIONS = 1000;
+
+/** Locate and parse the 0x9901 extra field of a method-99 entry. Null when absent or malformed. */
+export function parseAesExtra(extra: Buffer): AesParams | null {
+  let p = 0;
+  while (p + 4 <= extra.length) {
+    const id = extra.readUInt16LE(p);
+    const size = extra.readUInt16LE(p + 2);
+    if (id === AES_EXTRA_ID) {
+      if (p + 4 + 7 > extra.length) return null;
+      const aeVersion = extra.readUInt16LE(p + 4);
+      // p+6..p+7 is the vendor id "AE" — not load-bearing, skipped.
+      const strength = extra[p + 8];
+      const actualMethod = extra.readUInt16LE(p + 9);
+      if (strength !== 1 && strength !== 2 && strength !== 3) return null;
+      return { aeVersion, strength, actualMethod };
+    }
+    p += 4 + size;
+  }
+  return null;
+}
+
+// WinZip AES is AES-CTR with a LITTLE-ENDIAN block counter starting at 1. Node's aes-*-ctr
+// increments the IV as a BIG-ENDIAN 128-bit integer, which agrees only on the first block — so we
+// generate the keystream ourselves with ECB over an explicit LE counter block. Bounded to 2^32
+// blocks (64 GB), far past any realistic entry.
+function aesCtrXor(key: Buffer, input: Buffer): Buffer {
+  const out = Buffer.alloc(input.length);
+  const counter = Buffer.alloc(16);
+  const ecb = createCipheriv(`aes-${key.length * 8}-ecb`, key, null);
+  ecb.setAutoPadding(false);
+  for (let off = 0, block = 1; off < input.length; off += 16, block++) {
+    counter.writeUInt32LE(block, 0);
+    const keystream = ecb.update(counter);
+    const n = Math.min(16, input.length - off);
+    for (let i = 0; i < n; i++) out[off + i] = input[off + i] ^ keystream[i];
+  }
+  return out;
+}
+
+/**
+ * Decrypt a WinZip AES entry. `data` is the raw entry payload:
+ *   salt || 2-byte password verifier || ciphertext || 10-byte HMAC-SHA1
+ *
+ * Returns the still-COMPRESSED plaintext (inflate it per AesParams.actualMethod) and whether the
+ * authentication tag matched. Throws ZipPasswordError("wrong-password") when the verifier fails,
+ * which is the cheap check — it runs before any decryption work.
+ */
+export function aesDecrypt(
+  data: Buffer, password: string, strength: 1 | 2 | 3,
+): { plaintext: Buffer; macOk: boolean } {
+  const saltLen = SALT_LEN[strength];
+  const keyLen = KEY_LEN[strength];
+  if (data.length < saltLen + PW_VERIFY_LEN + MAC_LEN) {
+    throw new ZipPasswordError("AES entry is truncated", "unsupported-encryption");
+  }
+
+  const salt = data.subarray(0, saltLen);
+  const verifier = data.subarray(saltLen, saltLen + PW_VERIFY_LEN);
+  const ciphertext = data.subarray(saltLen + PW_VERIFY_LEN, data.length - MAC_LEN);
+  const mac = data.subarray(data.length - MAC_LEN);
+
+  // One PBKDF2 pass yields the encryption key, the MAC key, and the 2-byte verifier, concatenated.
+  const derived = pbkdf2Sync(password, salt, PBKDF2_ITERATIONS, keyLen * 2 + PW_VERIFY_LEN, "sha1");
+  const encKey = derived.subarray(0, keyLen);
+  const macKey = derived.subarray(keyLen, keyLen * 2);
+  const expectedVerifier = derived.subarray(keyLen * 2);
+
+  if (!timingSafeEqual(expectedVerifier, verifier)) {
+    throw new ZipPasswordError("wrong password for AES-encrypted entry", "wrong-password");
+  }
+
+  const plaintext = aesCtrXor(encKey, ciphertext);
+  // The HMAC is computed over the CIPHERTEXT, not the plaintext.
+  const computed = createHmac("sha1", macKey).update(ciphertext).digest().subarray(0, MAC_LEN);
+  return { plaintext, macOk: timingSafeEqual(computed, mac) };
 }

--- a/companion/src/analysis/zipCrypto.ts
+++ b/companion/src/analysis/zipCrypto.ts
@@ -1,0 +1,66 @@
+// Decryption primitives for password-protected ZIP entries. Pure functions over buffers — no ZIP
+// structure knowledge lives here (see zipArchive.ts for that) and no I/O.
+//
+// Needed because SO-CRATES can only ever try the password "infected": its upload handler builds the
+// password list server-side from the filename, and it extracts through Python's zipfile, which has
+// never supported WinZip AES. An analyst-supplied password, or any 7-Zip archive, has to be opened
+// here instead.
+
+// The CRC-32 table the cipher's key schedule needs. Rebuilt locally ON PURPOSE rather than imported
+// from zipArchive: zipArchive imports THIS module, so importing back would create a cycle whose
+// module-init order decides whether the table is populated when the cipher first runs. This module
+// stays a leaf with no local imports.
+const CRC_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+/**
+ * Decrypt a ZipCrypto (legacy PKWARE) entry. Returns the FULL decrypted buffer, including the
+ * 12-byte encryption header the caller must strip before inflating. The header's last byte is the
+ * password check — see verifyZipCryptoCheckByte.
+ */
+export function zipCryptoDecrypt(data: Buffer, password: string): Buffer {
+  // Three 32-bit keys with fixed PKWARE initial values, advanced one byte at a time.
+  let key0 = 0x12345678;
+  let key1 = 0x23456789;
+  let key2 = 0x34567890;
+
+  const crcUpdate = (c: number, b: number): number => (CRC_TABLE[(c ^ b) & 0xff] ^ (c >>> 8)) >>> 0;
+  const updateKeys = (b: number): void => {
+    key0 = crcUpdate(key0, b);
+    key1 = (key1 + (key0 & 0xff)) >>> 0;
+    key1 = (Math.imul(key1, 134775813) + 1) >>> 0;   // imul: the product overflows 2^53 otherwise
+    key2 = crcUpdate(key2, key1 >>> 24);
+  };
+
+  for (const b of Buffer.from(password, "utf8")) updateKeys(b);
+
+  const out = Buffer.alloc(data.length);
+  for (let i = 0; i < data.length; i++) {
+    const temp = (key2 | 2) & 0xffff;
+    const plain = data[i] ^ ((Math.imul(temp, temp ^ 1) >> 8) & 0xff);
+    out[i] = plain;
+    updateKeys(plain);   // the keystream depends on the PLAINTEXT, so update after decrypting
+  }
+  return out;
+}
+
+/**
+ * Validate the 12th decrypted header byte against the entry's metadata.
+ *
+ * The APPNOTE says this byte is the high byte of the CRC-32. But when general-purpose flag bit 3
+ * (data descriptor) is set the CRC is not known at write time, so writers substitute the high byte
+ * of the DOS mod time — Info-ZIP's `zip -P` does exactly this. Accept EITHER, or correct passwords
+ * get rejected. A one-byte check has a 1/256 false-accept rate by design; a wrong password that
+ * slips through fails the CRC check downstream.
+ */
+export function verifyZipCryptoCheckByte(header: Buffer, crc: number, modTime: number): boolean {
+  const checkByte = header[11];
+  return checkByte === (crc >>> 24) || checkByte === ((modTime >> 8) & 0xff);
+}

--- a/companion/src/analysis/zipExtract.ts
+++ b/companion/src/analysis/zipExtract.ts
@@ -1,0 +1,133 @@
+// Turns a (possibly encrypted) zip into the list of files worth analyzing, applying the password
+// ladder and the entry-safety rules. Split from zipArchive.ts so the ZIP format reader stays a
+// format reader and the policy — which passwords to try, what counts as an interesting entry, how
+// many to keep — lives in one reviewable place.
+//
+// This deliberately diverges from SO-CRATES, which keeps pcap_files[0] or non_hidden[0] and
+// discards the rest of a multi-entry archive. A sample bundle of "pcap plus three dropped binaries"
+// would lose three quarters of its evidence that way.
+
+import { readZip } from "./zipArchive.js";
+import { ZipPasswordError } from "./zipCrypto.js";
+
+/** Hard cap on files taken from one archive, so a crafted zip cannot fan out into many uploads. */
+export const MAX_ZIP_ENTRIES = 25;
+
+export interface ExtractedEntry {
+  path: string;
+  data: Buffer;
+}
+
+export interface ZipExtractResult {
+  entries: ExtractedEntry[];
+  /** Which password opened it, or null when the archive was not encrypted. Never persisted. */
+  passwordUsed: string | null;
+  /** Nested archives that were reported rather than recursed into. */
+  skippedNested: string[];
+  /** True when MAX_ZIP_ENTRIES clipped the list. */
+  truncated: boolean;
+}
+
+/**
+ * Passwords to try, in order: the analyst's, then `infected`, then the MTA-style dated variant when
+ * the filename carries a YYYY-MM-DD date. Mirrors what SO-CRATES tries server-side, plus the
+ * analyst-supplied password it has no way to accept.
+ */
+export function candidatePasswords(filename: string, supplied?: string): string[] {
+  const out: string[] = [];
+  const trimmed = supplied?.trim();
+  if (trimmed) out.push(trimmed);
+  if (!out.includes("infected")) out.push("infected");
+  const m = /(\d{4})-(\d{2})-(\d{2})/.exec(filename);
+  if (m) {
+    const dated = `infected_${m[1]}${m[2]}${m[3]}`;
+    if (!out.includes(dated)) out.push(dated);
+  }
+  return out;
+}
+
+// Entries that are never evidence: directories, dotfiles, and macOS resource-fork metadata.
+function isIgnorableEntry(path: string): boolean {
+  if (path.endsWith("/")) return true;
+  const base = path.split("/").pop() ?? "";
+  if (base === "" || base.startsWith(".")) return true;
+  return path.startsWith("__MACOSX/");
+}
+
+// Cheap central-directory scan for any entry with general-purpose bit 0 set. Used so an archive
+// that was never encrypted reports passwordUsed: null, rather than naming whichever candidate
+// happened to be tried first.
+function archiveIsEncrypted(archive: Buffer): boolean {
+  let eocd = -1;
+  for (let i = archive.length - 22; i >= 0; i--) {
+    if (archive.readUInt32LE(i) === 0x06054b50) { eocd = i; break; }
+  }
+  if (eocd < 0) return false;
+  const total = archive.readUInt16LE(eocd + 10);
+  let ptr = archive.readUInt32LE(eocd + 16);
+  for (let i = 0; i < total; i++) {
+    if (archive.readUInt32LE(ptr) !== 0x02014b50) return false;
+    if ((archive.readUInt16LE(ptr + 8) & 0x0001) !== 0) return true;
+    ptr += 46 + archive.readUInt16LE(ptr + 28) + archive.readUInt16LE(ptr + 30) + archive.readUInt16LE(ptr + 32);
+  }
+  return false;
+}
+
+// Zip-slip guard: an entry must stay inside the archive's own namespace.
+function assertContained(path: string): void {
+  const normalized = path.replace(/\\/g, "/");
+  if (normalized.startsWith("/") || /^[a-zA-Z]:/.test(normalized) || normalized.split("/").includes("..")) {
+    throw new Error(`zip entry "${path}" resolves outside the archive`);
+  }
+}
+
+/**
+ * Extract the analyzable file entries from `archive`. Tries each candidate password in turn and
+ * rethrows the last failure with an actionable message once all of them fail.
+ */
+export function extractZipEntries(archive: Buffer, filename: string, supplied?: string): ZipExtractResult {
+  const candidates = candidatePasswords(filename, supplied);
+  const encrypted = archiveIsEncrypted(archive);
+  let raw: { path: string; data: Buffer }[] | null = null;
+  let passwordUsed: string | null = null;
+  let lastErr: unknown = null;
+
+  // An unencrypted archive opens on the first attempt with the password simply ignored, so there is
+  // no separate probe here — archiveIsEncrypted only decides what we REPORT as passwordUsed.
+  for (const pw of candidates) {
+    try {
+      raw = readZip(archive, { password: pw });
+      passwordUsed = encrypted ? pw : null;
+      break;
+    } catch (err) {
+      lastErr = err;
+      // Not a password problem (corrupt / zip bomb / ZIP64 / unopenable AE header) — trying more
+      // passwords cannot help, so fail immediately with the real reason.
+      if (!(err instanceof ZipPasswordError)) throw err;
+      if (err.reason === "unsupported-encryption") throw err;
+    }
+  }
+
+  if (!raw) {
+    const tried = candidates.length === 1 ? "the default password" : `${candidates.length} passwords`;
+    throw new Error(
+      `could not open "${filename}": wrong password (tried ${tried}). ` +
+      `Enter the archive password in the import dialog.`,
+      { cause: lastErr },
+    );
+  }
+
+  const skippedNested: string[] = [];
+  const entries: ExtractedEntry[] = [];
+  let truncated = false;
+
+  for (const e of raw) {
+    assertContained(e.path);
+    if (isIgnorableEntry(e.path)) continue;
+    if (e.data.subarray(0, 2).toString("latin1") === "PK") { skippedNested.push(e.path); continue; }
+    if (entries.length >= MAX_ZIP_ENTRIES) { truncated = true; break; }
+    entries.push({ path: e.path, data: e.data });
+  }
+
+  return { entries, passwordUsed, skippedNested, truncated };
+}

--- a/companion/src/integrations/socrates/socratesApi.ts
+++ b/companion/src/integrations/socrates/socratesApi.ts
@@ -79,7 +79,10 @@ export async function uploadBuffer(
   baseUrl: string, data: Buffer, filename: string, fetchFn: FetchFn = fetch as FetchFn,
 ): Promise<SocratesUploadResult> {
   const form = new FormData();
-  form.append("file", new Blob([data]), filename);
+  // Copy into a plain Uint8Array: a Buffer's underlying store is ArrayBufferLike, which may be a
+  // SharedArrayBuffer as far as the type system is concerned, and BlobPart does not accept that.
+  // Blob copies its parts anyway, so this costs nothing extra in practice.
+  form.append("file", new Blob([new Uint8Array(data)]), filename);
   const res = await fetchFn(`${trimBase(baseUrl)}/api/upload`, { method: "POST", body: form });
   if (!res.ok) {
     const detail = await res.json().catch(() => ({}));

--- a/companion/src/integrations/socrates/socratesApi.ts
+++ b/companion/src/integrations/socrates/socratesApi.ts
@@ -1,0 +1,132 @@
+// Server-side client for the SO-CRATES HTTP API (dougburks/so-crates).
+//
+// Must be server-side: SO-CRATES sends no CORS headers and a `default-src 'self'` CSP, so the
+// dashboard cannot call it from the browser. It also has NO authentication and binds 127.0.0.1 by
+// default — see the non-local warning in Settings.
+//
+// The API is asynchronous and keyed by MD5: upload returns immediately, the caller polls, and the
+// results are then read from three separate verdict feeds. Because the key is the file's MD5, an
+// already-analyzed file can skip the upload entirely (probeAnalysis).
+
+import { createHash } from "node:crypto";
+import type { FetchFn } from "../../enrichment/provider.js";
+
+export interface SocratesStatus {
+  status: "ready" | "processing" | "error";
+  phase?: string;
+  message?: string;
+  meta?: { detected_type?: string; original?: string; extracted?: string };
+}
+
+export interface SocratesUploadResult {
+  status: "ready" | "processing";
+  md5: string;
+  phase?: string;
+}
+
+export interface SocratesVerdicts {
+  /** All verdict rows as one JSON array, ready for parseSocrates. */
+  text: string;
+  alerts: number;
+  yara: number;
+  sigma: number;
+}
+
+// SO-CRATES caps `limit` at MAX_QUERY_LIMIT (100,000) and defaults to 1000. Page at the default.
+const PAGE_SIZE = 1000;
+// Stop paging regardless, so a misbehaving server cannot spin forever.
+const MAX_PAGES = 100;
+
+function trimBase(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+/** The MD5 SO-CRATES keys an analysis by. MD5 is the server's choice of key, not a security claim. */
+export function md5Buffer(data: Buffer): string {
+  return createHash("md5").update(data).digest("hex");
+}
+
+async function getJson(url: string, fetchFn: FetchFn): Promise<unknown> {
+  const res = await fetchFn(url, { method: "GET" });
+  if (!res.ok) throw new Error(`SO-CRATES GET ${new URL(url).pathname} failed: HTTP ${res.status}`);
+  return res.json();
+}
+
+async function postJson(url: string, body: unknown, fetchFn: FetchFn): Promise<unknown> {
+  const res = await fetchFn(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`SO-CRATES POST ${new URL(url).pathname} failed: HTTP ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Ask whether this MD5 has already been analyzed, so an unchanged file skips the upload.
+ *
+ * Caveat: SO-CRATES never 404s here. A well-formed MD5 with no analysis directory reads as
+ * `{status: "processing", phase: ""}`, which is why the poller carries its own attempt ceiling.
+ */
+export async function probeAnalysis(
+  baseUrl: string, md5: string, fetchFn: FetchFn = fetch as FetchFn,
+): Promise<SocratesStatus> {
+  return await getJson(`${trimBase(baseUrl)}/api/status?md5=${encodeURIComponent(md5)}`, fetchFn) as SocratesStatus;
+}
+
+/** Upload a file for analysis as multipart/form-data. */
+export async function uploadBuffer(
+  baseUrl: string, data: Buffer, filename: string, fetchFn: FetchFn = fetch as FetchFn,
+): Promise<SocratesUploadResult> {
+  const form = new FormData();
+  form.append("file", new Blob([data]), filename);
+  const res = await fetchFn(`${trimBase(baseUrl)}/api/upload`, { method: "POST", body: form });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    const msg = (detail as { error?: string }).error ?? `HTTP ${res.status}`;
+    throw new Error(`SO-CRATES upload of "${filename}" failed: ${msg}`);
+  }
+  return await res.json() as SocratesUploadResult;
+}
+
+/** Poll whether analysis has finished. */
+export async function checkStatus(
+  baseUrl: string, md5: string, fetchFn: FetchFn = fetch as FetchFn,
+): Promise<SocratesStatus> {
+  return await postJson(`${trimBase(baseUrl)}/api/check-status`, { md5 }, fetchFn) as SocratesStatus;
+}
+
+// Page one feed until a short page comes back (or MAX_PAGES trips).
+async function fetchAllPages(url: string, fetchFn: FetchFn): Promise<Record<string, unknown>[]> {
+  const out: Record<string, unknown>[] = [];
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const sep = url.includes("?") ? "&" : "?";
+    const body = await getJson(`${url}${sep}offset=${page * PAGE_SIZE}&limit=${PAGE_SIZE}`, fetchFn);
+    if (!Array.isArray(body)) break;
+    for (const row of body) if (row && typeof row === "object") out.push(row as Record<string, unknown>);
+    if (body.length < PAGE_SIZE) break;
+  }
+  return out;
+}
+
+/**
+ * Fetch the three VERDICT feeds and merge them into one JSON array for parseSocrates.
+ *
+ * Never requests /api/events without a `type`: the default returns whole-capture dns/http/tls/flow
+ * telemetry, which would flood the timeline and break the Companion's post-detection principle.
+ * Every row is stamped `_Source: "SO-CRATES"` so importDetect's isSocrates() claims the blob.
+ */
+export async function fetchVerdicts(
+  baseUrl: string, md5: string, fetchFn: FetchFn = fetch as FetchFn,
+): Promise<SocratesVerdicts> {
+  const base = trimBase(baseUrl);
+  const q = encodeURIComponent(md5);
+  const [alerts, yara, sigma] = await Promise.all([
+    fetchAllPages(`${base}/api/events?md5=${q}&type=alert`, fetchFn),
+    fetchAllPages(`${base}/api/events?md5=${q}&type=filealerts`, fetchFn),
+    fetchAllPages(`${base}/api/sigma-alerts?md5=${q}`, fetchFn),
+  ]);
+
+  const rows = [...alerts, ...yara, ...sigma].map((r) => ({ ...r, _Source: "SO-CRATES" }));
+  return { text: JSON.stringify(rows), alerts: alerts.length, yara: yara.length, sigma: sigma.length };
+}

--- a/companion/src/integrations/socrates/socratesJobStore.ts
+++ b/companion/src/integrations/socrates/socratesJobStore.ts
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { CaseStore } from "../../storage/caseStore.js";
+import { atomicWrite } from "../../storage/atomicWrite.js";
+
+// Per-case record of SO-CRATES analyses. Persisted to a side file (state/socrates-jobs.json) so a
+// server restart does not strand an in-flight analysis — the dashboard still shows it and the
+// analyst can see why it never landed. Mirrors VeloHuntStore; NOT part of InvestigationState.
+
+export type SocratesJobStatus = "processing" | "importing" | "imported" | "error";
+
+export interface SocratesJob {
+  jobId: string;
+  md5: string;
+  sourceName: string;     // the file the analyst submitted
+  zipEntry?: string;      // the entry inside that archive, when the source was a zip
+  status: SocratesJobStatus;
+  phase?: string;         // SO-CRATES analysis phase: network | logs | files
+  startedAt: string;      // ISO
+  finishedAt?: string;    // ISO
+  addedEvents?: number;
+  addedIocs?: number;
+  error?: string;
+}
+
+const MAX_JOBS = 25;
+
+export class SocratesJobStore {
+  constructor(private readonly cases: CaseStore) {}
+
+  private path(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "socrates-jobs.json");
+  }
+
+  async list(caseId: string): Promise<SocratesJob[]> {
+    try {
+      const parsed = JSON.parse(await readFile(this.path(caseId), "utf8")) as unknown;
+      return Array.isArray(parsed) ? parsed as SocratesJob[] : [];
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+  }
+
+  async get(caseId: string, jobId: string): Promise<SocratesJob | null> {
+    return (await this.list(caseId)).find((j) => j.jobId === jobId) ?? null;
+  }
+
+  /** Add a job (prepended) or update an existing one in place, matched by jobId. */
+  async upsert(caseId: string, job: SocratesJob): Promise<SocratesJob> {
+    const jobs = await this.list(caseId);
+    const idx = jobs.findIndex((j) => j.jobId === job.jobId);
+    const next = idx >= 0 ? jobs.map((j, i) => (i === idx ? job : j)) : [job, ...jobs].slice(0, MAX_JOBS);
+    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+    return job;
+  }
+}

--- a/companion/src/integrations/socrates/socratesPoller.ts
+++ b/companion/src/integrations/socrates/socratesPoller.ts
@@ -1,0 +1,80 @@
+import type { SocratesJob, SocratesJobStore } from "./socratesJobStore.js";
+import type { SocratesStatus, SocratesVerdicts } from "./socratesApi.js";
+
+// Waits for one SO-CRATES analysis to finish, then hands its verdicts to the importer. Every
+// collaborator is injected so the whole loop is unit-testable without a server or real time.
+
+export interface PollerDeps {
+  store: SocratesJobStore;
+  checkStatus(md5: string): Promise<SocratesStatus>;
+  fetchVerdicts(md5: string): Promise<SocratesVerdicts>;
+  ingest(caseId: string, text: string, name: string): Promise<{ addedEvents: number; addedIocs: number }>;
+  sleep?(ms: number): Promise<void>;
+}
+
+// 5s × 240 = 20 minutes, enough for Suricata over a large PCAP. The ceiling is NOT optional:
+// SO-CRATES never 404s a well-formed but unknown MD5 — it answers "processing" forever — so
+// without this a typo'd or deleted analysis polls until the process dies.
+const DEFAULT_INTERVAL_MS = 5_000;
+const DEFAULT_MAX_ATTEMPTS = 240;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export async function pollUntilImported(
+  caseId: string,
+  job: SocratesJob,
+  deps: PollerDeps,
+  opts: { maxAttempts?: number; intervalMs?: number } = {},
+): Promise<SocratesJob> {
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const sleep = deps.sleep ?? defaultSleep;
+
+  const fail = async (message: string): Promise<SocratesJob> => {
+    const failed: SocratesJob = { ...job, status: "error", error: message, finishedAt: new Date().toISOString() };
+    await deps.store.upsert(caseId, failed);
+    return failed;
+  };
+
+  let current = job;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let status: SocratesStatus;
+    try {
+      status = await deps.checkStatus(current.md5);
+    } catch (err) {
+      return await fail(`SO-CRATES status check failed: ${(err as Error).message}`);
+    }
+
+    if (status.status === "error") return await fail(status.message ?? "SO-CRATES reported an analysis failure");
+
+    if (status.status === "ready") {
+      current = { ...current, status: "importing", phase: status.phase };
+      await deps.store.upsert(caseId, current);
+      try {
+        const verdicts = await deps.fetchVerdicts(current.md5);
+        const name = `${current.zipEntry ?? current.sourceName}.socrates.json`;
+        const r = await deps.ingest(caseId, verdicts.text, name);
+        const done: SocratesJob = {
+          ...current, status: "imported", addedEvents: r.addedEvents, addedIocs: r.addedIocs,
+          finishedAt: new Date().toISOString(),
+        };
+        await deps.store.upsert(caseId, done);
+        return done;
+      } catch (err) {
+        return await fail(`SO-CRATES result import failed: ${(err as Error).message}`);
+      }
+    }
+
+    // Still processing — record the phase so the dashboard can say "analyzing (network)".
+    if (status.phase && status.phase !== current.phase) {
+      current = { ...current, phase: status.phase };
+      await deps.store.upsert(caseId, current);
+    }
+    await sleep(intervalMs);
+  }
+
+  return await fail(
+    `SO-CRATES analysis timed out after ${maxAttempts} checks. The server never reported this ` +
+    `analysis ready — note that it returns "processing" for an unknown MD5 rather than a 404.`,
+  );
+}

--- a/companion/src/integrations/tools/customToolStore.ts
+++ b/companion/src/integrations/tools/customToolStore.ts
@@ -66,6 +66,7 @@ export function customToolToConfig(t: CustomTool): ToolConfig {
   return {
     id: t.id,
     binary: t.binary,
+    transport: "spawn",   // a custom tool is always a local binary; HTTP tools are built-in only
     runArgs: t.runArgs,
     updateCommand: t.updateCommand && t.updateCommand.trim() ? t.updateCommand.trim() : undefined,
     importKind: "auto",

--- a/companion/src/integrations/tools/toolConfig.ts
+++ b/companion/src/integrations/tools/toolConfig.ts
@@ -9,7 +9,11 @@
 // CLI→velociraptor, Suricata→network, Snort→snort, YARA→yara. The Companion runs the tool and ingests
 // its verdict; it does NOT re-implement detection (see CLAUDE.md).
 
-export type ToolId = "hayabusa" | "velociraptor_cli" | "suricata" | "snort" | "yara";
+export type ToolId = "hayabusa" | "velociraptor_cli" | "suricata" | "snort" | "yara" | "socrates";
+
+// How the Companion reaches the tool. "spawn" runs a local binary through the toolRunner; "http"
+// calls a service over the network and never touches the process spawner.
+export type ToolTransport = "spawn" | "http";
 
 // How the tool emits its result:
 //  - "stdout": read the process stdout (YARA, Snort -A fast -q)
@@ -19,7 +23,9 @@ export type OutputMode = "stdout" | "file" | "dir";
 
 export interface ToolConfig {
   id: string;                 // built-in ToolId or a custom-tool id
-  binary: string;             // executable path / PATH name (gates on/off)
+  binary: string;             // executable path / PATH name (gates on/off); "" for http tools
+  transport: ToolTransport;   // spawn a binary, or call an HTTP service
+  baseUrl?: string;           // http tools only — the service root, no trailing slash
   runArgs: string;            // args template with <target>/<output>/<rules> placeholders
   updateCommand?: string;     // FULL "update rules" command line (first token = executable); blank = no button
   importKind: string;         // fixed downstream importer kind
@@ -37,6 +43,7 @@ interface ToolDef {
   label: string;                    // display name
   repoUrl: string;                  // official repo (linked in the UI, never bundled)
   importKind: string;
+  transport: ToolTransport;
   defaultRunArgs: string;
   outputMode: OutputMode;
   defaultOutputFile?: string;
@@ -46,6 +53,19 @@ interface ToolDef {
   defaultUpdateCommand?: string;    // standalone update command line (Suricata: suricata-update)
 }
 
+// The extensions SO-CRATES claims. Explicit rather than a catch-all: SO-CRATES YARA-scans anything
+// that is not a PCAP or a log, so claiming "*" would divert every CSV/JSON import away from the
+// Companion's native importers. Extensionless and hash-named samples are covered by the
+// looksBinary() content sniff in analysis/dropScan.ts instead.
+export const SOCRATES_EXTS: string[] = [
+  ".pcap", ".pcapng", ".cap", ".trace",
+  ".evtx", ".evt",
+  ".exe", ".dll", ".sys", ".drv", ".scr", ".com", ".cpl", ".ocx", ".msi", ".bin", ".elf", ".so", ".dylib",
+  ".lnk", ".msp", ".cab",
+  ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".pdf", ".rtf",
+  ".zip", ".7z", ".rar",
+];
+
 // Static per-tool definitions (NOT env). The importKind + outputMode + claimed extensions are fixed;
 // env carries only the analyst's per-tool overrides (binary, args, rules, toggles).
 export const TOOL_DEFS: Record<ToolId, ToolDef> = {
@@ -54,6 +74,7 @@ export const TOOL_DEFS: Record<ToolId, ToolDef> = {
     label: "Hayabusa",
     repoUrl: "https://github.com/Yamato-Security/hayabusa",
     importKind: "hayabusa",
+    transport: "spawn",
     defaultRunArgs: "csv-timeline -f <target> -o <output> -w",
     outputMode: "file",
     defaultOutputFile: "hayabusa.csv",
@@ -66,6 +87,7 @@ export const TOOL_DEFS: Record<ToolId, ToolDef> = {
     label: "Velociraptor CLI (offline)",
     repoUrl: "https://github.com/Velocidex/velociraptor",
     importKind: "velociraptor",
+    transport: "spawn",
     // Runs the Windows.Hayabusa.Rules artifact (NON-built-in → loaded from the definitions zip) against a
     // FOLDER of EVTX (--ROOT). `<targetdir>` is a folder holding the input file under its ORIGINAL name, so
     // Velociraptor detects the channel from the filename and globs it. `--nobanner --no-debug` keep the
@@ -82,6 +104,7 @@ export const TOOL_DEFS: Record<ToolId, ToolDef> = {
     label: "Suricata",
     repoUrl: "https://suricata.io/download/",
     importKind: "network",
+    transport: "spawn",
     defaultRunArgs: "-r <target> -l <output>",
     outputMode: "dir",
     defaultOutputFile: "eve.json",
@@ -97,6 +120,7 @@ export const TOOL_DEFS: Record<ToolId, ToolDef> = {
     label: "Snort",
     repoUrl: "https://github.com/snort3/snort3",
     importKind: "snort",
+    transport: "spawn",
     defaultRunArgs: "-r <target> -c <rules> -A fast -q",
     outputMode: "stdout",
     usesRules: true,
@@ -107,10 +131,23 @@ export const TOOL_DEFS: Record<ToolId, ToolDef> = {
     label: "YARA",
     repoUrl: "https://github.com/VirusTotal/yara",
     importKind: "yara",
+    transport: "spawn",
     defaultRunArgs: "-s -m -r <rules> <target>",
     outputMode: "stdout",
     usesRules: true,
     extensions: [],   // YARA scans files/dirs on demand — not a raw drop-folder extension
+  },
+  socrates: {
+    id: "socrates",
+    label: "SO-CRATES",
+    repoUrl: "https://github.com/dougburks/so-crates",
+    importKind: "socrates",
+    transport: "http",
+    // Not a spawned command — the client in integrations/socrates drives the HTTP API instead.
+    defaultRunArgs: "",
+    outputMode: "stdout",
+    usesRules: false,
+    extensions: SOCRATES_EXTS,
   },
 };
 
@@ -121,6 +158,7 @@ const ENV_ID: Record<ToolId, string> = {
   suricata: "SURICATA",
   snort: "SNORT",
   yara: "YARA",
+  socrates: "SOCRATES",
 };
 
 function boolEnv(v: string | undefined, dflt: boolean): boolean {
@@ -137,14 +175,28 @@ function quoteIfNeeded(s: string): string {
 export function loadToolConfig(id: ToolId, env: NodeJS.ProcessEnv = process.env): ToolConfig | null {
   const def = TOOL_DEFS[id];
   const p = `DFIR_TOOL_${ENV_ID[id]}_`;
-  const binary = env[`${p}BINARY`]?.trim();
-  if (!binary) return null;
 
   // Auto-run is doubly gated: a master kill-switch (default on) AND the per-tool toggle (default OFF —
   // opt-in). Default off so a dropped/imported raw file ASKS the analyst first (a confirmation banner)
   // instead of silently spawning a tool; set _AUTO_RUN=on per tool for hands-off running.
   const masterAuto = boolEnv(env.DFIR_TOOL_AUTO_RUN, true);
   const toolAuto = boolEnv(env[`${p}AUTO_RUN`], false);
+
+  // HTTP tools are gated on a base URL, not an executable path.
+  if (def.transport === "http") {
+    const baseUrl = env[`${p}URL`]?.trim();
+    if (!baseUrl) return null;
+    return {
+      id, binary: "", transport: "http", baseUrl: baseUrl.replace(/\/+$/, ""),
+      runArgs: "", importKind: def.importKind, outputMode: def.outputMode,
+      autoRun: masterAuto && toolAuto,
+      timeoutMs: Number(env[`${p}TIMEOUT_MS`]) || 1_200_000,   // 20 min: Suricata over a large PCAP
+      maxOutputBytes: Number(env[`${p}MAX_OUTPUT`]) || 100 * 1024 * 1024,
+    };
+  }
+
+  const binary = env[`${p}BINARY`]?.trim();
+  if (!binary) return null;
 
   const envUpdate = env[`${p}UPDATE_CMD`]?.trim();
   const updateCommand = envUpdate
@@ -158,6 +210,7 @@ export function loadToolConfig(id: ToolId, env: NodeJS.ProcessEnv = process.env)
   return {
     id,
     binary,
+    transport: "spawn",
     runArgs: env[`${p}RUN_ARGS`]?.trim() || def.defaultRunArgs,
     updateCommand,
     importKind: def.importKind,
@@ -185,7 +238,9 @@ export function loadAllToolConfigs(env: NodeJS.ProcessEnv = process.env): Map<To
 // pcap→Suricata then Snort). Derived from TOOL_DEFS so it stays in sync.
 export function toolPreferenceForExtension(ext: string): ToolId[] {
   const e = ext.toLowerCase();
-  const order: ToolId[] = ["hayabusa", "velociraptor_cli", "suricata", "snort", "yara"];
+  // Order matters: the first CONFIGURED tool wins for drop-folder auto-run. SO-CRATES is last so a
+  // tuned local Suricata/Hayabusa keeps priority; the import banner offers every claimant instead.
+  const order: ToolId[] = ["hayabusa", "velociraptor_cli", "suricata", "snort", "yara", "socrates"];
   return order.filter((id) => TOOL_DEFS[id].extensions.includes(e));
 }
 

--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -135,7 +135,11 @@ export interface RouteContext {
   // Run a raw drop-folder file through whichever transport its tool uses (spawn → runToolAndIngest,
   // http → startSocratesAnalysis). Shared with the drop poller so the "Run pending" batch behaves
   // identically to auto-run.
-  runDropToolAndIngest(caseId: string, toolId: string, fullPath: string, name: string): Promise<void>;
+  // Returns true when the work is ASYNCHRONOUS (handed off, not finished), so the caller logs
+  // SUBMITTED instead of claiming an import that has not happened yet.
+  runDropToolAndIngest(
+    caseId: string, toolId: string, fullPath: string, name: string, dropRelpath?: string,
+  ): Promise<boolean>;
   // Import machinery shared between routes/import.ts and the createApp import seams that stay
   // (the Velociraptor bundle collector reuses dispatchImport/demoteForensicForCase/resynthesize,
   // the drop-folder poller reuses moveDropFile, and the push/tool paths reuse the whitelist/NSRL/

--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -132,6 +132,10 @@ export interface RouteContext {
     input: { data: Buffer; filename: string; zipPassword?: string },
   ): Promise<{ jobIds: string[]; skippedNested: string[]; truncated: boolean }>;
   socratesJobStore: SocratesJobStore;
+  // Run a raw drop-folder file through whichever transport its tool uses (spawn → runToolAndIngest,
+  // http → startSocratesAnalysis). Shared with the drop poller so the "Run pending" batch behaves
+  // identically to auto-run.
+  runDropToolAndIngest(caseId: string, toolId: string, fullPath: string, name: string): Promise<void>;
   // Import machinery shared between routes/import.ts and the createApp import seams that stay
   // (the Velociraptor bundle collector reuses dispatchImport/demoteForensicForCase/resynthesize,
   // the drop-folder poller reuses moveDropFile, and the push/tool paths reuse the whitelist/NSRL/

--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -14,6 +14,7 @@ import type { ImporterFailure, AiError, ImporterRunStat } from "../analysis/diag
 import type { Severity, InvestigationState } from "../analysis/stateTypes.js";
 import type { ToolConfig } from "../integrations/tools/toolConfig.js";
 import type { CustomTool } from "../integrations/tools/customToolStore.js";
+import type { SocratesJobStore } from "../integrations/socrates/socratesJobStore.js";
 import type { VeloMonitor } from "../analysis/veloMonitorStore.js";
 import type { HuntDeployInput } from "../analysis/huntOutcomes.js";
 import type { HuntUpload } from "../integrations/velociraptor/velociraptorApi.js";
@@ -123,6 +124,14 @@ export interface RouteContext {
     caseId: string, toolId: string, targetPath: string, opts?: { undoLabel?: string },
   ): Promise<{ storedName: string; addedEvents: number; addedIocs: number; analyzed: boolean }>;
   reloadCustomTools(): Promise<void>;
+  // Submit a file to SO-CRATES and start background polling. Zips are extracted first (SO-CRATES
+  // can only ever try the password "infected"), so one call may start several jobs — one per entry.
+  // Returns immediately; the caller polls GET /cases/:id/socrates/jobs.
+  startSocratesAnalysis(
+    caseId: string,
+    input: { data: Buffer; filename: string; zipPassword?: string },
+  ): Promise<{ jobIds: string[]; skippedNested: string[]; truncated: boolean }>;
+  socratesJobStore: SocratesJobStore;
   // Import machinery shared between routes/import.ts and the createApp import seams that stay
   // (the Velociraptor bundle collector reuses dispatchImport/demoteForensicForCase/resynthesize,
   // the drop-folder poller reuses moveDropFile, and the push/tool paths reuse the whitelist/NSRL/

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -135,9 +135,13 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         try {
           // Dispatch by transport: a spawn tool runs and imports inline; SO-CRATES hands off to its
           // background poller and the verdicts land when the analysis finishes.
-          await ctx.runDropToolAndIngest(caseId, toolId, join(dropDir, p.relpath), basename(p.relpath));
+          const async_ = await ctx.runDropToolAndIngest(caseId, toolId, join(dropDir, p.relpath), basename(p.relpath), p.relpath);
           await moveDropFile(dropDir, p.relpath, true).catch(() => { /* best-effort */ });
-          resolvedEntries.push({ status: "IMPORTED", relpath: p.relpath, reason: `via ${toolId} (tool run)` });
+          // SO-CRATES has only been HANDED the file at this point; the job appends the outcome when
+          // its analysis resolves, so do not claim an import that has not happened.
+          resolvedEntries.push(async_
+            ? { status: "SUBMITTED", relpath: p.relpath, reason: `handed to ${toolId}; verdicts land when analysis finishes` }
+            : { status: "IMPORTED", relpath: p.relpath, reason: `via ${toolId} (tool run)` });
           ran++;
         } catch (err) {
           failed++;

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -133,7 +133,9 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         const toolId = resolveToolForExt(p.ext, configured);
         if (!toolId) { skipped++; stillPending.push({ ...p, configured: false, suggestedTool: suggestedToolForExtension(p.ext) }); continue; }
         try {
-          await runToolAndIngest(caseId, toolId, join(dropDir, p.relpath));
+          // Dispatch by transport: a spawn tool runs and imports inline; SO-CRATES hands off to its
+          // background poller and the verdicts land when the analysis finishes.
+          await ctx.runDropToolAndIngest(caseId, toolId, join(dropDir, p.relpath), basename(p.relpath));
           await moveDropFile(dropDir, p.relpath, true).catch(() => { /* best-effort */ });
           resolvedEntries.push({ status: "IMPORTED", relpath: p.relpath, reason: `via ${toolId} (tool run)` });
           ran++;

--- a/companion/src/routes/tools.ts
+++ b/companion/src/routes/tools.ts
@@ -29,6 +29,12 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
   // createApp original read its closure `customTools`); the live custom-tool list comes from ctx.
   const isKnownTool = (toolId: string): boolean => toolId in TOOL_DEFS || ctx.customTools().some((t) => t.id === toolId);
 
+  // How this tool is reached. Custom tools are always local binaries, so anything not a built-in
+  // is "spawn". Used to decide whether the toolRunner (the PROCESS SPAWNER) is required — an HTTP
+  // tool like SO-CRATES must work on a machine with no local forensic binaries installed.
+  const transportOf = (toolId: string): "spawn" | "http" =>
+    (toolId in TOOL_DEFS ? TOOL_DEFS[toolId as ToolId].transport : "spawn");
+
   // ── External forensic tools (#211) ────────────────────────────────────────────────────────────
   // Per-tool configured/auto-run status for the Settings → Tools tab (no secret values). Derived LIVE
   // from env so it reflects settings just saved + reconnected.
@@ -41,6 +47,7 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
         label: TOOL_DEFS[id].label,
         repoUrl: TOOL_DEFS[id].repoUrl,
         importKind: TOOL_DEFS[id].importKind,
+        transport: TOOL_DEFS[id].transport,
         extensions: TOOL_DEFS[id].extensions,
         configured: !!cfg,
         autoRun: cfg?.autoRun ?? false,
@@ -52,6 +59,7 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
       id: t.id,
       label: t.name,
       importKind: "auto",
+      transport: "spawn" as const,
       extensions: t.extensions,
       configured: true,
       autoRun: t.autoRun,
@@ -80,8 +88,10 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
   app.post("/cases/:id/tools/:toolId/run", async (req: Request, res: Response) => {
     const caseId = req.params.id;
     const toolId = req.params.toolId;
-    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
     if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
+    if (transportOf(toolId) === "spawn" && !options.toolRunner) {
+      return res.status(501).json({ error: "external tools not configured" });
+    }
     if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
     const path = typeof req.body?.path === "string" ? req.body.path.trim() : "";
     if (!path) return res.status(400).json({ error: "path is required" });
@@ -103,13 +113,31 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
   app.post("/cases/:id/tools/:toolId/run-upload", async (req: Request, res: Response) => {
     const caseId = req.params.id;
     const toolId = req.params.toolId;
-    if (!options.toolRunner) return res.status(501).json({ error: "external tools not configured" });
     if (!isKnownTool(toolId)) return res.status(400).json({ error: `unknown tool "${toolId}"` });
+    if (transportOf(toolId) === "spawn" && !options.toolRunner) {
+      return res.status(501).json({ error: "external tools not configured" });
+    }
     if (!(await store.caseExists(caseId))) return res.status(404).json({ error: `case ${caseId} does not exist` });
     const filename = String(req.body?.filename ?? "").trim();
     const dataBase64 = typeof req.body?.dataBase64 === "string" ? req.body.dataBase64 : "";
     if (!filename || !dataBase64) return res.status(400).json({ error: "filename and dataBase64 are required" });
     if (!ctx.liveToolConfigs()().get(toolId)) return res.status(400).json({ error: `tool "${toolId}" is not configured` });
+
+    // HTTP tools never touch disk here — the bytes go straight to the service, and a zip is
+    // extracted first. Returns job ids rather than counts: the analysis is asynchronous.
+    if (transportOf(toolId) === "http") {
+      try {
+        const r = await ctx.startSocratesAnalysis(caseId, {
+          data: Buffer.from(dataBase64, "base64"),
+          filename,
+          zipPassword: typeof req.body?.zipPassword === "string" ? req.body.zipPassword : undefined,
+        });
+        return res.status(200).json({ ok: true, tool: toolId, ...r });
+      } catch (err) {
+        recordImportFailure(caseId, toolId, filename, err);
+        return res.status(400).json({ ok: false, error: (err as Error).message });
+      }
+    }
     // Stage into a FRESH per-upload dir under the file's ORIGINAL basename (no collisions, so no need to
     // mangle the name) — folder-root tools (Velociraptor --ROOT) detect the EVTX channel from the filename.
     const toolWork = join(store.caseDir(caseId), ".toolwork");
@@ -150,6 +178,14 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
     } catch (err) {
       return res.status(400).json({ ok: false, error: (err as Error).message });
     }
+  });
+
+  // In-flight and finished SO-CRATES analyses for this case — polled by the import banner so the
+  // analyst sees "analyzing (network)…" rather than a silent gap. SO-CRATES analysis is
+  // asynchronous, so the run route returns job ids and the results land here.
+  app.get("/cases/:id/socrates/jobs", async (req: Request, res: Response) => {
+    if (!(await store.caseExists(req.params.id))) return res.status(404).json({ error: `case ${req.params.id} does not exist` });
+    return res.status(200).json({ jobs: await ctx.socratesJobStore.list(req.params.id) });
   });
 
   // Custom tools (#211) — analyst-defined tools (name/binary/command/update/extensions) beyond the

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -1592,15 +1592,20 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // tools go through runToolAndIngest (synchronous); HTTP tools hand off to startSocratesAnalysis and
   // return immediately, with the poller landing the verdicts later. Shared by the drop-folder auto-run
   // and the "Run pending" batch so both behave identically.
-  async function runDropToolAndIngest(caseId: string, toolId: string, fullPath: string, name: string): Promise<void> {
+  // Returns true when the work is ASYNCHRONOUS (handed off, not finished) so the caller can log
+  // SUBMITTED rather than claiming an import that has not happened yet.
+  async function runDropToolAndIngest(
+    caseId: string, toolId: string, fullPath: string, name: string, dropRelpath?: string,
+  ): Promise<boolean> {
     const cfg = liveToolConfigs().get(toolId);
     if (!cfg) throw new Error(`tool "${toolId}" is not configured`);
     if (cfg.transport === "http") {
-      await startSocratesAnalysis(caseId, { data: await readFile(fullPath), filename: name });
-      return;
+      await startSocratesAnalysis(caseId, { data: await readFile(fullPath), filename: name, dropRelpath });
+      return true;
     }
     const r = await runToolAndIngest(caseId, toolId, fullPath);
     if (!r.analyzed) throw new Error(`${toolId} ran but AI is off — output saved as evidence but not analyzed`);
+    return false;
   }
 
   // Run a configured external tool against a raw on-disk file (contained in the case dir) and ingest its
@@ -1645,7 +1650,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // and it extracts through Python's zipfile, which cannot open AES archives at all.
   async function startSocratesAnalysis(
     caseId: string,
-    input: { data: Buffer; filename: string; zipPassword?: string },
+    input: { data: Buffer; filename: string; zipPassword?: string; dropRelpath?: string },
   ): Promise<{ jobIds: string[]; skippedNested: string[]; truncated: boolean }> {
     const cfg = liveToolConfigs().get("socrates");
     if (!cfg?.baseUrl) throw new Error("SO-CRATES is not configured — set DFIR_TOOL_SOCRATES_URL in Settings → Tools");
@@ -1704,6 +1709,20 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
           return { addedEvents: r.addedEvents, addedIocs: r.addedIocs };
         }),
       }, { maxAttempts: Math.max(1, Math.floor(cfg.timeoutMs / 5000)) })
+        .then(async (final) => {
+          // Close the SUBMITTED line in drop-log.txt with what actually happened. Without this the
+          // audit trail ends at "handed to socrates" and never says whether verdicts landed — and a
+          // failed analysis would leave a file sitting in _processed/ with no recorded outcome.
+          if (!input.dropRelpath) return;
+          const entry: DropLogEntry = final.status === "imported"
+            ? {
+              status: "IMPORTED", relpath: input.dropRelpath,
+              reason: `via socrates — +${final.addedEvents ?? 0} event(s), +${final.addedIocs ?? 0} IOC(s)`,
+            }
+            : { status: "FAILED", relpath: input.dropRelpath, reason: final.error ?? "SO-CRATES analysis failed" };
+          await appendDropLog(dropDirOf(caseId), formatDropLogLines([entry], new Date().toISOString()))
+            .catch((e) => logLine(`[drop] log append failed: ${(e as Error).message}`));
+        })
         .catch(() => { /* pollUntilImported already records failures on the job */ });
     }
 
@@ -1803,7 +1822,9 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     }
   }
 
-  async function processDropFile(caseId: string, dropDir: string, file: DropFileStat): Promise<{ ok: boolean; reason?: string; pending?: PendingRawInput }> {
+  async function processDropFile(
+    caseId: string, dropDir: string, file: DropFileStat,
+  ): Promise<{ ok: boolean; reason?: string; pending?: PendingRawInput; submitted?: string }> {
     const full = join(dropDir, file.relpath);
     const name = basename(file.relpath);
     try {
@@ -1846,8 +1867,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
           // Not runnable now → pending (banner). Do NOT move the file so a manual run can still act on it.
           return { ok: false, pending: { relpath: file.relpath, ext, suggestedTool: toolId ?? suggestedToolForExtension(ext), configured: !!toolId } };
         }
-        await runDropToolAndIngest(caseId, toolId, full, name);
-        return { ok: true };
+        const async_ = await runDropToolAndIngest(caseId, toolId, full, name, file.relpath);
+        // An HTTP tool has only been HANDED the file here; its verdicts land later (or the analysis
+        // fails), so the sweep logs SUBMITTED and the job appends the outcome when it resolves.
+        return async_ ? { ok: true, submitted: `handed to ${toolId}; verdicts land when analysis finishes` } : { ok: true };
       }
       if (isOversize(file.size, dropMaxBytes)) {
         return { ok: false, reason: `too large (${Math.round(file.size / 1048576)} MB > ${Math.round(dropMaxBytes / 1048576)} MB cap) — use Import-from-path` };
@@ -1893,6 +1916,9 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       });
 
       const imported: string[] = [];
+      // Handed to an asynchronous tool this sweep — logged SUBMITTED, with the outcome appended by the
+      // job itself when the analysis resolves.
+      const submitted: { relpath: string; reason: string }[] = [];
       const failed: DropFailure[] = [];
       const pendingRawInputs: PendingRawInput[] = [];
       let processed = 0;
@@ -1907,7 +1933,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
               pendingRawInputs.push(res.pending);
               return;
             }
-            if (res.ok) imported.push(file.relpath);
+            // A submitted file still counts as "imported" for the dashboard's drop banner (it was
+            // accepted and moved), but the drop-log records it as SUBMITTED until the analysis lands.
+            if (res.ok && res.submitted) { imported.push(file.relpath); submitted.push({ relpath: file.relpath, reason: res.submitted }); }
+            else if (res.ok) imported.push(file.relpath);
             else failed.push({ relpath: file.relpath, reason: res.reason ?? "import failed" });
             await moveDropFile(dropDir, file.relpath, res.ok).catch((e) => logLine(`[drop] move failed for ${file.relpath}: ${(e as Error).message}`));
             nextSeen.delete(file.relpath); // moved out of the watched area — forget it
@@ -1931,7 +1960,9 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       // raw-tool file gets ONE PENDING line the first time it's seen (dropPendingLogged dedups it across
       // the ~10s poll interval until it resolves).
       const { entries: logEntries, nextLoggedPending } = buildSweepLogEntries(
-        { imported, failed, pendingRawInputs },
+        // `imported` minus the async handoffs — those get a SUBMITTED line instead, so a file is
+        // never claimed as imported before its verdicts actually land.
+        { imported: imported.filter((r) => !submitted.some((s) => s.relpath === r)), submitted, failed, pendingRawInputs },
         dropPendingLogged.get(caseId) ?? new Set<string>(),
       );
       dropPendingLogged.set(caseId, nextLoggedPending);

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -1636,10 +1636,16 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
 
     const jobIds: string[] = [];
     for (const sub of submissions) {
-      const md5 = md5Buffer(sub.data);
-      // Already analyzed? Skip the upload — SO-CRATES keys everything by MD5.
-      const probe = await probeAnalysis(baseUrl, md5).catch(() => ({ status: "processing" as const }));
-      if (probe.status !== "ready") await uploadBuffer(baseUrl, sub.data, sub.name);
+      // Already analyzed? Skip the upload — SO-CRATES keys everything by MD5, so an unchanged file
+      // costs one request instead of a re-analysis.
+      const localMd5 = md5Buffer(sub.data);
+      const probe = await probeAnalysis(baseUrl, localMd5).catch(() => ({ status: "processing" as const }));
+      // Poll under the md5 the SERVER reports, not the one we computed. They usually agree, but
+      // SO-CRATES keys an archive on the hash of the file it extracts rather than the bytes it was
+      // sent — so trusting our own hash would poll a key that never becomes ready.
+      const md5 = probe.status === "ready"
+        ? localMd5
+        : (await uploadBuffer(baseUrl, sub.data, sub.name)).md5 || localMd5;
 
       const job: SocratesJob = {
         jobId: randomUUID(), md5, sourceName: input.filename, zipEntry: sub.zipEntry,

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -160,6 +160,12 @@ import {
 import { spawnToolRunner, type ToolRunner } from "./integrations/tools/toolRunner.js";
 import { runToolAgainstFile, resolveContainedPath } from "./integrations/tools/runToolImport.js";
 import { CustomToolStore, customToolToConfig, normalizeExt, type CustomTool } from "./integrations/tools/customToolStore.js";
+import { extractZipEntries } from "./analysis/zipExtract.js";
+import {
+  md5Buffer, probeAnalysis, uploadBuffer, checkStatus, fetchVerdicts,
+} from "./integrations/socrates/socratesApi.js";
+import { SocratesJobStore, type SocratesJob } from "./integrations/socrates/socratesJobStore.js";
+import { pollUntilImported } from "./integrations/socrates/socratesPoller.js";
 import {
   createOriginGuard,
   parseAllowedOrigins,
@@ -859,6 +865,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     return { unlocked, remembered: unlocked && isRememberedUnlockToken(token, id, salt, instanceSecret) };
   }
 
+  // Per-case record of asynchronous SO-CRATES analyses. Declared here (not beside
+  // startSocratesAnalysis further down) because the RouteContext literal below references it, and a
+  // `const` is not hoisted the way the surrounding function declarations are.
+  const socratesJobs = new SocratesJobStore(store);
+
   const ctx: RouteContext = {
     store,
     options,
@@ -894,6 +905,8 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     ingestStreamed,
     runToolAndIngest,
     reloadCustomTools,
+    startSocratesAnalysis,
+    socratesJobStore: socratesJobs,
     resolveImportKind: () => resolveImportKind,
     captureBuffers: () => buffers,
     synthInFlight: () => synthInFlight,
@@ -1565,9 +1578,13 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   async function runToolAndIngest(
     caseId: string, toolId: string, targetPath: string, opts: { undoLabel?: string } = {},
   ): Promise<{ storedName: string; addedEvents: number; addedIocs: number; analyzed: boolean }> {
-    if (!options.toolRunner) throw new Error("external tools not configured");
     const cfg = liveToolConfigs().get(toolId);
     if (!cfg) throw new Error(`tool "${toolId}" is not configured`);
+    // The toolRunner is the PROCESS SPAWNER. Only spawn-transport tools need it — gating http tools
+    // on it would make SO-CRATES unreachable on a machine with no local forensic binaries, which is
+    // exactly the machine most likely to want it.
+    if (cfg.transport === "http") throw new Error(`tool "${toolId}" is an HTTP tool — use startSocratesAnalysis`);
+    if (!options.toolRunner) throw new Error("external tools not configured");
     const caseDir = store.caseDir(caseId);
     const contained = resolveContainedPath(caseDir, targetPath);
     const { outputText, importKind } = await runToolAgainstFile({
@@ -1587,6 +1604,71 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       await pushImportCheckpoint(caseId, before, opts.undoLabel);
     }
     return r;
+  }
+
+  // Submit one file (or every entry of a zip) to SO-CRATES and poll for results in the background.
+  // Zip handling happens HERE rather than in SO-CRATES because its upload handler builds the
+  // password list server-side from the filename — an analyst-supplied password cannot reach it —
+  // and it extracts through Python's zipfile, which cannot open AES archives at all.
+  async function startSocratesAnalysis(
+    caseId: string,
+    input: { data: Buffer; filename: string; zipPassword?: string },
+  ): Promise<{ jobIds: string[]; skippedNested: string[]; truncated: boolean }> {
+    const cfg = liveToolConfigs().get("socrates");
+    if (!cfg?.baseUrl) throw new Error("SO-CRATES is not configured — set DFIR_TOOL_SOCRATES_URL in Settings → Tools");
+    const baseUrl = cfg.baseUrl;
+
+    // Decide what to submit: the file itself, or each entry of an archive.
+    let submissions: { data: Buffer; name: string; zipEntry?: string }[];
+    let skippedNested: string[] = [];
+    let truncated = false;
+    if (input.data.subarray(0, 2).toString("latin1") === "PK") {
+      const extracted = extractZipEntries(input.data, input.filename, input.zipPassword);
+      skippedNested = extracted.skippedNested;
+      truncated = extracted.truncated;
+      submissions = extracted.entries.map((e) => ({
+        data: e.data, name: basename(e.path), zipEntry: `${input.filename}!${e.path}`,
+      }));
+      if (submissions.length === 0) throw new Error(`"${input.filename}" contained no analyzable files`);
+    } else {
+      submissions = [{ data: input.data, name: input.filename }];
+    }
+
+    const jobIds: string[] = [];
+    for (const sub of submissions) {
+      const md5 = md5Buffer(sub.data);
+      // Already analyzed? Skip the upload — SO-CRATES keys everything by MD5.
+      const probe = await probeAnalysis(baseUrl, md5).catch(() => ({ status: "processing" as const }));
+      if (probe.status !== "ready") await uploadBuffer(baseUrl, sub.data, sub.name);
+
+      const job: SocratesJob = {
+        jobId: randomUUID(), md5, sourceName: input.filename, zipEntry: sub.zipEntry,
+        status: "processing", startedAt: new Date().toISOString(),
+      };
+      await socratesJobs.upsert(caseId, job);
+      jobIds.push(job.jobId);
+
+      // Uploading evidence leaves a copy on the SO-CRATES host, keyed by MD5 and retained until
+      // deleted. That belongs in the case record. Best-effort — never block the analysis.
+      await options.custodyStore?.recordExport(caseId, {
+        exportedBy: "companion",
+        destination: `SO-CRATES analysis at ${baseUrl} (md5 ${md5}, ${sub.zipEntry ?? sub.name})`,
+      }).catch(() => { /* custody is best-effort */ });
+
+      // Fire and forget: the poller updates the job record, which the dashboard polls.
+      void pollUntilImported(caseId, job, {
+        store: socratesJobs,
+        checkStatus: (m) => checkStatus(baseUrl, m),
+        fetchVerdicts: (m) => fetchVerdicts(baseUrl, m),
+        ingest: async (cid, text, name) => {
+          const r = await ingestStreamed(cid, "socrates", text, name);
+          return { addedEvents: r.addedEvents, addedIocs: r.addedIocs };
+        },
+      }, { maxAttempts: Math.max(1, Math.floor(cfg.timeoutMs / 5000)) })
+        .catch(() => { /* pollUntilImported already records failures on the job */ });
+    }
+
+    return { jobIds, skippedNested, truncated };
   }
 
   function dropDirOf(caseId: string): string { return join(store.caseDir(caseId), "drop"); }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -155,7 +155,7 @@ import {
 } from "./analysis/dropScan.js";
 import { formatDropLogLines, appendDropLog, buildSweepLogEntries, type DropLogEntry } from "./analysis/dropLog.js";
 import {
-  loadAllToolConfigs, toolForExtension, suggestedToolForExtension, type ToolId, type ToolConfig,
+  loadAllToolConfigs, toolForExtension, suggestedToolForExtension, SOCRATES_EXTS, type ToolId, type ToolConfig,
 } from "./integrations/tools/toolConfig.js";
 import { spawnToolRunner, type ToolRunner } from "./integrations/tools/toolRunner.js";
 import { runToolAgainstFile, resolveContainedPath } from "./integrations/tools/runToolImport.js";
@@ -870,6 +870,19 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
   // `const` is not hoisted the way the surrounding function declarations are.
   const socratesJobs = new SocratesJobStore(store);
 
+  // SO-CRATES pollers finish independently, but every ingest mutates the SAME case state behind the
+  // per-case state lock. Firing them concurrently — a 25-entry archive, or several files dropped at
+  // once — piles them all onto that lock. Chain them per case so verdicts land one at a time, in
+  // completion order. The chain never rejects (each link swallows), so one bad import cannot wedge
+  // every later one behind it.
+  const socratesIngestChain = new Map<string, Promise<unknown>>();
+  const queueSocratesIngest = <T>(caseId: string, fn: () => Promise<T>): Promise<T> => {
+    const prev = socratesIngestChain.get(caseId) ?? Promise.resolve();
+    const next = prev.then(fn, fn);
+    socratesIngestChain.set(caseId, next.catch(() => { /* keep the chain alive after a failure */ }));
+    return next;
+  };
+
   const ctx: RouteContext = {
     store,
     options,
@@ -907,6 +920,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     reloadCustomTools,
     startSocratesAnalysis,
     socratesJobStore: socratesJobs,
+    runDropToolAndIngest,
     resolveImportKind: () => resolveImportKind,
     captureBuffers: () => buffers,
     synthInFlight: () => synthInFlight,
@@ -1566,9 +1580,28 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     const custom = customTools.find((t) => configured.has(t.id) && t.extensions.some((x) => x.toLowerCase() === e));
     return custom ? custom.id : null;
   };
-  // Every file extension claimed by a built-in raw type OR a defined custom tool (for drop routing).
+  // Every file extension claimed by a built-in raw type, SO-CRATES, OR a defined custom tool (for drop
+  // routing). SOCRATES_EXTS is included unconditionally — even when SO-CRATES is not configured — so a
+  // dropped .exe is recognized as RAW and surfaces as pending ("configure a tool") instead of falling
+  // through to the text path, which would read the binary as UTF-8 and ingest garbage.
   const rawExtClaimed = (ext: string): boolean =>
-    RAW_TOOL_EXTS.has(ext.toLowerCase()) || customTools.some((t) => t.extensions.some((x) => x.toLowerCase() === ext.toLowerCase()));
+    RAW_TOOL_EXTS.has(ext.toLowerCase()) || SOCRATES_EXTS.includes(ext.toLowerCase())
+    || customTools.some((t) => t.extensions.some((x) => x.toLowerCase() === ext.toLowerCase()));
+
+  // Run a raw on-disk file through whichever transport its tool uses, and ingest the result. Spawn
+  // tools go through runToolAndIngest (synchronous); HTTP tools hand off to startSocratesAnalysis and
+  // return immediately, with the poller landing the verdicts later. Shared by the drop-folder auto-run
+  // and the "Run pending" batch so both behave identically.
+  async function runDropToolAndIngest(caseId: string, toolId: string, fullPath: string, name: string): Promise<void> {
+    const cfg = liveToolConfigs().get(toolId);
+    if (!cfg) throw new Error(`tool "${toolId}" is not configured`);
+    if (cfg.transport === "http") {
+      await startSocratesAnalysis(caseId, { data: await readFile(fullPath), filename: name });
+      return;
+    }
+    const r = await runToolAndIngest(caseId, toolId, fullPath);
+    if (!r.analyzed) throw new Error(`${toolId} ran but AI is off — output saved as evidence but not analyzed`);
+  }
 
   // Run a configured external tool against a raw on-disk file (contained in the case dir) and ingest its
   // output through the SAME chain as the Import button (ingestStreamed). Shared by the drop-folder
@@ -1666,10 +1699,10 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
         store: socratesJobs,
         checkStatus: (m) => checkStatus(baseUrl, m),
         fetchVerdicts: (m) => fetchVerdicts(baseUrl, m),
-        ingest: async (cid, text, name) => {
+        ingest: (cid, text, name) => queueSocratesIngest(cid, async () => {
           const r = await ingestStreamed(cid, "socrates", text, name);
           return { addedEvents: r.addedEvents, addedIocs: r.addedIocs };
-        },
+        }),
       }, { maxAttempts: Math.max(1, Math.floor(cfg.timeoutMs / 5000)) })
         .catch(() => { /* pollUntilImported already records failures on the job */ });
     }
@@ -1786,16 +1819,34 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
       // checked BEFORE the oversize cap), or surface it as pending so the dashboard offers "Run/Configure
       // <tool>". Auto-run is gated per-tool (#211). Images always go to the capture path, not here.
       const ext = extname(file.relpath).toLowerCase();
-      if (options.toolRunner && classifyDropFile(file.relpath) !== "image" && rawExtClaimed(ext)) {
+      // Sniff the head so an EXTENSIONLESS or hash-named sample (routine for malware) is still seen as
+      // raw rather than read as text. Only the first 8 KB — the file may be gigabytes.
+      let head: Buffer | undefined;
+      try {
+        const fh = await open(full, "r");
+        try {
+          const buf = Buffer.alloc(Math.min(8192, Math.max(0, file.size)));
+          if (buf.length) await fh.read(buf, 0, buf.length, 0);
+          head = buf;
+        } finally { await fh.close(); }
+      } catch { /* unreadable head → fall back to extension-only classification */ }
+
+      // A raw file no text importer can read: a claimed extension, or anything the sniff says is binary.
+      // NOT gated on options.toolRunner — that is the PROCESS SPAWNER, and SO-CRATES needs no spawner.
+      // Gating here would drop a binary into the text path on a box with no local forensic binaries.
+      if (classifyDropFile(file.relpath, head) === "raw-tool-input" || rawExtClaimed(ext)) {
         const configured = liveToolConfigs();
-        const toolId = resolveToolForExt(ext, configured);
+        // An extensionless binary is claimed by nobody, but SO-CRATES YARA-scans anything, so it is the
+        // fallback whenever it is configured.
+        const toolId = resolveToolForExt(ext, configured) ?? (configured.has("socrates") ? "socrates" : null);
         const cfg = toolId ? configured.get(toolId) : undefined;
-        if (!toolId || !cfg || !cfg.autoRun) {
+        // A spawn tool additionally needs the process spawner; an HTTP tool does not.
+        const runnable = !!cfg && cfg.autoRun && (cfg.transport === "http" || !!options.toolRunner);
+        if (!toolId || !cfg || !runnable) {
           // Not runnable now → pending (banner). Do NOT move the file so a manual run can still act on it.
           return { ok: false, pending: { relpath: file.relpath, ext, suggestedTool: toolId ?? suggestedToolForExtension(ext), configured: !!toolId } };
         }
-        const r = await runToolAndIngest(caseId, toolId, full);
-        if (!r.analyzed) return { ok: false, reason: `${toolId} ran but AI is off — output saved as evidence but not analyzed` };
+        await runDropToolAndIngest(caseId, toolId, full, name);
         return { ok: true };
       }
       if (isOversize(file.size, dropMaxBytes)) {

--- a/companion/tests/analysis/dropLog.test.ts
+++ b/companion/tests/analysis/dropLog.test.ts
@@ -11,7 +11,7 @@ describe("formatDropLogLines", () => {
 
   it("formats an IMPORTED line with no reason", () => {
     const lines = formatDropLogLines([{ status: "IMPORTED", relpath: "alerts.csv" }], at);
-    expect(lines).toEqual([`${at}  IMPORTED  alerts.csv`]);
+    expect(lines).toEqual([`${at}  IMPORTED   alerts.csv`]);
   });
 
   it("formats a FAILED line with a reason", () => {
@@ -19,7 +19,7 @@ describe("formatDropLogLines", () => {
       [{ status: "FAILED", relpath: "weird.csv", reason: "unrecognized file type (not a supported import format)" }],
       at,
     );
-    expect(lines).toEqual([`${at}  FAILED    weird.csv  — unrecognized file type (not a supported import format)`]);
+    expect(lines).toEqual([`${at}  FAILED     weird.csv  — unrecognized file type (not a supported import format)`]);
   });
 
   it("formats a PENDING line with a reason", () => {
@@ -27,7 +27,7 @@ describe("formatDropLogLines", () => {
       [{ status: "PENDING", relpath: "capture.evtx", reason: "no tool configured for .evtx" }],
       at,
     );
-    expect(lines).toEqual([`${at}  PENDING   capture.evtx  — no tool configured for .evtx`]);
+    expect(lines).toEqual([`${at}  PENDING    capture.evtx  — no tool configured for .evtx`]);
   });
 
   it("preserves entry order across multiple entries in one call", () => {
@@ -202,5 +202,44 @@ describe("buildSweepLogEntries", () => {
       original,
     );
     expect(original).toEqual(new Set(["existing.evtx"])); // unchanged — caller must use the returned set
+  });
+});
+
+describe("SUBMITTED (asynchronous tools)", () => {
+  const at = "2026-07-29T15:25:30.404Z";
+
+  it("formats a SUBMITTED line, aligned with the other statuses", () => {
+    const lines = formatDropLogLines(
+      [{ status: "SUBMITTED", relpath: "evil.exe", reason: "handed to socrates; verdicts land when analysis finishes" }],
+      at,
+    );
+    expect(lines).toEqual([`${at}  SUBMITTED  evil.exe  — handed to socrates; verdicts land when analysis finishes`]);
+  });
+
+  it("logs an async handoff as SUBMITTED, never as IMPORTED", () => {
+    // Claiming IMPORTED at handoff would assert an import that has not happened — and would still
+    // assert it if the analysis later failed.
+    const { entries } = buildSweepLogEntries(
+      {
+        imported: ["alerts.csv"],
+        submitted: [{ relpath: "evil.exe", reason: "handed to socrates; verdicts land when analysis finishes" }],
+        failed: [],
+        pendingRawInputs: [],
+      },
+      new Set<string>(),
+    );
+    expect(entries).toEqual([
+      { status: "IMPORTED", relpath: "alerts.csv" },
+      { status: "SUBMITTED", relpath: "evil.exe", reason: "handed to socrates; verdicts land when analysis finishes" },
+    ]);
+  });
+
+  it("omits the submitted section entirely when a caller does not pass one", () => {
+    // Back-compat: every existing caller passes only imported/failed/pendingRawInputs.
+    const { entries } = buildSweepLogEntries(
+      { imported: ["a.csv"], failed: [], pendingRawInputs: [] },
+      new Set<string>(),
+    );
+    expect(entries).toEqual([{ status: "IMPORTED", relpath: "a.csv" }]);
   });
 });

--- a/companion/tests/analysis/dropScan.test.ts
+++ b/companion/tests/analysis/dropScan.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   classifyDropFile,
+  looksBinary,
   rawToolInputExt,
   shouldIgnoreDropFile,
   selectReadyFiles,
@@ -95,5 +96,51 @@ describe("dropScan — oversize", () => {
     expect(isOversize(100, 50)).toBe(true);
     expect(isOversize(40, 50)).toBe(false);
     expect(isOversize(1e9, 0)).toBe(false);
+  });
+});
+
+describe("looksBinary", () => {
+  it("is false for plain ASCII text", () => {
+    expect(looksBinary(Buffer.from("2026-07-29 login succeeded for alice\n"))).toBe(false);
+  });
+
+  it("is false for UTF-8 text with accents and CJK", () => {
+    expect(looksBinary(Buffer.from("café — 日本語のログ\n", "utf8"))).toBe(false);
+  });
+
+  it("is true for a PE header", () => {
+    const pe = Buffer.concat([Buffer.from("MZ"), Buffer.alloc(64), Buffer.from("PE\0\0")]);
+    expect(looksBinary(pe)).toBe(true);
+  });
+
+  it("is true for an ELF header", () => {
+    expect(looksBinary(Buffer.from([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1, 0, 0, 0]))).toBe(true);
+  });
+
+  it("is false for an empty buffer", () => {
+    // Nothing to go on — do not claim an empty file is a malware sample.
+    expect(looksBinary(Buffer.alloc(0))).toBe(false);
+  });
+});
+
+describe("classifyDropFile with a content sample", () => {
+  it("still routes by extension when there is one", () => {
+    expect(classifyDropFile("Security.evtx")).toBe("raw-tool-input");
+    expect(classifyDropFile("shot.png")).toBe("image");
+    expect(classifyDropFile("auth.log")).toBe("artifact");
+  });
+
+  it("routes an extensionless binary sample to the tool path", () => {
+    const pe = Buffer.concat([Buffer.from("MZ"), Buffer.alloc(64)]);
+    expect(classifyDropFile("a1b2c3d4e5f6", pe)).toBe("raw-tool-input");
+  });
+
+  it("leaves an extensionless text file as an artifact", () => {
+    expect(classifyDropFile("notes", Buffer.from("just some text\n"))).toBe("artifact");
+  });
+
+  it("never lets the sniff override a known text extension", () => {
+    // A .csv with an odd byte is still a csv for the native importer, not a malware sample.
+    expect(classifyDropFile("data.csv", Buffer.from([0x00, 0x41, 0x42]))).toBe("artifact");
   });
 });

--- a/companion/tests/analysis/zipArchive.test.ts
+++ b/companion/tests/analysis/zipArchive.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { inflateRawSync } from "node:zlib";
 import { createZip, readZip, crc32, type ZipEntry } from "../../src/analysis/zipArchive.js";
+import { ZipPasswordError } from "../../src/analysis/zipCrypto.js";
 
 const EOCD_SIG = 0x06054b50;
 const LOCAL_SIG = 0x04034b50;
@@ -101,5 +102,59 @@ describe("readZip — zip-bomb guard (#247)", () => {
     // archives (e.g. a real forensic case's screenshots/state).
     const archive = createZip([{ path: "normal.bin", data: Buffer.from("just a normal file", "utf8") }]);
     expect(() => readZip(archive)).not.toThrow();
+  });
+});
+
+// Same two fixtures as tests/analysis/zipCrypto.test.ts — see that file for how they were produced.
+const ZC_ZIP_B64 =
+  "UEsDBAoACQAAAGWB/VzrJ0KsIwAAABcAAAAKABwAc2FtcGxlLmJpblVUCQAD7vtpau77aWp1eAsAAQToAwAABOgDAACSY93uO3OX" +
+  "/aoYARCx5Jfbd3EGx/7tlqbVxQgzvT21C/Kx6FBLBwjrJ0KsIwAAABcAAABQSwECHgMKAAkAAABlgf1c6ydCrCMAAAAXAAAACgAY" +
+  "AAAAAAABAAAAtIEAAAAAc2FtcGxlLmJpblVUBQAD7vtpanV4CwABBOgDAAAE6AMAAFBLBQYAAAAAAQABAFAAAAB3AAAAAAA=";
+const AES_ZIP_B64 =
+  "UEsDBDMAAQBjAGaB/VwAAAAAMwAAABcAAAAKAAsAc2FtcGxlLmJpbgGZBwACAEFFAwAAjSVbocfmvx3PE5161dsvWZeAGwRMGhH+" +
+  "U3dNZiO2mA/QMCMLIAwEGRmcHEdlOo1WBP7zUEsBAj8DMwABAGMAZoH9XAAAAAAzAAAAFwAAAAoALwAAAAAAAAAggLSBAAAAAHNh" +
+  "bXBsZS5iaW4KACAAAAAAAAEAGAC4I7e5Wx/dAQAAAAAAAAAAAAAAAAAAAAABmQcAAgBBRQMAAFBLBQYAAAAAAQABAGcAAABmAAAA" +
+  "AAA=";
+
+describe("readZip with encrypted entries", () => {
+  it("reads a ZipCrypto entry when given the password", () => {
+    const back = readZip(Buffer.from(ZC_ZIP_B64, "base64"), { password: "infected" });
+    expect(back).toHaveLength(1);
+    expect(back[0].path).toBe("sample.bin");
+    expect(back[0].data.toString("utf8")).toBe("MZ fake sample payload\n");
+  });
+
+  it("reads an AES-256 entry when given the password", () => {
+    const back = readZip(Buffer.from(AES_ZIP_B64, "base64"), { password: "infected" });
+    expect(back).toHaveLength(1);
+    expect(back[0].path).toBe("sample.bin");
+    expect(back[0].data.toString("utf8")).toBe("MZ fake sample payload\n");
+  });
+
+  it("throws password-required when an encrypted entry gets no password", () => {
+    try {
+      readZip(Buffer.from(AES_ZIP_B64, "base64"));
+      throw new Error("expected readZip to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ZipPasswordError);
+      expect((err as ZipPasswordError).reason).toBe("password-required");
+    }
+  });
+
+  it("throws wrong-password for a bad ZipCrypto password", () => {
+    try {
+      readZip(Buffer.from(ZC_ZIP_B64, "base64"), { password: "nope" });
+      throw new Error("expected readZip to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ZipPasswordError);
+      expect((err as ZipPasswordError).reason).toBe("wrong-password");
+    }
+  });
+
+  it("still round-trips unencrypted archives unchanged", () => {
+    const archive = createZip([{ path: "a.txt", data: Buffer.from("plain") }]);
+    expect(readZip(archive)[0].data.toString()).toBe("plain");
+    // A password on an unencrypted archive is simply ignored.
+    expect(readZip(archive, { password: "infected" })[0].data.toString()).toBe("plain");
   });
 });

--- a/companion/tests/analysis/zipCrypto.test.ts
+++ b/companion/tests/analysis/zipCrypto.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { zipCryptoDecrypt } from "../../src/analysis/zipCrypto.js";
+import { inflateRawSync } from "node:zlib";
+import {
+  zipCryptoDecrypt, parseAesExtra, aesDecrypt, ZipPasswordError,
+} from "../../src/analysis/zipCrypto.js";
 import { crc32 } from "../../src/analysis/zipArchive.js";
 
 // Produced by Info-ZIP: `zip -P infected zc.zip sample.bin`
@@ -49,5 +52,84 @@ describe("zipCryptoDecrypt", () => {
   it("produces a different check byte for a wrong password", () => {
     const { data, modTime } = rawEntry(archive);
     expect(zipCryptoDecrypt(data, "wrongpw")[11]).not.toBe(modTime >> 8);
+  });
+});
+
+// 7-Zip: `7z a -tzip -pinfected -mem=AES256 aes.zip sample.bin` — 23 bytes, STORED, one AES block.
+const AES_ZIP_B64 =
+  "UEsDBDMAAQBjAGaB/VwAAAAAMwAAABcAAAAKAAsAc2FtcGxlLmJpbgGZBwACAEFFAwAAjSVbocfmvx3PE5161dsvWZeAGwRMGhH+" +
+  "U3dNZiO2mA/QMCMLIAwEGRmcHEdlOo1WBP7zUEsBAj8DMwABAGMAZoH9XAAAAAAzAAAAFwAAAAoALwAAAAAAAAAggLSBAAAAAHNh" +
+  "bXBsZS5iaW4KACAAAAAAAAEAGAC4I7e5Wx/dAQAAAAAAAAAAAAAAAAAAAAABmQcAAgBBRQMAAFBLBQYAAAAAAQABAGcAAABmAAAA" +
+  "AAA=";
+
+// Same command over a 1000-byte file → 294 ciphertext bytes = 19 AES blocks, DEFLATED then encrypted.
+// This is the fixture that fails if the CTR counter is big-endian.
+const AES_BIG_ZIP_B64 =
+  "UEsDBDMAAQBjALCB/VwAAAAAQgEAAOgDAAAHAAsAYmlnLmJpbgGZBwACAEFFAwgAznxy0fDFGikZitS/zL9C4cbtevTbRU9oSTcl" +
+  "90FtHMR8/3kflzvaMYkSLR8tD73AyKE98yGd339dy1TAMd+ClE8kfG9F9akAmxdF1CkVwIMhrshTKOuTtFYkI1Lgnp9qcabmsPlR" +
+  "Cbj2lmanL1wdagvK8fyCVk/Q4p3cHAy+FWPOhXIzkAyyl22OQKeXKJiOaN99my8geQJqtHcRVXGlZWnJCUGqgGYrhy/kJIEBxPTu" +
+  "QDRqYoGVbexXewZBktHQxIz8lbf0dCAeSYvl+VWLaWXMZTFircZ2cgjsUqOP07aI189Xmlsqe6h2kW/Y9I8CzjnPrQ8ay0Bq8+8c" +
+  "RkB/ZFZbyB7oUjVemEC43tOVT0WJstYNe8KsGRnMGk9SOphoOlPwXvDTC//zkvt7bgARk4XCevvxLMBn1ZjP8MylZGZztVBLAQI/" +
+  "AzMAAQBjALCB/VwAAAAAQgEAAOgDAAAHAC8AAAAAAAAAIIC0gQAAAABiaWcuYmluCgAgAAAAAAABABgAymVADVwf3QEAAAAAAAAA" +
+  "AAAAAAAAAAAAAZkHAAIAQUUDCABQSwUGAAAAAAEAAQBkAAAAcgEAAAAA";
+
+// Entry data plus its central-directory extra field, without going through readZip.
+function rawEntryWithExtra(archive: Buffer): { data: Buffer; extra: Buffer } {
+  let eocd = -1;
+  for (let i = archive.length - 22; i >= 0; i--) {
+    if (archive.readUInt32LE(i) === 0x06054b50) { eocd = i; break; }
+  }
+  const ptr = archive.readUInt32LE(eocd + 16);
+  const compSize = archive.readUInt32LE(ptr + 20);
+  const nameLen = archive.readUInt16LE(ptr + 28);
+  const extraLen = archive.readUInt16LE(ptr + 30);
+  const localOffset = archive.readUInt32LE(ptr + 42);
+  const dataStart = localOffset + 30 + archive.readUInt16LE(localOffset + 26) + archive.readUInt16LE(localOffset + 28);
+  return {
+    data: archive.subarray(dataStart, dataStart + compSize),
+    extra: archive.subarray(ptr + 46 + nameLen, ptr + 46 + nameLen + extraLen),
+  };
+}
+
+describe("parseAesExtra", () => {
+  it("reads AE version, strength, and the real compression method", () => {
+    const { extra } = rawEntryWithExtra(Buffer.from(AES_ZIP_B64, "base64"));
+    expect(parseAesExtra(extra)).toEqual({ aeVersion: 2, strength: 3, actualMethod: 0 });
+  });
+
+  it("returns null when there is no 0x9901 field", () => {
+    expect(parseAesExtra(Buffer.alloc(0))).toBeNull();
+  });
+});
+
+describe("aesDecrypt", () => {
+  it("decrypts a single-block AES-256 entry", () => {
+    const { data } = rawEntryWithExtra(Buffer.from(AES_ZIP_B64, "base64"));
+    const { plaintext, macOk } = aesDecrypt(data, "infected", 3);
+    expect(plaintext.toString("utf8")).toBe("MZ fake sample payload\n");
+    expect(macOk).toBe(true);
+  });
+
+  it("decrypts a multi-block entry across all 19 AES blocks", () => {
+    // Guards the little-endian counter. With a big-endian counter the first 16 bytes match and
+    // everything after is garbage, so only a multi-block fixture catches it.
+    const { data, extra } = rawEntryWithExtra(Buffer.from(AES_BIG_ZIP_B64, "base64"));
+    const params = parseAesExtra(extra);
+    expect(params).not.toBeNull();
+    expect(params!.actualMethod).toBe(8);   // deflated before encryption
+    const { plaintext, macOk } = aesDecrypt(data, "infected", params!.strength);
+    expect(macOk).toBe(true);
+    const expected = Buffer.from(Array.from({ length: 1000 }, (_, i) => (i * 7 + 3) % 256));
+    expect(inflateRawSync(plaintext).equals(expected)).toBe(true);
+  });
+
+  it("throws ZipPasswordError with reason wrong-password for a bad password", () => {
+    const { data } = rawEntryWithExtra(Buffer.from(AES_ZIP_B64, "base64"));
+    expect(() => aesDecrypt(data, "wrongpw", 3)).toThrow(ZipPasswordError);
+    try {
+      aesDecrypt(data, "wrongpw", 3);
+    } catch (err) {
+      expect((err as ZipPasswordError).reason).toBe("wrong-password");
+    }
   });
 });

--- a/companion/tests/analysis/zipCrypto.test.ts
+++ b/companion/tests/analysis/zipCrypto.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { zipCryptoDecrypt } from "../../src/analysis/zipCrypto.js";
+import { crc32 } from "../../src/analysis/zipArchive.js";
+
+// Produced by Info-ZIP: `zip -P infected zc.zip sample.bin`
+// sample.bin content is exactly "MZ fake sample payload\n" (23 bytes, STORED).
+const ZC_ZIP_B64 =
+  "UEsDBAoACQAAAGWB/VzrJ0KsIwAAABcAAAAKABwAc2FtcGxlLmJpblVUCQAD7vtpau77aWp1eAsAAQToAwAABOgDAACSY93uO3OX" +
+  "/aoYARCx5Jfbd3EGx/7tlqbVxQgzvT21C/Kx6FBLBwjrJ0KsIwAAABcAAABQSwECHgMKAAkAAABlgf1c6ydCrCMAAAAXAAAACgAY" +
+  "AAAAAAABAAAAtIEAAAAAc2FtcGxlLmJpblVUBQAD7vtpanV4CwABBOgDAAAE6AMAAFBLBQYAAAAAAQABAFAAAAB3AAAAAAA=";
+
+// Pull the single entry's raw (still encrypted) bytes straight out of the archive, so this test
+// exercises the cipher alone and does not depend on readZip.
+function rawEntry(archive: Buffer): { data: Buffer; crc: number; modTime: number } {
+  let eocd = -1;
+  for (let i = archive.length - 22; i >= 0; i--) {
+    if (archive.readUInt32LE(i) === 0x06054b50) { eocd = i; break; }
+  }
+  const ptr = archive.readUInt32LE(eocd + 16);
+  const modTime = archive.readUInt16LE(ptr + 12);
+  const crc = archive.readUInt32LE(ptr + 16);
+  const compSize = archive.readUInt32LE(ptr + 20);
+  const nameLen = archive.readUInt16LE(ptr + 28);
+  const localOffset = archive.readUInt32LE(ptr + 42);
+  const dataStart = localOffset + 30 + archive.readUInt16LE(localOffset + 26) + archive.readUInt16LE(localOffset + 28);
+  return { data: archive.subarray(dataStart, dataStart + compSize), crc, modTime };
+}
+
+describe("zipCryptoDecrypt", () => {
+  const archive = Buffer.from(ZC_ZIP_B64, "base64");
+
+  it("decrypts an Info-ZIP ZipCrypto entry with the correct password", () => {
+    const { data, crc } = rawEntry(archive);
+    const body = zipCryptoDecrypt(data, "infected").subarray(12);
+    expect(body.toString("utf8")).toBe("MZ fake sample payload\n");
+    expect(crc32(body)).toBe(crc);
+  });
+
+  it("produces a check byte matching the mod-time high byte when flag bit 3 is set", () => {
+    // Regression guard: Info-ZIP sets the data-descriptor flag, so the check byte is the
+    // mod-time high byte, NOT the CRC high byte. Verifying only against the CRC rejects a
+    // correct password.
+    const { data, crc, modTime } = rawEntry(archive);
+    const checkByte = zipCryptoDecrypt(data, "infected")[11];
+    expect(checkByte).toBe(modTime >> 8);
+    expect(checkByte).not.toBe(crc >>> 24);
+  });
+
+  it("produces a different check byte for a wrong password", () => {
+    const { data, modTime } = rawEntry(archive);
+    expect(zipCryptoDecrypt(data, "wrongpw")[11]).not.toBe(modTime >> 8);
+  });
+});

--- a/companion/tests/analysis/zipExtract.test.ts
+++ b/companion/tests/analysis/zipExtract.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { createZip } from "../../src/analysis/zipArchive.js";
+import { candidatePasswords, extractZipEntries, MAX_ZIP_ENTRIES } from "../../src/analysis/zipExtract.js";
+
+const ZC_ZIP_B64 =
+  "UEsDBAoACQAAAGWB/VzrJ0KsIwAAABcAAAAKABwAc2FtcGxlLmJpblVUCQAD7vtpau77aWp1eAsAAQToAwAABOgDAACSY93uO3OX" +
+  "/aoYARCx5Jfbd3EGx/7tlqbVxQgzvT21C/Kx6FBLBwjrJ0KsIwAAABcAAABQSwECHgMKAAkAAABlgf1c6ydCrCMAAAAXAAAACgAY" +
+  "AAAAAAABAAAAtIEAAAAAc2FtcGxlLmJpblVUBQAD7vtpanV4CwABBOgDAAAE6AMAAFBLBQYAAAAAAQABAFAAAAB3AAAAAAA=";
+
+// `zip -P s3cret custom.zip secret.bin` — a password NOT in the default ladder, holding the
+// 24-byte file "custom password payload\n". This is the fixture that proves custom passwords work,
+// which is the one thing the SO-CRATES API can never do.
+const CUSTOM_ZIP_B64 =
+  "UEsDBAoACQAAAO2C/Vx7BJ0tJAAAABgAAAAKABwAc2VjcmV0LmJpblVUCQADzf5pas3+aWp1eAsAAQToAwAABOgDAACQ7YfTxb3j" +
+  "gnkcB9RnjbnCiwID4RlVYqmQgwa8AzOEfM/SLxRQSwcIewSdLSQAAAAYAAAAUEsBAh4DCgAJAAAA7YL9XHsEnS0kAAAAGAAAAAoA" +
+  "GAAAAAAAAQAAALSBAAAAAHNlY3JldC5iaW5VVAUAA83+aWp1eAsAAQToAwAABOgDAABQSwUGAAAAAAEAAQBQAAAAeAAAAAAA";
+
+describe("candidatePasswords", () => {
+  it("defaults to infected when nothing is supplied", () => {
+    expect(candidatePasswords("sample.zip")).toEqual(["infected"]);
+  });
+
+  it("puts the supplied password first, keeping infected as a fallback", () => {
+    expect(candidatePasswords("sample.zip", "hunter2")).toEqual(["hunter2", "infected"]);
+  });
+
+  it("derives the dated MTA-style password from a date in the filename", () => {
+    // malware-traffic-analysis.net convention, which SO-CRATES also follows.
+    expect(candidatePasswords("2026-02-03-traffic.zip")).toEqual(["infected", "infected_20260203"]);
+  });
+
+  it("does not duplicate infected when it is also the supplied password", () => {
+    expect(candidatePasswords("sample.zip", "infected")).toEqual(["infected"]);
+  });
+});
+
+describe("extractZipEntries", () => {
+  it("opens a ZipCrypto archive with the default password", () => {
+    const res = extractZipEntries(Buffer.from(ZC_ZIP_B64, "base64"), "zc.zip");
+    expect(res.passwordUsed).toBe("infected");
+    expect(res.entries.map((e) => e.path)).toEqual(["sample.bin"]);
+  });
+
+  it("keeps every file entry rather than only the first", () => {
+    const archive = createZip([
+      { path: "a.bin", data: Buffer.from("aaa") },
+      { path: "b.bin", data: Buffer.from("bbb") },
+      { path: "c.bin", data: Buffer.from("ccc") },
+    ]);
+    const res = extractZipEntries(archive, "bundle.zip");
+    expect(res.entries.map((e) => e.path)).toEqual(["a.bin", "b.bin", "c.bin"]);
+    expect(res.passwordUsed).toBeNull();
+  });
+
+  it("drops directory entries, dotfiles, and __MACOSX metadata", () => {
+    const archive = createZip([
+      { path: "payload/", data: Buffer.alloc(0) },
+      { path: "payload/evil.exe", data: Buffer.from("MZ") },
+      { path: ".DS_Store", data: Buffer.from("junk") },
+      { path: "__MACOSX/._evil.exe", data: Buffer.from("junk") },
+    ]);
+    expect(extractZipEntries(archive, "b.zip").entries.map((e) => e.path)).toEqual(["payload/evil.exe"]);
+  });
+
+  it("rejects zip-slip paths", () => {
+    const archive = createZip([{ path: "../../etc/passwd", data: Buffer.from("x") }]);
+    expect(() => extractZipEntries(archive, "evil.zip")).toThrow(/outside the archive/i);
+  });
+
+  it("reports nested zips instead of recursing into them", () => {
+    const inner = createZip([{ path: "deep.bin", data: Buffer.from("d") }]);
+    const archive = createZip([
+      { path: "outer.bin", data: Buffer.from("o") },
+      { path: "inner.zip", data: inner },
+    ]);
+    const res = extractZipEntries(archive, "nest.zip");
+    expect(res.entries.map((e) => e.path)).toEqual(["outer.bin"]);
+    expect(res.skippedNested).toEqual(["inner.zip"]);
+  });
+
+  it("caps the entry count and flags truncation", () => {
+    const many = Array.from({ length: MAX_ZIP_ENTRIES + 5 }, (_, i) => ({
+      path: `f${i}.bin`, data: Buffer.from(String(i)),
+    }));
+    const res = extractZipEntries(createZip(many), "many.zip");
+    expect(res.entries).toHaveLength(MAX_ZIP_ENTRIES);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("opens an archive whose password is NOT in the default ladder", () => {
+    // The whole point of the feature: SO-CRATES can only ever try `infected`.
+    const res = extractZipEntries(Buffer.from(CUSTOM_ZIP_B64, "base64"), "custom.zip", "s3cret");
+    expect(res.passwordUsed).toBe("s3cret");
+    expect(res.entries[0].data.toString("utf8")).toBe("custom password payload\n");
+  });
+
+  it("falls back to infected when the supplied password is wrong", () => {
+    // Deliberate: a typo in the password box should not fail an archive that infected opens.
+    const res = extractZipEntries(Buffer.from(ZC_ZIP_B64, "base64"), "zc.zip", "typo");
+    expect(res.passwordUsed).toBe("infected");
+  });
+
+  it("reports a wrong password once every candidate fails", () => {
+    // Nothing in the ladder opens this one, so the analyst gets an actionable error.
+    expect(() => extractZipEntries(Buffer.from(CUSTOM_ZIP_B64, "base64"), "custom.zip"))
+      .toThrow(/password/i);
+  });
+});

--- a/companion/tests/integrations/socratesApi.test.ts
+++ b/companion/tests/integrations/socratesApi.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  md5Buffer, probeAnalysis, uploadBuffer, checkStatus, fetchVerdicts,
+} from "../../src/integrations/socrates/socratesApi.js";
+
+// Minimal fetch double: map a URL substring to a JSON body, and record every requested URL.
+function mockFetch(routes: Array<[string, unknown]>, seen: string[] = []) {
+  return (async (input: unknown) => {
+    const url = String(input);
+    seen.push(url);
+    for (const [needle, body] of routes) {
+      if (url.includes(needle)) {
+        return { ok: true, status: 200, json: async () => body } as unknown as Response;
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({ error: "not found" }) } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("md5Buffer", () => {
+  it("computes the MD5 SO-CRATES keys analyses by", () => {
+    // Canonical: MD5("abc") = 900150983cd24fb0d6963f7d28e17f72
+    expect(md5Buffer(Buffer.from("abc"))).toBe("900150983cd24fb0d6963f7d28e17f72");
+  });
+});
+
+describe("probeAnalysis", () => {
+  it("reports ready for an already-analyzed md5", async () => {
+    const f = mockFetch([["/api/status", { status: "ready", meta: { detected_type: "pcap" } }]]);
+    const res = await probeAnalysis("http://localhost:8000", "a".repeat(32), f);
+    expect(res.status).toBe("ready");
+    expect(res.meta?.detected_type).toBe("pcap");
+  });
+});
+
+describe("uploadBuffer", () => {
+  it("posts multipart and returns the md5 and phase", async () => {
+    const seen: string[] = [];
+    const f = mockFetch([["/api/upload", { status: "processing", md5: "b".repeat(32), phase: "network" }]], seen);
+    const res = await uploadBuffer("http://localhost:8000", Buffer.from("PK"), "eve.pcap", f);
+    expect(res).toEqual({ status: "processing", md5: "b".repeat(32), phase: "network" });
+    expect(seen[0]).toContain("/api/upload");
+  });
+});
+
+describe("checkStatus", () => {
+  it("surfaces the error status and message", async () => {
+    const f = mockFetch([["/api/check-status", { status: "error", message: "suricata failed" }]]);
+    const res = await checkStatus("http://localhost:8000", "c".repeat(32), f);
+    expect(res.status).toBe("error");
+    expect(res.message).toBe("suricata failed");
+  });
+});
+
+describe("fetchVerdicts", () => {
+  it("pulls only the three verdict feeds, never the unfiltered event list", async () => {
+    const seen: string[] = [];
+    const f = mockFetch([
+      ["type=alert", [{ event_type: "alert", alert: { signature: "ET TROJAN" } }]],
+      ["type=filealerts", [{ event_type: "filealerts", filealerts: [{ rule: "evil" }] }]],
+      ["/api/sigma-alerts", [{ rule_title: "Suspicious PowerShell", rule_id: "abc-123" }]],
+    ], seen);
+
+    const res = await fetchVerdicts("http://localhost:8000", "d".repeat(32), f);
+    expect(res.alerts).toBe(1);
+    expect(res.yara).toBe(1);
+    expect(res.sigma).toBe(1);
+
+    // Post-detection principle: an unfiltered /api/events call would drag in whole-capture telemetry.
+    const events = seen.filter((u) => u.includes("/api/events"));
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.every((u) => u.includes("type="))).toBe(true);
+
+    const rows = JSON.parse(res.text) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r._Source === "SO-CRATES")).toBe(true);
+  });
+
+  it("pages until a short page arrives", async () => {
+    const seen: string[] = [];
+    const full = Array.from({ length: 1000 }, (_, i) => ({ event_type: "alert", n: i }));
+    let alertCall = 0;
+    const f = (async (input: unknown) => {
+      const url = String(input);
+      seen.push(url);
+      let body: unknown = [];
+      if (url.includes("type=alert")) body = alertCall++ === 0 ? full : [{ event_type: "alert", n: 1000 }];
+      return { ok: true, status: 200, json: async () => body } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const res = await fetchVerdicts("http://localhost:8000", "e".repeat(32), f);
+    expect(res.alerts).toBe(1001);
+    expect(seen.filter((u) => u.includes("type=alert") && u.includes("offset=1000"))).toHaveLength(1);
+  });
+});

--- a/companion/tests/integrations/socratesJob.test.ts
+++ b/companion/tests/integrations/socratesJob.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SocratesJobStore, type SocratesJob } from "../../src/integrations/socrates/socratesJobStore.js";
+import { pollUntilImported, type PollerDeps } from "../../src/integrations/socrates/socratesPoller.js";
+import type { SocratesStatus } from "../../src/integrations/socrates/socratesApi.js";
+
+// Minimal CaseStore stand-in: the store only ever calls stateDir().
+async function makeStore() {
+  const root = await mkdtemp(join(tmpdir(), "socrates-job-"));
+  await mkdir(join(root, "state"), { recursive: true });
+  const cases = { stateDir: () => join(root, "state") } as unknown as ConstructorParameters<typeof SocratesJobStore>[0];
+  return new SocratesJobStore(cases);
+}
+
+function job(over: Partial<SocratesJob> = {}): SocratesJob {
+  return {
+    jobId: "j1", md5: "a".repeat(32), sourceName: "evil.pcap",
+    status: "processing", startedAt: "2026-07-29T00:00:00.000Z", ...over,
+  };
+}
+
+describe("SocratesJobStore", () => {
+  it("returns an empty list before anything is written", async () => {
+    expect(await (await makeStore()).list("case-1")).toEqual([]);
+  });
+
+  it("round-trips a job and updates it in place by jobId", async () => {
+    const store = await makeStore();
+    await store.upsert("case-1", job());
+    await store.upsert("case-1", job({ status: "imported", addedEvents: 4 }));
+    const all = await store.list("case-1");
+    expect(all).toHaveLength(1);
+    expect(all[0].status).toBe("imported");
+    expect(all[0].addedEvents).toBe(4);
+  });
+
+  it("keeps multiple concurrent jobs newest first", async () => {
+    const store = await makeStore();
+    await store.upsert("case-1", job({ jobId: "j1" }));
+    await store.upsert("case-1", job({ jobId: "j2" }));
+    expect((await store.list("case-1")).map((j) => j.jobId)).toEqual(["j2", "j1"]);
+  });
+});
+
+describe("pollUntilImported", () => {
+  const noSleep = async () => {};
+
+  function deps(statuses: SocratesStatus[], over: Partial<PollerDeps> = {}): PollerDeps {
+    let i = 0;
+    return {
+      store: { upsert: async (_c: string, j: SocratesJob) => j } as unknown as SocratesJobStore,
+      checkStatus: async () => statuses[Math.min(i++, statuses.length - 1)],
+      fetchVerdicts: async () => ({ text: "[]", alerts: 1, yara: 0, sigma: 0 }),
+      ingest: async () => ({ addedEvents: 3, addedIocs: 2 }),
+      sleep: noSleep,
+      ...over,
+    };
+  }
+
+  it("imports once the analysis reports ready", async () => {
+    const d = deps([{ status: "processing", phase: "network" }, { status: "ready" }]);
+    const res = await pollUntilImported("case-1", job(), d);
+    expect(res.status).toBe("imported");
+    expect(res.addedEvents).toBe(3);
+    expect(res.addedIocs).toBe(2);
+    expect(res.finishedAt).toBeTruthy();
+  });
+
+  it("records the failure reason when analysis errors", async () => {
+    const res = await pollUntilImported("case-1", job(), deps([{ status: "error", message: "suricata died" }]));
+    expect(res.status).toBe("error");
+    expect(res.error).toContain("suricata died");
+  });
+
+  it("gives up after maxAttempts instead of polling a nonexistent md5 forever", async () => {
+    // /api/check-status never 404s, so an unknown md5 answers "processing" indefinitely.
+    const res = await pollUntilImported("case-1", job(), deps([{ status: "processing", phase: "" }]), { maxAttempts: 3 });
+    expect(res.status).toBe("error");
+    expect(res.error).toMatch(/timed out/i);
+  });
+
+  it("records an import failure rather than claiming success", async () => {
+    const d = deps([{ status: "ready" }], {
+      ingest: async () => { throw new Error("importer rejected the blob"); },
+    });
+    const res = await pollUntilImported("case-1", job(), d);
+    expect(res.status).toBe("error");
+    expect(res.error).toContain("importer rejected the blob");
+  });
+});

--- a/companion/tests/integrations/toolRunner.test.ts
+++ b/companion/tests/integrations/toolRunner.test.ts
@@ -14,6 +14,7 @@ import {
   loadToolConfig,
   loadAllToolConfigs,
   toolForExtension,
+  toolPreferenceForExtension,
   suggestedToolForExtension,
   TOOL_DEFS,
   type ToolId,
@@ -307,5 +308,48 @@ describe("updateToolRules", () => {
     const cfg = loadToolConfig("snort", { DFIR_TOOL_SNORT_BINARY: "snort" })!;
     const runner: ToolRunner = async () => ({ stdout: "", stderr: "", code: 0 });
     await expect(updateToolRules(cfg, runner)).rejects.toThrow(/no update command/i);
+  });
+});
+
+describe("SO-CRATES as an http-transport tool", () => {
+  it("is off until DFIR_TOOL_SOCRATES_URL is set", () => {
+    expect(loadToolConfig("socrates", {} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it("loads from a URL rather than a binary path", () => {
+    const cfg = loadToolConfig("socrates", { DFIR_TOOL_SOCRATES_URL: "http://localhost:8000/" } as NodeJS.ProcessEnv);
+    expect(cfg).not.toBeNull();
+    expect(cfg!.transport).toBe("http");
+    expect(cfg!.baseUrl).toBe("http://localhost:8000");   // trailing slash trimmed
+    expect(cfg!.importKind).toBe("socrates");
+  });
+
+  it("marks every built-in binary tool as spawn transport", () => {
+    for (const id of Object.keys(TOOL_DEFS) as ToolId[]) {
+      if (id === "socrates") continue;
+      expect(TOOL_DEFS[id].transport).toBe("spawn");
+    }
+  });
+
+  it("claims pcap, evtx, binary, and zip extensions", () => {
+    const claimed = TOOL_DEFS.socrates.extensions;
+    for (const ext of [".pcap", ".pcapng", ".evtx", ".exe", ".dll", ".zip"]) {
+      expect(claimed).toContain(ext);
+    }
+    // Text formats the Companion parses natively must NOT be claimed, or ordinary log imports
+    // would be diverted away from the native importers.
+    for (const ext of [".csv", ".json", ".log", ".xml"]) {
+      expect(claimed).not.toContain(ext);
+    }
+  });
+
+  it("ranks behind the configured binary tools for a shared extension", () => {
+    // Drop-folder auto-run takes the first configured claimant; a tuned local Suricata should win.
+    const order = toolPreferenceForExtension(".pcap");
+    expect(order.indexOf("socrates")).toBeGreaterThan(order.indexOf("suricata"));
+  });
+
+  it("is the suggested tool for a binary nothing else claims", () => {
+    expect(suggestedToolForExtension(".exe")).toBe("socrates");
   });
 });

--- a/companion/tests/server/socratesRoutes.test.ts
+++ b/companion/tests/server/socratesRoutes.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, buildRuntimePipeline } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ImportUndoStore } from "../../src/analysis/importUndo.js";
+import { loadToolConfig, type ToolId, type ToolConfig } from "../../src/integrations/tools/toolConfig.js";
+
+// A zip built by Info-ZIP with `zip -P infected`, holding one 23-byte file "sample.bin".
+const ZC_ZIP_B64 =
+  "UEsDBAoACQAAAGWB/VzrJ0KsIwAAABcAAAAKABwAc2FtcGxlLmJpblVUCQAD7vtpau77aWp1eAsAAQToAwAABOgDAACSY93uO3OX" +
+  "/aoYARCx5Jfbd3EGx/7tlqbVxQgzvT21C/Kx6FBLBwjrJ0KsIwAAABcAAABQSwECHgMKAAkAAABlgf1c6ydCrCMAAAAXAAAACgAY" +
+  "AAAAAAABAAAAtIEAAAAAc2FtcGxlLmJpblVUBQAD7vtpanV4CwABBOgDAAAE6AMAAFBLBQYAAAAAAQABAFAAAAB3AAAAAAA=";
+
+// SO-CRATES configured by URL. NOTE: no toolRunner is wired anywhere in this file — the whole point
+// is that an http-transport tool must work on a machine with no local forensic binaries.
+function socratesCfg(): Map<ToolId, ToolConfig> {
+  const cfg = loadToolConfig("socrates", { DFIR_TOOL_SOCRATES_URL: "http://127.0.0.1:59999" })!;
+  return new Map<ToolId, ToolConfig>([["socrates", cfg]]);
+}
+
+async function harness() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-socrates-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const pipeline = buildRuntimePipeline({
+    provider: undefined, synthesisProvider: undefined, stateStore, store,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+  const importUndoStore = new ImportUndoStore(store);
+  const app = createApp(store, {
+    pipeline, stateStore, importUndoStore, loadToolConfigs: socratesCfg,
+  });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, store };
+}
+
+describe("SO-CRATES routes", () => {
+  it("reports socrates as configured in /tools/status with http transport", async () => {
+    const { app } = await harness();
+    const r = await request(app).get("/tools/status");
+    expect(r.status).toBe(200);
+    const socrates = (r.body.tools as Array<{ id: string; configured: boolean; transport: string }>)
+      .find((t) => t.id === "socrates");
+    expect(socrates?.configured).toBe(true);
+    expect(socrates?.transport).toBe("http");
+  });
+
+  it("does NOT 501 the socrates run route when no toolRunner is configured", async () => {
+    const { app } = await harness();
+    const r = await request(app)
+      .post("/cases/c1/tools/socrates/run-upload")
+      .send({ filename: "sample.bin", dataBase64: Buffer.from("MZ").toString("base64") });
+    // The upload will fail (nothing is listening on :59999), but it must NOT be 501 "external tools
+    // not configured" — that gate is for spawn tools only.
+    expect(r.status).not.toBe(501);
+  });
+
+  it("still 501s a spawn tool when no toolRunner is configured", async () => {
+    const { app } = await harness();
+    const r = await request(app)
+      .post("/cases/c1/tools/hayabusa/run-upload")
+      .send({ filename: "Security.evtx", dataBase64: "AAAA" });
+    expect(r.status).toBe(501);
+  });
+
+  it("rejects a zip whose password is wrong with an actionable message", async () => {
+    const { app } = await harness();
+    const r = await request(app).post("/cases/c1/tools/socrates/run-upload").send({
+      filename: "zc.zip", dataBase64: ZC_ZIP_B64, zipPassword: "definitely-wrong",
+    });
+    // "definitely-wrong" fails, but the ladder falls back to "infected" which opens it — so the
+    // failure here is the unreachable server, never a password error.
+    expect(r.status).toBe(400);
+    expect(r.body.error).not.toMatch(/password/i);
+  });
+
+  it("returns an empty job list for a fresh case", async () => {
+    const { app } = await harness();
+    const r = await request(app).get("/cases/c1/socrates/jobs");
+    expect(r.status).toBe(200);
+    expect(r.body.jobs).toEqual([]);
+  });
+
+  it("404s the job list for a case that does not exist", async () => {
+    const { app } = await harness();
+    expect((await request(app).get("/cases/nope/socrates/jobs")).status).toBe(404);
+  });
+});

--- a/mkdocs-docs/reference/importing.md
+++ b/mkdocs-docs/reference/importing.md
@@ -54,6 +54,42 @@ seen for this case.
 
 Enabled by default. Configure via `DFIR_DROP_ENABLED`, `DFIR_DROP_POLL_S` (poll interval), `DFIR_DROP_MAX_BYTES` (size cap).
 
+## SO-CRATES (direct API)
+
+Set `DFIR_TOOL_SOCRATES_URL` (for example `http://localhost:8000`) in **Settings → Tools**. Importing
+a PCAP, binary, EVTX, or archive then offers SO-CRATES alongside any local tool that claims the same
+file — tick one or both, since a local Suricata and SO-CRATES run different rulesets. Verdicts flow
+into the forensic timeline tagged `SO-CRATES` plus the underlying engine.
+
+Analysis is asynchronous: the run returns immediately and the banner shows
+`SO-CRATES: analyzing (network)…` until results land. Because SO-CRATES keys every analysis by MD5,
+re-importing an unchanged file costs one request instead of a re-analysis.
+
+Only detections are imported — Suricata alerts, YARA file matches, and Zircolite Sigma alerts. Raw
+telemetry (dns/http/tls/flow) stays in SO-CRATES, one click away in its own UI.
+
+### Password-protected archives
+
+The Companion extracts the archive itself before uploading. This is deliberate: the SO-CRATES API
+can only ever try `infected` (its password list is built server-side from the filename, with no
+request field to override it) and it extracts through Python's `zipfile`, which cannot open
+WinZip AES archives at all — so a 7-Zip archive fails there under any password.
+
+- Leave the password box empty for `infected`; type one for anything else.
+- ZipCrypto and WinZip AES-128/192/256 are both supported.
+- A `YYYY-MM-DD` date in the filename also tries `infected_YYYYMMDD` (the malware-traffic-analysis.net
+  convention).
+- **Every** file in the archive is analyzed, up to 25 entries. SO-CRATES itself keeps only one file
+  per archive and discards the rest.
+- Nested archives are reported rather than unpacked recursively.
+
+### Exposure
+
+SO-CRATES has no authentication of any kind and binds `127.0.0.1` by default. Pointing
+`DFIR_TOOL_SOCRATES_URL` at a non-local address means unauthenticated evidence reachable by anyone
+who can route to it. Every submission is written to the case custody log, since the uploaded file
+stays on the SO-CRATES host until deleted there.
+
 ## Per-Format Import Buttons
 
 The toolbar also exposes per-format buttons for cases where you want to import by type explicitly:

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3319,6 +3319,15 @@
         </div>
         <div style="margin:4px 0 14px"><button class="tool-update" data-tool="yara" type="button">↻ Update rules</button></div>
 
+        <div class="settings-group-head">SO-CRATES <span style="color:var(--c-7e8aa0);font-weight:400">(HTTP service, not a local binary — pcap → Suricata, logs → Sigma, anything else → YARA · <a href="https://github.com/dougburks/so-crates" target="_blank" rel="noopener">repo</a>)</span></div>
+        <p class="rm-hint" style="font-size:11px;color:var(--c-9aa4b2);margin:2px 0 10px">The only tool here reached over HTTP rather than by spawning a binary, so it needs a URL instead of a path. Importing a PCAP, binary, EVTX, or archive will offer it alongside any local tool claiming the same file. Only detections are imported (Suricata alerts, YARA matches, Sigma alerts) — raw telemetry stays in SO-CRATES. Analysis is asynchronous; the import banner shows progress until results land. <strong>SO-CRATES has no authentication and binds <code>127.0.0.1</code> by default</strong> — a non-local URL means unauthenticated evidence reachable by anyone who can route to it. Every submission is written to the case custody log.</p>
+        <div class="sgrid">
+          <div class="sfield"><label>Base URL<span class="sfield-hint">DFIR_TOOL_SOCRATES_URL — e.g. http://localhost:8000; blank = off</span></label><input id="env-DFIR_TOOL_SOCRATES_URL" placeholder="(off)" /></div>
+          <div class="sfield"><label>Auto-run on drop<span class="sfield-hint">DFIR_TOOL_SOCRATES_AUTO_RUN — on/off (opt-in; a dropped file otherwise asks first)</span></label><input id="env-DFIR_TOOL_SOCRATES_AUTO_RUN" placeholder="off (opt-in)" /></div>
+          <div class="sfield"><label>Timeout (ms)<span class="sfield-hint">DFIR_TOOL_SOCRATES_TIMEOUT_MS — how long to wait for analysis (default 1200000 = 20 min)</span></label><input id="env-DFIR_TOOL_SOCRATES_TIMEOUT_MS" placeholder="1200000" /></div>
+        </div>
+        <div class="sfield-hint" style="display:block;margin:4px 0 14px">Password-protected archives are unpacked <em>here</em>, not by SO-CRATES: its API can only ever try <code>infected</code>, and it cannot open WinZip AES archives at all. Enter the password in the import banner; leave it blank for <code>infected</code>.</div>
+
         <div class="sfield-hint" style="display:block;margin-bottom:16px">Master auto-run kill-switch: <code>DFIR_TOOL_AUTO_RUN=off</code> disables all auto-run (set on the General tab's <code>.env</code>, or your env).</div>
         <div class="sfield-row" style="margin-bottom:16px">
           <div class="sfield"><label>Binary spawn retries<span class="sfield-hint">DFIR_TOOL_SPAWN_RETRIES — transient spawn-launch retry count for AV/sync-client locks (default 6)</span></label><input id="env-DFIR_TOOL_SPAWN_RETRIES" placeholder="6" /></div>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1126,6 +1126,10 @@
     .raw-banner button { padding: 4px 14px; font-size: 12px; margin-right: 6px; }
     .raw-banner .rb-yes { background: #2f7d32; color: #fff; border: none; border-radius: 5px; cursor: pointer; }
     .raw-banner .rb-no { background: transparent; color: var(--c-9aa4b2); border: 1px solid var(--c-2a3146); border-radius: 5px; cursor: pointer; }
+    /* One row per raw file: its name, a checkbox per claiming tool, and (for archives) a password box. */
+    .raw-banner .rb-row { margin: 4px 0; display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+    .raw-banner .rb-tool { font-size: 12px; opacity: 0.9; }
+    .raw-banner .rb-pw { width: 130px; font-size: 12px; padding: 2px 6px; }
     /* Second LLM opinion panel (#116) — independent-model QA cross-check with per-delta accept/reject. */
     .so-panel { font-size: 12px; color: var(--c-c7ced9); margin: 0 0 10px; padding: 9px 11px;
       border: 1px solid var(--c-2a2f3a); border-radius: 6px; background: var(--c-0f1115); }
@@ -10609,71 +10613,153 @@
         return set;
       }).catch(() => new Set());
     }
-    // Raw EVTX/PCAP picked in the Import dialog → ask ONCE before running a tool (yes/no, one banner for
-    // the whole batch). On Yes, each file's bytes are uploaded and run through its tool server-side. #211
+    // Every CONFIGURED tool claiming this extension, not just the first. SO-CRATES and a local
+    // Suricata run different rulesets, so an analyst may legitimately want both verdicts.
+    function toolsForExt(ext, status) {
+      return ((status && status.tools) || []).filter((t) => t.configured && (t.extensions || []).includes(ext));
+    }
+    // Raw evidence picked in the Import dialog → one banner listing each file with the tools that
+    // can analyze it. Zips also get a password box, defaulting to "infected". #211
     function askRunToolsOnImport(caseId, rawFiles) {
       const el = document.getElementById("rawToolBanner");
       if (!el) return;
       fetch("/tools/status").then((r) => r.ok ? r.json() : null).then((status) => {
-        const items = rawFiles.map((f) => {
+        const items = rawFiles.map((f, i) => {
           const ext = "." + (f.name.split(".").pop() || "").toLowerCase();
-          const toolId = toolForExt(ext, status);
-          return { file: f, ext, toolId, label: toolLabel(toolId, status), suggested: suggestToolForExt(ext, status) };
+          return { idx: i, file: f, ext, tools: toolsForExt(ext, status), isZip: /\.(zip|7z|rar)$/i.test(f.name) };
         });
-        const runnable = items.filter((i) => i.toolId);
-        const notCfg = items.filter((i) => !i.toolId);
-        const files = items.map((i) => `<code>${esc(i.file.name)}</code>`).join(", ");
+        const runnable = items.filter((it) => it.tools.length);
+        const notCfg = items.filter((it) => !it.tools.length);
         el.style.display = "block";
-        let head, actions;
-        if (runnable.length) {
-          const tools = [...new Set(runnable.map((i) => i.label))].join(", ");
+
+        if (!runnable.length) {
+          const sug = [...new Set(items.map((it) => toolLabel(suggestToolForExt(it.ext, status), status)))].join(", ");
           const many = rawFiles.length !== 1;
-          head = `<div class="rb-head">⚠️ ${rawFiles.length} raw ${many ? "files" : "file"} — the Companion can't read ${many ? "them" : "it"} directly. Run <strong>${esc(tools)}</strong> on ${many ? "them" : "it"}?</div>`;
-          actions = "";
-          if (notCfg.length) actions += `<div class="rb-files">${notCfg.length} file(s) have no configured tool and will be skipped — <a href="#" id="rawCfgLink">configure in Settings → Tools</a>.</div>`;
-          actions += `<button class="rb-yes" id="rawRunYes">Yes, run ${esc(tools)}</button><button class="rb-no" id="rawRunNo">No</button>`;
+          el.innerHTML =
+            '<div class="rb-head">⚠️ Raw evidence not directly supported</div>' +
+            '<div class="rb-files">The Companion analyzes tool <em>output</em>, not raw binaries. Configure <strong>' +
+            esc(sug) + '</strong> (Settings → Tools) to analyze ' + (many ? "these" : "this") +
+            ', then re-import — or copy into the case <strong>drop folder</strong> ' +
+            '(EVTX can also be exported to XML via <code>wevtutil qe /f:xml</code>).</div>' +
+            '<button class="rb-yes" id="rawCfgBtn">Settings → Tools</button><button class="rb-no" id="rawRunNo">Dismiss</button>';
         } else {
-          const sug = [...new Set(items.map((i) => toolLabel(i.suggested, status)))].join(", ");
+          let rows = "";
+          for (const it of runnable) {
+            const boxes = it.tools.map((t) =>
+              '<label class="rb-tool"><input type="checkbox" data-file="' + it.idx + '" value="' + esc(t.id) + '" checked> ' +
+              esc(t.label) + "</label>").join(" ");
+            const pw = it.isZip
+              ? '<input class="rb-pw" type="password" data-pw="' + it.idx + '" placeholder="infected" autocomplete="off">'
+              : "";
+            rows += '<div class="rb-row"><code>' + esc(it.file.name) + "</code> " + boxes + " " + pw + "</div>";
+          }
           const many = rawFiles.length !== 1;
-          head = `<div class="rb-head">⚠️ Raw evidence not directly supported</div>`;
-          actions = `<div class="rb-files">The Companion analyzes tool <em>output</em>, not raw binaries. Configure <strong>${esc(sug)}</strong> (Settings → Tools) to analyze ${many ? "these" : "this"}, then re-import — or copy into the case <strong>drop folder</strong> (EVTX can also be exported to XML via <code>wevtutil qe /f:xml</code>).</div>` +
-            `<button class="rb-yes" id="rawCfgBtn">Settings → Tools</button><button class="rb-no" id="rawRunNo">Dismiss</button>`;
+          let head = '<div class="rb-head">⚠️ ' + rawFiles.length + " raw " + (many ? "files" : "file") +
+            " — the Companion can't read " + (many ? "them" : "it") + " directly. Choose what to run:</div>";
+          if (notCfg.length) {
+            rows += '<div class="rb-files">' + notCfg.length + ' file(s) have no configured tool and will be skipped — ' +
+              '<a href="#" id="rawCfgLink">configure in Settings → Tools</a>.</div>';
+          }
+          el.innerHTML = head + rows +
+            '<button class="rb-yes" id="rawRunYes">Run selected</button><button class="rb-no" id="rawRunNo">No</button>';
         }
-        el.innerHTML = head + `<div class="rb-files">${files}</div>` + actions;
+
         const no = document.getElementById("rawRunNo"); if (no) no.onclick = () => { el.style.display = "none"; };
         const cfgBtn = document.getElementById("rawCfgBtn"); if (cfgBtn) cfgBtn.onclick = openToolsSettings;
-        const cfgLink = document.getElementById("rawCfgLink"); if (cfgLink) cfgLink.onclick = (ev) => { ev.preventDefault(); openToolsSettings(); };
+        const cfgLink = document.getElementById("rawCfgLink");
+        if (cfgLink) cfgLink.onclick = (ev) => { ev.preventDefault(); openToolsSettings(); };
         const yes = document.getElementById("rawRunYes");
-        if (yes) yes.onclick = () => runUploadRawFiles(caseId, runnable, el, yes);
+        if (yes) yes.onclick = () => {
+          // Expand the checkbox grid into one (file, tool, password) run per ticked box.
+          const runs = [];
+          el.querySelectorAll('input[type="checkbox"][data-file]:checked').forEach((cb) => {
+            const it = runnable.find((x) => String(x.idx) === cb.getAttribute("data-file"));
+            if (!it) return;
+            const pwEl = el.querySelector('input[data-pw="' + it.idx + '"]');
+            runs.push({ file: it.file, toolId: cb.value, zipPassword: pwEl ? pwEl.value : "" });
+          });
+          if (!runs.length) { el.style.display = "none"; return; }
+          runUploadRawFiles(caseId, runs, el, yes);
+        };
       }).catch(() => { el.style.display = "none"; });
     }
-    // Upload each raw file's bytes (base64) and run its tool via /tools/:id/run-upload. Batch, sequential.
+    // Upload each selected file's bytes and run its tool. Spawn tools return counts synchronously;
+    // SO-CRATES returns job ids because its analysis is asynchronous, so those are polled after.
     // Files too big for the JSON body cap are skipped with a hint to use the drop folder. #211
-    function runUploadRawFiles(caseId, items, el, btn) {
+    function runUploadRawFiles(caseId, runs, el, btn) {
       if (btn) { btn.disabled = true; btn.textContent = "Running…"; }
       const statusEl = document.getElementById("status");
       const LARGE_MB = 180; // base64 body must fit DFIR_MAX_BODY_MB (default 256 MB → ~190 MB raw)
       (async () => {
         let ran = 0, failed = 0, ev = 0, ioc = 0;
-        for (const it of items) {
-          statusEl.textContent = `running ${it.label || it.toolId} on ${it.file.name}…`;
+        const jobIds = [];
+        for (const it of runs) {
+          statusEl.textContent = "running " + it.toolId + " on " + it.file.name + "…";
           try {
-            if (it.file.size > LARGE_MB * 1024 * 1024) { failed++; statusEl.textContent = `${it.file.name} is too large to upload — copy it into the case drop folder instead`; continue; }
+            if (it.file.size > LARGE_MB * 1024 * 1024) {
+              failed++;
+              statusEl.textContent = it.file.name + " is too large to upload — copy it into the case drop folder instead";
+              continue;
+            }
             const b64 = await fileToBase64(it.file);
             if (!b64) { failed++; continue; }
-            const r = await fetch(`/cases/${caseId}/tools/${it.toolId}/run-upload`, {
-              method: "POST", headers: { "content-type": "application/json" },
-              body: JSON.stringify({ filename: it.file.name, dataBase64: b64 }),
+            const body = { filename: it.file.name, dataBase64: b64 };
+            if (it.zipPassword) body.zipPassword = it.zipPassword;
+            const r = await fetch("/cases/" + caseId + "/tools/" + it.toolId + "/run-upload", {
+              method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
             });
             const j = await r.json().catch(() => ({}));
-            if (!r.ok) { failed++; console.warn("tool run failed", it.file.name, j.error); continue; }
-            ran++; ev += j.addedEvents || 0; ioc += j.addedIocs || 0;
+            if (!r.ok) {
+              failed++;
+              // Surface the reason (wrong zip password, unreachable service) instead of a silent skip.
+              statusEl.textContent = it.file.name + ": " + (j.error || "failed");
+              console.warn("tool run failed", it.file.name, j.error);
+              continue;
+            }
+            ran++;
+            ev += j.addedEvents || 0;
+            ioc += j.addedIocs || 0;
+            if (Array.isArray(j.jobIds)) jobIds.push.apply(jobIds, j.jobIds);
+            if (j.truncated) statusEl.textContent = it.file.name + ": only the first 25 archive entries were submitted";
           } catch (e) { failed++; console.warn("tool run error", it.file.name, e && e.message); }
         }
         if (el) el.style.display = "none";
-        statusEl.textContent = `Ran ${ran} tool run(s): +${ev} event(s), +${ioc} IOC(s)` + (failed ? `, ${failed} failed/skipped` : "");
+        statusEl.textContent = "Ran " + ran + " run(s): +" + ev + " event(s), +" + ioc + " IOC(s)" +
+          (failed ? ", " + failed + " failed/skipped" : "") +
+          (jobIds.length ? " — " + jobIds.length + " SO-CRATES analysis/es running…" : "");
+        if (jobIds.length) pollSocratesJobs(caseId, jobIds);
         loadImportMeta(caseId);
       })();
+    }
+    // SO-CRATES analysis is asynchronous, so follow the jobs until every one is terminal. Polls at
+    // 5s and gives up after 20 minutes, matching the server-side attempt ceiling.
+    function pollSocratesJobs(caseId, jobIds) {
+      const statusEl = document.getElementById("status");
+      const wanted = new Set(jobIds);
+      let ticks = 0;
+      const timer = setInterval(async () => {
+        ticks++;
+        try {
+          const r = await fetch("/cases/" + caseId + "/socrates/jobs");
+          if (!r.ok) return;
+          const jobs = ((await r.json()).jobs || []).filter((j) => wanted.has(j.jobId));
+          const done = jobs.filter((j) => j.status === "imported" || j.status === "error");
+          const running = jobs.filter((j) => j.status !== "imported" && j.status !== "error");
+          if (running.length) {
+            const phase = running[0].phase ? " (" + running[0].phase + ")" : "";
+            statusEl.textContent = "SO-CRATES: analyzing" + phase + " — " + running.length + " remaining…";
+          }
+          if (jobs.length && done.length === jobs.length) {
+            clearInterval(timer);
+            const ev = done.reduce((n, j) => n + (j.addedEvents || 0), 0);
+            const errs = done.filter((j) => j.status === "error");
+            statusEl.textContent = "SO-CRATES finished: +" + ev + " event(s)" +
+              (errs.length ? ", " + errs.length + " failed — " + (errs[0].error || "") : "");
+            loadImportMeta(caseId);
+          }
+        } catch (e) { /* transient; keep polling */ }
+        if (ticks > 240) clearInterval(timer);
+      }, 5000);
     }
     function renderImportMeta(m) {
       paintTimelineImportMeta(m);


### PR DESCRIPTION
Importing a PCAP, binary, EVTX, or archive now offers to analyze it with [SO-CRATES](https://github.com/dougburks/so-crates), and the resulting detections land in the forensic timeline tagged `SO-CRATES` plus the underlying engine.

The parsing half already existed — `socratesImport.ts` parses all three verdict classes and the browser extension scrapes the SPA. The gap was the middle: the Companion never called SO-CRATES itself, so an analyst had to open it in a browser and upload by hand. This closes that.

## What the API actually does

Verified against `dougburks/so-crates` `socrates.py` at `main`, not just the published docs. Three findings shaped the design:

1. **No custom zip password is reachable.** The upload handler builds its password list server-side from the filename (`[b'infected']`, plus `infected_YYYYMMDD` when the name carries a date). No request field feeds it.
2. **ZipCrypto only.** Extraction goes through Python's `zipfile`, which has never supported WinZip AES — a 7-Zip archive cannot be opened there under any password.
3. **Multi-entry zips lose evidence.** It keeps `pcap_files[0]` or `non_hidden[0]` and discards the rest, silently.

So archives are unpacked Companion-side. That is the only way to support an analyst-supplied password or a 7-Zip archive, and it keeps every file in a sample bundle instead of three quarters of it.

Two more constraints worth recording: SO-CRATES sends no CORS headers and a `default-src 'self'` CSP, so the client has to be server-side; and `/api/status` **never 404s** — an unknown MD5 reads as `processing` forever, which is why the poller carries its own attempt ceiling.

## Design

- **Transport-aware tools registry.** `ToolConfig` gains `transport: "spawn" | "http"`. SO-CRATES is the first `http` tool, gated on `DFIR_TOOL_SOCRATES_URL` instead of a binary path. It ranks last in the extension preference so a tuned local Suricata/Hayabusa still wins drop-folder auto-run.
- **Verdicts only.** `type=alert`, `type=filealerts`, and `/api/sigma-alerts`, paged and merged. Never the unfiltered `/api/events`, which would drag whole-capture dns/http/tls/flow telemetry into the timeline.
- **Asynchronous.** A per-case job store and poller; the import banner shows `SO-CRATES: analyzing (network)…` until results land.
- **Zip decryption with no new dependency.** ZipCrypto and WinZip AES-128/192/256 built on `node:crypto`, so the single-EXE build is unaffected. Password order: analyst-supplied → `infected` → `infected_YYYYMMDD`.
- **Banner became a picker.** Every configured tool claiming a file gets a checkbox, since Suricata and SO-CRATES run different rulesets and an analyst may want both verdicts. Archives get a password box.

## Two format traps, both caught by testing against real archives

Fixtures were generated with real `zip -P` and `7z -mem=AES256` output, and the algorithms were run against them before being written into the implementation.

- **The AES counter is little-endian.** Node's `aes-*-ctr` increments the IV as a big-endian 128-bit integer, so only the first 16 bytes decrypt and everything after is garbage. A single-block fixture passes with this bug present, so there is a deliberate 19-block fixture guarding it.
- **The ZipCrypto check byte is not always the CRC byte.** Info-ZIP sets the data-descriptor flag, which makes it the mod-time high byte instead. An implementation following only the APPNOTE rejects *correct* passwords.

## Bugs found by running it, not by unit tests

- **The poller waited on the wrong MD5.** It computed the hash locally and discarded the one `/api/upload` returns; SO-CRATES keys an archive on the hash of the file it *extracts*. Every unit test passed with this present — it only showed up end-to-end.
- **A dropped binary went to the text importer.** `rawExtClaimed()` only knew `RAW_TOOL_EXTS`, so a `.exe` fell through to `readFile(utf8)` and would have been ingested as garbage evidence with AI on. The branch was also gated on `options.toolRunner` — the *process spawner* — so a box with no local binaries could never route a binary to SO-CRATES.
- **Concurrent ingests wedged a job.** Each poller ingests behind the per-case state lock; firing N at once (a 25-entry archive) piled onto that lock and left a job stuck in `importing`. Now serialized per case.

## Audit trail

`drop-log.txt` records an async handoff as `SUBMITTED`, and the job appends the real outcome when it resolves — claiming `IMPORTED` at handoff asserted an import that had not happened, and kept asserting it if the analysis later failed:

```
SUBMITTED  payload.exe  — handed to socrates; verdicts land when analysis finishes
IMPORTED   payload.exe  — via socrates — +3 event(s), +2 IOC(s)
SUBMITTED  doomed.exe   — handed to socrates; verdicts land when analysis finishes
FAILED     doomed.exe   — SO-CRATES status check failed: fetch failed
```

## Security notes for review

- SO-CRATES has **no authentication** and binds `127.0.0.1` by default. Settings and docs both warn that a non-local URL means unauthenticated evidence reachable by anyone who can route to it. Every submission is written to the case custody log, since the uploaded file stays on the SO-CRATES host until deleted there.
- Zip extraction keeps the existing zip-bomb caps, rejects zip-slip paths, caps entries at 25, and reports nested archives rather than recursing.
- Zip passwords are transient input — never logged or persisted.

## Verification

- **5984 tests across 483 files, all passing.** `npm run typecheck` clean.
- End-to-end against a stub SO-CRATES service: encrypted zip → decrypted → uploaded → polled → 3 events and 2 IOCs in the forensic timeline. Drop-folder path exercised with three binaries at once plus an extensionless hash-named sample that only the content sniff catches.
- Settings round-trip: saved via `POST /settings/env`, persisted to `.env`, live after `/tools/reconnect` with no restart.

## Known gap

`startSocratesAnalysis` takes a `Buffer`, so a drop-folder file is read fully into memory rather than streamed into the multipart POST. Fine for the Import dialog (already capped at ~180 MB), but a multi-GB PCAP in the drop folder would be buffered. Converting to a path-and-stream breaks no interface, since the zip branch needs the whole buffer anyway.

Also not included: a **Test connection** button. A typo'd URL currently surfaces only when you try to analyze something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
