### PR TITLE
fix(import): publish an encrypted import with one atomic rename

### DIFF
--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -1,4 +1,14 @@
-import { readdir, readFile, writeFile, mkdir, lstat } from "node:fs/promises";
+import {
+  readdir,
+  readFile,
+  writeFile,
+  mkdir,
+  mkdtemp,
+  rename as renamePath,
+  rm,
+  stat,
+  lstat,
+} from "node:fs/promises";
 import { join, dirname, isAbsolute } from "node:path";
 import { createHash } from "node:crypto";
 import { isValidCaseId, type CaseStore } from "../storage/caseStore.js";
@@ -16,6 +26,11 @@ import { INVESTIGATION_DB_FILENAME } from "./stateStore.js";
 // this covers screenshots and raw imported evidence files too, not just derived state.
 
 export const MIN_PASSWORD_LENGTH = 8;
+
+// Where an encrypted import extracts before it is published (#420). Dotted, and a level below the
+// cases, so nothing that enumerates the cases root can mistake a half-extracted archive for a case.
+const IMPORT_STAGING_DIRNAME = ".import-staging";
+const IMPORT_STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 export class CaseImportConflictError extends Error {
   constructor(public readonly caseId: string) {
@@ -408,25 +423,77 @@ export async function importEncryptedCase(
   }
 
   const counts = manifestCounts ?? countsFromEntries(entries);
-  const caseDir = store.caseDir(targetCaseId);
-  for (const dir of [
-    store.screenshotsDir(targetCaseId),
-    store.metadataDir(targetCaseId),
-    store.stateDir(targetCaseId),
-    store.reportsDir(targetCaseId),
-    store.importsDir(targetCaseId),
-  ]) {
-    await mkdir(dir, { recursive: true });
-  }
 
-  for (const entry of entries) {
-    const data = rewrittenByPath.get(entry.path) ?? entry.data;
-    const target = join(caseDir, entry.path);
-    await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, data);
+  // Extract into a private staging directory and publish it with a single rename (#420).
+  //
+  // The caseExists() check above is not a claim on the id — nothing stopped a second import from
+  // passing the same check and then interleaving its writes into the same destination. The result
+  // was a case that never existed in either archive: case.json from whichever import wrote it
+  // last, evidence files from both. Nothing downstream could detect that, so every analysis,
+  // report and custody record built on it was untrustworthy.
+  //
+  // rename() of a directory onto an existing non-empty directory fails on every platform, which
+  // makes it the exclusive atomic claim the existence check never was: the first import to finish
+  // publishes, and any other aiming at the same id gets a conflict instead of a merge. It also
+  // means a case directory only ever becomes visible complete — a failure part-way through the
+  // write loop used to leave an orphan that made caseExists() true for a case that never imported.
+  const staging = await createImportStaging(store, targetCaseId);
+  try {
+    for (const sub of ["screenshots", "metadata", "state", "reports", "imports"]) {
+      await mkdir(join(staging, sub), { recursive: true });
+    }
+
+    for (const entry of entries) {
+      const data = rewrittenByPath.get(entry.path) ?? entry.data;
+      const target = join(staging, entry.path);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, data);
+    }
+
+    try {
+      await renamePath(staging, join(store.casesRoot, targetCaseId)); // `rename` is taken: the id-rewrite flag above
+    } catch (err) {
+      // Platforms disagree on the errno for "destination directory is in the way" (ENOTEMPTY,
+      // EEXIST, EPERM on Windows), so ask the filesystem what actually happened rather than
+      // enumerating codes: if the target is a case now, someone else claimed it.
+      if (await store.caseExists(targetCaseId)) throw new CaseImportConflictError(targetCaseId);
+      throw err;
+    }
+  } finally {
+    // No-op after a successful rename; on any failure it is what keeps a half-extracted archive
+    // from surviving as a stale staging directory.
+    await rm(staging, { recursive: true, force: true }).catch(() => {
+      /* best effort */
+    });
   }
 
   const meta = await store.getCaseMeta(targetCaseId);
   if (!meta) throw new Error("import failed: case.json missing after write");
   return { meta, counts };
+}
+
+/**
+ * A unique, private directory to extract into, on the same filesystem as the destination so the
+ * publishing rename is atomic. It lives under a dotted subdirectory of the cases root rather than
+ * beside the cases: listCases() only treats a directory holding a readable case.json as a case, and
+ * a half-extracted archive holds exactly that.
+ *
+ * Also sweeps staging directories older than a day. The finally block above removes this run's on
+ * every path a process survives; the sweep is for the one it does not (a kill or a power loss
+ * mid-extraction), so those cannot accumulate forever. A day is far longer than any import, so it
+ * cannot collide with a slow one running concurrently.
+ */
+async function createImportStaging(store: CaseStore, targetCaseId: string): Promise<string> {
+  const stagingRoot = join(store.casesRoot, IMPORT_STAGING_DIRNAME);
+  await mkdir(stagingRoot, { recursive: true });
+  const cutoff = Date.now() - IMPORT_STAGING_MAX_AGE_MS;
+  for (const name of await readdir(stagingRoot).catch(() => [])) {
+    const path = join(stagingRoot, name);
+    const info = await stat(path).catch(() => null);
+    if (info && info.mtimeMs < cutoff)
+      await rm(path, { recursive: true, force: true }).catch(() => {
+        /* best effort */
+      });
+  }
+  return mkdtemp(join(stagingRoot, `${targetCaseId}-`));
 }

