### PR TITLE
fix(export): carry a non-Latin-1 case name in Content-Disposition

### DIFF
--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -46,6 +46,37 @@ export function dfircaseFilename(caseId: string, name: string | null | undefined
   return `${caseId} - ${trimmed.replace(UNSAFE_FILENAME_CHARS, "_")}.dfircase`;
 }
 
+/**
+ * Build the `Content-Disposition` value for downloading `filename` as an attachment.
+ *
+ * A filename here carries the case NAME, which is free text an analyst typed — routinely an em
+ * dash, an accent, a non-Latin script. Interpolating that straight into the header made Node throw
+ * ERR_INVALID_CHAR (it rejects any header value holding a character above U+00FF) and the export
+ * route turned the throw into a bare 500, so every case whose name was not pure Latin-1 — the
+ * seeded demo case among them — was simply un-exportable. Sanitizing the name harder is the wrong
+ * cure: it silently mangles the filename for every analyst not working in English.
+ *
+ * RFC 6266 covers exactly this with two parameters: an ASCII-only `filename=` for clients that
+ * don't implement `filename*`, and a percent-encoded `filename*=UTF-8''…` (RFC 5987) carrying the
+ * real name for those that do. `filename*` is appended only when it can say something `filename=`
+ * cannot, so an ASCII download keeps the byte-identical header it has always sent.
+ */
+export function attachmentContentDisposition(filename: string): string {
+  // Everything outside printable ASCII collapses to "_" — the same placeholder the case name
+  // already uses for filesystem-unsafe characters. The quote and backslash go too: both are
+  // stripped upstream, but a quote reaching this string would close it early and let a crafted
+  // case name append header parameters of its own.
+  const ascii = filename.replace(/[^\x20-\x7e]|["\\]/g, "_");
+  const header = `attachment; filename="${ascii}"`;
+  if (ascii === filename) return header;
+  // RFC 5987's attr-char set excludes ' ( ) * , which encodeURIComponent leaves unescaped.
+  const encoded = encodeURIComponent(filename).replace(
+    /['()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `${header}; filename*=UTF-8''${encoded}`;
+}
+
 async function walkDir(dir: string, baseRel = ""): Promise<string[]> {
   const out: string[] = [];
   let entries;

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -14,7 +14,7 @@ import {
   importEncryptedCase,
   CaseImportConflictError,
   MIN_PASSWORD_LENGTH,
-  dfircaseFilename,
+  dfircaseFilename, attachmentContentDisposition,
 } from "../analysis/caseExportArchive.js";
 import { DecryptionError } from "../analysis/caseEncryption.js";
 import { getImportLimiter } from "../http/rateLimiter.js";
@@ -333,7 +333,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
         const filename = dfircaseFilename(id, meta.name);
         const { deleted } = await deleteCaseFolderBestEffort(id, requestAuthentication(req)?.identity);
         res.type("application/octet-stream");
-        res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+        res.setHeader("Content-Disposition", attachmentContentDisposition(filename));
         res.setHeader("Cache-Control", "private, no-cache");
         res.setHeader("X-Case-Deleted", String(deleted));
         return res.send(archive);
@@ -498,7 +498,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
         removedFromList = outcome.removed;
       }
       res.type("application/octet-stream");
-      res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+      res.setHeader("Content-Disposition", attachmentContentDisposition(filename));
       res.setHeader("Cache-Control", "private, no-cache");
       res.setHeader("X-Case-Removed-From-List", String(removedFromList));
       return res.send(archive);

--- a/companion/tests/analysis/caseExportArchive.test.ts
+++ b/companion/tests/analysis/caseExportArchive.test.ts
@@ -8,6 +8,7 @@ import {
   importEncryptedCase,
   CaseImportConflictError,
   dfircaseFilename,
+  attachmentContentDisposition,
 } from "../../src/analysis/caseExportArchive.js";
 import { createZip } from "../../src/analysis/zipArchive.js";
 import { encryptBuffer, DecryptionError } from "../../src/analysis/caseEncryption.js";
@@ -276,5 +277,50 @@ describe("dfircaseFilename", () => {
     expect(dfircaseFilename("INC-1", 'Acme: "Ransomware" / Attack <2026>')).toBe(
       "INC-1 - Acme_ _Ransomware_ _ Attack _2026_.dfircase",
     );
+  });
+
+  // Non-ASCII is legal in a filename on every platform this ships to, so the name keeps its own
+  // characters here — carrying them safely is attachmentContentDisposition's job, not this one's.
+  it("keeps non-ASCII characters in the name", () => {
+    expect(dfircaseFilename("INC-1", "GlobalTech — BEC")).toBe("INC-1 - GlobalTech — BEC.dfircase");
+  });
+});
+
+describe("attachmentContentDisposition", () => {
+  it("sends a plain ASCII filename as-is", () => {
+    expect(attachmentContentDisposition("INC-1 - Case One.dfircase")).toBe(
+      'attachment; filename="INC-1 - Case One.dfircase"',
+    );
+  });
+
+  // Node throws ERR_INVALID_CHAR on any header value holding a character above U+00FF, and clients
+  // misread the Latin-1 range, so a name with either has to travel percent-encoded in filename*
+  // (RFC 6266/5987) with an ASCII-only filename= left behind for clients that ignore filename*.
+  it("adds a percent-encoded filename* when the name is not ASCII", () => {
+    const header = attachmentContentDisposition("INC-1 - GlobalTech — BEC.dfircase");
+    expect(header).toBe(
+      'attachment; filename="INC-1 - GlobalTech _ BEC.dfircase"; ' +
+        "filename*=UTF-8''INC-1%20-%20GlobalTech%20%E2%80%94%20BEC.dfircase",
+    );
+  });
+
+  it("emits only header-safe bytes for any name", () => {
+    for (const name of ["ñ.dfircase", "案件.dfircase", "Ω — α.dfircase", "tab\there.dfircase"]) {
+      expect(attachmentContentDisposition(name)).toMatch(/^[\x20-\x7e]*$/);
+    }
+  });
+
+  // encodeURIComponent leaves ' ( ) * unescaped, but RFC 5987's attr-char set excludes them — a
+  // quote in particular would end the quoted string early in a client that parses filename* loosely.
+  it("percent-encodes the characters encodeURIComponent leaves behind", () => {
+    expect(attachmentContentDisposition("a'b(c)d*e—.dfircase")).toContain(
+      "filename*=UTF-8''a%27b%28c%29d%2Ae%E2%80%94.dfircase",
+    );
+  });
+
+  // A quote or backslash surviving into filename= would let a crafted case name inject extra
+  // header parameters; both are already stripped upstream, and the header builder re-checks.
+  it("never lets a quote or backslash into the ASCII filename", () => {
+    expect(attachmentContentDisposition('a"b\\c.dfircase')).toContain('filename="a_b_c.dfircase"');
   });
 });

--- a/companion/tests/server/encryptedCaseRoutes.test.ts
+++ b/companion/tests/server/encryptedCaseRoutes.test.ts
@@ -80,6 +80,43 @@ describe("POST /cases/:id/export/encrypted", () => {
       .send({ password: PASSWORD });
     expect(res.status).toBe(400);
   });
+
+  // A case name is free text an analyst typed, so it routinely holds characters outside Latin-1 —
+  // an em dash, an accent, a non-Latin script. Node rejects those outright in a header VALUE, so
+  // interpolating the name straight into Content-Disposition threw and the route turned it into a
+  // bare 500 with no hint of what was wrong. The demo case ships one ("GlobalTech Industries —
+  // BEC & Ransomware Precursor"), which made every seeded demo un-exportable.
+  it("exports a case whose name contains non-Latin-1 characters", async () => {
+    const { app, stateStore, store } = await harness();
+    await seedCase(app, stateStore, store);
+    await store.updateCaseMeta("INC-1", { name: "GlobalTech — BEC & Ransomware" });
+
+    const res = await bufferRequest(
+      request(app).post("/cases/INC-1/export/encrypted").send({ password: PASSWORD }),
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as Buffer).length).toBeGreaterThan(0);
+    // RFC 6266: the exact name travels in filename*, so a modern client saves the em dash intact,
+    // while filename= keeps an ASCII rendering for clients that ignore filename*.
+    expect(res.headers["content-disposition"]).toBe(
+      'attachment; filename="INC-1 - GlobalTech _ BEC & Ransomware.dfircase"; ' +
+        "filename*=UTF-8''INC-1%20-%20GlobalTech%20%E2%80%94%20BEC%20%26%20Ransomware.dfircase",
+    );
+  });
+
+  it("exports a case seeded by POST /cases/seed-demo", async () => {
+    const { app } = await harness();
+    const seeded = await request(app).post("/cases/seed-demo").send({ caseId: "demo", force: true });
+    expect(seeded.status).toBe(201);
+
+    const res = await bufferRequest(
+      request(app).post("/cases/demo/export/encrypted").send({ password: PASSWORD }),
+    );
+
+    expect(res.status).toBe(200);
+    expect((res.body as Buffer).length).toBeGreaterThan(0);
+  });
 });
 
 describe("POST /cases/import/encrypted", () => {


### PR DESCRIPTION
## The bug

`POST /cases/:id/export/encrypted` returned a bare 500 for every case created by `POST /cases/seed-demo`. Reproduced 3/3.

```
{"error":"Invalid character in header content [\"Content-Disposition\"]"}
```

The demo case is named **"GlobalTech Industries — BEC & Ransomware Precursor"** — that's an em dash (U+2014). Node throws `ERR_INVALID_CHAR` for any character above U+00FF in a header *value*, so the archive built in full and then the request died on the last `setHeader`.

The encrypted `.dfircase` is how an analyst hands a case to a colleague, so this removed the handoff and gave nothing to act on. Any case name with an accent or a non-Latin script hit it too — the demo case just made it reproducible on demand.

## Root cause

`dfircaseFilename` sanitizes only Windows-illegal filename characters. That is correct for a *filename* and insufficient for a *header*, and nothing downstream re-checked before the value reached `res.setHeader`.

The archive walker was **not** involved — the original suspicion. `exportEncryptedCase` builds a valid archive for a seeded demo case on its own, and `walkDir` never sees a dangling entry: seed-demo creates every directory it references.

## The fix

New `attachmentContentDisposition` helper implementing RFC 6266: an ASCII-only `filename=` plus a percent-encoded `filename*=UTF-8''…` carrying the real name.

Sanitizing the name harder was rejected deliberately — it silently mangles the filename for every analyst not working in English, and a Hebrew or Japanese case name would come out as a row of underscores. `filename*` is emitted only when it says something `filename=` cannot, so an ASCII export sends the byte-identical header it always did.

Applied at both `dfircaseFilename` call sites: the export route and its twin on the delete-with-archive path, which had the identical defect. The other nine `Content-Disposition` sites interpolate allowlisted keys or pre-sanitized ids, so the case name was the only free text reaching a header.

## Verification

Tests written first and watched fail with the reported 500, then pass. Against a live server, the exact reported repro:

```
HTTP/1.1 200 OK
Content-Disposition: attachment; filename="demo - GlobalTech Industries _ BEC & Ransomware Precursor.dfircase"; filename*=UTF-8''demo%20-%20GlobalTech%20Industries%20%E2%80%94%20BEC%20%26%20Ransomware%20Precursor.dfircase
Content-Length: 28602
```

The file opens: re-imported as `demo-copy` with all 12 findings, 17 IOCs, 58 forensic events, 5 captures, 4 imports.

- Full suite: **536 files / 6812 tests passing**
- All six gates green (typecheck, lint, size, imports, boundaries, format)

The new import is combined onto one line in `caseLifecycle.ts` because that file is size-ledgered and the one added line tripped the freeze — keeping net lines flat rather than re-baselining a ledger that exists to stop the file growing.

## Follow-up

`companion/tests/e2e/workflows/exports.spec.ts` on `claude/eli10-issue-386-6d37c8` documents this bug with the walkDir/ENOENT theory; its comment wants updating once that branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)