### PR TITLE
feat(reports): add review and release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Controlled report review and immutable release** — audited draft/peer-review/approval states, evidence and integrity release gates, identity-bound sign-off, explicit supersession, version diffs, and frozen executive/technical/legal/IOC packs (closes #383).
 - **Authenticated team investigations** — optional OIDC/local sign-in, case RBAC, scoped service identities, signed analyst attribution, secure sessions/CSRF, and single-writer concurrency protection while preserving zero-config localhost mode (closes #382).
 - **Restart-safe background jobs** — durable import and Deep Pass checkpoints, stable job IDs, deterministic cancellation/retry, fair per-case queueing, and reconnect-safe progress recovery (closes #380).
 - **Production AI quality and calibration gates** — a versioned synthetic corpus now grades exact claim-to-evidence grounding, recall, false conclusions, calibrated uncertainty, useful next steps, cost, and clean-case abstention, with protected pinned-model baselines and prompt-change no-regression reports (closes #378).

--- a/companion/src/reports/reportReleaseStore.ts
+++ b/companion/src/reports/reportReleaseStore.ts
@@ -1,0 +1,426 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { CustodyChainBreak, CustodyChainHead, CustodyMismatch } from "../analysis/custody.js";
+import { hashManifestValue } from "../analysis/analysisRunHash.js";
+import type { AnalysisRunIntegrity, AnalysisRunManifest } from "../analysis/analysisRunTypes.js";
+import { StateLock } from "../analysis/stateLock.js";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import { defaultReportTemplate, orderedEnabledSections } from "./reportTemplate.js";
+import type { ReportVersionRecord } from "./reportVersionStore.js";
+import type { ReportActor, ReportWorkflow } from "./reportWorkflowTypes.js";
+
+export const REPORT_PACK_TYPES = ["executive", "technical", "legal", "ioc"] as const;
+export type ReportPackType = (typeof REPORT_PACK_TYPES)[number];
+
+export interface ReportReleaseSummary {
+  id: string;
+  sequence: number;
+  reportVersionId: string;
+  reportVersion: string;
+  releasedAt: string;
+  releasedBy: ReportActor;
+  supersedesReleaseId?: string;
+  manifestHash: string;
+}
+
+export interface ReportReleaseRecord extends ReportReleaseSummary {
+  schemaVersion: 1;
+  caseId: string;
+  previousManifestHash: string | null;
+  approval: ReportWorkflow["approvals"];
+  analysisRuns: Array<{ id: string; manifestHash: string }>;
+  custody: { head: CustodyChainHead };
+  snapshot: ReportVersionRecord;
+  packs: Record<ReportPackType, string>;
+  packHashes: Record<ReportPackType, string>;
+}
+
+export interface ReportReleaseIntegrity {
+  ok: boolean;
+  releases: number;
+  problems: string[];
+}
+
+interface ReportReleaseHead {
+  sequence: number;
+  manifestHash: string;
+}
+
+export interface ReportReleaseInput {
+  version: ReportVersionRecord;
+  workflow: ReportWorkflow;
+  actor: ReportActor;
+  supersedesReleaseId?: string;
+  analysisRuns: AnalysisRunManifest[];
+  analysisIntegrity: AnalysisRunIntegrity;
+  custody: {
+    head: CustodyChainHead;
+    chainBreaks: CustodyChainBreak[];
+    mismatches: CustodyMismatch[];
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isActor(value: unknown): value is ReportActor {
+  if (!isObject(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.displayName === "string" &&
+    (value.kind === "local" || value.kind === "oidc" || value.kind === "service" || value.kind === "solo")
+  );
+}
+
+function isReleaseSummary(value: unknown): value is ReportReleaseSummary {
+  if (!isObject(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.sequence === "number" &&
+    typeof value.reportVersionId === "string" &&
+    typeof value.reportVersion === "string" &&
+    typeof value.releasedAt === "string" &&
+    isActor(value.releasedBy) &&
+    (value.supersedesReleaseId === undefined || typeof value.supersedesReleaseId === "string") &&
+    typeof value.manifestHash === "string"
+  );
+}
+
+function isReleaseRecord(value: unknown): value is ReportReleaseRecord {
+  if (!isReleaseSummary(value) || !isObject(value)) return false;
+  const snapshot = value.snapshot;
+  const packs = value.packs;
+  const packHashes = value.packHashes;
+  const custody = value.custody;
+  return (
+    value.schemaVersion === 1 &&
+    typeof value.caseId === "string" &&
+    (value.previousManifestHash === null || typeof value.previousManifestHash === "string") &&
+    Array.isArray(value.approval) &&
+    Array.isArray(value.analysisRuns) &&
+    isObject(custody) &&
+    isObject(custody.head) &&
+    isObject(snapshot) &&
+    typeof snapshot.id === "string" &&
+    typeof snapshot.markdown === "string" &&
+    isObject(snapshot.state) &&
+    Array.isArray(snapshot.state.findings) &&
+    Array.isArray(snapshot.state.iocs) &&
+    Array.isArray(snapshot.state.forensicTimeline) &&
+    isObject(packs) &&
+    REPORT_PACK_TYPES.every((type) => typeof packs[type] === "string") &&
+    isObject(packHashes) &&
+    REPORT_PACK_TYPES.every((type) => typeof packHashes[type] === "string")
+  );
+}
+
+function validId(value: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(value);
+}
+
+function csvCell(value: string): string {
+  const guarded = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  return `"${guarded.replace(/"/g, '""')}"`;
+}
+
+function iocPack(version: ReportVersionRecord): string {
+  const rows = version.state.iocs.map((ioc) =>
+    [ioc.id, ioc.type, ioc.value, ioc.firstSeen, ioc.note ?? ""].map(csvCell).join(","),
+  );
+  return ["id,type,value,firstSeen,note", ...rows].join("\n") + "\n";
+}
+
+function executivePack(version: ReportVersionRecord): string {
+  const findings = version.state.findings
+    .filter((finding) => finding.status !== "dismissed")
+    .filter((finding) => finding.severity === "Critical" || finding.severity === "High")
+    .map((finding) => `- **${finding.severity}: ${finding.title}** — ${finding.description}`);
+  return [
+    "# Executive Incident Brief",
+    "",
+    version.meta.executiveSummary || "No separate executive summary was recorded.",
+    "",
+    "## Material findings",
+    "",
+    ...(findings.length > 0 ? findings : ["No Critical or High findings were in the approved evidence set."]),
+    "",
+  ].join("\n");
+}
+
+function legalPack(version: ReportVersionRecord, workflow: ReportWorkflow): string {
+  const approvals = workflow.approvals.map(
+    (approval) =>
+      `- ${approval.actorDisplayName} — ${approval.independent ? "independent peer review" : "self-review"} at ${approval.at}`,
+  );
+  const uncertainties = (version.state.uncertainties ?? []).map(
+    (item) =>
+      `- **${item.topic} (${item.status})** — ${item.basis || "No basis recorded"}; gap: ${item.gap || "none recorded"}`,
+  );
+  return [
+    "# Legal / Insurance Incident Pack",
+    "",
+    `Organization: ${version.meta.organization || "not recorded"}`,
+    `Incident ID: ${version.meta.incidentId || "not recorded"}`,
+    `Restrictions: ${version.meta.restrictions || "not recorded"}`,
+    "",
+    "## Approval record",
+    "",
+    ...approvals,
+    "",
+    "## Investigation limitations",
+    "",
+    version.meta.investigationLimitations || "No limitations were recorded.",
+    "",
+    "## Analytical uncertainty",
+    "",
+    ...(uncertainties.length > 0 ? uncertainties : ["No structured uncertainties were recorded."]),
+    "",
+  ].join("\n");
+}
+
+function buildPacks(version: ReportVersionRecord, workflow: ReportWorkflow): Record<ReportPackType, string> {
+  return {
+    executive: executivePack(version),
+    technical: version.markdown,
+    legal: legalPack(version, workflow),
+    ioc: iocPack(version),
+  };
+}
+
+function evidenceProblems(version: ReportVersionRecord): string[] {
+  const eventIds = new Set(version.state.forensicTimeline.map((event) => event.id));
+  const requireAll = version.template?.releaseRequirements.requireEvidenceLinks ?? false;
+  return version.state.findings.flatMap((finding) => {
+    const material = finding.severity === "Critical" || finding.severity === "High";
+    if (finding.status === "dismissed" || (!material && !requireAll)) return [];
+    const links = finding.relatedEventIds ?? [];
+    const invalid = links.filter((id) => !eventIds.has(id));
+    return links.length === 0 || invalid.length > 0
+      ? [`${finding.id} (${finding.title}) is missing evidence links`]
+      : [];
+  });
+}
+
+function releaseProblems(input: ReportReleaseInput): string[] {
+  const problems: string[] = [];
+  if (input.actor.kind === "service") problems.push("a service identity cannot release a report");
+  if (input.workflow.status !== "approved") problems.push("report workflow is not approved");
+  if (input.workflow.approvals.length === 0) problems.push("report has no structured approval");
+  if (
+    input.version.template?.releaseRequirements.requireIndependentReview &&
+    !input.workflow.approvals.some((approval) => approval.independent)
+  ) {
+    problems.push("report template requires independent review");
+  }
+  const enabled = new Set(orderedEnabledSections(input.version.template ?? defaultReportTemplate()));
+  for (const key of input.version.template?.releaseRequirements.requiredSections ?? []) {
+    if (!enabled.has(key)) problems.push(`report template requires section ${key}`);
+  }
+  problems.push(...evidenceProblems(input.version));
+  if (
+    input.workflow.annotations.some(
+      (item) => item.category === "uncertainty" && item.impact === "high" && !item.resolvedAt,
+    )
+  ) {
+    problems.push("unresolved high-impact uncertainty remains");
+  }
+  if (!input.analysisIntegrity.ok) problems.push("analysis run ledger integrity failed");
+  const runIds = new Set(input.analysisRuns.map((run) => run.id));
+  if ((input.version.analysisRunIds ?? []).length === 0) problems.push("report has no pinned analysis runs");
+  for (const id of input.version.analysisRunIds ?? []) {
+    if (!runIds.has(id)) problems.push(`pinned analysis run ${id} is missing`);
+  }
+  if (input.custody.chainBreaks.length > 0) problems.push("custody chain is broken");
+  if (input.custody.mismatches.some((item) => item.reason === "missing")) {
+    problems.push("missing artifact recorded in custody");
+  }
+  if (input.custody.mismatches.some((item) => item.reason === "hash-mismatch")) {
+    problems.push("artifact hash does not match custody record");
+  }
+  return problems;
+}
+
+export class ReportReleaseStore {
+  private readonly lock = new StateLock();
+
+  constructor(private readonly cases: CaseStore) {}
+
+  private dir(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "report-releases");
+  }
+
+  private indexPath(caseId: string): string {
+    return join(this.dir(caseId), "index.json");
+  }
+
+  private headPath(caseId: string): string {
+    return join(this.dir(caseId), "head.json");
+  }
+
+  private recordPath(caseId: string, releaseId: string): string {
+    if (!validId(releaseId)) throw new Error("invalid report release id");
+    return join(this.dir(caseId), `${releaseId}.json`);
+  }
+
+  async list(caseId: string): Promise<ReportReleaseSummary[]> {
+    try {
+      const value = JSON.parse(await readFile(this.indexPath(caseId), "utf8")) as unknown;
+      if (!Array.isArray(value) || !value.every(isReleaseSummary)) {
+        throw new Error("report release index is invalid");
+      }
+      return value;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+  }
+
+  async get(caseId: string, releaseId: string): Promise<ReportReleaseRecord | null> {
+    if (!validId(releaseId)) return null;
+    try {
+      const value = JSON.parse(await readFile(this.recordPath(caseId, releaseId), "utf8")) as unknown;
+      if (!isReleaseRecord(value)) throw new Error("report release record is invalid");
+      return value;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  private async readHead(caseId: string): Promise<ReportReleaseHead | null> {
+    try {
+      const value = JSON.parse(await readFile(this.headPath(caseId), "utf8")) as unknown;
+      if (!isObject(value) || typeof value.sequence !== "number" || typeof value.manifestHash !== "string") {
+        throw new Error("report release head is invalid");
+      }
+      return { sequence: value.sequence, manifestHash: value.manifestHash };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  create(caseId: string, input: ReportReleaseInput): Promise<ReportReleaseRecord> {
+    return this.lock.runExclusive(caseId, async () => {
+      const problems = releaseProblems(input);
+      if (problems.length > 0) throw new Error(`release blocked: ${problems.join("; ")}`);
+      const existing = await this.list(caseId);
+      if (existing.some((release) => release.reportVersionId === input.version.id)) {
+        throw new Error("this report version is already released");
+      }
+      const latest = existing[0];
+      if (latest && input.supersedesReleaseId !== latest.id) {
+        throw new Error(`a prior release exists; explicitly supersede ${latest.id}`);
+      }
+      if (!latest && input.supersedesReleaseId) throw new Error("there is no prior release to supersede");
+      const sequence = (latest?.sequence ?? 0) + 1;
+      const releasedAt = new Date().toISOString();
+      const id = `r${sequence}-${randomUUID().slice(0, 8)}`;
+      const packs = buildPacks(input.version, input.workflow);
+      const packHashes = Object.fromEntries(
+        REPORT_PACK_TYPES.map((type) => [type, hashManifestValue(packs[type])]),
+      ) as Record<ReportPackType, string>;
+      const analysisRuns = (input.version.analysisRunIds ?? []).map((id) => {
+        const run = input.analysisRuns.find((candidate) => candidate.id === id);
+        if (!run) throw new Error(`release blocked: pinned analysis run ${id} is missing`);
+        return { id, manifestHash: run.manifestHash };
+      });
+      const unhashed: Omit<ReportReleaseRecord, "manifestHash"> = {
+        id,
+        schemaVersion: 1,
+        sequence,
+        caseId,
+        reportVersionId: input.version.id,
+        reportVersion: input.version.version,
+        releasedAt,
+        releasedBy: input.actor,
+        ...(latest ? { supersedesReleaseId: latest.id } : {}),
+        previousManifestHash: latest?.manifestHash ?? null,
+        approval: input.workflow.approvals,
+        analysisRuns,
+        custody: { head: input.custody.head },
+        snapshot: input.version,
+        packs,
+        packHashes,
+      };
+      const record: ReportReleaseRecord = {
+        ...unhashed,
+        manifestHash: hashManifestValue(unhashed),
+      };
+      const summary: ReportReleaseSummary = {
+        id: record.id,
+        sequence: record.sequence,
+        reportVersionId: record.reportVersionId,
+        reportVersion: record.reportVersion,
+        releasedAt: record.releasedAt,
+        releasedBy: record.releasedBy,
+        ...(record.supersedesReleaseId ? { supersedesReleaseId: record.supersedesReleaseId } : {}),
+        manifestHash: record.manifestHash,
+      };
+      await mkdir(this.dir(caseId), { recursive: true });
+      await atomicWrite(this.recordPath(caseId, id), JSON.stringify(record, null, 2));
+      await atomicWrite(this.indexPath(caseId), JSON.stringify([summary, ...existing], null, 2));
+      await atomicWrite(
+        this.headPath(caseId),
+        JSON.stringify({ sequence: record.sequence, manifestHash: record.manifestHash }, null, 2),
+      );
+      return record;
+    });
+  }
+
+  async verify(caseId: string): Promise<ReportReleaseIntegrity> {
+    let summaries: ReportReleaseSummary[];
+    try {
+      summaries = [...(await this.list(caseId))].sort((left, right) => left.sequence - right.sequence);
+    } catch (err) {
+      return { ok: false, releases: 0, problems: [(err as Error).message] };
+    }
+    const problems: string[] = [];
+    let head: ReportReleaseHead | null;
+    try {
+      head = await this.readHead(caseId);
+    } catch (err) {
+      return {
+        ok: false,
+        releases: summaries.length,
+        problems: [(err as Error).message],
+      };
+    }
+    let previous: string | null = null;
+    for (const [index, summary] of summaries.entries()) {
+      let release: ReportReleaseRecord | null;
+      try {
+        release = await this.get(caseId, summary.id);
+      } catch (err) {
+        problems.push(`${summary.id}: ${(err as Error).message}`);
+        continue;
+      }
+      if (!release) {
+        problems.push(`${summary.id}: release record is missing`);
+        continue;
+      }
+      const { manifestHash, ...unhashed } = release;
+      if (hashManifestValue(unhashed) !== manifestHash) {
+        problems.push(`${summary.id}: manifest hash mismatch`);
+      }
+      if (release.sequence !== index + 1) problems.push(`${summary.id}: sequence mismatch`);
+      if (release.previousManifestHash !== previous) {
+        problems.push(`${summary.id}: previous manifest hash mismatch`);
+      }
+      if (summary.manifestHash !== release.manifestHash) {
+        problems.push(`${summary.id}: release index hash mismatch`);
+      }
+      previous = release.manifestHash;
+    }
+    const latest = summaries.at(-1);
+    if (latest && !head) problems.push("report release head is missing");
+    if (!latest && head) problems.push("report release head exists without releases");
+    if (latest && head && (latest.sequence !== head.sequence || latest.manifestHash !== head.manifestHash)) {
+      problems.push("report release head mismatch");
+    }
+    return { ok: problems.length === 0, releases: summaries.length, problems };
+  }
+}

--- a/companion/src/reports/reportTemplate.ts
+++ b/companion/src/reports/reportTemplate.ts
@@ -52,6 +52,12 @@ export interface ReportTemplateSection {
   enabled: boolean;
 }
 
+export interface ReportReleaseRequirements {
+  requiredSections: ReportSectionKey[];
+  requireIndependentReview: boolean;
+  requireEvidenceLinks: boolean;
+}
+
 export const DEFAULT_ACCENT = "#2d6cdf"; // mirrors the HTML report's historical accent
 export const DEFAULT_COVER_TITLE = "Incident Investigation Report";
 export const DEFAULT_TEMPLATE_ID = "standard";
@@ -89,9 +95,26 @@ export const reportTemplateSchema = z.object({
   showCompanyName: z.boolean().catch(true),
   // Section layout
   sections: z.array(sectionSchema).catch([]),
+  // Release governance (#383). Required sections must also be enabled; release preflight blocks
+  // otherwise. Evidence-link coverage extends the always-on High/Critical claim gate to every
+  // non-dismissed finding. Independent review is meaningful only with team authentication.
+  releaseRequirements: z
+    .object({
+      requiredSections: z.array(z.string()).catch([]),
+      requireIndependentReview: z.boolean().catch(false),
+      requireEvidenceLinks: z.boolean().catch(false),
+    })
+    .catch({
+      requiredSections: [],
+      requireIndependentReview: false,
+      requireEvidenceLinks: false,
+    }),
 });
 
-export type ReportTemplate = z.infer<typeof reportTemplateSchema>;
+type ParsedReportTemplate = z.infer<typeof reportTemplateSchema>;
+export type ReportTemplate = Omit<ParsedReportTemplate, "releaseRequirements"> & {
+  releaseRequirements: ReportReleaseRequirements;
+};
 
 // Normalize an arbitrary section list to FULL canonical coverage: keep provided (valid, deduped)
 // keys in their given order so analyst reordering survives, then append any canonical section not
@@ -142,6 +165,11 @@ export function normalizeReportTemplate(input: unknown): ReportTemplate {
     description: t.description.trim(),
     accentColor: normalizeHexColor(t.accentColor),
     sections: normalizeSections(t.sections),
+    releaseRequirements: {
+      ...t.releaseRequirements,
+      requiredSections: [...new Set(t.releaseRequirements.requiredSections)]
+        .filter((key): key is ReportSectionKey => SECTION_KEY_SET.has(key)),
+    },
   };
 }
 

--- a/companion/src/reports/reportVersionStore.ts
+++ b/companion/src/reports/reportVersionStore.ts
@@ -4,7 +4,23 @@ import { randomUUID, createHash } from "node:crypto";
 import { atomicWrite } from "../storage/atomicWrite.js";
 import type { CaseStore } from "../storage/caseStore.js";
 import type { Finding, IOC, ForensicEvent } from "../analysis/stateTypes.js";
+import type { Uncertainty } from "../analysis/stateTypes.js";
+import { authenticatedActorFields } from "../auth/identityContext.js";
 import type { ReportMeta } from "./reportMeta.js";
+import type { ReportTemplate } from "./reportTemplate.js";
+import {
+  ReportReleaseStore,
+  type ReportReleaseInput,
+  type ReportReleaseIntegrity,
+  type ReportReleaseRecord,
+  type ReportReleaseSummary,
+} from "./reportReleaseStore.js";
+import { ReportWorkflowStore } from "./reportWorkflowStore.js";
+import type {
+  ReportActor,
+  ReportAnnotationInput,
+  ReportWorkflow,
+} from "./reportWorkflowTypes.js";
 
 // Report versioning (#77): every `writeAll()` (report generation) snapshots the rendered markdown +
 // the human-authored report-meta + the diff-relevant slice of state (findings/IOCs/forensic timeline)
@@ -23,6 +39,7 @@ export interface ReportVersionDiffState {
   findings: Finding[];
   iocs: IOC[];
   forensicTimeline: ForensicEvent[];
+  uncertainties?: Uncertainty[];
 }
 
 export interface ReportVersionSummary {
@@ -36,12 +53,14 @@ export interface ReportVersionSummary {
   eventsCount: number;
   /** Exact analysis/import/enrichment/report runs this released snapshot was derived from (#377). */
   analysisRunIds?: string[];
+  createdBy?: ReportActor;
 }
 
 export interface ReportVersionRecord extends ReportVersionSummary {
   markdown: string;
   meta: ReportMeta;
   state: ReportVersionDiffState;
+  template?: ReportTemplate;
 }
 
 // Cap the number of retained versions per case (oldest pruned first) so state/report-versions/ can't
@@ -75,7 +94,13 @@ function nextVersionLabel(existing: readonly ReportVersionSummary[]): string {
 }
 
 export class ReportVersionStore {
-  constructor(private readonly cases: CaseStore) {}
+  private readonly workflows: ReportWorkflowStore;
+  private readonly releases: ReportReleaseStore;
+
+  constructor(private readonly cases: CaseStore) {
+    this.workflows = new ReportWorkflowStore(cases);
+    this.releases = new ReportReleaseStore(cases);
+  }
 
   private dir(caseId: string): string {
     return join(this.cases.stateDir(caseId), "report-versions");
@@ -124,6 +149,105 @@ export class ReportVersionStore {
     }
   }
 
+  async workflow(caseId: string, versionId: string): Promise<ReportWorkflow | null> {
+    const version = await this.get(caseId, versionId);
+    if (!version) return null;
+    return this.workflows.load(caseId, versionId, version.createdBy);
+  }
+
+  async submitForReview(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    reviewer: ReportActor,
+  ): Promise<ReportWorkflow> {
+    if (!(await this.get(caseId, versionId))) throw new Error("report version not found");
+    return this.workflows.submit(caseId, versionId, actor, reviewer);
+  }
+
+  async addReviewAnnotation(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    input: ReportAnnotationInput,
+  ): Promise<ReportWorkflow> {
+    const version = await this.get(caseId, versionId);
+    if (!version) throw new Error("report version not found");
+    const validTarget = input.targetType === "evidence"
+      ? version.state.forensicTimeline.some((event) => event.id === input.targetId)
+      : version.state.findings.some((finding) => finding.id === input.targetId);
+    if (!validTarget) throw new Error(`${input.targetType} target not found in this report version`);
+    return this.workflows.addAnnotation(caseId, versionId, actor, input);
+  }
+
+  resolveReviewAnnotation(
+    caseId: string,
+    versionId: string,
+    annotationId: string,
+    actor: ReportActor,
+    resolution: string,
+  ): Promise<ReportWorkflow> {
+    return this.workflows.resolveAnnotation(
+      caseId,
+      versionId,
+      annotationId,
+      actor,
+      resolution,
+    );
+  }
+
+  requestReportChanges(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    reason: string,
+  ): Promise<ReportWorkflow> {
+    return this.workflows.requestChanges(caseId, versionId, actor, reason);
+  }
+
+  approve(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    note: string,
+  ): Promise<ReportWorkflow> {
+    return this.workflows.approve(caseId, versionId, actor, note);
+  }
+
+  selfApprove(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    note: string,
+  ): Promise<ReportWorkflow> {
+    return this.workflows.selfApprove(caseId, versionId, actor, note);
+  }
+
+  async release(
+    caseId: string,
+    versionId: string,
+    input: Omit<ReportReleaseInput, "version" | "workflow">,
+  ): Promise<ReportReleaseRecord> {
+    const version = await this.get(caseId, versionId);
+    if (!version) throw new Error("report version not found");
+    const workflow = await this.workflows.load(caseId, versionId, version.createdBy);
+    const release = await this.releases.create(caseId, { ...input, version, workflow });
+    await this.workflows.markReleased(caseId, versionId, input.actor, release.id);
+    return release;
+  }
+
+  listReleases(caseId: string): Promise<ReportReleaseSummary[]> {
+    return this.releases.list(caseId);
+  }
+
+  getRelease(caseId: string, releaseId: string): Promise<ReportReleaseRecord | null> {
+    return this.releases.get(caseId, releaseId);
+  }
+
+  verifyReleases(caseId: string): Promise<ReportReleaseIntegrity> {
+    return this.releases.verify(caseId);
+  }
+
   // Persist a version snapshot after a report regeneration. Skips writing a new version (returns the
   // existing latest summary instead) when the rendered markdown is byte-identical to the most recent
   // version — a re-generation with nothing changed shouldn't grow the history. Best-effort: callers
@@ -136,6 +260,7 @@ export class ReportVersionStore {
       meta: ReportMeta;
       state: ReportVersionDiffState;
       analysisRunIds?: string[];
+      template?: ReportTemplate;
     },
   ): Promise<ReportVersionSummary> {
     const contentHash = createHash("sha256").update(input.markdown).digest("hex");
@@ -163,15 +288,37 @@ export class ReportVersionStore {
       iocsCount: input.state.iocs.length,
       eventsCount: input.state.forensicTimeline.length,
       analysisRunIds,
+      createdBy: (() => {
+        const authenticated = authenticatedActorFields();
+        return authenticated
+          ? {
+              id: authenticated.actorId,
+              displayName: authenticated.actorDisplayName,
+              kind: authenticated.actorKind,
+            }
+          : { id: "solo", displayName: "Solo investigator", kind: "solo" };
+      })(),
     };
-    const record: ReportVersionRecord = { ...summary, markdown: input.markdown, meta: input.meta, state: input.state };
+    const record: ReportVersionRecord = {
+      ...summary,
+      markdown: input.markdown,
+      meta: input.meta,
+      state: input.state,
+      ...(input.template ? { template: input.template } : {}),
+    };
 
     await mkdir(this.dir(caseId), { recursive: true });
     await atomicWrite(this.recordPath(caseId, id), JSON.stringify(record));
     const updated = [summary, ...existing];
     const cap = maxVersions();
-    const kept = updated.slice(0, cap);
-    const pruned = updated.slice(cap);
+    const protectedIds = new Set(
+      (await this.releases.list(caseId)).map((release) => release.reportVersionId),
+    );
+    const retainedWorking = new Set(
+      updated.filter((item) => !protectedIds.has(item.id)).slice(0, cap).map((item) => item.id),
+    );
+    const kept = updated.filter((item) => protectedIds.has(item.id) || retainedWorking.has(item.id));
+    const pruned = updated.filter((item) => !kept.includes(item));
     await this.saveIndex(caseId, kept);
     await Promise.all(pruned.map((p) => unlink(this.recordPath(caseId, p.id)).catch(() => {})));
     return summary;

--- a/companion/src/reports/reportWorkflowStore.ts
+++ b/companion/src/reports/reportWorkflowStore.ts
@@ -1,0 +1,341 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { StateLock } from "../analysis/stateLock.js";
+import { atomicWrite } from "../storage/atomicWrite.js";
+import type { CaseStore } from "../storage/caseStore.js";
+import {
+  REPORT_WORKFLOW_ACTIONS,
+  REPORT_WORKFLOW_STATUSES,
+  reportActorSchema,
+  reportAnnotationInputSchema,
+  type ReportActor,
+  type ReportAnnotationInput,
+  type ReportWorkflow,
+  type ReportWorkflowAction,
+} from "./reportWorkflowTypes.js";
+
+const workflowSchema = z.object({
+  versionId: z.string().min(1),
+  status: z.enum(REPORT_WORKFLOW_STATUSES),
+  createdBy: reportActorSchema,
+  assignedReviewer: reportActorSchema.optional(),
+  annotations: z.array(
+    reportAnnotationInputSchema.extend({
+      id: z.string().min(1),
+      authorId: z.string().min(1),
+      authorDisplayName: z.string().min(1),
+      createdAt: z.string().datetime(),
+      resolvedAt: z.string().datetime().optional(),
+      resolvedById: z.string().optional(),
+      resolvedByDisplayName: z.string().optional(),
+      resolution: z.string().optional(),
+    }),
+  ),
+  approvals: z.array(
+    z.object({
+      actorId: z.string().min(1),
+      actorDisplayName: z.string().min(1),
+      actorKind: z.enum(["local", "oidc", "service", "solo"]),
+      at: z.string().datetime(),
+      independent: z.boolean(),
+      note: z.string(),
+    }),
+  ),
+  history: z.array(
+    z.object({
+      at: z.string().datetime(),
+      action: z.enum(REPORT_WORKFLOW_ACTIONS),
+      actorId: z.string().min(1),
+      actorDisplayName: z.string().min(1),
+      detail: z.string(),
+    }),
+  ),
+  releaseId: z.string().optional(),
+});
+
+function validVersionId(value: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(value);
+}
+
+function defaultWorkflow(versionId: string, actor: ReportActor): ReportWorkflow {
+  const at = new Date().toISOString();
+  const createdBy = reportActorSchema.parse(actor);
+  return {
+    versionId,
+    status: "draft",
+    createdBy,
+    assignedReviewer: undefined,
+    annotations: [],
+    approvals: [],
+    history: [event("created", createdBy, at, "report version created as a draft")],
+  };
+}
+
+function event(
+  action: ReportWorkflowAction,
+  actor: ReportActor,
+  at: string,
+  detail: string,
+): ReportWorkflow["history"][number] {
+  return {
+    at,
+    action,
+    actorId: actor.id,
+    actorDisplayName: actor.displayName,
+    detail,
+  };
+}
+
+function cleanNote(value: string, field: string): string {
+  const note = value.trim();
+  if (!note || note.length > 4_000) throw new Error(`${field} must be 1-4000 characters`);
+  return note;
+}
+
+function requireStatus(workflow: ReportWorkflow, expected: ReportWorkflow["status"]): void {
+  if (workflow.status !== expected) {
+    throw new Error(`report must be ${expected}; current status is ${workflow.status}`);
+  }
+}
+
+function requireAssignedReviewer(workflow: ReportWorkflow, actor: ReportActor): void {
+  if (!workflow.assignedReviewer || workflow.assignedReviewer.id !== actor.id) {
+    throw new Error("only the assigned reviewer can perform this action");
+  }
+}
+
+export class ReportWorkflowStore {
+  private readonly lock = new StateLock();
+
+  constructor(private readonly cases: CaseStore) {}
+
+  private dir(caseId: string): string {
+    return join(this.cases.stateDir(caseId), "report-workflows");
+  }
+
+  private path(caseId: string, versionId: string): string {
+    if (!validVersionId(versionId)) throw new Error("invalid report version id");
+    return join(this.dir(caseId), `${versionId}.json`);
+  }
+
+  async load(caseId: string, versionId: string, createdBy?: ReportActor): Promise<ReportWorkflow> {
+    try {
+      return workflowSchema.parse(JSON.parse(await readFile(this.path(caseId, versionId), "utf8")));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return defaultWorkflow(
+          versionId,
+          createdBy ?? { id: "solo", displayName: "Solo investigator", kind: "solo" },
+        );
+      }
+      throw err;
+    }
+  }
+
+  private async save(caseId: string, workflow: ReportWorkflow): Promise<ReportWorkflow> {
+    const validated = workflowSchema.parse(workflow);
+    await mkdir(this.dir(caseId), { recursive: true });
+    await atomicWrite(this.path(caseId, workflow.versionId), JSON.stringify(validated, null, 2));
+    return validated;
+  }
+
+  private mutate(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    change: (workflow: ReportWorkflow) => ReportWorkflow,
+  ): Promise<ReportWorkflow> {
+    return this.lock.runExclusive(caseId, async () => {
+      const current = await this.load(caseId, versionId, actor);
+      return this.save(caseId, change(current));
+    });
+  }
+
+  submit(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    reviewer: ReportActor,
+  ): Promise<ReportWorkflow> {
+    return this.mutate(caseId, versionId, actor, (current) => {
+      requireStatus(current, "draft");
+      if (reviewer.kind === "service") throw new Error("a service identity cannot review a report");
+      if (actor.id === reviewer.id) throw new Error("the reviewer must be a different person");
+      const at = new Date().toISOString();
+      return {
+        ...current,
+        status: "peer-review",
+        assignedReviewer: reviewer,
+        history: [
+          ...current.history,
+          event("submitted-for-review", actor, at, `assigned reviewer ${reviewer.displayName}`),
+        ],
+      };
+    });
+  }
+
+  addAnnotation(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    input: ReportAnnotationInput,
+  ): Promise<ReportWorkflow> {
+    const annotation = reportAnnotationInputSchema.parse(input);
+    return this.mutate(caseId, versionId, actor, (current) => {
+      requireStatus(current, "peer-review");
+      requireAssignedReviewer(current, actor);
+      if (actor.kind === "service") throw new Error("a service identity cannot review a report");
+      const at = new Date().toISOString();
+      return {
+        ...current,
+        annotations: [
+          ...current.annotations,
+          {
+            ...annotation,
+            id: randomUUID(),
+            authorId: actor.id,
+            authorDisplayName: actor.displayName,
+            createdAt: at,
+          },
+        ],
+        history: [
+          ...current.history,
+          event("annotation-added", actor, at, `${annotation.targetType}:${annotation.targetId}`),
+        ],
+      };
+    });
+  }
+
+  resolveAnnotation(
+    caseId: string,
+    versionId: string,
+    annotationId: string,
+    actor: ReportActor,
+    resolution: string,
+  ): Promise<ReportWorkflow> {
+    const cleanResolution = cleanNote(resolution, "resolution");
+    return this.mutate(caseId, versionId, actor, (current) => {
+      if (current.status === "approved" || current.status === "released") {
+        throw new Error("approved or released review records cannot be changed");
+      }
+      const target = current.annotations.find((item) => item.id === annotationId);
+      if (!target) throw new Error("annotation not found");
+      if (target.resolvedAt) throw new Error("annotation is already resolved");
+      const at = new Date().toISOString();
+      return {
+        ...current,
+        annotations: current.annotations.map((item) =>
+          item.id === annotationId
+            ? {
+                ...item,
+                resolvedAt: at,
+                resolvedById: actor.id,
+                resolvedByDisplayName: actor.displayName,
+                resolution: cleanResolution,
+              }
+            : item,
+        ),
+        history: [
+          ...current.history,
+          event("annotation-resolved", actor, at, `${target.targetType}:${target.targetId}`),
+        ],
+      };
+    });
+  }
+
+  requestChanges(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    reason: string,
+  ): Promise<ReportWorkflow> {
+    const detail = cleanNote(reason, "reason");
+    return this.mutate(caseId, versionId, actor, (current) => {
+      requireStatus(current, "peer-review");
+      requireAssignedReviewer(current, actor);
+      if (actor.kind === "service") throw new Error("a service identity cannot review a report");
+      const at = new Date().toISOString();
+      return {
+        ...current,
+        status: "draft",
+        history: [...current.history, event("changes-requested", actor, at, detail)],
+      };
+    });
+  }
+
+  approve(caseId: string, versionId: string, actor: ReportActor, note: string): Promise<ReportWorkflow> {
+    const clean = cleanNote(note, "approval note");
+    return this.mutate(caseId, versionId, actor, (current) => {
+      requireStatus(current, "peer-review");
+      requireAssignedReviewer(current, actor);
+      if (actor.kind === "service") throw new Error("a service identity cannot approve a report");
+      const unresolved = current.annotations.filter(
+        (item) => item.category === "uncertainty" && item.impact === "high" && !item.resolvedAt,
+      );
+      if (unresolved.length > 0) throw new Error("unresolved high-impact uncertainty blocks approval");
+      const at = new Date().toISOString();
+      return {
+        ...current,
+        status: "approved",
+        approvals: [
+          ...current.approvals,
+          {
+            actorId: actor.id,
+            actorDisplayName: actor.displayName,
+            actorKind: actor.kind,
+            at,
+            independent: actor.id !== current.createdBy.id,
+            note: clean,
+          },
+        ],
+        history: [...current.history, event("approved", actor, at, clean)],
+      };
+    });
+  }
+
+  selfApprove(caseId: string, versionId: string, actor: ReportActor, note: string): Promise<ReportWorkflow> {
+    const clean = cleanNote(note, "self-review note");
+    return this.mutate(caseId, versionId, actor, (current) => {
+      requireStatus(current, "draft");
+      if (actor.kind === "service") throw new Error("a service identity cannot approve a report");
+      const at = new Date().toISOString();
+      return {
+        ...current,
+        status: "approved",
+        approvals: [
+          ...current.approvals,
+          {
+            actorId: actor.id,
+            actorDisplayName: actor.displayName,
+            actorKind: actor.kind,
+            at,
+            independent: false,
+            note: clean,
+          },
+        ],
+        history: [...current.history, event("self-approved", actor, at, clean)],
+      };
+    });
+  }
+
+  markReleased(
+    caseId: string,
+    versionId: string,
+    actor: ReportActor,
+    releaseId: string,
+  ): Promise<ReportWorkflow> {
+    return this.mutate(caseId, versionId, actor, (current) => {
+      requireStatus(current, "approved");
+      if (actor.kind === "service") throw new Error("a service identity cannot release a report");
+      const at = new Date().toISOString();
+      return {
+        ...current,
+        status: "released",
+        releaseId,
+        history: [...current.history, event("released", actor, at, releaseId)],
+      };
+    });
+  }
+}

--- a/companion/src/reports/reportWorkflowTypes.ts
+++ b/companion/src/reports/reportWorkflowTypes.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+export const REPORT_WORKFLOW_STATUSES = ["draft", "peer-review", "approved", "released"] as const;
+export type ReportWorkflowStatus = (typeof REPORT_WORKFLOW_STATUSES)[number];
+
+export const reportActorSchema = z.object({
+  id: z.string().min(1).max(200),
+  displayName: z.string().min(1).max(200),
+  kind: z.enum(["local", "oidc", "service", "solo"]),
+});
+export type ReportActor = z.infer<typeof reportActorSchema>;
+
+export const REPORT_ANNOTATION_TARGETS = ["claim", "finding", "evidence"] as const;
+export const REPORT_ANNOTATION_CATEGORIES = ["comment", "uncertainty"] as const;
+export const REPORT_ANNOTATION_IMPACTS = ["low", "medium", "high"] as const;
+
+export const reportAnnotationInputSchema = z.object({
+  targetType: z.enum(REPORT_ANNOTATION_TARGETS),
+  targetId: z.string().trim().min(1).max(240),
+  category: z.enum(REPORT_ANNOTATION_CATEGORIES),
+  impact: z.enum(REPORT_ANNOTATION_IMPACTS),
+  message: z.string().trim().min(1).max(4_000),
+});
+export type ReportAnnotationInput = z.infer<typeof reportAnnotationInputSchema>;
+
+export interface ReportAnnotation extends ReportAnnotationInput {
+  id: string;
+  authorId: string;
+  authorDisplayName: string;
+  createdAt: string;
+  resolvedAt?: string;
+  resolvedById?: string;
+  resolvedByDisplayName?: string;
+  resolution?: string;
+}
+
+export interface ReportApproval {
+  actorId: string;
+  actorDisplayName: string;
+  actorKind: ReportActor["kind"];
+  at: string;
+  independent: boolean;
+  note: string;
+}
+
+export const REPORT_WORKFLOW_ACTIONS = [
+  "created",
+  "submitted-for-review",
+  "annotation-added",
+  "annotation-resolved",
+  "changes-requested",
+  "self-approved",
+  "approved",
+  "released",
+] as const;
+export type ReportWorkflowAction = (typeof REPORT_WORKFLOW_ACTIONS)[number];
+
+export interface ReportWorkflowEvent {
+  at: string;
+  action: ReportWorkflowAction;
+  actorId: string;
+  actorDisplayName: string;
+  detail: string;
+}
+
+export interface ReportWorkflow {
+  versionId: string;
+  status: ReportWorkflowStatus;
+  createdBy: ReportActor;
+  assignedReviewer?: ReportActor;
+  annotations: ReportAnnotation[];
+  approvals: ReportApproval[];
+  history: ReportWorkflowEvent[];
+  releaseId?: string;
+}

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -640,7 +640,8 @@ export class ReportWriter {
         await this.reportVersions.snapshot(caseId, {
           markdown: c.markdown,
           meta,
-          state: { findings: state.findings, iocs: state.iocs, forensicTimeline: state.forensicTimeline },
+          state: { findings: state.findings, iocs: state.iocs, forensicTimeline: state.forensicTimeline, uncertainties: state.uncertainties },
+          template,
           analysisRunIds: [
             ...sourceRuns.map((run) => run.id),
             ...(reportRunId ? [reportRunId] : []),

--- a/companion/src/routes/reportVersions.ts
+++ b/companion/src/routes/reportVersions.ts
@@ -1,8 +1,90 @@
 import type { Express, Request, Response } from "express";
+import { z } from "zod";
+import { logActivity } from "../analysis/activityLog.js";
 import { diffFindings } from "../analysis/findingsDiff.js";
 import { diffIocs } from "../analysis/iocsDiff.js";
 import { diffTimeline } from "../analysis/timelineDiff.js";
+import { requestAuthentication } from "../auth/types.js";
+import { REPORT_PACK_TYPES } from "../reports/reportReleaseStore.js";
+import {
+  reportActorSchema,
+  reportAnnotationInputSchema,
+  type ReportActor,
+} from "../reports/reportWorkflowTypes.js";
 import type { RouteContext } from "./context.js";
+
+const noteSchema = z.object({ note: z.string().trim().min(1).max(4_000) });
+const reasonSchema = z.object({ reason: z.string().trim().min(1).max(4_000) });
+const resolveSchema = z.object({ resolution: z.string().trim().min(1).max(4_000) });
+const submitSchema = z.object({ reviewerId: z.string().trim().min(1).max(200) });
+const releaseSchema = z.object({
+  supersedesReleaseId: z.string().trim().min(1).max(200).optional(),
+});
+
+function requestActor(req: Request, ctx: RouteContext): ReportActor | null {
+  if (!ctx.options.teamAuth) {
+    return { id: "solo", displayName: "Solo investigator", kind: "solo" };
+  }
+  const auth = requestAuthentication(req);
+  if (auth?.kind !== "session" || auth.identity.kind === "service") return null;
+  return reportActorSchema.parse({
+    id: auth.identity.id,
+    displayName: auth.identity.displayName,
+    kind: auth.identity.kind,
+  });
+}
+
+function workflowError(res: Response, err: unknown): Response {
+  if (err instanceof z.ZodError) return res.status(400).json({ error: "invalid request body" });
+  const message = err instanceof Error ? err.message : "report workflow failed";
+  if (message.includes("not found")) return res.status(404).json({ error: message });
+  if (
+    message.includes("current status") ||
+    message.includes("blocked") ||
+    message.includes("already") ||
+    message.includes("supersede")
+  ) {
+    return res.status(409).json({ error: message });
+  }
+  return res.status(400).json({ error: message });
+}
+
+function auditWorkflow(
+  req: Request,
+  ctx: RouteContext,
+  caseId: string,
+  action: string,
+  targetId: string,
+  detail: string,
+): void {
+  const auth = requestAuthentication(req);
+  if (auth?.kind === "session") {
+    ctx.options.teamAuth?.store.addAudit(auth.identity, action, targetId, caseId, detail);
+  }
+  void logActivity(ctx.options.activityLogStore, ctx.options.onActivity, caseId, {
+    category: action === "report-released" ? "export" : "collaboration",
+    action,
+    detail,
+    targetType: "report-version",
+    targetId,
+  });
+}
+
+function reviewerActor(ctx: RouteContext, caseId: string, reviewerId: string): ReportActor | null {
+  const auth = ctx.options.teamAuth;
+  if (!auth) return null;
+  const identity = auth.store.getIdentity(reviewerId);
+  if (!identity || identity.disabled || identity.kind === "service") return null;
+  const role = auth.store.getCaseRole(identity.id, caseId);
+  if (
+    identity.globalRole !== "administrator" &&
+    role !== "reviewer" &&
+    role !== "administrator"
+  ) {
+    return null;
+  }
+  return { id: identity.id, displayName: identity.displayName, kind: identity.kind };
+}
 
 /**
  * Report versioning (#77): list the version snapshots a case has accumulated (one per report
@@ -20,7 +102,14 @@ export function registerReportVersionsRoutes(app: Express, ctx: RouteContext): v
   app.get("/cases/:id/report-versions", async (req: Request, res: Response) => {
     if (!options.reportVersionStore) return res.status(501).json({ error: "report versioning not configured" });
     try {
-      return res.status(200).json(await options.reportVersionStore.list(req.params.id));
+      const versions = await options.reportVersionStore.list(req.params.id);
+      const withWorkflow = await Promise.all(
+        versions.map(async (version) => ({
+          ...version,
+          workflow: await options.reportVersionStore!.workflow(req.params.id, version.id),
+        })),
+      );
+      return res.status(200).json(withWorkflow);
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -71,4 +160,382 @@ export function registerReportVersionsRoutes(app: Express, ctx: RouteContext): v
       return res.status(500).json({ error: (err as Error).message });
     }
   });
+
+  app.get("/cases/:id/report-reviewers", (req: Request, res: Response) => {
+    if (!options.teamAuth) return res.status(200).json({ mode: "solo", reviewers: [] });
+    const reviewers = options.teamAuth.store
+      .listCaseRoles(req.params.id)
+      .filter((entry) => entry.role === "reviewer" || entry.role === "administrator")
+      .filter((entry) => !entry.identity.disabled && entry.identity.kind !== "service")
+      .map((entry) => ({
+        id: entry.identity.id,
+        displayName: entry.identity.displayName,
+        kind: entry.identity.kind,
+        role: entry.role,
+      }));
+    return res.status(200).json({ mode: "team", reviewers });
+  });
+
+  app.get(
+    "/cases/:id/report-versions/:versionId/workflow",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      try {
+        const workflow = await options.reportVersionStore.workflow(
+          req.params.id,
+          req.params.versionId,
+        );
+        if (!workflow) return res.status(404).json({ error: "report version not found" });
+        return res.status(200).json({
+          ...workflow,
+          reviewMode: options.teamAuth ? "team" : "solo",
+        });
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.post(
+    "/cases/:id/report-versions/:versionId/workflow/submit",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      if (!options.teamAuth) {
+        return res.status(409).json({ error: "peer review requires team authentication" });
+      }
+      const actor = requestActor(req, ctx);
+      if (!actor) return res.status(403).json({ error: "a signed-in person must submit the report" });
+      try {
+        const { reviewerId } = submitSchema.parse(req.body as unknown);
+        const reviewer = reviewerActor(ctx, req.params.id, reviewerId);
+        if (!reviewer) {
+          return res.status(400).json({ error: "reviewer is not an eligible case reviewer" });
+        }
+        const workflow = await options.reportVersionStore.submitForReview(
+          req.params.id,
+          req.params.versionId,
+          actor,
+          reviewer,
+        );
+        auditWorkflow(
+          req,
+          ctx,
+          req.params.id,
+          "report-submitted-for-review",
+          req.params.versionId,
+          `assigned ${reviewer.displayName}`,
+        );
+        return res.status(200).json(workflow);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.post(
+    "/cases/:id/report-versions/:versionId/review/annotations",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      const actor = requestActor(req, ctx);
+      if (!actor) return res.status(403).json({ error: "a signed-in reviewer is required" });
+      try {
+        const input = reportAnnotationInputSchema.parse(req.body as unknown);
+        const workflow = await options.reportVersionStore.addReviewAnnotation(
+          req.params.id,
+          req.params.versionId,
+          actor,
+          input,
+        );
+        auditWorkflow(
+          req,
+          ctx,
+          req.params.id,
+          "report-review-annotation-added",
+          req.params.versionId,
+          `${input.targetType}:${input.targetId}`,
+        );
+        return res.status(201).json(workflow);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.post(
+    "/cases/:id/report-versions/:versionId/workflow/annotations/:annotationId/resolve",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      const actor = requestActor(req, ctx);
+      if (!actor) return res.status(403).json({ error: "a signed-in investigator is required" });
+      try {
+        const { resolution } = resolveSchema.parse(req.body as unknown);
+        const workflow = await options.reportVersionStore.resolveReviewAnnotation(
+          req.params.id,
+          req.params.versionId,
+          req.params.annotationId,
+          actor,
+          resolution,
+        );
+        auditWorkflow(
+          req,
+          ctx,
+          req.params.id,
+          "report-review-annotation-resolved",
+          req.params.versionId,
+          req.params.annotationId,
+        );
+        return res.status(200).json(workflow);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.post(
+    "/cases/:id/report-versions/:versionId/review/request-changes",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      const actor = requestActor(req, ctx);
+      if (!actor) return res.status(403).json({ error: "a signed-in reviewer is required" });
+      try {
+        const { reason } = reasonSchema.parse(req.body as unknown);
+        const workflow = await options.reportVersionStore.requestReportChanges(
+          req.params.id,
+          req.params.versionId,
+          actor,
+          reason,
+        );
+        auditWorkflow(
+          req,
+          ctx,
+          req.params.id,
+          "report-changes-requested",
+          req.params.versionId,
+          reason,
+        );
+        return res.status(200).json(workflow);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.post(
+    "/cases/:id/report-versions/:versionId/review/approve",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      const actor = requestActor(req, ctx);
+      if (!actor) return res.status(403).json({ error: "a signed-in reviewer is required" });
+      try {
+        const { note } = noteSchema.parse(req.body as unknown);
+        const workflow = await options.reportVersionStore.approve(
+          req.params.id,
+          req.params.versionId,
+          actor,
+          note,
+        );
+        auditWorkflow(
+          req,
+          ctx,
+          req.params.id,
+          "report-approved",
+          req.params.versionId,
+          note,
+        );
+        return res.status(200).json(workflow);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.post(
+    "/cases/:id/report-versions/:versionId/workflow/self-approve",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      if (options.teamAuth) {
+        return res.status(409).json({ error: "team mode requires independent peer review" });
+      }
+      const actor = requestActor(req, ctx)!;
+      try {
+        const { note } = noteSchema.parse(req.body as unknown);
+        const workflow = await options.reportVersionStore.selfApprove(
+          req.params.id,
+          req.params.versionId,
+          actor,
+          note,
+        );
+        auditWorkflow(
+          req,
+          ctx,
+          req.params.id,
+          "report-self-reviewed",
+          req.params.versionId,
+          note,
+        );
+        return res.status(200).json(workflow);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.post(
+    "/cases/:id/report-versions/:versionId/workflow/release",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      if (!options.analysisRunStore || !options.custodyStore) {
+        return res.status(501).json({ error: "release integrity services are not configured" });
+      }
+      const actor = requestActor(req, ctx);
+      if (!actor) return res.status(403).json({ error: "a signed-in investigator is required" });
+      try {
+        const body = releaseSchema.parse(req.body as unknown);
+        const version = await options.reportVersionStore.get(req.params.id, req.params.versionId);
+        if (!version) return res.status(404).json({ error: "report version not found" });
+        const runIds = version.analysisRunIds ?? [];
+        const runs = (
+          await Promise.all(runIds.map((id) => options.analysisRunStore!.get(req.params.id, id)))
+        ).filter((run): run is NonNullable<typeof run> => run !== null);
+        const [analysisIntegrity, head, chainBreaks, mismatches] = await Promise.all([
+          options.analysisRunStore.verify(req.params.id),
+          options.custodyStore.chainHead(req.params.id),
+          options.custodyStore.verifyChain(req.params.id),
+          options.custodyStore.verifyIntegrity(req.params.id),
+        ]);
+        const release = await options.reportVersionStore.release(
+          req.params.id,
+          req.params.versionId,
+          {
+            actor,
+            ...body,
+            analysisRuns: runs,
+            analysisIntegrity,
+            custody: { head, chainBreaks, mismatches },
+          },
+        );
+        auditWorkflow(
+          req,
+          ctx,
+          req.params.id,
+          "report-released",
+          req.params.versionId,
+          `${release.id} · ${release.manifestHash}`,
+        );
+        return res.status(201).json(release);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
+
+  app.get("/cases/:id/report-releases", async (req: Request, res: Response) => {
+    if (!options.reportVersionStore) {
+      return res.status(501).json({ error: "report versioning not configured" });
+    }
+    try {
+      return res.status(200).json(await options.reportVersionStore.listReleases(req.params.id));
+    } catch (err) {
+      return workflowError(res, err);
+    }
+  });
+
+  app.get("/cases/:id/report-releases/integrity", async (req: Request, res: Response) => {
+    if (!options.reportVersionStore) {
+      return res.status(501).json({ error: "report versioning not configured" });
+    }
+    return res.status(200).json(await options.reportVersionStore.verifyReleases(req.params.id));
+  });
+
+  app.get("/cases/:id/report-releases/diff", async (req: Request, res: Response) => {
+    if (!options.reportVersionStore) {
+      return res.status(501).json({ error: "report versioning not configured" });
+    }
+    const fromId = typeof req.query.from === "string" ? req.query.from : "";
+    const toId = typeof req.query.to === "string" ? req.query.to : "";
+    if (!fromId || !toId) return res.status(400).json({ error: "from and to are required" });
+    try {
+      const [from, to] = await Promise.all([
+        options.reportVersionStore.getRelease(req.params.id, fromId),
+        options.reportVersionStore.getRelease(req.params.id, toId),
+      ]);
+      if (!from || !to) return res.status(404).json({ error: "release not found" });
+      return res.status(200).json({
+        from: { id: from.id, releasedAt: from.releasedAt, version: from.reportVersion },
+        to: { id: to.id, releasedAt: to.releasedAt, version: to.reportVersion },
+        findings: diffFindings(from.snapshot.state.findings, to.snapshot.state.findings),
+        iocs: diffIocs(from.snapshot.state.iocs, to.snapshot.state.iocs),
+        timeline: diffTimeline(
+          from.snapshot.state.forensicTimeline,
+          to.snapshot.state.forensicTimeline,
+        ),
+      });
+    } catch (err) {
+      return workflowError(res, err);
+    }
+  });
+
+  app.get("/cases/:id/report-releases/:releaseId", async (req: Request, res: Response) => {
+    if (!options.reportVersionStore) {
+      return res.status(501).json({ error: "report versioning not configured" });
+    }
+    try {
+      const release = await options.reportVersionStore.getRelease(
+        req.params.id,
+        req.params.releaseId,
+      );
+      return release
+        ? res.status(200).json(release)
+        : res.status(404).json({ error: "release not found" });
+    } catch (err) {
+      return workflowError(res, err);
+    }
+  });
+
+  app.get(
+    "/cases/:id/report-releases/:releaseId/packs/:pack",
+    async (req: Request, res: Response) => {
+      if (!options.reportVersionStore) {
+        return res.status(501).json({ error: "report versioning not configured" });
+      }
+      const pack = req.params.pack;
+      if (!(REPORT_PACK_TYPES as readonly string[]).includes(pack)) {
+        return res.status(400).json({ error: "unknown release pack" });
+      }
+      try {
+        const release = await options.reportVersionStore.getRelease(
+          req.params.id,
+          req.params.releaseId,
+        );
+        if (!release) return res.status(404).json({ error: "release not found" });
+        const typedPack = pack as (typeof REPORT_PACK_TYPES)[number];
+        const extension = typedPack === "ioc" ? "csv" : "md";
+        res.type(typedPack === "ioc" ? "text/csv; charset=utf-8" : "text/markdown; charset=utf-8");
+        res.setHeader(
+          "Content-Disposition",
+          `attachment; filename="${typedPack}-${release.id}.${extension}"`,
+        );
+        res.setHeader("Cache-Control", "private, no-cache");
+        return res.send(release.packs[typedPack]);
+      } catch (err) {
+        return workflowError(res, err);
+      }
+    },
+  );
 }

--- a/companion/tests/http/teamAuth.test.ts
+++ b/companion/tests/http/teamAuth.test.ts
@@ -4,12 +4,17 @@ import { join } from "node:path";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+import { AnalysisRunStore } from "../../src/analysis/analysisRunStore.js";
 import { CommentsStore } from "../../src/analysis/comments.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
 import { JobManager } from "../../src/analysis/jobManager.js";
 import { StateLock } from "../../src/analysis/stateLock.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { AuthStore } from "../../src/auth/authStore.js";
 import { TeamAuth } from "../../src/auth/teamAuth.js";
+import { ReportMetaStore } from "../../src/reports/reportMeta.js";
+import { ReportVersionStore } from "../../src/reports/reportVersionStore.js";
+import { ReportWriter } from "../../src/reports/reportWriter.js";
 import { createApp } from "../../src/server.js";
 import { CaseStore } from "../../src/storage/caseStore.js";
 
@@ -221,6 +226,89 @@ describe("optional team authentication", () => {
     expect(entry.actorId).toBe(admin.identityId);
     expect(entry.actorDisplayName).toBe("Primary Admin");
     expect(entry.actor).toBe("Primary Admin");
+  });
+
+  it("enforces investigator/reviewer separation through report approval and release", async () => {
+    const stateStore = new StateStore(cases);
+    const reportMetaStore = new ReportMetaStore(cases);
+    const reportVersionStore = new ReportVersionStore(cases);
+    const analysisRunStore = new AnalysisRunStore(cases, { appVersion: "test" });
+    const custodyStore = new CustodyStore(cases);
+    const reportWriter = new ReportWriter(cases, stateStore, {
+      reportMeta: reportMetaStore,
+      reportVersions: reportVersionStore,
+      analysisRuns: analysisRunStore,
+    });
+    app = createApp(cases, {
+      teamAuth: auth,
+      stateStore,
+      reportMetaStore,
+      reportVersionStore,
+      analysisRunStore,
+      custodyStore,
+      reportWriter,
+    });
+    const admin = await bootstrap();
+    await admin.agent.post("/cases").set("X-DFIR-CSRF", admin.csrf).send({ caseId: "c1", name: "Case" });
+    const investigatorId = await createLocalUser(admin, "investigator");
+    const reviewerId = await createLocalUser(admin, "reviewer");
+    for (const [identityId, role] of [
+      [investigatorId, "investigator"],
+      [reviewerId, "reviewer"],
+    ]) {
+      expect(
+        (
+          await admin.agent
+            .put(`/auth/cases/c1/roles/${encodeURIComponent(identityId)}`)
+            .set("X-DFIR-CSRF", admin.csrf)
+            .send({ role })
+        ).status,
+      ).toBe(200);
+    }
+    const investigator = await login("investigator");
+    const reviewer = await login("reviewer");
+
+    expect(
+      (await investigator.agent.post("/cases/c1/report").set("X-DFIR-CSRF", investigator.csrf)).status,
+    ).toBe(200);
+    const version = (await investigator.agent.get("/cases/c1/report-versions")).body[0];
+    const submitted = await investigator.agent
+      .post(`/cases/c1/report-versions/${version.id}/workflow/submit`)
+      .set("X-DFIR-CSRF", investigator.csrf)
+      .send({ reviewerId });
+    expect(submitted.status).toBe(200);
+    expect(submitted.body.assignedReviewer.id).toBe(reviewerId);
+    expect(
+      (
+        await investigator.agent
+          .post(`/cases/c1/report-versions/${version.id}/review/approve`)
+          .set("X-DFIR-CSRF", investigator.csrf)
+          .send({ note: "self approval" })
+      ).status,
+    ).toBe(403);
+
+    const approved = await reviewer.agent
+      .post(`/cases/c1/report-versions/${version.id}/review/approve`)
+      .set("X-DFIR-CSRF", reviewer.csrf)
+      .send({ note: "Evidence and limitations checked" });
+    expect(approved.status).toBe(200);
+    expect(approved.body.approvals[0]).toMatchObject({ actorId: reviewerId, independent: true });
+    expect(
+      (
+        await reviewer.agent
+          .post(`/cases/c1/report-versions/${version.id}/workflow/release`)
+          .set("X-DFIR-CSRF", reviewer.csrf)
+          .send({})
+      ).status,
+    ).toBe(403);
+    expect(
+      (
+        await investigator.agent
+          .post(`/cases/c1/report-versions/${version.id}/workflow/release`)
+          .set("X-DFIR-CSRF", investigator.csrf)
+          .send({})
+      ).status,
+    ).toBe(201);
   });
 
   it("issues case-scoped service tokens that cannot cross case boundaries", async () => {

--- a/companion/tests/http/teamAuthPolicy.test.ts
+++ b/companion/tests/http/teamAuthPolicy.test.ts
@@ -44,6 +44,14 @@ describe("team-auth configuration and policy", () => {
       permission: "review",
       caseId: "c1",
     });
+    expect(resolveRequestPolicy("POST", "/cases/c1/report-versions/v1/review/approve")).toMatchObject({
+      permission: "review",
+      caseId: "c1",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/c1/report-versions/v1/workflow/release")).toMatchObject({
+      permission: "write",
+      caseId: "c1",
+    });
     expect(resolveRequestPolicy("GET", "/cases/c1/report.docx")).toMatchObject({
       permission: "export",
       caseId: "c1",

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -132,6 +132,22 @@ describe("dashboard.html", () => {
     expect(html).toContain("/report/report.md?download=1");
   });
 
+  it("controls review, approval, immutable release, supersession and frozen report packs", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    expect(html).toContain("Self-review &amp; approve");
+    expect(html).toContain("Submit");
+    expect(html).toContain("Request changes");
+    expect(html).toContain("Release frozen snapshot");
+    expect(html).toContain("Released-report chain intact");
+    expect(html).toContain("explicitly supersedes");
+    for (const pack of ["technical", "executive", "legal", "ioc"]) {
+      expect(html).toContain(`/packs/${pack}`);
+    }
+    expect(html).toContain('id="rtRequireIndependentReview"');
+    expect(html).toContain('id="rtRequireEvidenceLinks"');
+    expect(html).toContain("requiredSections: [...rtRequiredSections]");
+  });
+
   it("offers a PDF export (print-to-PDF) via the Export menu", async () => {
     const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
     expect(html).toContain('value="report-pdf"');

--- a/companion/tests/reports/reportReleaseStore.test.ts
+++ b/companion/tests/reports/reportReleaseStore.test.ts
@@ -1,0 +1,257 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AnalysisRunManifest } from "../../src/analysis/analysisRunTypes.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+import { defaultReportTemplate } from "../../src/reports/reportTemplate.js";
+import { ReportReleaseStore } from "../../src/reports/reportReleaseStore.js";
+import { emptyReportMeta } from "../../src/reports/reportMeta.js";
+import type { ReportVersionRecord } from "../../src/reports/reportVersionStore.js";
+import type { ReportWorkflow } from "../../src/reports/reportWorkflowTypes.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+
+const actor = { id: "investigator-1", displayName: "Investigator One", kind: "local" as const };
+const HASH = "a".repeat(64);
+
+function workflow(versionId = "version-1"): ReportWorkflow {
+  return {
+    versionId,
+    status: "approved",
+    createdBy: actor,
+    assignedReviewer: undefined,
+    annotations: [],
+    approvals: [
+      {
+        actorId: actor.id,
+        actorDisplayName: actor.displayName,
+        actorKind: actor.kind,
+        at: "2026-07-31T00:00:00.000Z",
+        independent: false,
+        note: "self-review",
+      },
+    ],
+    history: [],
+  };
+}
+
+function version(markdown = "# Approved report", id = "version-1"): ReportVersionRecord {
+  const state = emptyState("c1");
+  state.forensicTimeline.push({
+    id: "e1",
+    timestamp: "2026-07-30T00:00:00.000Z",
+    severity: "High",
+    description: "Malware executed",
+    mitreTechniques: ["T1204"],
+    relatedFindingIds: ["f1"],
+    sourceScreenshots: [],
+  });
+  state.findings.push({
+    id: "f1",
+    severity: "High",
+    title: "Malware execution",
+    description: "Malware executed on the host.",
+    relatedIocs: [],
+    sourceScreenshots: [],
+    mitreTechniques: ["T1204"],
+    relatedEventIds: ["e1"],
+    firstSeen: "2026-07-30T00:00:00.000Z",
+    lastUpdated: "2026-07-30T00:00:00.000Z",
+    status: "confirmed",
+  });
+  return {
+    id,
+    createdAt: "2026-07-31T00:00:00.000Z",
+    version: id === "version-1" ? "v1" : "v2",
+    manualVersion: "",
+    contentHash: HASH,
+    findingsCount: 1,
+    iocsCount: 0,
+    eventsCount: 1,
+    analysisRunIds: ["run-1"],
+    markdown,
+    meta: emptyReportMeta(),
+    state: {
+      findings: state.findings,
+      iocs: state.iocs,
+      forensicTimeline: state.forensicTimeline,
+      uncertainties: state.uncertainties,
+    },
+    template: defaultReportTemplate(),
+  };
+}
+
+function analysisRun(): AnalysisRunManifest {
+  return {
+    id: "run-1",
+    caseId: "c1",
+    schemaVersion: 1,
+    sequence: 1,
+    kind: "report",
+    status: "completed",
+    parentRunId: null,
+    startedAt: "2026-07-31T00:00:00.000Z",
+    finishedAt: "2026-07-31T00:00:01.000Z",
+    durationMs: 1000,
+    versions: { application: "test" },
+    input: { artifacts: [], eventIds: ["e1"], entityIds: ["f1"] },
+    execution: { retries: 0, warnings: [] },
+    output: { entityIds: ["f1"], hashes: [], claims: [] },
+    previousManifestHash: null,
+    manifestHash: HASH,
+  };
+}
+
+let cases: CaseStore;
+let releases: ReportReleaseStore;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-report-release-"));
+  cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  releases = new ReportReleaseStore(cases);
+});
+
+describe("ReportReleaseStore", () => {
+  it("creates a hash-pinned immutable snapshot and four packs", async () => {
+    const released = await releases.create("c1", {
+      version: version(),
+      workflow: workflow(),
+      actor,
+      analysisRuns: [analysisRun()],
+      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      custody: {
+        head: { records: 0, headSeq: null, headHash: "" },
+        chainBreaks: [],
+        mismatches: [],
+      },
+    });
+
+    expect(released.sequence).toBe(1);
+    expect(released.manifestHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(released.snapshot.markdown).toBe("# Approved report");
+    expect(released.analysisRuns).toEqual([{ id: "run-1", manifestHash: HASH }]);
+    expect(Object.keys(released.packs).sort()).toEqual(["executive", "ioc", "legal", "technical"]);
+    expect(released.packs.ioc).toContain("id,type,value");
+    expect((await releases.verify("c1")).ok).toBe(true);
+  });
+
+  it("blocks release when a material finding has no valid evidence link", async () => {
+    const ungrounded = version();
+    ungrounded.state.findings[0] = { ...ungrounded.state.findings[0], relatedEventIds: ["missing"] };
+
+    await expect(
+      releases.create("c1", {
+        version: ungrounded,
+        workflow: workflow(),
+        actor,
+        analysisRuns: [analysisRun()],
+        analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+        custody: {
+          head: { records: 0, headSeq: null, headHash: "" },
+          chainBreaks: [],
+          mismatches: [],
+        },
+      }),
+    ).rejects.toThrow("missing evidence");
+  });
+
+  it("blocks broken custody, missing artifacts, and damaged analysis ledgers", async () => {
+    const base = {
+      version: version(),
+      workflow: workflow(),
+      actor,
+      analysisRuns: [analysisRun()],
+      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      custody: {
+        head: { records: 1, headSeq: 1, headHash: HASH },
+        chainBreaks: [{ line: 1, seq: 1, reason: "prev-hash-mismatch" as const }],
+        mismatches: [],
+      },
+    };
+    await expect(releases.create("c1", base)).rejects.toThrow("custody chain");
+    await expect(
+      releases.create("c1", {
+        ...base,
+        custody: {
+          ...base.custody,
+          chainBreaks: [],
+          mismatches: [
+            {
+              artifactPath: "/missing/image.E01",
+              recordedSha256: HASH,
+              actualSha256: null,
+              reason: "missing" as const,
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow("missing artifact");
+    await expect(
+      releases.create("c1", {
+        ...base,
+        analysisIntegrity: { ok: false, manifests: 1, problems: ["head mismatch"] },
+        custody: { ...base.custody, chainBreaks: [] },
+      }),
+    ).rejects.toThrow("analysis run ledger");
+  });
+
+  it("requires explicit supersession and preserves the prior release", async () => {
+    const common = {
+      actor,
+      analysisRuns: [analysisRun()],
+      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      custody: {
+        head: { records: 0, headSeq: null, headHash: "" },
+        chainBreaks: [],
+        mismatches: [],
+      },
+    };
+    const first = await releases.create("c1", { ...common, version: version(), workflow: workflow() });
+    const secondVersion = version("# Corrected report", "version-2");
+
+    await expect(
+      releases.create("c1", {
+        ...common,
+        version: secondVersion,
+        workflow: workflow("version-2"),
+      }),
+    ).rejects.toThrow("supersede");
+
+    const second = await releases.create("c1", {
+      ...common,
+      version: secondVersion,
+      workflow: workflow("version-2"),
+      supersedesReleaseId: first.id,
+    });
+    expect(second.supersedesReleaseId).toBe(first.id);
+    expect((await releases.get("c1", first.id))?.snapshot.markdown).toBe("# Approved report");
+    expect(await releases.list("c1")).toEqual([
+      expect.objectContaining({ id: second.id, supersedesReleaseId: first.id }),
+      expect.objectContaining({ id: first.id }),
+    ]);
+  });
+
+  it("detects post-release snapshot tampering", async () => {
+    const released = await releases.create("c1", {
+      version: version(),
+      workflow: workflow(),
+      actor,
+      analysisRuns: [analysisRun()],
+      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      custody: {
+        head: { records: 0, headSeq: null, headHash: "" },
+        chainBreaks: [],
+        mismatches: [],
+      },
+    });
+    const path = join(cases.stateDir("c1"), "report-releases", `${released.id}.json`);
+    const altered = { ...released, snapshot: { ...released.snapshot, markdown: "tampered" } };
+    await writeFile(path, JSON.stringify(altered), "utf8");
+
+    expect(await releases.verify("c1")).toMatchObject({
+      ok: false,
+      problems: [expect.stringContaining("manifest hash mismatch")],
+    });
+  });
+});

--- a/companion/tests/reports/reportTemplate.test.ts
+++ b/companion/tests/reports/reportTemplate.test.ts
@@ -72,6 +72,11 @@ describe("normalizeReportTemplate", () => {
     expect(t.showLogo).toBe(true);
     expect(t.showCompanyName).toBe(true);
     expect(t.sections.length).toBe(ALL_SECTION_KEYS.length);
+    expect(t.releaseRequirements).toEqual({
+      requiredSections: [],
+      requireIndependentReview: false,
+      requireEvidenceLinks: false,
+    });
   });
 
   it("normalizes a malformed payload instead of throwing", () => {
@@ -80,6 +85,21 @@ describe("normalizeReportTemplate", () => {
     expect(t.accentColor).toBe(DEFAULT_ACCENT);
     expect(t.sections.length).toBe(ALL_SECTION_KEYS.length);
     expect(t.showLogo).toBe(true); // lenient .catch → default
+  });
+
+  it("normalizes release requirements and drops unknown required sections", () => {
+    const t = normalizeReportTemplate({
+      releaseRequirements: {
+        requiredSections: ["investigation", "bogus", "investigation"],
+        requireIndependentReview: true,
+        requireEvidenceLinks: true,
+      },
+    });
+    expect(t.releaseRequirements).toEqual({
+      requiredSections: ["investigation"],
+      requireIndependentReview: true,
+      requireEvidenceLinks: true,
+    });
   });
 });
 

--- a/companion/tests/reports/reportWorkflowStore.test.ts
+++ b/companion/tests/reports/reportWorkflowStore.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ReportWorkflowStore } from "../../src/reports/reportWorkflowStore.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+
+const investigator = {
+  id: "investigator-1",
+  displayName: "Investigator One",
+  kind: "local" as const,
+};
+const reviewer = {
+  id: "reviewer-1",
+  displayName: "Reviewer One",
+  kind: "oidc" as const,
+};
+
+let workflows: ReportWorkflowStore;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-report-workflow-"));
+  const cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  workflows = new ReportWorkflowStore(cases);
+});
+
+describe("ReportWorkflowStore", () => {
+  it("moves a report through independent review without letting the reviewer alter evidence", async () => {
+    const draft = await workflows.load("c1", "v1", investigator);
+    expect(draft.status).toBe("draft");
+
+    const inReview = await workflows.submit("c1", "v1", investigator, reviewer);
+    expect(inReview.status).toBe("peer-review");
+    expect(inReview.assignedReviewer).toEqual(reviewer);
+
+    const annotated = await workflows.addAnnotation("c1", "v1", reviewer, {
+      targetType: "finding",
+      targetId: "f1",
+      category: "uncertainty",
+      impact: "high",
+      message: "The conclusion needs a second evidence source.",
+    });
+    expect(annotated.annotations[0]).toMatchObject({
+      targetId: "f1",
+      impact: "high",
+    });
+    expect(annotated.annotations[0]).not.toHaveProperty("resolvedAt");
+
+    await expect(workflows.approve("c1", "v1", reviewer, "checked")).rejects.toThrow(
+      "unresolved high-impact",
+    );
+    await workflows.resolveAnnotation("c1", "v1", annotated.annotations[0].id, investigator, "linked e2");
+
+    const approved = await workflows.approve("c1", "v1", reviewer, "evidence checked");
+    expect(approved.status).toBe("approved");
+    expect(approved.approvals).toEqual([
+      expect.objectContaining({ actorId: reviewer.id, independent: true }),
+    ]);
+    expect(approved.history.map((event) => event.action)).toEqual([
+      "created",
+      "submitted-for-review",
+      "annotation-added",
+      "annotation-resolved",
+      "approved",
+    ]);
+  });
+
+  it("enforces separation of duties and the assigned reviewer", async () => {
+    await expect(workflows.submit("c1", "v1", investigator, investigator)).rejects.toThrow(
+      "different person",
+    );
+    await workflows.submit("c1", "v1", investigator, reviewer);
+
+    await expect(workflows.approve("c1", "v1", investigator, "self approval")).rejects.toThrow(
+      "assigned reviewer",
+    );
+    await expect(
+      workflows.approve(
+        "c1",
+        "v1",
+        { id: "reviewer-2", displayName: "Other Reviewer", kind: "local" },
+        "approval",
+      ),
+    ).rejects.toThrow("assigned reviewer");
+  });
+
+  it("returns requested changes to draft while preserving reviewer annotations", async () => {
+    await workflows.submit("c1", "v1", investigator, reviewer);
+    await workflows.addAnnotation("c1", "v1", reviewer, {
+      targetType: "evidence",
+      targetId: "e1",
+      category: "comment",
+      impact: "medium",
+      message: "Confirm the timestamp source.",
+    });
+
+    const changed = await workflows.requestChanges("c1", "v1", reviewer, "Timestamp needs checking");
+    expect(changed.status).toBe("draft");
+    expect(changed.annotations).toHaveLength(1);
+  });
+
+  it("records solo approval as self-review rather than independent review", async () => {
+    const approved = await workflows.selfApprove("c1", "v1", investigator, "Solo case review completed");
+    expect(approved.status).toBe("approved");
+    expect(approved.approvals[0]).toMatchObject({
+      actorId: investigator.id,
+      independent: false,
+      note: "Solo case review completed",
+    });
+  });
+});

--- a/companion/tests/server/reportVersionsRoutes.test.ts
+++ b/companion/tests/server/reportVersionsRoutes.test.ts
@@ -6,25 +6,37 @@ import request from "supertest";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
+import { AnalysisRunStore } from "../../src/analysis/analysisRunStore.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
 import { ScopeStore } from "../../src/analysis/scope.js";
 import { FalsePositiveStore } from "../../src/analysis/falsePositive.js";
 import { ReportMetaStore } from "../../src/reports/reportMeta.js";
 import { ReportVersionStore } from "../../src/reports/reportVersionStore.js";
 import { ReportWriter } from "../../src/reports/reportWriter.js";
 
-async function harness() {
+async function harness(withReleaseIntegrity = false) {
   const root = await mkdtemp(join(tmpdir(), "dfir-rv-"));
   const store = new CaseStore(root);
   const stateStore = new StateStore(store);
   const reportMetaStore = new ReportMetaStore(store);
   const reportVersionStore = new ReportVersionStore(store);
+  const analysisRunStore = new AnalysisRunStore(store, { appVersion: "test" });
+  const custodyStore = new CustodyStore(store);
   const reportWriter = new ReportWriter(store, stateStore, {
     scope: new ScopeStore(store),
     falsePositives: new FalsePositiveStore(store),
     reportMeta: reportMetaStore,
     reportVersions: reportVersionStore,
+    ...(withReleaseIntegrity ? { analysisRuns: analysisRunStore } : {}),
   });
-  const app = createApp(store, { stateStore, reportWriter, reportMetaStore, reportVersionStore });
+  const app = createApp(store, {
+    stateStore,
+    reportWriter,
+    reportMetaStore,
+    reportVersionStore,
+    analysisRunStore,
+    custodyStore,
+  });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
   return { app, store };
 }
@@ -119,5 +131,74 @@ describe("report-versions routes", () => {
 
     const restore = await request(app).post(`/cases/c1/report-versions/${traversal}/restore`);
     expect(restore.status).toBe(404);
+  });
+
+  it("offers an honest solo self-review path and freezes an immutable release", async () => {
+    const { app } = await harness(true);
+    await request(app).put("/cases/c1/report-meta").send({ organization: "ExampleCorp" });
+    await request(app).post("/cases/c1/report");
+    const version = (await request(app).get("/cases/c1/report-versions")).body[0];
+    expect(version.workflow.status).toBe("draft");
+
+    const workflow = await request(app)
+      .get(`/cases/c1/report-versions/${version.id}/workflow`);
+    expect(workflow.body.reviewMode).toBe("solo");
+    expect(
+      (await request(app)
+        .post(`/cases/c1/report-versions/${version.id}/workflow/submit`)
+        .send({ reviewerId: "someone" })).status,
+    ).toBe(409);
+
+    const approved = await request(app)
+      .post(`/cases/c1/report-versions/${version.id}/workflow/self-approve`)
+      .send({ note: "Checked evidence links and limitations." });
+    expect(approved.status).toBe(200);
+    expect(approved.body.approvals[0].independent).toBe(false);
+
+    const released = await request(app)
+      .post(`/cases/c1/report-versions/${version.id}/workflow/release`)
+      .send({});
+    expect(released.status).toBe(201);
+    expect(released.body.manifestHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(released.body.snapshot.meta.organization).toBe("ExampleCorp");
+    expect((await request(app).get("/cases/c1/report-releases/integrity")).body.ok).toBe(true);
+    expect(
+      (await request(app).get(
+        `/cases/c1/report-releases/${released.body.id}/packs/technical`,
+      )).text,
+    ).toContain("ExampleCorp");
+  });
+
+  it("requires explicit supersession and leaves the prior released snapshot unchanged", async () => {
+    const { app } = await harness(true);
+    await request(app).put("/cases/c1/report-meta").send({ organization: "First version" });
+    await request(app).post("/cases/c1/report");
+    const firstVersion = (await request(app).get("/cases/c1/report-versions")).body[0];
+    await request(app)
+      .post(`/cases/c1/report-versions/${firstVersion.id}/workflow/self-approve`)
+      .send({ note: "Self-reviewed" });
+    const firstRelease = (await request(app)
+      .post(`/cases/c1/report-versions/${firstVersion.id}/workflow/release`)
+      .send({})).body;
+
+    await request(app).put("/cases/c1/report-meta").send({ organization: "Corrected version" });
+    await request(app).post("/cases/c1/report");
+    const secondVersion = (await request(app).get("/cases/c1/report-versions")).body[0];
+    await request(app)
+      .post(`/cases/c1/report-versions/${secondVersion.id}/workflow/self-approve`)
+      .send({ note: "Self-reviewed correction" });
+    expect(
+      (await request(app)
+        .post(`/cases/c1/report-versions/${secondVersion.id}/workflow/release`)
+        .send({})).status,
+    ).toBe(409);
+
+    const secondRelease = await request(app)
+      .post(`/cases/c1/report-versions/${secondVersion.id}/workflow/release`)
+      .send({ supersedesReleaseId: firstRelease.id });
+    expect(secondRelease.status).toBe(201);
+    expect(secondRelease.body.supersedesReleaseId).toBe(firstRelease.id);
+    const preserved = await request(app).get(`/cases/c1/report-releases/${firstRelease.id}`);
+    expect(preserved.body.snapshot.meta.organization).toBe("First version");
   });
 });

--- a/mkdocs-docs/reference/dashboard.md
+++ b/mkdocs-docs/reference/dashboard.md
@@ -618,6 +618,42 @@ silently rewrite which analytical history that version represents.
 
 ---
 
+## Report Review and Release
+
+Open **Export → Report versions (diff & restore)…** after generating a report. Every generated
+version starts as a **Draft** and follows one of these paths:
+
+- Team mode: **Draft → Peer review → Approved → Released**. Select a case reviewer and submit the
+  version. The assigned reviewer can attach comments or high-impact uncertainty blockers directly
+  to a finding, claim, or evidence event; request changes without editing the investigator's
+  evidence; or approve after all high-impact blockers are resolved.
+- Solo mode: **Draft → Self-reviewed approval → Released**. The sign-off is explicitly labelled
+  self-reviewed. It is never presented as independent peer review.
+
+Release preflight refuses a version when a Critical/High finding lacks a valid evidence-event link,
+an analysis run is missing or its ledger is damaged, the custody chain is broken, an artifact is
+missing or has changed, or a required template rule is unmet. A successful release freezes the
+report text, metadata, findings, IOCs, forensic events, analytical uncertainty, report template,
+analysis-run hashes, custody-chain head, sign-offs, and four recipient packs behind one SHA-256
+manifest.
+
+The released-report integrity banner verifies the append-only release chain every time the dialog
+opens. Later case edits and report regeneration cannot modify an earlier release. To release a
+correction, approve a new report version and explicitly supersede the latest release; the original
+remains available and the new release links back to it.
+
+Each release provides four downloads built from the same frozen approved evidence set:
+
+- **Executive** — concise material findings and executive summary.
+- **Technical** — the exact approved full report.
+- **Legal/insurance** — restrictions, limitations, uncertainty, and sign-off record.
+- **IOCs** — spreadsheet-safe CSV of the approved indicators.
+
+Use the existing **From / To / Diff** controls for the visual version comparison. The release diff
+and release records are also machine-readable through the case API.
+
+---
+
 ## Chain of Custody
 
 Every artifact this case has stored, with its SHA-256 and each event that touched it — the same

--- a/mkdocs-docs/reference/settings.md
+++ b/mkdocs-docs/reference/settings.md
@@ -255,7 +255,13 @@ Manage report templates:
 - Edit the default template or create new ones
 - Set: cover title, subtitle, accent colour, running header/footer, logo visibility
 - Enable/disable and reorder report sections
+- Mark sections as mandatory at release
+- Require independent peer review and/or evidence links for every non-dismissed finding
 - Assign a template per case
+
+Critical and High findings always require valid evidence-event links, regardless of template. A
+template's evidence requirement extends that gate to every non-dismissed finding. Independent review
+requires team authentication; solo self-review cannot satisfy that rule.
 
 Built-in templates: **Standard** (full technical report), **Executive** (condensed), and any you create.
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3396,12 +3396,13 @@
     <div class="comment-modal" data-safe-style="max-width:640px">
       <h3>Report versions</h3>
       <p data-safe-style="color:var(--text-muted); font-size:12px; margin:0 0 10px">
-        One snapshot per report regeneration (a re-generation with nothing changed doesn't add a new
-        entry). Diff two versions to see what changed in findings, IOCs and the timeline, or restore an
-        earlier version's editable report metadata (title page, distribution, BIA, glossary,
-        recommendations…) — restoring does not touch findings/IOCs/timeline and does not regenerate the
-        report; re-run <em>Generate report</em> afterward.</p>
-      <div id="rvList" data-safe-style="max-height:200px; overflow:auto; font-size:12px; margin-bottom:10px; border:1px solid var(--border-color); border-radius:4px; padding:6px;">loading…</div>
+        Generated versions begin as drafts. Review and approve one before release; a release freezes the
+        exact report, evidence, analysis runs and custody state so later case edits cannot alter what was
+        delivered. Solo mode records an honest self-review; team mode keeps investigator and reviewer
+        duties separate.</p>
+      <div id="rvList" data-safe-style="max-height:300px; overflow:auto; font-size:12px; margin-bottom:10px; border:1px solid var(--border-color); border-radius:4px; padding:6px;">loading…</div>
+      <div id="rvReleaseIntegrity" data-safe-style="font-size:12px; color:var(--text-muted); margin:8px 0 4px;">checking released-report integrity…</div>
+      <div id="rvReleases" data-safe-style="max-height:180px; overflow:auto; font-size:12px; margin-bottom:10px;"></div>
       <div data-safe-style="display:flex; gap:10px; align-items:center; margin-bottom:8px; flex-wrap:wrap;">
         <label data-safe-style="font-size:12px;">From <select id="rvFrom" data-safe-style="margin-left:4px;"></select></label>
         <label data-safe-style="font-size:12px;">To <select id="rvTo" data-safe-style="margin-left:4px;"></select></label>
@@ -5004,8 +5005,17 @@
         </div>
 
         <div class="sfield">
-          <label>Sections <span class="sfield-hint" data-safe-style="display:inline">— check to include · ▲▼ to reorder</span></label>
+          <label>Sections <span class="sfield-hint" data-safe-style="display:inline">— include · require before release · ▲▼ to reorder</span></label>
           <div id="rtSections" data-safe-style="max-height:230px;overflow:auto;border:1px solid #2a2f3a;border-radius:6px;padding:4px"></div>
+        </div>
+
+        <div class="sfield">
+          <label>Release requirements</label>
+          <div data-safe-style="display:flex;gap:16px;flex-wrap:wrap;font-size:12px">
+            <label class="rm-check" data-safe-style="display:flex;align-items:center;gap:6px"><input type="checkbox" id="rtRequireIndependentReview" data-safe-style="width:auto" /> Require independent peer review</label>
+            <label class="rm-check" data-safe-style="display:flex;align-items:center;gap:6px"><input type="checkbox" id="rtRequireEvidenceLinks" data-safe-style="width:auto" /> Require evidence links for every finding</label>
+          </div>
+          <span class="sfield-hint">Critical and High findings always require valid evidence links. “Require” section boxes above block release if that section is disabled.</span>
         </div>
 
         <div data-safe-style="display:flex;gap:8px;align-items:center;margin-top:6px;flex-wrap:wrap">
@@ -19627,6 +19637,61 @@
     }
     function closeReportVersions() { document.getElementById("reportVersionsOverlay").classList.remove("open"); }
 
+    let rvReviewMode = "solo";
+    let rvReviewers = [];
+    let rvReleased = [];
+
+    function rvStatusLabel(workflow) {
+      const status = workflow?.status || "draft";
+      return status === "peer-review" ? "Peer review" : status[0].toUpperCase() + status.slice(1);
+    }
+
+    function rvAnnotationRows(workflow) {
+      const annotations = workflow?.annotations || [];
+      if (!annotations.length) return "";
+      return `<div data-safe-style="margin:5px 0 0 12px;color:var(--text-muted)">${annotations.map(a => {
+        const state = a.resolvedAt ? `resolved by ${esc(a.resolvedByDisplayName || "investigator")}` : "unresolved";
+        const resolve = a.resolvedAt ? "" : ` <button data-rv-resolve="${escAttr(a.id)}" data-version="${escAttr(workflow.versionId)}" data-safe-style="font-size:10px;padding:1px 5px">Resolve</button>`;
+        return `<div>↳ ${esc(a.category)} · ${esc(a.impact)} · ${esc(a.targetType)}:${esc(a.targetId)} — ${esc(a.message)} (${state})${resolve}</div>`;
+      }).join("")}</div>`;
+    }
+
+    function rvVersionActions(version) {
+      const workflow = version.workflow || { status: "draft", annotations: [] };
+      const restore = `<button data-restore="${escAttr(version.id)}" data-safe-style="font-size:11px">Restore meta</button>`;
+      if (workflow.status === "draft" && rvReviewMode === "solo") {
+        return `${restore}<button data-rv-self-approve="${escAttr(version.id)}" data-safe-style="font-size:11px">Self-review &amp; approve</button>`;
+      }
+      if (workflow.status === "draft") {
+        const choices = rvReviewers.map(r => `<option value="${escAttr(r.id)}">${esc(r.displayName)} (${esc(r.role)})</option>`).join("");
+        return choices
+          ? `${restore}<select data-rv-reviewer="${escAttr(version.id)}" data-safe-style="font-size:11px;max-width:170px">${choices}</select><button data-rv-submit="${escAttr(version.id)}" data-safe-style="font-size:11px">Submit</button>`
+          : `${restore}<span data-safe-style="color:var(--sev-medium)">No reviewer assigned to this case</span>`;
+      }
+      if (workflow.status === "peer-review") {
+        return `${restore}<button data-rv-note="${escAttr(version.id)}" data-safe-style="font-size:11px">Add review note</button><button data-rv-changes="${escAttr(version.id)}" data-safe-style="font-size:11px">Request changes</button><button data-rv-approve="${escAttr(version.id)}" data-safe-style="font-size:11px">Approve</button>`;
+      }
+      if (workflow.status === "approved") {
+        return `${restore}<button data-rv-release="${escAttr(version.id)}" data-safe-style="font-size:11px">Release frozen snapshot</button>`;
+      }
+      const releaseId = workflow.releaseId || "";
+      return releaseId
+        ? `<a href="/cases/${encodeURIComponent(document.getElementById("caseId").value.trim())}/report-releases/${encodeURIComponent(releaseId)}/packs/technical">Technical</a> · <a href="/cases/${encodeURIComponent(document.getElementById("caseId").value.trim())}/report-releases/${encodeURIComponent(releaseId)}/packs/executive">Executive</a> · <a href="/cases/${encodeURIComponent(document.getElementById("caseId").value.trim())}/report-releases/${encodeURIComponent(releaseId)}/packs/legal">Legal/insurance</a> · <a href="/cases/${encodeURIComponent(document.getElementById("caseId").value.trim())}/report-releases/${encodeURIComponent(releaseId)}/packs/ioc">IOCs</a>`
+        : restore;
+    }
+
+    function rvWireActions() {
+      const list = document.getElementById("rvList");
+      list.querySelectorAll("[data-restore]").forEach(btn => btn.onclick = () => doRestoreReportVersion(btn.dataset.restore));
+      list.querySelectorAll("[data-rv-self-approve]").forEach(btn => btn.onclick = () => rvSelfApprove(btn.dataset.rvSelfApprove));
+      list.querySelectorAll("[data-rv-submit]").forEach(btn => btn.onclick = () => rvSubmit(btn.dataset.rvSubmit));
+      list.querySelectorAll("[data-rv-note]").forEach(btn => btn.onclick = () => rvAddNote(btn.dataset.rvNote));
+      list.querySelectorAll("[data-rv-changes]").forEach(btn => btn.onclick = () => rvRequestChanges(btn.dataset.rvChanges));
+      list.querySelectorAll("[data-rv-approve]").forEach(btn => btn.onclick = () => rvApprove(btn.dataset.rvApprove));
+      list.querySelectorAll("[data-rv-release]").forEach(btn => btn.onclick = () => rvRelease(btn.dataset.rvRelease));
+      list.querySelectorAll("[data-rv-resolve]").forEach(btn => btn.onclick = () => rvResolve(btn.dataset.version, btn.dataset.rvResolve));
+    }
+
     async function loadReportVersions() {
       const caseId = document.getElementById("caseId").value.trim();
       const list = document.getElementById("rvList");
@@ -19635,22 +19700,45 @@
       if (!caseId) { list.textContent = "no case loaded"; return; }
       list.textContent = "loading…";
       try {
-        const res = await fetch(`/cases/${encodeURIComponent(caseId)}/report-versions`);
-        const versions = await res.json();
+        const c = encodeURIComponent(caseId);
+        const [res, reviewersRes, releasesRes, integrityRes] = await Promise.all([
+          fetch(`/cases/${c}/report-versions`),
+          fetch(`/cases/${c}/report-reviewers`),
+          fetch(`/cases/${c}/report-releases`),
+          fetch(`/cases/${c}/report-releases/integrity`),
+        ]);
+        const [versions, reviewers, releases, integrity] = await Promise.all([
+          res.json(), reviewersRes.json(), releasesRes.json(), integrityRes.json(),
+        ]);
         if (!res.ok) throw new Error(versions.error || ("HTTP " + res.status));
+        if (!reviewersRes.ok) throw new Error(reviewers.error || ("HTTP " + reviewersRes.status));
+        if (!releasesRes.ok) throw new Error(releases.error || ("HTTP " + releasesRes.status));
+        rvReviewMode = reviewers.mode || "solo";
+        rvReviewers = Array.isArray(reviewers.reviewers) ? reviewers.reviewers : [];
+        rvReleased = Array.isArray(releases) ? releases : [];
+        const integrityEl = document.getElementById("rvReleaseIntegrity");
+        integrityEl.textContent = integrity.ok
+          ? `✓ Released-report chain intact — ${integrity.releases} release(s)`
+          : `⚠ Released-report integrity FAILED — ${(integrity.problems || []).join("; ")}`;
+        integrityEl.style.color = integrity.ok ? "var(--sev-low)" : "var(--badge-danger-text)";
+        const releasesEl = document.getElementById("rvReleases");
+        releasesEl.innerHTML = rvReleased.length ? rvReleased.map(r => {
+          const supersedes = r.supersedesReleaseId ? ` · supersedes ${esc(r.supersedesReleaseId)}` : "";
+          return `<div data-safe-style="padding:3px 0;border-bottom:1px solid var(--border-color)"><strong>${esc(r.id)}</strong> · ${esc(r.reportVersion)} · released ${esc(new Date(r.releasedAt).toLocaleString())} by ${esc(r.releasedBy.displayName)}${supersedes}<br><span data-safe-style="font-family:monospace;color:var(--text-muted)">SHA-256 ${esc(r.manifestHash)}</span></div>`;
+        }).join("") : `<span data-safe-style="color:var(--text-muted)">No formal releases yet.</span>`;
         if (!versions.length) {
           list.textContent = "no versions yet — generate a report to create one";
           fromSel.innerHTML = ""; toSel.innerHTML = "";
           return;
         }
         list.innerHTML = versions.map(v => `
-          <div data-safe-style="display:flex; justify-content:space-between; align-items:center; gap:8px; padding:4px 0; border-bottom:1px solid var(--border-color);">
-            <span>${esc(v.version)}${v.manualVersion ? ` (rev ${esc(v.manualVersion)})` : ""} — ${esc(new Date(v.createdAt).toLocaleString())}
-              · ${v.findingsCount} finding(s), ${v.iocsCount} IOC(s), ${v.eventsCount} event(s)</span>
-            <button data-restore="${escAttr(v.id)}" data-safe-style="font-size:11px; flex:none;">Restore meta</button>
+          <div data-safe-style="padding:6px 0; border-bottom:1px solid var(--border-color);">
+            <div data-safe-style="display:flex;justify-content:space-between;gap:8px;align-items:flex-start"><span><strong>${esc(v.version)}</strong>${v.manualVersion ? ` (rev ${esc(v.manualVersion)})` : ""} — ${esc(new Date(v.createdAt).toLocaleString())}
+              · ${v.findingsCount} finding(s), ${v.iocsCount} IOC(s), ${v.eventsCount} event(s)<br><span data-safe-style="color:var(--text-muted)">${esc(rvStatusLabel(v.workflow))}${v.workflow?.assignedReviewer ? ` · reviewer ${esc(v.workflow.assignedReviewer.displayName)}` : ""}${v.workflow?.approvals?.length ? ` · ${v.workflow.approvals.some(a => a.independent) ? "independently reviewed" : "self-reviewed"}` : ""}</span></span>
+              <span data-safe-style="display:flex;gap:5px;align-items:center;justify-content:flex-end;flex-wrap:wrap">${rvVersionActions(v)}</span></div>
+            ${rvAnnotationRows(v.workflow)}
           </div>`).join("");
-        list.querySelectorAll("[data-restore]").forEach(btn =>
-          btn.onclick = () => doRestoreReportVersion(btn.getAttribute("data-restore")));
+        rvWireActions();
         const opts = versions.map(v => `<option value="${escAttr(v.id)}">${esc(v.version)} — ${esc(new Date(v.createdAt).toLocaleString())}</option>`).join("");
         fromSel.innerHTML = opts;
         toSel.innerHTML = opts;
@@ -19659,6 +19747,73 @@
       } catch (err) {
         list.textContent = "failed to load: " + err.message;
       }
+    }
+
+    async function rvPost(versionId, suffix, body) {
+      const caseId = document.getElementById("caseId").value.trim();
+      const msg = document.getElementById("rvMsg");
+      msg.textContent = "saving…";
+      try {
+        const res = await fetch(`/cases/${encodeURIComponent(caseId)}/report-versions/${encodeURIComponent(versionId)}/${suffix}`, {
+          method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+        });
+        const result = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(result.error || ("HTTP " + res.status));
+        msg.textContent = "saved ✓";
+        await loadReportVersions();
+        return result;
+      } catch (err) {
+        msg.textContent = err.message;
+        return null;
+      }
+    }
+
+    function rvSubmit(versionId) {
+      const select = document.querySelector(`[data-rv-reviewer="${CSS.escape(versionId)}"]`);
+      if (select?.value) rvPost(versionId, "workflow/submit", { reviewerId: select.value });
+    }
+
+    function rvSelfApprove(versionId) {
+      const note = prompt("Record what you checked during self-review. This will be labelled self-reviewed, not independently peer-reviewed.");
+      if (note?.trim()) rvPost(versionId, "workflow/self-approve", { note: note.trim() });
+    }
+
+    function rvAddNote(versionId) {
+      const ref = prompt("Attach the note to a finding/claim/evidence item (for example finding:f3 or evidence:e17):");
+      const match = /^(finding|claim|evidence):(.+)$/.exec((ref || "").trim());
+      if (!match) { document.getElementById("rvMsg").textContent = "Use finding:id, claim:id, or evidence:id."; return; }
+      const message = prompt("Review note:");
+      if (!message?.trim()) return;
+      const blocker = confirm("Is this a HIGH-impact unresolved uncertainty that must block approval?");
+      rvPost(versionId, "review/annotations", {
+        targetType: match[1], targetId: match[2].trim(),
+        category: blocker ? "uncertainty" : "comment", impact: blocker ? "high" : "medium",
+        message: message.trim(),
+      });
+    }
+
+    function rvResolve(versionId, annotationId) {
+      const resolution = prompt("How was this review note resolved?");
+      if (resolution?.trim()) rvPost(versionId, `workflow/annotations/${encodeURIComponent(annotationId)}/resolve`, { resolution: resolution.trim() });
+    }
+
+    function rvRequestChanges(versionId) {
+      const reason = prompt("What must the investigator change?");
+      if (reason?.trim()) rvPost(versionId, "review/request-changes", { reason: reason.trim() });
+    }
+
+    function rvApprove(versionId) {
+      const note = prompt("Approval note (what was checked and accepted):");
+      if (note?.trim()) rvPost(versionId, "review/approve", { note: note.trim() });
+    }
+
+    function rvRelease(versionId) {
+      const latest = rvReleased[0];
+      const warning = latest
+        ? `This creates a new immutable release that explicitly supersedes ${latest.id}. The prior release will remain preserved and linked.`
+        : "This freezes the exact report, evidence, analysis runs and custody state as the formal release.";
+      if (!confirm(warning + "\n\nContinue?")) return;
+      rvPost(versionId, "workflow/release", latest ? { supersedesReleaseId: latest.id } : {});
     }
 
     async function doReportVersionsDiff() {
@@ -23536,6 +23691,7 @@
     let rtTemplates = [];          // last fetched list of templates
     let rtCurrentId = "";          // id of the template being edited ("" = new/unsaved)
     let rtEditSections = [];       // [{ key, enabled }] for the editor, ordered
+    let rtRequiredSections = new Set();
 
     function loadReportTemplates(selectId) {
       return fetch("/report-templates").then(r => r.ok ? r.json() : []).then(list => {
@@ -23568,6 +23724,10 @@
       v("rtFooterText", t ? t.footerText : "");
       document.getElementById("rtShowLogo").checked = t ? t.showLogo !== false : true;
       document.getElementById("rtShowCompanyName").checked = t ? t.showCompanyName !== false : true;
+      const releaseReq = t?.releaseRequirements || {};
+      document.getElementById("rtRequireIndependentReview").checked = releaseReq.requireIndependentReview === true;
+      document.getElementById("rtRequireEvidenceLinks").checked = releaseReq.requireEvidenceLinks === true;
+      rtRequiredSections = new Set(Array.isArray(releaseReq.requiredSections) ? releaseReq.requiredSections : []);
       // Sections: start from the template's order (full coverage guaranteed server-side) or the default.
       const src = (t && Array.isArray(t.sections) && t.sections.length) ? t.sections : RT_SECTIONS.map(([key]) => ({ key, enabled: true }));
       rtEditSections = src.filter(s => RT_LABELS[s.key]).map(s => ({ key: s.key, enabled: s.enabled !== false }));
@@ -23587,12 +23747,22 @@
         `<div data-safe-style="display:flex;align-items:center;gap:8px;padding:3px 4px;border-bottom:1px solid #1a1f28;font-size:12px">`
         + `<input type="checkbox" class="rt-sec-en" data-i="${i}" ${s.enabled ? "checked" : ""} data-safe-style="width:auto;margin:0" />`
         + `<span data-safe-style="flex:1;${s.enabled ? "" : "color:#7e8aa0"}">${esc(RT_LABELS[s.key] || s.key)}</span>`
+        + `<label title="Block release unless this section is included" data-safe-style="display:flex;align-items:center;gap:3px;color:var(--text-muted)"><input type="checkbox" class="rt-sec-req" data-i="${i}" ${rtRequiredSections.has(s.key) ? "checked" : ""} data-safe-style="width:auto;margin:0" /> require</label>`
         + `<button type="button" class="rt-sec-up" data-i="${i}" title="Move up" ${i === 0 ? "disabled" : ""} data-safe-style="background:#2a2f3a;border:none;color:#cbd3df;border-radius:4px;padding:0 7px;cursor:pointer">▲</button>`
         + `<button type="button" class="rt-sec-down" data-i="${i}" title="Move down" ${i === rtEditSections.length - 1 ? "disabled" : ""} data-safe-style="background:#2a2f3a;border:none;color:#cbd3df;border-radius:4px;padding:0 7px;cursor:pointer">▼</button>`
         + `</div>`
       ).join("");
       el.querySelectorAll(".rt-sec-en").forEach(cb => cb.addEventListener("change", e => {
-        rtEditSections[+e.target.dataset.i].enabled = e.target.checked; rtRenderSections();
+        const section = rtEditSections[+e.target.dataset.i];
+        section.enabled = e.target.checked;
+        if (!section.enabled) rtRequiredSections.delete(section.key);
+        rtRenderSections();
+      }));
+      el.querySelectorAll(".rt-sec-req").forEach(cb => cb.addEventListener("change", e => {
+        const section = rtEditSections[+e.target.dataset.i];
+        if (e.target.checked) { rtRequiredSections.add(section.key); section.enabled = true; }
+        else rtRequiredSections.delete(section.key);
+        rtRenderSections();
       }));
       el.querySelectorAll(".rt-sec-up").forEach(b => b.addEventListener("click", e => rtMoveSection(+e.currentTarget.dataset.i, -1)));
       el.querySelectorAll(".rt-sec-down").forEach(b => b.addEventListener("click", e => rtMoveSection(+e.currentTarget.dataset.i, 1)));
@@ -23621,6 +23791,11 @@
         showLogo: document.getElementById("rtShowLogo").checked,
         showCompanyName: document.getElementById("rtShowCompanyName").checked,
         sections: rtEditSections,
+        releaseRequirements: {
+          requiredSections: [...rtRequiredSections],
+          requireIndependentReview: document.getElementById("rtRequireIndependentReview").checked,
+          requireEvidenceLinks: document.getElementById("rtRequireEvidenceLinks").checked,
+        },
       };
       msg.textContent = "saving…";
       fetch("/report-templates", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) })


### PR DESCRIPTION
## Summary

- add Draft, Peer Review, Approved, and Released report states with assigned-reviewer separation of duties and explicit solo self-review
- block releases when evidence links, significant uncertainties, analysis-run provenance, custody integrity, or required artifacts are incomplete
- create immutable chained release manifests with supersession, integrity verification, diffs, and executive, technical, legal, and IOC packs
- add dashboard controls, template release requirements, tests, documentation, and changelog coverage

## Validation

- npm run build
- npm run typecheck
- npm run lint
- npm run format:check
- npm run check:size
- npm run check:imports
- npm test (528 files, 6,683 tests)

Closes #383