### PR TITLE
fix(zip): enforce the WinZip-AES authentication tag instead of discarding it

### DIFF
--- a/companion/src/analysis/zipArchive.ts
+++ b/companion/src/analysis/zipArchive.ts
@@ -1,6 +1,6 @@
 import { deflateRawSync, inflateRawSync } from "node:zlib";
 import {
-  zipCryptoDecrypt, verifyZipCryptoCheckByte, parseAesExtra, aesDecrypt, ZipPasswordError,
+  zipCryptoDecrypt, verifyZipCryptoCheckByte, parseAesExtra, aesDecrypt, ZipPasswordError, ZipAuthenticationError,
 } from "./zipCrypto.js";
 
 // A tiny, dependency-free ZIP writer/reader. The redacted case export (#54) bundles the
@@ -205,11 +205,26 @@ export function readZip(archive: Buffer, opts: ReadZipOptions = {}): ZipEntry[] 
         if (!params) {
           throw new ZipPasswordError(`zip entry "${name}" uses AES but has no readable AE header`, "unsupported-encryption");
         }
-        const { plaintext } = aesDecrypt(compressed, password, params.strength);
+        const { plaintext, macOk } = aesDecrypt(compressed, password, params.strength);
+        // Fail closed on the HMAC, for BOTH AE-1 and AE-2. The tag is the only cryptographic
+        // integrity control WinZip AES has; the CRC is neither a substitute (CRC-32 is linear and
+        // non-cryptographic, and its stored value sits in the central directory the same adversary
+        // can rewrite) nor even present for AE-2. This was previously computed and dropped, which
+        // left AE-2 entries with no integrity verification of any kind: the cipher is AES-CTR, so
+        // flipping a ciphertext bit flips exactly that plaintext bit, and a modified log line, hash
+        // or command line was accepted as authentic (#428). params.aeVersion and params.actualMethod
+        // come from the archive's own 0x9901 field, so the attacker picks AE-2 and STORED to route
+        // around both checks — which is precisely why this one may not be conditional.
+        if (!macOk) {
+          throw new ZipAuthenticationError(
+            `zip entry "${name}" failed AES authentication — the archive was modified after it was ` +
+            `created (or, once in 65536, the password is wrong in a way the verifier missed)`,
+          );
+        }
         compressed = plaintext;
         effectiveMethod = params.actualMethod;
-        // AE-2 stores a zero CRC by design, so the usual integrity check would always fail.
-        // The HMAC already authenticated the data.
+        // AE-2 stores a zero CRC by design, so the usual check would always fail. Skipping it is
+        // sound only because the HMAC above ran and passed.
         verifyCrc = params.aeVersion !== 2;
       } else {
         const decrypted = zipCryptoDecrypt(compressed, password);

--- a/companion/src/analysis/zipCrypto.ts
+++ b/companion/src/analysis/zipCrypto.ts
@@ -84,6 +84,24 @@ export class ZipPasswordError extends Error {
   }
 }
 
