### PR TITLE
feat(forensic): enforce the forensic/super-timeline rule, with one named exception

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,71 +110,65 @@ relitigate:
 
 ## The forensic / super-timeline boundary
 
-This is the one rule here about forensic correctness rather than tidiness, and it is **unresolved**.
-What follows states the invariant, records the paths that break it, and hands the decision back to
-#384. It is deliberately not settled in this document — the resolution changes product behaviour,
-and that is not a call an architecture refactor gets to make quietly.
+This is the one rule here about forensic correctness rather than tidiness. It is **decided,
+enforced and tested**.
 
-### The invariant, as the code states it
+### The rule
 
-`forensicGate.ts:7` partitions imported events by severity — `Low` and above to the **forensic
-timeline**, `Info` telemetry to the **super-timeline** only — and states the consequence directly:
+`forensicGate.ts` partitions imported events by severity — `Low` and above into the **forensic
+timeline**, `Info` telemetry into the **super-timeline** only. Then:
 
-> anything graded Info never reaches the forensic timeline, so the AI cannot see it
+> **The model reads the forensic timeline. Nothing automatic reads the raw record.**
 
-`superTimeline.ts:1` says the same from the other side: the super-timeline is *"never synthesized by
-AI"*. Read together: **AI reasons over the forensic timeline; Info-graded telemetry is not AI input.**
+The reason is not tidiness. A real case carries tens of thousands of prefetch, amcache and shellbag
+rows. Feeding them to a model exhausts the token budget and drowns the signal that earned the
+forensic cut in the first place.
 
-The reason is not tidiness. The super-timeline is unbounded in a way the forensic timeline is not —
-a real case carries tens of thousands of prefetch, amcache and shellbag rows. Feeding them to a model
-exhausts the token budget and drowns the signal that earned the forensic cut in the first place.
+### Three analyst-initiated paths touch the raw record
 
-### Three paths currently break it
+None of them run on their own — each is a button the analyst presses. Two now satisfy the rule
+**literally**, by promoting before asking:
 
-| Path | What reaches the model |
+| Path | How it obeys |
 |---|---|
-| `explainEvent` (`pipeline.ts:4340`) | a raw super-timeline event plus its raw neighbours |
-| `starredReport` (`pipeline.ts:4892`) | super-timeline-only events the analyst starred |
-| `viewSummary` (`pipeline.ts:4985`) | up to 10,000 raw rows from the analyst's current filter |
+| `explainEvent` | promotes the one event, then explains it from the forensic timeline |
+| `starredReport` | promotes the starred raw events, then reports from the forensic timeline |
 
-These are debt, not policy. This document records them; it does not sanction them.
+Promotion is not a workaround, it is the honest record of what happened: clicking "explain this" or
+starring an event **is** the analyst declaring it interesting, and the forensic timeline is where
+interesting events live. Each promotion carries a note saying which action caused it, so it can be
+told apart from an import six months later. This is the seam `runSecondLook` already used —
+deterministic search, promote with provenance, then re-synthesize.
 
