### PR TITLE
feat(data): add canonical forensic event schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Canonical forensic event schema** — versioned structured identities, timestamps, source pointers, artifact hashes, mapping versions, and field-level provenance now underpin representative Windows, Linux, cloud, network, email, memory, and EDR imports while legacy cases upgrade incrementally and graph joins no longer depend on description wording (closes #374).
 - **Indexed SQLite case storage** — investigation entities and the distinct super-timeline now use a worker-backed, cursor-paged database with atomic legacy-JSON migration, integrity-checked backups/restores, bounded timeline/graph reads, and a Node 22.5+ runtime floor (closes #373).
 - **One-click Jira / ServiceNow push from the finding panel** (#297) — the routes shipped in #272 finally have a UI: every finding row carries a **Jira** and a **SNow** chip, and the finding bulk bar gains **Push to Jira** / **Push to ServiceNow** for the whole selection via the new `POST /cases/:id/push/{jira,servicenow}/bulk` endpoints. A batch reports created / updated / skipped, and a finding the ticket system refuses is named rather than aborting the rest. Both sets of buttons stay hidden until the integration is configured; re-pushing still updates the ticket the Companion opened instead of duplicating it. The ten `DFIR_JIRA_*` / `DFIR_SERVICENOW_*` environment variables are now documented in `.env.example`, the README route table and the manual.
 

--- a/companion/src/analysis/auditdImport.ts
+++ b/companion/src/analysis/auditdImport.ts
@@ -21,6 +21,7 @@
 // rows so a summary report still lands on the timeline rather than being dropped.
 
 import type { Severity } from "./stateTypes.js";
+import { createCanonicalEvent, stampSourceArtifactHash } from "./canonicalEvent.js";
 import {
   aggregateEvents,
   cleanIp,
@@ -353,17 +354,89 @@ function mapAuditEvent(ev: AuditEvent, iocSink: Map<string, SiemIoc>): MappedEve
     .slice(0, 400);
 
   const procName = baseName(exe) || comm || undefined;
+  const timestamp = ev.tsMs > 0 ? new Date(ev.tsMs).toISOString() : "";
+  const pidRaw = Number(f["pid"]);
+  const pid = Number.isInteger(pidRaw) && pidRaw > 0 ? pidRaw : undefined;
+  const authEvent = ptype === "USER_LOGIN" || ptype === "USER_AUTH" || ptype === "USER_ACCT";
+  const sourceAddress = cleanIp(addr) || saddrInfo?.ip;
+  const canonical = createCanonicalEvent({
+    event: {
+      category: authEvent ? "authentication" : procName || cmdLine ? "process" : "other",
+      type: authEvent ? "logon" : procName || cmdLine ? "observation" : ptype.toLowerCase(),
+      ...(authEvent ? { outcome: failed ? "failed" : "success" } : {}),
+    },
+    ...(acct ? {
+      actor: {
+        kind: "account",
+        id: acct,
+        ...(!/^\d+$/.test(acct) ? { name: acct } : {}),
+      },
+      account: {
+        id: acct,
+        ...(!/^\d+$/.test(acct) ? { name: acct } : {}),
+      },
+    } : {}),
+    ...(node ? { target: { kind: "host", name: node } } : {}),
+    ...(authEvent ? {
+      authentication: { sessionId: ev.serial, mechanism: ptype.toLowerCase() },
+      ...(term ? { session: { id: ev.serial, terminal: term } } : { session: { id: ev.serial } }),
+    } : {}),
+    ...(sourceAddress ? {
+      network: {
+        source: {
+          address: sourceAddress,
+          ...(saddrInfo?.port ? { port: saddrInfo.port } : {}),
+        },
+      },
+    } : {}),
+    ...(procName || exe || cmdLine || pid ? {
+      process: {
+        ...(pid ? { pid } : {}),
+        ...(procName ? { name: procName } : {}),
+        ...(exe ? { executable: exe } : {}),
+        ...(cmdLine ? { commandLine: cmdLine } : {}),
+      },
+    } : {}),
+    ...(ev.pathNames[0] ? {
+      file: { path: ev.pathNames[0], name: baseName(ev.pathNames[0]) },
+    } : {}),
+    time: {
+      observed: ev.tsMs > 0 ? String(ev.tsMs / 1000) : "",
+      normalized: timestamp,
+      timezone: "UTC",
+      precision: "millisecond",
+    },
+    evidence: {
+      rawRecords: [{ source: "auditd", locator: `serial:${ev.serial}`, recordId: ev.serial }],
+    },
+    producer: {
+      importer: "auditd",
+      parserVersion: "1",
+      mappingVersion: "auditd-v1",
+      ruleVersions: ["auditd-severity-v1"],
+    },
+    rawFieldMap: {
+      "time.observed": ["msg=audit"],
+      ...(acct ? { "actor.id": ["acct", "uid", "auid"], "account.id": ["acct", "uid", "auid"] } : {}),
+      ...(node ? { "target.name": ["node"] } : {}),
+      ...(procName ? { "process.name": ["exe", "comm"] } : {}),
+      ...(exe ? { "process.executable": ["exe"] } : {}),
+      ...(cmdLine ? { "process.commandLine": ["EXECVE.a0..aN", "proctitle", "cmd"] } : {}),
+      ...(sourceAddress ? { "network.source.address": ["addr", "hostname", "SOCKADDR.saddr"] } : {}),
+    },
+  });
   return {
-    timestamp: ev.tsMs > 0 ? new Date(ev.tsMs).toISOString() : "",
+    timestamp,
     description,
     severity,
     mitre,
     aggKey,
+    canonical,
     sources: ["auditd"],
     ...(node ? { asset: node } : {}),
     ...(exe && exe.includes("/") ? { path: exe } : {}),
     ...(procName ? { processName: procName } : {}),
-    ...(addr || saddrInfo ? { srcIp: cleanIp(addr) || saddrInfo?.ip } : {}),
+    ...(sourceAddress ? { srcIp: sourceAddress } : {}),
     ...(saddrInfo?.port ? { port: saddrInfo.port } : {}),
   };
 }
@@ -447,15 +520,16 @@ export function parseAuditdLog(text: string, opts: AuditdImportOptions = {}): Au
     minSeverity: opts.minSeverity,
     maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
+  const finalEvents = stampSourceArtifactHash(events, text);
 
-  const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
+  const represented = finalEvents.reduce((n, e) => n + (e.count ?? 1), 0);
   const hostname = [...hostTally.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
 
   return {
-    events,
+    events: finalEvents,
     iocs: [...iocSink.values()].slice(0, maxIocs),
     total,
-    kept: events.length,
+    kept: finalEvents.length,
     dropped: Math.max(0, total - represented),
     groups,
     format,

--- a/companion/src/analysis/awsImport.ts
+++ b/companion/src/analysis/awsImport.ts
@@ -12,6 +12,7 @@
 // in the description. NOT a detection engine — the same deterministic mapping pattern.
 
 import type { Severity } from "./stateTypes.js";
+import { createCanonicalEvent, stampSourceArtifactHash } from "./canonicalEvent.js";
 import {
   extractRecords,
   aggregateEvents,
@@ -22,6 +23,7 @@ import {
   isObject,
   getCI,
   getPath,
+  firstStr,
   oneLine,
   normalizeTime,
   type MappedEvent,
@@ -110,21 +112,32 @@ const AWS_ACTIONS: Record<string, ActionDef> = {
 function truthy(v: unknown): boolean { return v === true || /^(true|1|yes)$/i.test(str(v).trim()); }
 
 // The acting principal: IAM user name, the assumed-role's issuer, the ARN, or the type.
-function principal(ui: unknown): { name: string; isRoot: boolean } {
+function principal(ui: unknown): { name: string; isRoot: boolean; id?: string; type?: string; arn?: string; accountId?: string } {
   if (!isObject(ui)) return { name: str(ui), isRoot: false };
+  const type = str(getCI(ui, "type"));
+  const arn = str(getCI(ui, "arn"));
+  const id = str(getCI(ui, "principalId")) || str(getCI(ui, "userId"));
+  const accountId = str(getCI(ui, "accountId"));
   const name = str(getCI(ui, "userName"))
     || str(getPath(ui, "sessionContext.sessionIssuer.userName"))
-    || str(getCI(ui, "arn"))
+    || arn
     || str(getCI(ui, "invokedBy"))
-    || str(getCI(ui, "type"));
-  return { name, isRoot: /^root$/i.test(str(getCI(ui, "type"))) };
+    || type;
+  return {
+    name,
+    isRoot: /^root$/i.test(type),
+    ...(id ? { id } : {}),
+    ...(type ? { type } : {}),
+    ...(arn ? { arn } : {}),
+    ...(accountId ? { accountId } : {}),
+  };
 }
 
 function shortSource(eventSource: string): string {
   return eventSource.replace(/\.amazonaws\.com$/i, "");
 }
 
-function mapRecord(rec: Row, sink: Map<string, SiemIoc>): MappedEvent | null {
+function mapRecord(rec: Row, sink: Map<string, SiemIoc>, recordIndex = 0): MappedEvent | null {
   const name = str(getCI(rec, "eventName"));
   const source = str(getCI(rec, "eventSource"));
   if (!name || !source) return null;
@@ -134,7 +147,8 @@ function mapRecord(rec: Row, sink: Map<string, SiemIoc>): MappedEvent | null {
   let severity: Severity = def?.severity ?? (readOnly ? "Info" : "Low");
   const mitre = [...(def?.mitre ?? [])];
 
-  const { name: who, isRoot } = principal(getCI(rec, "userIdentity"));
+  const identity = principal(getCI(rec, "userIdentity"));
+  const { name: who, isRoot } = identity;
   const region = str(getCI(rec, "awsRegion"));
   const errorCode = str(getCI(rec, "errorCode"));
   const rawIp = str(getCI(rec, "sourceIPAddress"));
@@ -164,10 +178,67 @@ function mapRecord(rec: Row, sink: Map<string, SiemIoc>): MappedEvent | null {
   if (isRoot) description += " [root]";
   if (errorCode) description += ` [${errorCode}]`;
   description = description.slice(0, 600);
+  const observedTimestamp = str(getCI(rec, "eventTime"));
+  const normalizedTimestamp = normalizeTime(observedTimestamp);
+  const request = getCI(rec, "requestParameters");
+  const resource = isObject(request)
+    ? firstStr(request, ["resource", "resourceName", "userName", "roleName", "bucketName", "key"])
+    : "";
+  const canonical = createCanonicalEvent({
+    event: {
+      category: "cloud",
+      type: "api",
+      action: name,
+      outcome: failed ? "failed" : "success",
+    },
+    ...(who ? {
+      actor: {
+        kind: "cloud_principal",
+        name: who,
+        ...(identity.id ? { id: identity.id } : {}),
+      },
+    } : {}),
+    ...(resource ? { target: { kind: "other", name: resource } } : {}),
+    ...(ip ? { network: { source: { address: ip } } } : {}),
+    cloud: {
+      provider: "aws",
+      ...(identity.id ? { principalId: identity.id } : {}),
+      ...(identity.type ? { principalType: identity.type } : {}),
+      ...(identity.accountId ? { accountId: identity.accountId } : {}),
+      ...(region ? { region } : {}),
+      ...(resource ? { resource } : {}),
+    },
+    time: { observed: observedTimestamp, normalized: normalizedTimestamp },
+    evidence: {
+      rawRecords: [{
+        source: "aws-cloudtrail",
+        locator: `record:${recordIndex}`,
+        ...(str(getCI(rec, "eventID")).trim() ? { recordId: str(getCI(rec, "eventID")).trim() } : {}),
+      }],
+    },
+    producer: {
+      importer: "aws-cloudtrail",
+      parserVersion: "1",
+      mappingVersion: "cloudtrail-v1",
+      ruleVersions: ["cloudtrail-action-severity-v1"],
+    },
+    rawFieldMap: {
+      "event.action": ["eventName"],
+      "event.outcome": ["errorCode", "responseElements.ConsoleLogin"],
+      "time.observed": ["eventTime"],
+      ...(who ? { "actor.name": ["userIdentity.userName", "userIdentity.arn", "userIdentity.type"] } : {}),
+      ...(identity.id ? { "actor.id": ["userIdentity.principalId", "userIdentity.userId"] } : {}),
+      ...(ip ? { "network.source.address": ["sourceIPAddress"] } : {}),
+      "cloud.provider": ["eventSource"],
+      ...(region ? { "cloud.region": ["awsRegion"] } : {}),
+      ...(resource ? { "cloud.resource": ["requestParameters"] } : {}),
+    },
+  });
 
   return {
-    timestamp: normalizeTime(str(getCI(rec, "eventTime"))),
+    timestamp: normalizedTimestamp,
     description, severity, mitre,
+    canonical,
     aggKey: `aws|${name}|${who}|${ip || rawIp}|${errorCode}`.toLowerCase().slice(0, 400),
     sources: ["AWS CloudTrail"],
   };
@@ -183,8 +254,8 @@ export function parseCloudTrail(text: string, opts: AwsImportOptions = {}): AwsP
 
   const iocSink = new Map<string, SiemIoc>();
   const mapped: MappedEvent[] = [];
-  for (const rec of records) {
-    const m = mapRecord(rec, iocSink);
+  for (const [recordIndex, rec] of records.entries()) {
+    const m = mapRecord(rec, iocSink, recordIndex);
     if (m) mapped.push(m);
   }
   if (mapped.length === 0) {
@@ -196,13 +267,14 @@ export function parseCloudTrail(text: string, opts: AwsImportOptions = {}): AwsP
     minSeverity: opts.minSeverity,
     maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
+  const finalEvents = stampSourceArtifactHash(events, text);
 
-  const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
+  const represented = finalEvents.reduce((n, e) => n + (e.count ?? 1), 0);
   return {
-    events,
+    events: finalEvents,
     iocs: [...iocSink.values()].slice(0, maxIocs),
     total,
-    kept: events.length,
+    kept: finalEvents.length,
     dropped: Math.max(0, total - represented),
     groups,
     format: "cloudtrail",

--- a/companion/src/analysis/canonicalEvent.ts
+++ b/companion/src/analysis/canonicalEvent.ts
@@ -1,0 +1,529 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { ForensicEvent } from "./stateTypes.js";
+
+export const CANONICAL_EVENT_SCHEMA_VERSION = "1.0.0" as const;
+
+const confidenceSchema = z.enum(["high", "medium", "low"]);
+const entityKindSchema = z.enum([
+  "account", "host", "process", "file", "registry", "service", "task",
+  "mailbox", "cloud_principal", "network", "other",
+]);
+
+export const canonicalEntitySchema = z.object({
+  kind: entityKindSchema,
+  id: z.string().optional(),
+  name: z.string().optional(),
+  domain: z.string().optional(),
+  address: z.string().optional(),
+  port: z.number().int().positive().max(65535).optional(),
+});
+
+const canonicalProcessSchema = z.object({
+  pid: z.number().int().positive().optional(),
+  name: z.string().optional(),
+  executable: z.string().optional(),
+  commandLine: z.string().optional(),
+  parent: z.object({
+    pid: z.number().int().positive().optional(),
+    name: z.string().optional(),
+    executable: z.string().optional(),
+  }).optional(),
+});
+
+const rawRecordPointerSchema = z.object({
+  source: z.string().min(1),
+  locator: z.string().min(1),
+  recordId: z.string().optional(),
+});
+
+const fieldProvenanceSchema = z.object({
+  origin: z.enum(["raw", "derived"]),
+  confidence: confidenceSchema,
+  rawFields: z.array(z.string()).optional(),
+  derivation: z.string().optional(),
+  recordLocators: z.array(z.string().min(1)).min(1),
+});
+
+export const canonicalEventEnvelopeSchema = z.object({
+  schemaVersion: z.literal(CANONICAL_EVENT_SCHEMA_VERSION),
+  event: z.object({
+    category: z.enum([
+      "authentication", "process", "network", "file", "registry", "service",
+      "task", "email", "cloud", "memory", "other",
+    ]),
+    type: z.string().min(1),
+    action: z.string().optional(),
+    outcome: z.string().optional(),
+  }),
+  actor: canonicalEntitySchema.optional(),
+  subject: canonicalEntitySchema.optional(),
+  object: canonicalEntitySchema.optional(),
+  target: canonicalEntitySchema.optional(),
+  account: z.object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    domain: z.string().optional(),
+  }).optional(),
+  authentication: z.object({
+    sessionId: z.string().optional(),
+    logonType: z.number().int().nonnegative().optional(),
+    protocol: z.string().optional(),
+    mechanism: z.string().optional(),
+  }).optional(),
+  session: z.object({
+    id: z.string().optional(),
+    terminal: z.string().optional(),
+    interactive: z.boolean().optional(),
+  }).optional(),
+  network: z.object({
+    source: z.object({
+      address: z.string().optional(),
+      port: z.number().int().positive().max(65535).optional(),
+      hostname: z.string().optional(),
+    }).optional(),
+    destination: z.object({
+      address: z.string().optional(),
+      port: z.number().int().positive().max(65535).optional(),
+      hostname: z.string().optional(),
+    }).optional(),
+    protocol: z.string().optional(),
+  }).optional(),
+  process: canonicalProcessSchema.optional(),
+  file: z.object({
+    path: z.string().optional(),
+    name: z.string().optional(),
+    sha256: z.string().optional(),
+    md5: z.string().optional(),
+  }).optional(),
+  registry: z.object({
+    key: z.string().optional(),
+    valueName: z.string().optional(),
+    valueData: z.string().optional(),
+  }).optional(),
+  service: z.object({
+    name: z.string().optional(),
+    displayName: z.string().optional(),
+    executable: z.string().optional(),
+  }).optional(),
+  task: z.object({
+    name: z.string().optional(),
+    command: z.string().optional(),
+  }).optional(),
+  mailbox: z.object({
+    messageId: z.string().optional(),
+    sender: z.string().optional(),
+    recipients: z.array(z.string()).optional(),
+    subject: z.string().optional(),
+  }).optional(),
+  cloud: z.object({
+    provider: z.string().optional(),
+    principalId: z.string().optional(),
+    principalType: z.string().optional(),
+    tenant: z.string().optional(),
+    accountId: z.string().optional(),
+    region: z.string().optional(),
+    resource: z.string().optional(),
+  }).optional(),
+  time: z.object({
+    observed: z.string(),
+    normalized: z.string(),
+    timezone: z.string(),
+    precision: z.enum(["date", "minute", "second", "millisecond", "microsecond", "unknown"]),
+    clockConfidence: z.enum(["recorded", "inferred", "unknown"]),
+  }),
+  evidence: z.object({
+    rawRecords: z.array(rawRecordPointerSchema).min(1),
+    sourceArtifactHash: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional(),
+  }),
+  producer: z.object({
+    importer: z.string().min(1),
+    parserVersion: z.string().min(1),
+    mappingVersion: z.string().min(1),
+    ruleVersions: z.array(z.string()).optional(),
+  }),
+  fieldProvenance: z.record(fieldProvenanceSchema),
+});
+
+export type CanonicalEntity = z.infer<typeof canonicalEntitySchema>;
+export type CanonicalEventEnvelope = z.infer<typeof canonicalEventEnvelopeSchema>;
+export type CanonicalEventCategory = CanonicalEventEnvelope["event"]["category"];
+export type CanonicalFieldProvenance = CanonicalEventEnvelope["fieldProvenance"][string];
+
+type CanonicalNormalizedFields = Omit<
+  CanonicalEventEnvelope,
+  "schemaVersion" | "evidence" | "producer" | "fieldProvenance"
+>;
+
+export type CreateCanonicalEventInput = Omit<CanonicalNormalizedFields, "time"> & {
+  time: Pick<CanonicalEventEnvelope["time"], "observed" | "normalized"> &
+    Partial<Omit<CanonicalEventEnvelope["time"], "observed" | "normalized">>;
+  evidence: CanonicalEventEnvelope["evidence"];
+  producer: CanonicalEventEnvelope["producer"];
+  rawFieldMap?: Record<string, string[]>;
+  confidenceMap?: Record<string, CanonicalFieldProvenance["confidence"]>;
+  derivationMap?: Record<string, string>;
+};
+
+function timezoneOf(observed: string): string {
+  if (/Z$/i.test(observed.trim())) return "UTC";
+  const offset = /([+-]\d{2}:?\d{2})$/.exec(observed.trim())?.[1];
+  return offset ? offset.replace(/^([+-]\d{2})(\d{2})$/, "$1:$2") : "unknown";
+}
+
+function precisionOf(observed: string): CanonicalEventEnvelope["time"]["precision"] {
+  const s = observed.trim();
+  if (!s) return "unknown";
+  const fraction = /[.,](\d+)(?:Z|[+-]\d{2}:?\d{2})?$/.exec(s)?.[1]?.length ?? 0;
+  if (fraction > 3) return "microsecond";
+  if (fraction > 0) return "millisecond";
+  if (/\d{1,2}:\d{2}:\d{2}/.test(s)) return "second";
+  if (/\d{1,2}:\d{2}/.test(s)) return "minute";
+  if (/\d{4}-\d{2}-\d{2}/.test(s)) return "date";
+  return "unknown";
+}
+
+function normalizedLeafPaths(value: unknown, prefix = ""): string[] {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value.length && prefix ? [prefix] : [];
+  if (typeof value !== "object") return prefix ? [prefix] : [];
+  const out: string[] = [];
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    out.push(...normalizedLeafPaths(child, prefix ? `${prefix}.${key}` : key));
+  }
+  return out;
+}
+
+function normalizedPart(envelope: CanonicalEventEnvelope): CanonicalNormalizedFields {
+  const {
+    schemaVersion: _schemaVersion,
+    evidence: _evidence,
+    producer: _producer,
+    fieldProvenance: _fieldProvenance,
+    ...normalized
+  } = envelope;
+  return normalized;
+}
+
+export function createCanonicalEvent(input: CreateCanonicalEventInput): CanonicalEventEnvelope {
+  const {
+    rawFieldMap = {},
+    confidenceMap = {},
+    derivationMap = {},
+    ...fields
+  } = input;
+  const time: CanonicalEventEnvelope["time"] = {
+    observed: input.time.observed,
+    normalized: input.time.normalized,
+    timezone: input.time.timezone ?? timezoneOf(input.time.observed),
+    precision: input.time.precision ?? precisionOf(input.time.observed),
+    clockConfidence: input.time.clockConfidence ?? (input.time.observed ? "recorded" : "unknown"),
+  };
+  const base = {
+    ...fields,
+    time,
+  } as CanonicalNormalizedFields & Pick<CanonicalEventEnvelope, "evidence" | "producer">;
+  const firstLocator = input.evidence.rawRecords[0]?.locator;
+  if (!firstLocator) throw new Error("Canonical events require at least one raw-record locator");
+  const fieldProvenance: CanonicalEventEnvelope["fieldProvenance"] = {};
+  for (const path of normalizedLeafPaths(base).filter((path) => !path.startsWith("evidence.") && !path.startsWith("producer."))) {
+    const rawFields = rawFieldMap[path];
+    const derivation = derivationMap[path];
+    fieldProvenance[path] = rawFields?.length
+      ? {
+          origin: "raw",
+          confidence: confidenceMap[path] ?? "high",
+          rawFields: [...rawFields],
+          recordLocators: [firstLocator],
+        }
+      : {
+          origin: "derived",
+          confidence: confidenceMap[path] ?? "high",
+          derivation: derivation ?? `${input.producer.mappingVersion}: deterministic mapping from referenced raw record`,
+          recordLocators: [firstLocator],
+        };
+  }
+  return canonicalEventEnvelopeSchema.parse({
+    schemaVersion: CANONICAL_EVENT_SCHEMA_VERSION,
+    ...base,
+    fieldProvenance,
+  });
+}
+
+export function canonicalConformanceIssues(envelope: unknown): string[] {
+  if (envelope == null) return ["canonical envelope missing"];
+  const parsed = canonicalEventEnvelopeSchema.safeParse(envelope);
+  if (!parsed.success) {
+    return parsed.error.issues.map((issue) =>
+      `${issue.path.join(".") || "canonical"}: ${issue.message}`,
+    );
+  }
+  const issues: string[] = [];
+  const canonical = parsed.data;
+  const rawLocators = new Set(canonical.evidence.rawRecords.map((record) => record.locator));
+  for (const path of normalizedLeafPaths(normalizedPart(canonical))) {
+    if (!canonical.fieldProvenance[path]) issues.push(`missing field provenance: ${path}`);
+  }
+  for (const [path, provenance] of Object.entries(canonical.fieldProvenance)) {
+    if (provenance.origin === "raw" && !provenance.rawFields?.length) {
+      issues.push(`raw provenance has no source field: ${path}`);
+    }
+    if (provenance.origin === "derived" && !provenance.derivation) {
+      issues.push(`derived provenance has no rule: ${path}`);
+    }
+    for (const locator of provenance.recordLocators) {
+      if (!rawLocators.has(locator)) issues.push(`field provenance references an unknown record: ${path} -> ${locator}`);
+    }
+  }
+  return issues;
+}
+
+export function sourceArtifactHash(text: string): string {
+  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+export function stampSourceArtifactHash<T extends { canonical?: CanonicalEventEnvelope }>(
+  events: readonly T[],
+  text: string,
+): T[] {
+  const hash = sourceArtifactHash(text);
+  return events.map((event) => event.canonical
+    ? {
+        ...event,
+        canonical: {
+          ...event.canonical,
+          evidence: { ...event.canonical.evidence, sourceArtifactHash: hash },
+        },
+      }
+    : { ...event });
+}
+
+export function mergeCanonicalEvents(
+  first: CanonicalEventEnvelope | undefined,
+  incoming: CanonicalEventEnvelope | undefined,
+): CanonicalEventEnvelope | undefined {
+  if (!first) return incoming;
+  if (!incoming) return first;
+  const firstVersion = (first as { schemaVersion?: string }).schemaVersion;
+  const incomingVersion = (incoming as { schemaVersion?: string }).schemaVersion;
+  if (firstVersion !== CANONICAL_EVENT_SCHEMA_VERSION) return first;
+  if (incomingVersion !== CANONICAL_EVENT_SCHEMA_VERSION) return incoming;
+  const pointers = [...first.evidence.rawRecords];
+  for (const pointer of incoming.evidence.rawRecords) {
+    if (!pointers.some((p) => p.source === pointer.source && p.locator === pointer.locator)) pointers.push(pointer);
+  }
+  const fieldProvenance = { ...first.fieldProvenance };
+  for (const [path, provenance] of Object.entries(incoming.fieldProvenance)) {
+    const existing = fieldProvenance[path];
+    if (!existing) {
+      fieldProvenance[path] = provenance;
+      continue;
+    }
+    fieldProvenance[path] = {
+      ...existing,
+      recordLocators: [...new Set([...(existing.recordLocators ?? []), ...(provenance.recordLocators ?? [])])],
+    };
+  }
+  return {
+    ...first,
+    evidence: {
+      rawRecords: pointers,
+      sourceArtifactHash: first.evidence.sourceArtifactHash ?? incoming.evidence.sourceArtifactHash,
+    },
+    fieldProvenance,
+  };
+}
+
+interface LegacyLogon {
+  account: string;
+  outcome: "success" | "failed";
+  logonType?: number;
+  sourceIp?: string;
+  workstation?: string;
+  sessionId?: string;
+}
+
+const LEGACY_LOGON_MARKER = /(Successful|Failed) logon \(EID (?:4624|4625)\)/;
+const LEGACY_ACCOUNT = /(?<![\\/:.\w])(NT AUTHORITY|NT SERVICE|Window Manager|Font Driver Host|[A-Za-z][A-Za-z0-9.-]{1,30})\\([A-Za-z0-9._$-]{2,40})(?![\\/\w])/g;
+
+function legacyLogon(event: ForensicEvent): LegacyLogon | undefined {
+  const marker = LEGACY_LOGON_MARKER.exec(event.description);
+  if (!marker) return undefined;
+  const separator = event.description.indexOf(" - ");
+  if (separator !== -1 && marker.index > separator) return undefined;
+  const rest = event.description.slice(marker.index + marker[0].length);
+  const segment = rest.replace(/^ - /, "").split(/ - (?=[A-Za-z]+=)| @ | \[/)[0]?.trim() ?? "";
+  const account = segment.split(", ")[0]?.trim();
+  if (!account || account.includes("=")) return undefined;
+  const rawType = /\bLogonType=(\d+)\b/.exec(event.description)?.[1];
+  const sourceIp = /\bIpAddress=(\S+)/.exec(event.description)?.[1];
+  const workstation = /\bWorkstationName=(\S+)/.exec(event.description)?.[1];
+  const sessionId = /\b(?:TargetLogonId|LogonId)=(\S+)/.exec(event.description)?.[1];
+  return {
+    account,
+    outcome: marker[1] === "Successful" ? "success" : "failed",
+    ...(rawType ? { logonType: Number(rawType) } : {}),
+    ...(sourceIp ? { sourceIp } : {}),
+    ...(workstation ? { workstation } : {}),
+    ...(sessionId ? { sessionId } : {}),
+  };
+}
+
+function legacyAccount(event: ForensicEvent): string | undefined {
+  LEGACY_ACCOUNT.lastIndex = 0;
+  const match = LEGACY_ACCOUNT.exec(event.description);
+  return match ? `${match[1]}\\${match[2]}` : undefined;
+}
+
+function fileName(path: string | undefined): string | undefined {
+  return path?.split(/[\\/]/).pop() || undefined;
+}
+
+function legacyCanonical(event: ForensicEvent): CanonicalEventEnvelope {
+  const logon = legacyLogon(event);
+  const accountName = logon?.account ?? legacyAccount(event);
+  const category: CanonicalEventCategory = logon
+    ? "authentication"
+    : event.processName || event.parentName || event.pid || event.commandLine
+      ? "process"
+      : event.srcIp || event.dstIp
+        ? "network"
+        : event.path || event.sha256 || event.md5
+          ? "file"
+          : "other";
+  const actor: CanonicalEntity | undefined = accountName
+    ? { kind: "account", name: accountName }
+    : undefined;
+  const target: CanonicalEntity | undefined = event.asset
+    ? { kind: "host", name: event.asset }
+    : undefined;
+  const process = event.processName || event.parentName || event.pid || event.commandLine
+    ? {
+        ...(event.pid ? { pid: event.pid } : {}),
+        ...(event.processName ? { name: event.processName } : {}),
+        ...(event.path ? { executable: event.path } : {}),
+        ...(event.commandLine ? { commandLine: event.commandLine } : {}),
+        ...(event.parentName ? { parent: { name: event.parentName } } : {}),
+      }
+    : undefined;
+  const file = event.path || event.sha256 || event.md5
+    ? {
+        ...(event.path ? { path: event.path, name: fileName(event.path) } : {}),
+        ...(event.sha256 ? { sha256: event.sha256 } : {}),
+        ...(event.md5 ? { md5: event.md5 } : {}),
+      }
+    : undefined;
+  const network = event.srcIp || event.dstIp || event.port
+    ? {
+        ...(event.srcIp ? { source: { address: event.srcIp } } : {}),
+        ...(event.dstIp || event.port ? {
+          destination: {
+            ...(event.dstIp ? { address: event.dstIp } : {}),
+            ...(event.port ? { port: event.port } : {}),
+          },
+        } : {}),
+      }
+    : undefined;
+  return createCanonicalEvent({
+    event: {
+      category,
+      type: logon ? "logon" : category === "process" ? "observation" : category === "network" ? "connection" : category === "file" ? "observation" : "event",
+      ...(event.action ? { action: event.action } : {}),
+      ...(logon ? { outcome: logon.outcome } : {}),
+    },
+    ...(actor ? { actor } : {}),
+    ...(target ? { target } : {}),
+    ...(accountName ? {
+      account: {
+        name: accountName,
+        ...(accountName.includes("\\") ? { domain: accountName.split("\\")[0] } : {}),
+      },
+    } : {}),
+    ...(logon ? {
+      authentication: {
+        ...(logon.sessionId ? { sessionId: logon.sessionId } : {}),
+        ...(logon.logonType !== undefined ? { logonType: logon.logonType } : {}),
+      },
+      ...(logon.workstation ? { session: { terminal: logon.workstation } } : {}),
+    } : {}),
+    ...(network || logon?.sourceIp ? {
+      network: {
+        ...network,
+        ...(logon?.sourceIp ? { source: { address: logon.sourceIp } } : {}),
+      },
+    } : {}),
+    ...(process ? { process } : {}),
+    ...(file ? { file } : {}),
+    time: { observed: event.timestamp, normalized: event.timestamp },
+    evidence: {
+      rawRecords: [{ source: "legacy-forensic-event", locator: `event:${event.id}`, recordId: event.id }],
+    },
+    producer: {
+      importer: "legacy-upgrade",
+      parserVersion: "1",
+      mappingVersion: "legacy-event-to-canonical-v1",
+    },
+    rawFieldMap: {
+      "time.observed": ["timestamp"],
+      "time.normalized": ["timestamp"],
+      ...(event.asset ? { "target.name": ["asset"] } : {}),
+      ...(event.processName ? { "process.name": ["processName"] } : {}),
+      ...(event.parentName ? { "process.parent.name": ["parentName"] } : {}),
+      ...(event.pid ? { "process.pid": ["pid"] } : {}),
+      ...(event.commandLine ? { "process.commandLine": ["commandLine"] } : {}),
+      ...(event.path ? { "file.path": ["path"] } : {}),
+      ...(event.sha256 ? { "file.sha256": ["sha256"] } : {}),
+      ...(event.md5 ? { "file.md5": ["md5"] } : {}),
+      ...(event.srcIp ? { "network.source.address": ["srcIp"] } : {}),
+      ...(event.dstIp ? { "network.destination.address": ["dstIp"] } : {}),
+      ...(event.port ? { "network.destination.port": ["port"] } : {}),
+    },
+    confidenceMap: accountName ? { "actor.name": "medium", "account.name": "medium" } : {},
+    derivationMap: {
+      ...(accountName ? {
+        "actor.name": "legacy-event-to-canonical-v1: one-time guarded identity extraction from legacy display text",
+        "account.name": "legacy-event-to-canonical-v1: one-time guarded identity extraction from legacy display text",
+      } : {}),
+    },
+  });
+}
+
+export function upgradeForensicEvent(event: ForensicEvent): ForensicEvent {
+  if (event.canonical?.schemaVersion === CANONICAL_EVENT_SCHEMA_VERSION) return event;
+  // A future major/minor version may contain meaning this build does not understand. Preserve it
+  // verbatim instead of silently downgrading it; explicit version migrations are registered here.
+  if (event.canonical) return event;
+  return { ...event, canonical: legacyCanonical(event) };
+}
+
+function currentCanonical(event: ForensicEvent): CanonicalEventEnvelope | undefined {
+  const upgraded = upgradeForensicEvent(event);
+  return upgraded.canonical?.schemaVersion === CANONICAL_EVENT_SCHEMA_VERSION
+    ? upgraded.canonical
+    : undefined;
+}
+
+export function canonicalAccounts(event: ForensicEvent): string[] {
+  const canonical = currentCanonical(event);
+  if (!canonical) return [];
+  const names = [
+    canonical.actor?.kind === "account" ? canonical.actor.name : undefined,
+    canonical.subject?.kind === "account" ? canonical.subject.name : undefined,
+    canonical.object?.kind === "account" ? canonical.object.name : undefined,
+    canonical.target?.kind === "account" ? canonical.target.name : undefined,
+    canonical.account?.name,
+  ].filter((name): name is string => !!name?.trim());
+  return [...new Set(names)];
+}
+
+export function canonicalProcess(event: ForensicEvent): CanonicalEventEnvelope["process"] {
+  return currentCanonical(event)?.process;
+}
+
+export function canonicalNetwork(event: ForensicEvent): CanonicalEventEnvelope["network"] {
+  return currentCanonical(event)?.network;
+}
+
+export function canonicalFile(event: ForensicEvent): CanonicalEventEnvelope["file"] {
+  return currentCanonical(event)?.file;
+}

--- a/companion/src/analysis/ecarImport.ts
+++ b/companion/src/analysis/ecarImport.ts
@@ -28,6 +28,7 @@
 // aggregates, sorts, and caps identically to every other deterministic importer.
 
 import type { Severity } from "./stateTypes.js";
+import { createCanonicalEvent, stampSourceArtifactHash } from "./canonicalEvent.js";
 import {
   extractRecords,
   aggregateEvents,
@@ -166,6 +167,8 @@ export function mapEcarRecord(rec: Row, sink: Map<string, SiemIoc>): MappedEvent
         ...(procName ? { processName: procName } : {}),
         ...(parentName ? { parentName } : {}),
         ...(pid !== undefined ? { pid } : {}),
+        ...(cmd ? { commandLine: cmd } : {}),
+        ...(image ? { path: image } : {}),
       };
     }
 
@@ -311,6 +314,126 @@ export function mapEcarRecord(rec: Row, sink: Map<string, SiemIoc>): MappedEvent
   }
 }
 
+function canonicalizeEcarRecord(rec: Row, mapped: MappedEvent, recordIndex: number): MappedEvent {
+  const p = props(rec);
+  const object = oneLine(str(rec["object"])).toLowerCase();
+  const action = oneLine(str(rec["action"])).toLowerCase();
+  const host = oneLine(str(rec["hostname"]));
+  const principal = oneLine(str(rec["principal"]));
+  const image = prop(p, "image_path");
+  const parentImage = prop(p, "parent_image_path");
+  const commandLine = prop(p, "command_line");
+  const processName = mapped.processName || baseName(image) || undefined;
+  const parentName = mapped.parentName || baseName(parentImage) || undefined;
+  const registryKey = prop(p, "registry_key");
+  const registryValue = prop(p, "registry_value");
+  const filePath = prop(p, "file_path") || mapped.path;
+  const srcIp = mapped.srcIp || cleanIp(prop(p, "src_ip"));
+  const dstIp = mapped.dstIp || cleanIp(prop(p, "dst_ip"));
+  const destinationPort = mapped.port ?? portNum(prop(p, "dst_port"));
+  const sourcePort = portNum(prop(p, "src_port"));
+  const logonTypeRaw = prop(p, "logon_type");
+  const logonType = Number.isFinite(Number(logonTypeRaw)) ? Number(logonTypeRaw) : undefined;
+  const outcome = prop(p, "outcome").toLowerCase();
+  const category = object === "process" || object === "thread" ? "process"
+    : object === "flow" ? "network"
+    : object === "user_session" ? "authentication"
+    : object === "registry" ? "registry"
+    : object === "file" || object === "module" ? "file"
+    : "other";
+  const type = object === "process" && action === "create" ? "start"
+    : object === "process" && action === "terminate" ? "stop"
+    : object === "user_session" && action === "login" ? "logon"
+    : action || "event";
+  const observedTimestamp = str(rec["timestamp_ms"]);
+  const canonical = createCanonicalEvent({
+    event: {
+      category,
+      type,
+      ...(action ? { action } : {}),
+      ...(object === "user_session" && action === "login"
+        ? { outcome: /fail/.test(outcome) || !!prop(p, "failure_reason") ? "failed" : "success" }
+        : {}),
+    },
+    ...(principal ? { actor: { kind: "account", name: principal }, account: { name: principal } } : {}),
+    ...(host ? { target: { kind: "host", name: host } } : {}),
+    ...(category === "authentication" ? {
+      authentication: {
+        ...(logonType !== undefined ? { logonType } : {}),
+        ...(prop(p, "session_id") ? { sessionId: prop(p, "session_id") } : {}),
+      },
+    } : {}),
+    ...(srcIp || dstIp || destinationPort || sourcePort ? {
+      network: {
+        ...(srcIp || sourcePort ? {
+          source: {
+            ...(srcIp ? { address: srcIp } : {}),
+            ...(sourcePort ? { port: sourcePort } : {}),
+          },
+        } : {}),
+        ...(dstIp || destinationPort ? {
+          destination: {
+            ...(dstIp ? { address: dstIp } : {}),
+            ...(destinationPort ? { port: destinationPort } : {}),
+          },
+        } : {}),
+        ...(prop(p, "protocol") ? { protocol: prop(p, "protocol") } : {}),
+      },
+    } : {}),
+    ...(category === "process" ? {
+      process: {
+        ...(mapped.pid ? { pid: mapped.pid } : {}),
+        ...(processName ? { name: processName } : {}),
+        ...(image ? { executable: image } : {}),
+        ...(commandLine ? { commandLine } : {}),
+        ...(parentName || parentImage ? {
+          parent: {
+            ...(parentName ? { name: parentName } : {}),
+            ...(parentImage ? { executable: parentImage } : {}),
+          },
+        } : {}),
+      },
+    } : {}),
+    ...(filePath ? { file: { path: filePath, name: baseName(filePath) } } : {}),
+    ...(registryKey ? {
+      registry: {
+        key: registryKey,
+        ...(registryValue ? { valueData: registryValue } : {}),
+      },
+    } : {}),
+    time: {
+      observed: observedTimestamp,
+      normalized: mapped.timestamp,
+      timezone: "UTC",
+      precision: "millisecond",
+    },
+    evidence: {
+      rawRecords: [{ source: "ecar", locator: `record:${recordIndex}` }],
+    },
+    producer: {
+      importer: "ecar",
+      parserVersion: "1",
+      mappingVersion: "ecar-v1",
+      ruleVersions: ["ecar-tradecraft-v1"],
+    },
+    rawFieldMap: {
+      "event.action": ["action"],
+      "time.observed": ["timestamp_ms"],
+      ...(principal ? { "actor.name": ["principal"], "account.name": ["principal"] } : {}),
+      ...(host ? { "target.name": ["hostname"] } : {}),
+      ...(mapped.pid ? { "process.pid": ["pid"] } : {}),
+      ...(processName ? { "process.name": ["properties.image_path", "properties.command_line"] } : {}),
+      ...(image ? { "process.executable": ["properties.image_path"] } : {}),
+      ...(commandLine ? { "process.commandLine": ["properties.command_line"] } : {}),
+      ...(srcIp ? { "network.source.address": ["properties.src_ip"] } : {}),
+      ...(dstIp ? { "network.destination.address": ["properties.dst_ip"] } : {}),
+      ...(filePath ? { "file.path": ["properties.file_path", "properties.image_path"] } : {}),
+      ...(registryKey ? { "registry.key": ["properties.registry_key"] } : {}),
+    },
+  });
+  return { ...mapped, canonical };
+}
+
 // Is this NDJSON/array of records ECAR? The signature is the (timestamp_ms + object + action) triple —
 // distinctive to the ECAR schema and absent from the other JSON feeds. Pure; used by importDetect.
 export function isEcarRecord(rec: unknown): boolean {
@@ -329,13 +452,13 @@ export function parseEcarJson(text: string, opts: EcarImportOptions = {}): EcarP
   const hostTally = new Map<string, number>();
   const mapped: MappedEvent[] = [];
 
-  for (const rec of records) {
+  for (const [recordIndex, rec] of records.entries()) {
     if (!rec || typeof rec !== "object") continue;
     const r = rec as Row;
     const host = oneLine(str(r["hostname"]));
     if (host) hostTally.set(host, (hostTally.get(host) ?? 0) + 1);
     const m = mapEcarRecord(r, sink);
-    if (m) mapped.push(m);
+    if (m) mapped.push(canonicalizeEcarRecord(r, m, recordIndex));
   }
 
   const { events, groups } = aggregateEvents(mapped, {
@@ -343,15 +466,16 @@ export function parseEcarJson(text: string, opts: EcarImportOptions = {}): EcarP
     minSeverity: opts.minSeverity,
     maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
+  const finalEvents = stampSourceArtifactHash(events, text);
 
-  const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
+  const represented = finalEvents.reduce((n, e) => n + (e.count ?? 1), 0);
   const hostname = [...hostTally.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
 
   return {
-    events,
+    events: finalEvents,
     iocs: [...sink.values()].slice(0, maxIocs),
     total: records.length,
-    kept: events.length,
+    kept: finalEvents.length,
     dropped: Math.max(0, records.length - represented),
     groups,
     format,

--- a/companion/src/analysis/emailImport.ts
+++ b/companion/src/analysis/emailImport.ts
@@ -23,6 +23,7 @@
 // export the message as `.eml`.
 
 import type { Severity } from "./stateTypes.js";
+import { createCanonicalEvent, stampSourceArtifactHash } from "./canonicalEvent.js";
 import { addIoc, cleanIp, type SiemEvent, type SiemIoc } from "./siemImport.js";
 
 export interface EmailImportOptions {
@@ -522,6 +523,52 @@ function buildEvent(p: ParsedEmail, severity: Severity): SiemEvent {
     const linkHosts = [...new Set(p.urls.map(urlHost).filter((h): h is string => !!h && !IPV4.test(h) && DOMAIN_RE.test(h)))];
     if (linkHosts.length) desc += ` linking ${linkHosts.slice(0, 5).join(", ")}`;
   }
+  const sender = p.from?.address;
+  const recipient = p.to[0]?.address;
+  const canonical = createCanonicalEvent({
+    event: { category: "email", type: "message", action: "receive" },
+    ...(sender ? { actor: { kind: "mailbox", name: sender } } : {}),
+    ...(recipient ? { target: { kind: "mailbox", name: recipient } } : {}),
+    ...(p.attachments[0] ? {
+      object: { kind: "file", name: p.attachments[0].filename },
+      file: {
+        name: p.attachments[0].filename,
+        ...(p.attachments[0].sha256 ? { sha256: p.attachments[0].sha256 } : {}),
+        ...(p.attachments[0].md5 ? { md5: p.attachments[0].md5 } : {}),
+      },
+    } : {}),
+    mailbox: {
+      ...(p.messageId ? { messageId: p.messageId } : {}),
+      ...(sender ? { sender } : {}),
+      ...(p.to.length ? { recipients: p.to.map((address) => address.address) } : {}),
+      ...(p.subject ? { subject: p.subject } : {}),
+    },
+    ...(p.originatingIp ? { network: { source: { address: p.originatingIp } } } : {}),
+    time: { observed: p.rawDate, normalized: p.date },
+    evidence: {
+      rawRecords: [{
+        source: p.format === "eml" ? "rfc822-message" : "outlook-msg",
+        locator: p.messageId ? `message-id:${p.messageId}` : "message:0",
+        ...(p.messageId ? { recordId: p.messageId } : {}),
+      }],
+    },
+    producer: {
+      importer: "email",
+      parserVersion: "1",
+      mappingVersion: "email-message-v1",
+      ruleVersions: ["email-auth-severity-v1"],
+    },
+    rawFieldMap: {
+      "time.observed": ["Date"],
+      ...(sender ? { "actor.name": ["From"], "mailbox.sender": ["From"] } : {}),
+      ...(recipient ? { "target.name": ["To"] } : {}),
+      ...(p.to.length ? { "mailbox.recipients": ["To", "Cc"] } : {}),
+      ...(p.messageId ? { "mailbox.messageId": ["Message-ID"] } : {}),
+      ...(p.subject ? { "mailbox.subject": ["Subject"] } : {}),
+      ...(p.originatingIp ? { "network.source.address": ["X-Originating-IP", "Received"] } : {}),
+      ...(p.attachments[0] ? { "object.name": ["Content-Disposition.filename"], "file.name": ["Content-Disposition.filename"] } : {}),
+    },
+  });
 
   return {
     id: "",
@@ -530,6 +577,7 @@ function buildEvent(p: ParsedEmail, severity: Severity): SiemEvent {
     severity,
     mitreTechniques: mitre,
     sources: ["Email"],
+    canonical,
   };
 }
 
@@ -575,7 +623,7 @@ export function parseEmail(text: string, opts: EmailImportOptions = {}): EmailPa
   }
 
   const severity = emailSeverity(parsed);
-  const event = buildEvent(parsed, severity);
+  const [event] = stampSourceArtifactHash([buildEvent(parsed, severity)], text);
   const iocs = collectIocs(parsed, maxIocs);
 
   return {

--- a/companion/src/analysis/evidenceGraph.ts
+++ b/companion/src/analysis/evidenceGraph.ts
@@ -1,6 +1,13 @@
 import type { InvestigationState, ForensicEvent, Severity } from "./stateTypes.js";
-import { extractAccounts, filterTimeline, type TimeWindow } from "./assetGraph.js";
+import { filterTimeline, type TimeWindow } from "./assetGraph.js";
 import { tacticForTechniques, type IrisTactic } from "../integrations/iris/mitreTactics.js";
+import {
+  canonicalAccounts,
+  canonicalFile,
+  canonicalNetwork,
+  canonicalProcess,
+  upgradeForensicEvent,
+} from "./canonicalEvent.js";
 
 // Derives the EVIDENCE CHAIN GRAPH — the *causal* view of an incident, complementing the
 // chronological forensic timeline and the (associative) asset↔IoC graph. Where the asset
@@ -127,10 +134,28 @@ function isPseudoAccount(acct: string): boolean {
   return PSEUDO_ACCT_DOMAIN.test(domain.trim()) || PSEUDO_ACCT_USER.test(user.trim());
 }
 
+function eventAsset(event: ForensicEvent): string {
+  const target = event.canonical?.target;
+  return ((target?.kind === "host" ? target.name : undefined) ?? event.asset ?? "").trim();
+}
+
+function eventHash(event: ForensicEvent): string {
+  const file = canonicalFile(event);
+  return (file?.sha256 ?? file?.md5 ?? "").trim().toLowerCase();
+}
+
+function eventPath(event: ForensicEvent): string {
+  return (canonicalFile(event)?.path ?? "").trim();
+}
+
+function eventAction(event: ForensicEvent): string {
+  return event.canonical?.event.action ?? event.action ?? "";
+}
+
 export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindow): EvidenceGraph {
   // Scope the timeline to the requested window (#83) once, up front; every derivation pass below
   // reads `timeline` instead of state.forensicTimeline, so edges/nodes only form from in-window events.
-  const timeline = filterTimeline(state.forensicTimeline, window);
+  const timeline = filterTimeline(state.forensicTimeline, window).map(upgradeForensicEvent);
   // Nodes are materialized lazily so only those that participate in ≥1 edge are emitted.
   const nodeMap = new Map<string, EvidenceNode>();
   function mergeNode(id: string, kind: EvidenceNodeKind, label: string, asset: string | undefined, eventIds: readonly string[], sev: Severity): EvidenceNode {
@@ -159,10 +184,11 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
 
   // ── spawned: parent→child from each event's own process pair ──────────────────────────
   for (const e of timeline) {
-    if (!e.parentName || !e.processName) continue;
-    const parent = e.parentName.trim(), child = e.processName.trim();
+    const process = canonicalProcess(e);
+    if (!process?.parent?.name || !process.name) continue;
+    const parent = process.parent.name.trim(), child = process.name.trim();
     if (!parent || !child || parent.toLowerCase() === child.toLowerCase()) continue; // skip self-spawn
-    const asset = (e.asset ?? "").trim();
+    const asset = eventAsset(e);
     const pId = procNodeId(asset, parent), cId = procNodeId(asset, child);
     ensureNode(pId, "process", parent, asset || undefined, e);
     ensureNode(cId, "process", child, asset || undefined, e);
@@ -176,8 +202,8 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
   // ── lateral_move (hash): same binary on ≥2 distinct hosts ─────────────────────────────
   const byHash = new Map<string, Map<string, ForensicEvent>>(); // hash -> assetLower -> a backing event
   for (const e of timeline) {
-    const h = (e.sha256 ?? e.md5 ?? "").trim().toLowerCase();
-    const asset = (e.asset ?? "").trim();
+    const h = eventHash(e);
+    const asset = eventAsset(e);
     if (!h || !asset) continue;
     const hosts = byHash.get(h) ?? new Map();
     if (!hosts.has(asset.toLowerCase())) hosts.set(asset.toLowerCase(), e);
@@ -188,12 +214,13 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
     const entries = [...hosts.entries()].sort((a, b) => a[0].localeCompare(b[0])); // [assetLower, event]
     for (let i = 1; i < entries.length; i++) {
       const [, ea] = entries[i - 1], [, eb] = entries[i]; // chain consecutive hosts → k-1 edges
-      const aNode = ensureNode(hostNodeId(ea.asset!.trim()), "host", ea.asset!.trim(), undefined, ea);
-      const bNode = ensureNode(hostNodeId(eb.asset!.trim()), "host", eb.asset!.trim(), undefined, eb);
+      const aAsset = eventAsset(ea), bAsset = eventAsset(eb);
+      const aNode = ensureNode(hostNodeId(aAsset), "host", aAsset, undefined, ea);
+      const bNode = ensureNode(hostNodeId(bAsset), "host", bAsset, undefined, eb);
       addEdge({
         id: `lateral|hash:${h}|${aNode.id}|${bNode.id}`, type: "lateral_move",
         source: aNode.id, target: bNode.id, confidence: "high", rule: "shared-hash",
-        basis: `same binary ${shortHash(h)} on ${ea.asset!.trim()} + ${eb.asset!.trim()}`, eventId: eb.id,
+        basis: `same binary ${shortHash(h)} on ${aAsset} + ${bAsset}`, eventId: eb.id,
       });
     }
   }
@@ -201,9 +228,9 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
   // ── lateral_move (account): same account active on ≥2 distinct hosts (account → host star) ──
   const byAccount = new Map<string, Map<string, ForensicEvent>>(); // account -> assetLower -> event
   for (const e of timeline) {
-    const asset = (e.asset ?? "").trim();
+    const asset = eventAsset(e);
     if (!asset) continue;
-    for (const acct of extractAccounts(e.description)) {
+    for (const acct of canonicalAccounts(e)) {
       if (isPseudoAccount(acct)) continue;   // skip DWM/UMFD/MSI… virtual principals — not users
       const hosts = byAccount.get(acct) ?? new Map();
       if (!hosts.has(asset.toLowerCase())) hosts.set(asset.toLowerCase(), e);
@@ -214,12 +241,13 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
     if (hosts.size < 2) continue;
     const acctId = accountNodeId(acct);
     for (const [, e] of [...hosts.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+      const asset = eventAsset(e);
       ensureNode(acctId, "account", acct, undefined, e);
-      const hNode = ensureNode(hostNodeId(e.asset!.trim()), "host", e.asset!.trim(), undefined, e);
+      const hNode = ensureNode(hostNodeId(asset), "host", asset, undefined, e);
       addEdge({
         id: `lateral|acct:${acct}|${hNode.id}`, type: "lateral_move",
         source: acctId, target: hNode.id, confidence: "medium", rule: "shared-account",
-        basis: `${acct} active on ${e.asset!.trim()}`, eventId: e.id,
+        basis: `${acct} active on ${asset}`, eventId: e.id,
       });
     }
   }
@@ -230,25 +258,26 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
   const writesByHash = new Map<string, ForensicEvent[]>();
   const execsByHash = new Map<string, ForensicEvent[]>();
   for (const e of timeline) {
-    if (!e.action) continue;
-    const h = (e.sha256 ?? e.md5 ?? "").trim().toLowerCase();
+    const action = eventAction(e);
+    if (!action) continue;
+    const h = eventHash(e);
     if (!h) continue;
-    if (e.action === "write") {
+    if (action === "write") {
       const arr = writesByHash.get(h) ?? []; arr.push(e); writesByHash.set(h, arr);
-    } else if (e.action === "execute") {
+    } else if (action === "execute") {
       const arr = execsByHash.get(h) ?? []; arr.push(e); execsByHash.set(h, arr);
     }
   }
   for (const [h, writes] of writesByHash) {
     const execs = execsByHash.get(h);
     if (!execs?.length) continue;
-    const samplePath = writes.find((e) => e.path)?.path ?? execs.find((e) => e.path)?.path;
+    const samplePath = writes.map(eventPath).find(Boolean) ?? execs.map(eventPath).find(Boolean);
     const fileName = samplePath?.split(/[/\\]/).pop() ?? shortHash(h);
     const fId = fileNodeId(h);
     // mergeNode is only called when an edge is about to be created so the file node never
     // ends up in the graph without at least one edge referencing it.
     for (const we of writes) {
-      const wAsset = (we.asset ?? "").trim();
+      const wAsset = eventAsset(we);
       if (!wAsset) continue;
       mergeNode(fId, "file", fileName, undefined, [we.id], we.severity);
       const wHId = hostNodeId(wAsset);
@@ -260,13 +289,14 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
       });
     }
     for (const xe of execs) {
-      const xAsset = (xe.asset ?? "").trim();
+      const xAsset = eventAsset(xe);
       if (!xAsset) continue;
       mergeNode(fId, "file", fileName, undefined, [xe.id], xe.severity);
       let xNodeId: string;
-      if (xe.processName) {
-        xNodeId = procNodeId(xAsset, xe.processName.trim());
-        ensureNode(xNodeId, "process", xe.processName.trim(), xAsset, xe);
+      const processName = canonicalProcess(xe)?.name?.trim();
+      if (processName) {
+        xNodeId = procNodeId(xAsset, processName);
+        ensureNode(xNodeId, "process", processName, xAsset, xe);
       } else {
         xNodeId = hostNodeId(xAsset);
         ensureNode(xNodeId, "host", xAsset, undefined, xe);
@@ -283,10 +313,11 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
   // Requires dstIp. Source is srcIp (network node) when present, otherwise the event's asset
   // (host node — the host that made the connection). Skips if source cannot be determined.
   for (const e of timeline) {
-    const dst = (e.dstIp ?? "").trim();
+    const network = canonicalNetwork(e);
+    const dst = (network?.destination?.address ?? "").trim();
     if (!dst) continue;
-    const srcIp = (e.srcIp ?? "").trim();
-    const srcAsset = (e.asset ?? "").trim();
+    const srcIp = (network?.source?.address ?? "").trim();
+    const srcAsset = eventAsset(e);
     const src = srcIp || srcAsset;
     if (!src || src === dst) continue;
     // Source: use a network node for an explicit srcIp, host node for the event's asset.
@@ -297,8 +328,9 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
     } else {
       ensureNode(srcId, "host", srcAsset, undefined, e);
     }
-    const dstId = netNodeId(dst, e.port);
-    const dstLabel = dst + (e.port ? `:${e.port}` : "");
+    const port = network?.destination?.port;
+    const dstId = netNodeId(dst, port);
+    const dstLabel = dst + (port ? `:${port}` : "");
     mergeNode(dstId, "network", dstLabel, undefined, [e.id], e.severity);
     nodeMap.get(dstId)!.ip = dst;
     addEdge({
@@ -396,7 +428,7 @@ function timeOf(ts: string): number {
 }
 
 export function buildLateralPaths(state: InvestigationState, window?: TimeWindow): LateralPath[] {
-  const timeline = filterTimeline(state.forensicTimeline, window);
+  const timeline = filterTimeline(state.forensicTimeline, window).map(upgradeForensicEvent);
 
   // The EARLIEST event tying each host to a given hash/account (not just "a" event, as in
   // buildEvidenceGraph's byHash/byAccount — here the hop order depends on real chronology).
@@ -404,7 +436,7 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
     const byKey = new Map<string, Map<string, ForensicEvent>>();
     for (const e of timeline) {
       const key = (pick(e) ?? "").trim().toLowerCase();
-      const asset = (e.asset ?? "").trim();
+      const asset = eventAsset(e);
       if (!key || !asset) continue;
       const hosts = byKey.get(key) ?? new Map<string, ForensicEvent>();
       const assetKey = asset.toLowerCase();
@@ -448,10 +480,10 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
   );
   const provenance = new Map<string, { vendorOnly: boolean; hasPath: boolean; grave: boolean }>();
   for (const e of timeline) {
-    const key = (e.sha256 ?? e.md5 ?? "").trim().toLowerCase();
+    const key = eventHash(e);
     if (!key) continue;
     const rec = provenance.get(key) ?? { vendorOnly: true, hasPath: false, grave: false };
-    const p = (e.path ?? "").trim();
+    const p = eventPath(e);
     if (p) {
       rec.hasPath = true;
       if (!VENDOR_INSTALL_ROOT.test(p)) rec.vendorOnly = false;
@@ -468,15 +500,15 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
   // prefix). Falls back to the short hash when no path was recorded for the file.
   const binaryNameByHash = new Map<string, string>();
   for (const e of timeline) {
-    const key = (e.sha256 ?? e.md5 ?? "").trim().toLowerCase();
-    const p = (e.path ?? "").trim();
+    const key = eventHash(e);
+    const p = eventPath(e);
     if (!key || !p || binaryNameByHash.has(key)) continue;
     const base = p.split(/[\\/]/).pop();
     if (base) binaryNameByHash.set(key, base);
   }
 
   // shared-hash hops: chronological chain across every host the binary touched (high confidence).
-  const byHash = earliestPerHost((e) => e.sha256 ?? e.md5);
+  const byHash = earliestPerHost(eventHash);
   for (const [h, hosts] of byHash) {
     if (hosts.size < 2) continue;
     if (isInstalledSoftware(h)) continue;              // installed vendor software ≠ movement
@@ -484,12 +516,13 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
     const binary = binaryNameByHash.get(h) ?? shortHash(h);
     for (let i = 1; i < ordered.length; i++) {
       const from = ordered[i - 1], to = ordered[i];
+      const fromAsset = eventAsset(from), toAsset = eventAsset(to);
       hops.push({
-        from: hostNodeId(from.asset!.trim()), to: hostNodeId(to.asset!.trim()),
+        from: hostNodeId(fromAsset), to: hostNodeId(toAsset),
         fromTimestamp: from.timestamp, toTimestamp: to.timestamp,
         confidence: "high", rule: "shared-hash",
         actor: binary, actorKind: "binary",
-        basis: `same binary ${shortHash(h)}: ${from.asset!.trim()} → ${to.asset!.trim()}`,
+        basis: `same binary ${shortHash(h)}: ${fromAsset} → ${toAsset}`,
         eventIds: [from.id, to.id],
       });
     }
@@ -499,9 +532,9 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
   // (medium confidence — a roaming account is signal, not proof of an attacker's hand).
   const byAccount = new Map<string, Map<string, ForensicEvent>>();
   for (const e of timeline) {
-    const asset = (e.asset ?? "").trim();
+    const asset = eventAsset(e);
     if (!asset) continue;
-    for (const acct of extractAccounts(e.description)) {
+    for (const acct of canonicalAccounts(e)) {
       if (isPseudoAccount(acct)) continue;
       const hosts = byAccount.get(acct) ?? new Map<string, ForensicEvent>();
       const assetKey = asset.toLowerCase();
@@ -515,12 +548,13 @@ export function buildLateralPaths(state: InvestigationState, window?: TimeWindow
     const ordered = [...hosts.values()].sort((a, b) => timeOf(a.timestamp) - timeOf(b.timestamp));
     for (let i = 1; i < ordered.length; i++) {
       const from = ordered[i - 1], to = ordered[i];
+      const fromAsset = eventAsset(from), toAsset = eventAsset(to);
       hops.push({
-        from: hostNodeId(from.asset!.trim()), to: hostNodeId(to.asset!.trim()),
+        from: hostNodeId(fromAsset), to: hostNodeId(toAsset),
         fromTimestamp: from.timestamp, toTimestamp: to.timestamp,
         confidence: "medium", rule: "shared-account",
         actor: acct, actorKind: "account",
-        basis: `${acct} active on ${from.asset!.trim()} then ${to.asset!.trim()}`,
+        basis: `${acct} active on ${fromAsset} then ${toAsset}`,
         eventIds: [from.id, to.id],
       });
     }

--- a/companion/src/analysis/evtxXmlImport.ts
+++ b/companion/src/analysis/evtxXmlImport.ts
@@ -140,5 +140,5 @@ export function parseWinEventXml(text: string): Row[] {
 // Parse a Windows Event Log XML export into a SIEM result (identical shape to parseSiemExport).
 export function parseEvtxXml(text: string, opts: SiemImportOptions = {}): SiemParseResult {
   const records = parseWinEventXml(text);
-  return buildSiemResult(records, "winevent-xml", opts);
+  return buildSiemResult(records, "winevent-xml", opts, text);
 }

--- a/companion/src/analysis/loginGraph.ts
+++ b/companion/src/analysis/loginGraph.ts
@@ -1,13 +1,11 @@
 import type { ForensicEvent } from "./stateTypes.js";
 import { LOGON_TYPES, logonRisk } from "./siemImport.js";
+import { upgradeForensicEvent } from "./canonicalEvent.js";
 
 // Builds the Login Graph (Timesketch-style directed account → host logon graph) from the
-// super-timeline. PARSES the deterministic descriptions mapWindows() rendered at import time
-// ("{tool} Successful logon (EID 4624) - DOMAIN\\user - LogonType=N - IpAddress=… @ host") —
-// no new import-time field, so existing stored cases get the graph with no re-import.
-// Pure + deterministic, no AI, no I/O. Sibling of assetGraph.ts.
-
-const LOGON_MARKER = /(Successful|Failed) logon \(EID (?:4624|4625)\)/;
+// super-timeline. Identity/session facts come from the canonical envelope; the legacy upgrader is
+// the only place allowed to recover them from pre-schema display text. Description wording is
+// therefore no longer a graph contract. Pure + deterministic, no AI, no I/O.
 
 export interface ParsedLogon {
   account: string;                  // full form as rendered, e.g. "CORP\\jdoe", "NT AUTHORITY\\SYSTEM"
@@ -19,39 +17,31 @@ export interface ParsedLogon {
   workstation?: string;
 }
 
-// Parse one super-timeline row. Returns null when the row is not a 4624/4625 logon, carries no
-// account segment, or has no asset — malformed rows are skipped, never fatal.
+// Read one structured login event. Returns null for non-logon or incomplete rows.
 export function parseLoginEvent(e: ForensicEvent): ParsedLogon | null {
-  const m = LOGON_MARKER.exec(e.description);
-  if (!m) return null;
-  // Injection guard: on a genuine row the marker sits in the `${tool} ${label} (EID n)` prefix,
-  // BEFORE the first ` - ` separator (channelLabel values and event labels are ` - `-free, and every
-  // importer path routes through mapWindows). A marker AFTER it is log content echoed into a field
-  // value (e.g. a CommandLine containing "Successful logon (EID 4624) - EVIL\\fake @ x") — an
-  // attacker-controlled string that must not plant a fake account→host edge in the graph.
-  const sep = e.description.indexOf(" - ");
-  if (sep !== -1 && m.index > sep) return null;
-  const host = (e.asset ?? "").trim();
-  if (!host) return null;
-  // Accounts segment: everything after the marker up to the first `Key=value` field, the ` @ host`
-  // suffix, or the 4624 ` [TypeName …]` overlay. mapWindows renders accounts (when present) as the
-  // first ` - `-joined segment, comma-separated, TARGET account first (winAccounts pair order).
-  const rest = e.description.slice(m.index + m[0].length);
-  const seg = rest.replace(/^ - /, "").split(/ - (?=[A-Za-z]+=)| @ | \[/)[0]?.trim() ?? "";
-  const account = seg.split(", ")[0]?.trim();
-  if (!account || account.includes("=")) return null;   // no accounts rendered on this row
-  const lt = /\bLogonType=(\d+)\b/.exec(e.description);
-  const logonType = lt ? Number(lt[1]) : undefined;
-  const ip = /\bIpAddress=(\S+)/.exec(e.description)?.[1];
-  const ws = /\bWorkstationName=(\S+)/.exec(e.description)?.[1];
+  const canonical = upgradeForensicEvent(e).canonical;
+  if (canonical?.event.category !== "authentication" || canonical.event.type !== "logon") return null;
+  const account = (
+    canonical.actor?.kind === "account" ? canonical.actor.name : undefined
+  ) ?? canonical.account?.name;
+  const host = (
+    canonical.target?.kind === "host" ? canonical.target.name : undefined
+  ) ?? e.asset;
+  const cleanAccount = account?.trim() ?? "";
+  const cleanHost = host?.trim() ?? "";
+  if (!cleanAccount || !cleanHost) return null;
+  const logonType = canonical.authentication?.logonType;
+  const sourceIp = canonical.network?.source?.address;
+  const workstation = canonical.session?.terminal;
+  const outcome = canonical.event.outcome === "failed" ? "failed" : "success";
   return {
-    account,
-    host,
+    account: cleanAccount,
+    host: cleanHost,
     ...(logonType !== undefined ? { logonType } : {}),
     typeName: logonType !== undefined ? (LOGON_TYPES[logonType] ?? `type ${logonType}`) : "Unknown",
-    outcome: m[1] === "Successful" ? "success" : "failed",
-    ...(ip ? { sourceIp: ip } : {}),
-    ...(ws ? { workstation: ws } : {}),
+    outcome,
+    ...(sourceIp ? { sourceIp } : {}),
+    ...(workstation ? { workstation } : {}),
   };
 }
 

--- a/companion/src/analysis/memoryImport.ts
+++ b/companion/src/analysis/memoryImport.ts
@@ -32,6 +32,7 @@
 // import time. The same forensic timeline the screenshot pipeline feeds.
 
 import type { Severity } from "./stateTypes.js";
+import { createCanonicalEvent, stampSourceArtifactHash } from "./canonicalEvent.js";
 import {
   aggregateEvents,
   genericIocs,
@@ -220,6 +221,7 @@ function procName(row: Row): string {
 function mapProcess(label: string, tool: string, rows: Row[], sink: Map<string, SiemIoc>): MappedEvent[] {
   const out: MappedEvent[] = [];
   const psscan = /psscan|psxview/.test(label);
+  let recordIndex = 0;
 
   // Index PID → name (across the whole tree) so a flat table resolves PPID → parent name.
   const pidIndex = new Map<string, string>();
@@ -232,9 +234,11 @@ function mapProcess(label: string, tool: string, rows: Row[], sink: Map<string, 
     }
   };
   index(rows);
+  recordIndex = 0;
 
   const walk = (list: Row[], parent: string): void => {
     for (const r of list) {
+      const locatorIndex = recordIndex++;
       const name = procName(r);
       const pid = pickPid(r);
       const ppid = pick(r, ["PPID", "ppid"]);
@@ -250,15 +254,62 @@ function mapProcess(label: string, tool: string, rows: Row[], sink: Map<string, 
         let description = `${tool} ${label}: ${name || "?"} (PID ${pid || "?"}${ppid ? `, PPID ${ppid}` : ""}${exitNote})`;
         if (created) description += ` started ${created}`;
         if (cmd) description += ` — ${oneLine(cmd).slice(0, 160)}`;
+        const pidNumber = Number(pid);
+        const parentPidNumber = Number(ppid);
+        const canonical = createCanonicalEvent({
+          event: { category: "process", type: "observation" },
+          subject: {
+            kind: "process",
+            ...(pid ? { id: pid } : {}),
+            ...(name ? { name } : {}),
+          },
+          process: {
+            ...(Number.isInteger(pidNumber) && pidNumber > 0 ? { pid: pidNumber } : {}),
+            ...(name ? { name } : {}),
+            ...(path ? { executable: path } : {}),
+            ...(cmd ? { commandLine: cmd } : {}),
+            ...(parentName || (Number.isInteger(parentPidNumber) && parentPidNumber > 0) ? {
+              parent: {
+                ...(Number.isInteger(parentPidNumber) && parentPidNumber > 0 ? { pid: parentPidNumber } : {}),
+                ...(parentName ? { name: parentName } : {}),
+              },
+            } : {}),
+          },
+          ...(path ? { file: { path, name: baseName(path) } } : {}),
+          time: { observed: created, normalized: created },
+          evidence: {
+            rawRecords: [{
+              source: `${tool.toLowerCase()}-${label}`,
+              locator: `row:${locatorIndex}`,
+              ...(pid ? { recordId: pid } : {}),
+            }],
+          },
+          producer: {
+            importer: "memory",
+            parserVersion: "1",
+            mappingVersion: "memory-process-v1",
+          },
+          rawFieldMap: {
+            "time.observed": ["CreateTime", "process_create_time", "CreatedTime", "start_time"],
+            ...(pid ? { "subject.id": ["PID"], "process.pid": ["PID"] } : {}),
+            ...(name ? { "subject.name": PROC_NAME_KEYS, "process.name": PROC_NAME_KEYS } : {}),
+            ...(path ? { "process.executable": ["Path"], "file.path": ["Path"] } : {}),
+            ...(cmd ? { "process.commandLine": ["Cmd", "CommandLine", "Args"] } : {}),
+            ...(ppid ? { "process.parent.pid": ["PPID"] } : {}),
+          },
+        });
         out.push({
           timestamp: created,
           description: description.slice(0, 600),
           severity: "Info",
           mitre: [],
+          canonical,
           aggKey: `mem|proc|${(name || "?").toLowerCase()}|${pid}|${ppid}${psscan ? "|scan" : ""}`.slice(0, 400),
           sources: [tool],
           ...(name ? { processName: name } : {}),
           ...(parentName ? { parentName } : {}),
+          ...(Number.isInteger(pidNumber) && pidNumber > 0 ? { pid: pidNumber } : {}),
+          ...(cmd ? { commandLine: cmd } : {}),
           ...(path && /[\\/]/.test(path) ? { path } : {}),
         });
       }
@@ -1194,13 +1245,14 @@ export function parseMemory(text: string, opts: MemoryImportOptions = {}): Memor
     minSeverity: opts.minSeverity,
     maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
+  const finalEvents = stampSourceArtifactHash(events, text);
 
-  const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
+  const represented = finalEvents.reduce((n, e) => n + (e.count ?? 1), 0);
   return {
-    events,
+    events: finalEvents,
     iocs: [...sink.values()].slice(0, maxIocs),
     total,
-    kept: events.length,
+    kept: finalEvents.length,
     dropped: Math.max(0, total - represented),
     groups,
     tables: tables.length,

--- a/companion/src/analysis/networkImport.ts
+++ b/companion/src/analysis/networkImport.ts
@@ -15,6 +15,7 @@
 // Events are tagged "Suricata" / "Zeek" for cross-source correlation.
 
 import type { Severity } from "./stateTypes.js";
+import { createCanonicalEvent, stampSourceArtifactHash } from "./canonicalEvent.js";
 import {
   extractRecords,
   aggregateEvents,
@@ -158,7 +159,7 @@ function suricataIocs(row: Row, etype: string, sink: Map<string, SiemIoc>): void
   if (isObject(fi)) { addHash(sink, getCI(fi, "sha256")); addHash(sink, getCI(fi, "md5")); addFile(sink, getCI(fi, "filename")); }
 }
 
-function mapSuricataAlert(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
+function mapSuricataAlert(row: Row, host: string, sink: Map<string, SiemIoc>, recordIndex = 0): MappedEvent {
   const sig = str(getPath(row, "alert.signature")) || "alert";
   const category = str(getPath(row, "alert.category"));
   const sigId = str(getPath(row, "alert.signature_id"));
@@ -174,12 +175,63 @@ function mapSuricataAlert(row: Row, host: string, sink: Map<string, SiemIoc>): M
   if (src && dst) description += ` - ${src}${sp ? `:${sp}` : ""} → ${dst}${dp ? `:${dp}` : ""}${proto ? ` ${proto}` : ""}`;
   if (host) description += ` @ ${host}`;
   description = description.slice(0, 600);
+  const sourcePort = Number(sp);
+  const destinationPort = Number(dp);
+  const observedTimestamp = str(getCI(row, "timestamp"));
+  const normalizedTimestamp = netTime(getCI(row, "timestamp"));
+  const canonical = createCanonicalEvent({
+    event: { category: "network", type: "alert", action: sig },
+    ...(src ? { actor: { kind: "network", address: src } } : {}),
+    ...(dst ? { target: { kind: "network", address: dst, ...(Number.isInteger(destinationPort) && destinationPort > 0 ? { port: destinationPort } : {}) } } : {}),
+    network: {
+      ...(src ? {
+        source: {
+          address: src,
+          ...(Number.isInteger(sourcePort) && sourcePort > 0 ? { port: sourcePort } : {}),
+        },
+      } : {}),
+      ...(dst ? {
+        destination: {
+          address: dst,
+          ...(Number.isInteger(destinationPort) && destinationPort > 0 ? { port: destinationPort } : {}),
+        },
+      } : {}),
+      ...(proto ? { protocol: proto } : {}),
+    },
+    time: { observed: observedTimestamp, normalized: normalizedTimestamp },
+    evidence: {
+      rawRecords: [{
+        source: "suricata-eve",
+        locator: `record:${recordIndex}`,
+        ...(str(getCI(row, "flow_id")).trim() ? { recordId: str(getCI(row, "flow_id")).trim() } : {}),
+      }],
+    },
+    producer: {
+      importer: "network",
+      parserVersion: "1",
+      mappingVersion: "suricata-alert-v1",
+      ruleVersions: ["suricata-severity-v1"],
+    },
+    rawFieldMap: {
+      "event.action": ["alert.signature"],
+      "time.observed": ["timestamp"],
+      ...(src ? { "actor.address": ["src_ip"], "network.source.address": ["src_ip"] } : {}),
+      ...(dst ? { "target.address": ["dest_ip"], "network.destination.address": ["dest_ip"] } : {}),
+      ...(Number.isInteger(sourcePort) && sourcePort > 0 ? { "network.source.port": ["src_port"] } : {}),
+      ...(Number.isInteger(destinationPort) && destinationPort > 0 ? {
+        "target.port": ["dest_port"],
+        "network.destination.port": ["dest_port"],
+      } : {}),
+      ...(proto ? { "network.protocol": ["proto"] } : {}),
+    },
+  });
 
   return {
-    timestamp: netTime(getCI(row, "timestamp")),
+    timestamp: normalizedTimestamp,
     description,
     severity,
     mitre,
+    canonical,
     aggKey: `suricata|${sigId || sig.toLowerCase()}|${src}|${dst}|${dp}`.slice(0, 400),
     sources: ["Suricata"],
     ...(host ? { asset: host } : {}),
@@ -216,7 +268,7 @@ function zeekIocs(row: Row, path: string, sink: Map<string, SiemIoc>): void {
   }
 }
 
-function mapZeekNotice(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
+function mapZeekNotice(row: Row, host: string, sink: Map<string, SiemIoc>, recordIndex = 0): MappedEvent {
   const note = str(getCI(row, "note")) || "notice";
   const msg = str(getCI(row, "msg"));
   const sub = str(getCI(row, "sub"));
@@ -228,12 +280,39 @@ function mapZeekNotice(row: Row, host: string, sink: Map<string, SiemIoc>): Mapp
   if (src && dst) description += ` [${src} → ${dst}]`;
   if (host) description += ` @ ${host}`;
   description = description.slice(0, 600);
+  const observedTimestamp = str(getCI(row, "ts"));
+  const normalizedTimestamp = netTime(getCI(row, "ts"));
+  const canonical = createCanonicalEvent({
+    event: { category: "network", type: "notice", action: note },
+    ...(src ? { actor: { kind: "network", address: src } } : {}),
+    ...(dst ? { target: { kind: "network", address: dst } } : {}),
+    network: {
+      ...(src ? { source: { address: src } } : {}),
+      ...(dst ? { destination: { address: dst } } : {}),
+    },
+    time: { observed: observedTimestamp, normalized: normalizedTimestamp },
+    evidence: {
+      rawRecords: [{
+        source: "zeek-notice",
+        locator: `record:${recordIndex}`,
+        ...(str(getCI(row, "uid")).trim() ? { recordId: str(getCI(row, "uid")).trim() } : {}),
+      }],
+    },
+    producer: { importer: "network", parserVersion: "1", mappingVersion: "zeek-notice-v1" },
+    rawFieldMap: {
+      "event.action": ["note"],
+      "time.observed": ["ts"],
+      ...(src ? { "actor.address": ["src"], "network.source.address": ["src"] } : {}),
+      ...(dst ? { "target.address": ["dst"], "network.destination.address": ["dst"] } : {}),
+    },
+  });
 
   return {
-    timestamp: netTime(getCI(row, "ts")),
+    timestamp: normalizedTimestamp,
     description,
     severity: "Medium", // a Zeek notice is, by definition, worth surfacing
     mitre: mitreFromText(note, msg),
+    canonical,
     aggKey: `zeek|${note.toLowerCase()}|${src}|${dst}`.slice(0, 400),
     sources: ["Zeek"],
     ...(host ? { asset: host } : {}),
@@ -301,6 +380,43 @@ function mapFlow(f: FlowAgg, host: string): MappedEvent {
     ` — ${f.count} connection${f.count === 1 ? "" : "s"},` +
     ` ${humanBytes(f.origBytes)} sent, ${humanBytes(f.respBytes)} received`;
   if (host) description += ` @ ${host}`;
+  const destinationPort = Number(f.port);
+  const canonical = createCanonicalEvent({
+    event: { category: "network", type: "flow", action: "connect" },
+    ...(f.src ? { actor: { kind: "network", address: f.src } } : {}),
+    ...(f.dst ? {
+      target: {
+        kind: "network",
+        address: f.dst,
+        ...(Number.isInteger(destinationPort) && destinationPort > 0 ? { port: destinationPort } : {}),
+      },
+    } : {}),
+    network: {
+      ...(f.src ? { source: { address: f.src } } : {}),
+      ...(f.dst ? {
+        destination: {
+          address: f.dst,
+          ...(Number.isInteger(destinationPort) && destinationPort > 0 ? { port: destinationPort } : {}),
+        },
+      } : {}),
+      ...(f.proto ? { protocol: f.proto } : {}),
+    },
+    time: { observed: f.firstTs, normalized: f.firstTs },
+    evidence: {
+      rawRecords: [{ source: "zeek-conn", locator: `flow:${f.src}|${f.dst}|${f.port}|${f.proto}` }],
+    },
+    producer: { importer: "network", parserVersion: "1", mappingVersion: "zeek-flow-v1" },
+    rawFieldMap: {
+      "time.observed": ["ts"],
+      ...(f.src ? { "actor.address": ["id.orig_h"], "network.source.address": ["id.orig_h"] } : {}),
+      ...(f.dst ? { "target.address": ["id.resp_h"], "network.destination.address": ["id.resp_h"] } : {}),
+      ...(Number.isInteger(destinationPort) && destinationPort > 0 ? {
+        "target.port": ["id.resp_p"],
+        "network.destination.port": ["id.resp_p"],
+      } : {}),
+      ...(f.proto ? { "network.protocol": ["proto"] } : {}),
+    },
+  });
   return {
     timestamp: f.firstTs,
     description: description.slice(0, 600),
@@ -309,6 +425,7 @@ function mapFlow(f: FlowAgg, host: string): MappedEvent {
     // a flow on its own asserts nothing about technique.
     severity: "Info",
     mitre: [],
+    canonical,
     // Already unique per flow, so the shared aggregator passes these straight through rather than
     // re-folding them (and the description, not `count`, carries the connection tally).
     aggKey: `zeek|conn|${f.src}|${f.dst}|${f.port}|${f.proto}`.slice(0, 400),
@@ -348,7 +465,7 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
   // Per-stream Zeek JSON (no `_path`): the filename is the authoritative stream for the whole file.
   const fileStream = opts.filename ? zeekStreamFromName(opts.filename) : "";
 
-  for (const row of records) {
+  for (const [recordIndex, row] of records.entries()) {
     const host = pickHost(row);
     if (host) hostTally.set(host, (hostTally.get(host) ?? 0) + 1);
 
@@ -360,7 +477,7 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
       sawSuricata = true;
       suricataIocs(row, etype, rowSink);
       if (etype === "alert") {
-        const m = mapSuricataAlert(row, host, rowSink);
+        const m = mapSuricataAlert(row, host, rowSink, recordIndex);
         mergeRowIocs(iocSink, rowSink, m.aggKey);
         mapped.push(m);
         alerts++;
@@ -373,7 +490,7 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
       sawZeek = true;
       zeekIocs(row, zstream, rowSink);
       if (zstream === "notice") {
-        const m = mapZeekNotice(row, host, rowSink);
+        const m = mapZeekNotice(row, host, rowSink, recordIndex);
         mergeRowIocs(iocSink, rowSink, m.aggKey);
         mapped.push(m);
         alerts++;
@@ -403,16 +520,17 @@ export function parseNetworkLogs(text: string, opts: NetworkImportOptions = {}):
     minSeverity: opts.minSeverity,
     maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
+  const finalEvents = stampSourceArtifactHash(events, text);
 
-  const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
+  const represented = finalEvents.reduce((n, e) => n + (e.count ?? 1), 0);
   const hostname = [...hostTally.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
   const format = sawSuricata && sawZeek ? "mixed" : sawSuricata ? "suricata" : sawZeek ? "zeek" : "empty";
 
   return {
-    events,
+    events: finalEvents,
     iocs: [...iocSink.values()].slice(0, maxIocs),
     total,
-    kept: events.length,
+    kept: finalEvents.length,
     dropped: Math.max(0, total - represented),
     groups,
     alerts,

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { canonicalEventEnvelopeSchema } from "./canonicalEvent.js";
 
 // Enums use .catch(fallback) so ONE unexpected value (e.g. an IOC type of "malware")
 // maps to the fallback instead of rejecting the ENTIRE synthesis response.
@@ -59,6 +60,9 @@ export const deltaSchema = z.object({
     severity: severity.default("Info").catch("Info"),
     mitreTechniques: z.array(z.string()).default([]),
     relatedFindingIds: z.array(z.string()).default([]),
+    // Deterministic importers attach the canonical envelope. It remains optional so AI output and
+    // legacy cases keep parsing; persistence upgrades legacy events at the read boundary.
+    canonical: canonicalEventEnvelopeSchema.optional(),
     // Aggregation: when one event represents many collapsed occurrences (e.g. "20
     // failed logins"), count is the number of occurrences and endTimestamp the time
     // of the last one. Absent/1 means a single discrete event.

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -22,6 +22,12 @@
 // with a conservative bump for LOLBin / suspicious command lines and LSASS access.
 
 import type { Severity } from "./stateTypes.js";
+import {
+  createCanonicalEvent,
+  mergeCanonicalEvents,
+  stampSourceArtifactHash,
+  type CanonicalEventEnvelope,
+} from "./canonicalEvent.js";
 import { toUtcIso } from "./timeUtc.js";
 import { reconTechniques } from "./reconTechniques.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
@@ -46,6 +52,7 @@ export interface SiemEvent {
   description: string;
   severity: Severity;
   mitreTechniques: string[];
+  canonical?: CanonicalEventEnvelope;
   count?: number;
   endTimestamp?: string;
   sha256?: string;
@@ -561,6 +568,7 @@ export interface MappedEvent {
   severity: Severity;
   mitre: string[];
   aggKey: string;
+  canonical?: CanonicalEventEnvelope;
   sha256?: string;
   md5?: string;
   path?: string;
@@ -662,7 +670,17 @@ export function logonRisk(logonType: number, sourceIp: string): { typeName: stri
   }
 }
 
-export function mapWindows(rec: Row, host: string, iocSink: Map<string, SiemIoc>): MappedEvent | null {
+interface CanonicalRecordContext {
+  source: string;
+  recordIndex: number;
+}
+
+export function mapWindows(
+  rec: Row,
+  host: string,
+  iocSink: Map<string, SiemIoc>,
+  canonicalContext: CanonicalRecordContext = { source: "windows-event", recordIndex: 0 },
+): MappedEvent | null {
   const eidRaw = getCI(rec, "event_id") ?? getCI(rec, "EventID") ?? getPath(rec, "winlog.event_id") ?? getPath(rec, "event.code");
   const eid = Number(typeof eidRaw === "object" && isObject(eidRaw) ? getCI(eidRaw, "#text") : eidRaw);
   const channel = firstStr(rec, ["log_name", "channel", "Channel", "winlog.channel", "source_name"]);
@@ -774,6 +792,129 @@ export function mapWindows(rec: Row, host: string, iocSink: Map<string, SiemIoc>
   const pid = (!isSysmon && eid === 4688) ? parsePid(str(getCI(ed, "NewProcessId")))
     : (isSysmon && eid === 1) ? parsePid(str(getCI(ed, "ProcessId")))
     : undefined;
+  const commandLine = def.kind === "process" ? str(getCI(ed, "CommandLine")) : "";
+  const observedTimestamp = str(getCI(ed, "UtcTime")).trim() || firstStr(rec, TIME_KEYS);
+  const normalizedTimestamp = pickTimestamp(rec, ed);
+  const sourceIp = cleanIp(str(getCI(ed, "IpAddress")) || str(getCI(ed, "SourceIp")));
+  const destinationIp = cleanIp(str(getCI(ed, "DestinationIp")));
+  const destinationPort = Number(str(getCI(ed, "DestinationPort")));
+  const logonTypeRaw = str(getCI(ed, "LogonType")).trim();
+  const logonType = logonTypeRaw && Number.isFinite(Number(logonTypeRaw)) ? Number(logonTypeRaw) : undefined;
+  const isLogon = !isSysmon && (eid === 4624 || eid === 4625);
+  const accountName = accts[0];
+  const category = isLogon ? "authentication"
+    : def.kind === "process" || def.kind === "procaccess" ? "process"
+    : def.kind === "network" || def.kind === "dns" ? "network"
+    : def.kind === "file" ? "file"
+    : def.kind === "service" ? "service"
+    : str(getCI(ed, "TaskName")) ? "task"
+    : str(getCI(ed, "TargetObject")) ? "registry"
+    : "other";
+  const canonical = createCanonicalEvent({
+    event: {
+      category,
+      type: isLogon ? "logon"
+        : def.kind === "process" ? "start"
+        : def.kind === "procaccess" ? "access"
+        : def.kind === "network" ? "connection"
+        : def.kind === "dns" ? "query"
+        : def.kind ?? "event",
+      ...(isLogon ? { outcome: eid === 4624 ? "success" : "failed" } : {}),
+    },
+    ...(accountName ? { actor: { kind: "account" as const, name: accountName } } : {}),
+    ...(host ? { target: { kind: "host" as const, name: host } } : {}),
+    ...(accountName ? {
+      account: {
+        name: accountName,
+        ...(accountName.includes("\\") ? { domain: accountName.split("\\")[0] } : {}),
+      },
+    } : {}),
+    ...(isLogon ? {
+      authentication: {
+        ...(logonType !== undefined ? { logonType } : {}),
+        ...(str(getCI(ed, "TargetLogonId")).trim() ? { sessionId: str(getCI(ed, "TargetLogonId")).trim() } : {}),
+      },
+      ...(str(getCI(ed, "WorkstationName")).trim()
+        ? { session: { terminal: str(getCI(ed, "WorkstationName")).trim() } }
+        : {}),
+    } : {}),
+    ...(sourceIp || destinationIp || (Number.isInteger(destinationPort) && destinationPort > 0) ? {
+      network: {
+        ...(sourceIp ? { source: { address: sourceIp } } : {}),
+        ...(destinationIp || (Number.isInteger(destinationPort) && destinationPort > 0) ? {
+          destination: {
+            ...(destinationIp ? { address: destinationIp } : {}),
+            ...(Number.isInteger(destinationPort) && destinationPort > 0 ? { port: destinationPort } : {}),
+          },
+        } : {}),
+        ...(str(getCI(ed, "Protocol")).trim() ? { protocol: str(getCI(ed, "Protocol")).trim() } : {}),
+      },
+    } : {}),
+    ...(def.kind === "process" || def.kind === "procaccess" ? {
+      process: {
+        ...(pid !== undefined ? { pid } : {}),
+        ...(processName ? { name: processName } : {}),
+        ...(imagePath ? { executable: imagePath } : {}),
+        ...(commandLine ? { commandLine } : {}),
+        ...(parentName ? {
+          parent: {
+            name: parentName,
+            ...(str(getCI(ed, "ParentImage")).trim() ? { executable: str(getCI(ed, "ParentImage")).trim() } : {}),
+          },
+        } : {}),
+      },
+    } : {}),
+    ...(imagePath || sha256 || md5 ? {
+      file: {
+        ...(imagePath ? { path: imagePath, name: baseName(imagePath) } : {}),
+        ...(sha256 ? { sha256 } : {}),
+        ...(md5 ? { md5 } : {}),
+      },
+    } : {}),
+    ...(str(getCI(ed, "TargetObject")).trim() ? {
+      registry: {
+        key: str(getCI(ed, "TargetObject")).trim(),
+        ...(str(getCI(ed, "Details")).trim() ? { valueData: str(getCI(ed, "Details")).trim() } : {}),
+      },
+    } : {}),
+    ...(def.kind === "service" ? {
+      service: {
+        ...(str(getCI(ed, "ServiceName")).trim() ? { name: str(getCI(ed, "ServiceName")).trim() } : {}),
+        ...(str(getCI(ed, "ServiceFileName")).trim() ? { executable: str(getCI(ed, "ServiceFileName")).trim() } : {}),
+      },
+    } : {}),
+    ...(str(getCI(ed, "TaskName")).trim() ? {
+      task: {
+        name: str(getCI(ed, "TaskName")).trim(),
+        ...(commandLine ? { command: commandLine } : {}),
+      },
+    } : {}),
+    time: { observed: observedTimestamp, normalized: normalizedTimestamp },
+    evidence: {
+      rawRecords: [{
+        source: canonicalContext.source,
+        locator: `row:${canonicalContext.recordIndex}`,
+        ...(str(getCI(rec, "EventRecordID")).trim() ? { recordId: str(getCI(rec, "EventRecordID")).trim() } : {}),
+      }],
+    },
+    producer: {
+      importer: "windows-event",
+      parserVersion: "1",
+      mappingVersion: "windows-event-v1",
+      ruleVersions: ["windows-event-severity-v1"],
+    },
+    rawFieldMap: {
+      "time.observed": ["EventData.UtcTime", ...TIME_KEYS],
+      ...(accountName ? { "actor.name": ["EventData.TargetDomainName", "EventData.TargetUserName"] } : {}),
+      ...(host ? { "target.name": ["Computer", "host.name"] } : {}),
+      ...(logonType !== undefined ? { "authentication.logonType": ["EventData.LogonType"] } : {}),
+      ...(sourceIp ? { "network.source.address": ["EventData.IpAddress", "EventData.SourceIp"] } : {}),
+      ...(destinationIp ? { "network.destination.address": ["EventData.DestinationIp"] } : {}),
+      ...(processName ? { "process.name": ["EventData.Image", "EventData.NewProcessName", "EventData.SourceImage"] } : {}),
+      ...(pid !== undefined ? { "process.pid": ["EventData.ProcessId", "EventData.NewProcessId"] } : {}),
+      ...(commandLine ? { "process.commandLine": ["EventData.CommandLine"] } : {}),
+    },
+  });
 
   // IOCs from the structured fields.
   for (const ipKey of ["IpAddress", "DestinationIp", "SourceIp", "ClientAddress"]) {
@@ -796,10 +937,11 @@ export function mapWindows(rec: Row, host: string, iocSink: Map<string, SiemIoc>
   if (def.kind === "dns" && dns && dns !== "-" && /\./.test(dns)) addIoc(iocSink, "domain", dns.replace(/\.$/, ""));
 
   return {
-    timestamp: pickTimestamp(rec, ed),
+    timestamp: normalizedTimestamp,
     description,
     severity,
     mitre,
+    canonical,
     // pid (on process-creation events) is in the key so distinct creations stay distinct rows rather
     // than aggregating into one — preserving per-process granularity and enabling pid correlation.
     aggKey: `win|${channel}|${eid}|${accts.join(",")}|${subject}${pid !== undefined ? `|pid=${pid}` : ""}`.toLowerCase(),
@@ -811,7 +953,7 @@ export function mapWindows(rec: Row, host: string, iocSink: Map<string, SiemIoc>
     ...(def.kind === "process" && parentName ? { parentName } : {}),
     ...(pid !== undefined ? { pid } : {}),
     // Command line on process-creation events → chainSignature for cross-tool correlation (#68).
-    ...(def.kind === "process" && str(getCI(ed, "CommandLine")) ? { commandLine: str(getCI(ed, "CommandLine")) } : {}),
+    ...(commandLine ? { commandLine } : {}),
   };
 }
 
@@ -1089,6 +1231,7 @@ export function createEventAggregator(
         if (m.sources) for (const s of m.sources) { (existing.sources ??= []); if (!existing.sources.includes(s)) existing.sources.push(s); }
         if (!existing.artifactName && m.artifactName) existing.artifactName = m.artifactName; // first-wins provenance
         if (!existing.message && m.message) existing.message = m.message; // first-wins full detail
+        existing.canonical = mergeCanonicalEvents(existing.canonical, m.canonical);
       } else {
         byKey.set(key, {
           id: "",
@@ -1096,6 +1239,7 @@ export function createEventAggregator(
           description: m.description,
           severity: m.severity,
           mitreTechniques: [...m.mitre],
+          ...(m.canonical ? { canonical: m.canonical } : {}),
           count: 1,
           aggKey: m.aggKey,
           ...(m.sha256 ? { sha256: m.sha256 } : {}),
@@ -1152,7 +1296,12 @@ export function aggregateEvents(
 // generic field auto-detection fallback, aggregation + caps). Shared by parseSiemExport (which
 // unwraps JSON/NDJSON containers first) and the Windows-Event-XML importer (which parses the XML
 // envelope to the same record shape) so both produce an identical SiemParseResult. Pure.
-export function buildSiemResult(records: Row[], format: string, opts: SiemImportOptions = {}): SiemParseResult {
+export function buildSiemResult(
+  records: Row[],
+  format: string,
+  opts: SiemImportOptions = {},
+  sourceText?: string,
+): SiemParseResult {
   const maxIocs = opts.maxIocs ?? 5000;
   const total = records.length;
 
@@ -1160,11 +1309,11 @@ export function buildSiemResult(records: Row[], format: string, opts: SiemImport
   const hostTally = new Map<string, number>();
   const mapped: MappedEvent[] = [];
 
-  for (const rec of records) {
+  for (const [recordIndex, rec] of records.entries()) {
     const host = pickHost(rec);
     if (host) hostTally.set(host, (hostTally.get(host) ?? 0) + 1);
     const rowSink = new Map<string, SiemIoc>();
-    const m = mapWindows(rec, host, rowSink) ?? mapGeneric(rec, host, rowSink);
+    const m = mapWindows(rec, host, rowSink, { source: format, recordIndex }) ?? mapGeneric(rec, host, rowSink);
     mergeRowIocs(iocSink, rowSink, m.aggKey);
     mapped.push(m);
   }
@@ -1175,11 +1324,12 @@ export function buildSiemResult(records: Row[], format: string, opts: SiemImport
     maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
 
-  const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
+  const finalEvents = sourceText ? stampSourceArtifactHash(events, sourceText) : events;
+  const represented = finalEvents.reduce((n, e) => n + (e.count ?? 1), 0);
   const hostname = [...hostTally.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "";
 
   return {
-    events,
+    events: finalEvents,
     iocs: [...iocSink.values()].slice(0, maxIocs),
     total,
     kept: events.length,
@@ -1192,5 +1342,5 @@ export function buildSiemResult(records: Row[], format: string, opts: SiemImport
 
 export function parseSiemExport(text: string, opts: SiemImportOptions = {}): SiemParseResult {
   const { records, format } = extractRecords(text);
-  return buildSiemResult(records, format, opts);
+  return buildSiemResult(records, format, opts, text);
 }

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -10,6 +10,7 @@ import { toUtcIso } from "./timeUtc.js";
 import { matchIocToExclude } from "./iocExclude.js";
 import { repairIocValue } from "./iocValue.js";
 import { sanitizeUncertainties } from "./uncertainty.js";
+import { mergeCanonicalEvents } from "./canonicalEvent.js";
 
 // Trim a raw collect directive (investigation-guidance #8) to its non-empty string fields; returns
 // undefined when nothing useful is present, so an all-blank object isn't persisted.
@@ -201,6 +202,7 @@ export function mergeDelta(
     mitreTechniques: [...e.mitreTechniques],
     relatedFindingIds: [...e.relatedFindingIds],
     sourceScreenshots: [...e.sourceScreenshots],
+    ...(e.canonical ? { canonical: e.canonical } : {}),
   }));
   // Index by id for O(1) dedup lookup. A linear `forensicTimeline.find(...)` per incoming event is
   // O(n²) and melts down on large deterministic imports (e.g. a full MFT/USN with DFIR_MAX_EVENTS
@@ -239,6 +241,9 @@ export function mergeDelta(
       if (incoming.processName) existing.processName = incoming.processName;
       if (incoming.parentName) existing.parentName = incoming.parentName;
       if (incoming.pid !== undefined) existing.pid = incoming.pid;
+      if (incoming.commandLine) existing.commandLine = incoming.commandLine;
+      if (incoming.chainSignature) existing.chainSignature = incoming.chainSignature;
+      existing.canonical = mergeCanonicalEvents(existing.canonical, incoming.canonical);
       if (incoming.action) existing.action = incoming.action;
       if (incoming.srcIp) existing.srcIp = incoming.srcIp;
       if (incoming.dstIp) existing.dstIp = incoming.dstIp;
@@ -265,6 +270,9 @@ export function mergeDelta(
         ...(incoming.processName ? { processName: incoming.processName } : {}),
         ...(incoming.parentName ? { parentName: incoming.parentName } : {}),
         ...(incoming.pid !== undefined ? { pid: incoming.pid } : {}),
+        ...(incoming.commandLine ? { commandLine: incoming.commandLine } : {}),
+        ...(incoming.chainSignature ? { chainSignature: incoming.chainSignature } : {}),
+        ...(incoming.canonical ? { canonical: incoming.canonical } : {}),
         ...(incoming.action ? { action: incoming.action } : {}),
         ...(incoming.srcIp ? { srcIp: incoming.srcIp } : {}),
         ...(incoming.dstIp ? { dstIp: incoming.dstIp } : {}),

--- a/companion/src/analysis/stateStore.ts
+++ b/companion/src/analysis/stateStore.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
 import { caseSqliteWorker } from "./caseSqliteWorker.js";
 import { type ForensicEvent, type InvestigationState, emptyState } from "./stateTypes.js";
+import { upgradeForensicEvent } from "./canonicalEvent.js";
 
 export const INVESTIGATION_DB_FILENAME = "investigation.sqlite";
 const LEGACY_STATE_FILENAME = "investigation.json";
@@ -150,14 +151,20 @@ export class StateStore implements InvestigationStateStorage {
         caseId,
       });
     }
-    return { ...emptyState(caseId), ...(parsed ?? {}), caseId };
+    const state = { ...emptyState(caseId), ...(parsed ?? {}), caseId };
+    return state.forensicTimeline.length
+      ? { ...state, forensicTimeline: state.forensicTimeline.map(upgradeForensicEvent) }
+      : state;
   }
 
   async save(state: InvestigationState): Promise<void> {
+    const canonicalState = state.forensicTimeline.length
+      ? { ...state, forensicTimeline: state.forensicTimeline.map(upgradeForensicEvent) }
+      : state;
     await caseSqliteWorker.request<void>({
       op: "saveState",
-      dbPath: this.databasePath(state.caseId),
-      state,
+      dbPath: this.databasePath(canonicalState.caseId),
+      state: canonicalState,
     });
     void this.onRetry;
   }
@@ -187,7 +194,7 @@ export class StateStore implements InvestigationStateStorage {
         includeTotal: query.includeTotal,
       },
     });
-    return page;
+    return { ...page, entities: page.entities.map(upgradeForensicEvent) };
   }
 
   async appendForensicEvents(caseId: string, events: readonly ForensicEvent[]): Promise<number> {
@@ -199,7 +206,7 @@ export class StateStore implements InvestigationStateStorage {
       op: "appendEntities",
       dbPath: this.databasePath(caseId),
       kind: "forensicTimeline",
-      entities: [...events],
+      entities: events.map(upgradeForensicEvent),
     });
   }
 

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -1,4 +1,5 @@
 import type { IocExcludeRule } from "./iocExclude.js";
+import type { CanonicalEventEnvelope } from "./canonicalEvent.js";
 
 export type Severity = "Critical" | "High" | "Medium" | "Low" | "Info";
 export type FindingStatus = "open" | "confirmed" | "dismissed";
@@ -142,6 +143,10 @@ export interface ForensicEvent {
   mitreTechniques: string[];
   relatedFindingIds: string[];
   sourceScreenshots: string[];
+  // Versioned structured envelope (#374). Legacy display/correlation fields remain during the
+  // incremental migration, but identity-aware consumers read this envelope so prose wording is
+  // never their data contract. StateStore upgrades older events on read without removing fields.
+  canonical?: CanonicalEventEnvelope;
   count?: number;               // occurrences when this event aggregates many collapsed lines (e.g. 20); absent ⇒ 1
   endTimestamp?: string;        // time of the last occurrence when aggregated (timestamp is the first)
   // Clock-skew projection (#228), set ONLY on read-path copies while timeline alignment is on and

--- a/companion/src/analysis/superTimelineStore.ts
+++ b/companion/src/analysis/superTimelineStore.ts
@@ -13,6 +13,7 @@ import {
   type SuperQueryResult,
 } from "./superTimeline.js";
 import { eventMatchesExclude, eventMatchesSearch } from "./searchFilter.js";
+import { upgradeForensicEvent } from "./canonicalEvent.js";
 
 // The super-timeline remains logically separate from the forensic timeline: it has a distinct
 // entity kind, query API, labels, cap, and no path into synthesis. Sharing the case database is a
@@ -73,7 +74,7 @@ export class SuperTimelineStore {
     return caseSqliteWorker.request<number>({
       op: "appendSuper",
       dbPath: this.databasePath(caseId),
-      events,
+      events: events.map(upgradeForensicEvent),
       max: this.max,
     });
   }
@@ -131,11 +132,12 @@ export class SuperTimelineStore {
 
   async get(caseId: string, id: string): Promise<ForensicEvent | null> {
     await this.ensureMigrated(caseId);
-    return caseSqliteWorker.request({
+    const event = await caseSqliteWorker.request<ForensicEvent | null>({
       op: "getSuper",
       dbPath: this.databasePath(caseId),
       id,
     });
+    return event ? upgradeForensicEvent(event) : null;
   }
 
   // Compatibility method for the tagger and targeted AI lookup. New large-case consumers should
@@ -187,7 +189,7 @@ export class SuperTimelineStore {
           limit: Math.max(1, Math.min(MAX_QUERY_PAGE, Math.floor(batchSize))),
         },
       });
-      for (const row of result.rows) yield row;
+      for (const row of result.rows) yield { ...row, event: upgradeForensicEvent(row.event) };
       cursor = result.nextCursor;
     } while (cursor);
   }

--- a/companion/tests/analysis/canonicalEvent.test.ts
+++ b/companion/tests/analysis/canonicalEvent.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANONICAL_EVENT_SCHEMA_VERSION,
+  canonicalConformanceIssues,
+  createCanonicalEvent,
+  mergeCanonicalEvents,
+  upgradeForensicEvent,
+} from "../../src/analysis/canonicalEvent.js";
+import { parseAuditdLog } from "../../src/analysis/auditdImport.js";
+import { parseCloudTrail } from "../../src/analysis/awsImport.js";
+import { parseEcarJson } from "../../src/analysis/ecarImport.js";
+import { parseEmail } from "../../src/analysis/emailImport.js";
+import { parseMemory } from "../../src/analysis/memoryImport.js";
+import { parseNetworkLogs } from "../../src/analysis/networkImport.js";
+import { parseSiemExport } from "../../src/analysis/siemImport.js";
+import type { CanonicalEventEnvelope } from "../../src/analysis/canonicalEvent.js";
+import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+function expectConformant(event: { canonical?: CanonicalEventEnvelope }): CanonicalEventEnvelope {
+  expect(event.canonical).toBeDefined();
+  expect(event.canonical?.schemaVersion).toBe(CANONICAL_EVENT_SCHEMA_VERSION);
+  expect(event.canonical?.evidence.sourceArtifactHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+  expect(canonicalConformanceIssues(event.canonical)).toEqual([]);
+  return event.canonical!;
+}
+
+describe("canonical forensic-event envelope", () => {
+  it("requires provenance for every normalized leaf field", () => {
+    const canonical = createCanonicalEvent({
+      event: { category: "authentication", type: "logon", outcome: "success" },
+      actor: { kind: "account", name: "CORP\\analyst" },
+      target: { kind: "host", name: "SRV-01" },
+      authentication: { logonType: 10, protocol: "RDP" },
+      time: {
+        observed: "2026-07-30 12:34:56 +03:00",
+        normalized: "2026-07-30T09:34:56.000Z",
+      },
+      evidence: { rawRecords: [{ source: "test", locator: "row:0" }] },
+      producer: { importer: "test", parserVersion: "1", mappingVersion: "1" },
+      rawFieldMap: {
+        "actor.name": ["TargetUserName", "TargetDomainName"],
+        "target.name": ["Computer"],
+        "authentication.logonType": ["LogonType"],
+      },
+    });
+
+    expect(canonicalConformanceIssues(canonical)).toEqual([]);
+    const broken = {
+      ...canonical,
+      fieldProvenance: Object.fromEntries(
+        Object.entries(canonical.fieldProvenance).filter(([path]) => path !== "actor.name"),
+      ),
+    };
+    expect(canonicalConformanceIssues(broken)).toContain("missing field provenance: actor.name");
+
+    const unknownRecord = {
+      ...canonical,
+      fieldProvenance: {
+        ...canonical.fieldProvenance,
+        "actor.name": {
+          ...canonical.fieldProvenance["actor.name"],
+          recordLocators: ["row:missing"],
+        },
+      },
+    };
+    expect(canonicalConformanceIssues(unknownRecord))
+      .toContain("field provenance references an unknown record: actor.name -> row:missing");
+  });
+
+  it("upgrades a legacy event without changing its display contract or discarding legacy fields", () => {
+    const legacy: ForensicEvent = {
+      id: "legacy-1",
+      timestamp: "2026-07-30T10:00:00Z",
+      description: "Windows Security Successful logon (EID 4624) - CORP\\jdoe - LogonType=3 - IpAddress=10.0.0.5 @ SRV-01",
+      severity: "Low",
+      mitreTechniques: [],
+      relatedFindingIds: [],
+      sourceScreenshots: ["evidence.png"],
+      asset: "SRV-01",
+      sources: ["Windows Event Log"],
+    };
+
+    const upgraded = upgradeForensicEvent(legacy);
+    expect(upgraded).toMatchObject(legacy);
+    expect(upgraded.description).toBe(legacy.description);
+    expect(upgraded.canonical).toMatchObject({
+      schemaVersion: CANONICAL_EVENT_SCHEMA_VERSION,
+      event: { category: "authentication", type: "logon", outcome: "success" },
+      actor: { kind: "account", name: "CORP\\jdoe" },
+      target: { kind: "host", name: "SRV-01" },
+      authentication: { logonType: 3 },
+    });
+    expect(canonicalConformanceIssues(upgraded.canonical)).toEqual([]);
+    expect(upgradeForensicEvent(upgraded)).toBe(upgraded);
+  });
+
+  it("preserves an unknown future schema version verbatim for an explicit future migration", () => {
+    const future = {
+      id: "future-1",
+      timestamp: "2026-07-30T10:00:00Z",
+      description: "future event",
+      severity: "Info" as const,
+      mitreTechniques: [],
+      relatedFindingIds: [],
+      sourceScreenshots: [],
+      canonical: { schemaVersion: "2.0.0", opaqueFutureField: { keep: true } },
+    } as unknown as ForensicEvent;
+
+    expect(upgradeForensicEvent(future)).toBe(future);
+    expect((upgradeForensicEvent(future).canonical as unknown as Record<string, unknown>).opaqueFutureField)
+      .toEqual({ keep: true });
+
+    const current = createCanonicalEvent({
+      event: { category: "other", type: "event" },
+      time: { observed: "2026-07-30T10:00:00Z", normalized: "2026-07-30T10:00:00Z" },
+      evidence: { rawRecords: [{ source: "test", locator: "row:0" }] },
+      producer: { importer: "test", parserVersion: "1", mappingVersion: "1" },
+    });
+    const futureCanonical = future.canonical as unknown as CanonicalEventEnvelope;
+    expect(mergeCanonicalEvents(current, futureCanonical)).toBe(futureCanonical);
+    expect(mergeCanonicalEvents(futureCanonical, current)).toBe(futureCanonical);
+  });
+});
+
+describe("representative importer conformance", () => {
+  it("maps Windows authentication identity and session context", () => {
+    const [event] = parseSiemExport(JSON.stringify([{
+      EventID: 4624,
+      Channel: "Security",
+      Computer: "SRV-01",
+      "@timestamp": "2026-07-30T10:00:00Z",
+      EventData: {
+        TargetUserName: "jdoe",
+        TargetDomainName: "CORP",
+        LogonType: "10",
+        IpAddress: "203.0.113.10",
+        WorkstationName: "WKSTN-01",
+        TargetLogonId: "0x123",
+      },
+    }])).events;
+
+    expect(expectConformant(event)).toMatchObject({
+      event: { category: "authentication", type: "logon", outcome: "success" },
+      actor: { kind: "account", name: "CORP\\jdoe" },
+      target: { kind: "host", name: "SRV-01" },
+      authentication: { logonType: 10, sessionId: "0x123" },
+      network: { source: { address: "203.0.113.10" } },
+    });
+  });
+
+  it("maps Linux audit identity and process context", () => {
+    const text = [
+      'type=SYSCALL msg=audit(1785405600.123:77): node=linux-1 auid=1000 uid=1000 exe="/usr/bin/bash" comm="bash" success=yes',
+      'type=EXECVE msg=audit(1785405600.123:77): argc=2 a0="/usr/bin/bash" a1="-l"',
+    ].join("\n");
+    const [event] = parseAuditdLog(text).events;
+
+    expect(expectConformant(event)).toMatchObject({
+      actor: { kind: "account", id: "1000" },
+      target: { kind: "host", name: "linux-1" },
+      process: { name: "bash", executable: "/usr/bin/bash", commandLine: "/usr/bin/bash -l" },
+      producer: { importer: "auditd" },
+    });
+  });
+
+  it("maps a cloud principal and API target", () => {
+    const [event] = parseCloudTrail(JSON.stringify([{
+      eventTime: "2026-07-30T10:00:00Z",
+      eventName: "CreateAccessKey",
+      eventSource: "iam.amazonaws.com",
+      awsRegion: "us-east-1",
+      sourceIPAddress: "203.0.113.11",
+      userIdentity: {
+        type: "IAMUser",
+        userName: "incident-user",
+        arn: "arn:aws:iam::123456789012:user/incident-user",
+      },
+      requestParameters: { userName: "target-user" },
+    }])).events;
+
+    expect(expectConformant(event)).toMatchObject({
+      event: { category: "cloud", type: "api", action: "CreateAccessKey" },
+      actor: { kind: "cloud_principal", name: "incident-user" },
+      cloud: { provider: "aws", region: "us-east-1" },
+      producer: { importer: "aws-cloudtrail" },
+    });
+  });
+
+  it("maps source and destination network entities", () => {
+    const [event] = parseNetworkLogs(JSON.stringify([{
+      timestamp: "2026-07-30T10:00:00.000Z",
+      event_type: "alert",
+      src_ip: "10.0.0.5",
+      src_port: 51515,
+      dest_ip: "203.0.113.12",
+      dest_port: 443,
+      proto: "TCP",
+      alert: { signature: "Test alert", signature_id: 42, severity: 1 },
+    }])).events;
+
+    expect(expectConformant(event)).toMatchObject({
+      event: { category: "network", type: "alert" },
+      network: {
+        source: { address: "10.0.0.5", port: 51515 },
+        destination: { address: "203.0.113.12", port: 443 },
+        protocol: "TCP",
+      },
+      producer: { importer: "network" },
+    });
+  });
+
+  it("maps mailbox principals and message identity", () => {
+    const [event] = parseEmail([
+      "From: Sender <sender@example.invalid>",
+      "To: Recipient <recipient@example.test>",
+      "Date: Thu, 30 Jul 2026 10:00:00 +0000",
+      "Message-ID: <message-1@example.invalid>",
+      "Subject: Quarterly review",
+      "",
+      "Please review the attachment.",
+    ].join("\r\n")).events;
+
+    expect(expectConformant(event)).toMatchObject({
+      event: { category: "email", type: "message" },
+      actor: { kind: "mailbox", name: "sender@example.invalid" },
+      target: { kind: "mailbox", name: "recipient@example.test" },
+      mailbox: {
+        messageId: "message-1@example.invalid",
+        sender: "sender@example.invalid",
+        recipients: ["recipient@example.test"],
+      },
+      producer: { importer: "email" },
+    });
+  });
+
+  it("maps memory process identity", () => {
+    const [event] = parseMemory(JSON.stringify([{
+      PID: 4242,
+      PPID: 4,
+      ImageFileName: "powershell.exe",
+      CreateTime: "2026-07-30T10:00:00Z",
+      CommandLine: "powershell.exe -NoProfile",
+    }]), { filename: "windows.pslist.json" }).events;
+
+    expect(expectConformant(event)).toMatchObject({
+      event: { category: "process", type: "observation" },
+      process: { pid: 4242, name: "powershell.exe" },
+      producer: { importer: "memory" },
+    });
+  });
+
+  it("maps EDR process identity", () => {
+    const [event] = parseEcarJson(JSON.stringify([{
+      timestamp_ms: 1785405600000,
+      hostname: "EDR-01",
+      object: "PROCESS",
+      action: "CREATE",
+      pid: 4242,
+      properties: {
+        image_path: "C:\\Windows\\System32\\cmd.exe",
+        parent_image_path: "C:\\Windows\\explorer.exe",
+        command_line: "cmd.exe /c whoami",
+      },
+    }])).events;
+
+    expect(expectConformant(event)).toMatchObject({
+      event: { category: "process", type: "start", action: "create" },
+      target: { kind: "host", name: "EDR-01" },
+      process: { pid: 4242, name: "cmd.exe", parent: { name: "explorer.exe" } },
+      producer: { importer: "ecar" },
+    });
+  });
+});

--- a/companion/tests/analysis/evidenceGraph.test.ts
+++ b/companion/tests/analysis/evidenceGraph.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildEvidenceGraph, buildLateralPaths } from "../../src/analysis/evidenceGraph.js";
 import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+import { createCanonicalEvent } from "../../src/analysis/canonicalEvent.js";
 
 const HASH = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 const HASH2 = "1111111122222222333333334444444455555555666666667777777788888888";
@@ -19,6 +20,31 @@ function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
 }
 
 describe("buildEvidenceGraph — spawned (process tree)", () => {
+  it("builds the process edge from canonical identities without legacy process fields or prose", () => {
+    const s = emptyState("c1");
+    s.forensicTimeline.push(ev({
+      id: "canonical-process",
+      description: "wording has no structured identity",
+      canonical: createCanonicalEvent({
+        event: { category: "process", type: "start" },
+        target: { kind: "host", name: "HOST-CANONICAL" },
+        process: { name: "child.exe", parent: { name: "parent.exe" } },
+        time: { observed: "2026-05-20T09:00:00Z", normalized: "2026-05-20T09:00:00Z" },
+        evidence: { rawRecords: [{ source: "test", locator: "row:0" }] },
+        producer: { importer: "test", parserVersion: "1", mappingVersion: "1" },
+      }),
+    }));
+
+    const graph = buildEvidenceGraph(s);
+    expect(graph.edges).toHaveLength(2);
+    expect(graph.edges).toContainEqual(expect.objectContaining({
+      type: "spawned",
+      source: "proc:host-canonical:parent.exe",
+      target: "proc:host-canonical:child.exe",
+    }));
+    expect(graph.edges).toContainEqual(expect.objectContaining({ type: "ran_on" }));
+  });
+
   it("chains parent→child→grandchild into one tree via shared process nodes", () => {
     const s = emptyState("c1");
     s.forensicTimeline.push(
@@ -69,6 +95,28 @@ describe("buildEvidenceGraph — spawned (process tree)", () => {
 });
 
 describe("buildEvidenceGraph — lateral_move", () => {
+  it("correlates canonical accounts even when descriptions contain no account", () => {
+    const s = emptyState("c1");
+    for (const [id, host] of [["e1", "HOST-A"], ["e2", "HOST-B"]] as const) {
+      s.forensicTimeline.push(ev({
+        id,
+        description: "authentication display text changed",
+        canonical: createCanonicalEvent({
+          event: { category: "authentication", type: "logon", outcome: "success" },
+          actor: { kind: "account", name: "CORP\\structured-user" },
+          target: { kind: "host", name: host },
+          time: { observed: "2026-05-20T09:00:00Z", normalized: "2026-05-20T09:00:00Z" },
+          evidence: { rawRecords: [{ source: "test", locator: `row:${id}` }] },
+          producer: { importer: "test", parserVersion: "1", mappingVersion: "1" },
+        }),
+      }));
+    }
+
+    const edges = buildEvidenceGraph(s).edges.filter((edge) => edge.rule === "shared-account");
+    expect(edges).toHaveLength(2);
+    expect(edges.every((edge) => edge.source === "account:corp\\structured-user")).toBe(true);
+  });
+
   it("links hosts sharing the same binary hash (high confidence)", () => {
     const s = emptyState("c1");
     s.forensicTimeline.push(

--- a/companion/tests/analysis/loginGraph.test.ts
+++ b/companion/tests/analysis/loginGraph.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
+import { createCanonicalEvent } from "../../src/analysis/canonicalEvent.js";
 import {
   parseLoginEvent, displayAccountName, isNoiseAccount,
   buildLoginGraph, loginEdgeEvents, DEFAULT_MAX_EDGES,
@@ -28,6 +29,34 @@ const LOGON = (acct: string, host: string, type: number, o: { failed?: boolean; 
   });
 
 describe("parseLoginEvent", () => {
+  it("reads identity from the canonical envelope when display wording changes", () => {
+    const event = ev({
+      description: "Authentication event wording deliberately changed",
+      asset: "legacy-wrong-host",
+      canonical: createCanonicalEvent({
+        event: { category: "authentication", type: "logon", outcome: "success" },
+        actor: { kind: "account", name: "CORP\\canonical-user" },
+        target: { kind: "host", name: "SRV-CANONICAL" },
+        authentication: { logonType: 10, sessionId: "0xabc" },
+        session: { terminal: "WKSTN-01" },
+        network: { source: { address: "203.0.113.20" } },
+        time: { observed: "2026-06-10T12:00:00Z", normalized: "2026-06-10T12:00:00Z" },
+        evidence: { rawRecords: [{ source: "test", locator: "row:0" }] },
+        producer: { importer: "test", parserVersion: "1", mappingVersion: "1" },
+      }),
+    });
+
+    expect(parseLoginEvent(event)).toEqual({
+      account: "CORP\\canonical-user",
+      host: "SRV-CANONICAL",
+      logonType: 10,
+      typeName: "RemoteInteractive/RDP",
+      outcome: "success",
+      sourceIp: "203.0.113.20",
+      workstation: "WKSTN-01",
+    });
+  });
+
   it("parses a successful domain-account logon with type, source ip and workstation", () => {
     const p = parseLoginEvent(ev({
       description: "Windows Security Successful logon (EID 4624) - CORP\\jdoe - LogonType=10 - IpAddress=203.0.113.7 - WorkstationName=WKSTN-02 @ SRV-01 [RemoteInteractive/RDP from 203.0.113.7]",

--- a/companion/tests/analysis/stateStore.test.ts
+++ b/companion/tests/analysis/stateStore.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
+import { upgradeForensicEvent } from "../../src/analysis/canonicalEvent.js";
 
 let caseStore: CaseStore;
 let stateStore: StateStore;
@@ -48,14 +49,14 @@ describe("StateStore", () => {
       aliasValues: ["www.example.invalid"], extractedFrom: ["e1"], note: "sinkholed",
       enrichments: [{ source: "test", verdict: "suspicious", fetchedAt: "2026-07-30T11:00:00Z", tags: ["c2"] }],
     }];
-    state.forensicTimeline = [{
+    state.forensicTimeline = [upgradeForensicEvent({
       id: "e1", timestamp: "2026-07-30T10:00:00Z", endTimestamp: "2026-07-30T10:01:00Z",
       description: "PowerShell connected", message: "full event message", severity: "High",
       mitreTechniques: ["T1059.001"], relatedFindingIds: ["f1"], sourceScreenshots: ["one.png"],
       asset: "HOST-1", sources: ["EDR"], artifactName: "Windows.Events", processName: "powershell.exe",
       parentName: "winword.exe", pid: 42, commandLine: "powershell -enc AAAA", dstIp: "192.0.2.1",
       port: 443, provenance: ["second-look"],
-    }];
+    })];
     state.openThreads = [{ id: "t1", description: "scope", status: "closed", openedAt: "a", closedAt: "b" }];
     state.timeline = [{ timestamp: "2026-07-30T10:00:00Z", windowSequence: 1, description: "reviewed", sourceScreenshots: ["one.png"] }];
     state.mitreTechniques = [{ id: "T1059.001", name: "PowerShell", findingIds: ["f1"] }];
@@ -93,6 +94,31 @@ describe("StateStore", () => {
     await stateStore.save(next);
 
     expect(await new StateStore(caseStore).load("c1")).toEqual(next);
+  });
+
+  it("upgrades legacy timeline rows on load while preserving their display and legacy fields", async () => {
+    const state = emptyState("c1");
+    state.forensicTimeline = [{
+      id: "legacy-auth",
+      timestamp: "2026-07-30T10:00:00Z",
+      description: "Windows Security Successful logon (EID 4624) - CORP\\jdoe - LogonType=3 @ SRV-01",
+      severity: "Low",
+      mitreTechniques: [],
+      relatedFindingIds: [],
+      sourceScreenshots: ["auth.png"],
+      asset: "SRV-01",
+    }];
+    await stateStore.save(state);
+
+    const [loaded] = (await stateStore.load("c1")).forensicTimeline;
+    expect(loaded.description).toBe(state.forensicTimeline[0].description);
+    expect(loaded.sourceScreenshots).toEqual(["auth.png"]);
+    expect(loaded.asset).toBe("SRV-01");
+    expect(loaded.canonical).toMatchObject({
+      event: { category: "authentication", type: "logon", outcome: "success" },
+      actor: { name: "CORP\\jdoe" },
+      target: { name: "SRV-01" },
+    });
   });
 
   it("queries indexed event fields with a stable cursor", async () => {

--- a/mkdocs-docs/reference/canonical-events.md
+++ b/mkdocs-docs/reference/canonical-events.md
@@ -1,0 +1,66 @@
+# Canonical Event Data
+
+Every imported timeline event keeps the familiar timestamp, severity, description, host, source,
+and indicator fields shown in the dashboard and reports. Behind those display fields, the Companion
+now also stores a versioned canonical event envelope. This gives equivalent evidence from different
+tools the same internal shape, so correlation does not depend on one importer's sentence wording.
+
+## What is normalized
+
+When the source record contains the information, the envelope represents:
+
+- the actor, subject, object, and target of the activity;
+- accounts, authentication results, logon types, and session identifiers;
+- source and destination network endpoints;
+- processes, parents, executable paths, command lines, and process identifiers;
+- files and hashes, registry objects, services, and scheduled tasks;
+- mailboxes, message identifiers, senders, and recipients;
+- cloud principals, providers, regions, accounts, and resources; and
+- the observed timestamp alongside its normalized UTC value, timezone, precision, and clock
+  confidence.
+
+Windows Event Log, Linux auditd, AWS CloudTrail, Suricata/Zeek, email, Volatility/Rekall, and ECAR
+are the first representative mappings. Other importers can adopt the same envelope incrementally
+without changing what analysts see.
+
+## Traceability
+
+Each envelope points back to its raw record by a stable locator and records the SHA-256 of the
+source artifact when the importer has the original file. It also names the importer, parser,
+mapping, and deterministic rule versions used.
+
+Every normalized leaf field carries its own provenance:
+
+- **raw** means the value came directly from named source fields;
+- **derived** names the deterministic mapping or migration rule that produced it; and
+- **confidence** is high, medium, or low for that individual mapping.
+
+Importer conformance tests reject an envelope that contains an untraceable normalized field. This
+provenance is internal evidence lineage; it does not replace the case's Chain of Custody record.
+
+## Schema and migration policy
+
+The first schema version is `1.0.0`.
+
+- A **patch** version may clarify validation or a deterministic mapping without changing the
+  meaning of existing fields.
+- A **minor** version may add optional fields. Existing readers must continue to accept events that
+  do not have them.
+- A **major** version is required to remove a field or change its meaning. It must ship with an
+  explicit, tested migration.
+- An event with no envelope is a legacy event. It is upgraded on read using its existing structured
+  fields; guarded description parsing is confined to this one-time legacy migration. The original
+  event remains intact and the new envelope is persisted on the next normal case save.
+- An unknown future schema version must be preserved, not silently rewritten or downgraded.
+
+Migration is therefore incremental: opening an older case does not require a bulk rewrite or a
+re-import, and no legacy field or report wording is removed.
+
+## Graphs and display wording
+
+The Login Graph and Evidence Chain now read account, authentication, process, file, and network
+identity from the canonical envelope. Changing a displayed sentence cannot silently change a graph
+edge or join.
+
+Descriptions remain backward-compatible during migration. Existing report wording is unchanged;
+new structured mappings can evolve without making prose the source of truth again.

--- a/mkdocs-docs/reference/importing.md
+++ b/mkdocs-docs/reference/importing.md
@@ -41,6 +41,10 @@ Before importing, you can set a **minimum severity** filter. Events below the fl
 
 All of the above except CSV/log/DFIR-IRIS are **fully deterministic — no AI call** — they map the tool's own verdict/fields, not re-detect threats.
 
+Deterministic imports also retain a [versioned canonical event envelope](canonical-events.md) with
+structured identities and field-level provenance. This lets graphs and cross-source correlation use
+the source facts rather than parsing the displayed description back into data.
+
 ## Evidence Drop Folder (Auto-Import Inbox)
 
 Every case gets a `cases/<id>/drop/` folder on creation. Copy any file into it — at any depth, subfolders included — and a background poller picks it up once the file size/mtime is stable (safe for Dropbox/OneDrive sync), then imports it through the same detection + import chain as the **Import** button. Screenshots are ingested as capture evidence; everything else is imported as an artifact.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Case Management: reference/cases.md
     - Evidence Capture: reference/evidence-capture.md
     - Importing Evidence: reference/importing.md
+    - Canonical Event Data: reference/canonical-events.md
     - AI Analysis: reference/ai-analysis.md
     - Presidio & PII Masking: reference/presidio.md
     - Dashboard Panels: reference/dashboard.md


### PR DESCRIPTION
## Summary

- add a versioned canonical forensic event envelope with field-level raw/derived provenance and source artifact hashes
- map representative Windows, Linux, cloud, network, email, memory, and EDR imports while preserving legacy display fields
- migrate old cases incrementally and move login/evidence graph identity joins off description parsing
- document schema versioning and migration policy with importer conformance fixtures

## Validation

- npm run build
- npm run typecheck
- npm test -- --silent (487 files, 6,230 tests)
- focused canonical/state/graph suite (5 files, 123 tests)

Closes #374