--- a/companion/tests/analysis/caseExportArchive.test.ts
+++ b/companion/tests/analysis/caseExportArchive.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, readFile, writeFile, mkdir, symlink, link } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, writeFile, mkdir, symlink, link } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
@@ -21,8 +22,8 @@ async function harness() {
   return new CaseStore(root);
 }
 
-async function seedCase(store: CaseStore, caseId: string) {
-  await store.createCase({ caseId, name: "Case One", investigator: "alice", aiProvider: "anthropic" });
+async function seedCase(store: CaseStore, caseId: string, name = "Case One") {
+  await store.createCase({ caseId, name, investigator: "alice", aiProvider: "anthropic" });
   await store.saveScreenshot(caseId, "shot-001.webp", Buffer.from([0x52, 0x49, 0x46, 0x46, 1, 2, 3]));
   await store.appendCapture(caseId, {
     caseId,
@@ -184,6 +185,62 @@ describe("importEncryptedCase", () => {
     await seedCase(store, "INC-1");
     const archive = await exportEncryptedCase(store, "INC-1", PASSWORD);
     await expect(importEncryptedCase(store, archive, PASSWORD)).rejects.toThrow(CaseImportConflictError);
+  });
+
+  // #420: caseExists() is a check, not a claim. Two imports aimed at the same id both passed it and
+  // then interleaved their writes into the same destination, producing a case that existed in
+  // neither archive — case.json from whichever finished last, evidence files from both. Nothing
+  // downstream can detect that, so every analysis and custody record built on it is untrustworthy.
+  it("cannot merge two archives into one case when imports race for the same id", async () => {
+    const store = await harness();
+    await seedCase(store, "SRC-A", "Case A");
+    await seedCase(store, "SRC-B", "Case B");
+    await store.saveImport("SRC-A", "only-in-a.json", JSON.stringify({ from: "A" }));
+    await store.saveImport("SRC-B", "only-in-b.json", JSON.stringify({ from: "B" }));
+    const archiveA = await exportEncryptedCase(store, "SRC-A", PASSWORD);
+    const archiveB = await exportEncryptedCase(store, "SRC-B", PASSWORD);
+
+    const results = await Promise.allSettled([
+      importEncryptedCase(store, archiveA, PASSWORD, { targetCaseId: "TARGET" }),
+      importEncryptedCase(store, archiveB, PASSWORD, { targetCaseId: "TARGET" }),
+    ]);
+
+    expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+    const loser = results.find((r) => r.status === "rejected");
+    expect((loser as PromiseRejectedResult).reason).toBeInstanceOf(CaseImportConflictError);
+
+    // Exactly one archive's evidence is present — never both, never a blend.
+    const hasA = existsSync(join(store.importsDir("TARGET"), "only-in-a.json"));
+    const hasB = existsSync(join(store.importsDir("TARGET"), "only-in-b.json"));
+    expect(hasA).toBe(!hasB);
+    // ...and the metadata agrees with the evidence, which is the property that actually broke.
+    const meta = await store.getCaseMeta("TARGET");
+    expect(meta?.name).toBe(hasA ? "Case A" : "Case B");
+  });
+
+  it("leaves no staging directory behind, on the winning or the losing path", async () => {
+    const store = await harness();
+    await seedCase(store, "SRC-A");
+    const archive = await exportEncryptedCase(store, "SRC-A", PASSWORD);
+    await importEncryptedCase(store, archive, PASSWORD, { targetCaseId: "OK-1" });
+    await expect(importEncryptedCase(store, archive, PASSWORD, { targetCaseId: "OK-1" })).rejects.toThrow(
+      CaseImportConflictError,
+    );
+    await expect(
+      importEncryptedCase(store, Buffer.from("not an archive at all"), PASSWORD, { targetCaseId: "OK-2" }),
+    ).rejects.toThrow();
+
+    expect(await readdir(join(store.casesRoot, ".import-staging"))).toEqual([]);
+  });
+
+  it("keeps the staging directory out of the case list", async () => {
+    const store = await harness();
+    await seedCase(store, "SRC-A");
+    const archive = await exportEncryptedCase(store, "SRC-A", PASSWORD);
+    await importEncryptedCase(store, archive, PASSWORD, { targetCaseId: "LISTED" });
+    // A half-extracted archive holds a readable case.json, which is exactly what listCases treats
+    // as a case — so staging lives a level down, under a dotted directory.
+    expect((await store.listCases()).map((m) => m.caseId).sort()).toEqual(["LISTED", "SRC-A"]);
   });
 
   it("throws DecryptionError on the wrong password", async () => {


### PR DESCRIPTION
Closes #420.

`importEncryptedCase` checked that the destination case did not exist and then wrote the archive straight into it:

```ts
if (await store.caseExists(targetCaseId)) throw new CaseImportConflictError(targetCaseId);
…
for (const entry of entries) await writeFile(join(caseDir, entry.path), data);
```

**The check is not a claim.** Two concurrent imports aimed at the same target id both pass it — the first `await` yields the event loop before either has written anything — and then interleave their writes into the same directory.

The result is a case that existed in **neither** archive: `case.json` from whichever import wrote it last, evidence files from both. Nothing downstream can detect that, so every analysis, report and custody record built on such a case is untrustworthy.

## The fix

Extraction goes to a private staging directory and is published with **one `rename`**.

`rename()` of a directory onto an existing non-empty directory fails on every platform, which makes it the exclusive atomic claim the existence check never was: the first import to finish publishes, and any other aiming at the same id gets a `CaseImportConflictError` instead of a merge.

The errno differs by platform (`ENOTEMPTY`, `EEXIST`, `EPERM` on Windows), so the catch asks the filesystem what actually happened — *is the target a case now?* — rather than enumerating codes and risking a real I/O error being reported as a conflict.

It also fixes the **failure** path, which the old code called out in a comment but did not achieve: a throw part-way through the write loop left an orphaned directory that made `caseExists()` true for a case that never imported. A case directory now only ever becomes visible complete.

## Where staging lives

`<casesRoot>/.import-staging/<caseId>-XXXXXX` — same filesystem (so the rename is atomic), one level below the cases and behind a dotted name. That placement is load-bearing: `listCases()` treats any directory holding a readable `case.json` as a case, which is exactly what a half-extracted archive holds.

The `finally` block removes this run's staging directory on every path a process survives. A sweep of entries older than a day covers the one it does not — a kill or power loss mid-extraction — so they cannot accumulate.

## Tests

Three new tests in `tests/analysis/caseExportArchive.test.ts`; the first two fail on master:

- **the race itself** — two archives with distinct evidence files and distinct case names, imported concurrently to one target. Exactly one fulfils, the loser rejects with `CaseImportConflictError`, exactly one archive's evidence is present, and the published `case.json` name agrees with the evidence that landed. On master both imports report success and the case is a blend.
- **no staging left behind** on the winning path, the conflict path, and the corrupt-archive path.
- **staging is not listed as a case** by `listCases()`.

## Gates

All seven clean; full suite **6860 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)