### PR TITLE
fix(auth): bound local login per client, not only per account

### DIFF
--- a/companion/src/auth/authRoutes.ts
+++ b/companion/src/auth/authRoutes.ts
@@ -1,12 +1,11 @@
 import type { Express, Request, Response } from "express";
-import { AttemptLimiter } from "../http/rateLimiter.js";
+import { getLoginLimiter, getLoginIpLimiter } from "../http/rateLimiter.js";
 import { withNonce } from "../http/securityHeaders.js";
 import { readPublicAsset } from "../serverAssets.js";
 import type { TeamAuth } from "./teamAuth.js";
 import { isValidCaseId, type CaseStore } from "../storage/caseStore.js";
+import { isValidUsername } from "./authStore.js";
 import { isCaseRole, isGlobalRole, isServicePermission, type RequestAuthentication } from "./types.js";
-
-const loginLimiter = new AttemptLimiter(5, 30_000);
 
 function bodyObject(req: Request): Record<string, unknown> {
   return req.body && typeof req.body === "object" && !Array.isArray(req.body)
@@ -206,7 +205,24 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
   app.post("/auth/local/login", async (req: Request, res: Response) => {
     const body = bodyObject(req);
     const username = bodyString(body, "username");
-    const key = `${req.ip}:${username.toLowerCase()}`;
+    const ip = req.ip ?? "unknown";
+    // Client-wide budget FIRST, and consumed by every attempt. The per-account key below is
+    // `ip:username`, so rotating the username handed out a fresh bucket per request: the five-try
+    // lockout still protected one named account, but an unauthenticated caller could run an
+    // unbounded sequence of scrypt verifications, permanent audit rows and limiter Map entries
+    // from a single client (#421).
+    if (!getLoginIpLimiter().tryAcquire(ip)) {
+      res.setHeader("Retry-After", "60");
+      return res.status(429).json({ error: "too many attempts, try again later" });
+    }
+    // A username that could never name an account buys nothing: no lookup, no verification against
+    // the dummy hash, no audit row. Same generic 401 as a wrong password — this must not become a
+    // way to tell "no such user" from "wrong password".
+    if (!isValidUsername(username)) {
+      return res.status(401).json({ error: "invalid username or password" });
+    }
+    const loginLimiter = getLoginLimiter();
+    const key = `${ip}:${username.toLowerCase()}`;
     const remaining = loginLimiter.remainingLockout(key);
     if (remaining > 0) {
       res.setHeader("Retry-After", String(Math.ceil(remaining / 1_000)));
@@ -215,7 +231,15 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
     const identity = await auth.store.verifyLocalCredentials(username, bodyString(body, "password"));
     if (!identity) {
       loginLimiter.recordFailure(key);
-      auth.store.addAudit(undefined, "local-login-failed", undefined, undefined, `username=${username}`);
+      // Bounded even though isValidUsername already caps it at 64 — the audit table is permanent,
+      // and the detail column should never be the place a length assumption is first tested.
+      auth.store.addAudit(
+        undefined,
+        "local-login-failed",
+        undefined,
+        undefined,
+        `username=${username.slice(0, 64)}`,
+      );
       return res.status(401).json({ error: "invalid username or password" });
     }
     loginLimiter.clear(key);

--- a/companion/src/auth/authStore.ts
+++ b/companion/src/auth/authStore.ts
@@ -73,9 +73,19 @@ function tokenHash(token: string): string {
   return createHash("sha256").update(token, "utf8").digest("hex");
 }
 
+const USERNAME_SYNTAX = /^[A-Za-z0-9][A-Za-z0-9._@-]{2,63}$/;
+
+/** The same rule account creation enforces, as a predicate. The login route needs it to reject a
+ *  malformed username BEFORE the database lookup, the scrypt verification against the dummy hash,
+ *  and the permanent audit row — none of which a string that could never name an account should
+ *  ever be able to buy (#421). */
+export function isValidUsername(value: string): boolean {
+  return USERNAME_SYNTAX.test(value.trim());
+}
+
 function normalizeUsername(value: string): string {
   const username = value.trim();
-  if (!/^[A-Za-z0-9][A-Za-z0-9._@-]{2,63}$/.test(username)) {
+  if (!isValidUsername(username)) {
     throw new Error("username must be 3-64 letters, numbers, dots, dashes, underscores, or @");
   }
   return username;

--- a/companion/src/http/rateLimiter.ts
+++ b/companion/src/http/rateLimiter.ts
@@ -148,6 +148,10 @@ let _unlockSweepTimer: NodeJS.Timeout | null = null;
 let _aiSweepTimer: NodeJS.Timeout | null = null;
 let _importSweepTimer: NodeJS.Timeout | null = null;
 let _importIpSweepTimer: NodeJS.Timeout | null = null;
+let _loginLimiter: AttemptLimiter | null = null;
+let _loginIpLimiter: SlidingWindowLimiter | null = null;
+let _loginSweepTimer: NodeJS.Timeout | null = null;
+let _loginIpSweepTimer: NodeJS.Timeout | null = null;
 
 export function getUnlockLimiter(): AttemptLimiter {
   if (!_unlockLimiter) {
@@ -202,6 +206,37 @@ export function getImportIpLimiter(): SlidingWindowLimiter {
   return _importIpLimiter;
 }
 
+/** Per-ACCOUNT failed-login limiter for POST /auth/local/login, keyed by client IP + username.
+ *  That key is what makes it insufficient on its own: an unauthenticated caller who rotates the
+ *  username gets a fresh bucket per request, so this limiter alone bounded brute force against one
+ *  named account while bounding nothing per client (#421). Pair it with getLoginIpLimiter().
+ *
+ *  It used to be a bare `new AttemptLimiter(...)` module constant in authRoutes.ts, with no sweep
+ *  scheduled — one permanent Map entry per (ip, username) ever tried. */
+export function getLoginLimiter(): AttemptLimiter {
+  if (!_loginLimiter) {
+    const limiter = new AttemptLimiter(5, 30_000);
+    _loginLimiter = limiter;
+    _loginSweepTimer = setInterval(() => limiter.sweep(), SWEEP_INTERVAL_MS);
+    _loginSweepTimer.unref?.();
+  }
+  return _loginLimiter;
+}
+
+/** Client-wide login budget, keyed by IP alone and consumed by EVERY login attempt — not only the
+ *  failures — because the cost being bounded is the scrypt verification itself, which a miss pays
+ *  in full against the dummy hash. 60 a minute is far past any human at a login form and still
+ *  caps one client at roughly one password hash per second. */
+export function getLoginIpLimiter(): SlidingWindowLimiter {
+  if (!_loginIpLimiter) {
+    const limiter = new SlidingWindowLimiter(60, 60_000);
+    _loginIpLimiter = limiter;
+    _loginIpSweepTimer = setInterval(() => limiter.sweep(), SWEEP_INTERVAL_MS);
+    _loginIpSweepTimer.unref?.();
+  }
+  return _loginIpLimiter;
+}
+
 /** Reset singletons (tests). Also clears each singleton's sweep timer so repeated
  *  reset+get cycles in a test suite don't stack up abandoned intervals. */
 export function resetLimiters(): void {
@@ -209,6 +244,8 @@ export function resetLimiters(): void {
   if (_aiSweepTimer) clearInterval(_aiSweepTimer);
   if (_importSweepTimer) clearInterval(_importSweepTimer);
   if (_importIpSweepTimer) clearInterval(_importIpSweepTimer);
+  if (_loginSweepTimer) clearInterval(_loginSweepTimer);
+  if (_loginIpSweepTimer) clearInterval(_loginIpSweepTimer);
   _unlockSweepTimer = null;
   _aiSweepTimer = null;
   _importSweepTimer = null;
@@ -217,4 +254,8 @@ export function resetLimiters(): void {
   _aiLimiter = null;
   _importLimiter = null;
   _importIpLimiter = null;
+  _loginSweepTimer = null;
+  _loginIpSweepTimer = null;
+  _loginLimiter = null;
+  _loginIpLimiter = null;
 }

--- a/companion/tests/http/loginRateLimit.test.ts
+++ b/companion/tests/http/loginRateLimit.test.ts
@@ -1,0 +1,127 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStore } from "../../src/auth/authStore.js";
+import { TeamAuth } from "../../src/auth/teamAuth.js";
+import { createApp } from "../../src/server.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { getLoginLimiter, resetLimiters } from "../../src/http/rateLimiter.js";
+
+/**
+ * POST /auth/local/login, resource bounds (#421).
+ *
+ * The limiter was keyed by `ip:username`, so an unauthenticated caller who changed the username on
+ * every request got a fresh bucket each time — and with it an unbounded sequence of scrypt
+ * verifications against the dummy hash, permanent audit rows, and Map entries in a limiter nothing
+ * ever swept. The five-attempt lockout still protected one named account; it bounded nothing per
+ * client.
+ */
+const BOOTSTRAP_TOKEN = "test-bootstrap-token-with-enough-entropy";
+
+let cases: CaseStore;
+let authStore: AuthStore;
+let app: ReturnType<typeof createApp>;
+
+beforeEach(async () => {
+  resetLimiters();
+  const root = await mkdtemp(join(tmpdir(), "dfir-login-limit-"));
+  cases = new CaseStore(join(root, "cases"));
+  authStore = new AuthStore(join(root, "auth.sqlite"));
+  const auth = new TeamAuth({
+    store: authStore,
+    bootstrapToken: BOOTSTRAP_TOKEN,
+    cookieSecure: false,
+    sessionTtlMs: 60 * 60_000,
+  });
+  app = createApp(cases, { teamAuth: auth });
+  await request(app).post("/auth/bootstrap").send({
+    bootstrapToken: BOOTSTRAP_TOKEN,
+    username: "admin",
+    password: "correct horse battery staple",
+    displayName: "Primary Admin",
+  });
+});
+
+afterEach(() => {
+  resetLimiters();
+  vi.useRealTimers();
+});
+
+async function attempt(username: string) {
+  return request(app).post("/auth/local/login").send({ username, password: "not the password" });
+}
+
+describe("login limiter — rotating usernames", () => {
+  it("reaches the client-wide limit instead of running forever", async () => {
+    // Each username is well-formed and nonexistent: on master every one of these got its own
+    // bucket and its own scrypt verification, and none ever reached a 429.
+    let sawLimit = false;
+    for (let i = 0; i < 70; i++) {
+      const res = await attempt(`rotating-user-${i}`);
+      if (res.status === 429) {
+        sawLimit = true;
+        break;
+      }
+      expect(res.status).toBe(401);
+    }
+    expect(sawLimit).toBe(true);
+  });
+
+  it("bounds the audit table along with the attempts", async () => {
+    for (let i = 0; i < 70; i++) await attempt(`audit-rotate-${i}`);
+    // One row per attempt that reached the credential check; the 429s add none.
+    const failures = authStore.listAudit(500).filter((e) => e.action === "local-login-failed");
+    expect(failures.length).toBeLessThan(70);
+  });
+
+  it("still locks out a single named account after five tries", async () => {
+    // The per-account control is unchanged — the client-wide budget is an addition, not a swap.
+    for (let i = 0; i < 5; i++) expect((await attempt("admin")).status).toBe(401);
+    const res = await attempt("admin");
+    expect(res.status).toBe(429);
+    expect(res.headers["retry-after"]).toBeTruthy();
+  });
+
+  it("lets a correct password through", async () => {
+    const res = await request(app)
+      .post("/auth/local/login")
+      .send({ username: "admin", password: "correct horse battery staple" });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("login limiter — malformed usernames", () => {
+  it("rejects a username that could never name an account, without an audit row", async () => {
+    const before = authStore.listAudit(500).length;
+    for (const bad of ["", "ab", "x".repeat(200), "has space", "back\\slash", "sql'inject"]) {
+      const res = await attempt(bad);
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("invalid username or password"); // no user enumeration
+    }
+    expect(authStore.listAudit(500).length).toBe(before);
+  });
+
+  it("does not create a limiter bucket for a malformed username", async () => {
+    await attempt("!!!");
+    // remainingLockout on a key that was never recorded is 0; the point is that no entry exists
+    // at all, so a rotation of malformed names cannot grow the Map.
+    expect(getLoginLimiter().sweep(Date.now() + 7_200_000)).toBe(0);
+  });
+});
+
+describe("login limiter — state does not accumulate", () => {
+  it("sweeps idle keys on a schedule rather than keeping them forever", async () => {
+    vi.useFakeTimers();
+    resetLimiters();
+    const limiter = getLoginLimiter(); // creating it schedules the sweep interval
+    limiter.recordFailure("10.0.0.1:someone");
+    expect(limiter.remainingLockout("10.0.0.1:someone")).toBe(0); // one failure, not yet locked
+
+    // Past the 1h idle window, and past at least one 5-minute sweep tick.
+    await vi.advanceTimersByTimeAsync(3_600_000 + 5 * 60_000 + 1_000);
+    // The entry is gone, so a fresh failure starts from scratch rather than continuing a cycle.
+    expect(limiter.sweep(Date.now() + 7_200_000)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #421.

The local-login limiter was keyed by client IP **plus the submitted username**:

```ts
const key = `${req.ip}:${username.toLowerCase()}`;
```

Rotating the username handed out a fresh bucket on every request. The five-attempt lockout still protected one *named account*; it bounded nothing per *client*.

Every miss on a nonexistent user still paid for a full scrypt verification against the dummy password hash, inserted a permanent authentication-audit row, and added an entry to an in-memory limiter with **no sweep scheduled**. On a remotely reachable team deployment, an unauthenticated caller could hold the password-hashing worker pool busy indefinitely while growing both process memory and the auth database, never once seeing a 429.

## Three controls, in the order a request meets them

1. **Client-wide budget**, keyed by IP alone — 60/minute, consumed by *every* attempt rather than only the failures, because the cost being bounded is the scrypt verification itself and a miss pays it in full. Far past any human at a login form; caps one client at roughly one password hash per second.
2. **Username syntax**, checked against the same 3–64 rule `normalizeUsername` already enforces at account creation, *before* the database lookup, the hash verification, and the audit row. A string that could never name an account now buys none of them. The response is the same generic 401 as a wrong password — this must not become a way to tell "no such user" from "wrong password".
3. **The existing per-account lockout**, unchanged.

## Limiter lifecycle

The limiter moves out of `authRoutes.ts`, where it was a bare `new AttemptLimiter(...)` module constant, into the `rateLimiter.ts` singletons alongside the unlock / import / AI limiters. It therefore gets the periodic sweep those already have, and `resetLimiters()` clears it.

That last part was also a **test-isolation bug**: because the old instance was outside `resetLimiters()`, a lockout from one test leaked into the next. Running the new suite against the old route shows it — "lets a correct password through" fails purely from a leaked lockout.

The username copied into the audit detail is bounded too. `isValidUsername` already caps it at 64, but the audit table is permanent and its detail column should not be where a length assumption is first tested.

## Tests

`tests/http/loginRateLimit.test.ts` (new), 7 tests. Against the old route: 4 fail.

- 70 rotating well-formed usernames now reach a 429 (on master, all 70 return 401 having each paid a KDF)
- the audit table stops growing with them
- malformed usernames (`""`, `"ab"`, 200 chars, spaces, backslash, quote) → 401 with **no** audit row and **no** limiter bucket
- the per-account five-try lockout still fires, and a correct password still logs in
- a fake-timer test proving idle keys are swept on schedule rather than kept forever

## Gates

All seven clean; full suite **6864 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)