### PR TITLE
feat(settings): add live cross-tab settings search

### DIFF
--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -2838,7 +2838,11 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
 
   // Whitelisted static client assets: vendored libraries (Leaflet for the Geographic map, #133;
   // cytoscape+dagre for the graphs) plus first-party browser modules (the shared graph-view module
-  // used by the Login/Assets/Evidence graphs, and the command palette, #238). Whitelisted paths only.
+  // used by the Login/Assets/Evidence graphs, the command palette #238, and the Settings search
+  // filter). Whitelisted paths only — a new module under public/js/ is NOT served until it is
+  // named here, and the browser's only symptom is a silent 404 with the feature simply absent.
+  // tests/settings/settingsSearch.test.ts pins every /js/ module dashboard.html loads to an entry
+  // in this map, so the next one cannot ship half-wired.
   // Registered inside createApp so the routes are available in tests (startServer calls createApp).
   const vendorFiles: Record<string, string> = {
     "/vendor/leaflet/leaflet.js": "application/javascript; charset=utf-8",
@@ -2848,6 +2852,7 @@ export function createApp(store: CaseStore, options: AppOptions = {}): Express {
     "/vendor/cytoscape/cytoscape-dagre.js": "application/javascript; charset=utf-8",
     "/js/graph-view.js": "application/javascript; charset=utf-8",
     "/js/command-palette.js": "application/javascript; charset=utf-8",
+    "/js/settings-search.js": "application/javascript; charset=utf-8",
   };
   for (const [route, type] of Object.entries(vendorFiles)) {
     app.get(route, async (_req, res) => {

--- a/companion/tests/settings/settingsEssentialAll.test.ts
+++ b/companion/tests/settings/settingsEssentialAll.test.ts
@@ -159,10 +159,14 @@ describe("Settings Essential mode — structural invariants the CSS depends on",
 describe("Settings Essential mode — wiring", () => {
   it("hides everything unmarked, beating the inline display JS sets on panels", async () => {
     const html = await dashboard();
+    // The `:not([data-searching])` on each is what suspends Essential while the search box has a
+    // query, so a search can reach the tabs and fields this mode hides. Keeping it here means
+    // dropping it is a failure in BOTH suites; tests/settings/settingsSearch.test.ts additionally
+    // pins it onto every Essential rule, including ones added after this list.
     for (const rule of [
-      '.settings-modal[data-mode="essential"] .stab:not([data-essential])',
-      '.settings-modal[data-mode="essential"] .stab-pane:not([data-essential="pane"]) > *:not([data-essential])',
-      '.settings-modal[data-mode="essential"] :is(.sfield-row, .sfield-row3, .sgrid) > .sfield:not([data-essential])',
+      '.settings-modal[data-mode="essential"]:not([data-searching]) .stab:not([data-essential])',
+      '.settings-modal[data-mode="essential"]:not([data-searching]) .stab-pane:not([data-essential="pane"]) > *:not([data-essential])',
+      '.settings-modal[data-mode="essential"]:not([data-searching]) :is(.sfield-row, .sfield-row3, .sgrid) > .sfield:not([data-essential])',
     ]) {
       const at = html.indexOf(rule);
       expect(at, `missing CSS rule: ${rule}`).toBeGreaterThan(-1);

--- a/companion/tests/settings/settingsSearch.test.ts
+++ b/companion/tests/settings/settingsSearch.test.ts
@@ -135,3 +135,38 @@ describe("dashboard.html search CSS", () => {
     for (const rule of rules) expect(rule).toContain(":not([data-searching])");
   });
 });
+
+describe("dashboard.html search wiring", () => {
+  it("loads the module", async () => {
+    const h = await dashboard();
+    expect(h).toContain('<script type="module" src="/js/settings-search.js"></script>');
+  });
+
+  // The server serves public/js by an EXACT-PATH whitelist (`vendorFiles` in src/server.ts), not a
+  // static directory. A module that is not named there 404s, and the only symptom in the browser is
+  // the feature silently not existing — no console error the dashboard surfaces, nothing failing in
+  // any other suite. Written as "every module the dashboard loads" rather than naming this one file,
+  // so the next /js/ module is covered the day it is added.
+  it("whitelists every /js/ module the dashboard loads", async () => {
+    const [h, server] = await Promise.all([
+      dashboard(),
+      readFile(new URL("../../src/server.ts", import.meta.url), "utf8"),
+    ]);
+    const loaded = [...h.matchAll(/<script type="module" src="(\/js\/[^"]+)"><\/script>/g)].map((m) => m[1]);
+    expect(loaded).toContain("/js/settings-search.js");
+    for (const path of loaded) {
+      expect(server, `${path} is loaded by dashboard.html but not whitelisted in server.ts vendorFiles`)
+        .toContain(`"${path}": "application/javascript; charset=utf-8"`);
+    }
+  });
+
+  it("publishes the config the module reads, and resets the box on open", async () => {
+    const h = await dashboard();
+    // Live references, not snapshots: the module calls applyMode() on clear so a tab Essential
+    // hides falls back through the inline script's own path rather than a copy of it.
+    expect(h).toContain("window.DfirSettingsSearchConfig = { applyMode: applySettingsMode, mode: settingsMode };");
+    // Optional chaining: openSettingsModal is defined in a classic inline script, which runs
+    // BEFORE the module that publishes window.DfirSettingsSearch.
+    expect(h).toContain("window.DfirSettingsSearch?.reset();");
+  });
+});

--- a/companion/tests/settings/settingsSearch.test.ts
+++ b/companion/tests/settings/settingsSearch.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
 // The module lives outside companion/, next to command-palette.js and graph-view.js. Its pure
 // exports touch no DOM, so importing them in node works — same arrangement as commandPalette.test.ts,
 // but with a .d.ts alongside so this file stays inside `npm run typecheck` instead of joining the
@@ -90,5 +91,47 @@ describe("searchMessage", () => {
 
   it("names the query when nothing matched", () => {
     expect(searchMessage({ tabs: 0, fields: 0, query: " nope " })).toBe('No settings match "nope"');
+  });
+});
+
+const dashboard = () => readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+
+describe("dashboard.html search markup", () => {
+  it("carries the input and message span the module binds to", async () => {
+    const h = await dashboard();
+    expect(h).toContain('id="settingsSearch"');
+    expect(h).toContain('aria-label="Search settings"');
+    expect(h).toContain('id="settingsSearchMsg"');
+  });
+});
+
+describe("dashboard.html search CSS", () => {
+  it("hides tabs, pane children and row siblings that are not hits", async () => {
+    const h = await dashboard();
+    expect(h).toContain('.settings-modal[data-searching] .stab:not([data-hit]) { display: none !important; }');
+    expect(h).toContain('.settings-modal[data-searching] .stab-pane:not([data-hit="pane"]) > *:not([data-hit]) { display: none !important; }');
+    expect(h).toContain('.settings-modal[data-searching] :is(.sfield-row, .sfield-row3, .sgrid) > .sfield:not([data-hit]) { display: none !important; }');
+  });
+
+  it("renders the tab match count from the attribute", async () => {
+    const h = await dashboard();
+    expect(h).toContain('.settings-modal[data-searching] .stab[data-hit-count]::after');
+    expect(h).toContain("content: attr(data-hit-count)");
+  });
+
+  it("steps the Essential/All toggle aside while searching", async () => {
+    const h = await dashboard();
+    expect(h).toContain('.settings-modal[data-searching] .settings-mode { display: none; }');
+  });
+
+  // THE REGRESSION GUARD. Search spans All by suspending Essential wholesale, which only works
+  // while EVERY Essential rule opts out of it. A fourth rule added later without the opt-out would
+  // keep hiding fields mid-search and silently re-break cross-tab search — with no failing test
+  // anywhere else, because Essential mode itself would still look perfect.
+  it("suspends every Essential rule while a search is active", async () => {
+    const h = await dashboard();
+    const rules = h.match(/^\s*\.settings-modal\[data-mode="essential"\].*$/gm) ?? [];
+    expect(rules.length).toBeGreaterThanOrEqual(3);
+    for (const rule of rules) expect(rule).toContain(":not([data-searching])");
   });
 });

--- a/companion/tests/settings/settingsSearch.test.ts
+++ b/companion/tests/settings/settingsSearch.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+// The module lives outside companion/, next to command-palette.js and graph-view.js. Its pure
+// exports touch no DOM, so importing them in node works — same arrangement as commandPalette.test.ts,
+// but with a .d.ts alongside so this file stays inside `npm run typecheck` instead of joining the
+// exclude list in tsconfig.test.json.
+import {
+  normalize,
+  matchTokens,
+  landingTab,
+  searchMessage,
+} from "../../../public/js/settings-search.js";
+
+/** Real haystacks, assembled the way buildIndex() assembles them (see fieldText): the label text,
+ *  the hint text, then the input id, joined with spaces. */
+const LEAKCHECK = "LeakCheck key DFIR_LEAKCHECK_KEY env-DFIR_LEAKCHECK_KEY";
+const MAX_EVENTS = "Max events per import DFIR_MAX_EVENTS env-DFIR_MAX_EVENTS 2000";
+
+describe("normalize", () => {
+  it("lowercases, turns _ and - into spaces, and collapses whitespace", () => {
+    expect(normalize("DFIR_MAX_EVENTS")).toBe("dfir max events");
+    expect(normalize("  Report-Templates\n")).toBe("report templates");
+  });
+
+  it("survives null and undefined", () => {
+    expect(normalize(null)).toBe("");
+    expect(normalize(undefined)).toBe("");
+  });
+});
+
+describe("matchTokens", () => {
+  it("requires every token, in any order", () => {
+    expect(matchTokens("leakcheck key", LEAKCHECK)).toBe(true);
+    expect(matchTokens("key leakcheck", LEAKCHECK)).toBe(true);
+    expect(matchTokens("leakcheck shodan", LEAKCHECK)).toBe(false);
+  });
+
+  it("finds an env key by its human wording and by the key itself", () => {
+    // The whole point of normalize(): DFIR_MAX_EVENTS becomes "dfir max events" on both sides.
+    expect(matchTokens("max events", MAX_EVENTS)).toBe(true);
+    expect(matchTokens("DFIR_MAX_EVENTS", MAX_EVENTS)).toBe(true);
+    expect(matchTokens("dfir-max-events", MAX_EVENTS)).toBe(true);
+  });
+
+  it("is case insensitive", () => {
+    expect(matchTokens("LEAKCHECK", LEAKCHECK)).toBe(true);
+  });
+
+  it("matches inside a word, not just at boundaries", () => {
+    expect(matchTokens("check", LEAKCHECK)).toBe(true);
+  });
+
+  it("treats an empty query as a vacuous AND", () => {
+    // Callers short-circuit before this, but the identity has to be the harmless one: a matcher
+    // that returned false on "" would blank the modal for one frame on every clear.
+    expect(matchTokens("", LEAKCHECK)).toBe(true);
+    expect(matchTokens("   ", LEAKCHECK)).toBe(true);
+  });
+});
+
+describe("landingTab", () => {
+  it("stays on the current tab when it has hits", () => {
+    expect(landingTab(["general", "ai", "tools"], "ai")).toBe("ai");
+  });
+
+  it("falls to the first hit tab when the current one has none", () => {
+    expect(landingTab(["ai", "tools"], "general")).toBe("ai");
+  });
+
+  it("returns null when nothing matched", () => {
+    expect(landingTab([], "general")).toBe(null);
+  });
+
+  it("copes with no active tab", () => {
+    expect(landingTab(["ai"], null)).toBe("ai");
+    expect(landingTab([], null)).toBe(null);
+  });
+});
+
+describe("searchMessage", () => {
+  it("reports fields and tabs, with agreeing plurals", () => {
+    expect(searchMessage({ tabs: 3, fields: 12, query: "key" })).toBe("12 fields in 3 tabs");
+    expect(searchMessage({ tabs: 1, fields: 1, query: "vt" })).toBe("1 field in 1 tab");
+  });
+
+  it("reports tabs alone for a name-only match", () => {
+    // Typing "kev" hits the KEV tab, whose pane is filled by JS at click time and holds no .sfield.
+    expect(searchMessage({ tabs: 1, fields: 0, query: "kev" })).toBe("1 tab");
+    expect(searchMessage({ tabs: 2, fields: 0, query: "template" })).toBe("2 tabs");
+  });
+
+  it("names the query when nothing matched", () => {
+    expect(searchMessage({ tabs: 0, fields: 0, query: " nope " })).toBe('No settings match "nope"');
+  });
+});

--- a/mkdocs-docs/reference/settings.md
+++ b/mkdocs-docs/reference/settings.md
@@ -35,6 +35,27 @@ whatever you have typed.
 
 ---
 
+## Search
+
+The box beside the Settings title filters every field as you type. Tokens are ANDed and matched as
+substrings, against a field's label, its hint, and its env key: `max events`, `DFIR_MAX_EVENTS` and
+`dfir-max-events` all find the same control, so a key copied out of `.env` or the docs works as-is.
+Select options are searchable too — `ollama` finds the AI provider dropdown.
+
+**Search always spans All, whichever mode you are in.** You search precisely because you cannot find
+something, so a search confined to Essential would report "no results" for a field that exists. Tabs
+Essential hides — Velociraptor, Tools, Dashboard Views and the rest — appear in the tab bar while a
+search is active, each badged with the number of fields it will show. Typing a tab's own name (`kev`,
+`whitelist`, `nsrl`) matches the tab and shows its pane unfiltered, which is how the tabs that manage
+content rather than configuration stay reachable.
+
+The Essential / All toggle steps aside while a search is active, because search has suspended the
+Essential filter and the toggle would have no visible effect. Clear the box — empty it, use the ⨯, or
+press Escape in it — and the toggle returns with your choice unchanged. Searching never rewrites the
+remembered Essential/All preference, and closing Settings clears the box.
+
+---
+
 ## General
 
 - Case root location

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -13,6 +13,7 @@
   <script defer src="/vendor/cytoscape/cytoscape-dagre.js"></script>
   <script type="module" src="/js/graph-view.js"></script>
   <script type="module" src="/js/command-palette.js"></script>
+  <script type="module" src="/js/settings-search.js"></script>
   <script nonce="__CSP_NONCE__">
     /* Theme bootstrap (issue #53) — runs before paint so there is no flash. Effective theme =
        explicit localStorage choice, else the OS preference. */
@@ -20137,6 +20138,7 @@
       loadUpdateCheck();
       // After the reset-to-first-tab above, so the fallback in applySettingsMode sees a real
       // active tab; before .open, so Essential mode never flashes the full list.
+      window.DfirSettingsSearch?.reset();
       applySettingsMode(settingsMode());
       document.getElementById("settingsOverlay").classList.add("open");
     }
@@ -20150,6 +20152,12 @@
     document.getElementById("settingsCloseBtn").onclick = closeSettingsModal;
     document.getElementById("settingsModeEssential").onclick = () => applySettingsMode("essential");
     document.getElementById("settingsModeAll").onclick = () => applySettingsMode("all");
+
+    // Live references, not snapshots — the search module calls applyMode() when the box is cleared
+    // so a tab Essential hides falls back through the code above rather than a duplicate of it.
+    // Set at inline-script top level, read by the module at call time: module scripts run after
+    // classic inline ones, so there is no ordering handshake to get wrong in either direction.
+    window.DfirSettingsSearchConfig = { applyMode: applySettingsMode, mode: settingsMode };
 
     // ── Comprehensive Setup wizard (#181) ───────────────────────────────────────────────────
     // A multi-step onboarding overlay covering every config that has no default and won't work

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1564,9 +1564,35 @@
     .settings-mode button { background: none; border: none; color: var(--c-9aa4b2); font-size: 11px; font-weight: 500; padding: 3px 12px; cursor: pointer; }
     .settings-mode button:hover { color: var(--c-cbd3df); background: var(--hover-wash); }
     .settings-mode button.active { background: var(--c-2d6cdf); color: #fff; }
-    .settings-modal[data-mode="essential"] .stab:not([data-essential]) { display: none !important; }
-    .settings-modal[data-mode="essential"] .stab-pane:not([data-essential="pane"]) > *:not([data-essential]) { display: none !important; }
-    .settings-modal[data-mode="essential"] :is(.sfield-row, .sfield-row3, .sgrid) > .sfield:not([data-essential]) { display: none !important; }
+    .settings-modal[data-mode="essential"]:not([data-searching]) .stab:not([data-essential]) { display: none !important; }
+    .settings-modal[data-mode="essential"]:not([data-searching]) .stab-pane:not([data-essential="pane"]) > *:not([data-essential]) { display: none !important; }
+    .settings-modal[data-mode="essential"]:not([data-searching]) :is(.sfield-row, .sfield-row3, .sgrid) > .sfield:not([data-essential]) { display: none !important; }
+    /* ── Search ─────────────────────────────────────────────────────────────────────────────
+       `data-searching` on the modal means a non-empty query is active. The three Essential rules
+       above opt OUT of it rather than these rules out-specificing three `!important` declarations —
+       one uniform edit, and it is what lets a search reach a tab Essential hides entirely. A test
+       in tests/settings/settingsSearch.test.ts pins that opt-out onto every Essential rule.
+
+       Marking the ancestor chain in JS is what keeps these selectors this simple: no :has(), and no
+       runtime pass working out whether a container still has visible children. The last two mirror
+       the Essential pair exactly — hide unmarked top-level pane children, then unmarked fields
+       inside a marked row — so there is one shape to learn, not two. */
+    .settings-search { flex: 0 1 220px; min-width: 110px; background: var(--c-242a35); color: var(--c-cbd3df);
+      border: 1px solid var(--c-353c49); border-radius: 6px; padding: 4px 8px; font-size: 12px; font-family: inherit; font-weight: 400; }
+    .settings-search::placeholder { color: var(--c-5a6475); }
+    .settings-search:focus { outline: none; border-color: var(--c-2d6cdf); }
+    .settings-search-msg { font-size: 11px; font-weight: 400; color: var(--c-9aa4b2); margin-left: auto; }
+    .settings-search-msg[hidden] { display: none; }
+    /* The mode toggle steps aside while searching. Leaving it live would be a dead control: search
+       has suspended Essential, so clicking it would rewrite the stored preference to no visible
+       effect. It returns, unchanged, when the box is cleared. */
+    .settings-modal[data-searching] .settings-mode { display: none; }
+    .settings-modal[data-searching] .stab:not([data-hit]) { display: none !important; }
+    .settings-modal[data-searching] .stab-pane:not([data-hit="pane"]) > *:not([data-hit]) { display: none !important; }
+    .settings-modal[data-searching] :is(.sfield-row, .sfield-row3, .sgrid) > .sfield:not([data-hit]) { display: none !important; }
+    .settings-modal[data-searching] .stab[data-hit-count]::after { content: attr(data-hit-count);
+      margin-left: 6px; padding: 0 5px; border-radius: 8px; background: var(--c-2a2f3a); color: var(--c-9aa4b2); font-size: 10px; }
+    .settings-modal[data-searching] .stab.active[data-hit-count]::after { background: var(--c-2d6cdf); color: #fff; }
     /* No inner scroll — the whole list expands and the single .stab-pane scrollbar handles overflow. */
     .sec-checks { display: flex; flex-direction: column; gap: 1px; margin-top: 4px; }
     .sec-check { display: flex; align-items: center; font-size: 12px; padding: 4px 6px; border-radius: 5px; user-select: none; }
@@ -2345,6 +2371,8 @@
   <div id="settingsOverlay" class="comment-overlay">
     <div class="comment-modal settings-modal">
       <h3>Settings
+        <input id="settingsSearch" class="settings-search" type="search" placeholder="Search settings…" aria-label="Search settings" autocomplete="off" />
+        <span id="settingsSearchMsg" class="settings-search-msg" hidden></span>
         <span class="settings-mode" role="group" aria-label="Settings detail level">
           <button type="button" id="settingsModeEssential">Essential</button>
           <button type="button" id="settingsModeAll">All</button>

--- a/public/js/settings-search.d.ts
+++ b/public/js/settings-search.d.ts
@@ -1,0 +1,16 @@
+// Hand-written declarations for settings-search.js.
+//
+// companion/tsconfig.test.json checks the whole tests/ tree, so a test importing an untyped .js
+// module fails with TS7016 and every callback derived from it becomes an implicit any — which is
+// exactly why tests/analysis/commandPalette.test.ts sits on that config's exclude list. This file
+// is the fix that config's own comment names, so settingsSearch.test.ts stays checked instead of
+// joining the debt register.
+
+export declare function normalize(s: unknown): string;
+export declare function matchTokens(query: unknown, haystack: unknown): boolean;
+export declare function landingTab(hitTabs: string[], activeTab?: string | null): string | null;
+export declare function searchMessage(opts?: {
+  tabs?: number;
+  fields?: number;
+  query?: string;
+}): string;

--- a/public/js/settings-search.js
+++ b/public/js/settings-search.js
@@ -1,0 +1,54 @@
+// Settings search — the live cross-tab filter in the Settings modal.
+//
+// Loaded in the browser as an ES module (<script type="module" src="/js/settings-search.js">), the
+// same arrangement graph-view.js and command-palette.js use. CSP already allows /js/* via 'self'
+// (see companion/src/http/securityHeaders.ts), so no header change is needed.
+//
+// Division of labour, mirroring command-palette.js: the pure half below is exported by name so
+// Vitest can drive it in node, where there is no DOM. Everything under the "browser glue" banner
+// touches the document and is deliberately thin for that reason.
+
+/** Lowercase, `_`/`-` → space, collapse whitespace, trim.
+ *
+ *  Applied to BOTH sides of every comparison, which is the whole trick: "max events" finds
+ *  DFIR_MAX_EVENTS, and pasting DFIR_MAX_EVENTS straight from .env or the docs finds it too. */
+export function normalize(s) {
+  return String(s == null ? "" : s)
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** True when every whitespace-separated token of `query` appears somewhere in `haystack`.
+ *
+ *  Substring, not fuzzy. command-palette.js's fuzzyScore has a scattered-subsequence tier, which is
+ *  right for a RANKED list where a weak match sinks harmlessly to the bottom. This is an unranked
+ *  in-place filter in DOM order — there is nothing to sink, so a query like "ai" matching half the
+ *  modal by letter-scatter would be pure noise with no way to bury it.
+ *
+ *  An empty query is a vacuous AND and returns true; callers short-circuit before that. */
+export function matchTokens(query, haystack) {
+  const tokens = normalize(query).split(" ").filter(Boolean);
+  if (!tokens.length) return true;
+  const hay = normalize(haystack);
+  return tokens.every((t) => hay.includes(t));
+}
+
+/** Which tab to show for a set of hits: stay put if the tab you are on has any (so typing does not
+ *  yank you away mid-edit), else the first tab that does, else null — the "no matches" state. */
+export function landingTab(hitTabs, activeTab) {
+  const tabs = Array.isArray(hitTabs) ? hitTabs : [];
+  if (activeTab && tabs.includes(activeTab)) return activeTab;
+  return tabs.length ? tabs[0] : null;
+}
+
+/** The text for #settingsSearchMsg. `fields` is how many .sfield elements will be visible; `tabs`
+ *  how many tab buttons are hits. fields === 0 with tabs > 0 is the name-match-only case (typing
+ *  "kev" or "whitelist"), whose pane is filled by JS at click time and holds no .sfield at all. */
+export function searchMessage({ tabs = 0, fields = 0, query = "" } = {}) {
+  const plural = (n, word) => `${n} ${word}${n === 1 ? "" : "s"}`;
+  if (!tabs) return `No settings match "${String(query).trim()}"`;
+  if (fields > 0) return `${plural(fields, "field")} in ${plural(tabs, "tab")}`;
+  return plural(tabs, "tab");
+}

--- a/public/js/settings-search.js
+++ b/public/js/settings-search.js
@@ -52,3 +52,166 @@ export function searchMessage({ tabs = 0, fields = 0, query = "" } = {}) {
   if (fields > 0) return `${plural(fields, "field")} in ${plural(tabs, "tab")}`;
   return plural(tabs, "tab");
 }
+
+// ── Browser glue ──────────────────────────────────────────────────────────────────────────────
+// Everything below touches the document. The guard at the very bottom is what keeps the exports
+// above importable in node.
+
+/** Every string worth matching a field on, joined with spaces.
+ *
+ *  Node by node rather than one el.textContent read, because the markup is
+ *  `<label>LeakCheck key<span class="sfield-hint">DFIR_LEAKCHECK_KEY</span></label>` — a single
+ *  textContent read yields "LeakCheck keyDFIR_LEAKCHECK_KEY", label and env key fused into one word
+ *  with no separator, so "key" would match but "leakcheck key" would not.
+ *
+ *  <option> text is in deliberately: it is how searching "ollama" finds the AI provider select, and
+ *  "critical" the import-severity one. Ids come along because a few fields carry the env key only
+ *  on the input. Overlap between the parts is harmless for substring matching. */
+function fieldText(el) {
+  const parts = [];
+  for (const n of el.querySelectorAll("label, .sfield-hint, option")) parts.push(n.textContent);
+  for (const n of el.querySelectorAll("[placeholder]")) parts.push(n.getAttribute("placeholder"));
+  for (const n of el.querySelectorAll("[id]")) parts.push(n.id);
+  parts.push(el.textContent);
+  return parts.join(" ");
+}
+
+const modalEl = () => document.querySelector(".settings-modal");
+
+let index = [];
+
+/** Walked once per modal open, not per keystroke. */
+function buildIndex() {
+  index = [...document.querySelectorAll(".stab-pane .sfield")].map((el) => ({
+    el,
+    pane: el.closest(".stab-pane"),
+    text: fieldText(el),
+  }));
+}
+
+function stripHits() {
+  const m = modalEl();
+  if (!m) return;
+  m.removeAttribute("data-searching");
+  for (const el of m.querySelectorAll("[data-hit]")) el.removeAttribute("data-hit");
+  for (const el of m.querySelectorAll("[data-hit-count]")) el.removeAttribute("data-hit-count");
+}
+
+/** Keep every wrapper between a hit and its pane, so .sfield-row and .sgrid survive the
+ *  "hide unmarked top-level pane children" rule. */
+function markChain(el, pane) {
+  for (let n = el.parentElement; n && n !== pane; n = n.parentElement) {
+    if (!n.hasAttribute("data-hit")) n.setAttribute("data-hit", "container");
+  }
+}
+
+/** A .settings-group-head is a SIBLING of the fields it governs, not an ancestor, so markChain
+ *  cannot reach it and a filtered field would show with its group context stripped away. Walk the
+ *  pane's top-level children in order, remember the last heading, and keep it once a hit follows.
+ *  (Every top-level child that survives the filter carries data-hit by now — either its own, from
+ *  being a hit .sfield, or "container" from markChain.) */
+function markHeadings(pane) {
+  let head = null;
+  for (const child of pane.children) {
+    if (child.classList.contains("settings-group-head")) { head = child; continue; }
+    if (head && child.hasAttribute("data-hit")) { head.setAttribute("data-hit", "container"); head = null; }
+  }
+}
+
+/** Re-run the inline script's own mode application rather than a copy of it, so an active tab that
+ *  Essential hides — which only became active because the search revealed it — falls back through
+ *  the existing path in applySettingsMode. */
+function restoreMode() {
+  const msg = document.getElementById("settingsSearchMsg");
+  if (msg) { msg.textContent = ""; msg.hidden = true; }
+  const cfg = window.DfirSettingsSearchConfig;
+  if (cfg) cfg.applyMode(cfg.mode());
+}
+
+function applySearch(query) {
+  const m = modalEl();
+  if (!m) return;
+  stripHits();
+  if (!String(query).trim()) { restoreMode(); return; }
+
+  for (const f of index) {
+    if (!matchTokens(query, f.text)) continue;
+    f.el.setAttribute("data-hit", "");
+    markChain(f.el, f.pane);
+  }
+
+  const hitTabs = [];
+  let visibleFields = 0;
+  for (const btn of document.querySelectorAll(".stab")) {
+    const pane = document.getElementById("stab-" + btn.dataset.stab);
+    if (!pane) continue;
+    // A tab-name match is against the button's own label alone ("IOC Whitelist", "Report
+    // Templates"), never its pane. It is what keeps the JS-filled panes reachable: their rows do
+    // not exist in the DOM when the search runs, and they are case data rather than settings.
+    const nameMatch = matchTokens(query, btn.textContent);
+    if (nameMatch) pane.setAttribute("data-hit", "pane");
+    // THE COUNT INVARIANT: data-hit-count is always how many .sfield elements the tab will SHOW.
+    // A name-matched pane renders unfiltered, so that is all of them — and 0 for the content
+    // managers, where no badge renders but the tab is still a hit and still clickable.
+    const count = nameMatch
+      ? pane.querySelectorAll(".sfield").length
+      : pane.querySelectorAll(".sfield[data-hit]").length;
+    if (!nameMatch && !count) continue;
+    btn.setAttribute("data-hit", "");
+    if (count) btn.setAttribute("data-hit-count", String(count));
+    hitTabs.push(btn.dataset.stab);
+    visibleFields += count;
+  }
+
+  for (const pane of document.querySelectorAll(".stab-pane")) {
+    if (pane.getAttribute("data-hit") !== "pane") markHeadings(pane);
+  }
+
+  m.setAttribute("data-searching", "");
+  const msg = document.getElementById("settingsSearchMsg");
+  if (msg) {
+    msg.textContent = searchMessage({ tabs: hitTabs.length, fields: visibleFields, query });
+    msg.hidden = false;
+  }
+
+  const active = document.querySelector(".stab.active");
+  const land = landingTab(hitTabs, active ? active.dataset.stab : null);
+  if (land && (!active || active.dataset.stab !== land)) {
+    const btn = document.querySelector(`.stab[data-stab="${land}"]`);
+    // .click() rather than a class toggle, so the inline handler's per-tab loaders still fire.
+    if (btn) btn.click();
+  }
+}
+
+function clearSearch() {
+  const input = document.getElementById("settingsSearch");
+  if (input) input.value = "";
+  stripHits();
+  restoreMode();
+}
+
+/** Called by openSettingsModal: a stale filter must never survive a close/reopen, and panes can
+ *  gain fields between opens. */
+function reset() {
+  clearSearch();
+  buildIndex();
+}
+
+function wire() {
+  const input = document.getElementById("settingsSearch");
+  if (!input) return;
+  window.DfirSettingsSearch = { reset, clear: clearSearch };
+  buildIndex();
+  // type="search" fires `input` for its native clear affordance too, so that path needs no handler.
+  input.addEventListener("input", () => applySearch(input.value));
+  // Scoped to the input, and stopPropagation so it stays that way: the Settings modal has no
+  // Escape-to-close binding today and adding one is a separate decision.
+  input.addEventListener("keydown", (e) => {
+    if (e.key !== "Escape") return;
+    e.stopPropagation();
+    clearSearch();
+  });
+}
+
+// Guarded so the pure exports above can be imported in node (Vitest) with no DOM present.
+if (typeof document !== "undefined" && typeof window !== "undefined") wire();


### PR DESCRIPTION
## Summary
- add a pure settings-search matcher
- add search markup and styling
- wire live filtering across settings tabs