### PR TITLE
fix(import): 404 an unknown case on every import route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Reproducible analysis-run ledger** — imports, deterministic tagging, enrichment, synthesis, Deep Pass, and reports now leave immutable, hash-chained manifests that pin their evidence and dependencies; analysts can inspect, replay, and compare runs while reports and exports retain the exact run history (closes #377).
 - **Internal Hunt Workbench and typed query language** — structured, indexed and cursor-paged searches across an explicitly selected forensic or super-timeline dataset, with Boolean/range/time/regex filters, aggregation, rare values, saved parameterized hunts, result pivots/actions, cancellation and resource limits (closes #376).
 
+### Fixed
+- **Imports into a non-existent case are rejected** — all 24 `/cases/:id/import*` routes now 404 an unknown case id instead of accepting it; a typo'd id used to return 202 and orphan the evidence, an `imports.jsonl` line and a custody record under a directory that never appeared in the case list.
+
 ## [0.34.0] - 2026-07-31
 
 ### Added

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -41,6 +41,7 @@ import { sendPipelineError } from "./presidioApproval.js";
 import type { RouteContext } from "./context.js";
 import { recordImportRun } from "./importRunRecorder.js";
 import { registerImportResumeHandler } from "./importRecovery.js";
+import { registerImportCaseGuard } from "./importCaseGuard.js";
 import { createImportJobTracking, IMPORT_JOB_PENDING_DETAIL } from "./importJobTracking.js";
 
 /**
@@ -62,6 +63,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
     applyWhitelistToCase, applyNsrlToCase, applyDeobfuscationToCase,
   } = ctx;
   registerImportResumeHandler(ctx);
+  registerImportCaseGuard(app, store); // 404 an unknown case before ANY import route touches disk
 
   // Auto-tag only newly imported super-timeline events; best-effort and TAGGER_AUTO-gated.
   const autoTagImported = (caseId: string, added: ForensicEvent[]): Promise<void> =>
@@ -176,13 +178,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
       const action = caseMeta.status === "archived" ? "restore it" : "reopen it";
       return res.status(423).json({ error: `Case "${caseId}" is ${caseMeta.status} — ${action} before importing evidence` });
     }
-    // Evidence-first parity with POST /captures + GET /state: never silently accept evidence for a
-    // case that doesn't exist. "Connect" attaches without creating, so a typo'd / never-created case
-    // id would otherwise 202-"accept" the import and orphan it on disk (no case meta, invisible in the
-    // case list) — silent loss of forensic evidence. Fail loud so the analyst creates the case first.
-    if (!(await store.caseExists(caseId))) {
-      return res.status(404).json({ error: `case ${caseId} does not exist — create it in the dashboard first` });
-    }
+    // (the case-existence 404 is mounted by registerImportCaseGuard, ahead of this handler)
     const text = typeof req.body?.text === "string" ? req.body.text
       : typeof req.body?.json === "string" ? req.body.json
       : typeof req.body?.csv === "string" ? req.body.csv : "";
@@ -344,11 +340,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
       const action = caseMeta.status === "archived" ? "restore it" : "reopen it";
       return res.status(423).json({ error: `Case "${caseId}" is ${caseMeta.status} — ${action} before importing evidence` });
     }
-    // Same evidence-first guard as POST /import + /captures + /state: never ingest into a case that
-    // doesn't exist (it would write an orphaned, case-meta-less import on disk).
-    if (!(await store.caseExists(caseId))) {
-      return res.status(404).json({ error: `case ${caseId} does not exist — create it in the dashboard first` });
-    }
+    // (the case-existence 404 is mounted by registerImportCaseGuard, ahead of this handler)
     const filePath = typeof req.body?.path === "string" ? req.body.path.trim() : "";
     if (!filePath) return res.status(400).json({ error: "path is required (absolute path to a file on the server)" });
     const minSeverity = parseMinSeverity(req.body?.minSeverity);

--- a/companion/src/routes/importCaseGuard.ts
+++ b/companion/src/routes/importCaseGuard.ts
@@ -1,0 +1,67 @@
+import type { Express, NextFunction, Request, Response } from "express";
+import type { CaseStore } from "../storage/caseStore.js";
+
+// Every POST route that ingests evidence into a case: the unified sniffing import, the server-side
+// file import, and each per-format importer. Kept as ONE list so the existence guard below is
+// mounted across all of them at once — tests/server/importMissingCase.test.ts walks the live
+// Express router and fails if a new /cases/:id/import* POST route is added without being listed.
+//
+// Excludes /cases/:id/import/undo and /import/redo (they replay state that is already in the case,
+// and 501 without an undo store) and the GET /import-meta, /drop-status readers.
+export const EVIDENCE_IMPORT_ROUTES = [
+  "import",
+  "import-file",
+  "import-csv",
+  "import-log",
+  "import-thor",
+  "import-siem",
+  "import-chainsaw",
+  "import-hayabusa",
+  "import-velociraptor",
+  "import-network",
+  "import-kape",
+  "import-cybertriage",
+  "import-m365",
+  "import-aws",
+  "import-cloud-activity",
+  "import-plaso",
+  "import-sandbox",
+  "import-memory",
+  "import-email",
+  "import-thehive",
+  "import-auditd",
+  "import-journald",
+  "import-sysdig",
+  "import-wazuh",
+] as const;
+
+// Evidence-first guard for every import route — parity with POST /captures and GET /state, which
+// already 404 an unknown case. The companion never creates a case as a side effect of ingesting
+// evidence (see CaseStore.caseExists): creation is a deliberate dashboard action.
+//
+// The "Connect" toolbar action attaches to a case id WITHOUT creating it, so a typo'd or
+// never-created id used to 202-"accept" an import and orphan it on disk — the raw evidence, an
+// imports.jsonl line, a custody record and a session log, all under a directory with no case.json
+// that GET /cases therefore never lists. The analyst saw success and the evidence was gone.
+//
+// Mounted as ONE handler ahead of the route handlers rather than repeated inside each of them:
+// routes/import.ts is size-frozen (#384), and a single mount cannot drift route to route.
+//
+// Runs before each route's own payload parsing and before the closed/archived 423 check. Both are
+// deliberate: an unknown case id is not a payload problem and nothing should touch disk before the
+// case identity is settled, and an archived case still satisfies caseExists() (caseDir() falls back
+// to _archived/), so archived/closed cases keep their 423 rather than collapsing into this 404.
+export function registerImportCaseGuard(app: Express, store: CaseStore): void {
+  const paths = EVIDENCE_IMPORT_ROUTES.map((route) => `/cases/:id/${route}`);
+  app.post(paths, async (req: Request, res: Response, next: NextFunction) => {
+    const caseId = req.params.id;
+    try {
+      if (await store.caseExists(caseId)) return next();
+    } catch (err) {
+      return next(err);
+    }
+    return res
+      .status(404)
+      .json({ error: `case ${caseId} does not exist — create it in the dashboard first` });
+  });
+}

--- a/companion/tests/server/importMissingCase.test.ts
+++ b/companion/tests/server/importMissingCase.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import request from "supertest";
@@ -7,6 +7,8 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
+import { MockProvider } from "../../src/providers/provider.js";
+import { EVIDENCE_IMPORT_ROUTES } from "../../src/routes/importCaseGuard.js";
 
 // Regression: POST /cases/:id/import — evidence imported into a case that does not exist.
 // Found by /qa on 2026-06-25.
@@ -55,13 +57,20 @@ const CHAINSAW_HUNT = [
   },
 ];
 
-async function makeApp() {
+// `withSynthesis` wires a canned provider ONLY so import-csv / import-log clear their
+// `hasSynthesisProvider()` 501 gate and actually reach the case-existence check. No model call
+// ever happens in these tests — the guard answers before any analysis is dispatched.
+async function makeApp(opts: { withSynthesis?: boolean } = {}) {
   const root = await mkdtemp(join(tmpdir(), "dfir-import-missing-"));
   const store = new CaseStore(root);
   const stateStore = new StateStore(store);
+  const canned = opts.withSynthesis ? new MockProvider("mock", "{}") : undefined;
   // No-AI pipeline: deterministic importers populate the timeline without any model call.
   const pipeline = buildRuntimePipeline({
-    provider: undefined, synthesisProvider: undefined, stateStore, store,
+    provider: canned,
+    synthesisProvider: canned,
+    stateStore,
+    store,
     imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
   });
   const app = createApp(store, { pipeline, stateStore, importMetaStore: new ImportMetaStore(store) });
@@ -112,5 +121,101 @@ describe("POST /cases/:id/import — case existence guard", () => {
     expect(res.status).toBe(404);
     expect(res.body.error).toMatch(/does not exist/i);
     expect(await store.caseExists("does-not-exist")).toBe(false);
+  });
+});
+
+// Every per-format import route. The unified POST /import and POST /import-file above were guarded
+// when the defect was first found; the 22 per-format routes were not, so the SAME typo'd case id
+// still 202-accepted evidence through any of them. They are documented as "programmatic use" and no
+// dashboard/extension caller posts to them, so nothing depended on the implicit-creation behaviour.
+const PER_FORMAT_IMPORT_ROUTES = [
+  "import-csv",
+  "import-log",
+  "import-thor",
+  "import-siem",
+  "import-chainsaw",
+  "import-hayabusa",
+  "import-velociraptor",
+  "import-network",
+  "import-kape",
+  "import-cybertriage",
+  "import-m365",
+  "import-aws",
+  "import-cloud-activity",
+  "import-plaso",
+  "import-sandbox",
+  "import-memory",
+  "import-email",
+  "import-thehive",
+  "import-auditd",
+  "import-journald",
+  "import-sysdig",
+  "import-wazuh",
+] as const;
+
+describe("per-format import routes — case existence guard", () => {
+  // The body is deliberately non-empty and format-agnostic: it clears each route's "text/csv/json is
+  // required" 400 so an UNGUARDED route gets as far as parsing (or as far as saveImport). The guard
+  // must answer 404 before any of that — a case id that does not exist is not a payload problem.
+  const anyBody = { filename: "eviction.dat", text: "x", csv: "x", json: "x", log: "x", eml: "x" };
+
+  it.each(PER_FORMAT_IMPORT_ROUTES)("404s /cases/:id/%s into a case that does not exist", async (route) => {
+    const { app, store } = await makeApp({ withSynthesis: true });
+
+    const res = await request(app).post(`/cases/ghost-case-xyz/${route}`).send(anyBody);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/does not exist/i);
+    expect(await store.caseExists("ghost-case-xyz")).toBe(false);
+  });
+
+  // The reported reproduction, end to end: a valid CSV into a typo'd case id used to return
+  // 202 {accepted:true} and leave imports/0001_ghost.csv, metadata/imports.jsonl, a custody
+  // record and a session log on disk — under a case GET /cases never lists. Nothing may be written.
+  it("writes nothing to disk for a valid CSV into a case that does not exist", async () => {
+    const { app, store } = await makeApp({ withSynthesis: true });
+    const csv = "timestamp,message\n2023-01-02T10:00:00Z,encoded powershell from winword\n";
+
+    const res = await request(app)
+      .post("/cases/ghost-case-xyz/import-csv")
+      .send({ filename: "ghost.csv", csv });
+
+    expect(res.status).toBe(404);
+    await expect(stat(store.caseDir("ghost-case-xyz"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await request(app).get("/cases")).body).toEqual([]);
+  });
+
+  it("still accepts the same CSV into an existing case (the guard does not break the happy path)", async () => {
+    const { app } = await makeApp({ withSynthesis: true });
+    await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const csv = "timestamp,message\n2023-01-02T10:00:00Z,encoded powershell from winword\n";
+
+    const res = await request(app).post("/cases/c1/import-csv").send({ filename: "real.csv", csv });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toMatchObject({ accepted: true, rows: 1 });
+  });
+
+  // The lists above are hand-maintained, so they can only pin the routes that existed when they
+  // were written. This walks the LIVE Express router instead: any POST /cases/:id/import* route
+  // added later is discovered here, and fails until it is added to EVIDENCE_IMPORT_ROUTES — which
+  // is what actually mounts the guard. Without this, the next importer silently ships unguarded.
+  it("guards every POST /cases/:id/import* route registered on the app", async () => {
+    const { app } = await makeApp({ withSynthesis: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const layers = (app as any)._router.stack as Array<{
+      route?: { path: string; methods: Record<string, boolean> };
+    }>;
+    const registered = new Set(
+      layers
+        .map((l) => l.route)
+        .filter((r): r is { path: string; methods: Record<string, boolean> } => Boolean(r?.methods?.post))
+        // /import/undo and /import/redo replay existing state — they ingest no evidence.
+        .filter((r) => /^\/cases\/:id\/import(-[a-z0-9-]+)?$/.test(r.path))
+        .map((r) => r.path.replace("/cases/:id/", "")),
+    );
+
+    expect(registered.size).toBeGreaterThan(0);
+    expect([...registered].sort()).toEqual([...EVIDENCE_IMPORT_ROUTES].sort());
   });
 });


### PR DESCRIPTION
## The defect

`POST /cases/ghost-case-xyz/import-csv` for a case that does not exist returned `202 {"accepted":true}` and wrote to disk:

```
cases/ghost-case-xyz/imports/0001_ghost.csv
cases/ghost-case-xyz/metadata/imports.jsonl
cases/ghost-case-xyz/metadata/custody.jsonl
cases/ghost-case-xyz/logs/session-*.log
```

`GET /cases` then returned `[]` — the directory has no `case.json`, so it is never listed. A typo in a case id silently wrote real evidence plus a custody record somewhere the investigator cannot see. `POST /captures` and `GET /state` already 404 a missing case; `GET /cases/:id/custody` does too.

## Scope

`/import` and `/import-file` were guarded in an earlier pass. The **22 per-format importers were not**, so the same typo still got in through any of them — including 14 that weren't in the original report (`import-kape`, `-cybertriage`, `-m365`, `-aws`, `-cloud-activity`, `-plaso`, `-sandbox`, `-memory`, `-email`, `-thehive`, `-auditd`, `-journald`, `-sysdig`, `-wazuh`). All 24 evidence-ingesting import routes are now covered.

## Approach

One handler mounted across all 24 paths (`companion/src/routes/importCaseGuard.ts`) rather than 22 inline copies. `routes/import.ts` is size-frozen (#384) and `check:size` rejects growth; a single mount also cannot drift route to route. The two existing inline guards collapse into it, so `import.ts` comes out **8 lines shorter**.

Ordering, all deliberate:
- **before payload parsing** — an unknown case id is not a payload problem, and nothing should touch disk before the case identity is settled
- **before the closed/archived 423** — an archived case still satisfies `caseExists` (`caseDir()` falls back to `_archived/`), so archived/closed cases keep their 423
- **after `teamAuth.middleware()`** (mounted at `server.ts:855`, routes at `1045`) — an unauthenticated caller cannot probe case existence through it

## Compatibility

No caller depended on the implicit creation. The extension posts to `/import` (`companionClient.ts:42`); the dashboard posts to `/import-file` and `/import` (`dashboard.html:21051`). Nothing anywhere reaches the per-format routes, which are documented as programmatic-only.

## Tests

`companion/tests/server/importMissingCase.test.ts`, 28 passing:
- every per-format route 404s for a ghost case
- the reported reproduction end to end: a valid CSV writes **nothing** to disk and the case stays absent from `GET /cases`
- the happy path still 202s
- a test that walks the live Express router, so a future `/cases/:id/import*` route cannot ship unguarded — verified non-vacuous by temporarily adding an unguarded route and watching it fail

Written test-first: 23 red (including the 202 reproduction), then green.

## Verification

Run against `origin/master` merged in (team auth had just landed):

- `npm test` — 524 files, 6661 tests, all pass
- `npm run typecheck` / `lint` / `format:check` / `check:size` / `check:imports` — all clean

## Follow-up

`companion/tests/e2e/workflows/import.spec.ts` on `claude/eli10-issue-386-6d37c8` still pins the old 202 as a characterization test. Once this lands, flip it to 404 and rename it — do not re-baseline it.

Found while adding browser E2E coverage for #386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)