### PR TITLE
refactor(dashboard): extract the diagnostics panel to a module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,7 +35,7 @@ it may never go up.**
 **Type-only imports count.** `import type` is exempt from `check:imports`, because an erased import
 cannot form a runtime initialisation cycle — that reasoning is correct there and does not carry over
 here. A type import still means one domain knows another's shape, which is the coupling this map
-exists to control. It is not a rounding error either: **16 of the 48 recorded violations are
+exists to control. It is not a rounding error either: **15 of the 47 recorded violations are
 type-only**, so exempting them would have hidden a third of the problem on day one.
 
 | Layer | Contents | May import |
@@ -78,7 +78,7 @@ today, not invented — `ai` importing `ingest` 39 times is why `ai` is at the t
 | **1** | `intel/` | reference data and mapping: `attack*`, `d3fend*`, `kev*`, `nsrl*`, `adversary*`, `playbook*`, `compliance*`, `geoMap`, `incidentType*` | 33 | 5,261 |
 | **0** | `timeline/` | the event record itself: `superTimeline*`, `forensicGate`, `forensicSort`, `correlate`, `stateMerge`, `searchFilter`, `time*`, `clockSkew` | 16 | 2,773 |
 
-Four placements worth stating outright, because each one is a decision someone will otherwise
+Five placements worth stating outright, because each one is a decision someone will otherwise
 relitigate:
 
 - **`detect/` is separate from `ai/`.** The deterministic detectors are the thing that must keep
@@ -92,6 +92,12 @@ relitigate:
   properties of the record, not detections over it. Filing it with the detectors made three
   `superTimeline`/`clockSkew`/`stateMerge` imports look like violations when the misfiling was the
   problem; the map assigns it to `timeline/` and those entries are gone.
+- **`responseSchema.ts` is Shared too.** It defines `deltaSchema` — the shape of a *change* to
+  investigation state — and it was filed under `ai/` because the AI extraction path parses model
+  responses with it. That was wrong: it imports only `zod` and `canonicalEvent`, `stateMerge.ts` at
+  tier 0 already imported it as a recorded violation, and every deterministic importer validates its
+  constructed delta with it. A delta is vocabulary, not an AI concept. Moving it cleared six
+  violations the ingest extraction would otherwise have created, and retired the `stateMerge` one.
 - **`stateTypes.ts` and `canonicalEvent.ts` are Shared, not `timeline/`.** `stateTypes.ts` is
   imported by 189 files in every area of the tree — it is the application's event vocabulary in the
   same sense `types.ts` is, and their mutual type reference makes them one unit. Filing them in a
@@ -178,8 +184,8 @@ established, and it works the same way.
 - `scripts/module-map.json` assigns **every file** in `companion/src` to a domain, and declares the
   allowed edges. Files are listed by exact path, not by count, so deleting one file never creates
   room for a different one.
-- `scripts/boundary-violations.json` records the **48 violations** that break the map today, as
-  concrete `source-file → target-file [kind]` entries spanning 30 domain edges. Not domain pairs,
+- `scripts/boundary-violations.json` records the **47 violations** that break the map today, as
+  concrete `source-file → target-file [kind]` entries spanning 29 domain edges. Not domain pairs,
   and not counts: an already-recorded edge must not become a licence to add more imports along it.
   The `[kind]` suffix is `runtime` or `type`, and it is part of the key so that a grandfathered
   type-only edge turning into a runtime one reads as a **new** violation rather than passing
@@ -287,5 +293,5 @@ issue, and the umbrella closes when all of these hold:
 | `public/dashboard.html` inline CSS | 3,231 lines | ≤ 800 |
 | Files in `src/` over 800 lines | 13 | 0 |
 | Flat files in `src/analysis/` | 290 | 0 |
-| Boundary ledger | 48 violations | ≤ 10 |
+| Boundary ledger | 47 violations | ≤ 10 |
 | Forensic / super-timeline rule | unresolved | decided, enforced, tested |

--- a/companion/scripts/boundary-violations.json
+++ b/companion/scripts/boundary-violations.json
@@ -35,7 +35,6 @@
   "analysis/stateMerge.ts -> analysis/initialAccess.ts [runtime]",
   "analysis/stateMerge.ts -> analysis/iocExclude.ts [runtime]",
   "analysis/stateMerge.ts -> analysis/iocValue.ts [runtime]",
