### PR TITLE
Tell Linux and macOS users how to stop the other companion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **One-click Jira / ServiceNow push from the finding panel** (#297) — the routes shipped in #272 finally have a UI: every finding row carries a **Jira** and a **SNow** chip, and the finding bulk bar gains **Push to Jira** / **Push to ServiceNow** for the whole selection via the new `POST /cases/:id/push/{jira,servicenow}/bulk` endpoints. A batch reports created / updated / skipped, and a finding the ticket system refuses is named rather than aborting the rest. Both sets of buttons stay hidden until the integration is configured; re-pushing still updates the ticket the Companion opened instead of duplicating it. The ten `DFIR_JIRA_*` / `DFIR_SERVICENOW_*` environment variables are now documented in `.env.example`, the README route table and the manual.
 
 ### Fixed
+- **The "port already in use" message now tells Linux and macOS users how to stop the other companion** — it only ever printed the PowerShell one-liner; it now also prints `kill $(lsof -ti tcp:4773)` (and the `fuser -k 4773/tcp` fallback). Same addition in the manual, the getting-started page and `companion/README.md`.
 - **A Jira ticket link no longer opens raw JSON** (#297) — the issue URL the Companion records pointed at the REST resource (`/rest/api/3/issue/10001`) taken from the create response's `self` field; it is now the browse page (`/browse/IR-42`) an analyst can actually read. A link recorded by an earlier build is corrected the next time that finding is pushed.
 
 ### Added

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -105,7 +105,14 @@ Dashboard is then at **http://127.0.0.1:4773/dashboard**. Mount a local volume f
 
 > **Already running?** If the dashboard says "companion offline", the server is not running. If you see `EADDRINUSE`, another instance is already running — just use that one, or free the port:
 > ```powershell
+> # Windows
 > Get-NetTCPConnection -LocalPort 4773 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+> ```
+> ```bash
+> # Linux / macOS
+> kill $(lsof -ti tcp:4773)
+> # Linux only, if lsof isn't installed
+> fuser -k 4773/tcp
 > ```
 
 ### 3.2 First-Run Setup Wizard

--- a/companion/README.md
+++ b/companion/README.md
@@ -24,7 +24,8 @@ http://127.0.0.1:4773/dashboard. On startup it logs the resolved cases root, e.g
 > `npm run dev`; server code loads once at startup, so changes need a restart.
 
 > If you see `EADDRINUSE`, a companion is already running. Reuse it, or free the port:
-> `Get-NetTCPConnection -LocalPort 4773 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }`
+> Windows — `Get-NetTCPConnection -LocalPort 4773 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }`;
+> Linux/macOS — `kill $(lsof -ti tcp:4773)` (or, Linux: `fuser -k 4773/tcp`).
 
 ## Configuration (`companion/.env`, gitignored)
 

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -4214,8 +4214,9 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
       console.error(
         `\n[DFIR] Port ${port} is already in use — a DFIR companion is probably already running.\n` +
           `       Use the existing one (http://127.0.0.1:${port}/dashboard), or stop it first:\n` +
-          `       PowerShell:  Get-NetTCPConnection -LocalPort ${port} -State Listen | ` +
-          `ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\n`,
+          `       PowerShell:   Get-NetTCPConnection -LocalPort ${port} -State Listen | ` +
+          `ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\n` +
+          `       Linux/macOS:  kill $(lsof -ti tcp:${port})    (or, Linux: fuser -k ${port}/tcp)\n`,
       );
       process.exit(1);
     }

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -4214,8 +4214,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
       console.error(
         `\n[DFIR] Port ${port} is already in use — a DFIR companion is probably already running.\n` +
           `       Use the existing one (http://127.0.0.1:${port}/dashboard), or stop it first:\n` +
-          `       PowerShell:   Get-NetTCPConnection -LocalPort ${port} -State Listen | ` +
-          `ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\n` +
+          `       PowerShell:   Get-NetTCPConnection -LocalPort ${port} -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }\n` +
           `       Linux/macOS:  kill $(lsof -ti tcp:${port})    (or, Linux: fuser -k ${port}/tcp)\n`,
       );
       process.exit(1);

--- a/mkdocs-docs/getting-started.md
+++ b/mkdocs-docs/getting-started.md
@@ -58,7 +58,14 @@ Choose the method that fits your setup:
 !!! warning "Port already in use?"
     If the dashboard says "companion offline", the server is not running. If you see `EADDRINUSE`, another instance is already running — just use that one, or free the port:
     ```powershell
+    # Windows
     Get-NetTCPConnection -LocalPort 4773 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+    ```
+    ```bash
+    # Linux / macOS
+    kill $(lsof -ti tcp:4773)
+    # Linux only, if lsof isn't installed
+    fuser -k 4773/tcp
     ```
 
 ---


### PR DESCRIPTION
## What

The `EADDRINUSE` startup message only ever printed the PowerShell one-liner, so a Linux or macOS analyst hitting a port clash got told to "stop it first" with no command they could run.

`companion/src/server.ts` now prints both:

```
[DFIR] Port 4773 is already in use — a DFIR companion is probably already running.
       Use the existing one (http://127.0.0.1:4773/dashboard), or stop it first:
       PowerShell:   Get-NetTCPConnection -LocalPort 4773 -State Listen | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
       Linux/macOS:  kill $(lsof -ti tcp:4773)    (or, Linux: fuser -k 4773/tcp)
```

`lsof` leads because it covers both Linux and macOS and sends SIGTERM; `fuser -k` is Linux-only and SIGKILLs, so it is the fallback for hosts without lsof.

The same addition went to the three docs that repeated the Windows-only instruction: `USER_MANUAL.md`, `mkdocs-docs/getting-started.md`, `companion/README.md`. `companion/scripts/build-sea.mjs` is untouched — that README ships inside the portable *Windows* build, where PowerShell is the right answer.

## Verification

- Ran the real server with port 4999 held by another listener: it printed the message above verbatim and exited 1.
- Ran both suggested commands against a squatting process — `kill $(lsof -ti tcp:4999)` and `fuser -k 4999/tcp` each freed the port (confirmed with `ss -ltn`).
- `npm run typecheck`, `npm run format:check`, `npx eslint src/server.ts` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)