### PR TITLE
fix(velociraptor): say what import-external contacts instead of just "not configured"

### DIFF
--- a/companion/src/analysis/veloRef.ts
+++ b/companion/src/analysis/veloRef.ts
@@ -33,6 +33,16 @@ const NOTEBOOK_PATH = /\/notebooks?(?:[/?#]|$)/i;
 // entirely when the analyst pastes this specific tab's URL.
 const UPLOADS_PATH = /\/uploads(?:[/?#]|$)/i;
 
+// The "Velociraptor API not configured" refusal for POST /cases/:id/velociraptor/import-external.
+// It lives with the ref parser because the confusion it clears up is about what a REF is: the route
+// reads like an offline import (it "imports", and you POST it a body), but the body is a pointer to a
+// collection on the server, not the collection itself — so every path behind this gate makes an
+// outbound call and the gate is load-bearing. An analyst holding a colleague's export otherwise reads
+// it as a pointless requirement, so the message names what would be contacted and hands them
+// import-velociraptor, which parses pasted JSON and needs no server at all.
+export const EXTERNAL_IMPORT_NEEDS_SERVER =
+  "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG). This endpoint does not import an export you paste in — it takes a hunt/flow reference and fetches that collection's results from your Velociraptor server, so it needs a live connection to it. To import Velociraptor JSON you already have (a colleague's export, a saved collection), use POST /cases/:id/import-velociraptor instead, which is fully offline.";
+
 function tokens(s: string, re: RegExp): string[] {
   return [...s.matchAll(re)].map((m) => m[1]);
 }

--- a/companion/src/routes/velociraptor.ts
+++ b/companion/src/routes/velociraptor.ts
@@ -2,7 +2,7 @@ import type { Express, Request, Response } from "express";
 import { reloadEnvPrefix } from "../settings/envManager.js";
 import { logActivity } from "../analysis/activityLog.js";
 import { parseMinSeverity } from "../analysis/severityFloor.js";
-import { parseVeloRef } from "../analysis/veloRef.js";
+import { parseVeloRef, EXTERNAL_IMPORT_NEEDS_SERVER } from "../analysis/veloRef.js";
 import { buildVelociraptorClient, matchClient, ALL_CLIENTS, normalizeHuntExpirySeconds, type HuntTarget, type VeloArtifactInfo } from "../integrations/velociraptor/velociraptorApi.js";
 import type { VeloMonitor } from "../analysis/veloMonitorStore.js";
 import type { VeloHuntJob } from "../analysis/veloHuntStore.js";
@@ -499,7 +499,7 @@ export function registerVelociraptorRoutes(app: Express, ctx: RouteContext): voi
   // Paste a hunt id / flow / GUI URL; discover what it collected (for a flow, resolve the host) and
   // import via the SAME chain as every other Velociraptor import — optionally to the super-timeline only.
   app.post("/cases/:id/velociraptor/import-external", async (req: Request, res: Response) => {
-    if (!options.velociraptorClient) return res.status(501).json({ error: "Velociraptor API not configured (set DFIR_VELOCIRAPTOR_API_CONFIG)" });
+    if (!options.velociraptorClient) return res.status(501).json({ error: EXTERNAL_IMPORT_NEEDS_SERVER });
     if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
     const caseId = req.params.id;
     const ref = parseVeloRef(String(req.body?.ref ?? ""));

--- a/companion/tests/server/veloImportExternal.test.ts
+++ b/companion/tests/server/veloImportExternal.test.ts
@@ -92,7 +92,37 @@ async function makeApp(
   return { app, stateStore, getRowsFetchCalls: () => rowsFetchCalls };
 }
 
+// The same app with NO Velociraptor client — the "API not configured" gate. Every branch of this route
+// fetches from the server (getHuntArtifacts/huntResultsByArtifact/getFlowInfo/collectionResults/*Uploads),
+// so the gate is load-bearing, not incidental.
+async function makeUnconfiguredApp() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-velo-ext-off-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const superTimelineStore = new SuperTimelineStore(store);
+  const pipeline = buildRuntimePipeline({
+    provider: undefined, synthesisProvider: undefined, stateStore, store,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+  const app = createApp(store, { pipeline, stateStore, superTimelineStore });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return app;
+}
+
 describe("POST /cases/:id/velociraptor/import-external", () => {
+  // This route LOOKS like an offline import ("import" + a body you POST), but the body is a hunt/flow
+  // REFERENCE, not an export — the rows are fetched from the server. An analyst holding a colleague's
+  // export reads a bare "not configured" as a pointless gate, so the 501 must name what it would contact
+  // and hand them the genuinely offline route (POST /cases/:id/import-velociraptor).
+  it("501s naming the server it would contact, and points at the offline import route", async () => {
+    const app = await makeUnconfiguredApp();
+    const res = await request(app).post("/cases/c1/velociraptor/import-external").send({ ref: "H.ABC" });
+    expect(res.status).toBe(501);
+    expect(res.body.error).toMatch(/DFIR_VELOCIRAPTOR_API_CONFIG/);
+    expect(res.body.error).toMatch(/fetches/i);              // says it makes an outbound call
+    expect(res.body.error).toMatch(/import-velociraptor/);   // names the offline alternative
+  });
+
   it("400s on an unparseable ref", async () => {
     const { app } = await makeApp();
     const res = await request(app).post("/cases/c1/velociraptor/import-external").send({ ref: "junk" });


### PR DESCRIPTION
## The report, and why the gate stayed

`POST /cases/:id/velociraptor/import-external` was reported as gating an **offline** import behind a live-server requirement, with the request to drop the 501 — on the reading that the route "parses a payload the caller supplies and merges it into the case," and the caveat: *confirm the route genuinely makes no outbound call before removing the gate.*

It does make one, on every path. So the gate stayed.

`req.body.ref` is a hunt/flow **reference**, not an export — a pointer to a collection living on the server. The rows are then fetched:

| Ref kind | Outbound calls |
|---|---|
| hunt | `getHuntArtifacts` → `huntResultsByArtifact` |
| hunt + uploads tab | `huntUploads` |
| flow | `getFlowInfo` → `collectionResults` per artifact |
| flow + uploads tab | `flowUploads` |

All of these bottom out in `runRaw` → the injected `VqlRunner`, whose real implementation spawns the `velociraptor` binary with `--api_config` and talks gRPC+mTLS to the server. Removing the gate would convert a clear 501 into a 502 from a failed process spawn.

Two other details in the report didn't hold: the route is Velociraptor-specific (there is no IRIS/MISP/TheHive `import-external`), and the cited evidence — `companion/tests/e2e/workflows/integrations.spec.ts` — doesn't exist in this tree.

## What this changes instead

The underlying complaint is real, just misdiagnosed. The route *reads* like an offline import — it "imports", and you POST it a body — and the bare `"Velociraptor API not configured"` gave an analyst holding a colleague's export no way to see that the offline path already exists.

It does exist: **`POST /cases/:id/import-velociraptor`** parses pasted JSON, needs no client, and is not gated on the Velociraptor API. The offline path was never blocked, only undiscoverable from this error. The 501 now names what it would contact and hands the analyst that route.

## Note on placement

The message lives in `veloRef.ts`, not the route, because the size ledger freezes `routes/velociraptor.ts` and says to move new code out rather than grow it — inlining the explanation took the file to 896/888. `veloRef.ts` is the ref parser, and the confusion being corrected is precisely that *a ref is not an export*, so it's a fitting home. The route change is a two-line swap that adds no lines.

## Verification

- New test written failing first — it failed on the **message only**, confirming the 501 status was already correct.
- Full suite: **6805 tests / 536 files passing**.
- `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)