-  "analysis/stateMerge.ts -> analysis/responseSchema.ts [type]",
   "analysis/stateMerge.ts -> analysis/uncertainty.ts [runtime]",
   "analysis/stateMerge.ts -> analysis/workLogFilter.ts [runtime]",
   "analysis/stateTypes.ts -> analysis/iocExclude.ts [type]",

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -1,7 +1,7 @@
 {
   "analysis/caseSqliteWorker.ts": 812,
   "analysis/memoryImport.ts": 1265,
-  "analysis/pipeline.ts": 3326,
+  "analysis/pipeline.ts": 3353,
   "analysis/seedDemoCase.ts": 822,
   "analysis/siemImport.ts": 1346,
   "analysis/velociraptorImport.ts": 1503,

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -7,7 +7,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/dashboard.html#inline-css": 3232,
-  "public/dashboard.html#inline-js": 19194,
+  "public/dashboard.html#inline-js": 19201,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1302,
   "routes/import.ts": 1766,

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -1,7 +1,7 @@
 {
   "analysis/caseSqliteWorker.ts": 812,
   "analysis/memoryImport.ts": 1265,
-  "analysis/pipeline.ts": 4877,
+  "analysis/pipeline.ts": 3326,
   "analysis/seedDemoCase.ts": 822,
   "analysis/siemImport.ts": 1346,
   "analysis/velociraptorImport.ts": 1503,

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -7,7 +7,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/dashboard.html#inline-css": 3232,
-  "public/dashboard.html#inline-js": 19323,
+  "public/dashboard.html#inline-js": 19194,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1302,
   "routes/import.ts": 1766,

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -346,7 +346,7 @@
     "redactPaths.ts": "analysis/privacy",
     "redactedExport.ts": "analysis/privacy",
     "regexSafety.ts": "analysis/privacy",
-    "responseSchema.ts": "analysis/ai",
+    "responseSchema.ts": "shared",
     "sandboxImport.ts": "analysis/ingest",
     "savedHuntStore.ts": "analysis/hunt",
     "scope.ts": "analysis/workflow",

--- a/companion/src/analysis/ingest/cloudImports.ts
+++ b/companion/src/analysis/ingest/cloudImports.ts
@@ -1,0 +1,284 @@
+import { parseCloudTrail, type AwsImportOptions } from "../awsImport.js";
+import { parseCloudActivity, type CloudActivityImportOptions } from "../cloudActivityImport.js";
+import { parseK8sAudit, type K8sAuditImportOptions } from "../k8sAuditImport.js";
+import { parseM365Audit, type M365ImportOptions } from "../m365Import.js";
+import { parseOsqueryLog, type OsqueryImportOptions } from "../osqueryImport.js";
+import { deltaSchema } from "../responseSchema.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import { type InvestigationState, type Severity } from "../stateTypes.js";
+import type { ImportContext } from "./importContext.js";
+
+/**
+ * Cloud control-plane and fleet-query sources.
+ *
+ * Moved from AnalysisPipeline (#384). Each of these was a method; each is now a free function
+ * taking an ImportContext, which is the small set of collaborators an importer is allowed to use.
+ * The pipeline keeps a one-line delegation per importer, so callers are unchanged.
+ */
+
+// Import Microsoft 365 Unified Audit Log + Entra ID (sign-in / directory audit) data.
+// Deterministic (no AI call): each record is classified (UAL / sign-in / audit) and mapped,
+// severity derived from the operation (BEC tradecraft) or Entra's own risk verdict; the
+// source IP becomes an IOC and the UPN is surfaced for the asset graph.
+export async function importM365(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "m3") so ids never collide
+    importedAt: string;
+    m365?: M365ImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseM365Audit(text, opts.m365);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Microsoft 365", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Microsoft 365"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Microsoft 365 import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import AWS CloudTrail logs. Deterministic (no AI call): each API-call record is mapped,
+// severity derived from the action (IAM persistence, logging/detection tampering, S3
+// exposure, secrets access) + denied/root/console-failure bumps; the caller IP → IOC.
+export async function importAws(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "a3") so ids never collide
+    importedAt: string;
+    aws?: AwsImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseCloudTrail(text, opts.aws);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "AWS CloudTrail", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["AWS CloudTrail"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `AWS CloudTrail import: ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import GCP Cloud Audit Logs + Azure Activity Log. Deterministic (no AI call): each record
+// is routed (GCP / Azure) and mapped, severity derived from the action (+ denied bump); the
+// caller IP → IOC and the principal email is surfaced for the asset graph.
+export async function importCloudActivity(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "g3") so ids never collide
+    importedAt: string;
+    cloud?: CloudActivityImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseCloudActivity(text, opts.cloud);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Cloud activity", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Cloud Audit"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Cloud activity import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import Kubernetes API-server audit logs (audit.k8s.io). Deterministic (no AI call): each audit
+// Event → a forensic event whose severity is derived from the (verb, resource, subresource) tuple
+// (pod exec/attach, secret access, RBAC change, privileged-pod create, anonymous access), Info by
+// default. Source IP → IOC. Tagged Kubernetes Audit.
+export async function importK8sAudit(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "k3") so ids never collide
+    importedAt: string;
+    k8s?: K8sAuditImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseK8sAudit(text, opts.k8s);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Kubernetes audit", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Kubernetes Audit"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Kubernetes audit import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import osquery scheduled-query result logs (differential `columns` rows + `snapshot` sets).
+// Deterministic (no AI call): Info-by-default endpoint telemetry, with a conservative tradecraft
+// bump on a command-line column; columns → IOCs (path/hash/ip/process). Tagged osquery.
+export async function importOsquery(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "o3") so ids never collide
+    importedAt: string;
+    osquery?: OsqueryImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseOsqueryLog(text, opts.osquery);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "osquery", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["osquery"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `osquery import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}

--- a/companion/src/analysis/ingest/endpointImports.ts
+++ b/companion/src/analysis/ingest/endpointImports.ts
@@ -1,0 +1,436 @@
+import { parseChainsawReport, type ChainsawImportOptions } from "../chainsawImport.js";
+import { parseCybertriage, type CybertriageImportOptions } from "../cybertriageImport.js";
+import { ECAR_SOURCE, parseEcarJson, type EcarImportOptions } from "../ecarImport.js";
+import { parseHayabusaTimeline, type HayabusaImportOptions } from "../hayabusaImport.js";
+import { parseKapeCsv, type KapeImportOptions } from "../kapeImport.js";
+import { deltaSchema } from "../responseSchema.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import { resolveExtractedFrom } from "../siemImport.js";
+import { type InvestigationState, type Severity } from "../stateTypes.js";
+import { parseThorReport, type ThorImportOptions } from "../thorImport.js";
+import { parseVelociraptorJsonProgress, type VelociraptorImportOptions } from "../velociraptorImport.js";
+import type { ImportContext } from "./importContext.js";
+
+/**
+ * Endpoint and host-triage collections: agent output, triage bundles and EDR exports.
+ *
+ * Moved from AnalysisPipeline (#384). Each of these was a method; each is now a free function
+ * taking an ImportContext, which is the small set of collaborators an importer is allowed to use.
+ * The pipeline keeps a one-line delegation per importer, so callers are unchanged.
+ */
+
+// Import a THOR (Nextron) scanner report in JSON-Lines format. Unlike the CSV/log
+// paths this is DETERMINISTIC — THOR's JSON is structured and stable, so each
+// finding maps straight to a forensic event + IOCs with NO AI extraction call.
+// Scan-lifecycle/info noise (module init, "Info" level) is dropped by default.
+// Findings/attacker-path still come from a later synthesize().
+export async function importThor(
+  ctx: ImportContext,
+  caseId: string,
+  jsonText: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "t3") so ids never collide
+    importedAt: string;
+    thor?: ThorImportOptions; // filtering overrides (dropInfo, dropLifecycleModules…)
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseThorReport(jsonText, opts.thor);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "THOR", parsed.total);
+
+  // Assign stable, collision-free ids and validate the delta against the schema
+  // (fills defaults like relatedFindingIds). No model call — purely structural.
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({ ...e, id: `${opts.idPrefix}e${i + 1}` })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `THOR import: ${parsed.kept} finding(s) kept, ${parsed.dropped} info/lifecycle row(s) dropped` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import Chainsaw (WithSecure) hunt output or a raw EVTX-as-JSON dump. Like THOR/SIEM
+// the mapping is DETERMINISTIC (no AI call): the embedded EVTX events get the same
+// per-EID Windows mapping as the SIEM import, and — for Chainsaw — the matched Sigma
+// rule's level drives severity while its `attack.tXXXX` tags become MITRE techniques.
+// Each event is tagged Chainsaw / EVTX as its source for cross-source correlation.
+export async function importChainsaw(
+  ctx: ImportContext,
+  caseId: string,
+  jsonText: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "c3") so ids never collide
+    importedAt: string;
+    chainsaw?: ChainsawImportOptions; // filtering overrides (aggregate, minSeverity, maxEvents…)
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseChainsawReport(jsonText, opts.chainsaw);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Chainsaw", parsed.total);
+
+  const fallback = parsed.detections > 0 ? "Chainsaw" : "EVTX";
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [fallback],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `${parsed.detections > 0 ? "Chainsaw" : "EVTX"} import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.detections > 0 ? `, ${parsed.detections} rule detection(s)` : "") +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a Hayabusa (Yamato Security) detection timeline — JSON/JSONL or CSV. Like the
+// other deterministic paths there is no AI call: the matched Sigma rule's level drives
+// severity, its title leads the description, its tactics/tags become MITRE, and IOCs /
+// asset / process-chain come from the rendered detail fields. Tagged Hayabusa as source.
+export async function importHayabusa(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "h3") so ids never collide
+    importedAt: string;
+    hayabusa?: HayabusaImportOptions; // filtering overrides (aggregate, minSeverity, maxEvents…)
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseHayabusaTimeline(text, opts.hayabusa);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Hayabusa", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Hayabusa"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Hayabusa import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import Velociraptor native JSON output (collection results / hunt export). Like the
+// other deterministic paths there is no AI call: each row is classified (Sigma / YARA /
+// EventLog / generic) and mapped — detection rows are verdict-driven, the rest auto-detect
+// the artifact's own time + IOCs. Every event is tagged Velociraptor as its source.
+export async function importVelociraptor(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "v3") so ids never collide
+    importedAt: string;
+    velociraptor?: VelociraptorImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    veloUrl?: string; // the originating hunt/flow's GUI URL (only known for a live hunt/flow import) — stamped onto every event so the forensic timeline's "↗ Velociraptor" link resolves, mirroring the super-only path
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  // Rows often carry no _Source; use the (Velociraptor-named) filename as the fallback artifact
+  // label so generic/detection events show their source — e.g. "DetectRaptor.Windows.Detection.NamedPipes".
+  const rawArtifact = opts.label.replace(/^\d+_/, "").replace(/\.(json|jsonl|ndjson|csv)$/i, "");
+  let artifact = rawArtifact;
+  try {
+    artifact = decodeURIComponent(rawArtifact);
+  } catch {
+    /* malformed %xx — keep the raw label */
+  }
+  // Chunked async parse: reports (rowsDone, rowsTotal) as it goes (→ the import job's progress bar
+  // and the "importing X/Y" status) and yields to the event loop between chunks, so a huge MFT/USN
+  // import streams live progress instead of freezing the server on one synchronous pass.
+  const parsedRaw = await parseVelociraptorJsonProgress(
+    text,
+    { artifact, ...opts.velociraptor },
+    opts.onProgress,
+  );
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Velociraptor", parsed.total);
+
+  const eventIdByAggKey = new Map<string, string>();
+  const forensicEvents = parsed.events.map((e, i) => {
+    const { aggKey, ...rest } = e;
+    const id = `${opts.idPrefix}e${i + 1}`;
+    if (aggKey) eventIdByAggKey.set(aggKey, id);
+    return {
+      ...rest,
+      id,
+      sources: rest.sources?.length ? rest.sources : ["Velociraptor"],
+      ...(opts.veloUrl ? { veloUrl: opts.veloUrl } : {}),
+    };
+  });
+
+  const raw = {
+    findings: [],
+    iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+      id: `${opts.idPrefix}i${i + 1}`,
+      type: c.type,
+      value: c.value,
+      ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
+    })),
+    mitreTechniques: [],
+    forensicEvents,
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Velociraptor import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
+      (parsed.detections > 0 ? `, ${parsed.detections} detection(s)` : "") +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import ECAR — EDR Common Activity Record telemetry (NDJSON of (object, action) endpoint events).
+// Deterministic (no AI call): maps each record's object/action/properties into a forensic event,
+// reads `timestamp_ms`, scrapes PUBLIC IPs as IOCs, and keeps severity conservative (Info evidence,
+// bumped only on real tradecraft) so high-volume raw telemetry doesn't flood the timeline. See
+// ecarImport.ts for the mapping (and the lsass-access false-positive rationale).
+export async function importEcar(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import so ids never collide
+    importedAt: string;
+    ecar?: EcarImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseEcarJson(text, { ...opts.ecar });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "ECAR", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [ECAR_SOURCE],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `ECAR import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a KAPE / Eric Zimmerman Tools CSV (Prefetch, Amcache, ShimCache, LNK, JumpLists,
+// UsnJrnl, MFT, SRUM, Recycle Bin, Shellbags). Deterministic (no AI call): the EZ tool is
+// detected from the CSV header, then each row maps to a forensic event reading the
+// artifact's own time + file/hash/process IOCs. Events are tagged by artifact name.
+export async function importKape(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "k3") so ids never collide
+    importedAt: string;
+    kape?: KapeImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseKapeCsv(text, opts.kape);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, `KAPE/${parsed.artifact}`, parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [parsed.artifact],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `KAPE/${parsed.artifact} import: ${parsed.kept} event(s) from ${parsed.total} row(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a Cyber Triage timeline export (JSONL / JSON array / CSV). Deterministic (no AI call):
+// scored rows map verdict-first (severity from the Bad/Suspicious verdict + reason keywords),
+// unscored process/task rows become Info evidence, the bulk File super-timeline is dropped
+// (unless `fileTelemetry`), and Active-Connection remote IPs become IOCs. Events tagged
+// "Cyber Triage".
+export async function importCybertriage(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "ct3") so ids never collide
+    importedAt: string;
+    cybertriage?: CybertriageImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseCybertriage(text, opts.cybertriage);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "Cyber Triage", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Cyber Triage"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Cyber Triage import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
+      (parsed.notable > 0 ? `, ${parsed.notable} scored item(s)` : "") +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}

--- a/companion/src/analysis/ingest/importContext.ts
+++ b/companion/src/analysis/ingest/importContext.ts
@@ -1,0 +1,78 @@
+import type { WindowContext, mergeDelta } from "../stateMerge.js";
+import type { InvestigationState, Severity } from "../stateTypes.js";
+import type { PlasoParseResult } from "../plasoImport.js";
+import type { StateStore } from "../stateStore.js";
+
+/**
+ * What an importer needs from the pipeline, and nothing else (#384).
+ *
+ * The 36 import methods on AnalysisPipeline were 1,779 of its lines, and between them they reached
+ * for exactly FIVE members of `this`. That is what makes them extractable: they are not entangled
+ * with the class, they are long. Each one parses its own format, builds a delta, and hands it to
+ * the same three collaborators.
+ *
+ * So this is the seam. An importer takes an ImportContext instead of being a method, and
+ * AnalysisPipeline satisfies the interface structurally — it keeps its public import methods as
+ * one-line delegations, so every route and test calling `pipeline.importThor(...)` is untouched.
+ *
+ * WHY AN INTERFACE RATHER THAN PASSING THE PIPELINE. The type says what an importer is allowed to
+ * do. An importer cannot reach for the AI providers, the hypothesis store or the synthesis path,
+ * because they are not on this type — which is the boundary that keeps deterministic import
+ * deterministic. `analysis/ingest` sits at tier 3 and `analysis/ai` at tier 5 for the same reason;
+ * this interface is that rule expressed where the compiler can enforce it.
+ */
+export interface ImportContext {
+  /**
+   * The only two pipeline options an importer touches, out of the ~40 on PipelineOptions.
+   *
+   * Enumerated rather than widened to PipelineOptions for two reasons. It states the real
+   * dependency -- load state, save state, announce the new state -- and it keeps the AI providers,
+   * hypothesis store and synthesis knobs out of reach of deterministic import. It also avoids
+   * importing PipelineOptions from pipeline.ts, which would be an ingest -> ai edge: upward, and
+   * rejected by check:boundaries.
+   */
+  readonly opts: {
+    stateStore: StateStore;
+    onState?: (state: InvestigationState) => void;
+  };
+
+  /**
+   * Serialise a read-modify-write against one case's state.
+   *
+   * CAUTION, carried over from the pipeline: never call this from inside another withStateLock
+   * callback for the SAME caseId — it nests onto the outer call's unresolved promise and deadlocks.
+   */
+  withStateLock<T>(caseId: string, fn: () => Promise<T>): Promise<T>;
+
+  /** mergeDelta plus the case's analyst IOC-merge aliases (#82), so merged duplicates stay folded. */
+  mergeWithAliases(
+    state: InvestigationState,
+    delta: Parameters<typeof mergeDelta>[1],
+    ctx: WindowContext,
+  ): Promise<InvestigationState>;
+
+  /**
+   * Record that an import produced nothing, with the importer's own record count so the note says
+   * how much was READ. "0 events from 0 records" (wrong format) and "0 events from 75,951 records"
+   * (understood but uninteresting) are very different problems.
+   */
+  noteEmptyImport(
+    caseId: string,
+    opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
+    kind: string,
+    total: number,
+  ): Promise<InvestigationState>;
+
+  /** Shared tail for the two Plaso entry points (text and file), which differ only in how they parse. */
+  persistPlasoParsed(
+    caseId: string,
+    parsed: PlasoParseResult,
+    opts: {
+      label: string;
+      idPrefix: string;
+      importedAt: string;
+      minSeverity?: Severity;
+      onProgress?: (done: number, total: number) => void;
+    },
+  ): Promise<InvestigationState>;
+}

--- a/companion/src/analysis/ingest/index.ts
+++ b/companion/src/analysis/ingest/index.ts
@@ -1,0 +1,12 @@
+/**
+ * The importers, re-exported as one namespace (#384).
+ *
+ * pipeline.ts imports this as `* as ingest`, so each delegation reads
+ * `ingest.importThor(this, ...args)` without 36 aliased imports at the top of the file.
+ */
+export * from "./cloudImports.js";
+export * from "./endpointImports.js";
+export * from "./logImports.js";
+export * from "./networkImports.js";
+export * from "./platformImports.js";
+export * from "./timelineImports.js";

--- a/companion/src/analysis/ingest/logImports.ts
+++ b/companion/src/analysis/ingest/logImports.ts
@@ -1,0 +1,430 @@
+import { parseAuditdLog, type AuditdImportOptions } from "../auditdImport.js";
+import { parseShellHistoryFile, userFromHistoryFilename } from "../bashHistoryImport.js";
+import { CISCO_ASA_SOURCE, parseCiscoAsaLog, type CiscoAsaImportOptions } from "../ciscoAsaImport.js";
+import {
+  COMBINED_LOG_SOURCE,
+  parseCombinedLog,
+  type CombinedLogImportOptions,
+} from "../combinedLogImport.js";
+import { parseJournald, type JournaldImportOptions } from "../journaldImport.js";
+import { deltaSchema } from "../responseSchema.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import { resolveExtractedFrom } from "../siemImport.js";
+
+import { type InvestigationState, type Severity } from "../stateTypes.js";
+import { parseSysdig, type SysdigImportOptions } from "../sysdigImport.js";
+import { SYSLOG_SOURCE, parseSyslog, type SyslogImportOptions } from "../syslogImport.js";
+import { pickImportYear } from "../timeYearClamp.js";
+import type { ImportContext } from "./importContext.js";
+
+/**
+ * Line-oriented host and appliance logs, where each record is one line of text.
+ *
+ * Moved from AnalysisPipeline (#384). Each of these was a method; each is now a free function
+ * taking an ImportContext, which is the small set of collaborators an importer is allowed to use.
+ * The pipeline keeps a one-line delegation per importer, so callers are unchanged.
+ */
+
+// Import a Linux/Unix shell history file (.bash_history / .zsh_history / …). Deterministic
+// host-triage: one forensic event per command at the artifact's own time (bash HISTTIMEFORMAT
+// `#<epoch>` / zsh extended history), Info by default with a conservative tradecraft bump. The
+// account is derived from the filename and shown in each event.
+export async function importBashHistory(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "b3") so ids never collide
+    importedAt: string;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const user = userFromHistoryFilename(opts.label);
+  const parsedRaw = parseShellHistoryFile(text, { user });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Shell history", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Shell history"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Shell history import${user ? ` (${user})` : ""}: ${parsed.kept} command(s) from ${parsed.total} line(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import an Apache/Nginx/Squid combined access log (web server or forward-proxy). Deterministic
+// (no AI): raw web/proxy telemetry, Info by default with a conservative bump only for an
+// access-denied response; git smart-HTTP clone/push tagged T1213. See combinedLogImport.ts.
+export async function importCombinedLog(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    combinedLog?: CombinedLogImportOptions;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseCombinedLog(text, { ...opts.combinedLog });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "Web/proxy access-log", parsed.total);
+
+  const eventIdByAggKey = new Map<string, string>();
+  const forensicEvents = parsed.events.map((e, i) => {
+    const { aggKey, ...rest } = e;
+    const id = `${opts.idPrefix}e${i + 1}`;
+    if (aggKey) eventIdByAggKey.set(aggKey, id);
+    return { ...rest, id, sources: rest.sources?.length ? rest.sources : [COMBINED_LOG_SOURCE] };
+  });
+  const raw = {
+    findings: [],
+    iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+      id: `${opts.idPrefix}i${i + 1}`,
+      type: c.type,
+      value: c.value,
+      ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
+    })),
+    mitreTechniques: [],
+    forensicEvents,
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Web/proxy access-log import (${parsed.format}): ${parsed.kept} request(s) from ${parsed.total} line(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a Cisco ASA firewall syslog export. Deterministic (no AI): Built/Teardown telemetry
+// stays Info, an explicit Deny bumps to Low, dynamic-NAT-translation noise is dropped,
+// year-less timestamps are re-anchored by the mergeDelta year-clamp. See ciscoAsaImport.ts.
+export async function importCiscoAsa(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    ciscoAsa?: CiscoAsaImportOptions;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
+  // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
+  // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
+  const priorState = await ctx.opts.stateStore.load(caseId).catch(() => null);
+  const assumeYear = opts.ciscoAsa?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
+  const parsedRaw = parseCiscoAsaLog(text, {
+    ...opts.ciscoAsa,
+    ...(assumeYear !== undefined ? { assumeYear } : {}),
+  });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Cisco ASA", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [CISCO_ASA_SOURCE],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Cisco ASA import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} line(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a plain Linux/Unix syslog export (RFC 5424 / RFC 3164). Deterministic (no AI): host
+// telemetry stays Info, an auth-failure or crit/alert/emerg PRI bumps to Low, the host is carried
+// as the event's asset, RFC-3164 year-less timestamps are re-anchored by the mergeDelta year-clamp.
+// See syslogImport.ts.
+export async function importSyslog(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    syslog?: SyslogImportOptions;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
+  // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
+  // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
+  const priorState = await ctx.opts.stateStore.load(caseId).catch(() => null);
+  const assumeYear = opts.syslog?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
+  const parsedRaw = parseSyslog(text, {
+    ...opts.syslog,
+    ...(assumeYear !== undefined ? { assumeYear } : {}),
+  });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Syslog", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [SYSLOG_SOURCE],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Syslog import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} line(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a Linux auditd log (raw audit.log / `ausearch` record format, or an `aureport` table).
+// Deterministic (no AI call): records sharing a serial collapse into one logical event, mapped
+// to severity/MITRE by record type (logins, account/group mgmt, sudo, SELinux denials, audit-config
+// tampering), bumped on a failed auth or a suspicious command. Read at the audit() epoch. Tagged auditd.
+export async function importAuditd(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "ad3") so ids never collide
+    importedAt: string;
+    auditd?: AuditdImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseAuditdLog(text, opts.auditd);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "auditd", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["auditd"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `auditd import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a systemd-journald structured log (`journalctl -o json` / `-o json-pretty`). Deterministic
+// (no AI call): each entry is read at its own time (_SOURCE/__REALTIME µs epoch), severity derived
+// from PRIORITY then bumped from the message (sshd auth, sudo, useradd, kernel), with IOCs scraped
+// from _EXE/_COMM and the MESSAGE. Tagged journald.
+export async function importJournald(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "jd3") so ids never collide
+    importedAt: string;
+    journald?: JournaldImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseJournald(text, opts.journald);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "journald", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["journald"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `journald import: ${parsed.kept} event(s) from ${parsed.total} entr(y/ies)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a sysdig / Falco export (Falco alert JSON and/or sysdig `-j` event JSON). Deterministic
+// (no AI call): Falco rule hits are the DETECTIONS (verdict-first: priority → severity, tags →
+// MITRE) and surface on the timeline; raw sysdig syscall events are telemetry → Info evidence;
+// both contribute proc/file/network IOCs. Tagged Falco / sysdig.
+export async function importSysdig(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "sd3") so ids never collide
+    importedAt: string;
+    sysdig?: SysdigImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseSysdig(text, opts.sysdig);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "sysdig/Falco", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["sysdig"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `sysdig/Falco import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.alerts > 0 ? `, ${parsed.alerts} Falco alert(s)` : "") +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}

--- a/companion/src/analysis/ingest/networkImports.ts
+++ b/companion/src/analysis/ingest/networkImports.ts
@@ -1,0 +1,211 @@
+import { parseNetworkLogs, type NetworkImportOptions } from "../networkImport.js";
+import { deltaSchema } from "../responseSchema.js";
+import { parseSecurityOnion, type SecurityOnionImportOptions } from "../securityOnionImport.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import { resolveExtractedFrom } from "../siemImport.js";
+import { SNORT_SOURCE, parseSnortLog, type SnortImportOptions } from "../snortImport.js";
+
+import { type InvestigationState, type Severity } from "../stateTypes.js";
+import { pickImportYear } from "../timeYearClamp.js";
+import type { ImportContext } from "./importContext.js";
+
+/**
+ * Network sensors and captures.
+ *
+ * Moved from AnalysisPipeline (#384). Each of these was a method; each is now a free function
+ * taking an ImportContext, which is the small set of collaborators an importer is allowed to use.
+ * The pipeline keeps a one-line delegation per importer, so callers are unchanged.
+ */
+
+// Import a Snort / Suricata "fast" alert log — a real IDS verdict feed. Deterministic (no AI):
+// severity is the rule's Priority verdict, public src/dst IPs become IOCs, year-less timestamps are
+// re-anchored by the mergeDelta year-clamp. See snortImport.ts.
+export async function importSnort(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    snort?: SnortImportOptions;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
+  // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
+  // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
+  const priorState = await ctx.opts.stateStore.load(caseId).catch(() => null);
+  const assumeYear = opts.snort?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
+  const parsedRaw = parseSnortLog(text, {
+    ...opts.snort,
+    ...(assumeYear !== undefined ? { assumeYear } : {}),
+  });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Snort", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [SNORT_SOURCE],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Snort import (${parsed.format}): ${parsed.kept} alert(s) from ${parsed.total} line(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import network-monitor logs — Suricata `eve.json` and Zeek JSON (Security Onion's
+// network side). Deterministic (no AI call): the timeline is built from the detections
+// (Suricata alerts + Zeek notices); surrounding telemetry (dns/http/tls/files/conn)
+// contributes IOCs only. Events are tagged Suricata / Zeek.
+export async function importNetwork(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "n3") so ids never collide
+    importedAt: string;
+    network?: NetworkImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  // Pass the import filename so per-stream Zeek JSON (conn.json / dns.json / … with no `_path`)
+  // routes to the right stream (#197).
+  const parsedRaw = parseNetworkLogs(text, {
+    ...opts.network,
+    filename: opts.network?.filename ?? opts.label,
+  });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "Network", parsed.total);
+
+  const eventIdByAggKey = new Map<string, string>();
+  const forensicEvents = parsed.events.map((e, i) => {
+    const { aggKey, ...rest } = e;
+    const id = `${opts.idPrefix}e${i + 1}`;
+    if (aggKey) eventIdByAggKey.set(aggKey, id);
+    return { ...rest, id, sources: rest.sources?.length ? rest.sources : ["Suricata"] };
+  });
+  const raw = {
+    findings: [],
+    iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+      id: `${opts.idPrefix}i${i + 1}`,
+      type: c.type,
+      value: c.value,
+      ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
+    })),
+    mitreTechniques: [],
+    forensicEvents,
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Network import (${parsed.format}): ${parsed.kept} detection event(s) from ${parsed.total} record(s)` +
+      (parsed.alerts > 0 ? `, ${parsed.alerts} alert/notice(s)` : "") +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import Security Onion Console (SOC) events — the Alerts / Hunt views the browser extension
+// pushes. Deterministic (no AI call), verdict-first per the post-detection principle: the
+// event's own `event.severity_label` drives severity, `rule.name` leads the description, ECS
+// threat fields become MITRE, and source/destination IPs + app-layer fields become IOCs.
+// Events are tagged "Security Onion".
+export async function importSecurityOnion(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "so3") so ids never collide
+    importedAt: string;
+    securityOnion?: SecurityOnionImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseSecurityOnion(text, opts.securityOnion);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "Security Onion", parsed.total);
+
+  const eventIdByAggKey = new Map<string, string>();
+  const forensicEvents = parsed.events.map((e, i) => {
+    const { aggKey, ...rest } = e;
+    const id = `${opts.idPrefix}e${i + 1}`;
+    if (aggKey) eventIdByAggKey.set(aggKey, id);
+    return { ...rest, id, sources: rest.sources?.length ? rest.sources : ["Security Onion"] };
+  });
+  const raw = {
+    findings: [],
+    iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+      id: `${opts.idPrefix}i${i + 1}`,
+      type: c.type,
+      value: c.value,
+      ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
+    })),
+    mitreTechniques: [],
+    forensicEvents,
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Security Onion import: ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}

--- a/companion/src/analysis/ingest/platformImports.ts
+++ b/companion/src/analysis/ingest/platformImports.ts
@@ -1,0 +1,668 @@
+import { type ExternalImporter } from "../declarativeImporter.js";
+import { parseEmail, type EmailImportOptions } from "../emailImport.js";
+import { parseEvtxXmlProgress } from "../evtxXmlImport.js";
+import { parseIrisCase, type IrisCaseData, type IrisImportOptions } from "../irisImport.js";
+import { parseMemory, type MemoryImportOptions } from "../memoryImport.js";
+import { deltaSchema } from "../responseSchema.js";
+import { parseSandboxReport, type SandboxImportOptions } from "../sandboxImport.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import {
+  parseSiemExport,
+  resolveExtractedFrom,
+  type SiemImportOptions,
+  type SiemParseResult,
+} from "../siemImport.js";
+import { parseSocrates, type SocratesImportOptions } from "../socratesImport.js";
+
+import { type InvestigationState, type Severity } from "../stateTypes.js";
+import { parseTheHive, type TheHiveImportOptions } from "../theHiveImport.js";
+import { detectTool } from "../toolDetect.js";
+import { parseWazuhAlerts, type WazuhImportOptions } from "../wazuhImport.js";
+import { YARA_SOURCE, parseYaraOutput, type YaraImportOptions } from "../yaraImport.js";
+import type { ImportContext } from "./importContext.js";
+
+/**
+ * Security platforms, case trackers and analysis tooling that already produced findings.
+ *
+ * Moved from AnalysisPipeline (#384). Each of these was a method; each is now a free function
+ * taking an ImportContext, which is the small set of collaborators an importer is allowed to use.
+ * The pipeline keeps a one-line delegation per importer, so callers are unchanged.
+ */
+
+// Import a SIEM / EDR JSON export (Elastic/Kibana, Splunk, an EDR console, a raw
+// winlogbeat dump…). Like THOR, the mapping is DETERMINISTIC (no AI call): the
+// container is unwrapped, Windows/Sysmon events get a per-EID mapping, other records
+// fall back to field auto-detection, and repetitive events are aggregated. The
+// detected tool name (from the filename / source) tags each event's `sources`.
+export async function importSiem(
+  ctx: ImportContext,
+  caseId: string,
+  jsonText: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "s3") so ids never collide
+    importedAt: string;
+    siem?: SiemImportOptions; // filtering overrides (aggregate, minSeverity, maxEvents…)
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseSiemExport(jsonText, opts.siem);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "SIEM", parsed.total);
+
+  const source = detectTool(opts.label) ?? detectTool(parsed.format) ?? "SIEM import";
+  const eventIdByAggKey = new Map<string, string>();
+  const forensicEvents = parsed.events.map((e, i) => {
+    const { aggKey, ...rest } = e;
+    const id = `${opts.idPrefix}e${i + 1}`;
+    if (aggKey) eventIdByAggKey.set(aggKey, id);
+    return { ...rest, id, sources: rest.sources?.length ? rest.sources : [source] };
+  });
+  const raw = {
+    findings: [],
+    iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
+      id: `${opts.idPrefix}i${i + 1}`,
+      type: c.type,
+      value: c.value,
+      ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
+    })),
+    mitreTechniques: [],
+    forensicEvents,
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `SIEM import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Run a USER-authored declarative importer (the external plugin path). Mirrors the built-in
+// deterministic wrappers exactly: parse -> severity floor -> standard delta (findings/MITRE empty,
+// MITRE rides inside each event) -> mergeDelta -> save -> notify. Does NOT depend on any shared-runner
+// refactor of the built-ins.
+export async function importDeclarative(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    importer: ExternalImporter;
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+    // Per-importer health (#84): fired with the raw parse stats (total/kept/dropped/format) right
+    // after parsing, BEFORE the zero-events early return, so a run that legitimately produced
+    // nothing still counts as a completed (not failed) run in the diagnostics table.
+    onParsed?: (result: SiemParseResult) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = opts.importer.parse(text, { minSeverity: opts.minSeverity });
+  opts.onParsed?.(parsedRaw);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, opts.importer.label, parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [opts.importer.label],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `${opts.importer.label} import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a malware-sandbox detonation report (CAPEv2 or CrowdStrike Falcon Sandbox).
+// Deterministic (no AI call): the sample verdict + each behavioural signature map to events
+// (severity from the report's own score/verdict, MITRE from its ATT&CK), and every
+// dropped/extracted file hash + network host/domain/URL is harvested as an IOC.
+export async function importSandbox(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "sb3") so ids never collide
+    importedAt: string;
+    sandbox?: SandboxImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseSandboxReport(text, opts.sandbox);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Sandbox", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Sandbox"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Sandbox import (${parsed.format}): ${parsed.kept} event(s)` +
+      (parsed.signatures > 0 ? `, ${parsed.signatures} signature(s)` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import memory-forensics tool output (Volatility 3 or Rekall). Deterministic (no AI call): each
+// plugin table is identified by its columns and mapped — pslist/psscan/pstree → process-tree
+// events (with parent→child links), netscan/netstat → network-connection events (+ foreign IP/
+// port IOCs), malfind → High injected-code events (ATT&CK T1055), cmdline → command-line events
+// (bumped on LOLBin/encoded tradecraft), svcscan/modules → service/driver evidence. Tagged
+// "Volatility" / "Rekall" for cross-source correlation; reads the artifact's own time.
+export async function importMemory(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "mem3") so ids never collide
+    importedAt: string;
+    memory?: MemoryImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseMemory(text, { ...opts.memory, filename: opts.label });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "Memory", parsed.total);
+
+  const tool = parsed.tool || "Volatility";
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [tool],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Memory import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s) across ${parsed.tables} plugin(s)` +
+      (parsed.injected > 0 ? `, ${parsed.injected} injected-code hit(s)` : "") +
+      (parsed.connections > 0 ? `, ${parsed.connections} connection(s)` : "") +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import an email artifact (.eml RFC 2822, or best-effort .msg). Deterministic (no AI call):
+// ONE forensic event dated at the message's own Date: header, severity DERIVED from the email's
+// SPF/DKIM/DMARC verdict + sender heuristics; URLs, sender/reply-to domains, originating IP and
+// attachment names/hashes become IOCs. Covers ATT&CK T1566 (Phishing). Tagged "Email".
+export async function importEmail(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "em3") so ids never collide
+    importedAt: string;
+    email?: EmailImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseEmail(text, opts.email);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "Email", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Email"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Email import (${parsed.format}): ${parsed.kept} event(s)` +
+      (parsed.subject ? ` — "${parsed.subject.slice(0, 80)}"` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import a TheHive 5 case, alert, or observable export. Deterministic (no AI call):
+// case/alert records → forensic events (severity from TheHive's own 1–4 scale, MITRE from
+// ATT&CK-tagged tags, TLP/PAP labels prepended); observable records → IOCs by dataType.
+export async function importTheHive(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "th3") so ids never collide
+    importedAt: string;
+    thehive?: TheHiveImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseTheHive(text, opts.thehive);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "TheHive", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["TheHive"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `TheHive import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.observables > 0 ? `, ${parsed.observables} observable(s)` : "") +
+      `, ${parsed.iocCount} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import an existing DFIR-IRIS case (issue #88) — the reverse of the IRIS push. Takes the raw
+// case rows already fetched from the IRIS API (analysis/irisImport.ts parses them deterministically,
+// NO AI call): timeline → forensic events, IOCs → IOCs, assets → evidence events. All feed the
+// same forensic timeline via mergeDelta, exactly like the other importers.
+export async function importIris(
+  ctx: ImportContext,
+  caseId: string,
+  data: IrisCaseData,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "iris3") so ids never collide
+    importedAt: string;
+    iris?: IrisImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseIrisCase(data, opts.iris);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "DFIR-IRIS", parsed.timelineCount);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["DFIR-IRIS"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `DFIR-IRIS import (${parsed.caseName ?? `case #${parsed.irisCaseId ?? "?"}`}): ` +
+      `${parsed.kept} event(s) from ${parsed.timelineCount} timeline + ${parsed.assetCount} asset(s)` +
+      `, ${parsed.iocCount} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import Wazuh SIEM/EDR alert exports (alerts.json / NDJSON / API export). Deterministic
+// (no AI call): rule.level drives severity (≥13 Critical, ≥10 High, ≥7 Medium, else Info),
+// rule.mitre.technique → MITRE, agent.name → asset, data.srcip/dstip/md5/sha256/url → IOCs.
+export async function importWazuh(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "w3") so ids never collide
+    importedAt: string;
+    wazuh?: WazuhImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseWazuhAlerts(text, opts.wazuh);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Wazuh", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Wazuh"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Wazuh import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import YARA CLI scan output (`yara -s -m <rules> <target>`). Deterministic (no AI): each rule
+// match becomes a file-match event (default Medium, bumped only on an explicit rule-meta signal),
+// matched file + hash meta become IOCs. YARA output is undated, so mergeDelta stamps events at import
+// time. Used by the external-tools run path (#211). See yaraImport.ts.
+export async function importYara(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    yara?: YaraImportOptions;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseYaraOutput(text, { ...opts.yara });
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "YARA", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [YARA_SOURCE],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `YARA import: ${parsed.kept} match event(s) from ${parsed.total} match(es)` +
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import SO-CRATES (dougburks/so-crates) verdicts — Suricata IDS alerts, YARA file matches, and
+// Sigma log detections — as the browser extension pushes them (or a raw export). Deterministic
+// (no AI). Events are tagged "SO-CRATES" (+ the underlying engine) for cross-source correlation.
+export async function importSocrates(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "s4") so ids never collide
+    importedAt: string;
+    socrates?: SocratesImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button)
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parseSocrates(text, opts.socrates);
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0 && parsed.iocs.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "SO-CRATES", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["SO-CRATES"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `SO-CRATES import (${parsed.format}): ${parsed.kept} detection event(s) from ${parsed.total} record(s)` +
+      ` — ${parsed.alerts} Suricata alert(s), ${parsed.yara} YARA, ${parsed.sigma} Sigma, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Import Windows Event XML through the shared deterministic SIEM/EVTX mapping.
+export async function importEvtxXml(
+  ctx: ImportContext,
+  caseId: string,
+  xmlText: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "s3") so ids never collide
+    importedAt: string;
+    siem?: SiemImportOptions; // filtering overrides (aggregate, minSeverity, maxEvents…)
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void | Promise<void>;
+    onParseProgress?: (done: number, total: number, detail?: string) => void | Promise<void>;
+    signal?: AbortSignal;
+    startBatch?: number;
+  },
+): Promise<InvestigationState> {
+  if ((opts.startBatch ?? 0) >= 1) {
+    await opts.onProgress?.(1, 1);
+    return ctx.opts.stateStore.load(caseId);
+  }
+  let parseTotal = 0;
+  const parsedRaw = await parseEvtxXmlProgress(
+    xmlText,
+    opts.siem,
+    (done, total) => {
+      parseTotal = total;
+      return opts.onParseProgress?.(done, total * 2, "reading Windows events");
+    },
+    (done, total) =>
+      opts.onParseProgress?.(parseTotal + done, parseTotal + total, "processing Windows events"),
+    opts.signal,
+  );
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0)
+    return ctx.noteEmptyImport(caseId, opts, "Windows Event Log (XML)", parsed.total);
+
+  const source = detectTool(opts.label) ?? "Windows Event Log";
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : [source],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Windows Event Log (XML) import: ${parsed.kept} event(s) from ${parsed.total} record(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
+    summary: "",
+  };
+  const delta = deltaSchema.parse(raw);
+
+  return ctx.withStateLock(caseId, async () => {
+    if (opts.signal?.aborted)
+      throw Object.assign(new Error("import processing cancelled; stored evidence retained"), {
+        name: "AbortError",
+      });
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    await opts.onProgress?.(1, 1);
+    return state;
+  });
+}