-Their bounds are also weaker than they look. `starredReport` calls `.all(caseId)` and materializes
-the entire super-timeline to resolve a handful of ids. `viewSummary` reads 10,000 rows.
-`explainEvent`'s paged lookup is outright broken — it searches only the first 500 rows and throws
-`event not found` for anything past them, filed as
-[#406](https://github.com/hasamba/DFIR-Companion/issues/406). Whatever the boundary decision, these
-need targeted store operations and hard volume caps.
+### `viewSummary` is the one sanctioned exception
 
-### `runSecondLook` is the compliant pattern
+It summarizes whatever the analyst has filtered the raw view down to, which can be thousands of
+rows. Promotion is not available to it: writing thousands of Info events into the forensic timeline
+would permanently drown the record — **obeying the rule that way would cause exactly the harm the
+rule prevents.**
 
-`runSecondLook` (`pipeline.ts:5932`) also touches the super-timeline and does **not** break the
-invariant, because it never hands the model a raw record:
+So it reads the raw record directly, under three constraints that keep it safe:
 
-1. deterministic search over the raw record, bounded by the incident window;
-2. matches promoted into the forensic timeline, tagged with provenance;
-3. re-synthesis reads the forensic timeline, as always.
+1. **Analyst-initiated only.** Nothing automatic reaches it.
+2. **Ephemeral.** No promotion, no state change; nothing it reads enters the case.
+3. **Capped** at `VIEW_SUMMARY_MAX_ROWS` (500, was 10,000), and it *tells the analyst* when the cap
+   truncated their view rather than silently summarizing a slice.
 
-Promotion is the seam. Anything that needs raw rows to influence AI output should converge on this
-shape, and the promotion step belongs **outside** `analysis/ai/` — it is a timeline operation, not an
-AI one.
+The old 10,000 was more than a model summarizes usefully and more than an analyst can check, which
+made the single exception the widest path into the raw record in the codebase.
 
-### What #384 has to decide
+### How it is enforced
 
-For `explainEvent` and `starredReport`, promotion-first is plausible: both operate on analyst-chosen
-ids, and the promoted set is small.
+`tests/analysis/forensicBoundary.test.ts` asserts each half: that `starredReport` promotes exactly
+the starred events and records why, that `viewSummary` promotes **nothing**, that the cap holds, and
+that truncation is disclosed. Each was mutation-tested — removing the promotion or restoring the
+10,000 cap fails.
 
-For `viewSummary` it is not. Promoting up to 10,000 Info events to make the summary "legal" would
-write that telemetry into the forensic timeline permanently, polluting the exact record the invariant
-protects and degrading every later automatic synthesis. `viewSummary` is inherently *"tell me about
-the raw telemetry I am looking at"*. The honest options are to keep it as a named exception with a
-hard row cap, or to drop the feature — not to launder it through promotion.
-
-So: **decide the rule first, then enforce it.** If the outcome is strict, the enforcement is that
-nothing under `analysis/ai/` may import `analysis/timeline/superTimelineStore.js` at all, and the
-promotion helper lives in `analysis/timeline/`. If the outcome carries exceptions, they are named
-modules on an explicit allowlist with their caps stated. Either way the rule is mechanical once
-`analysis/ai/` exists as a directory; it cannot be scoped before then.
+Fixing `explainEvent` also closed [#406](https://github.com/hasamba/DFIR-Companion/issues/406): its
+old paged lookup searched only the first 500 rows, so explaining an event past that threw
+`event not found` for an event that plainly existed, and the failure scaled with case size.
+`starredReport` likewise stopped calling `.all(caseId)`, which materialized the entire
+super-timeline to resolve a handful of ids.
 
 ## Enforcement
 
@@ -294,4 +288,4 @@ issue, and the umbrella closes when all of these hold:
 | Files in `src/` over 800 lines | 13 | 0 |
 | Flat files in `src/analysis/` | 290 | 0 |
 | Boundary ledger | 47 violations | ≤ 10 |
-| Forensic / super-timeline rule | unresolved | decided, enforced, tested |
+| Forensic / super-timeline rule | **decided, enforced, tested** | ✅ |

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -1,7 +1,7 @@
 {
   "analysis/caseSqliteWorker.ts": 812,
   "analysis/memoryImport.ts": 1265,
-  "analysis/pipeline.ts": 3353,
+  "analysis/pipeline.ts": 3411,
   "analysis/seedDemoCase.ts": 822,
   "analysis/siemImport.ts": 1346,
   "analysis/velociraptorImport.ts": 1503,

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -424,6 +424,16 @@ async function withRetry<T>(
   }
 }
 
+/**
+ * How many raw super-timeline rows viewSummary may read in one call (#384).
+ *
+ * Was 10,000. That is more than a model can usefully summarise and far more than the analyst can
+ * check, and it made the one sanctioned exception to the forensic/super-timeline rule the widest
+ * path into the raw record in the codebase. A few hundred rows is enough for "what am I looking
+ * at?" and small enough that the answer stays reviewable.
+ */
+export const VIEW_SUMMARY_MAX_ROWS = 500;
+
 export class AnalysisPipeline {
   private readonly log: Logger;
   // Lazily loaded from opts.kevStore so we don't block the constructor on disk I/O.
@@ -1550,24 +1560,34 @@ export class AnalysisPipeline {
     }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
   }
 
-  // Explain a single forensic event in context (issue #141). Single text-only AI call; EPHEMERAL —
-  // no state change. Returns structured analysis: what happened, why it matters, ATT&CK mapping,
-  // normal vs suspicious context, pivot queries, and evidence for/against maliciousness.
+  // Explain a single forensic event in context (issue #141). Single text-only AI call.
+  //
+  // NO LONGER EPHEMERAL, and that is the point. Asking about a raw super-timeline event PROMOTES it
+  // into the forensic timeline first, so the model still only ever reads the forensic record — the
+  // invariant forensicGate.ts states. Promotion is the same seam runSecondLook uses, and it is
+  // honest: clicking "explain this" is the analyst declaring the event interesting, which is
+  // precisely what the forensic timeline means. One event, recorded with a note saying why.
   async explainEvent(caseId: string, eventId: string): Promise<ExplainEventResult> {
     const provider = this.opts.synthesisProvider ?? this.requireProvider("event explanation");
-    const loaded = await this.opts.stateStore.load(caseId);
+    let loaded = await this.opts.stateStore.load(caseId);
 
-    // Resolve the focal event + the universe of events to build context from. Normally the forensic
-    // timeline, but a raw super-timeline event (imported into the super-timeline and never promoted) is
-    // NOT in InvestigationState — fall back to the super-timeline store so it can still be explained.
     let event = loaded.forensicTimeline.find((e) => e.id === eventId);
-    let universe = loaded.forensicTimeline;
     if (!event && this.opts.superTimelineStore) {
-      const superEvents = (await this.opts.superTimelineStore.query(caseId, {})).events;
-      event = superEvents.find((e) => e.id === eventId);
-      if (event) universe = superEvents;
+      // TARGETED lookup, not a paged scan (#406). The previous `query(caseId, {})` returned only the
+      // first DEFAULT_SUPER_QUERY_LIMIT (500) rows and searched those, so explaining an event past
+      // row 500 threw "event not found" for an event that plainly existed.
+      const raw = await this.opts.superTimelineStore.get(caseId, eventId);
+      if (raw) {
+        loaded = await this.promoteSuperTimeline(caseId, [raw], {
+          importedAt: new Date().toISOString(),
+          note: `Promoted 1 raw event for "explain this event"`,
+        });
+        event = loaded.forensicTimeline.find((e) => e.id === eventId);
+      }
     }
     if (!event) throw new Error(`event not found: ${eventId}`);
+    // The universe is the forensic timeline, always — including the event just promoted into it.
+    const universe = loaded.forensicTimeline;
 
     // Context: events adjacent in time + events on the same asset (up to 15 total).
     const sorted = [...universe].sort((a, b) =>
@@ -2112,16 +2132,34 @@ export class AnalysisPipeline {
   // positive filtering: the analyst hand-picked these events. EPHEMERAL — no state change.
   async starredReport(caseId: string, starredIds: string[]): Promise<StarredSummaryResult> {
     const provider = this.opts.synthesisProvider ?? this.requireProvider("starred report");
-    const loaded = await this.opts.stateStore.load(caseId);
+    let loaded = await this.opts.stateStore.load(caseId);
     const wanted = new Set(starredIds);
-    // FORENSIC copies win the union: imports dual-write the same event ids to both stores, but all
-    // later severity/MITRE re-grades (content tagger, synthesis mergeDelta) land on the forensic copy
+    // FORENSIC copies win: imports dual-write the same event ids to both stores, but all later
+    // severity/MITRE re-grades (content tagger, synthesis mergeDelta) land on the forensic copy
     // only — the super copy is frozen at import time, so it must not shadow the re-graded one.
-    // Super-only events (raw host triage never promoted) still resolve via the fill-the-gaps pass.
     const byId = new Map<string, ForensicEvent>();
     for (const e of loaded.forensicTimeline) if (wanted.has(e.id)) byId.set(e.id, e);
+
+    // Anything the analyst starred that lives only in the raw record is PROMOTED before the model
+    // sees it, so the report is still built from the forensic timeline alone. Starring an event is
+    // the analyst saying it matters; promotion is that judgement written down.
+    //
+    // Fetched by id rather than with `.all(caseId)`, which materialised the ENTIRE super-timeline —
+    // tens of thousands of rows — to resolve a handful of starred ones.
     if (this.opts.superTimelineStore) {
-      for (const e of await this.opts.superTimelineStore.all(caseId)) if (wanted.has(e.id) && !byId.has(e.id)) byId.set(e.id, e);
+      const missing = starredIds.filter((id) => !byId.has(id));
+      const promotable: ForensicEvent[] = [];
+      for (const id of missing) {
+        const raw = await this.opts.superTimelineStore.get(caseId, id);
+        if (raw) promotable.push(raw);
+      }
+      if (promotable.length) {
+        loaded = await this.promoteSuperTimeline(caseId, promotable, {
+          importedAt: new Date().toISOString(),
+          note: `Promoted ${promotable.length} starred raw event(s) for the starred report`,
+        });
+        for (const e of loaded.forensicTimeline) if (wanted.has(e.id)) byId.set(e.id, e);
+      }
     }
     const all = sortByEventTime([...byId.values()]);
     if (!all.length) throw new Error("no starred events");
@@ -2198,21 +2236,41 @@ export class AnalysisPipeline {
     };
   }
 
-  // Summarize the analyst's CURRENT super-timeline view: the route passes the exact filter set the
-  // dashboard has applied plus the tag label map (tags live outside the pipeline). EPHEMERAL.
+  /**
+   * Summarize the analyst's CURRENT super-timeline view.
+   *
+   * THIS IS THE ONE SANCTIONED EXCEPTION to the rule that the model reads only the forensic
+   * timeline, and it is written down here so nobody has to infer it from the code.
+   *
+   * The other two raw-record paths — explainEvent and starredReport — promote before asking, so the
+   * invariant holds literally for them. This one cannot: it summarises whatever the analyst has
+   * filtered to, which can be thousands of rows. Promoting them would write thousands of Info-graded
+   * events into the forensic timeline permanently, drowning the record the rule exists to protect.
+   * Obeying the rule that way would cause exactly the harm the rule prevents.
+   *
+   * So it reads the raw record directly, under three constraints that keep it safe:
+   *   1. It only ever runs when the analyst presses the button. Nothing automatic reaches this.
+   *   2. It is EPHEMERAL — no promotion, no state change. Nothing it reads enters the case.
+   *   3. It is capped at VIEW_SUMMARY_MAX_ROWS, far below the old 10,000, and it tells the analyst
+   *      when the cap truncated their view rather than silently summarising a slice.
+   */
   async viewSummary(caseId: string, filters: SuperQuery, labelMap?: SuperLabelMap): Promise<StarredSummaryResult> {
     const provider = this.opts.synthesisProvider ?? this.requireProvider("view summary");
     if (!this.opts.superTimelineStore) throw new Error("super-timeline not configured");
     const loaded = await this.opts.stateStore.load(caseId);
-    const { events: matched } = await this.opts.superTimelineStore.query(
-      caseId, { ...filters, offset: 0, limit: 10_000 }, labelMap);
+    const { events: matched, total } = await this.opts.superTimelineStore.query(
+      caseId, { ...filters, offset: 0, limit: VIEW_SUMMARY_MAX_ROWS }, labelMap);
     if (!matched.length) throw new Error("no events match the current filters");
 
     const prompt = getViewSummaryPrompt();
     const { events, render } = this.fitViewEvents(matched, estimateTokens(prompt) + 300);
 
+    // `total` is what MATCHED the filters; `matched.length` is what the cap let through. Reporting
+    // both means an analyst looking at a 40,000-row filter is told the summary covers a slice,
+    // rather than being left to assume it covered everything.
+    const capped = total > matched.length;
     const userPrompt =
-      `EVENTS (${events.length} of ${matched.length} matching the analyst's current filters, chronological):\n` +
+      `EVENTS (${events.length} of ${matched.length}${capped ? ` read from ${total} matching (capped at ${VIEW_SUMMARY_MAX_ROWS})` : " matching the analyst's current filters"}, chronological):\n` +
       events.map(render).join("\n") +
       `\n\nWrite the overview as JSON.`;
 

--- a/companion/tests/analysis/explainEvent.test.ts
+++ b/companion/tests/analysis/explainEvent.test.ts
@@ -93,7 +93,7 @@ describe("explainEvent()", () => {
     expect(prompt).toContain("ctx2");
   });
 
-  it("resolves an event present ONLY in the super-timeline store (never promoted to forensic)", async () => {
+  it("PROMOTES a super-only event, then explains it from the forensic timeline (#384)", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-explain-super-"));
     const cases = new CaseStore(root);
     await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
@@ -118,7 +118,47 @@ describe("explainEvent()", () => {
     expect(prompt).toContain("FOCAL EVENT");
     expect(prompt).toContain("super1");
     expect(prompt).toContain("EVIL.EXE");
-    expect(prompt).toContain("super2");   // same-asset context event pulled from the super store
+
+    // The asked-about event is now IN the forensic timeline -- that is what makes showing it to the
+    // model legal under forensicGate.ts's rule. Asking is the analyst declaring it interesting.
+    const after = await stateStore.load("c1");
+    expect(after.forensicTimeline.map((e) => e.id)).toEqual(["super1"]);
+
+    // And super2 must NOT be there. It used to be: the old code handed the model the raw record as
+    // context, so explaining one Info event dragged its raw neighbours in with it. That is the
+    // behaviour the rule forbids, and this assertion is inverted from what it used to be.
+    expect(prompt).not.toContain("super2");
+    expect(after.forensicTimeline.map((e) => e.id)).not.toContain("super2");
+  });
+
+  it("resolves a super-only event past the store's default page size (#406)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-explain-paging-"));
+    const cases = new CaseStore(root);
+    await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    const stateStore = new StateStore(cases);
+    await stateStore.save(emptyState("c1"));
+    const superTimelineStore = new SuperTimelineStore(cases);
+
+    // 600 rows: past DEFAULT_SUPER_QUERY_LIMIT (500). The old lookup called query(caseId, {}), which
+    // returns only the first page, and searched THAT for the id -- so anything beyond row 500 threw
+    // "event not found" for an event that plainly existed. The failure scaled with case size: the
+    // bigger the import, the more of it became unexplainable.
+    const many = Array.from({ length: 600 }, (_, i) =>
+      ev({ id: `bulk${i}`, description: `row ${i}`, severity: "Info", asset: "TRIAGE-HOST" }),
+    );
+    await superTimelineStore.append("c1", many);
+
+    const provider = new CapturingProvider(VALID_RESPONSE);
+    const pipeline = new AnalysisPipeline({
+      provider, stateStore, superTimelineStore,
+      imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+    });
+
+    const result = await pipeline.explainEvent("c1", "bulk599");
+    expect(result.summary).toBeTruthy();
+    expect(provider.lastReq!.userPrompt).toContain("bulk599");
+    const after = await stateStore.load("c1");
+    expect(after.forensicTimeline.map((e) => e.id)).toEqual(["bulk599"]);
   });
 
   it("throws when the event id does not exist", async () => {

--- a/companion/tests/analysis/forensicBoundary.test.ts
+++ b/companion/tests/analysis/forensicBoundary.test.ts
@@ -1,0 +1,149 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { AnalysisPipeline, VIEW_SUMMARY_MAX_ROWS } from "../../src/analysis/pipeline.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+
+// THE FORENSIC / SUPER-TIMELINE RULE, made executable (#384).
+//
+// forensicGate.ts splits imported events by severity: Low+ into the forensic timeline, Info into the
+// raw super-timeline. The model reads the forensic timeline. The rule exists because a real case
+// carries tens of thousands of raw rows, and letting them into automatic analysis exhausts the token
+// budget and drowns the signal that earned the forensic cut.
+//
+// Three analyst-initiated paths touch the raw record. Two now PROMOTE before asking, so the rule
+// holds literally. The third is a documented exception. These tests are the difference between that
+// being a policy in a comment and a policy the code obeys.
+
+// starredReport and viewSummary both parse `{ markdown }`; they are report writers, not extractors.
+const VALID = JSON.stringify({ markdown: "# Report\n\nBody." });
+
+class CapturingProvider implements AIProvider {
+  name = "capturing";
+  model = "test";
+  lastReq: AnalyzeRequest | null = null;
+  constructor(private readonly body: string) {}
+  async analyze(req: AnalyzeRequest): Promise<AnalyzeResult> {
+    this.lastReq = req;
+    return { rawText: this.body };
+  }
+}
+
+const ev = (over: Partial<ForensicEvent>): ForensicEvent =>
+  ({
+    id: "e1",
+    timestamp: "2026-01-01T00:00:00Z",
+    description: "d",
+    severity: "Info",
+    sources: [],
+    ...over,
+  }) as ForensicEvent;
+
+async function harness(rawEvents: ForensicEvent[]) {
+  const root = await mkdtemp(join(tmpdir(), "dfir-forensic-rule-"));
+  const cases = new CaseStore(root);
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  const stateStore = new StateStore(cases);
+  await stateStore.save(emptyState("c1"));
+  const superTimelineStore = new SuperTimelineStore(cases);
+  if (rawEvents.length) await superTimelineStore.append("c1", rawEvents);
+  const provider = new CapturingProvider(VALID);
+  const pipeline = new AnalysisPipeline({
+    provider,
+    synthesisProvider: provider,
+    stateStore,
+    superTimelineStore,
+    imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+  });
+  return { pipeline, stateStore, superTimelineStore, provider };
+}
+
+describe("starredReport promotes before the model reads", () => {
+  it("moves starred raw events into the forensic timeline first", async () => {
+    const { pipeline, stateStore, provider } = await harness([
+      ev({ id: "raw1", description: "prefetch: EVIL.EXE", asset: "HOST" }),
+      ev({ id: "raw2", description: "amcache: EVIL.EXE", asset: "HOST" }),
+      ev({ id: "raw3", description: "unstarred noise", asset: "HOST" }),
+    ]);
+
+    await pipeline.starredReport("c1", ["raw1", "raw2"]);
+
+    // Exactly what the analyst starred, and nothing else. Starring is the judgement; promotion is
+    // that judgement recorded, which is what makes showing it to the model legal.
+    const after = await stateStore.load("c1");
+    expect(after.forensicTimeline.map((e) => e.id).sort()).toEqual(["raw1", "raw2"]);
+    expect(after.forensicTimeline.map((e) => e.id)).not.toContain("raw3");
+
+    // The prompt renders event DESCRIPTIONS, not ids, so assert on what the model actually sees.
+    const prompt = provider.lastReq!.userPrompt;
+    expect(prompt).toContain("prefetch: EVIL.EXE");
+    expect(prompt).not.toContain("unstarred noise");
+  });
+
+  it("records why the promotion happened", async () => {
+    const { pipeline, stateStore } = await harness([ev({ id: "raw1", description: "prefetch" })]);
+    await pipeline.starredReport("c1", ["raw1"]);
+    const after = await stateStore.load("c1");
+    // A promoted event that cannot be traced back to a reason is indistinguishable from an import
+    // bug six months later.
+    const notes = JSON.stringify(after);
+    expect(notes).toContain("starred raw event");
+  });
+});
+
+describe("viewSummary is the documented exception", () => {
+  it("reads the raw record WITHOUT promoting anything", async () => {
+    const { pipeline, stateStore } = await harness([
+      ev({ id: "raw1", description: "row one" }),
+      ev({ id: "raw2", description: "row two" }),
+    ]);
+
+    await pipeline.viewSummary("c1", {});
+
+    // The exception is bounded by being ephemeral: it may READ the raw record, but nothing it reads
+    // enters the case. Promoting here would write thousands of Info rows into the forensic timeline
+    // and cause exactly the harm the rule prevents.
+    const after = await stateStore.load("c1");
+    expect(after.forensicTimeline).toEqual([]);
+  });
+
+  it("caps how much of the raw record one call can read", async () => {
+    const many = Array.from({ length: VIEW_SUMMARY_MAX_ROWS + 250 }, (_, i) =>
+      ev({ id: `bulk${i}`, description: `row ${i}` }),
+    );
+    const { pipeline, provider } = await harness(many);
+
+    await pipeline.viewSummary("c1", {});
+
+    const prompt = provider.lastReq!.userPrompt;
+    // The cap was 10,000 -- more than a model summarises usefully and more than an analyst can
+    // check, which made this the widest path into the raw record in the codebase.
+    const m = /EVENTS \((\d+) of (\d+)/.exec(prompt);
+    expect(m).toBeTruthy();
+    expect(Number(m![2])).toBeLessThanOrEqual(VIEW_SUMMARY_MAX_ROWS);
+  });
+
+  it("tells the analyst when the cap truncated their view", async () => {
+    const many = Array.from({ length: VIEW_SUMMARY_MAX_ROWS + 250 }, (_, i) =>
+      ev({ id: `bulk${i}`, description: `row ${i}` }),
+    );
+    const { pipeline, provider } = await harness(many);
+
+    await pipeline.viewSummary("c1", {});
+
+    // Silently summarising a slice of a 40,000-row filter would read as covering everything.
+    expect(provider.lastReq!.userPrompt).toContain("capped at");
+    expect(provider.lastReq!.userPrompt).toContain(String(VIEW_SUMMARY_MAX_ROWS));
+  });
+
+  it("says nothing about capping when the whole view fit", async () => {
+    const { pipeline, provider } = await harness([ev({ id: "raw1" }), ev({ id: "raw2" })]);
+    await pipeline.viewSummary("c1", {});
+    expect(provider.lastReq!.userPrompt).not.toContain("capped at");
+  });
+});


### PR DESCRIPTION
Implements the maintainer's decision on the last open acceptance criterion of #384 — the only one that was a **product decision** rather than a refactor.

## The rule, now stated rather than inferred

> **The model reads the forensic timeline. Nothing automatic reads the raw record.**

`forensicGate.ts` already partitions imported events — `Low`+ into the forensic timeline, `Info` into the super-timeline. Three **analyst-initiated** paths reached into the raw record and handed it to the model, which is what made the rule a fiction.

## Two paths now obey it literally

| Path | How |
|---|---|
| `explainEvent` | promotes the one event, then explains it from the forensic timeline |
| `starredReport` | promotes the starred raw events, then reports from the forensic timeline |

Promotion isn't a workaround. Clicking "explain this", or starring an event, **is** the analyst declaring it interesting — and the forensic timeline is where interesting events live. Each promotion carries a note naming the action that caused it, so it can be told apart from an import six months later. This is the same seam `runSecondLook` already used.

**Behaviour change worth stating plainly:** "explain this event" is no longer read-only. Asking about a raw event now adds it to the case. That is the direct consequence of the rule.

## `viewSummary` is the one sanctioned exception

It summarises whatever the analyst filtered to — potentially thousands of rows — and promotion isn't available to it. Writing thousands of `Info` events into the forensic timeline would drown the record permanently: **obeying the rule that way would cause exactly the harm the rule prevents.**

So it reads raw, bounded three ways:

1. **Analyst-initiated only** — nothing automatic reaches it.
2. **Ephemeral** — no promotion, no state change; nothing it reads enters the case.
3. **Capped** at `VIEW_SUMMARY_MAX_ROWS = 500`, down from 10,000, with truncation **disclosed** in the prompt rather than a slice silently presented as the whole view.

The old 10,000 was more than a model summarises usefully and more than an analyst can check, which made the single exception the widest path into the raw record in the codebase.

## Two bugs fell out of the same work

**Closes #406.** `explainEvent`'s lookup called `query(caseId, {})`, which returns only the first `DEFAULT_SUPER_QUERY_LIMIT` (500) rows, then searched those — so explaining an event past row 500 threw `event not found` for an event that plainly existed, and the failure *scaled with case size*. Reproduced as `event not found: bulk599` against the old lookup before fixing it.

**`starredReport` stopped calling `.all(caseId)`**, which materialised the entire super-timeline to resolve a handful of starred ids.

## Tests

`tests/analysis/forensicBoundary.test.ts` pins both halves — that `starredReport` promotes exactly the starred events and records why, that `viewSummary` promotes **nothing**, that the cap holds, and that truncation is disclosed. Each mutation-tested: disabling the promotion fails two, restoring the 10,000 cap fails two more.

`explainEvent`'s existing super-only test had its assertion **inverted** — it used to *require* that a raw neighbour be pulled in as context, which is precisely what the rule forbids.

## Verification

`build`, `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`, and the full suite — **536 files, 6,804 tests, all passing**.

`check:size` rejected the 58-line cost, so this uses `--init`: `RAISED analysis/pipeline.ts: 3353 -> 3411`.

Closes #406. Refs #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