+/**
+ * The WinZip-AES HMAC did not match — the entry's ciphertext is not what the archive's author
+ * encrypted. Deliberately NOT a ZipPasswordError: the password already cleared the 2-byte
+ * verifier, so trying more candidates is pointless, and callers that retry on a password failure
+ * (zipExtract) must stop and report this instead.
+ *
+ * It is also not a generic "corrupt ZIP" error. WinZip AES is AES-CTR, which is bit-for-bit
+ * malleable — flipping a ciphertext bit flips exactly that plaintext bit — so a failed tag over
+ * evidence means targeted, predictable modification at least as plausibly as it means bit rot.
+ * An analyst needs to be able to tell "wrong password" from "this archive was altered".
+ */
+export class ZipAuthenticationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ZipAuthenticationError";
+  }
+}
+
 export interface AesParams {
   aeVersion: number;       // 1 or 2; AE-2 zeroes the entry CRC, so callers must skip the CRC check
   strength: 1 | 2 | 3;     // AES-128 / AES-192 / AES-256

--- a/companion/tests/analysis/zipArchive.test.ts
+++ b/companion/tests/analysis/zipArchive.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { inflateRawSync } from "node:zlib";
 import { createZip, readZip, crc32, type ZipEntry } from "../../src/analysis/zipArchive.js";
-import { ZipPasswordError } from "../../src/analysis/zipCrypto.js";
+import { ZipPasswordError, ZipAuthenticationError, aesDecrypt } from "../../src/analysis/zipCrypto.js";
 
 const EOCD_SIG = 0x06054b50;
 const LOCAL_SIG = 0x04034b50;
@@ -149,6 +149,73 @@ describe("readZip with encrypted entries", () => {
       expect(err).toBeInstanceOf(ZipPasswordError);
       expect((err as ZipPasswordError).reason).toBe("wrong-password");
     }
+  });
+
+  // #428: aesDecrypt has always computed the WinZip-AES HMAC and returned it as `macOk`; readZip
+  // destructured `plaintext` and threw it away. For AE-2 the CRC check is skipped as well (the
+  // format stores a zero CRC), so those entries had NO integrity verification of any kind.
+  // WinZip AES is AES-CTR: flipping one ciphertext bit flips exactly that plaintext bit, so an
+  // adversary who can touch the archive in transit can make targeted edits to evidence.
+  describe("AES tamper detection", () => {
+    // Overwrite one byte in the middle of the entry's ciphertext, leaving salt, password verifier
+    // and the stored HMAC untouched — so the password still verifies and only the tag disagrees.
+    function tamper(b64: string): Buffer {
+      const archive = Buffer.from(b64, "base64");
+      let eocd = -1;
+      for (let i = archive.length - 22; i >= 0; i--) {
+        if (archive.readUInt32LE(i) === EOCD_SIG) { eocd = i; break; }
+      }
+      const central = archive.readUInt32LE(eocd + 16);
+      const localOffset = archive.readUInt32LE(central + 42);
+      const dataStart = localOffset + 30 + archive.readUInt16LE(localOffset + 26) + archive.readUInt16LE(localOffset + 28);
+      const AES256_SALT = 16, PW_VERIFY = 2;
+      const target = dataStart + AES256_SALT + PW_VERIFY + 5;   // 6th ciphertext byte
+      archive[target] ^= 0x20;   // one bit — enough to rewrite a character of the plaintext
+      return archive;
+    }
+
+    it("rejects an AE-2 entry whose ciphertext was altered after creation", () => {
+      expect(() => readZip(tamper(AES_ZIP_B64), { password: "infected" }))
+        .toThrow(ZipAuthenticationError);
+    });
+
+    it("reports tampering distinctly from a wrong password", () => {
+      // The analyst has to be able to tell "try another password" from "this archive was altered";
+      // a ZipAuthenticationError is deliberately NOT a ZipPasswordError, so the password-retry
+      // loop in zipExtract stops rather than reporting a password problem.
+      try {
+        readZip(tamper(AES_ZIP_B64), { password: "infected" });
+        throw new Error("expected readZip to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ZipAuthenticationError);
+        expect(err).not.toBeInstanceOf(ZipPasswordError);
+        expect((err as Error).message).toMatch(/modified/i);
+      }
+    });
+
+    it("the flipped bit really did reach the plaintext — this is what used to be accepted", () => {
+      // Proves the test above is testing something: without the macOk check the modified bytes
+      // came straight back, because the entry is STORED and AE-2 skips the CRC.
+      const archive = tamper(AES_ZIP_B64);
+      let eocd = -1;
+      for (let i = archive.length - 22; i >= 0; i--) {
+        if (archive.readUInt32LE(i) === EOCD_SIG) { eocd = i; break; }
+      }
+      const central = archive.readUInt32LE(eocd + 16);
+      const compSize = archive.readUInt32LE(central + 20);
+      const localOffset = archive.readUInt32LE(central + 42);
+      const dataStart = localOffset + 30 + archive.readUInt16LE(localOffset + 26) + archive.readUInt16LE(localOffset + 28);
+      const { plaintext, macOk } = aesDecrypt(archive.subarray(dataStart, dataStart + compSize), "infected", 3);
+      expect(macOk).toBe(false);
+      expect(plaintext.toString("utf8")).not.toBe("MZ fake sample payload\n");
+      // One bit flipped in the ciphertext → exactly one character changed in the evidence.
+      expect(plaintext.toString("utf8")).toBe("MZ faKe sample payload\n");
+    });
+
+    it("an untampered AE-2 entry still opens", () => {
+      const back = readZip(Buffer.from(AES_ZIP_B64, "base64"), { password: "infected" });
+      expect(back[0].data.toString("utf8")).toBe("MZ fake sample payload\n");
+    });
   });
 
   it("still round-trips unencrypted archives unchanged", () => {

--- a/companion/tests/analysis/zipExtract.test.ts
+++ b/companion/tests/analysis/zipExtract.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createZip } from "../../src/analysis/zipArchive.js";
 import { candidatePasswords, extractZipEntries, MAX_ZIP_ENTRIES } from "../../src/analysis/zipExtract.js";
+import { ZipAuthenticationError } from "../../src/analysis/zipCrypto.js";
 
 const ZC_ZIP_B64 =
   "UEsDBAoACQAAAGWB/VzrJ0KsIwAAABcAAAAKABwAc2FtcGxlLmJpblVUCQAD7vtpau77aWp1eAsAAQToAwAABOgDAACSY93uO3OX" +
@@ -14,6 +15,13 @@ const CUSTOM_ZIP_B64 =
   "UEsDBAoACQAAAO2C/Vx7BJ0tJAAAABgAAAAKABwAc2VjcmV0LmJpblVUCQADzf5pas3+aWp1eAsAAQToAwAABOgDAACQ7YfTxb3j" +
   "gnkcB9RnjbnCiwID4RlVYqmQgwa8AzOEfM/SLxRQSwcIewSdLSQAAAAYAAAAUEsBAh4DCgAJAAAA7YL9XHsEnS0kAAAAGAAAAAoA" +
   "GAAAAAAAAQAAALSBAAAAAHNlY3JldC5iaW5VVAUAA83+aWp1eAsAAQToAwAABOgDAABQSwUGAAAAAAEAAQBQAAAAeAAAAAAA";
+
+// 7-Zip: `7z a -tzip -pinfected -mem=AES256 aes.zip sample.bin` — AE-2, STORED, 23 bytes.
+const AES_ZIP_B64 =
+  "UEsDBDMAAQBjAGaB/VwAAAAAMwAAABcAAAAKAAsAc2FtcGxlLmJpbgGZBwACAEFFAwAAjSVbocfmvx3PE5161dsvWZeAGwRMGhH+" +
+  "U3dNZiO2mA/QMCMLIAwEGRmcHEdlOo1WBP7zUEsBAj8DMwABAGMAZoH9XAAAAAAzAAAAFwAAAAoALwAAAAAAAAAggLSBAAAAAHNh" +
+  "bXBsZS5iaW4KACAAAAAAAAEAGAC4I7e5Wx/dAQAAAAAAAAAAAAAAAAAAAAABmQcAAgBBRQMAAFBLBQYAAAAAAQABAGcAAABmAAAA" +
+  "AAA=";
 
 describe("candidatePasswords", () => {
   it("defaults to infected when nothing is supplied", () => {
@@ -104,5 +112,24 @@ describe("extractZipEntries", () => {
     // Nothing in the ladder opens this one, so the analyst gets an actionable error.
     expect(() => extractZipEntries(Buffer.from(CUSTOM_ZIP_B64, "base64"), "custom.zip"))
       .toThrow(/password/i);
+  });
+
+  // #428: this is the evidence-ingestion entry point, and the password ladder is where a tamper
+  // signal would go missing. ZipAuthenticationError is deliberately not a ZipPasswordError, so the
+  // loop stops on the first candidate and reports the modification instead of walking the rest of
+  // the ladder and blaming the password.
+  it("surfaces AES tampering as tampering, not as 'wrong password (tried N passwords)'", () => {
+    const archive = Buffer.from(AES_ZIP_B64, "base64");
+    let eocd = -1;
+    for (let i = archive.length - 22; i >= 0; i--) {
+      if (archive.readUInt32LE(i) === 0x06054b50) { eocd = i; break; }
+    }
+    const central = archive.readUInt32LE(eocd + 16);
+    const localOffset = archive.readUInt32LE(central + 42);
+    const dataStart = localOffset + 30 + archive.readUInt16LE(localOffset + 26) + archive.readUInt16LE(localOffset + 28);
+    archive[dataStart + 16 + 2 + 5] ^= 0x20;   // past salt + verifier, into the ciphertext
+
+    expect(() => extractZipEntries(archive, "aes.zip")).toThrow(ZipAuthenticationError);
+    expect(() => extractZipEntries(archive, "aes.zip")).toThrow(/modified/i);
   });
 });


### PR DESCRIPTION
Closes #428.

`aesDecrypt()` computes the WinZip-AES HMAC-SHA1 tag and returns `{ plaintext, macOk }` precisely so the caller can reject tampered data. The only production caller did:

```ts
const { plaintext } = aesDecrypt(compressed, password, params.strength);   // macOk dropped
```

`macOk` was read nowhere in `src/` — only in two unit assertions that check it is *computed*, never that it is *enforced*.

For **AE-2** entries there was no fallback either. The format stores a zero CRC, so `verifyCrc = params.aeVersion !== 2` skips the CRC check too. Those entries had **no integrity verification of any kind**, behind a comment asserting an invariant the code did not enforce:

```
// AE-2 stores a zero CRC by design, so the usual integrity check would always fail.
// The HMAC already authenticated the data.
```

## Why it matters

WinZip AES is AES-CTR (`aesCtrXor`), which is bit-for-bit malleable — flipping a ciphertext bit flips exactly that plaintext bit. An adversary who can modify a password-protected archive in transit could make targeted, predictable edits to decrypted evidence and the importer accepted them silently. The path is reachable from evidence ingestion via `extractZipEntries`.

`params.aeVersion` and `params.actualMethod` both come from the archive's own `0x9901` extra field — the same bytes the adversary controls — so they select AE-2 (skip the CRC) and STORED (no deflate in the way) and the flipped bytes flow straight through. That is exactly why the tag check may not be conditional on either.

## The fix

`readZip` fails closed on `macOk`, for **AE-1 and AE-2 alike**. The CRC is not a substitute at either version: CRC-32 is linear and non-cryptographic, and its stored value lives in the central directory the attacker can rewrite.

The failure is a new **`ZipAuthenticationError`**, deliberately *not* a `ZipPasswordError`:

- the password already cleared the 2-byte PBKDF2 verifier, so trying more candidates is pointless — `zipExtract`'s password ladder stops instead of walking the rest and blaming the password;
- an analyst needs to tell *"wrong password"* from *"this archive was altered"*. The message names the 1-in-65536 case where a wrong password beats the verifier, so the distinction stays honest rather than overclaiming.

The stale comment at the CRC skip now says what the code does.

## Tests

Four new tests, three failing on master:

- `zipArchive.test.ts` — one flipped ciphertext bit in the AE-2 fixture → `ZipAuthenticationError`; asserted *not* to be a `ZipPasswordError`; an untampered entry still opens.
- A test that decrypts the same tampered entry directly and shows what used to come back: `macOk === false`, plaintext `"MZ faKe sample payload"` — one character rewritten, no error raised. This is the proof the other tests are testing something.
- `zipExtract.test.ts` — the same tampered archive through the evidence-ingestion entry point, asserting the password ladder surfaces tampering rather than `"wrong password (tried N passwords)"`.

## Gates

All seven clean; full suite **6862 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)