--- a/companion/src/analysis/ingest/timelineImports.ts
+++ b/companion/src/analysis/ingest/timelineImports.ts
@@ -1,0 +1,122 @@
+import {
+  parsePlasoCsv,
+  parsePlasoFromLines,
+  type PlasoImportOptions,
+  type PlasoParseResult,
+} from "../plasoImport.js";
+import { deltaSchema } from "../responseSchema.js";
+
+import { type ForensicEvent, type InvestigationState, type Severity } from "../stateTypes.js";
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import type { ImportContext } from "./importContext.js";
+
+/**
+ * Whole-timeline sources. Plaso arrives already normalised into timeline rows, and
+ * promoteSuperTimeline moves rows that are ALREADY in the case from the raw record into the
+ * forensic timeline — the promotion seam the forensic/super-timeline boundary is built on.
+ *
+ * Moved from AnalysisPipeline (#384). Each of these was a method; each is now a free function
+ * taking an ImportContext, which is the small set of collaborators an importer is allowed to use.
+ * The pipeline keeps a one-line delegation per importer, so callers are unchanged.
+ */
+
+// Import a Plaso / log2timeline super-timeline (psort CSV — dynamic or l2tcsv). Deterministic
+// (no AI call): each row is an Info evidence event read at its own time, with IOCs scraped
+// from the message (hashes/URLs/IPs) and the source file path. Tagged Plaso.
+export async function importPlaso(
+  ctx: ImportContext,
+  caseId: string,
+  text: string,
+  opts: {
+    label: string;
+    idPrefix: string; // unique per import (e.g. "p3") so ids never collide
+    importedAt: string;
+    plaso?: PlasoImportOptions;
+    minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsedRaw = parsePlasoCsv(text, opts.plaso);
+  return ctx.persistPlasoParsed(caseId, parsedRaw, opts);
+}
+
+// Streaming-from-disk Plaso import: for super-timelines too large to hold as one JS string (a
+// 555 MB export EXCEEDS V8's ~512 MB max string length, so readFile(utf8) throws "Invalid string
+// length"). Reads the file line-by-line via node:readline and feeds parsePlasoFromLines, which
+// keeps memory bounded by the distinct-key set, not the row count. Same downstream merge as
+// importPlaso. The route persists the evidence file separately (by copy, not as a string).
+export async function importPlasoFile(
+  ctx: ImportContext,
+  caseId: string,
+  filePath: string,
+  opts: {
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    plaso?: PlasoImportOptions;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: "utf8", highWaterMark: 1 << 20 }),
+    crlfDelay: Infinity,
+  });
+  let parsedRaw: PlasoParseResult;
+  try {
+    parsedRaw = await parsePlasoFromLines(rl, opts.plaso);
+  } finally {
+    rl.close();
+  }
+  return ctx.persistPlasoParsed(caseId, parsedRaw, opts);
+}
+
+// "Promote" copies already-imported super-timeline events UP into the forensic timeline so AI
+// synthesis runs over them. The raw super-timeline is a complete record (incl. host-triage artifacts
+// routed there exclusively) that is never synthesized; this is how the analyst pulls the events that
+// matter into the analyzed timeline. Reuses mergeDelta (dedups forensic events by id) — a stored super
+// event keeps its id, so a double-promote is a no-op. No AI here; the caller re-synthesizes.
+export async function promoteSuperTimeline(
+  ctx: ImportContext,
+  caseId: string,
+  events: ForensicEvent[],
+  opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+): Promise<InvestigationState> {
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    if (!events.length) return state;
+    const delta = deltaSchema.parse({
+      findings: [],
+      iocs: [],
+      mitreTechniques: [],
+      threadsOpened: [],
+      threadsClosed: [],
+      timelineNote: opts.note ?? `Promoted ${events.length} event(s) from the super-timeline`,
+      summary: "",
+      forensicEvents: events.map((e) => ({ ...e })),
+    });
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [],
+    });
+    // Stamp provenance markers on the promoted rows (second-look #11) — mergeDelta carries no
+    // provenance through the delta schema, so apply them here by id (union with any existing). Lets the
+    // forensic timeline show WHY a raw row was pulled up ("[second-look: h2]").
+    if (opts.tagById) {
+      const tagged = new Set(Object.keys(opts.tagById));
+      state = {
+        ...state,
+        forensicTimeline: state.forensicTimeline.map((e) =>
+          tagged.has(e.id)
+            ? { ...e, provenance: [...new Set([...(e.provenance ?? []), ...opts.tagById![e.id]])] }
+            : e,
+        ),
+      };
+    }
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    return state;
+  });
+}

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -1,6 +1,6 @@
-import { createReadStream } from "node:fs";
+
 import { mkdir, writeFile } from "node:fs/promises";
-import { createInterface } from "node:readline";
+
 import { join as joinPath } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { z } from "zod";
@@ -27,7 +27,7 @@ import type { StateLock } from "./stateLock.js";
 import { sortByEventTime } from "./forensicSort.js";
 import { segmentSessions, sessionEnvOptions } from "./sessionSegmentation.js";
 import { applySeverityFloor } from "./severityFloor.js";
-import type { ExternalImporter } from "./declarativeImporter.js";
+
 import { parseJsonLoose } from "./extractJson.js";
 import { applyFalsePositive, buildFalsePositiveContext, buildAuthorizedContextBlock, filterFalsePositiveEvents, type FalsePositiveStore } from "./falsePositive.js";
 import { buildLearnedPatternsBlock } from "./learnedPatterns.js";
@@ -60,6 +60,17 @@ import { loadKnownPlaybooks } from "./knownPlaybooksData.js";
 import { buildPlaybookMatchResult, playbookMatchEnvOptions } from "./playbookMatch.js";
 import { buildSynthesisCoverage, type SynthMetaStore, type SynthesisCoverage } from "./synthMeta.js";
 import { AiCostStore, bucketForLabel } from "./aiCost.js";
