### PR TITLE
feat(extension): require explicit site access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - **Strict browser rendering policy** — dashboard views and HTML exports now sanitize untrusted content under nonce-based CSP and Trusted Types, blocking script, URL, and CSS injection (closes #387).
+- **Least-privilege capture extension** — installs with zero host access, asks for one console origin at a time, supports revocation and one-off active-tab capture, refuses restricted/private pages, and records permission changes locally (closes #388).
 
 ## [0.34.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ list of known compromised hosts and users.
 - **Setup wizard** — guided multi-step dashboard overlay (auto-shown first-run; also in Settings → General / AI) to configure AI (extraction **and** synthesis model, separately), the integrations (Velociraptor, DFIR-IRIS, Timesketch, Notion, ClickUp), threat-intel enrichment + customer-exposure providers, push ingest, NSRL, and a notification webhook (Slack/Teams/Mattermost/Discord) — each with Save → apply-live → connection/status test, and a ✓/○ progress rail. Everything is optional and dismissible
 
 ### Capture & ingest
-- **MV3 browser extension** — timer + event-driven capture (navigation/tab/click), `Ctrl+Shift+S` hotkey, offline queue + auto-sync, per-case Start/Stop
+- **Least-privilege MV3 browser extension** — zero site access at install, exact-origin console approval/revocation, one-off active-tab capture, timer + event-driven capture, local permission audit, offline queue + auto-sync
 - **One-click artifact push** — Splunk/Velociraptor/Kibana/Security Onion/SO-CRATES/CrowdStrike/VolWeb injects **Push to DFIR-Companion** button; intercepts API JSON or scrapes table; the popup shows the auto-detected console with a dropdown to force a different adapter (or none) per tab
 - **Right-click "Send to DFIR-Companion"** — send a page's selected text, a nearby table, or a link's URL straight to the connected case from any page, not just recognized consoles
 - **Case management** — **+ New case** in dashboard (templates auto-load incident questions + import hints); captures to unknown case rejected

--- a/companion/src/http/originGuard.ts
+++ b/companion/src/http/originGuard.ts
@@ -244,7 +244,10 @@ export function createOriginGuard(cfg: GuardConfig = {}): RequestHandler {
       res.header("Access-Control-Allow-Origin", origin); // echo the caller, never "*"
       res.header("Vary", "Origin"); // the response varies by origin, so it must not be cached across them
       res.header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-      res.header("Access-Control-Allow-Headers", "Content-Type");
+      // Without a broad extension host permission, Companion requests use normal CORS. The
+      // optional team service token travels in Authorization, so trusted extension origins need
+      // that header in addition to the dashboard's Content-Type.
+      res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
       // Chromium Private Network Access: a request from an extension page to a private address
       // (127.0.0.1) is blocked unless the preflight allows it. Only ever granted to a trusted origin.
       res.header("Access-Control-Allow-Private-Network", "true");

--- a/companion/tests/http/originGuard.test.ts
+++ b/companion/tests/http/originGuard.test.ts
@@ -284,6 +284,7 @@ describe("createOriginGuard", () => {
     expect(res.status).toBe(204);
     expect(res.headers["access-control-allow-private-network"]).toBe("true");
     expect(res.headers["access-control-allow-methods"]).toMatch(/POST/);
+    expect(res.headers["access-control-allow-headers"]).toMatch(/Authorization/);
   });
 
   it("lets a no-Origin request through untouched", async () => {

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — DFIR Companion: Evidence Capture & Push
 
-_Last updated: 2026-07-10_
+_Last updated: 2026-07-31_
 
 This is the privacy policy for the **DFIR Companion — Evidence Capture & Push** browser
 extension (the "Extension"), published for Chrome and other Chromium browsers. It is part of
@@ -14,17 +14,18 @@ licensed AGPL-3.0-only.
 extension authors, to any analytics service, or to any other third party. There is no
 tracking, no telemetry, and no remote logging.**
 
-You — the analyst — are always in control of what is sent and when.
+You — the analyst — are always in control of what is sent and when. A fresh installation has
+**no access to any website**. Persistent access is granted one console origin at a time.
 
 ## What the Extension does
 
 The Extension supports a forensic investigation workflow in two ways:
 
-1. **Screenshot evidence capture.** It captures screenshots of the **active browser tab** —
-   on a periodic timer, on navigation/tab-switch events, or on demand (toolbar button or the
-   `Ctrl+Shift+S` shortcut) — and submits them as evidence to your local DFIR Companion.
+1. **Screenshot evidence capture.** A one-off capture uses temporary `activeTab` access after
+   you click the Extension. Ongoing timer/navigation/tab-switch capture runs only on an origin
+   you previously approved. Screenshots are submitted as evidence to your DFIR Companion.
 
-2. **Detection / artifact push from DFIR consoles.** When you are viewing a recognized
+2. **Detection / artifact push from approved DFIR consoles.** When you are viewing a recognized
    security tool's web console (for example **Splunk**, **Velociraptor**, **Elastic/Kibana**,
    or **CrowdStrike Falcon**), the Extension can extract the **structured results you are
    looking at** (the JSON the console already fetched, or the visible results table) and push
@@ -32,7 +33,7 @@ The Extension supports a forensic investigation workflow in two ways:
    button. This step only ever runs on your explicit click — nothing is sent automatically
    from these pages.
 
-3. **Right-click "Send to DFIR-Companion".** On any page, you can right-click a text
+3. **Right-click "Send to DFIR-Companion".** On a page where you invoke the menu, you can send a text
    selection, a table, or a link and choose "Send to DFIR-Companion" to push that selected
    text, the nearest table's rows, or the link's URL to your local companion. Like the Push
    button above, this only ever runs when you explicitly choose it from the menu.
@@ -47,6 +48,9 @@ The Extension supports a forensic investigation workflow in two ways:
 - **Extension settings and an offline send-queue**, stored locally via `chrome.storage`
   (e.g. the selected case, capture interval, the companion server URL, and any captures that
   could not be delivered yet because the companion was unreachable).
+- **Approved origins and a local permission audit.** The browser retains the origins you approve.
+  The Extension retains the latest 100 grant, denial, and revocation records (time, action, and
+  origin) in local extension storage so permission changes are visible.
 
 ## Where the data goes
 
@@ -63,21 +67,35 @@ The Extension supports a forensic investigation workflow in two ways:
 
 | Permission | Why |
 |---|---|
-| `activeTab` | Read/capture the tab you are currently viewing so it can be saved as evidence. |
-| `tabs` | Identify the active tab and react to tab switches for event-driven capture. |
-| `webNavigation` | Capture on page navigations (so the timeline reflects what you browsed). |
-| `scripting` | Inject the small content script / page hook that powers the Push button and reads the console results you are viewing. |
+| `activeTab` | Temporarily capture the current tab after an explicit toolbar, menu, or shortcut action. |
+| `webNavigation` | React to navigation on an already-approved origin. |
+| `scripting` | Inject the Push button and console-result hook only after host access is granted. |
 | `contextMenus` | Add the right-click "Send to DFIR-Companion" menu items (send selection / table / link). |
 | `storage` | Persist your settings and hold the offline send-queue locally. |
 | `alarms` | Drive the optional periodic-capture timer. |
-| `host_permissions: <all_urls>` | Evidence capture and the DFIR-console Push feature must work on any site or self-hosted console (security tools run on arbitrary hosts/ports), so the Extension needs access to all sites. It still only **sends** data to your local companion, and the Push feature only acts when you click it. |
+| Optional `http://*/*` / `https://*/*` hosts | Lets the browser offer an exact-origin permission at runtime. The wildcard is never granted at install: approving `https://velo.example:8889` grants that origin only. |
+
+The Extension refuses browser-internal pages, local `file:`/`data:` pages, and private/incognito
+tabs. Firefox is marked `not_allowed` for private browsing; Chromium is excluded by default and the
+Extension still refuses private tabs if a user later enables it there.
+
+## What an approved console page exposes
+
+On an approved origin, the content script reads the page URL/title, tool-identifying DOM markers,
+the visible results table when you click Push, and only the API response bodies matching the active
+DFIR-console adapter. Matching response rows stay in that page's memory until you click Push; they
+are not uploaded automatically. Revoking the origin disables the page integration immediately,
+clears the hook's match patterns, removes the Push button, and makes the service worker reject any
+late message from that page.
 
 ## Data retention
 
 The Extension itself does not retain forensic data beyond the local send-queue needed to
 deliver captures to your companion. Once delivered, evidence is stored and managed by **your**
 DFIR Companion server, under your control. Clearing the Extension's storage (or removing the
-Extension) clears its settings and any undelivered queued captures.
+Extension) clears its settings, permission audit, and any undelivered queued captures. Approved
+origins can be revoked from the popup, the Extension options page, or the browser's extension
+permission controls.
 
 ## Children's privacy
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -4,6 +4,10 @@ MV3 extension that captures the active tab (timer + events) and sends to the com
 one-click pushes structured artifacts straight from DFIR consoles (Splunk / Velociraptor / Elastic /
 CrowdStrike) into the case timeline.
 
+It installs with **zero website access**. Open a console, click the extension, and approve that
+exact origin before enabling ongoing capture or the in-page Push integration. **Capture this tab
+once** uses temporary `activeTab` access and does not retain site permission.
+
 ## Install — Chrome Web Store
 
 Listed publication is set up via CI (see [Publishing](#publishing-chrome-web-store)); once the
@@ -55,11 +59,28 @@ Verified end-to-end against the companion: live capture, offline queue/sync, das
 
 ## Keyboard shortcut
 
-`Ctrl+Shift+S` (macOS `Cmd+Shift+S`) toggles capture on/off without opening the popup — turning it on takes one capture immediately and the toolbar badge flashes `REC`/`off`. Rebind it at `chrome://extensions/shortcuts` (or via the **rebind** link in the popup). If the default key conflicts with another extension at install time, Chrome leaves it unset until you assign one there.
+`Ctrl+Shift+S` (macOS `Cmd+Shift+S`) toggles ongoing capture on/off. Ongoing capture fails closed on
+an origin that has not been approved: open the popup on that console once and choose **Allow this
+site**. Rebind the shortcut at `chrome://extensions/shortcuts` (or via the **rebind** link in the
+popup). If the default key conflicts with another extension at install time, Chrome leaves it unset
+until you assign one there.
+
+## Site access
+
+1. Open the Velociraptor, Splunk, Kibana, or other web console you want to use.
+2. Click the DFIR Companion extension icon.
+3. Click **Allow this site** and approve the browser's exact-origin prompt.
+4. Select a case. Use **Start** for ongoing capture, **Capture this tab once** for a temporary
+   screenshot, or the console's floating Push button for structured rows.
+
+The popup always says whether the current origin is connected. **Review permissions and audit log**
+lists every granted origin with a Revoke button and the latest 100 local grant/denial/revocation
+records. Revocation disables the integration immediately. Browser/private pages, `file:`/`data:`
+pages, and private browsing are refused.
 
 ## Automated artifact fetching (#102)
 
-On a recognized DFIR console the content script activates a **site adapter** and injects a floating
+On an approved, recognized DFIR console the content script activates a **site adapter** and injects a floating
 **📤 Push … → DFIR-Companion** button (bottom-right by default). It only sends when *you* click it —
 explicit analyst intent, nothing automatic. **Drag the button** anywhere if a site's own UI covers
 it; the position is remembered across pages/tabs and always kept on-screen.
@@ -85,7 +106,7 @@ On click the rows are POSTed to the companion's unified import route
 (`POST /cases/:id/import`) for the **case currently selected in the popup** — the same case used for
 screenshot capture. The server auto-detects the format and routes it into the timeline + IOCs. The
 button shows the result (`✓ Pushed N rows to "<case>"` or the error). On an unrecognized site the
-extension does nothing extra — plain screenshot capture is unaffected.
+extension does nothing extra. No content script is injected at all until the origin is approved.
 
 > Pick a case in the popup first (the artifact push uses it). The push reuses the localhost,
 > unauthenticated import path — no token needed (unlike the server's external `/push` webhook).
@@ -115,8 +136,17 @@ account can be created independently of merging:
 
 **One-time human steps** (CI can't do these): create the $5 Chrome developer account, do the first
 upload + fill the listing (name/description/icon/screenshots/privacy policy) + data-use disclosures,
-and submit for review. With `<all_urls>` host access, expect a manual review (days) on first
-submission. After that, tagged releases publish new versions automatically.
+and submit for review. Host access is optional and requested one origin at a time, so the install
+does not carry an all-sites warning. After that, tagged releases publish new versions automatically.
+
+### Managed enterprise origins (Chrome)
+
+Administrators can use Chrome's `ExtensionSettings` policy to force-install/pin the extension and
+set `runtime_blocked_hosts` to `*://*`, with only the organization's approved console origins in
+`runtime_allowed_hosts`. This browser policy is a hard ceiling: it does not let the extension work
+around an analyst denial, and no origin outside the managed allow-list can be granted. Use exact
+origins such as `https://velociraptor.example` rather than a broad wildcard. The Extension options
+page reflects the permissions the browser has actually granted.
 
 ## Publishing (Firefox / AMO)
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,8 +9,8 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["tabs", "activeTab", "webNavigation", "storage", "alarms", "scripting", "contextMenus"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": ["activeTab", "webNavigation", "storage", "alarms", "scripting", "contextMenus"],
+  "optional_host_permissions": ["http://*/*", "https://*/*"],
   "options_ui": { "page": "options.html", "open_in_tab": true },
   "background": { "service_worker": "serviceWorker.js", "type": "module" },
   "action": {
@@ -30,8 +30,5 @@
     "_execute_action": {
       "description": "Open the DFIR Companion popup"
     }
-  },
-  "content_scripts": [
-    { "matches": ["<all_urls>"], "js": ["content.js"], "run_at": "document_idle" }
-  ]
+  }
 }

--- a/extension/scripts/manifest-firefox.mjs
+++ b/extension/scripts/manifest-firefox.mjs
@@ -30,7 +30,7 @@ export const GECKO_ID = "dfir-companion@hasamba.github.io";
 export const MIN_FIREFOX_VERSION = "128.0";
 
 /** The manifest keys this transform is allowed to change. Asserted by tests/firefox.test.ts. */
-export const FIREFOX_ONLY_KEYS = ["browser_specific_settings", "background"];
+export const FIREFOX_ONLY_KEYS = ["browser_specific_settings", "background", "incognito"];
 
 /**
  * @param {object} base Parsed manifest.json.
@@ -54,6 +54,10 @@ export function toFirefoxManifest(base) {
       out.browser_specific_settings = {
         gecko: { id: GECKO_ID, strict_min_version: MIN_FIREFOX_VERSION },
       };
+      // Chrome rejects `not_allowed`; Firefox supports it and then makes private windows entirely
+      // invisible to the add-on. Chrome stays excluded by default and the runtime independently
+      // refuses every incognito Tab even if an analyst later enables the extension there.
+      out.incognito = "not_allowed";
     }
     if (key === "background") {
       // `type: "module"` carries over — Firefox has supported ES module background scripts since

--- a/extension/src/artifactCapture.ts
+++ b/extension/src/artifactCapture.ts
@@ -26,6 +26,7 @@ import { DFIR_CAPTURE_MSG, DFIR_CONFIG_MSG, DFIR_READY_MSG } from "./adapters/br
 import { clampButtonPosition, isDrag, parseButtonPos, type ButtonPos } from "./buttonPosition.js";
 import type { EnsureHookMessage, PushArtifactMessage, PushArtifactResult, CaptureStatusResult } from "./types.js";
 import { browserApi } from "./browser.js";
+import { isExtensionContextInvalidated, runBestEffortExtensionCall } from "./extensionContext.js";
 
 const BTN_ID = "dfir-companion-push-btn";
 // storage.local key holding the analyst's dragged button position (null = default corner).
@@ -43,6 +44,7 @@ let currentCaseId = "";
 let buttonPos: ButtonPos | null = null;
 // Set briefly after a drag so the trailing click does not fire a push.
 let suppressClick = false;
+let disabled = false;
 
 export async function initArtifactCapture(): Promise<void> {
   detectedAdapterId = adapterForPage(location.href, document)?.id ?? null;
@@ -87,6 +89,19 @@ export async function initArtifactCapture(): Promise<void> {
   });
 }
 
+export function setArtifactCaptureEnabled(enabled: boolean): void {
+  disabled = !enabled;
+  latest = null;
+  if (!enabled) {
+    activeAdapter = null;
+    document.getElementById(BTN_ID)?.remove();
+    window.postMessage({ source: DFIR_CONFIG_MSG, patterns: [] }, "*");
+    return;
+  }
+  detectedAdapterId = adapterForPage(location.href, document)?.id ?? null;
+  applyAdapter();
+}
+
 // (Re)compute which adapter is active from detection + override, reset captured state, and — when
 // an adapter is now active — (re)request the MAIN-world hook with its API patterns. Called once at
 // init, and again whenever the popup changes the override for this tab. Unlike before manual
@@ -94,6 +109,11 @@ export async function initArtifactCapture(): Promise<void> {
 // adapterForPage doesn't recognize — cheaply, since applyAdapter() itself no-ops until an adapter
 // is actually active — so a later popup override can still activate capture on that page.
 function applyAdapter(): void {
+  if (disabled) {
+    activeAdapter = null;
+    document.getElementById(BTN_ID)?.remove();
+    return;
+  }
   const id = resolveActiveAdapter(detectedAdapterId, overrideAdapterId);
   if (id !== (activeAdapter?.id ?? null)) {
     activeAdapter = id ? adapterById(id) : null;
@@ -129,6 +149,10 @@ function onExtensionMessage(
     return true;
   }
   if (m.kind === "set_adapter_override") {
+    if (disabled) {
+      sendResponse(captureStatus());
+      return true;
+    }
     overrideAdapterId = typeof m.overrideAdapterId === "string" ? m.overrideAdapterId : "";
     applyAdapter();
     sendResponse(captureStatus());
@@ -155,7 +179,10 @@ function captureStatus(): CaptureStatusResult {
 // prior navigation in this tab (it's idempotent).
 function requestHookInjection(): void {
   const msg: EnsureHookMessage = { kind: "ensure_hook" };
-  try { void browserApi.runtime.sendMessage(msg); } catch { /* SW asleep / page CSP — scrape still works */ }
+  runBestEffortExtensionCall(
+    () => browserApi.runtime.sendMessage(msg),
+    () => setArtifactCaptureEnabled(false),
+  );
 }
 
 function sendConfig(): void {
@@ -350,7 +377,10 @@ function attachDrag(btn: HTMLButtonElement): void {
     window.setTimeout(() => { suppressClick = false; }, 0);
     const rect = btn.getBoundingClientRect();
     buttonPos = { left: rect.left, top: rect.top };
-    try { void browserApi.storage.local.set({ [POS_KEY]: buttonPos }); } catch { /* storage unavailable */ }
+    runBestEffortExtensionCall(
+      () => browserApi.storage.local.set({ [POS_KEY]: buttonPos }),
+      () => setArtifactCaptureEnabled(false),
+    );
   };
   btn.addEventListener("pointerup", end);
   btn.addEventListener("pointercancel", end);
@@ -394,7 +424,10 @@ async function onClick(): Promise<void> {
       flash(`✗ ${res?.error ?? "Push failed"}`, "#b42318");
     }
   } catch (err) {
-    flash(`✗ ${(err as Error).message}`, "#b42318");
+    const message = isExtensionContextInvalidated(err)
+      ? "Extension updated — refresh this page"
+      : (err as Error).message;
+    flash(`✗ ${message}`, "#b42318");
   } finally {
     busy = false;
   }

--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -1,11 +1,24 @@
-import { initArtifactCapture } from "./artifactCapture.js";
+import { initArtifactCapture, setArtifactCaptureEnabled } from "./artifactCapture.js";
 import { initContextMenuCapture } from "./contextMenuCapture.js";
 import { browserApi } from "./browser.js";
+import { isExtensionContextInvalidated, runBestEffortExtensionCall } from "./extensionContext.js";
+import { originPatternMatchesUrl } from "./siteAccess.js";
+import type { SiteAccessChangedMessage } from "./types.js";
 
 let lastKeyNotify = 0;
+let siteAccessEnabled = true;
+
+function disableInvalidatedContext(): void {
+  siteAccessEnabled = false;
+  setArtifactCaptureEnabled(false);
+}
 
 function notify(reason: "click" | "keydown") {
-  browserApi.runtime.sendMessage({ kind: "user_event", reason }).catch(() => {});
+  if (!siteAccessEnabled) return;
+  runBestEffortExtensionCall(
+    () => browserApi.runtime.sendMessage({ kind: "user_event", reason }),
+    disableInvalidatedContext,
+  );
 }
 
 document.addEventListener("click", () => notify("click"), { capture: true, passive: true });
@@ -21,9 +34,19 @@ document.addEventListener("keydown", () => {
 // Automated artifact fetching (#102): on recognized DFIR consoles (Splunk / Velociraptor /
 // Security Onion / SO-CRATES / Elastic / CrowdStrike / VolWeb) inject a "Push to DFIR-Companion"
 // button + the API-interception hook. Every other site gets no button/hook by default, but the
-// popup's manual override (see popup.ts) can still force one on — so a lightweight listener is
-// always registered, even where nothing is currently detected.
+// popup's manual override (see popup.ts) can still force one on. This bundle itself is injected
+// only after the analyst approves the current origin.
 
-// Context-menu send (#new): right-click-target tracking + toast rendering, active on every page.
-initContextMenuCapture();
-void initArtifactCapture();
+browserApi.runtime.onMessage.addListener((message) => {
+  const change = message as Partial<SiteAccessChangedMessage>;
+  if (change.kind !== "site_access_changed" || !Array.isArray(change.origins)) return;
+  if (!change.origins.some((origin) => originPatternMatchesUrl(origin, location.href))) return;
+  siteAccessEnabled = change.allowed === true;
+  setArtifactCaptureEnabled(siteAccessEnabled);
+});
+
+// Context-menu send (#new): right-click-target tracking + toast rendering on analyst-approved pages.
+initContextMenuCapture(() => siteAccessEnabled);
+void initArtifactCapture().catch((error: unknown) => {
+  if (isExtensionContextInvalidated(error)) disableInvalidatedContext();
+});

--- a/extension/src/contextMenuCapture.ts
+++ b/extension/src/contextMenuCapture.ts
@@ -1,6 +1,7 @@
-// Context-menu send (right-click → "Send … to DFIR-Companion"). Runs on every page (content.js
-// already matches <all_urls>) so it works even where no adapter is registered — unlike the
-// adapter-driven floating push button in artifactCapture.ts.
+// Context-menu send (right-click → "Send … to DFIR-Companion"). Runs on every approved origin,
+// including pages where no adapter is registered — unlike the adapter-driven floating push button
+// in artifactCapture.ts. Selection/link sends need no page script and remain available as one-off
+// context-menu actions; table targeting requires this approved-page listener.
 //
 // Chrome's contextMenus API gives no reference to the element under the cursor, so table
 // targeting uses the standard workaround: remember the element from the native "contextmenu"
@@ -19,7 +20,7 @@ const TOAST_ID = "dfir-companion-toast";
 let toastTimer: number | undefined;
 let lastRightClickTarget: Element | null = null;
 
-export function initContextMenuCapture(): void {
+export function initContextMenuCapture(isEnabled: () => boolean = () => true): void {
   // Capture phase so this fires even if a page's own contextmenu handler stops propagation.
   document.addEventListener("contextmenu", (e) => {
     lastRightClickTarget = e.target instanceof Element ? e.target : null;
@@ -28,10 +29,11 @@ export function initContextMenuCapture(): void {
   browserApi.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     const kind = (msg as { kind?: string })?.kind;
     if (kind === "get_context_table") {
-      sendResponse(findContextTable() satisfies ContextTableResult);
+      sendResponse((isEnabled() ? findContextTable() : { rows: null }) satisfies ContextTableResult);
       return; // synchronous response — no need to keep the channel open
     }
     if (kind === "context_push_result") {
+      if (!isEnabled()) return;
       const { ok, message } = msg as ContextPushResultMessage;
       showToast(message, ok ? "#1a7f37" : "#b42318");
       return;

--- a/extension/src/extensionContext.ts
+++ b/extension/src/extensionContext.ts
@@ -1,0 +1,23 @@
+const INVALIDATED_CONTEXT = /extension context invalidated/i;
+
+export function isExtensionContextInvalidated(error: unknown): boolean {
+  if (error instanceof Error) return INVALIDATED_CONTEXT.test(error.message);
+  return typeof error === "string" && INVALIDATED_CONTEXT.test(error);
+}
+
+// A content script survives in the page after an unpacked extension is reloaded, but its browser
+// API calls become invalid. Chrome may throw synchronously here rather than return a rejected
+// promise, so a trailing `.catch()` alone cannot contain the expected development/update failure.
+export function runBestEffortExtensionCall(
+  send: () => Promise<unknown>,
+  onInvalidated: () => void,
+): void {
+  const handleFailure = (error: unknown): void => {
+    if (isExtensionContextInvalidated(error)) onInvalidated();
+  };
+  try {
+    void send().catch(handleFailure);
+  } catch (error) {
+    handleFailure(error);
+  }
+}

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -4,13 +4,20 @@
   <meta charset="utf-8" />
   <title>DFIR Capture — Options</title>
   <style>
-    body { font-family: system-ui, sans-serif; max-width: 480px; margin: 40px auto; padding: 0 20px; }
+    body { font-family: system-ui, sans-serif; max-width: 620px; margin: 40px auto; padding: 0 20px; }
     h2 { font-size: 16px; margin-bottom: 16px; }
     label { display: block; font-size: 13px; margin-top: 12px; }
     input { width: 100%; box-sizing: border-box; padding: 6px; margin-top: 4px; }
     .hint { margin-top: 6px; font-size: 11px; color: #888; }
     button { margin-top: 16px; padding: 8px 20px; cursor: pointer; }
     #msg { margin-top: 12px; font-size: 13px; color: #2d6cdf; }
+    section { margin-top: 28px; padding-top: 18px; border-top: 1px solid #ddd; }
+    h3 { font-size: 15px; margin: 0 0 8px; }
+    ul { padding: 0; list-style: none; }
+    li { display: flex; gap: 10px; align-items: center; padding: 7px 0; border-bottom: 1px solid #eee; }
+    li code { flex: 1; overflow-wrap: anywhere; }
+    li button { margin: 0; padding: 4px 9px; }
+    #accessAudit li { display: block; font: 12px ui-monospace, monospace; }
   </style>
 </head>
 <body>
@@ -27,6 +34,16 @@
   </label>
   <button id="save">Save</button>
   <div id="msg"></div>
+  <section>
+    <h3>Approved console origins</h3>
+    <p class="hint">Only these sites have persistent page access. Approve a new origin by opening that console and clicking the DFIR Companion icon.</p>
+    <ul id="approvedOrigins"></ul>
+  </section>
+  <section>
+    <h3>Permission audit log</h3>
+    <p class="hint">The latest grants, denials, and revocations are kept locally in this browser profile.</p>
+    <ul id="accessAudit"></ul>
+  </section>
   <script type="module" src="options.js"></script>
 </body>
 </html>

--- a/extension/src/options.ts
+++ b/extension/src/options.ts
@@ -1,5 +1,50 @@
 import { DEFAULT_SETTINGS, normalizeCompanionUrl, type Settings } from "./types.js";
 import { browserApi } from "./browser.js";
+import { readAuditEntries, SITE_ACCESS_AUDIT_KEY } from "./siteAccess.js";
+
+function appendEmptyState(list: HTMLUListElement, text: string): void {
+  const item = document.createElement("li");
+  item.textContent = text;
+  item.className = "hint";
+  list.appendChild(item);
+}
+
+async function renderSiteAccess(): Promise<void> {
+  const originsList = document.getElementById("approvedOrigins") as HTMLUListElement;
+  const auditList = document.getElementById("accessAudit") as HTMLUListElement;
+  const [permissions, stored] = await Promise.all([
+    browserApi.permissions.getAll(),
+    browserApi.storage.local.get(SITE_ACCESS_AUDIT_KEY),
+  ]);
+  const origins = (permissions.origins ?? []).filter((origin) => /^https?:\/\//.test(origin)).sort();
+  originsList.replaceChildren();
+  if (!origins.length) appendEmptyState(originsList, "No console origins approved.");
+  for (const origin of origins) originsList.appendChild(originRow(origin));
+
+  const entries = readAuditEntries(stored[SITE_ACCESS_AUDIT_KEY]).slice(-25).reverse();
+  auditList.replaceChildren();
+  if (!entries.length) appendEmptyState(auditList, "No permission changes recorded yet.");
+  for (const entry of entries) {
+    const item = document.createElement("li");
+    item.textContent = `${entry.at}  ${entry.action.toUpperCase()}  ${entry.origin}`;
+    auditList.appendChild(item);
+  }
+}
+
+function originRow(origin: string): HTMLLIElement {
+  const item = document.createElement("li");
+  const label = document.createElement("code");
+  label.textContent = origin;
+  const revoke = document.createElement("button");
+  revoke.type = "button";
+  revoke.textContent = "Revoke";
+  revoke.onclick = async () => {
+    await browserApi.permissions.remove({ origins: [origin] });
+    await renderSiteAccess();
+  };
+  item.append(label, revoke);
+  return item;
+}
 
 async function init() {
   const stored = await browserApi.storage.local.get("settings");
@@ -9,6 +54,10 @@ async function init() {
   const msg = document.getElementById("msg")!;
   input.value = settings.companionUrl;
   tokenInput.value = settings.serviceToken;
+  await renderSiteAccess();
+
+  browserApi.permissions.onAdded.addListener(() => void renderSiteAccess());
+  browserApi.permissions.onRemoved.addListener(() => void renderSiteAccess());
 
   document.getElementById("save")!.onclick = async () => {
     const updated = {

--- a/extension/src/pageHook.ts
+++ b/extension/src/pageHook.ts
@@ -11,16 +11,18 @@
 // and a thrown clone/read never disturbs the page. The data stays in-page until the analyst clicks
 // the push button — nothing leaves the browser here.
 //
-// Standalone bundle: these message-source strings MUST match src/adapters/bridge.ts.
-const DFIR_READY_MSG = "dfir-companion-hook-ready";
-const DFIR_CONFIG_MSG = "dfir-companion-hook-config";
-const DFIR_CAPTURE_MSG = "dfir-companion-hook-capture";
-
-// Don't forward absurdly large bodies across the postMessage bridge (the companion can still ingest
-// big files via the dashboard; this just keeps the in-page channel sane). ~8 MB of response text.
-const MAX_BODY = 8_000_000;
-
 (function installDfirHook(): void {
+  // Keep every declaration inside the function. executeScript may evaluate this classic script
+  // repeatedly in the same MAIN world; top-level const declarations would collide before the
+  // installed guard can run. These message-source strings MUST match src/adapters/bridge.ts.
+  const DFIR_READY_MSG = "dfir-companion-hook-ready";
+  const DFIR_CONFIG_MSG = "dfir-companion-hook-config";
+  const DFIR_CAPTURE_MSG = "dfir-companion-hook-capture";
+
+  // Don't forward absurdly large bodies across the postMessage bridge (the companion can still
+  // ingest big files via the dashboard; this just keeps the in-page channel sane). ~8 MB of text.
+  const MAX_BODY = 8_000_000;
+
   const w = window as unknown as { __dfirHookInstalled?: boolean };
   if (w.__dfirHookInstalled) return; // idempotent — survive double injection (SPA re-navigations)
   w.__dfirHookInstalled = true;

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -11,11 +11,22 @@
     #status { margin-top: 10px; font-size: 12px; color: #555; }
     .on { color: #2d6cdf; } .off { color: #cc3333; }
     .hint { margin-top: 8px; font-size: 11px; color: #888; }
+    .access { margin-top: 10px; padding: 9px; border: 1px solid #ccc; border-radius: 7px; }
+    .access-title { font-size: 12px; font-weight: 650; }
+    #siteOrigin { margin-top: 3px; font: 11px ui-monospace, monospace; overflow-wrap: anywhere; }
+    #siteAccessAction { width: 100%; margin-top: 8px; }
   </style>
 </head>
 <body>
   <strong>DFIR Capture</strong>
   <label>Case <select id="caseId"></select></label>
+  <div id="siteAccessPanel" class="access">
+    <div class="access-title">Site access: <span id="siteAccessState">checking…</span></div>
+    <div id="siteOrigin"></div>
+    <div id="siteAccessHint" class="hint"></div>
+    <button id="siteAccessAction" type="button">Allow this site</button>
+    <div class="hint"><a href="#" id="manageSiteAccess">Review permissions and audit log</a></div>
+  </div>
   <div id="toolRow">
     <label>Detected tool <select id="toolOverride"></select></label>
     <div id="toolHint" class="hint"></div>
@@ -34,6 +45,9 @@
   <div class="row">
     <button id="start">Start</button>
     <button id="stop">Stop</button>
+  </div>
+  <div class="row">
+    <button id="captureOnce">Capture this tab once</button>
   </div>
   <div id="hotkey" style="margin-top:8px; font-size:11px; color:#888;">
     Shortcut: <kbd id="hotkeyKeys">Ctrl+Shift+S</kbd> toggles capture · <a href="#" id="rebind">rebind</a>

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -1,7 +1,22 @@
 import { DEFAULT_SETTINGS, normalizeCompanionUrl, type Settings } from "./types.js";
 import { ADAPTERS } from "./adapters/registry.js";
 import { OVERRIDE_NONE } from "./adapters/override.js";
-import type { CaptureStatusResult, GetCaptureStatusMessage, SetAdapterOverrideMessage } from "./types.js";
+import {
+  appendAuditEntry,
+  hasSiteAccess,
+  isCapturableTab,
+  originPatternFromUrl,
+  requestSiteAccess,
+  revokeSiteAccess,
+  SITE_ACCESS_AUDIT_KEY,
+} from "./siteAccess.js";
+import type {
+  ActivateSiteMessage,
+  CaptureOnceMessage,
+  CaptureStatusResult,
+  GetCaptureStatusMessage,
+  SetAdapterOverrideMessage,
+} from "./types.js";
 import { browserApi, isFirefox } from "./browser.js";
 
 const $ = (id: string) => document.getElementById(id) as HTMLInputElement;
@@ -10,10 +25,21 @@ const statusEl = () => document.getElementById("status") as HTMLDivElement;
 
 const toolSelect = () => document.getElementById("toolOverride") as HTMLSelectElement;
 const toolHint = () => document.getElementById("toolHint") as HTMLDivElement;
+interface PopupTab {
+  id?: number;
+  url?: string;
+  incognito?: boolean;
+}
+
+let currentTab: PopupTab | null = null;
+
+async function activeTab(): Promise<PopupTab | null> {
+  const [tab] = await browserApi.tabs.query({ active: true, currentWindow: true });
+  return tab ?? null;
+}
 
 async function activeTabId(): Promise<number | null> {
-  const [tab] = await browserApi.tabs.query({ active: true, currentWindow: true });
-  return tab?.id ?? null;
+  return currentTab?.id ?? (await activeTab())?.id ?? null;
 }
 
 function populateToolOptions(sel: HTMLSelectElement): void {
@@ -60,6 +86,86 @@ async function initToolOverride(): Promise<void> {
     } catch {
       toolHint().textContent = "override failed — reload the page and try again";
     }
+  };
+}
+
+async function recordDeniedAccess(origin: string): Promise<void> {
+  const stored = await browserApi.storage.local.get(SITE_ACCESS_AUDIT_KEY);
+  const entry = { at: new Date().toISOString(), origin, action: "denied" as const };
+  await browserApi.storage.local.set({
+    [SITE_ACCESS_AUDIT_KEY]: appendAuditEntry(stored[SITE_ACCESS_AUDIT_KEY], entry),
+  });
+}
+
+function setSiteAccessText(state: string, hint: string, className: "on" | "off"): void {
+  const stateEl = document.getElementById("siteAccessState")!;
+  stateEl.textContent = state;
+  stateEl.className = className;
+  document.getElementById("siteAccessHint")!.textContent = hint;
+}
+
+async function refreshSiteAccess(): Promise<void> {
+  const button = document.getElementById("siteAccessAction") as HTMLButtonElement;
+  const originEl = document.getElementById("siteOrigin")!;
+  if (!currentTab || !isCapturableTab(currentTab) || !currentTab.url) {
+    originEl.textContent = "restricted or private browser page";
+    setSiteAccessText("unavailable", "DFIR Companion cannot read or capture this page.", "off");
+    button.hidden = true;
+    return;
+  }
+  const origin = originPatternFromUrl(currentTab.url)!;
+  const allowed = await hasSiteAccess(currentTab.url, browserApi.permissions);
+  originEl.textContent = origin.replace(/\/\*$/, "");
+  button.hidden = false;
+  button.textContent = allowed ? "Revoke this site" : "Allow this site";
+  button.dataset.allowed = String(allowed);
+  setSiteAccessText(
+    allowed ? "connected" : "not connected",
+    allowed
+      ? "This origin can show the console Push button and use ongoing capture."
+      : "No page data is readable until you approve this exact origin.",
+    allowed ? "on" : "off",
+  );
+  if (allowed && typeof currentTab.id === "number") {
+    const message: ActivateSiteMessage = { kind: "activate_site", tabId: currentTab.id };
+    await browserApi.runtime.sendMessage(message).catch(() => false);
+  }
+}
+
+async function grantCurrentSite(): Promise<boolean> {
+  if (!currentTab?.url || !isCapturableTab(currentTab)) return false;
+  try {
+    const result = await requestSiteAccess(currentTab.url, browserApi.permissions);
+    if (result.status === "denied") await recordDeniedAccess(result.origin);
+    await refreshSiteAccess();
+    if (result.status !== "granted") {
+      statusEl().textContent = "site access denied — capture remains off";
+      return false;
+    }
+    await initToolOverride();
+    return true;
+  } catch (error) {
+    statusEl().textContent = `site access unavailable: ${(error as Error).message}`;
+    return false;
+  }
+}
+
+async function revokeCurrentSite(): Promise<void> {
+  if (!currentTab?.url) return;
+  const removed = await revokeSiteAccess(currentTab.url, browserApi.permissions);
+  await refreshSiteAccess();
+  statusEl().textContent = removed ? "site access revoked" : "site access could not be revoked";
+}
+
+function wireSiteAccessControls(): void {
+  document.getElementById("siteAccessAction")!.onclick = async () => {
+    const allowed = (document.getElementById("siteAccessAction") as HTMLButtonElement).dataset.allowed === "true";
+    if (allowed) await revokeCurrentSite();
+    else await grantCurrentSite();
+  };
+  document.getElementById("manageSiteAccess")!.onclick = (event) => {
+    event.preventDefault();
+    void browserApi.runtime.openOptionsPage();
   };
 }
 
@@ -179,6 +285,7 @@ async function showHotkey(): Promise<void> {
 }
 
 async function init() {
+  currentTab = await activeTab();
   const s = await load();
   $("companionUrl").value = s.companionUrl;
   $("serviceToken").value = s.serviceToken;
@@ -188,6 +295,8 @@ async function init() {
   await refreshStatus(s);
   await showLastCapture();
   await showHotkey();
+  wireSiteAccessControls();
+  await refreshSiteAccess();
   await initToolOverride();
 
   // Auto-save the case selection immediately on change so the analyst can switch cases
@@ -216,6 +325,7 @@ async function init() {
       statusEl().textContent = "select a case — create one in the dashboard, then Refresh cases";
       return;
     }
+    if (!(await grantCurrentSite())) return;
     await save(f);
     await refreshStatus(f);
   };
@@ -223,6 +333,23 @@ async function init() {
     const f = readForm(false);
     await save(f);
     await refreshStatus(f);
+  };
+  document.getElementById("captureOnce")!.onclick = async () => {
+    const current = await load();
+    const f = readForm(current.running);
+    if (!f.caseId) {
+      statusEl().textContent = "select a case before capturing";
+      return;
+    }
+    if (!currentTab || !isCapturableTab(currentTab)) {
+      statusEl().textContent = "this browser or private page cannot be captured";
+      return;
+    }
+    await save(f);
+    const message: CaptureOnceMessage = { kind: "capture_once" };
+    const result = await browserApi.runtime.sendMessage(message) as { ok: boolean; error?: string };
+    statusEl().textContent = result.ok ? "one-off capture saved" : `capture blocked — ${result.error ?? "unknown error"}`;
+    await showLastCapture();
   };
 }
 

--- a/extension/src/serviceWorker.ts
+++ b/extension/src/serviceWorker.ts
@@ -5,13 +5,28 @@ import { setActionIcon } from "./actionIcon.js";
 import { buildArtifactFilename } from "./adapters/artifactName.js";
 import { browserApi } from "./browser.js";
 import {
-  DEFAULT_SETTINGS, type ContextPushResultMessage, type ContextTableResult,
+  appendAuditEntry,
+  hasSiteAccess,
+  isCapturableTab,
+  originPatternFromUrl,
+  originPatternMatchesUrl,
+  SITE_ACCESS_AUDIT_KEY,
+  type SiteAccessAuditAction,
+} from "./siteAccess.js";
+import {
+  DEFAULT_SETTINGS,
+  type ContextPushResultMessage, type ContextTableResult,
   type GetContextTableMessage, type PushArtifactMessage, type PushArtifactResult,
-  type Settings, type TriggerType,
+  type Settings, type SiteAccessChangedMessage, type TriggerType,
 } from "./types.js";
 
 const ALARM = "dfir-capture-timer";
 const queue = new CaptureQueue();
+
+interface CaptureAttemptResult {
+  ok: boolean;
+  error?: string;
+}
 
 async function getSettings(): Promise<Settings> {
   const stored = await browserApi.storage.local.get("settings");
@@ -25,18 +40,39 @@ function controllerFor(settings: Settings): CaptureController {
   );
 }
 
-async function captureActiveTab(trigger: TriggerType): Promise<void> {
+async function tabHasPersistentAccess(tab: chrome.tabs.Tab): Promise<boolean> {
+  if (!isCapturableTab(tab) || !tab.url) return false;
+  return hasSiteAccess(tab.url, browserApi.permissions);
+}
+
+async function recordBlockedCapture(trigger: TriggerType, error: string): Promise<CaptureAttemptResult> {
+  await browserApi.storage.local.set({
+    lastCapture: { at: new Date().toISOString(), trigger, url: "", bytes: 0, diag: `blocked — ${error}` },
+  });
+  await browserApi.action.setBadgeText({ text: "NO" });
+  await browserApi.action.setBadgeBackgroundColor({ color: "#777777" });
+  return { ok: false, error };
+}
+
+async function captureActiveTab(trigger: TriggerType, oneOff = false): Promise<CaptureAttemptResult> {
   const settings = await getSettings();
-  if (!settings.running || !settings.caseId) return;
+  if ((!settings.running && !oneOff) || !settings.caseId) {
+    return { ok: false, error: "select a case before capturing" };
+  }
 
   const [tab] = await browserApi.tabs.query({ active: true, lastFocusedWindow: true });
-  if (!tab || tab.id === undefined || !tab.url || tab.url.startsWith("chrome")) return;
+  if (!tab || tab.id === undefined || !tab.url || !isCapturableTab(tab)) {
+    return recordBlockedCapture(trigger, "this browser or private page cannot be captured");
+  }
+  if (!oneOff && !(await tabHasPersistentAccess(tab))) {
+    return recordBlockedCapture(trigger, "site access is not granted; open the extension on this site");
+  }
 
   let dataUrl: string;
   try {
     dataUrl = await browserApi.tabs.captureVisibleTab(tab.windowId, { format: "png" });
   } catch {
-    return; // e.g. capturing not allowed on this page
+    return recordBlockedCapture(trigger, "the browser denied screenshot access; click the extension and try again");
   }
   const imageBase64 = dataUrl.replace(/^data:image\/\w+;base64,/, "");
 
@@ -73,6 +109,9 @@ async function captureActiveTab(trigger: TriggerType): Promise<void> {
     await browserApi.action.setBadgeText({ text: status.online ? (status.queued ? String(status.queued) : "") : "off" });
     await browserApi.action.setBadgeBackgroundColor({ color: status.online ? "#2d6cdf" : "#cc3333" });
   }
+  return status.rejected
+    ? { ok: false, error: diag }
+    : { ok: true };
 }
 
 // Inject the MAIN-world fetch/XHR hook (pageHook.js) into a tab the content script recognized as a
@@ -85,11 +124,53 @@ async function captureActiveTab(trigger: TriggerType): Promise<void> {
 // isolated world — there
 // the hook would wrap the content script's own `fetch`, which no page script ever calls, so it
 // would install, report ready, and then capture nothing at all.
-async function injectHook(tabId: number | undefined): Promise<void> {
-  if (typeof tabId !== "number") return;
+async function recordSiteAccess(action: SiteAccessAuditAction, origin: string): Promise<void> {
+  const stored = await browserApi.storage.local.get(SITE_ACCESS_AUDIT_KEY);
+  const entry = { at: new Date().toISOString(), origin, action };
+  await browserApi.storage.local.set({
+    [SITE_ACCESS_AUDIT_KEY]: appendAuditEntry(stored[SITE_ACCESS_AUDIT_KEY], entry),
+  });
+}
+
+async function ensureContentScript(tabId: number, origin: string): Promise<void> {
+  const accessMessage: SiteAccessChangedMessage = {
+    kind: "site_access_changed",
+    origins: [origin],
+    allowed: true,
+  };
+  try {
+    await browserApi.tabs.sendMessage(tabId, { kind: "get_capture_status" });
+    await browserApi.tabs.sendMessage(tabId, accessMessage);
+    return;
+  } catch {
+    // No content script in this document yet.
+  }
+  await browserApi.scripting.executeScript({ target: { tabId }, files: ["content.js"] });
+}
+
+async function activateSite(tabId: number): Promise<boolean> {
+  let tab: chrome.tabs.Tab;
+  try {
+    tab = await browserApi.tabs.get(tabId);
+  } catch {
+    return false;
+  }
+  if (!(await tabHasPersistentAccess(tab))) return false;
+  const origin = originPatternFromUrl(tab.url ?? "");
+  if (!origin) return false;
+  try {
+    await ensureContentScript(tabId, origin);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function injectHook(tab: chrome.tabs.Tab | undefined): Promise<void> {
+  if (typeof tab?.id !== "number" || !(await tabHasPersistentAccess(tab))) return;
   try {
     await browserApi.scripting.executeScript({
-      target: { tabId },
+      target: { tabId: tab.id },
       world: "MAIN",
       files: ["pageHook.js"],
     });
@@ -99,7 +180,13 @@ async function injectHook(tabId: number | undefined): Promise<void> {
 // Push a tool artifact (intercepted JSON or scraped table) the content script captured to the
 // companion's unified import route (#102). Uses the active case from settings — the artifact path
 // reuses the same case the analyst already selected for screenshot capture.
-async function pushArtifact(msg: PushArtifactMessage): Promise<PushArtifactResult> {
+async function pushArtifact(
+  msg: PushArtifactMessage,
+  sourceTab?: chrome.tabs.Tab,
+): Promise<PushArtifactResult> {
+  if (sourceTab && !(await tabHasPersistentAccess(sourceTab))) {
+    return { ok: false, error: "Site access was revoked — open the extension to reconnect this console." };
+  }
   const settings = await getSettings();
   if (!settings.caseId) {
     return { ok: false, error: "No case selected — open the extension popup and pick a case." };
@@ -165,7 +252,7 @@ async function handleContextMenuClick(
   info: chrome.contextMenus.OnClickData,
   tab: chrome.tabs.Tab | undefined,
 ): Promise<void> {
-  if (!tab?.id) return;
+  if (typeof tab?.id !== "number" || tab.incognito) return;
   const tabId = tab.id;
 
   let text: string | undefined;
@@ -212,6 +299,40 @@ async function handleContextMenuClick(
   void sendContextToast(tabId, res.ok, res.ok ? `Pushed to "${res.caseId}"` : (res.error ?? "Push failed"));
 }
 
+function changedOrigins(change: chrome.permissions.Permissions): string[] {
+  return (change.origins ?? []).filter((origin) => typeof origin === "string");
+}
+
+async function notifyContentScripts(origins: string[], allowed: boolean): Promise<void> {
+  if (!origins.length) return;
+  const message: SiteAccessChangedMessage = { kind: "site_access_changed", origins, allowed };
+  const tabs = await browserApi.tabs.query({});
+  await Promise.all(tabs.map(async (tab) => {
+    if (typeof tab.id !== "number") return;
+    try { await browserApi.tabs.sendMessage(tab.id, message); } catch { /* no content script */ }
+  }));
+}
+
+async function activateMatchingTabs(origins: string[]): Promise<void> {
+  const tabs = await browserApi.tabs.query({});
+  const matchingIds = tabs.flatMap((tab) => {
+    if (typeof tab.id !== "number" || !isCapturableTab(tab)) return [];
+    const matches = origins.some((origin) => originPatternMatchesUrl(origin, tab.url ?? ""));
+    return matches ? [tab.id] : [];
+  });
+  await Promise.all(matchingIds.map((tabId) => activateSite(tabId)));
+}
+
+async function handlePermissionChange(
+  action: SiteAccessAuditAction,
+  change: chrome.permissions.Permissions,
+): Promise<void> {
+  const origins = changedOrigins(change);
+  for (const origin of origins) await recordSiteAccess(action, origin);
+  if (action === "granted") await activateMatchingTabs(origins);
+  else await notifyContentScripts(origins, false);
+}
+
 async function rescheduleAlarm(): Promise<void> {
   const settings = await getSettings();
   await browserApi.alarms.clear(ALARM);
@@ -228,12 +349,19 @@ async function rescheduleAlarm(): Promise<void> {
 // shortcut feels responsive instead of waiting for the next timer tick.
 async function toggleCapture(): Promise<void> {
   const settings = await getSettings();
+  if (!settings.running) {
+    const [tab] = await browserApi.tabs.query({ active: true, lastFocusedWindow: true });
+    if (!tab || !(await tabHasPersistentAccess(tab))) {
+      await recordBlockedCapture("manual", "site access is required; open the extension on this site");
+      return;
+    }
+  }
   const next: Settings = { ...settings, running: !settings.running };
   await browserApi.storage.local.set({ settings: next });
   await rescheduleAlarm();
   await browserApi.action.setBadgeText({ text: next.running ? "REC" : "off" });
   await browserApi.action.setBadgeBackgroundColor({ color: next.running ? "#cc3333" : "#777777" });
-  if (next.running) void captureActiveTab("timer");
+  if (next.running) void captureActiveTab("manual");
 }
 
 browserApi.alarms.onAlarm.addListener((alarm) => {
@@ -243,19 +371,41 @@ browserApi.tabs.onActivated.addListener(() => void captureActiveTab("tab_switch"
 browserApi.webNavigation.onCommitted.addListener((d) => {
   if (d.frameId === 0) void captureActiveTab("navigation");
 });
+browserApi.webNavigation.onCompleted.addListener((details) => {
+  if (details.frameId === 0) void activateSite(details.tabId);
+});
 browserApi.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.kind === "user_event") { void captureActiveTab("click"); return; }
   if (msg?.kind === "settings_changed") { void rescheduleAlarm(); return; }
-  if (msg?.kind === "ensure_hook") { void injectHook(sender.tab?.id); return; }
+  if (msg?.kind === "ensure_hook") { void injectHook(sender.tab); return; }
+  if (msg?.kind === "activate_site") {
+    const tabId = (msg as { tabId?: unknown }).tabId;
+    if (sender.tab || typeof tabId !== "number" || !Number.isInteger(tabId)) {
+      sendResponse(false);
+      return;
+    }
+    void activateSite(tabId).then(sendResponse);
+    return true;
+  }
+  if (msg?.kind === "capture_once") {
+    if (sender.tab) {
+      sendResponse({ ok: false, error: "one-off capture requires an extension action" });
+      return;
+    }
+    void captureActiveTab("manual", true).then(sendResponse);
+    return true;
+  }
   if (msg?.kind === "push_artifact") {
     // Async — return true to keep the message channel open until pushArtifact resolves.
-    void pushArtifact(msg as PushArtifactMessage).then(sendResponse);
+    void pushArtifact(msg as PushArtifactMessage, sender.tab).then(sendResponse);
     return true;
   }
 });
 browserApi.runtime.onInstalled.addListener(() => { void rescheduleAlarm(); void registerContextMenus(); });
 browserApi.runtime.onStartup.addListener(() => void rescheduleAlarm());
 browserApi.contextMenus.onClicked.addListener((info, tab) => void handleContextMenuClick(info, tab));
+browserApi.permissions.onAdded.addListener((change) => void handlePermissionChange("granted", change));
+browserApi.permissions.onRemoved.addListener((change) => void handlePermissionChange("revoked", change));
 // Keyboard shortcut (default Ctrl+Shift+S / Cmd+Shift+S) to toggle capture on/off.
 browserApi.commands?.onCommand.addListener((command) => {
   if (command === "toggle-capture") void toggleCapture();

--- a/extension/src/siteAccess.ts
+++ b/extension/src/siteAccess.ts
@@ -1,0 +1,105 @@
+export const SITE_ACCESS_AUDIT_KEY = "siteAccessAudit";
+const MAX_AUDIT_ENTRIES = 100;
+
+export interface PermissionGateway {
+  contains(permissions: chrome.permissions.Permissions): Promise<boolean>;
+  request(permissions: chrome.permissions.Permissions): Promise<boolean>;
+  remove(permissions: chrome.permissions.Permissions): Promise<boolean>;
+}
+
+export type SiteAccessResult =
+  | { status: "granted" | "denied"; origin: string }
+  | { status: "restricted"; origin: null };
+
+export type SiteAccessAuditAction = "granted" | "denied" | "revoked";
+
+export interface SiteAccessAuditEntry {
+  at: string;
+  origin: string;
+  action: SiteAccessAuditAction;
+}
+
+export interface SiteTab {
+  url?: string;
+  incognito?: boolean;
+}
+
+/** Return the smallest host pattern that covers one ordinary web origin. */
+export function originPatternFromUrl(rawUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  return `${url.origin}/*`;
+}
+
+export function originPatternMatchesUrl(pattern: string, rawUrl: string): boolean {
+  const current = originPatternFromUrl(rawUrl);
+  if (!current) return false;
+  if (pattern === "<all_urls>" || pattern === current) return true;
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  const match = /^(\*|https?|file):\/\/([^/]+)\/\*$/.exec(pattern);
+  if (!match) return false;
+  const [, scheme, host] = match;
+  if (scheme !== "*" && `${scheme}:` !== url.protocol) return false;
+  if (host === "*") return true;
+  if (host.startsWith("*.")) {
+    const suffix = host.slice(2).toLowerCase();
+    return url.hostname === suffix || url.hostname.endsWith(`.${suffix}`);
+  }
+  return url.host.toLowerCase() === host.toLowerCase();
+}
+
+export function isCapturableTab(tab: SiteTab): boolean {
+  return tab.incognito !== true && typeof tab.url === "string" && originPatternFromUrl(tab.url) !== null;
+}
+
+export async function hasSiteAccess(rawUrl: string, gateway: PermissionGateway): Promise<boolean> {
+  const origin = originPatternFromUrl(rawUrl);
+  if (!origin) return false;
+  return gateway.contains({ origins: [origin] });
+}
+
+export async function requestSiteAccess(
+  rawUrl: string,
+  gateway: PermissionGateway,
+): Promise<SiteAccessResult> {
+  const origin = originPatternFromUrl(rawUrl);
+  if (!origin) return { status: "restricted", origin: null };
+  const granted = await gateway.request({ origins: [origin] });
+  return { status: granted ? "granted" : "denied", origin };
+}
+
+export async function revokeSiteAccess(rawUrl: string, gateway: PermissionGateway): Promise<boolean> {
+  const origin = originPatternFromUrl(rawUrl);
+  if (!origin) return false;
+  return gateway.remove({ origins: [origin] });
+}
+
+export function readAuditEntries(value: unknown): SiteAccessAuditEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isAuditEntry).slice(-MAX_AUDIT_ENTRIES);
+}
+
+export function appendAuditEntry(
+  existing: unknown,
+  entry: SiteAccessAuditEntry,
+): SiteAccessAuditEntry[] {
+  return [...readAuditEntries(existing), entry].slice(-MAX_AUDIT_ENTRIES);
+}
+
+function isAuditEntry(value: unknown): value is SiteAccessAuditEntry {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Record<string, unknown>;
+  return typeof item.at === "string"
+    && typeof item.origin === "string"
+    && (item.action === "granted" || item.action === "denied" || item.action === "revoked");
+}

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -1,4 +1,4 @@
-export type TriggerType = "timer" | "navigation" | "tab_switch" | "click";
+export type TriggerType = "timer" | "navigation" | "tab_switch" | "click" | "manual";
 
 export interface CapturePayload {
   caseId: string;
@@ -137,4 +137,19 @@ export interface CaptureStatusResult {
   overrideAdapterId: string;  // mirrors the popup <select> value — see SetAdapterOverrideMessage
   activeLabel: string | null; // the adapter actually in effect (detected, unless overridden)
   rowCount: number;           // rows captured so far under the active adapter
+}
+
+export interface ActivateSiteMessage {
+  kind: "activate_site";
+  tabId: number;
+}
+
+export interface CaptureOnceMessage {
+  kind: "capture_once";
+}
+
+export interface SiteAccessChangedMessage {
+  kind: "site_access_changed";
+  origins: string[];
+  allowed: boolean;
 }

--- a/extension/tests/extensionContext.test.ts
+++ b/extension/tests/extensionContext.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { runBestEffortExtensionCall } from "../src/extensionContext.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+
+describe("runBestEffortExtensionCall", () => {
+  it("contains synchronous context-invalidation errors", () => {
+    const onInvalidated = vi.fn();
+
+    expect(() => runBestEffortExtensionCall(
+      () => { throw new Error("Extension context invalidated."); },
+      onInvalidated,
+    )).not.toThrow();
+    expect(onInvalidated).toHaveBeenCalledTimes(1);
+  });
+
+  it("contains asynchronous context-invalidation errors", async () => {
+    const onInvalidated = vi.fn();
+
+    runBestEffortExtensionCall(
+      () => Promise.reject(new Error("Extension context invalidated.")),
+      onInvalidated,
+    );
+    await vi.waitFor(() => expect(onInvalidated).toHaveBeenCalledTimes(1));
+  });
+
+  it("ignores unrelated best-effort delivery failures", async () => {
+    const onInvalidated = vi.fn();
+
+    runBestEffortExtensionCall(
+      () => Promise.reject(new Error("Receiving end does not exist.")),
+      onInvalidated,
+    );
+    await Promise.resolve();
+    expect(onInvalidated).not.toHaveBeenCalled();
+  });
+
+  it("leaves no uncontained fire-and-forget extension calls in the content bundle", () => {
+    const sources = ["content.ts", "artifactCapture.ts", "contextMenuCapture.ts"]
+      .map((name) => readFileSync(resolve(testDir, `../src/${name}`), "utf8"))
+      .join("\n");
+
+    expect(sources).not.toMatch(
+      /void browserApi\.(?:runtime\.sendMessage|storage\.local\.(?:get|set|remove))\(/,
+    );
+  });
+});

--- a/extension/tests/firefox.test.ts
+++ b/extension/tests/firefox.test.ts
@@ -36,14 +36,17 @@ describe("the generated Firefox manifest", () => {
     expect(firefoxManifest.background.scripts).toContain("serviceWorker.js");
   });
 
-  it("requests host access via host_permissions, not permissions", () => {
-    // MV3 splits the two keys: match patterns in `permissions` are not valid MV3 and Firefox
-    // drops them with a manifest warning, leaving the add-on with no host access at all.
-    expect(firefoxManifest.host_permissions).toContain("<all_urls>");
+  it("keeps host access optional and out of permissions", () => {
+    expect(firefoxManifest.host_permissions ?? []).toEqual([]);
+    expect(firefoxManifest.optional_host_permissions).toEqual(["http://*/*", "https://*/*"]);
     const matchPatterns = (firefoxManifest.permissions as string[]).filter(
       (p) => p.includes("://") || p === "<all_urls>",
     );
     expect(matchPatterns).toEqual([]);
+  });
+
+  it("cannot be enabled in Firefox private browsing", () => {
+    expect(firefoxManifest.incognito).toBe("not_allowed");
   });
 
   it("keeps the same capture shortcut", () => {

--- a/extension/tests/manifest.test.ts
+++ b/extension/tests/manifest.test.ts
@@ -22,4 +22,18 @@ describe("manifest.json permissions", () => {
   it("requests contextMenus for the right-click send feature", () => {
     expect(manifest.permissions).toContain("contextMenus");
   });
+
+  it("installs without persistent access to websites", () => {
+    expect(manifest.host_permissions ?? []).toEqual([]);
+    expect(manifest.content_scripts ?? []).toEqual([]);
+    expect(manifest.permissions).not.toContain("tabs");
+  });
+
+  it("declares web origins as runtime-only permissions", () => {
+    expect(manifest.optional_host_permissions).toEqual(["http://*/*", "https://*/*"]);
+  });
+
+  it("does not request private browsing access at install", () => {
+    expect(manifest.incognito).toBeUndefined();
+  });
 });

--- a/extension/tests/pageHook.test.ts
+++ b/extension/tests/pageHook.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { createContext, runInContext } from "node:vm";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it, vi } from "vitest";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+
+function compiledPageHook(): string {
+  const source = readFileSync(resolve(testDir, "../src/pageHook.ts"), "utf8");
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.None,
+    },
+  }).outputText;
+}
+
+describe("pageHook", () => {
+  it("can be injected repeatedly into the same page", () => {
+    const addEventListener = vi.fn();
+    const pageWindow = {
+      addEventListener,
+      postMessage: vi.fn(),
+      fetch: undefined,
+      XMLHttpRequest: undefined,
+    };
+    const context = createContext({ window: pageWindow });
+    const hook = compiledPageHook();
+
+    runInContext(hook, context);
+    expect(() => runInContext(hook, context)).not.toThrow();
+    expect(addEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extension/tests/siteAccess.test.ts
+++ b/extension/tests/siteAccess.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendAuditEntry,
+  isCapturableTab,
+  originPatternMatchesUrl,
+  originPatternFromUrl,
+  readAuditEntries,
+  requestSiteAccess,
+  revokeSiteAccess,
+  type PermissionGateway,
+} from "../src/siteAccess.js";
+
+function permissionGateway(result: boolean, alreadyGranted = false): PermissionGateway & {
+  requested: string[][];
+  removed: string[][];
+} {
+  const requested: string[][] = [];
+  const removed: string[][] = [];
+  return {
+    requested,
+    removed,
+    contains: async () => alreadyGranted,
+    request: async ({ origins }) => {
+      requested.push(origins ?? []);
+      return result;
+    },
+    remove: async ({ origins }) => {
+      removed.push(origins ?? []);
+      return result;
+    },
+  };
+}
+
+describe("site access boundaries", () => {
+  it("turns an approved web page into one exact-origin permission", () => {
+    expect(originPatternFromUrl("https://velo.example:8889/app/index.html#/hunts")).toBe(
+      "https://velo.example:8889/*",
+    );
+  });
+
+  it.each([
+    "chrome://extensions",
+    "about:addons",
+    "moz-extension://abc/options.html",
+    "file:///tmp/evidence.html",
+    "data:text/plain,evidence",
+    "not a URL",
+  ])("refuses restricted page %s", (url) => {
+    expect(originPatternFromUrl(url)).toBeNull();
+  });
+
+  it("refuses private tabs even when their URL is otherwise supported", () => {
+    expect(isCapturableTab({ url: "https://velo.example/app/", incognito: true })).toBe(false);
+  });
+
+  it("matches exact and browser-wide permission changes to the current page", () => {
+    expect(originPatternMatchesUrl("https://velo.example:8889/*", "https://velo.example:8889/app/")).toBe(true);
+    expect(originPatternMatchesUrl("https://*/*", "https://velo.example:8889/app/")).toBe(true);
+    expect(originPatternMatchesUrl("http://*/*", "https://velo.example:8889/app/")).toBe(false);
+  });
+});
+
+describe("optional host permission flow", () => {
+  it("requests only the current origin and reports a grant", async () => {
+    const gateway = permissionGateway(true);
+
+    const result = await requestSiteAccess("https://velo.example:8889/app/index.html", gateway);
+
+    expect(result).toEqual({ status: "granted", origin: "https://velo.example:8889/*" });
+    expect(gateway.requested).toEqual([["https://velo.example:8889/*"]]);
+  });
+
+  it("fails closed when the analyst denies access", async () => {
+    const gateway = permissionGateway(false);
+
+    const result = await requestSiteAccess("https://velo.example/app/", gateway);
+
+    expect(result).toEqual({ status: "denied", origin: "https://velo.example/*" });
+  });
+
+  it("revokes only the selected origin", async () => {
+    const gateway = permissionGateway(true);
+
+    const result = await revokeSiteAccess("https://velo.example/app/", gateway);
+
+    expect(result).toBe(true);
+    expect(gateway.removed).toEqual([["https://velo.example/*"]]);
+  });
+});
+
+describe("permission audit", () => {
+  it("drops malformed stored values and keeps a bounded immutable history", () => {
+    const original = [{ at: "2026-07-31T10:00:00.000Z", origin: "https://one.example/*", action: "granted" }];
+    const next = appendAuditEntry(original, {
+      at: "2026-07-31T10:01:00.000Z",
+      origin: "https://two.example/*",
+      action: "revoked",
+    });
+
+    expect(next).toHaveLength(2);
+    expect(original).toHaveLength(1);
+    expect(appendAuditEntry([{ nope: true }], next[1])).toEqual([next[1]]);
+  });
+
+  it("keeps only the latest 100 permission changes", () => {
+    let entries: unknown = [];
+    for (let i = 0; i < 105; i += 1) {
+      entries = appendAuditEntry(entries, {
+        at: `2026-07-31T10:${String(i).padStart(2, "0")}:00.000Z`,
+        origin: `https://console-${i}.example/*`,
+        action: "granted",
+      });
+    }
+    const history = readAuditEntries(entries);
+    expect(history).toHaveLength(100);
+    expect(history[0].origin).toBe("https://console-5.example/*");
+  });
+});

--- a/mkdocs-docs/reference/evidence-capture.md
+++ b/mkdocs-docs/reference/evidence-capture.md
@@ -2,25 +2,49 @@
 
 ## How It Works
 
-The extension captures a screenshot of the current browser tab and POSTs it to `POST /captures` on the Companion server. The server saves the image to `cases/<id>/screenshots/` before doing anything else — evidence is always persisted first, before any AI analysis.
+The extension captures a screenshot of the current browser tab and sends it to the Companion. The
+server saves the image before doing anything else — evidence is always persisted first, before any
+AI analysis.
+
+A fresh installation has no access to websites. On the console you want to use, click the extension
+icon and **Allow this site**. The browser prompt names that exact origin. Access remains limited to
+that origin until you revoke it from the popup, the Extension options page, or the browser's own
+extension controls.
 
 ## Capture Modes
 
 | Method | How |
 |--------|-----|
-| **Hotkey** | `Ctrl+Shift+S` in any browser tab |
-| **Extension popup** | Click the extension icon → select case → click Capture |
-| **Floating push button** | Button injected into recognised DFIR consoles; single-click sends the current event/row |
+| **One-off screenshot** | Click the extension icon → select case → **Capture this tab once**. Uses temporary tab access; no site grant is retained. |
+| **Ongoing screenshots** | Approve the console origin → select case → **Start**. Timer/navigation/tab-switch capture is limited to approved origins. |
+| **Hotkey** | `Ctrl+Shift+S` toggles ongoing capture; an unapproved site fails closed and tells you to use the popup. |
+| **Floating push button** | Injected only into an approved, recognised DFIR console; a click sends the current rows. |
+
+Browser-internal pages, local files, data URLs, and private/incognito tabs cannot be captured.
 
 ## Recognised Consoles (One-Click Push)
 
-The extension automatically injects a push button into:
+After origin approval, the extension can inject a push button into:
 
 - **Security Onion** (Alerts, Hunt, Dashboards)
 - **SO-CRATES** (network/file events, Sigma detections)
 - **Elasticsearch/Kibana** (standard and modern async-search)
 
-For any other browser-based tool (Velociraptor, Splunk, a custom SIEM, etc.), use `Ctrl+Shift+S` to enable capture mode and click the floating Push chip.
+Velociraptor, Splunk, Kibana/Elastic, CrowdStrike, VolWeb, and other supported/self-hosted consoles
+are recognized by their URL or page signature. A custom origin still requires the same explicit
+**Allow this site** action.
+
+## What Page Data Is Used
+
+On an approved console, the extension reads the page URL/title, tool-identifying page markers, the
+visible table when you click Push, and API responses matching that console adapter. Matching rows
+stay in page memory and are transmitted only after you click Push. Screenshots are sent only when a
+capture action or enabled capture trigger fires. Nothing is sent to the extension authors or an
+analytics service.
+
+The options page shows approved origins and a local log of the latest 100 grants, denials, and
+revocations. Revoking an origin removes the Push button, disables the page hook, and blocks late
+messages from that page.
 
 ## Screenshot OCR Full-Text Search
 


### PR DESCRIPTION
## Summary

- require an analyst to grant each Velociraptor origin before the extension can capture or push data
- inject capture code only on approved origins and fail closed after permission revocation or an extension reload
- update Chrome and Firefox permissions, site-access controls, documentation, and regression coverage
- allow authenticated extension requests through the Companion trusted-origin preflight

## Validation

- Companion: build, typecheck, lint, format check, file-size check, import-cycle check, and 6,683 tests
- Extension: typecheck, 206 tests, Chrome build, and Firefox build
- Branch content secret and PII scan

Closes #388