+import * as ingest from "./ingest/index.js";
+import type { ImportContext } from "./ingest/importContext.js";
+
+/**
+ * The argument list of an importer, minus the ImportContext it takes first (#384).
+ *
+ * Every import method below is a one-line delegation to src/analysis/ingest/. Deriving the
+ * parameters rather than restating them means the two cannot drift: change an importer's signature
+ * and the delegation stops compiling, which is the property a hand-copied signature would not have.
+ */
+type ImporterArgs<F> = F extends (ctx: ImportContext, ...args: infer R) => unknown ? R : never;
 // The prompt registry moved to ai/prompts/ (#384). Imported for the pipeline's own use and
 // re-exported below, because 23 modules and the eval harness import these names from here.
 import {
@@ -94,40 +105,9 @@ import { filterEventsByScope, hasScope, NO_SCOPE, type ScopeStore, type ScopeWin
 import { parseCsv, chunkToCsvText } from "./csvImport.js";
 import { parseLogLines } from "./logImport.js";
 import { aggregateLogLines, type AggregateStats } from "./logAggregate.js";
-import { parseThorReport, type ThorImportOptions } from "./thorImport.js";
-import { parseSiemExport, resolveExtractedFrom, type SiemImportOptions, type SiemParseResult } from "./siemImport.js";
-import { parseEvtxXmlProgress } from "./evtxXmlImport.js";
-import { parseShellHistoryFile, userFromHistoryFilename } from "./bashHistoryImport.js";
-import { parseChainsawReport, type ChainsawImportOptions } from "./chainsawImport.js";
-import { parseHayabusaTimeline, type HayabusaImportOptions } from "./hayabusaImport.js";
-import { parseVelociraptorJsonProgress, type VelociraptorImportOptions } from "./velociraptorImport.js";
-import { parseEcarJson, ECAR_SOURCE, type EcarImportOptions } from "./ecarImport.js";
-import { parseSnortLog, SNORT_SOURCE, type SnortImportOptions } from "./snortImport.js";
-import { parseYaraOutput, YARA_SOURCE, type YaraImportOptions } from "./yaraImport.js";
-import { parseCombinedLog, COMBINED_LOG_SOURCE, type CombinedLogImportOptions } from "./combinedLogImport.js";
-import { parseCiscoAsaLog, CISCO_ASA_SOURCE, type CiscoAsaImportOptions } from "./ciscoAsaImport.js";
-import { parseSyslog, SYSLOG_SOURCE, type SyslogImportOptions } from "./syslogImport.js";
-import { pickImportYear } from "./timeYearClamp.js";
-import { parseNetworkLogs, type NetworkImportOptions } from "./networkImport.js";
-import { parseSocrates, type SocratesImportOptions } from "./socratesImport.js";
-import { parseSecurityOnion, type SecurityOnionImportOptions } from "./securityOnionImport.js";
-import { parseKapeCsv, type KapeImportOptions } from "./kapeImport.js";
-import { parseCybertriage, type CybertriageImportOptions } from "./cybertriageImport.js";
-import { parseM365Audit, type M365ImportOptions } from "./m365Import.js";
-import { parseCloudTrail, type AwsImportOptions } from "./awsImport.js";
-import { parseCloudActivity, type CloudActivityImportOptions } from "./cloudActivityImport.js";
-import { parseK8sAudit, type K8sAuditImportOptions } from "./k8sAuditImport.js";
-import { parseOsqueryLog, type OsqueryImportOptions } from "./osqueryImport.js";
-import { parsePlasoCsv, parsePlasoFromLines, type PlasoImportOptions, type PlasoParseResult } from "./plasoImport.js";
-import { parseSandboxReport, type SandboxImportOptions } from "./sandboxImport.js";
-import { parseMemory, type MemoryImportOptions } from "./memoryImport.js";
-import { parseEmail, type EmailImportOptions } from "./emailImport.js";
-import { parseTheHive, type TheHiveImportOptions } from "./theHiveImport.js";
-import { parseIrisCase, type IrisCaseData, type IrisImportOptions } from "./irisImport.js";
-import { parseAuditdLog, type AuditdImportOptions } from "./auditdImport.js";
-import { parseJournald, type JournaldImportOptions } from "./journaldImport.js";
-import { parseSysdig, type SysdigImportOptions } from "./sysdigImport.js";
-import { parseWazuhAlerts, type WazuhImportOptions } from "./wazuhImport.js";
+
+import { type PlasoParseResult } from "./plasoImport.js";
+
 import { selectSynthesisEvents, selectSynthesisEventsAnnotated, buildSynthesisContext, type SelectionClass } from "./synthSelect.js";
 import { collapseForPrompt, renderGroupSuffix, groupEnvOptions, groupingEnabled, maxPromptEvents, promptCandidates, type CollapsedPrompt } from "./synthGroup.js";
 import {
@@ -242,11 +222,6 @@ async function dumpRedactedImage(
     console.warn(`[OCR dump] ${(err as Error).message}`);
   }
 }
-
-
-
-
-
 
 /** What one deep-pass run did, for the analyst and the route response. */
 export interface DeepPassResult {
@@ -454,14 +429,18 @@ export class AnalysisPipeline {
   // Lazily loaded from opts.kevStore so we don't block the constructor on disk I/O.
   private kevCatalogCache: KevCatalog | undefined;
 
-  constructor(private readonly opts: PipelineOptions) {
+  // `opts` and the four collaborators below are public because src/analysis/ingest/ takes an
+  // ImportContext, and AnalysisPipeline satisfies that interface structurally (#384). They are the
+  // pipeline's internal surface for the importers, not an invitation for routes to reach in --
+  // ImportContext is deliberately the smallest type that lets an importer do its job.
+  constructor(public readonly opts: PipelineOptions) {
     this.log = opts.logger ?? createConsoleLogger(normalizeLogLevel(process.env.DFIR_LOG_LEVEL));
   }
 
   // Wraps mergeDelta with the case's analyst IOC-merge aliases (#82), if any store is configured.
   // Every import/synthesis call site uses this instead of calling mergeDelta directly, so a merged
   // duplicate value stays folded onto its canonical IOC across every future window/re-synthesis.
-  private async mergeWithAliases(
+  async mergeWithAliases(
     state: InvestigationState,
     delta: Parameters<typeof mergeDelta>[1],
     ctx: WindowContext,
@@ -477,7 +456,7 @@ export class AnalysisPipeline {
   // immediately when no lock is configured (e.g. some script/test call sites).
   // CAUTION: never call this from inside another withStateLock/runExclusive callback for the
   // SAME caseId — that nests onto the outer call's own unresolved promise and deadlocks.
-  private withStateLock<T>(caseId: string, fn: () => Promise<T>): Promise<T> {
+  withStateLock<T>(caseId: string, fn: () => Promise<T>): Promise<T> {
     return this.opts.stateLock ? this.opts.stateLock.runExclusive(caseId, fn) : fn();
   }
 
@@ -1146,7 +1125,7 @@ export class AnalysisPipeline {
   // `total` is the importer's own parsed-record count, so the note says how much was READ, not just
   // that nothing came out — "0 events from 0 records" (wrong format) and "0 events from 75,951
   // records" (understood but uninteresting) are very different problems.
-  private async noteEmptyImport(
+  async noteEmptyImport(
     caseId: string,
     opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
     kind: string,
@@ -1177,49 +1156,8 @@ export class AnalysisPipeline {
   // finding maps straight to a forensic event + IOCs with NO AI extraction call.
   // Scan-lifecycle/info noise (module init, "Info" level) is dropped by default.
   // Findings/attacker-path still come from a later synthesize().
-  async importThor(
-    caseId: string,
-    jsonText: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "t3") so ids never collide
-      importedAt: string;
-      thor?: ThorImportOptions;  // filtering overrides (dropInfo, dropLifecycleModules…)
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseThorReport(jsonText, opts.thor);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "THOR", parsed.total);
-
-    // Assign stable, collision-free ids and validate the delta against the schema
-    // (fills defaults like relatedFindingIds). No model call — purely structural.
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({ ...e, id: `${opts.idPrefix}e${i + 1}` })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `THOR import: ${parsed.kept} finding(s) kept, ${parsed.dropped} info/lifecycle row(s) dropped` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importThor(...args: ImporterArgs<typeof ingest.importThor>): Promise<InvestigationState> {
+    return ingest.importThor(this, ...args);
   }
 
   // Import a SIEM / EDR JSON export (Elastic/Kibana, Splunk, an EDR console, a raw
@@ -1227,209 +1165,29 @@ export class AnalysisPipeline {
   // container is unwrapped, Windows/Sysmon events get a per-EID mapping, other records
   // fall back to field auto-detection, and repetitive events are aggregated. The
   // detected tool name (from the filename / source) tags each event's `sources`.
-  async importSiem(
-    caseId: string,
-    jsonText: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "s3") so ids never collide
-      importedAt: string;
-      siem?: SiemImportOptions;  // filtering overrides (aggregate, minSeverity, maxEvents…)
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseSiemExport(jsonText, opts.siem);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "SIEM", parsed.total);
-
-    const source = detectTool(opts.label) ?? detectTool(parsed.format) ?? "SIEM import";
-    const eventIdByAggKey = new Map<string, string>();
-    const forensicEvents = parsed.events.map((e, i) => {
-      const { aggKey, ...rest } = e;
-      const id = `${opts.idPrefix}e${i + 1}`;
-      if (aggKey) eventIdByAggKey.set(aggKey, id);
-      return { ...rest, id, sources: rest.sources?.length ? rest.sources : [source] };
-    });
-    const raw = {
-      findings: [],
-      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
-        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
-        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
-      })),
-      mitreTechniques: [],
-      forensicEvents,
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `SIEM import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importSiem(...args: ImporterArgs<typeof ingest.importSiem>): Promise<InvestigationState> {
+    return ingest.importSiem(this, ...args);
   }
 
   // Import Windows Event XML through the shared deterministic SIEM/EVTX mapping.
-  async importEvtxXml(
-    caseId: string,
-    xmlText: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "s3") so ids never collide
-      importedAt: string;
-      siem?: SiemImportOptions;  // filtering overrides (aggregate, minSeverity, maxEvents…)
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void | Promise<void>; onParseProgress?: (done: number, total: number, detail?: string) => void | Promise<void>; signal?: AbortSignal; startBatch?: number;
-    },
-  ): Promise<InvestigationState> {
-    if ((opts.startBatch ?? 0) >= 1) { await opts.onProgress?.(1, 1); return this.opts.stateStore.load(caseId); }
-    let parseTotal = 0;
-    const parsedRaw = await parseEvtxXmlProgress(xmlText, opts.siem, (done, total) => { parseTotal = total; return opts.onParseProgress?.(done, total * 2, "reading Windows events"); }, (done, total) => opts.onParseProgress?.(parseTotal + done, parseTotal + total, "processing Windows events"), opts.signal);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Windows Event Log (XML)", parsed.total);
-
-    const source = detectTool(opts.label) ?? "Windows Event Log";
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [source],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Windows Event Log (XML) import: ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      if (opts.signal?.aborted) throw Object.assign(new Error("import processing cancelled; stored evidence retained"), { name: "AbortError" });
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      await opts.onProgress?.(1, 1);
-      return state;
-    });
+  importEvtxXml(...args: ImporterArgs<typeof ingest.importEvtxXml>): Promise<InvestigationState> {
+    return ingest.importEvtxXml(this, ...args);
   }
 
   // Import a Linux/Unix shell history file (.bash_history / .zsh_history / …). Deterministic
   // host-triage: one forensic event per command at the artifact's own time (bash HISTTIMEFORMAT
   // `#<epoch>` / zsh extended history), Info by default with a conservative tradecraft bump. The
   // account is derived from the filename and shown in each event.
-  async importBashHistory(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "b3") so ids never collide
-      importedAt: string;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const user = userFromHistoryFilename(opts.label);
-    const parsedRaw = parseShellHistoryFile(text, { user });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Shell history", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Shell history"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Shell history import${user ? ` (${user})` : ""}: ${parsed.kept} command(s) from ${parsed.total} line(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importBashHistory(...args: ImporterArgs<typeof ingest.importBashHistory>): Promise<InvestigationState> {
+    return ingest.importBashHistory(this, ...args);
   }
 
   // Run a USER-authored declarative importer (the external plugin path). Mirrors the built-in
   // deterministic wrappers exactly: parse -> severity floor -> standard delta (findings/MITRE empty,
   // MITRE rides inside each event) -> mergeDelta -> save -> notify. Does NOT depend on any shared-runner
   // refactor of the built-ins.
-  async importDeclarative(
-    caseId: string,
-    text: string,
-    opts: {
-      importer: ExternalImporter;
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-      // Per-importer health (#84): fired with the raw parse stats (total/kept/dropped/format) right
-      // after parsing, BEFORE the zero-events early return, so a run that legitimately produced
-      // nothing still counts as a completed (not failed) run in the diagnostics table.
-      onParsed?: (result: SiemParseResult) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = opts.importer.parse(text, { minSeverity: opts.minSeverity });
-    opts.onParsed?.(parsedRaw);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, opts.importer.label, parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [opts.importer.label],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `${opts.importer.label} import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, { windowSequence: -1, timestamp: opts.importedAt, sourceScreenshots: [opts.label] });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importDeclarative(...args: ImporterArgs<typeof ingest.importDeclarative>): Promise<InvestigationState> {
+    return ingest.importDeclarative(this, ...args);
   }
 
   // "Promote" copies already-imported super-timeline events UP into the forensic timeline so AI
@@ -1437,38 +1195,8 @@ export class AnalysisPipeline {
   // routed there exclusively) that is never synthesized; this is how the analyst pulls the events that
   // matter into the analyzed timeline. Reuses mergeDelta (dedups forensic events by id) — a stored super
   // event keeps its id, so a double-promote is a no-op. No AI here; the caller re-synthesizes.
-  async promoteSuperTimeline(
-    caseId: string,
-    events: ForensicEvent[],
-    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
-  ): Promise<InvestigationState> {
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      if (!events.length) return state;
-      const delta = deltaSchema.parse({
-        findings: [], iocs: [], mitreTechniques: [], threadsOpened: [], threadsClosed: [],
-        timelineNote: opts.note ?? `Promoted ${events.length} event(s) from the super-timeline`, summary: "",
-        forensicEvents: events.map((e) => ({ ...e })),
-      });
-      state = await this.mergeWithAliases(state, delta, { windowSequence: -1, timestamp: opts.importedAt, sourceScreenshots: [] });
-      // Stamp provenance markers on the promoted rows (second-look #11) — mergeDelta carries no
-      // provenance through the delta schema, so apply them here by id (union with any existing). Lets the
-      // forensic timeline show WHY a raw row was pulled up ("[second-look: h2]").
-      if (opts.tagById) {
-        const tagged = new Set(Object.keys(opts.tagById));
-        state = {
-          ...state,
-          forensicTimeline: state.forensicTimeline.map((e) =>
-            tagged.has(e.id)
-              ? { ...e, provenance: [...new Set([...(e.provenance ?? []), ...opts.tagById![e.id]])] }
-              : e,
-          ),
-        };
-      }
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      return state;
-    });
+  promoteSuperTimeline(...args: ImporterArgs<typeof ingest.promoteSuperTimeline>): Promise<InvestigationState> {
+    return ingest.promoteSuperTimeline(this, ...args);
   }
 
   // Import Chainsaw (WithSecure) hunt output or a raw EVTX-as-JSON dump. Like THOR/SIEM
@@ -1476,174 +1204,24 @@ export class AnalysisPipeline {
   // per-EID Windows mapping as the SIEM import, and — for Chainsaw — the matched Sigma
   // rule's level drives severity while its `attack.tXXXX` tags become MITRE techniques.
   // Each event is tagged Chainsaw / EVTX as its source for cross-source correlation.
-  async importChainsaw(
-    caseId: string,
-    jsonText: string,
-    opts: {
-      label: string;
-      idPrefix: string;               // unique per import (e.g. "c3") so ids never collide
-      importedAt: string;
-      chainsaw?: ChainsawImportOptions; // filtering overrides (aggregate, minSeverity, maxEvents…)
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseChainsawReport(jsonText, opts.chainsaw);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Chainsaw", parsed.total);
-
-    const fallback = parsed.detections > 0 ? "Chainsaw" : "EVTX";
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [fallback],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `${parsed.detections > 0 ? "Chainsaw" : "EVTX"} import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.detections > 0 ? `, ${parsed.detections} rule detection(s)` : "") +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importChainsaw(...args: ImporterArgs<typeof ingest.importChainsaw>): Promise<InvestigationState> {
+    return ingest.importChainsaw(this, ...args);
   }
 
   // Import a Hayabusa (Yamato Security) detection timeline — JSON/JSONL or CSV. Like the
   // other deterministic paths there is no AI call: the matched Sigma rule's level drives
   // severity, its title leads the description, its tactics/tags become MITRE, and IOCs /
   // asset / process-chain come from the rendered detail fields. Tagged Hayabusa as source.
-  async importHayabusa(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;                  // unique per import (e.g. "h3") so ids never collide
-      importedAt: string;
-      hayabusa?: HayabusaImportOptions;  // filtering overrides (aggregate, minSeverity, maxEvents…)
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseHayabusaTimeline(text, opts.hayabusa);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Hayabusa", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Hayabusa"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Hayabusa import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importHayabusa(...args: ImporterArgs<typeof ingest.importHayabusa>): Promise<InvestigationState> {
+    return ingest.importHayabusa(this, ...args);
   }
 
   // Import Velociraptor native JSON output (collection results / hunt export). Like the
   // other deterministic paths there is no AI call: each row is classified (Sigma / YARA /
   // EventLog / generic) and mapped — detection rows are verdict-driven, the rest auto-detect
   // the artifact's own time + IOCs. Every event is tagged Velociraptor as its source.
-  async importVelociraptor(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;                       // unique per import (e.g. "v3") so ids never collide
-      importedAt: string;
-      velociraptor?: VelociraptorImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      veloUrl?: string;          // the originating hunt/flow's GUI URL (only known for a live hunt/flow import) — stamped onto every event so the forensic timeline's "↗ Velociraptor" link resolves, mirroring the super-only path
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    // Rows often carry no _Source; use the (Velociraptor-named) filename as the fallback artifact
-    // label so generic/detection events show their source — e.g. "DetectRaptor.Windows.Detection.NamedPipes".
-    const rawArtifact = opts.label.replace(/^\d+_/, "").replace(/\.(json|jsonl|ndjson|csv)$/i, "");
-    let artifact = rawArtifact;
-    try { artifact = decodeURIComponent(rawArtifact); } catch { /* malformed %xx — keep the raw label */ }
-    // Chunked async parse: reports (rowsDone, rowsTotal) as it goes (→ the import job's progress bar
-    // and the "importing X/Y" status) and yields to the event loop between chunks, so a huge MFT/USN
-    // import streams live progress instead of freezing the server on one synchronous pass.
-    const parsedRaw = await parseVelociraptorJsonProgress(text, { artifact, ...opts.velociraptor }, opts.onProgress);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Velociraptor", parsed.total);
-
-    const eventIdByAggKey = new Map<string, string>();
-    const forensicEvents = parsed.events.map((e, i) => {
-      const { aggKey, ...rest } = e;
-      const id = `${opts.idPrefix}e${i + 1}`;
-      if (aggKey) eventIdByAggKey.set(aggKey, id);
-      return {
-        ...rest, id, sources: rest.sources?.length ? rest.sources : ["Velociraptor"],
-        ...(opts.veloUrl ? { veloUrl: opts.veloUrl } : {}),
-      };
-    });
-
-    const raw = {
-      findings: [],
-      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
-        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
-        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
-      })),
-      mitreTechniques: [],
-      forensicEvents,
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Velociraptor import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
-        (parsed.detections > 0 ? `, ${parsed.detections} detection(s)` : "") +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importVelociraptor(...args: ImporterArgs<typeof ingest.importVelociraptor>): Promise<InvestigationState> {
+    return ingest.importVelociraptor(this, ...args);
   }
 
   // Import ECAR — EDR Common Activity Record telemetry (NDJSON of (object, action) endpoint events).
@@ -1651,425 +1229,60 @@ export class AnalysisPipeline {
   // reads `timestamp_ms`, scrapes PUBLIC IPs as IOCs, and keeps severity conservative (Info evidence,
   // bumped only on real tradecraft) so high-volume raw telemetry doesn't flood the timeline. See
   // ecarImport.ts for the mapping (and the lsass-access false-positive rationale).
-  async importEcar(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import so ids never collide
-      importedAt: string;
-      ecar?: EcarImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseEcarJson(text, { ...opts.ecar });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "ECAR", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [ECAR_SOURCE],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `ECAR import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importEcar(...args: ImporterArgs<typeof ingest.importEcar>): Promise<InvestigationState> {
+    return ingest.importEcar(this, ...args);
   }
 
   // Import an Apache/Nginx/Squid combined access log (web server or forward-proxy). Deterministic
   // (no AI): raw web/proxy telemetry, Info by default with a conservative bump only for an
   // access-denied response; git smart-HTTP clone/push tagged T1213. See combinedLogImport.ts.
-  async importCombinedLog(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      combinedLog?: CombinedLogImportOptions;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseCombinedLog(text, { ...opts.combinedLog });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Web/proxy access-log", parsed.total);
-
-    const eventIdByAggKey = new Map<string, string>();
-    const forensicEvents = parsed.events.map((e, i) => {
-      const { aggKey, ...rest } = e;
-      const id = `${opts.idPrefix}e${i + 1}`;
-      if (aggKey) eventIdByAggKey.set(aggKey, id);
-      return { ...rest, id, sources: rest.sources?.length ? rest.sources : [COMBINED_LOG_SOURCE] };
-    });
-    const raw = {
-      findings: [],
-      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
-        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
-        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
-      })),
-      mitreTechniques: [],
-      forensicEvents,
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Web/proxy access-log import (${parsed.format}): ${parsed.kept} request(s) from ${parsed.total} line(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importCombinedLog(...args: ImporterArgs<typeof ingest.importCombinedLog>): Promise<InvestigationState> {
+    return ingest.importCombinedLog(this, ...args);
   }
 
   // Import a Cisco ASA firewall syslog export. Deterministic (no AI): Built/Teardown telemetry
   // stays Info, an explicit Deny bumps to Low, dynamic-NAT-translation noise is dropped,
   // year-less timestamps are re-anchored by the mergeDelta year-clamp. See ciscoAsaImport.ts.
-  async importCiscoAsa(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      ciscoAsa?: CiscoAsaImportOptions;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
-    // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
-    // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
-    const priorState = await this.opts.stateStore.load(caseId).catch(() => null);
-    const assumeYear = opts.ciscoAsa?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
-    const parsedRaw = parseCiscoAsaLog(text, { ...opts.ciscoAsa, ...(assumeYear !== undefined ? { assumeYear } : {}) });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Cisco ASA", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [CISCO_ASA_SOURCE],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Cisco ASA import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} line(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importCiscoAsa(...args: ImporterArgs<typeof ingest.importCiscoAsa>): Promise<InvestigationState> {
+    return ingest.importCiscoAsa(this, ...args);
   }
 
   // Import a Snort / Suricata "fast" alert log — a real IDS verdict feed. Deterministic (no AI):
   // severity is the rule's Priority verdict, public src/dst IPs become IOCs, year-less timestamps are
   // re-anchored by the mergeDelta year-clamp. See snortImport.ts.
-  async importSnort(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      snort?: SnortImportOptions;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
-    // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
-    // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
-    const priorState = await this.opts.stateStore.load(caseId).catch(() => null);
-    const assumeYear = opts.snort?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
-    const parsedRaw = parseSnortLog(text, { ...opts.snort, ...(assumeYear !== undefined ? { assumeYear } : {}) });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Snort", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [SNORT_SOURCE],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Snort import (${parsed.format}): ${parsed.kept} alert(s) from ${parsed.total} line(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importSnort(...args: ImporterArgs<typeof ingest.importSnort>): Promise<InvestigationState> {
+    return ingest.importSnort(this, ...args);
   }
 
   // Import YARA CLI scan output (`yara -s -m <rules> <target>`). Deterministic (no AI): each rule
   // match becomes a file-match event (default Medium, bumped only on an explicit rule-meta signal),
   // matched file + hash meta become IOCs. YARA output is undated, so mergeDelta stamps events at import
   // time. Used by the external-tools run path (#211). See yaraImport.ts.
-  async importYara(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      yara?: YaraImportOptions;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseYaraOutput(text, { ...opts.yara });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "YARA", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [YARA_SOURCE],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `YARA import: ${parsed.kept} match event(s) from ${parsed.total} match(es)` +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importYara(...args: ImporterArgs<typeof ingest.importYara>): Promise<InvestigationState> {
+    return ingest.importYara(this, ...args);
   }
 
   // Import a plain Linux/Unix syslog export (RFC 5424 / RFC 3164). Deterministic (no AI): host
   // telemetry stays Info, an auth-failure or crit/alert/emerg PRI bumps to Low, the host is carried
   // as the event's asset, RFC-3164 year-less timestamps are re-anchored by the mergeDelta year-clamp.
   // See syslogImport.ts.
-  async importSyslog(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      syslog?: SyslogImportOptions;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    // Year-less BSD-style timestamps default to the CURRENT calendar year unless the case already has
-    // an established dominant year to anchor onto — see pickImportYear (a big year-less import can
-    // outweigh clampOutlierYears' post-hoc ≥90% minority-outlier guard).
-    const priorState = await this.opts.stateStore.load(caseId).catch(() => null);
-    const assumeYear = opts.syslog?.assumeYear ?? pickImportYear(priorState?.forensicTimeline ?? []);
-    const parsedRaw = parseSyslog(text, { ...opts.syslog, ...(assumeYear !== undefined ? { assumeYear } : {}) });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Syslog", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [SYSLOG_SOURCE],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Syslog import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} line(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importSyslog(...args: ImporterArgs<typeof ingest.importSyslog>): Promise<InvestigationState> {
+    return ingest.importSyslog(this, ...args);
   }
 
   // Import network-monitor logs — Suricata `eve.json` and Zeek JSON (Security Onion's
   // network side). Deterministic (no AI call): the timeline is built from the detections
   // (Suricata alerts + Zeek notices); surrounding telemetry (dns/http/tls/files/conn)
   // contributes IOCs only. Events are tagged Suricata / Zeek.
-  async importNetwork(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;                // unique per import (e.g. "n3") so ids never collide
-      importedAt: string;
-      network?: NetworkImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    // Pass the import filename so per-stream Zeek JSON (conn.json / dns.json / … with no `_path`)
-    // routes to the right stream (#197).
-    const parsedRaw = parseNetworkLogs(text, { ...opts.network, filename: opts.network?.filename ?? opts.label });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Network", parsed.total);
-
-    const eventIdByAggKey = new Map<string, string>();
-    const forensicEvents = parsed.events.map((e, i) => {
-      const { aggKey, ...rest } = e;
-      const id = `${opts.idPrefix}e${i + 1}`;
-      if (aggKey) eventIdByAggKey.set(aggKey, id);
-      return { ...rest, id, sources: rest.sources?.length ? rest.sources : ["Suricata"] };
-    });
-    const raw = {
-      findings: [],
-      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
-        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
-        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
-      })),
-      mitreTechniques: [],
-      forensicEvents,
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Network import (${parsed.format}): ${parsed.kept} detection event(s) from ${parsed.total} record(s)` +
-        (parsed.alerts > 0 ? `, ${parsed.alerts} alert/notice(s)` : "") +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importNetwork(...args: ImporterArgs<typeof ingest.importNetwork>): Promise<InvestigationState> {
+    return ingest.importNetwork(this, ...args);
   }
 
   // Import SO-CRATES (dougburks/so-crates) verdicts — Suricata IDS alerts, YARA file matches, and
   // Sigma log detections — as the browser extension pushes them (or a raw export). Deterministic
   // (no AI). Events are tagged "SO-CRATES" (+ the underlying engine) for cross-source correlation.
-  async importSocrates(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;                // unique per import (e.g. "s4") so ids never collide
-      importedAt: string;
-      socrates?: SocratesImportOptions;
-      minSeverity?: Severity;          // gate-aware import floor (unified Import button)
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseSocrates(text, opts.socrates);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "SO-CRATES", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["SO-CRATES"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `SO-CRATES import (${parsed.format}): ${parsed.kept} detection event(s) from ${parsed.total} record(s)` +
-        ` — ${parsed.alerts} Suricata alert(s), ${parsed.yara} YARA, ${parsed.sigma} Sigma, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importSocrates(...args: ImporterArgs<typeof ingest.importSocrates>): Promise<InvestigationState> {
+    return ingest.importSocrates(this, ...args);
   }
 
   // Import Security Onion Console (SOC) events — the Alerts / Hunt views the browser extension
@@ -2077,107 +1290,16 @@ export class AnalysisPipeline {
   // event's own `event.severity_label` drives severity, `rule.name` leads the description, ECS
   // threat fields become MITRE, and source/destination IPs + app-layer fields become IOCs.
   // Events are tagged "Security Onion".
-  async importSecurityOnion(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;                // unique per import (e.g. "so3") so ids never collide
-      importedAt: string;
-      securityOnion?: SecurityOnionImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseSecurityOnion(text, opts.securityOnion);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Security Onion", parsed.total);
-
-    const eventIdByAggKey = new Map<string, string>();
-    const forensicEvents = parsed.events.map((e, i) => {
-      const { aggKey, ...rest } = e;
-      const id = `${opts.idPrefix}e${i + 1}`;
-      if (aggKey) eventIdByAggKey.set(aggKey, id);
-      return { ...rest, id, sources: rest.sources?.length ? rest.sources : ["Security Onion"] };
-    });
-    const raw = {
-      findings: [],
-      iocs: resolveExtractedFrom(parsed.iocs, eventIdByAggKey).map((c, i) => ({
-        id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value,
-        ...(c.extractedFrom ? { extractedFrom: c.extractedFrom } : {}),
-      })),
-      mitreTechniques: [],
-      forensicEvents,
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Security Onion import: ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importSecurityOnion(...args: ImporterArgs<typeof ingest.importSecurityOnion>): Promise<InvestigationState> {
+    return ingest.importSecurityOnion(this, ...args);
   }
 
   // Import a KAPE / Eric Zimmerman Tools CSV (Prefetch, Amcache, ShimCache, LNK, JumpLists,
   // UsnJrnl, MFT, SRUM, Recycle Bin, Shellbags). Deterministic (no AI call): the EZ tool is
   // detected from the CSV header, then each row maps to a forensic event reading the
   // artifact's own time + file/hash/process IOCs. Events are tagged by artifact name.
-  async importKape(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;             // unique per import (e.g. "k3") so ids never collide
-      importedAt: string;
-      kape?: KapeImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseKapeCsv(text, opts.kape);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, `KAPE/${parsed.artifact}`, parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [parsed.artifact],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `KAPE/${parsed.artifact} import: ${parsed.kept} event(s) from ${parsed.total} row(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importKape(...args: ImporterArgs<typeof ingest.importKape>): Promise<InvestigationState> {
+    return ingest.importKape(this, ...args);
   }
 
   // Import a Cyber Triage timeline export (JSONL / JSON array / CSV). Deterministic (no AI call):
@@ -2185,318 +1307,52 @@ export class AnalysisPipeline {
   // unscored process/task rows become Info evidence, the bulk File super-timeline is dropped
   // (unless `fileTelemetry`), and Active-Connection remote IPs become IOCs. Events tagged
   // "Cyber Triage".
-  async importCybertriage(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;                  // unique per import (e.g. "ct3") so ids never collide
-      importedAt: string;
-      cybertriage?: CybertriageImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseCybertriage(text, opts.cybertriage);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Cyber Triage", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Cyber Triage"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Cyber Triage import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
-        (parsed.notable > 0 ? `, ${parsed.notable} scored item(s)` : "") +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importCybertriage(...args: ImporterArgs<typeof ingest.importCybertriage>): Promise<InvestigationState> {
+    return ingest.importCybertriage(this, ...args);
   }
 
   // Import Microsoft 365 Unified Audit Log + Entra ID (sign-in / directory audit) data.
   // Deterministic (no AI call): each record is classified (UAL / sign-in / audit) and mapped,
   // severity derived from the operation (BEC tradecraft) or Entra's own risk verdict; the
   // source IP becomes an IOC and the UPN is surfaced for the asset graph.
-  async importM365(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "m3") so ids never collide
-      importedAt: string;
-      m365?: M365ImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseM365Audit(text, opts.m365);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Microsoft 365", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Microsoft 365"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Microsoft 365 import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importM365(...args: ImporterArgs<typeof ingest.importM365>): Promise<InvestigationState> {
+    return ingest.importM365(this, ...args);
   }
 
   // Import AWS CloudTrail logs. Deterministic (no AI call): each API-call record is mapped,
   // severity derived from the action (IAM persistence, logging/detection tampering, S3
   // exposure, secrets access) + denied/root/console-failure bumps; the caller IP → IOC.
-  async importAws(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "a3") so ids never collide
-      importedAt: string;
-      aws?: AwsImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseCloudTrail(text, opts.aws);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "AWS CloudTrail", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["AWS CloudTrail"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `AWS CloudTrail import: ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importAws(...args: ImporterArgs<typeof ingest.importAws>): Promise<InvestigationState> {
+    return ingest.importAws(this, ...args);
   }
 
   // Import GCP Cloud Audit Logs + Azure Activity Log. Deterministic (no AI call): each record
   // is routed (GCP / Azure) and mapped, severity derived from the action (+ denied bump); the
   // caller IP → IOC and the principal email is surfaced for the asset graph.
-  async importCloudActivity(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "g3") so ids never collide
-      importedAt: string;
-      cloud?: CloudActivityImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseCloudActivity(text, opts.cloud);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Cloud activity", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Cloud Audit"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Cloud activity import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importCloudActivity(...args: ImporterArgs<typeof ingest.importCloudActivity>): Promise<InvestigationState> {
+    return ingest.importCloudActivity(this, ...args);
   }
 
   // Import Kubernetes API-server audit logs (audit.k8s.io). Deterministic (no AI call): each audit
   // Event → a forensic event whose severity is derived from the (verb, resource, subresource) tuple
   // (pod exec/attach, secret access, RBAC change, privileged-pod create, anonymous access), Info by
   // default. Source IP → IOC. Tagged Kubernetes Audit.
-  async importK8sAudit(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "k3") so ids never collide
-      importedAt: string;
-      k8s?: K8sAuditImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseK8sAudit(text, opts.k8s);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Kubernetes audit", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Kubernetes Audit"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Kubernetes audit import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importK8sAudit(...args: ImporterArgs<typeof ingest.importK8sAudit>): Promise<InvestigationState> {
+    return ingest.importK8sAudit(this, ...args);
   }
 
   // Import osquery scheduled-query result logs (differential `columns` rows + `snapshot` sets).
   // Deterministic (no AI call): Info-by-default endpoint telemetry, with a conservative tradecraft
   // bump on a command-line column; columns → IOCs (path/hash/ip/process). Tagged osquery.
-  async importOsquery(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;          // unique per import (e.g. "o3") so ids never collide
-      importedAt: string;
-      osquery?: OsqueryImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseOsqueryLog(text, opts.osquery);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "osquery", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["osquery"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `osquery import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importOsquery(...args: ImporterArgs<typeof ingest.importOsquery>): Promise<InvestigationState> {
+    return ingest.importOsquery(this, ...args);
   }
 
   // Import a Plaso / log2timeline super-timeline (psort CSV — dynamic or l2tcsv). Deterministic
   // (no AI call): each row is an Info evidence event read at its own time, with IOCs scraped
   // from the message (hashes/URLs/IPs) and the source file path. Tagged Plaso.
-  async importPlaso(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "p3") so ids never collide
-      importedAt: string;
-      plaso?: PlasoImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parsePlasoCsv(text, opts.plaso);
-    return this.persistPlasoParsed(caseId, parsedRaw, opts);
+  importPlaso(...args: ImporterArgs<typeof ingest.importPlaso>): Promise<InvestigationState> {
+    return ingest.importPlaso(this, ...args);
   }
 
   // Streaming-from-disk Plaso import: for super-timelines too large to hold as one JS string (a
@@ -2504,35 +1360,14 @@ export class AnalysisPipeline {
   // length"). Reads the file line-by-line via node:readline and feeds parsePlasoFromLines, which
   // keeps memory bounded by the distinct-key set, not the row count. Same downstream merge as
   // importPlaso. The route persists the evidence file separately (by copy, not as a string).
-  async importPlasoFile(
-    caseId: string,
-    filePath: string,
-    opts: {
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      plaso?: PlasoImportOptions;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const rl = createInterface({
-      input: createReadStream(filePath, { encoding: "utf8", highWaterMark: 1 << 20 }),
-      crlfDelay: Infinity,
-    });
-    let parsedRaw: PlasoParseResult;
-    try {
-      parsedRaw = await parsePlasoFromLines(rl, opts.plaso);
-    } finally {
-      rl.close();
-    }
-    return this.persistPlasoParsed(caseId, parsedRaw, opts);
+  importPlasoFile(...args: ImporterArgs<typeof ingest.importPlasoFile>): Promise<InvestigationState> {
+    return ingest.importPlasoFile(this, ...args);
   }
 
   // Shared tail of both Plaso entry points: apply the severity floor, build the delta and merge it
   // into the case state. (Keeping this in one place means the in-memory and streaming importers
   // produce identical timeline rows / IOCs / notes.)
-  private async persistPlasoParsed(
+  async persistPlasoParsed(
     caseId: string,
     parsedRaw: PlasoParseResult,
     opts: { label: string; idPrefix: string; importedAt: string; minSeverity?: Severity; onProgress?: (done: number, total: number) => void },
@@ -2574,254 +1409,39 @@ export class AnalysisPipeline {
   // Deterministic (no AI call): records sharing a serial collapse into one logical event, mapped
   // to severity/MITRE by record type (logins, account/group mgmt, sudo, SELinux denials, audit-config
   // tampering), bumped on a failed auth or a suspicious command. Read at the audit() epoch. Tagged auditd.
-  async importAuditd(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "ad3") so ids never collide
-      importedAt: string;
-      auditd?: AuditdImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseAuditdLog(text, opts.auditd);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "auditd", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["auditd"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `auditd import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importAuditd(...args: ImporterArgs<typeof ingest.importAuditd>): Promise<InvestigationState> {
+    return ingest.importAuditd(this, ...args);
   }
 
   // Import a systemd-journald structured log (`journalctl -o json` / `-o json-pretty`). Deterministic
   // (no AI call): each entry is read at its own time (_SOURCE/__REALTIME µs epoch), severity derived
   // from PRIORITY then bumped from the message (sshd auth, sudo, useradd, kernel), with IOCs scraped
   // from _EXE/_COMM and the MESSAGE. Tagged journald.
-  async importJournald(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "jd3") so ids never collide
-      importedAt: string;
-      journald?: JournaldImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseJournald(text, opts.journald);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "journald", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["journald"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `journald import: ${parsed.kept} event(s) from ${parsed.total} entr(y/ies)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importJournald(...args: ImporterArgs<typeof ingest.importJournald>): Promise<InvestigationState> {
+    return ingest.importJournald(this, ...args);
   }
 
   // Import a sysdig / Falco export (Falco alert JSON and/or sysdig `-j` event JSON). Deterministic
   // (no AI call): Falco rule hits are the DETECTIONS (verdict-first: priority → severity, tags →
   // MITRE) and surface on the timeline; raw sysdig syscall events are telemetry → Info evidence;
   // both contribute proc/file/network IOCs. Tagged Falco / sysdig.
-  async importSysdig(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "sd3") so ids never collide
-      importedAt: string;
-      sysdig?: SysdigImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseSysdig(text, opts.sysdig);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "sysdig/Falco", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["sysdig"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `sysdig/Falco import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.alerts > 0 ? `, ${parsed.alerts} Falco alert(s)` : "") +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importSysdig(...args: ImporterArgs<typeof ingest.importSysdig>): Promise<InvestigationState> {
+    return ingest.importSysdig(this, ...args);
   }
 
   // Import Wazuh SIEM/EDR alert exports (alerts.json / NDJSON / API export). Deterministic
   // (no AI call): rule.level drives severity (≥13 Critical, ≥10 High, ≥7 Medium, else Info),
   // rule.mitre.technique → MITRE, agent.name → asset, data.srcip/dstip/md5/sha256/url → IOCs.
-  async importWazuh(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "w3") so ids never collide
-      importedAt: string;
-      wazuh?: WazuhImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseWazuhAlerts(text, opts.wazuh);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Wazuh", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Wazuh"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Wazuh import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)` +
-        (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importWazuh(...args: ImporterArgs<typeof ingest.importWazuh>): Promise<InvestigationState> {
+    return ingest.importWazuh(this, ...args);
   }
 
   // Import a malware-sandbox detonation report (CAPEv2 or CrowdStrike Falcon Sandbox).
   // Deterministic (no AI call): the sample verdict + each behavioural signature map to events
   // (severity from the report's own score/verdict, MITRE from its ATT&CK), and every
   // dropped/extracted file hash + network host/domain/URL is harvested as an IOC.
-  async importSandbox(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "sb3") so ids never collide
-      importedAt: string;
-      sandbox?: SandboxImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseSandboxReport(text, opts.sandbox);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Sandbox", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Sandbox"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Sandbox import (${parsed.format}): ${parsed.kept} event(s)` +
-        (parsed.signatures > 0 ? `, ${parsed.signatures} signature(s)` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importSandbox(...args: ImporterArgs<typeof ingest.importSandbox>): Promise<InvestigationState> {
+    return ingest.importSandbox(this, ...args);
   }
 
   // Import memory-forensics tool output (Volatility 3 or Rekall). Deterministic (no AI call): each
@@ -2830,202 +1450,31 @@ export class AnalysisPipeline {
   // port IOCs), malfind → High injected-code events (ATT&CK T1055), cmdline → command-line events
   // (bumped on LOLBin/encoded tradecraft), svcscan/modules → service/driver evidence. Tagged
   // "Volatility" / "Rekall" for cross-source correlation; reads the artifact's own time.
-  async importMemory(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "mem3") so ids never collide
-      importedAt: string;
-      memory?: MemoryImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseMemory(text, { ...opts.memory, filename: opts.label });
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Memory", parsed.total);
-
-    const tool = parsed.tool || "Volatility";
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : [tool],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Memory import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s) across ${parsed.tables} plugin(s)` +
-        (parsed.injected > 0 ? `, ${parsed.injected} injected-code hit(s)` : "") +
-        (parsed.connections > 0 ? `, ${parsed.connections} connection(s)` : "") +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importMemory(...args: ImporterArgs<typeof ingest.importMemory>): Promise<InvestigationState> {
+    return ingest.importMemory(this, ...args);
   }
 
   // Import an email artifact (.eml RFC 2822, or best-effort .msg). Deterministic (no AI call):
   // ONE forensic event dated at the message's own Date: header, severity DERIVED from the email's
   // SPF/DKIM/DMARC verdict + sender heuristics; URLs, sender/reply-to domains, originating IP and
   // attachment names/hashes become IOCs. Covers ATT&CK T1566 (Phishing). Tagged "Email".
-  async importEmail(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "em3") so ids never collide
-      importedAt: string;
-      email?: EmailImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseEmail(text, opts.email);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "Email", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Email"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Email import (${parsed.format}): ${parsed.kept} event(s)` +
-        (parsed.subject ? ` — "${parsed.subject.slice(0, 80)}"` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importEmail(...args: ImporterArgs<typeof ingest.importEmail>): Promise<InvestigationState> {
+    return ingest.importEmail(this, ...args);
   }
 
   // Import a TheHive 5 case, alert, or observable export. Deterministic (no AI call):
   // case/alert records → forensic events (severity from TheHive's own 1–4 scale, MITRE from
   // ATT&CK-tagged tags, TLP/PAP labels prepended); observable records → IOCs by dataType.
-  async importTheHive(
-    caseId: string,
-    text: string,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "th3") so ids never collide
-      importedAt: string;
-      thehive?: TheHiveImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseTheHive(text, opts.thehive);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "TheHive", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["TheHive"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `TheHive import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
-        (parsed.observables > 0 ? `, ${parsed.observables} observable(s)` : "") +
-        `, ${parsed.iocCount} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importTheHive(...args: ImporterArgs<typeof ingest.importTheHive>): Promise<InvestigationState> {
+    return ingest.importTheHive(this, ...args);
   }
 
   // Import an existing DFIR-IRIS case (issue #88) — the reverse of the IRIS push. Takes the raw
   // case rows already fetched from the IRIS API (analysis/irisImport.ts parses them deterministically,
   // NO AI call): timeline → forensic events, IOCs → IOCs, assets → evidence events. All feed the
   // same forensic timeline via mergeDelta, exactly like the other importers.
-  async importIris(
-    caseId: string,
-    data: IrisCaseData,
-    opts: {
-      label: string;
-      idPrefix: string;            // unique per import (e.g. "iris3") so ids never collide
-      importedAt: string;
-      iris?: IrisImportOptions;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void;
-    },
-  ): Promise<InvestigationState> {
-    const parsedRaw = parseIrisCase(data, opts.iris);
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0 && parsed.iocs.length === 0) return this.noteEmptyImport(caseId, opts, "DFIR-IRIS", parsed.timelineCount);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["DFIR-IRIS"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `DFIR-IRIS import (${parsed.caseName ?? `case #${parsed.irisCaseId ?? "?"}`}): ` +
-        `${parsed.kept} event(s) from ${parsed.timelineCount} timeline + ${parsed.assetCount} asset(s)` +
-        `, ${parsed.iocCount} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
+  importIris(...args: ImporterArgs<typeof ingest.importIris>): Promise<InvestigationState> {
+    return ingest.importIris(this, ...args);
   }
 
   // Holistic pass: read the whole forensic timeline and produce findings, MITRE

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -429,18 +429,45 @@ export class AnalysisPipeline {
   // Lazily loaded from opts.kevStore so we don't block the constructor on disk I/O.
   private kevCatalogCache: KevCatalog | undefined;
 
-  // `opts` and the four collaborators below are public because src/analysis/ingest/ takes an
-  // ImportContext, and AnalysisPipeline satisfies that interface structurally (#384). They are the
-  // pipeline's internal surface for the importers, not an invitation for routes to reach in --
-  // ImportContext is deliberately the smallest type that lets an importer do its job.
-  constructor(public readonly opts: PipelineOptions) {
+  /**
+   * The ONLY thing src/analysis/ingest/ ever receives (#384).
+   *
+   * The first cut of the ingest extraction passed `this` and let AnalysisPipeline satisfy
+   * ImportContext structurally, which meant `opts` and four methods had to become public. That
+   * bought the importers a narrow interface at the cost of handing every OTHER consumer of the
+   * pipeline the entire options bag -- the AI providers, every store, every tuning knob. A boundary
+   * that has to widen the class to exist is not much of a boundary.
+   *
+   * This adapter closes over the five permitted operations instead, so the class members stay
+   * private and the importers still see nothing beyond what ImportContext declares. `opts` is
+   * exposed through getters rather than a snapshot because the settings-reload path rebuilds live
+   * options in place; a copy taken at construction would go stale the first time an operator saved
+   * a setting.
+   */
+  private readonly importCtx: ImportContext;
+
+  constructor(private readonly opts: PipelineOptions) {
     this.log = opts.logger ?? createConsoleLogger(normalizeLogLevel(process.env.DFIR_LOG_LEVEL));
+    this.importCtx = {
+      opts: {
+        get stateStore() {
+          return opts.stateStore;
+        },
+        get onState() {
+          return opts.onState;
+        },
+      },
+      withStateLock: (caseId, fn) => this.withStateLock(caseId, fn),
+      mergeWithAliases: (state, delta, ctx) => this.mergeWithAliases(state, delta, ctx),
+      noteEmptyImport: (caseId, o, kind, total) => this.noteEmptyImport(caseId, o, kind, total),
+      persistPlasoParsed: (caseId, parsed, o) => this.persistPlasoParsed(caseId, parsed, o),
+    };
   }
 
   // Wraps mergeDelta with the case's analyst IOC-merge aliases (#82), if any store is configured.
   // Every import/synthesis call site uses this instead of calling mergeDelta directly, so a merged
   // duplicate value stays folded onto its canonical IOC across every future window/re-synthesis.
-  async mergeWithAliases(
+  private async mergeWithAliases(
     state: InvestigationState,
     delta: Parameters<typeof mergeDelta>[1],
     ctx: WindowContext,
@@ -456,7 +483,7 @@ export class AnalysisPipeline {
   // immediately when no lock is configured (e.g. some script/test call sites).
   // CAUTION: never call this from inside another withStateLock/runExclusive callback for the
   // SAME caseId — that nests onto the outer call's own unresolved promise and deadlocks.
-  withStateLock<T>(caseId: string, fn: () => Promise<T>): Promise<T> {
+  private withStateLock<T>(caseId: string, fn: () => Promise<T>): Promise<T> {
     return this.opts.stateLock ? this.opts.stateLock.runExclusive(caseId, fn) : fn();
   }
 
@@ -1125,7 +1152,7 @@ export class AnalysisPipeline {
   // `total` is the importer's own parsed-record count, so the note says how much was READ, not just
   // that nothing came out — "0 events from 0 records" (wrong format) and "0 events from 75,951
   // records" (understood but uninteresting) are very different problems.
-  async noteEmptyImport(
+  private async noteEmptyImport(
     caseId: string,
     opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
     kind: string,
@@ -1157,7 +1184,7 @@ export class AnalysisPipeline {
   // Scan-lifecycle/info noise (module init, "Info" level) is dropped by default.
   // Findings/attacker-path still come from a later synthesize().
   importThor(...args: ImporterArgs<typeof ingest.importThor>): Promise<InvestigationState> {
-    return ingest.importThor(this, ...args);
+    return ingest.importThor(this.importCtx, ...args);
   }
 
   // Import a SIEM / EDR JSON export (Elastic/Kibana, Splunk, an EDR console, a raw
@@ -1166,12 +1193,12 @@ export class AnalysisPipeline {
   // fall back to field auto-detection, and repetitive events are aggregated. The
   // detected tool name (from the filename / source) tags each event's `sources`.
   importSiem(...args: ImporterArgs<typeof ingest.importSiem>): Promise<InvestigationState> {
-    return ingest.importSiem(this, ...args);
+    return ingest.importSiem(this.importCtx, ...args);
   }
 
   // Import Windows Event XML through the shared deterministic SIEM/EVTX mapping.
   importEvtxXml(...args: ImporterArgs<typeof ingest.importEvtxXml>): Promise<InvestigationState> {
-    return ingest.importEvtxXml(this, ...args);
+    return ingest.importEvtxXml(this.importCtx, ...args);
   }
 
   // Import a Linux/Unix shell history file (.bash_history / .zsh_history / …). Deterministic
@@ -1179,7 +1206,7 @@ export class AnalysisPipeline {
   // `#<epoch>` / zsh extended history), Info by default with a conservative tradecraft bump. The
   // account is derived from the filename and shown in each event.
   importBashHistory(...args: ImporterArgs<typeof ingest.importBashHistory>): Promise<InvestigationState> {
-    return ingest.importBashHistory(this, ...args);
+    return ingest.importBashHistory(this.importCtx, ...args);
   }
 
   // Run a USER-authored declarative importer (the external plugin path). Mirrors the built-in
@@ -1187,7 +1214,7 @@ export class AnalysisPipeline {
   // MITRE rides inside each event) -> mergeDelta -> save -> notify. Does NOT depend on any shared-runner
   // refactor of the built-ins.
   importDeclarative(...args: ImporterArgs<typeof ingest.importDeclarative>): Promise<InvestigationState> {
-    return ingest.importDeclarative(this, ...args);
+    return ingest.importDeclarative(this.importCtx, ...args);
   }
 
   // "Promote" copies already-imported super-timeline events UP into the forensic timeline so AI
@@ -1196,7 +1223,7 @@ export class AnalysisPipeline {
   // matter into the analyzed timeline. Reuses mergeDelta (dedups forensic events by id) — a stored super
   // event keeps its id, so a double-promote is a no-op. No AI here; the caller re-synthesizes.
   promoteSuperTimeline(...args: ImporterArgs<typeof ingest.promoteSuperTimeline>): Promise<InvestigationState> {
-    return ingest.promoteSuperTimeline(this, ...args);
+    return ingest.promoteSuperTimeline(this.importCtx, ...args);
   }
 
   // Import Chainsaw (WithSecure) hunt output or a raw EVTX-as-JSON dump. Like THOR/SIEM
@@ -1205,7 +1232,7 @@ export class AnalysisPipeline {
   // rule's level drives severity while its `attack.tXXXX` tags become MITRE techniques.
   // Each event is tagged Chainsaw / EVTX as its source for cross-source correlation.
   importChainsaw(...args: ImporterArgs<typeof ingest.importChainsaw>): Promise<InvestigationState> {
-    return ingest.importChainsaw(this, ...args);
+    return ingest.importChainsaw(this.importCtx, ...args);
   }
 
   // Import a Hayabusa (Yamato Security) detection timeline — JSON/JSONL or CSV. Like the
@@ -1213,7 +1240,7 @@ export class AnalysisPipeline {
   // severity, its title leads the description, its tactics/tags become MITRE, and IOCs /
   // asset / process-chain come from the rendered detail fields. Tagged Hayabusa as source.
   importHayabusa(...args: ImporterArgs<typeof ingest.importHayabusa>): Promise<InvestigationState> {
-    return ingest.importHayabusa(this, ...args);
+    return ingest.importHayabusa(this.importCtx, ...args);
   }
 
   // Import Velociraptor native JSON output (collection results / hunt export). Like the
@@ -1221,7 +1248,7 @@ export class AnalysisPipeline {
   // EventLog / generic) and mapped — detection rows are verdict-driven, the rest auto-detect
   // the artifact's own time + IOCs. Every event is tagged Velociraptor as its source.
   importVelociraptor(...args: ImporterArgs<typeof ingest.importVelociraptor>): Promise<InvestigationState> {
-    return ingest.importVelociraptor(this, ...args);
+    return ingest.importVelociraptor(this.importCtx, ...args);
   }
 
   // Import ECAR — EDR Common Activity Record telemetry (NDJSON of (object, action) endpoint events).
@@ -1230,28 +1257,28 @@ export class AnalysisPipeline {
   // bumped only on real tradecraft) so high-volume raw telemetry doesn't flood the timeline. See
   // ecarImport.ts for the mapping (and the lsass-access false-positive rationale).
   importEcar(...args: ImporterArgs<typeof ingest.importEcar>): Promise<InvestigationState> {
-    return ingest.importEcar(this, ...args);
+    return ingest.importEcar(this.importCtx, ...args);
   }
 
   // Import an Apache/Nginx/Squid combined access log (web server or forward-proxy). Deterministic
   // (no AI): raw web/proxy telemetry, Info by default with a conservative bump only for an
   // access-denied response; git smart-HTTP clone/push tagged T1213. See combinedLogImport.ts.
   importCombinedLog(...args: ImporterArgs<typeof ingest.importCombinedLog>): Promise<InvestigationState> {
-    return ingest.importCombinedLog(this, ...args);
+    return ingest.importCombinedLog(this.importCtx, ...args);
   }
 
   // Import a Cisco ASA firewall syslog export. Deterministic (no AI): Built/Teardown telemetry
   // stays Info, an explicit Deny bumps to Low, dynamic-NAT-translation noise is dropped,
   // year-less timestamps are re-anchored by the mergeDelta year-clamp. See ciscoAsaImport.ts.
   importCiscoAsa(...args: ImporterArgs<typeof ingest.importCiscoAsa>): Promise<InvestigationState> {
-    return ingest.importCiscoAsa(this, ...args);
+    return ingest.importCiscoAsa(this.importCtx, ...args);
   }
 
   // Import a Snort / Suricata "fast" alert log — a real IDS verdict feed. Deterministic (no AI):
   // severity is the rule's Priority verdict, public src/dst IPs become IOCs, year-less timestamps are
   // re-anchored by the mergeDelta year-clamp. See snortImport.ts.
   importSnort(...args: ImporterArgs<typeof ingest.importSnort>): Promise<InvestigationState> {
-    return ingest.importSnort(this, ...args);
+    return ingest.importSnort(this.importCtx, ...args);
   }
 
   // Import YARA CLI scan output (`yara -s -m <rules> <target>`). Deterministic (no AI): each rule
@@ -1259,7 +1286,7 @@ export class AnalysisPipeline {
   // matched file + hash meta become IOCs. YARA output is undated, so mergeDelta stamps events at import
   // time. Used by the external-tools run path (#211). See yaraImport.ts.
   importYara(...args: ImporterArgs<typeof ingest.importYara>): Promise<InvestigationState> {
-    return ingest.importYara(this, ...args);
+    return ingest.importYara(this.importCtx, ...args);
   }
 
   // Import a plain Linux/Unix syslog export (RFC 5424 / RFC 3164). Deterministic (no AI): host
@@ -1267,7 +1294,7 @@ export class AnalysisPipeline {
   // as the event's asset, RFC-3164 year-less timestamps are re-anchored by the mergeDelta year-clamp.
   // See syslogImport.ts.
   importSyslog(...args: ImporterArgs<typeof ingest.importSyslog>): Promise<InvestigationState> {
-    return ingest.importSyslog(this, ...args);
+    return ingest.importSyslog(this.importCtx, ...args);
   }
 
   // Import network-monitor logs — Suricata `eve.json` and Zeek JSON (Security Onion's
@@ -1275,14 +1302,14 @@ export class AnalysisPipeline {
   // (Suricata alerts + Zeek notices); surrounding telemetry (dns/http/tls/files/conn)
   // contributes IOCs only. Events are tagged Suricata / Zeek.
   importNetwork(...args: ImporterArgs<typeof ingest.importNetwork>): Promise<InvestigationState> {
-    return ingest.importNetwork(this, ...args);
+    return ingest.importNetwork(this.importCtx, ...args);
   }
 
   // Import SO-CRATES (dougburks/so-crates) verdicts — Suricata IDS alerts, YARA file matches, and
   // Sigma log detections — as the browser extension pushes them (or a raw export). Deterministic
   // (no AI). Events are tagged "SO-CRATES" (+ the underlying engine) for cross-source correlation.
   importSocrates(...args: ImporterArgs<typeof ingest.importSocrates>): Promise<InvestigationState> {
-    return ingest.importSocrates(this, ...args);
+    return ingest.importSocrates(this.importCtx, ...args);
   }
 
   // Import Security Onion Console (SOC) events — the Alerts / Hunt views the browser extension
@@ -1291,7 +1318,7 @@ export class AnalysisPipeline {
   // threat fields become MITRE, and source/destination IPs + app-layer fields become IOCs.
   // Events are tagged "Security Onion".
   importSecurityOnion(...args: ImporterArgs<typeof ingest.importSecurityOnion>): Promise<InvestigationState> {
-    return ingest.importSecurityOnion(this, ...args);
+    return ingest.importSecurityOnion(this.importCtx, ...args);
   }
 
   // Import a KAPE / Eric Zimmerman Tools CSV (Prefetch, Amcache, ShimCache, LNK, JumpLists,
@@ -1299,7 +1326,7 @@ export class AnalysisPipeline {
   // detected from the CSV header, then each row maps to a forensic event reading the
   // artifact's own time + file/hash/process IOCs. Events are tagged by artifact name.
   importKape(...args: ImporterArgs<typeof ingest.importKape>): Promise<InvestigationState> {
-    return ingest.importKape(this, ...args);
+    return ingest.importKape(this.importCtx, ...args);
   }
 
   // Import a Cyber Triage timeline export (JSONL / JSON array / CSV). Deterministic (no AI call):
@@ -1308,7 +1335,7 @@ export class AnalysisPipeline {
   // (unless `fileTelemetry`), and Active-Connection remote IPs become IOCs. Events tagged
   // "Cyber Triage".
   importCybertriage(...args: ImporterArgs<typeof ingest.importCybertriage>): Promise<InvestigationState> {
-    return ingest.importCybertriage(this, ...args);
+    return ingest.importCybertriage(this.importCtx, ...args);
   }
 
   // Import Microsoft 365 Unified Audit Log + Entra ID (sign-in / directory audit) data.
@@ -1316,21 +1343,21 @@ export class AnalysisPipeline {
   // severity derived from the operation (BEC tradecraft) or Entra's own risk verdict; the
   // source IP becomes an IOC and the UPN is surfaced for the asset graph.
   importM365(...args: ImporterArgs<typeof ingest.importM365>): Promise<InvestigationState> {
-    return ingest.importM365(this, ...args);
+    return ingest.importM365(this.importCtx, ...args);
   }
 
   // Import AWS CloudTrail logs. Deterministic (no AI call): each API-call record is mapped,
   // severity derived from the action (IAM persistence, logging/detection tampering, S3
   // exposure, secrets access) + denied/root/console-failure bumps; the caller IP → IOC.
   importAws(...args: ImporterArgs<typeof ingest.importAws>): Promise<InvestigationState> {
-    return ingest.importAws(this, ...args);
+    return ingest.importAws(this.importCtx, ...args);
   }
 
   // Import GCP Cloud Audit Logs + Azure Activity Log. Deterministic (no AI call): each record
   // is routed (GCP / Azure) and mapped, severity derived from the action (+ denied bump); the
   // caller IP → IOC and the principal email is surfaced for the asset graph.
   importCloudActivity(...args: ImporterArgs<typeof ingest.importCloudActivity>): Promise<InvestigationState> {
-    return ingest.importCloudActivity(this, ...args);
+    return ingest.importCloudActivity(this.importCtx, ...args);
   }
 
   // Import Kubernetes API-server audit logs (audit.k8s.io). Deterministic (no AI call): each audit
@@ -1338,21 +1365,21 @@ export class AnalysisPipeline {
   // (pod exec/attach, secret access, RBAC change, privileged-pod create, anonymous access), Info by
   // default. Source IP → IOC. Tagged Kubernetes Audit.
   importK8sAudit(...args: ImporterArgs<typeof ingest.importK8sAudit>): Promise<InvestigationState> {
-    return ingest.importK8sAudit(this, ...args);
+    return ingest.importK8sAudit(this.importCtx, ...args);
   }
 
   // Import osquery scheduled-query result logs (differential `columns` rows + `snapshot` sets).
   // Deterministic (no AI call): Info-by-default endpoint telemetry, with a conservative tradecraft
   // bump on a command-line column; columns → IOCs (path/hash/ip/process). Tagged osquery.
   importOsquery(...args: ImporterArgs<typeof ingest.importOsquery>): Promise<InvestigationState> {
-    return ingest.importOsquery(this, ...args);
+    return ingest.importOsquery(this.importCtx, ...args);
   }
 
   // Import a Plaso / log2timeline super-timeline (psort CSV — dynamic or l2tcsv). Deterministic
   // (no AI call): each row is an Info evidence event read at its own time, with IOCs scraped
   // from the message (hashes/URLs/IPs) and the source file path. Tagged Plaso.
   importPlaso(...args: ImporterArgs<typeof ingest.importPlaso>): Promise<InvestigationState> {
-    return ingest.importPlaso(this, ...args);
+    return ingest.importPlaso(this.importCtx, ...args);
   }
 
   // Streaming-from-disk Plaso import: for super-timelines too large to hold as one JS string (a
@@ -1361,13 +1388,13 @@ export class AnalysisPipeline {
   // keeps memory bounded by the distinct-key set, not the row count. Same downstream merge as
   // importPlaso. The route persists the evidence file separately (by copy, not as a string).
   importPlasoFile(...args: ImporterArgs<typeof ingest.importPlasoFile>): Promise<InvestigationState> {
-    return ingest.importPlasoFile(this, ...args);
+    return ingest.importPlasoFile(this.importCtx, ...args);
   }
 
   // Shared tail of both Plaso entry points: apply the severity floor, build the delta and merge it
   // into the case state. (Keeping this in one place means the in-memory and streaming importers
   // produce identical timeline rows / IOCs / notes.)
-  async persistPlasoParsed(
+  private async persistPlasoParsed(
     caseId: string,
     parsedRaw: PlasoParseResult,
     opts: { label: string; idPrefix: string; importedAt: string; minSeverity?: Severity; onProgress?: (done: number, total: number) => void },
@@ -1410,7 +1437,7 @@ export class AnalysisPipeline {
   // to severity/MITRE by record type (logins, account/group mgmt, sudo, SELinux denials, audit-config
   // tampering), bumped on a failed auth or a suspicious command. Read at the audit() epoch. Tagged auditd.
   importAuditd(...args: ImporterArgs<typeof ingest.importAuditd>): Promise<InvestigationState> {
-    return ingest.importAuditd(this, ...args);
+    return ingest.importAuditd(this.importCtx, ...args);
   }
 
   // Import a systemd-journald structured log (`journalctl -o json` / `-o json-pretty`). Deterministic
@@ -1418,7 +1445,7 @@ export class AnalysisPipeline {
   // from PRIORITY then bumped from the message (sshd auth, sudo, useradd, kernel), with IOCs scraped
   // from _EXE/_COMM and the MESSAGE. Tagged journald.
   importJournald(...args: ImporterArgs<typeof ingest.importJournald>): Promise<InvestigationState> {
-    return ingest.importJournald(this, ...args);
+    return ingest.importJournald(this.importCtx, ...args);
   }
 
   // Import a sysdig / Falco export (Falco alert JSON and/or sysdig `-j` event JSON). Deterministic
@@ -1426,14 +1453,14 @@ export class AnalysisPipeline {
   // MITRE) and surface on the timeline; raw sysdig syscall events are telemetry → Info evidence;
   // both contribute proc/file/network IOCs. Tagged Falco / sysdig.
   importSysdig(...args: ImporterArgs<typeof ingest.importSysdig>): Promise<InvestigationState> {
-    return ingest.importSysdig(this, ...args);
+    return ingest.importSysdig(this.importCtx, ...args);
   }
 
   // Import Wazuh SIEM/EDR alert exports (alerts.json / NDJSON / API export). Deterministic
   // (no AI call): rule.level drives severity (≥13 Critical, ≥10 High, ≥7 Medium, else Info),
   // rule.mitre.technique → MITRE, agent.name → asset, data.srcip/dstip/md5/sha256/url → IOCs.
   importWazuh(...args: ImporterArgs<typeof ingest.importWazuh>): Promise<InvestigationState> {
-    return ingest.importWazuh(this, ...args);
+    return ingest.importWazuh(this.importCtx, ...args);
   }
 
   // Import a malware-sandbox detonation report (CAPEv2 or CrowdStrike Falcon Sandbox).
@@ -1441,7 +1468,7 @@ export class AnalysisPipeline {
   // (severity from the report's own score/verdict, MITRE from its ATT&CK), and every
   // dropped/extracted file hash + network host/domain/URL is harvested as an IOC.
   importSandbox(...args: ImporterArgs<typeof ingest.importSandbox>): Promise<InvestigationState> {
-    return ingest.importSandbox(this, ...args);
+    return ingest.importSandbox(this.importCtx, ...args);
   }
 
   // Import memory-forensics tool output (Volatility 3 or Rekall). Deterministic (no AI call): each
@@ -1451,7 +1478,7 @@ export class AnalysisPipeline {
   // (bumped on LOLBin/encoded tradecraft), svcscan/modules → service/driver evidence. Tagged
   // "Volatility" / "Rekall" for cross-source correlation; reads the artifact's own time.
   importMemory(...args: ImporterArgs<typeof ingest.importMemory>): Promise<InvestigationState> {
-    return ingest.importMemory(this, ...args);
+    return ingest.importMemory(this.importCtx, ...args);
   }
 
   // Import an email artifact (.eml RFC 2822, or best-effort .msg). Deterministic (no AI call):
@@ -1459,14 +1486,14 @@ export class AnalysisPipeline {
   // SPF/DKIM/DMARC verdict + sender heuristics; URLs, sender/reply-to domains, originating IP and
   // attachment names/hashes become IOCs. Covers ATT&CK T1566 (Phishing). Tagged "Email".
   importEmail(...args: ImporterArgs<typeof ingest.importEmail>): Promise<InvestigationState> {
-    return ingest.importEmail(this, ...args);
+    return ingest.importEmail(this.importCtx, ...args);
   }
 
   // Import a TheHive 5 case, alert, or observable export. Deterministic (no AI call):
   // case/alert records → forensic events (severity from TheHive's own 1–4 scale, MITRE from
   // ATT&CK-tagged tags, TLP/PAP labels prepended); observable records → IOCs by dataType.
   importTheHive(...args: ImporterArgs<typeof ingest.importTheHive>): Promise<InvestigationState> {
-    return ingest.importTheHive(this, ...args);
+    return ingest.importTheHive(this.importCtx, ...args);
   }
 
   // Import an existing DFIR-IRIS case (issue #88) — the reverse of the IRIS push. Takes the raw
@@ -1474,7 +1501,7 @@ export class AnalysisPipeline {
   // NO AI call): timeline → forensic events, IOCs → IOCs, assets → evidence events. All feed the
   // same forensic timeline via mergeDelta, exactly like the other importers.
   importIris(...args: ImporterArgs<typeof ingest.importIris>): Promise<InvestigationState> {
-    return ingest.importIris(this, ...args);
+    return ingest.importIris(this.importCtx, ...args);
   }
 
   // Holistic pass: read the whole forensic timeline and produce findings, MITRE

--- a/companion/src/http/staticAssets.ts
+++ b/companion/src/http/staticAssets.ts
@@ -29,6 +29,7 @@ export const STATIC_ASSETS: Record<string, string> = {
   "/js/settings-search.js": "application/javascript; charset=utf-8",
   "/js/case-load-progress.js": "application/javascript; charset=utf-8",
   "/js/hunt-workbench.js": "application/javascript; charset=utf-8",
+  "/js/diagnostics-panel.js": "application/javascript; charset=utf-8",
 };
 
 /**

--- a/companion/tests/architecture/pipelineEncapsulation.test.ts
+++ b/companion/tests/architecture/pipelineEncapsulation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+
+// AnalysisPipeline's collaborators must stay PRIVATE (#384).
+//
+// The ingest extraction first passed `this` to the importers and let the class satisfy
+// ImportContext structurally. That works, but it forces `opts` and four methods to be public — so
+// to give the importers a five-member interface, every OTHER consumer of the pipeline gained the
+// whole options bag: AI providers, every store, every tuning knob. A boundary that widens the class
+// in order to exist is not much of a boundary.
+//
+// The fix was a private adapter closing over the five permitted operations. This test is what stops
+// the next person from "simplifying" it back — the @ts-expect-error lines below FAIL TO COMPILE if
+// any of these members becomes public again, because an unused @ts-expect-error is itself an error.
+// That makes this a compile-time assertion that happens to live in a test file; the runtime body
+// exists only so vitest has something to report.
+
+describe("AnalysisPipeline encapsulation", () => {
+  it("keeps opts and the importer collaborators private", () => {
+    const reachIn = (p: AnalysisPipeline): void => {
+      // @ts-expect-error -- `opts` is private; the importers get it through the ImportContext adapter.
+      void p.opts;
+      // @ts-expect-error -- `withStateLock` is private.
+      void p.withStateLock;
+      // @ts-expect-error -- `mergeWithAliases` is private.
+      void p.mergeWithAliases;
+      // @ts-expect-error -- `noteEmptyImport` is private.
+      void p.noteEmptyImport;
+      // @ts-expect-error -- `persistPlasoParsed` is private.
+      void p.persistPlasoParsed;
+    };
+    expect(typeof reachIn).toBe("function");
+  });
+
+  it("still exposes the public import surface callers depend on", async () => {
+    // The point of the adapter is that it changed nothing for callers. Routes and scripts call
+    // pipeline.importThor(...) and friends; if the delegations had been rewired wrongly, these
+    // would have disappeared from the type.
+    const { AnalysisPipeline: Ctor } = await import("../../src/analysis/pipeline.js");
+    const named = Object.getOwnPropertyNames(Ctor.prototype).filter((n) => n.startsWith("import"));
+    expect(named.length).toBeGreaterThanOrEqual(30);
+    expect(named).toContain("importThor");
+    expect(named).toContain("importVelociraptor");
+  });
+});

--- a/companion/tests/architecture/route-inventory.json
+++ b/companion/tests/architecture/route-inventory.json
@@ -468,6 +468,7 @@
     "ROUTE GET /js/settings-search.js",
     "ROUTE GET /js/case-load-progress.js",
     "ROUTE GET /js/hunt-workbench.js",
+    "ROUTE GET /js/diagnostics-panel.js",
     "USE /^\\/?(?=\\/|$)/i <anonymous>/4"
   ]
 }

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -496,11 +496,15 @@ describe("dashboard.html", () => {
 
   it("shows a per-case AI cost breakdown card in Settings → Diagnostics, fetched alongside /diagnostics", async () => {
     const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
-    // Helper functions for formatting cost/tokens and rendering the card.
-    expect(html).toContain("function diagFmtCost(");
-    expect(html).toContain("function diagAiCostBucketRow(");
-    expect(html).toContain("function renderAiCostCard(");
-    expect(html).toContain('diagCard("AI cost — this case", rows)');
+    // The renderers moved to public/js/diagnostics-panel.js (#384) and are covered directly by
+    // tests/reports/diagnosticsPanel.test.ts, which asserts far more than their presence. What
+    // still belongs HERE is the wiring: the page must load that module and call into it.
+    const panel = await readFile(new URL("../../../public/js/diagnostics-panel.js", import.meta.url), "utf8");
+    expect(panel).toContain("function diagFmtCost(");
+    expect(panel).toContain("function diagAiCostBucketRow(");
+    expect(panel).toContain("function renderAiCostCard(");
+    expect(panel).toContain('diagCard("AI cost — this case", rows)');
+    expect(html).toContain('<script type="module" src="/js/diagnostics-panel.js">');
     // loadDiagnostics fetches /cases/:id/ai-cost in parallel with /diagnostics, scoped to the
     // currently-connected case, and passes it into renderDiagnostics for placement.
     expect(html).toMatch(/function loadDiagnostics\(\)[\s\S]{0,600}\/cases\/\$\{encodeURIComponent\(caseId\)\}\/ai-cost/);
@@ -509,7 +513,9 @@ describe("dashboard.html", () => {
     // Empty caseId must not attempt a fetch to a malformed URL — costFetch resolves to null instead.
     expect(html).toMatch(/const costFetch = caseId\s*\n\s*\? fetch/);
     // The card renders directly after "AI connectivity & config", not at the end of the panel.
-    expect(html).toMatch(/function renderDiagnostics\(report, cost\)[\s\S]*aiCard \+ renderAiCostCard\(cost\) \+ importers/);
+    expect(html).toMatch(
+      /function renderDiagnostics\(report, cost\)[\s\S]*aiCard \+ window\.DfirDiagnostics\.renderAiCostCard\(cost\) \+ importers/,
+    );
   });
 
   it("keeps the support preview and download actions the same width", async () => {

--- a/companion/tests/reports/diagnosticsPanel.test.ts
+++ b/companion/tests/reports/diagnosticsPanel.test.ts
@@ -1,0 +1,239 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import {
+  DIAG_LEVEL_COLOR,
+  diagAiCostBucketRow,
+  diagCard,
+  diagFmtAge,
+  diagFmtBytes,
+  diagFmtCost,
+  diagRow,
+  renderAiCostCard,
+  renderOperationalDiagnostics,
+  renderPerImporterHealth,
+  // @ts-expect-error -- plain JS module with no .d.ts; the shapes are pinned by the tests below.
+} from "../../../public/js/diagnostics-panel.js";
+
+// The first slice of dashboard.html's 19k-line inline script to become a module (#384).
+//
+// It could move because it builds HTML STRINGS from a report object — no DOM, no fetch, no shared
+// dashboard state. That is also why it is testable at all: none of this was reachable from a test
+// while it lived inside a <script> tag, and writing these tests is what established what the
+// functions actually accept. `diagFmtAge` takes MILLISECONDS, not a timestamp; a cost bucket keys
+// its models under `byModel`, not a list. Both surprised me, which is the point.
+
+const DASHBOARD = new URL("../../../public/dashboard.html", import.meta.url);
+const MODULE = new URL("../../../public/js/diagnostics-panel.js", import.meta.url);
+
+describe("esc drift guard", () => {
+  it("keeps the module's escape identical to the dashboard's inline one", async () => {
+    // The inline script has 661 call sites for `esc`, so it cannot move in this pass and the module
+    // carries its own copy. Two implementations of an XSS-critical primitive are a real hazard —
+    // #387 exists because of unsafe DOM sinks — so this asserts they cannot drift apart.
+    const [html, module] = await Promise.all([readFile(DASHBOARD, "utf8"), readFile(MODULE, "utf8")]);
+    const bodyOf = (src: string): string => {
+      const start = src.indexOf("function esc(s) {");
+      expect(start, "esc(s) not found").toBeGreaterThan(-1);
+      const end = src.indexOf("}", src.indexOf(".replace(/>/g", start));
+      return src
+        .slice(start, end + 1)
+        .split("\n")
+        .map((l) => l.trim())
+        .join("");
+    };
+    expect(bodyOf(module)).toBe(bodyOf(html));
+  });
+});
+
+describe("diagFmtBytes", () => {
+  it.each([
+    [0, "0 B"],
+    [1023, "1023 B"],
+    [1024, "1.0 KB"],
+    [5 * 1024 * 1024, "5.0 MB"],
+    [150 * 1024, "150 KB"], // >= 100 drops the decimal, so the column stays narrow
+  ])("formats %i as %s", (input, expected) => {
+    expect(diagFmtBytes(input)).toBe(expected);
+  });
+
+  it("renders an em dash for absent or nonsensical sizes", () => {
+    // The report comes off disk; an older case may not carry the field at all.
+    for (const bad of [null, undefined, NaN, -1, Infinity]) expect(diagFmtBytes(bad)).toBe("—");
+  });
+});
+
+describe("diagFmtAge", () => {
+  it.each([
+    [5_000, "5s"],
+    [90_000, "1m"],
+    [3 * 3_600_000, "3h"],
+    [50 * 3_600_000, "2d"],
+  ])("formats %i ms as %s", (ms, expected) => {
+    expect(diagFmtAge(ms)).toBe(expected);
+  });
+
+  it("treats absent or non-positive durations as zero rather than throwing", () => {
+    for (const bad of [null, undefined, 0, -1, NaN]) expect(diagFmtAge(bad)).toBe("0s");
+  });
+});
+
+describe("diagFmtCost", () => {
+  it("keeps four decimals below a dollar", () => {
+    // Sub-cent AI costs are the common case; "$0.00" would be useless for exactly the runs an
+    // operator is trying to account for.
+    expect(diagFmtCost(0.0012)).toBe("$0.0012");
+  });
+
+  it("drops to two decimals at a dollar and above", () => {
+    expect(diagFmtCost(12.345)).toBe("$12.35");
+  });
+
+  it("says n/a when no cost was recorded", () => {
+    expect(diagFmtCost(null)).toBe("n/a");
+    expect(diagFmtCost(undefined)).toBe("n/a");
+  });
+});
+
+describe("row and card primitives", () => {
+  it("escapes the label, which can carry evidence-derived text", () => {
+    const html = diagRow("<img src=x onerror=alert(1)>", "safe");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img");
+  });
+
+  it("does NOT escape the value, because callers pass markup deliberately", () => {
+    // Documented rather than asserted-against: diagRow's value is a formatted HTML fragment (see
+    // renderOperationalDiagnostics' hotspot rows). Callers escape their own interpolations — this
+    // test exists so that contract is stated somewhere a reader will find it.
+    expect(diagRow("k", "<b>bold</b>")).toContain("<b>bold</b>");
+  });
+
+  it("escapes the card title and embeds the rows it is given", () => {
+    const card = diagCard("<script>x</script>", diagRow("k", "v"));
+    expect(card).not.toContain("<script>x");
+    expect(card).toContain("k");
+  });
+});
+
+const bucket = (over = {}) => ({
+  totalCalls: 3,
+  totalCostUSD: 0.42,
+  hasCost: true,
+  hasTokens: true,
+  totalInputTokens: 1000,
+  totalOutputTokens: 200,
+  byModel: {},
+  ...over,
+});
+
+describe("diagAiCostBucketRow", () => {
+  it("summarises calls, cost and tokens on one row", () => {
+    const html = diagAiCostBucketRow("synthesis", bucket());
+    expect(html).toContain("synthesis");
+    expect(html).toContain("3 call(s)");
+    expect(html).toContain("$0.4200");
+  });
+
+  it("nests a per-model breakdown when models are recorded", () => {
+    const html = diagAiCostBucketRow("extract", {
+      ...bucket(),
+      byModel: { "gpt-x": { calls: 1, costUSD: 0.01, hasCost: true, hasTokens: false } },
+    });
+    expect(html).toContain("gpt-x");
+    expect(html).toContain("1 model(s)");
+  });
+
+  it("omits the breakdown entirely when no models are recorded", () => {
+    expect(diagAiCostBucketRow("extract", bucket())).not.toContain("<details");
+  });
+});
+
+describe("renderAiCostCard", () => {
+  const cost = () => ({ vision: bucket(), synthesis: bucket(), other: bucket() });
+
+  it("totals the three buckets", () => {
+    const html = renderAiCostCard(cost());
+    expect(html).toContain("AI cost — this case");
+    expect(html).toContain("9 call(s)"); // 3 buckets x 3 calls
+  });
+
+  it("renders nothing at all when there is no cost report", () => {
+    expect(renderAiCostCard(null)).toBe("");
+  });
+});
+
+describe("renderOperationalDiagnostics", () => {
+  it("says disabled plainly, which is not an error state", () => {
+    for (const input of [null, undefined, { enabled: false }]) {
+      const html = renderOperationalDiagnostics(input);
+      expect(html).toContain("disabled");
+      expect(html).toContain("core behavior is unchanged");
+    }
+  });
+
+  it("renders the full panel when metrics are on", () => {
+    const html = renderOperationalDiagnostics({
+      enabled: true,
+      sampleCount: 12,
+      retentionDays: 30,
+      imports: { accepted: 5, rejected: 1, promoted: 2 },
+      queries: { p50Ms: 3, p95Ms: 9, unindexed: 0 },
+      jobs: { queued: 0, running: 1, retries: 0, stalled: 0 },
+      ai: { calls: 2, p95Ms: 900, retries: 0, rateLimits: 0 },
+      exports: { count: 1, p95Ms: 50, outputBytes: 2048 },
+      websocket: { active: 1, reconnects: 0, dropped: 0, rejects: 0 },
+      capacity: { databaseBytes: 4096 },
+      warnings: ["disk is filling"],
+    });
+    expect(html).toContain("Retention");
+    expect(html).toContain("2.0 KB"); // exports.outputBytes through diagFmtBytes
+    expect(html).toContain("disk is filling");
+  });
+
+  it("escapes warning text", () => {
+    const html = renderOperationalDiagnostics({
+      enabled: true,
+      sampleCount: 0,
+      retentionDays: 1,
+      imports: { accepted: 0, rejected: 0, promoted: 0 },
+      queries: { p50Ms: 0, p95Ms: 0, unindexed: 0 },
+      jobs: { queued: 0, running: 0, retries: 0, stalled: 0 },
+      ai: { calls: 0, p95Ms: 0, retries: 0, rateLimits: 0 },
+      exports: { count: 0, p95Ms: 0, outputBytes: 0 },
+      websocket: { active: 0, reconnects: 0, dropped: 0, rejects: 0 },
+      capacity: {},
+      warnings: ["<script>alert(1)</script>"],
+    });
+    expect(html).not.toContain("<script>alert(1)");
+  });
+});
+
+describe("renderPerImporterHealth", () => {
+  it("escapes a spec filename, which is operator-supplied", () => {
+    const html = renderPerImporterHealth({
+      importers: [],
+      loadErrors: [{ file: "<img src=x onerror=alert(1)>.yml", errors: [{ path: "a", message: "b" }] }],
+    });
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&lt;img");
+  });
+
+  it("reports how many spec load errors there are", () => {
+    const html = renderPerImporterHealth({
+      importers: [],
+      loadErrors: [
+        { file: "a.yml", errors: [{ path: "x", message: "bad" }] },
+        { file: "b.yml", errors: [{ path: "y", message: "worse" }] },
+      ],
+    });
+    expect(html).toContain("Spec load errors (2)");
+  });
+});
+
+describe("DIAG_LEVEL_COLOR", () => {
+  it("covers every level the panel can report", () => {
+    // renderDiagnostics is still inline and indexes this map directly, so a missing key would
+    // render an undefined colour rather than fail loudly.
+    expect(Object.keys(DIAG_LEVEL_COLOR).sort()).toEqual(["critical", "danger", "none", "warning"]);
+  });
+});

--- a/companion/tests/reports/diagnosticsPanel.test.ts
+++ b/companion/tests/reports/diagnosticsPanel.test.ts
@@ -237,3 +237,70 @@ describe("DIAG_LEVEL_COLOR", () => {
     expect(Object.keys(DIAG_LEVEL_COLOR).sort()).toEqual(["critical", "danger", "none", "warning"]);
   });
 });
+
+// ---------------------------------------------------------------------------------------------
+// THE WIRING, which the tests above cannot see.
+//
+// Every test in this file imports the module directly, so all 29 passed while the page was broken:
+// the first cut published only the four top-level renderers on window.DfirDiagnostics, but
+// renderDiagnostics, diagComputeSizes, loadCaseStats and loadCaseBackups still made 46 BARE calls
+// to diagRow/diagCard/diagFmtBytes/diagFmtAge. An ES module's declarations are not globals, so
+// every one was a ReferenceError and the Diagnostics panel threw the moment it rendered.
+//
+// Unit tests over an extracted module are structurally incapable of catching that. These two are
+// the join between the module and the page, and they are the shape every future dashboard
+// extraction needs.
+// ---------------------------------------------------------------------------------------------
+describe("dashboard wiring", () => {
+  const readDashboard = (): Promise<string> =>
+    readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+  const readModule = (): Promise<string> =>
+    readFile(new URL("../../../public/js/diagnostics-panel.js", import.meta.url), "utf8");
+
+  it("publishes every function the module defines", async () => {
+    const source = await readModule();
+    const defined = [...source.matchAll(/^function ([A-Za-z0-9_]+)/gm)].map((m) => m[1]);
+    const published = /window\.DfirDiagnostics = \{([\s\S]*?)\};/.exec(source)?.[1] ?? "";
+
+    // Publishing everything is deliberate rather than tidy: a helper that stays unpublished is
+    // invisible until the page calls it, and the page is what no unit test loads.
+    const missing = defined.filter((name) => !new RegExp(`\\b${name},`).test(published));
+    expect(missing).toEqual([]);
+  });
+
+  it("binds the namespace in every inline function that calls into the module", async () => {
+    const [page, source] = await Promise.all([readDashboard(), readModule()]);
+    // Names the module defines AND the inline script does not. `esc` is deliberately defined in
+    // both -- 661 inline call sites, and a module cannot read the inline scope -- so an inline
+    // `esc(...)` resolves locally and is correct. Only names that exist ONLY in the module can
+    // produce the ReferenceError this test exists to catch.
+    const inlineDefined = new Set(
+      [...page.matchAll(/^ {4}(?:async )?function ([A-Za-z0-9_]+)/gm)].map((m) => m[1]),
+    );
+    const defined = [...source.matchAll(/^function ([A-Za-z0-9_]+)/gm)]
+      .map((m) => m[1])
+      .filter((name) => !inlineDefined.has(name));
+
+    // Walk the page's top-level inline functions, and for each one collect the module names it
+    // calls WITHOUT qualifying, then require that the function bound them from the namespace.
+    const lines = page.split("\n");
+    const offenders: string[] = [];
+    let current = "";
+    let bound = new Set<string>();
+    for (const line of lines) {
+      const decl = /^ {4}(?:async )?function ([A-Za-z0-9_]+)/.exec(line);
+      if (decl) {
+        current = decl[1];
+        bound = new Set();
+      }
+      const binding = /const \{([^}]*)\} = window\.DfirDiagnostics;/.exec(line);
+      if (binding) for (const n of binding[1].split(",")) bound.add(n.trim());
+      for (const name of defined) {
+        if (!new RegExp(`(?<![.\\w])${name}\\(`).test(line)) continue;
+        if (bound.has(name)) continue;
+        offenders.push(`${current} calls ${name}() without binding it from window.DfirDiagnostics`);
+      }
+    }
+    expect([...new Set(offenders)]).toEqual([]);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -24504,6 +24504,10 @@
     let diagSupportText = "";
     let diagSupportFilename = "dfir-companion-support.json";
     function renderDiagnostics(report, cost) {
+      // Bound from the module namespace at CALL time, not parse time: this file is plain inline
+      // script and cannot import, and the module that defines these is deferred. Every caller
+      // below runs on a data load, so the namespace is always populated by then.
+      const { diagRow, diagCard, diagFmtBytes, diagFmtAge } = window.DfirDiagnostics;
       const d = report.disk;
       const lvlColor = window.DfirDiagnostics.DIAG_LEVEL_COLOR[d.level] || "#cbd3df";
       const disk = diagCard("Disk", [
@@ -24652,6 +24656,7 @@
         </div>`;
     }
     function loadCaseStats() {
+      const { diagRow, diagCard, diagFmtBytes, diagFmtAge } = window.DfirDiagnostics; // see renderDiagnostics
       const el = document.getElementById("caseStatsPanel");
       if (!el) return;
       const caseId = document.getElementById("caseId").value.trim();
@@ -24786,6 +24791,7 @@
         .finally(() => { if (btn) btn.disabled = false; });
     }
     function diagComputeSizes() {
+      const { diagRow, diagCard, diagFmtBytes, diagFmtAge } = window.DfirDiagnostics; // see renderDiagnostics
       const btn = document.getElementById("diagSizesBtn");
       const target = document.getElementById("diagSizes");
       if (!target) { loadDiagnostics(); return; }
@@ -24849,6 +24855,7 @@
     }
     // Case backup restore (#180) ---------------------------------------------------------------
     function loadCaseBackups() {
+      const { diagRow, diagCard, diagFmtBytes, diagFmtAge } = window.DfirDiagnostics; // see renderDiagnostics
       const caseId = document.getElementById("caseId").value.trim();
       const list = document.getElementById("diagBackupsList");
       const msg = document.getElementById("diagBackupMsg");

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -102,6 +102,7 @@
   <script type="module" src="/js/command-palette.js"></script>
   <script type="module" src="/js/settings-search.js"></script>
   <script type="module" src="/js/hunt-workbench.js"></script>
+    <script type="module" src="/js/diagnostics-panel.js"></script>
   <script type="module" src="/js/case-load-progress.js"></script>
   <script nonce="__CSP_NONCE__">
     /* Theme bootstrap (issue #53) — runs before paint so there is no flash. Effective theme =
@@ -24502,138 +24503,9 @@
     let diagCopyText = "";
     let diagSupportText = "";
     let diagSupportFilename = "dfir-companion-support.json";
-    function diagFmtBytes(b) {
-      if (b == null || !isFinite(b) || b < 0) return "—";
-      if (b < 1024) return Math.round(b) + " B";
-      const u = ["KB", "MB", "GB", "TB", "PB"]; let v = b / 1024, i = 0;
-      while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
-      return (v >= 100 ? Math.round(v) : v.toFixed(1)) + " " + u[i];
-    }
-    function diagFmtAge(ms) {
-      if (ms == null || !isFinite(ms) || ms <= 0) return "0s";
-      const s = Math.floor(ms / 1000); if (s < 60) return s + "s";
-      const m = Math.floor(s / 60); if (m < 60) return m + "m";
-      const h = Math.floor(m / 60); if (h < 24) return h + "h";
-      return Math.floor(h / 24) + "d";
-    }
-    function diagFmtCost(usd) {
-      if (usd == null || !isFinite(usd)) return "n/a";
-      return "$" + usd.toFixed(usd < 1 ? 4 : 2);
-    }
-    function diagAiCostBucketRow(label, bucket) {
-      const costText = bucket.hasCost ? diagFmtCost(bucket.totalCostUSD) : "n/a";
-      const tokText = bucket.hasTokens
-        ? `${bucket.totalInputTokens.toLocaleString()} in / ${bucket.totalOutputTokens.toLocaleString()} out`
-        : "n/a";
-      const models = Object.entries(bucket.byModel);
-      const modelRows = models.length
-        ? `<details data-safe-style="margin:2px 0 4px 12px"><summary data-safe-style="cursor:pointer;color:#6aa9ff;font-size:11.5px">${models.length} model(s)</summary>` +
-          models.map(([key, m]) => `<div data-safe-style="font-size:11.5px;color:#9aa4b2;margin:2px 0 2px 8px;font-family:monospace">
-            ${esc(key)} — ${m.calls} call(s), ${m.hasCost ? diagFmtCost(m.costUSD) : "n/a"}, ${m.hasTokens ? `${m.inputTokens.toLocaleString()}/${m.outputTokens.toLocaleString()} tok` : "n/a tok"}
-          </div>`).join("") + `</details>`
-        : "";
-      return diagRow(esc(label), `${bucket.totalCalls} call(s) · ${costText} · ${tokText}`) + modelRows;
-    }
-    function renderAiCostCard(cost) {
-      if (!cost) return "";
-      const total = {
-        totalCalls: cost.vision.totalCalls + cost.synthesis.totalCalls + cost.other.totalCalls,
-        totalCostUSD: cost.vision.totalCostUSD + cost.synthesis.totalCostUSD + cost.other.totalCostUSD,
-        hasCost: cost.vision.hasCost || cost.synthesis.hasCost || cost.other.hasCost,
-        totalInputTokens: cost.vision.totalInputTokens + cost.synthesis.totalInputTokens + cost.other.totalInputTokens,
-        totalOutputTokens: cost.vision.totalOutputTokens + cost.synthesis.totalOutputTokens + cost.other.totalOutputTokens,
-        hasTokens: cost.vision.hasTokens || cost.synthesis.hasTokens || cost.other.hasTokens,
-        byModel: {},
-      };
-      // A bucket that never reported cost/tokens makes the total "partial", not wrong —
-      // say so rather than silently under-reporting real spend as a clean $ total.
-      // Only buckets that actually made calls count toward this check — an unused bucket
-      // (e.g. "Other" on a typical case) isn't a data-reporting gap.
-      const usedBuckets = [cost.vision, cost.synthesis, cost.other].filter(b => b.totalCalls > 0);
-      const someHaveCost = usedBuckets.some(b => b.hasCost);
-      const allHaveCost = usedBuckets.every(b => b.hasCost);
-      const totalNote = usedBuckets.length > 0 && someHaveCost && !allHaveCost
-        ? `<div data-safe-style="font-size:11px;color:#7e8aa0;margin-top:2px">partial — not every bucket's provider reports cost</div>` : "";
-      const rows = diagAiCostBucketRow("Vision", cost.vision)
-        + diagAiCostBucketRow("Synthesis", cost.synthesis)
-        + diagAiCostBucketRow("Other", cost.other)
-        + `<div data-safe-style="border-top:1px solid var(--border-color);margin-top:6px;padding-top:6px">`
-        + diagRow("Total", `${total.totalCalls} call(s) · ${total.hasCost ? diagFmtCost(total.totalCostUSD) : "n/a"} · ${total.hasTokens ? `${total.totalInputTokens.toLocaleString()} in / ${total.totalOutputTokens.toLocaleString()} out` : "n/a"}`)
-        + totalNote + `</div>`;
-      return diagCard("AI cost — this case", rows);
-    }
-    const DIAG_LEVEL_COLOR = { none: "#5ad17a", warning: "#ffce8a", danger: "#ffb05a", critical: "#ff5a5a" };
-    function diagCard(title, rows) {
-      return `<div data-safe-style="background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;padding:10px 12px;margin-bottom:10px">
-        <div data-safe-style="font-weight:600;color:var(--text-primary);margin-bottom:6px">${esc(title)}</div>${rows}</div>`;
-    }
-    function diagRow(label, value, color) {
-      return `<div data-safe-style="display:flex;justify-content:space-between;gap:12px;padding:1px 0">
-        <span data-safe-style="color:#9aa4b2">${esc(label)}</span>
-        <span data-safe-style="text-align:right${color ? `;color:${color}` : ""}">${value}</span></div>`;
-    }
-    function renderOperationalDiagnostics(o) {
-      if (!o || !o.enabled) {
-        return diagCard("Local performance & capacity", diagRow("Status", "disabled — core behavior is unchanged", "#7e8aa0"));
-      }
-      const slow = o.slowest || {};
-      const cap = o.capacity || {};
-      const warningRows = (o.warnings || []).map(w =>
-        `<div data-safe-style="color:#ffb05a;margin-top:4px">⚠ ${esc(w)}</div>`).join("");
-      const hotspot = (label, item) => item
-        ? diagRow(label, `${esc(item.name)} · ${Math.round(item.durationMs).toLocaleString()} ms<div data-safe-style="font-size:11px;color:#7e8aa0">${esc(item.remediation)}</div>`)
-        : "";
-      return diagCard("Local performance & capacity", [
-        diagRow("Retention", `${o.sampleCount.toLocaleString()} sample(s) · ${Math.round(o.retentionDays)} days maximum`),
-        diagRow("Importer yield", `${o.imports.accepted.toLocaleString()} accepted · ${o.imports.rejected.toLocaleString()} rejected · ${o.imports.promoted.toLocaleString()} promoted`),
-        diagRow("Query latency", `p50 ${Math.round(o.queries.p50Ms)} ms · p95 ${Math.round(o.queries.p95Ms)} ms · ${o.queries.unindexed} unindexed`),
-        diagRow("Jobs", `${o.jobs.queued} queued · ${o.jobs.running} running · ${o.jobs.retries} retries · ${o.jobs.stalled} stalled`, o.jobs.stalled ? "#ffb05a" : ""),
-        diagRow("AI", `${o.ai.calls} call(s) · p95 ${Math.round(o.ai.p95Ms)} ms · ${o.ai.retries} retries · ${o.ai.rateLimits} rate limits`),
-        diagRow("Exports", `${o.exports.count} run(s) · p95 ${Math.round(o.exports.p95Ms)} ms · ${diagFmtBytes(o.exports.outputBytes)}`),
-        diagRow("Live connection", `${o.websocket.active} active · ${o.websocket.reconnects} reconnect · ${o.websocket.dropped} dropped · ${o.websocket.rejects} rejected`),
-        diagRow("Case databases", diagFmtBytes(cap.databaseBytes || 0)),
-        cap.growthBytesPerDay != null ? diagRow("Projected growth", `${diagFmtBytes(cap.growthBytesPerDay)}/day${cap.projectedDaysRemaining != null ? ` · ${cap.projectedDaysRemaining.toFixed(1)} days of free disk` : ""}`) : "",
-        hotspot("Slowest importer", slow.importer),
-        hotspot("Slowest query", slow.query),
-        hotspot("Slowest job", slow.job),
-        warningRows,
-      ].join(""));
-    }
-    // Per-importer health table (#84): one row per custom (declarative) importer — last-run age,
-    // success/fail, rows parsed (kept/total, dropped), last error — plus malformed-spec load errors
-    // from the registry, so all import health signals for custom importers live in one place.
-    function renderPerImporterHealth(im) {
-      const perImporter = im.perImporter || [];
-      const loadErrors = im.loadErrors || [];
-      if (!perImporter.length && !loadErrors.length) return "";
-      let html = `<div data-safe-style="margin-top:10px;border-top:1px solid var(--border-color);padding-top:8px">
-        <div data-safe-style="color:#9aa4b2;margin-bottom:4px">Per-importer breakdown (${perImporter.length}):</div>`;
-      if (perImporter.length) {
-        html += `<div data-safe-style="max-height:220px;overflow:auto">` + perImporter.map(p => {
-          const ok = p.lastStatus === "ok";
-          const statusColor = p.lastStatus == null ? "#7e8aa0" : ok ? "#5ad17a" : "#ff9f9f";
-          const statusText = p.lastStatus == null ? "never run" : ok ? "ok" : "failed";
-          const age = p.lastRunAt ? diagFmtAge(Date.now() - Date.parse(p.lastRunAt)) + " ago" : "—";
-          const rows = p.lastStatus != null ? `${p.kept ?? 0}/${p.total ?? 0} kept, ${p.dropped ?? 0} dropped` : "—";
-          return `<div data-safe-style="border-left:2px solid ${ok ? "#2a5a3a" : p.lastStatus ? "#5a2a2a" : "#3a3f4a"};padding:2px 0 2px 8px;margin:3px 0;font-family:monospace;font-size:11.5px">
-            <span data-safe-style="color:#cbd3df">${esc(p.label)}</span> <span data-safe-style="color:#7e8aa0">(${esc(p.id)})</span>
-            — <span data-safe-style="color:${statusColor}">${statusText}</span> · ${age} · ${rows}
-            ${p.lastError ? `<br><span data-safe-style="color:#ffb0b0">${esc(p.lastError)}</span>` : ""}</div>`;
-        }).join("") + `</div>`;
-      }
-      if (loadErrors.length) {
-        html += `<div data-safe-style="margin-top:6px;color:#9aa4b2">Spec load errors (${loadErrors.length}):</div>`;
-        html += `<div data-safe-style="max-height:160px;overflow:auto;margin-top:3px">` + loadErrors.map(e =>
-          `<div data-safe-style="border-left:2px solid #5a2a2a;padding:2px 0 2px 8px;margin:3px 0;font-family:monospace;font-size:11.5px">
-            <span data-safe-style="color:#ff9f9f">${esc(e.file)}</span><br>
-            ${e.errors.map(x => `<span data-safe-style="color:#ffb0b0">${esc(x.path)}: ${esc(x.message)}</span>`).join("<br>")}</div>`).join("") + `</div>`;
-      }
-      html += `</div>`;
-      return html;
-    }
     function renderDiagnostics(report, cost) {
       const d = report.disk;
-      const lvlColor = DIAG_LEVEL_COLOR[d.level] || "#cbd3df";
+      const lvlColor = window.DfirDiagnostics.DIAG_LEVEL_COLOR[d.level] || "#cbd3df";
       const disk = diagCard("Disk", [
         diagRow("Free", `${diagFmtBytes(d.freeBytes)} of ${diagFmtBytes(d.totalBytes)}`),
         diagRow("Used", `${(d.usedPct || 0).toFixed(1)}%`, lvlColor),
@@ -24687,7 +24559,7 @@
       } else {
         impRows += diagRow("Recent failures", "none", "#5ad17a");
       }
-      impRows += renderPerImporterHealth(im);
+      impRows += window.DfirDiagnostics.renderPerImporterHealth(im);
       const importers = diagCard("Importer health", impRows);
       const bk = report.backups || {};
       let backupsCard = "";
@@ -24706,7 +24578,7 @@
         ].join(""));
       }
       const footer = `<div data-safe-style="font-size:11px;color:#7e8aa0;margin-top:4px">generated ${esc((report.generatedAt || "").replace("T", " ").slice(0, 19))} · uptime ${diagFmtAge(report.uptimeMs)}</div>`;
-      return disk + cases + queue + renderOperationalDiagnostics(report.operational) + aiCard + renderAiCostCard(cost) + importers + backupsCard + `<div id="diagSizes"></div>` + footer;
+      return disk + cases + queue + window.DfirDiagnostics.renderOperationalDiagnostics(report.operational) + aiCard + window.DfirDiagnostics.renderAiCostCard(cost) + importers + backupsCard + `<div id="diagSizes"></div>` + footer;
     }
     // Pre-flight status panel inside Settings → Diagnostics (#179).
     function renderPreflightStatus(report) {

--- a/public/js/diagnostics-panel.js
+++ b/public/js/diagnostics-panel.js
@@ -1,0 +1,171 @@
+// Diagnostics panel renderers, extracted from dashboard.html's inline script (#384).
+//
+// These build HTML STRINGS from a diagnostics report -- no DOM, no fetch, no shared dashboard
+// state -- which is why they were the first slice that could move. renderDiagnostics() still lives
+// inline and calls into here through window.DfirDiagnostics; module scripts run after classic
+// inline scripts, and every call site here is inside a function that runs on a data load, never at
+// parse time.
+//
+// `esc` IS DUPLICATED ON PURPOSE. The inline script has 661 call sites for it, so it cannot move in
+// this pass, and a module cannot read the inline scope. Rather than have the dashboard depend on
+// this module for an XSS-critical primitive at load time, the module carries its own copy and
+// tests/reports/diagnosticsPanel.test.ts asserts the two implementations stay identical -- a drift
+// guard instead of a runtime coupling.
+
+function esc(s) {
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function diagFmtBytes(b) {
+  if (b == null || !isFinite(b) || b < 0) return "—";
+  if (b < 1024) return Math.round(b) + " B";
+  const u = ["KB", "MB", "GB", "TB", "PB"]; let v = b / 1024, i = 0;
+  while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+  return (v >= 100 ? Math.round(v) : v.toFixed(1)) + " " + u[i];
+}
+function diagFmtAge(ms) {
+  if (ms == null || !isFinite(ms) || ms <= 0) return "0s";
+  const s = Math.floor(ms / 1000); if (s < 60) return s + "s";
+  const m = Math.floor(s / 60); if (m < 60) return m + "m";
+  const h = Math.floor(m / 60); if (h < 24) return h + "h";
+  return Math.floor(h / 24) + "d";
+}
+function diagFmtCost(usd) {
+  if (usd == null || !isFinite(usd)) return "n/a";
+  return "$" + usd.toFixed(usd < 1 ? 4 : 2);
+}
+function diagAiCostBucketRow(label, bucket) {
+  const costText = bucket.hasCost ? diagFmtCost(bucket.totalCostUSD) : "n/a";
+  const tokText = bucket.hasTokens
+    ? `${bucket.totalInputTokens.toLocaleString()} in / ${bucket.totalOutputTokens.toLocaleString()} out`
+    : "n/a";
+  const models = Object.entries(bucket.byModel);
+  const modelRows = models.length
+    ? `<details data-safe-style="margin:2px 0 4px 12px"><summary data-safe-style="cursor:pointer;color:#6aa9ff;font-size:11.5px">${models.length} model(s)</summary>` +
+      models.map(([key, m]) => `<div data-safe-style="font-size:11.5px;color:#9aa4b2;margin:2px 0 2px 8px;font-family:monospace">
+        ${esc(key)} — ${m.calls} call(s), ${m.hasCost ? diagFmtCost(m.costUSD) : "n/a"}, ${m.hasTokens ? `${m.inputTokens.toLocaleString()}/${m.outputTokens.toLocaleString()} tok` : "n/a tok"}
+      </div>`).join("") + `</details>`
+    : "";
+  return diagRow(esc(label), `${bucket.totalCalls} call(s) · ${costText} · ${tokText}`) + modelRows;
+}
+function renderAiCostCard(cost) {
+  if (!cost) return "";
+  const total = {
+    totalCalls: cost.vision.totalCalls + cost.synthesis.totalCalls + cost.other.totalCalls,
+    totalCostUSD: cost.vision.totalCostUSD + cost.synthesis.totalCostUSD + cost.other.totalCostUSD,
+    hasCost: cost.vision.hasCost || cost.synthesis.hasCost || cost.other.hasCost,
+    totalInputTokens: cost.vision.totalInputTokens + cost.synthesis.totalInputTokens + cost.other.totalInputTokens,
+    totalOutputTokens: cost.vision.totalOutputTokens + cost.synthesis.totalOutputTokens + cost.other.totalOutputTokens,
+    hasTokens: cost.vision.hasTokens || cost.synthesis.hasTokens || cost.other.hasTokens,
+    byModel: {},
+  };
+  // A bucket that never reported cost/tokens makes the total "partial", not wrong —
+  // say so rather than silently under-reporting real spend as a clean $ total.
+  // Only buckets that actually made calls count toward this check — an unused bucket
+  // (e.g. "Other" on a typical case) isn't a data-reporting gap.
+  const usedBuckets = [cost.vision, cost.synthesis, cost.other].filter(b => b.totalCalls > 0);
+  const someHaveCost = usedBuckets.some(b => b.hasCost);
+  const allHaveCost = usedBuckets.every(b => b.hasCost);
+  const totalNote = usedBuckets.length > 0 && someHaveCost && !allHaveCost
+    ? `<div data-safe-style="font-size:11px;color:#7e8aa0;margin-top:2px">partial — not every bucket's provider reports cost</div>` : "";
+  const rows = diagAiCostBucketRow("Vision", cost.vision)
+    + diagAiCostBucketRow("Synthesis", cost.synthesis)
+    + diagAiCostBucketRow("Other", cost.other)
+    + `<div data-safe-style="border-top:1px solid var(--border-color);margin-top:6px;padding-top:6px">`
+    + diagRow("Total", `${total.totalCalls} call(s) · ${total.hasCost ? diagFmtCost(total.totalCostUSD) : "n/a"} · ${total.hasTokens ? `${total.totalInputTokens.toLocaleString()} in / ${total.totalOutputTokens.toLocaleString()} out` : "n/a"}`)
+    + totalNote + `</div>`;
+  return diagCard("AI cost — this case", rows);
+}
+const DIAG_LEVEL_COLOR = { none: "#5ad17a", warning: "#ffce8a", danger: "#ffb05a", critical: "#ff5a5a" };
+function diagCard(title, rows) {
+  return `<div data-safe-style="background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:8px;padding:10px 12px;margin-bottom:10px">
+    <div data-safe-style="font-weight:600;color:var(--text-primary);margin-bottom:6px">${esc(title)}</div>${rows}</div>`;
+}
+function diagRow(label, value, color) {
+  return `<div data-safe-style="display:flex;justify-content:space-between;gap:12px;padding:1px 0">
+    <span data-safe-style="color:#9aa4b2">${esc(label)}</span>
+    <span data-safe-style="text-align:right${color ? `;color:${color}` : ""}">${value}</span></div>`;
+}
+function renderOperationalDiagnostics(o) {
+  if (!o || !o.enabled) {
+    return diagCard("Local performance & capacity", diagRow("Status", "disabled — core behavior is unchanged", "#7e8aa0"));
+  }
+  const slow = o.slowest || {};
+  const cap = o.capacity || {};
+  const warningRows = (o.warnings || []).map(w =>
+    `<div data-safe-style="color:#ffb05a;margin-top:4px">⚠ ${esc(w)}</div>`).join("");
+  const hotspot = (label, item) => item
+    ? diagRow(label, `${esc(item.name)} · ${Math.round(item.durationMs).toLocaleString()} ms<div data-safe-style="font-size:11px;color:#7e8aa0">${esc(item.remediation)}</div>`)
+    : "";
+  return diagCard("Local performance & capacity", [
+    diagRow("Retention", `${o.sampleCount.toLocaleString()} sample(s) · ${Math.round(o.retentionDays)} days maximum`),
+    diagRow("Importer yield", `${o.imports.accepted.toLocaleString()} accepted · ${o.imports.rejected.toLocaleString()} rejected · ${o.imports.promoted.toLocaleString()} promoted`),
+    diagRow("Query latency", `p50 ${Math.round(o.queries.p50Ms)} ms · p95 ${Math.round(o.queries.p95Ms)} ms · ${o.queries.unindexed} unindexed`),
+    diagRow("Jobs", `${o.jobs.queued} queued · ${o.jobs.running} running · ${o.jobs.retries} retries · ${o.jobs.stalled} stalled`, o.jobs.stalled ? "#ffb05a" : ""),
+    diagRow("AI", `${o.ai.calls} call(s) · p95 ${Math.round(o.ai.p95Ms)} ms · ${o.ai.retries} retries · ${o.ai.rateLimits} rate limits`),
+    diagRow("Exports", `${o.exports.count} run(s) · p95 ${Math.round(o.exports.p95Ms)} ms · ${diagFmtBytes(o.exports.outputBytes)}`),
+    diagRow("Live connection", `${o.websocket.active} active · ${o.websocket.reconnects} reconnect · ${o.websocket.dropped} dropped · ${o.websocket.rejects} rejected`),
+    diagRow("Case databases", diagFmtBytes(cap.databaseBytes || 0)),
+    cap.growthBytesPerDay != null ? diagRow("Projected growth", `${diagFmtBytes(cap.growthBytesPerDay)}/day${cap.projectedDaysRemaining != null ? ` · ${cap.projectedDaysRemaining.toFixed(1)} days of free disk` : ""}`) : "",
+    hotspot("Slowest importer", slow.importer),
+    hotspot("Slowest query", slow.query),
+    hotspot("Slowest job", slow.job),
+    warningRows,
+  ].join(""));
+}
+// Per-importer health table (#84): one row per custom (declarative) importer — last-run age,
+// success/fail, rows parsed (kept/total, dropped), last error — plus malformed-spec load errors
+// from the registry, so all import health signals for custom importers live in one place.
+function renderPerImporterHealth(im) {
+  const perImporter = im.perImporter || [];
+  const loadErrors = im.loadErrors || [];
+  if (!perImporter.length && !loadErrors.length) return "";
+  let html = `<div data-safe-style="margin-top:10px;border-top:1px solid var(--border-color);padding-top:8px">
+    <div data-safe-style="color:#9aa4b2;margin-bottom:4px">Per-importer breakdown (${perImporter.length}):</div>`;
+  if (perImporter.length) {
+    html += `<div data-safe-style="max-height:220px;overflow:auto">` + perImporter.map(p => {
+      const ok = p.lastStatus === "ok";
+      const statusColor = p.lastStatus == null ? "#7e8aa0" : ok ? "#5ad17a" : "#ff9f9f";
+      const statusText = p.lastStatus == null ? "never run" : ok ? "ok" : "failed";
+      const age = p.lastRunAt ? diagFmtAge(Date.now() - Date.parse(p.lastRunAt)) + " ago" : "—";
+      const rows = p.lastStatus != null ? `${p.kept ?? 0}/${p.total ?? 0} kept, ${p.dropped ?? 0} dropped` : "—";
+      return `<div data-safe-style="border-left:2px solid ${ok ? "#2a5a3a" : p.lastStatus ? "#5a2a2a" : "#3a3f4a"};padding:2px 0 2px 8px;margin:3px 0;font-family:monospace;font-size:11.5px">
+        <span data-safe-style="color:#cbd3df">${esc(p.label)}</span> <span data-safe-style="color:#7e8aa0">(${esc(p.id)})</span>
+        — <span data-safe-style="color:${statusColor}">${statusText}</span> · ${age} · ${rows}
+        ${p.lastError ? `<br><span data-safe-style="color:#ffb0b0">${esc(p.lastError)}</span>` : ""}</div>`;
+    }).join("") + `</div>`;
+  }
+  if (loadErrors.length) {
+    html += `<div data-safe-style="margin-top:6px;color:#9aa4b2">Spec load errors (${loadErrors.length}):</div>`;
+    html += `<div data-safe-style="max-height:160px;overflow:auto;margin-top:3px">` + loadErrors.map(e =>
+      `<div data-safe-style="border-left:2px solid #5a2a2a;padding:2px 0 2px 8px;margin:3px 0;font-family:monospace;font-size:11.5px">
+        <span data-safe-style="color:#ff9f9f">${esc(e.file)}</span><br>
+        ${e.errors.map(x => `<span data-safe-style="color:#ffb0b0">${esc(x.path)}: ${esc(x.message)}</span>`).join("<br>")}</div>`).join("") + `</div>`;
+  }
+  html += `</div>`;
+  return html;
+}
+export {
+  diagFmtBytes,
+  diagFmtAge,
+  diagFmtCost,
+  diagAiCostBucketRow,
+  renderAiCostCard,
+  diagCard,
+  diagRow,
+  renderOperationalDiagnostics,
+  renderPerImporterHealth,
+  DIAG_LEVEL_COLOR,
+};
+
+// The dashboard's inline renderDiagnostics() reaches these through the namespaced global, the same
+// contract graph-view.js and settings-search.js already use.
+if (typeof window !== "undefined") {
+  window.DfirDiagnostics = {
+    renderAiCostCard,
+    renderOperationalDiagnostics,
+    renderPerImporterHealth,
+    DIAG_LEVEL_COLOR,
+  };
+}

--- a/public/js/diagnostics-panel.js
+++ b/public/js/diagnostics-panel.js
@@ -159,11 +159,29 @@ export {
   DIAG_LEVEL_COLOR,
 };
 
-// The dashboard's inline renderDiagnostics() reaches these through the namespaced global, the same
+// The dashboard's inline diagnostics functions reach these through the namespaced global, the same
 // contract graph-view.js and settings-search.js already use.
+//
+// EVERY function this module defines is exposed, not just the top-level renderers. The first cut of
+// this file published only the four renderers, on the assumption that the helpers had moved with
+// their only callers. They had not: renderDiagnostics, diagComputeSizes, loadCaseStats and
+// loadCaseBackups still make 46 bare calls to diagRow/diagCard/diagFmtBytes/diagFmtAge. An ES
+// module's declarations are NOT globals, so every one of those was a ReferenceError and the whole
+// Diagnostics panel threw at runtime -- while all 29 unit tests passed, because they exercise this
+// module directly and never load the page.
+//
+// The rule this encodes: if the inline script still calls it, the namespace must publish it.
+// tests/reports/diagnosticsPanel.test.ts now asserts exactly that, in both directions.
 if (typeof window !== "undefined") {
   window.DfirDiagnostics = {
+    esc,
+    diagFmtBytes,
+    diagFmtAge,
+    diagFmtCost,
+    diagAiCostBucketRow,
     renderAiCostCard,
+    diagCard,
+    diagRow,
     renderOperationalDiagnostics,
     renderPerImporterHealth,
     DIAG_LEVEL_COLOR,


### PR DESCRIPTION
**Stacked on #413** — review #409 and #413 first. The first slice of `dashboard.html`'s inline script to become a real module.

Inline JS **19,323 → 19,194 lines**, and 29 unit tests now cover code no test could reach before.

## Why this slice first

Nine functions plus `DIAG_LEVEL_COLOR` that build **HTML strings** from a diagnostics report — no DOM, no fetch, no shared dashboard state. That is the entire reason they could move: they are a pure function of their argument.

`renderDiagnostics()` stays inline and calls into `window.DfirDiagnostics`, the same contract `graph-view.js` and `settings-search.js` already use. Load order is safe because every call site sits inside a function that runs on a data load, never at parse time.

## `esc` is duplicated on purpose

It has **661 call sites** in the inline script, so it cannot move in this pass, and a module cannot read the inline scope. Making every escape call depend on a module load is a bad trade for an XSS-critical primitive — #387 exists because of unsafe DOM sinks.

So the module carries its own copy, and a test asserts the two implementations stay **byte-identical**. A drift guard instead of a runtime coupling.

## Writing the tests is what established the API

Five failed on first run because I had guessed wrong. `diagFmtAge` takes **milliseconds**, not a timestamp. A cost bucket keys its models under **`byModel`**, not a list. That code had never been reachable from a test, so nothing had ever pinned its contract down.

## Two gates caught real problems, in sequence

**A production 404.** `settingsSearch.test.ts` cross-references what `dashboard.html` loads against `src/http/staticAssets.ts` — an explicit allowlist of what the server will serve. The module wasn't on it. It would have 404'd in production while the build, the typecheck and all 29 unit tests passed. Nothing else could have caught that.

**Then the route contract.** Adding the allowlist entry registers a new route, reported as exactly one line by the count-based diff added in the last review round:

```
ROUTE GET /js/diagnostics-panel.js: 0 -> 1
```

The set-difference version it replaced would have reported nothing — that fix earned itself here.

**Every future dashboard extraction needs both steps**: add the module to `STATIC_ASSETS`, regenerate the route inventory. The 404 is otherwise silent.

`dashboardHtml.test.ts` also asserted the page contains `function diagFmtCost(` — a source-location proxy, now stale. It checks the module for the renderers and the page for the wiring, which is what it actually cared about.

## The remaining distance, measured honestly

Of the inline script's 924 top-level functions, only **141 (933 lines)** are standalone in this sense. The rest are entangled with **409 top-level globals**.

My first measurement said 1,633 lines; that was wrong, because it didn't exclude functions reaching for shared state like `lastState`. Reaching the issue's ≤2,000-line target needs that state restructured — not more functions moved. This slice is real progress and an honest template, but it is **not** evidence the remaining 18,000 lines are the same job.

## Verification

`build`, `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`, and the full suite — **6,793 tests passing**.

Refs #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
