### PR TITLE
fix(import): meter every encrypted import that pays for a key derivation

### DIFF
--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -9,7 +9,7 @@
   "public/dashboard.html#inline-css": 3234,
   "public/dashboard.html#inline-js": 19203,
   "reports/markdown.ts": 1461,
-  "routes/caseLifecycle.ts": 1269,
+  "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,
   "routes/mcp.ts": 845,
   "routes/velociraptor.ts": 888,

--- a/companion/src/http/rateLimiter.ts
+++ b/companion/src/http/rateLimiter.ts
@@ -143,9 +143,11 @@ const SWEEP_INTERVAL_MS = 5 * 60_000;
 let _unlockLimiter: AttemptLimiter | null = null;
 let _aiLimiter: SlidingWindowLimiter | null = null;
 let _importLimiter: AttemptLimiter | null = null;
+let _importIpLimiter: SlidingWindowLimiter | null = null;
 let _unlockSweepTimer: NodeJS.Timeout | null = null;
 let _aiSweepTimer: NodeJS.Timeout | null = null;
 let _importSweepTimer: NodeJS.Timeout | null = null;
+let _importIpSweepTimer: NodeJS.Timeout | null = null;
 
 export function getUnlockLimiter(): AttemptLimiter {
   if (!_unlockLimiter) {
@@ -182,16 +184,37 @@ export function getImportLimiter(): AttemptLimiter {
   return _importLimiter;
 }
 
+/** Request budget for POST /cases/import/encrypted, keyed by client IP and consumed by every
+ *  attempt that reaches decryption — whatever the outcome. It exists because the failure limiter
+ *  above deliberately does not count a CaseImportConflictError (the archive opened; that is an
+ *  analyst re-importing, not an attack) and a conflict still pays for a full synchronous scrypt
+ *  derivation, so repeated conflicts were an unmetered way to block the event loop (#424).
+ *
+ *  10 a minute: a whole-case import is a rare, heavyweight operation, so this is far above real
+ *  use and still bounds the derivations one client can buy. */
+export function getImportIpLimiter(): SlidingWindowLimiter {
+  if (!_importIpLimiter) {
+    const limiter = new SlidingWindowLimiter(10, 60_000);
+    _importIpLimiter = limiter;
+    _importIpSweepTimer = setInterval(() => limiter.sweep(), SWEEP_INTERVAL_MS);
+    _importIpSweepTimer.unref?.();
+  }
+  return _importIpLimiter;
+}
+
 /** Reset singletons (tests). Also clears each singleton's sweep timer so repeated
  *  reset+get cycles in a test suite don't stack up abandoned intervals. */
 export function resetLimiters(): void {
   if (_unlockSweepTimer) clearInterval(_unlockSweepTimer);
   if (_aiSweepTimer) clearInterval(_aiSweepTimer);
   if (_importSweepTimer) clearInterval(_importSweepTimer);
+  if (_importIpSweepTimer) clearInterval(_importIpSweepTimer);
   _unlockSweepTimer = null;
   _aiSweepTimer = null;
   _importSweepTimer = null;
+  _importIpSweepTimer = null;
   _unlockLimiter = null;
   _aiLimiter = null;
   _importLimiter = null;
+  _importIpLimiter = null;
 }

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -11,13 +11,10 @@ import { registerSeedDemoRoutes } from "./seedDemo.js";
 import { archiveCase } from "../analysis/caseArchive.js";
 import {
   exportEncryptedCase,
-  importEncryptedCase,
-  CaseImportConflictError,
   MIN_PASSWORD_LENGTH,
   dfircaseFilename, attachmentContentDisposition,
 } from "../analysis/caseExportArchive.js";
-import { DecryptionError } from "../analysis/caseEncryption.js";
-import { getImportLimiter } from "../http/rateLimiter.js";
+import { registerEncryptedImportRoutes } from "./encryptedImport.js";
 import { computeCaseStats } from "../analysis/caseStats.js";
 import { projectAlignment } from "../analysis/clockSkew.js";
 import { logActivity, ACTIVITY_CATEGORIES, type ActivityCategory } from "../analysis/activityLog.js";
@@ -477,71 +474,9 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
     }
   });
 
-  // Import a `.dfircase` encrypted archive into a NEW case (replaces issue #56's snapshot
-  // import). Body: { data: base64, password, targetCaseId? } — base64-in-JSON, matching this
-  // codebase's existing convention for binary uploads elsewhere (no multipart/multer). 409 if the
-  // target id already exists (the dashboard re-prompts with a new id), 400 on a wrong password,
-  // corrupt archive, or malformed payload.
-  //
-  // Rate-limited like /unlock, and for a sharper reason: opening an archive costs a deliberate
-  // ~1s scrypt derivation (caseEncryption.ts) on the SYNCHRONOUS path, so an unauthenticated
-  // caller looping wrong-password imports holds the event loop — the whole server, not just this
-  // route — for as long as it cares to. The origin guard doesn't stop it (a caller with no Origin
-  // header is allowed by design, see http/originGuard.ts) and in container mode the port is on the
-  // network. Keyed by client IP because an import names no case until it has been decrypted; the
-  // key is coarse behind a reverse proxy that doesn't strip its own address, where every caller
-  // shares one bucket. That's the deliberate trade: a shared 30s import lockout is a far smaller
-  // failure than a wedged event loop, and refusing to trust a spoofable X-Forwarded-For is worth
-  // more than a per-caller bucket.
-  app.post("/cases/import/encrypted", async (req: Request, res: Response) => {
-    const limiter = getImportLimiter();
-    const limiterKey = req.ip ?? "unknown";
-    try {
-      const remaining = limiter.remainingLockout(limiterKey);
-      if (remaining > 0) {
-        res.setHeader("Retry-After", String(Math.ceil(remaining / 1000)));
-        return res.status(429).json({ error: "too many failed imports, try again later", retryAfterMs: remaining });
-      }
-      const body = (req.body ?? {}) as Record<string, unknown>;
-      const { data, password, targetCaseId } = body;
-      if (typeof data !== "string" || !data.trim()) {
-        return res.status(400).json({ error: "data (base64) is required" });
-      }
-      if (typeof password !== "string" || !password) {
-        return res.status(400).json({ error: "password is required" });
-      }
-      const fileBuffer = Buffer.from(data, "base64");
-      const { meta, counts } = await importEncryptedCase(store, fileBuffer, password, {
-        targetCaseId: typeof targetCaseId === "string" && targetCaseId.trim() ? targetCaseId.trim() : undefined,
-      });
-      options.teamAuth?.grantCreator(req, meta.caseId);
-      // An archived case.json is written back byte-for-byte on import (see
-      // caseExportArchive.ts), so an exported case that had a case-lock password carries
-      // its salt+hash into the archive. Sanitize before responding — never let it reach
-      // the client, same as every other route that serializes a CaseMeta.
-      limiter.clear(limiterKey);
-      return res.status(201).json({ ...sanitizeCaseMeta(meta), counts });
-    } catch (err) {
-      // A conflict means the archive DID open — a real analyst re-importing, not an attacker
-      // burning CPU. Deliberately not counted as a failure.
-      if (err instanceof CaseImportConflictError) {
-        return res.status(409).json({ error: err.message, caseId: err.caseId });
-      }
-      if (err instanceof DecryptionError) {
-        const lockout = limiter.recordFailure(limiterKey);
-        if (lockout > 0) {
-          res.setHeader("Retry-After", String(Math.ceil(lockout / 1000)));
-          return res.status(429).json({ error: "too many failed imports, locked out", retryAfterMs: lockout });
-        }
-        return res.status(400).json({ error: err.message });
-      }
-      const msg = (err as Error).message;
-      if (/not a valid case archive|invalid target case id/i.test(msg)) {
-        return res.status(400).json({ error: msg });
-      }
-      return res.status(500).json({ error: msg });
-    }
-  });
+  // Import a `.dfircase` encrypted archive into a NEW case — POST /cases/import/encrypted
+  // (routes/encryptedImport.ts).
+  registerEncryptedImportRoutes(app, ctx);
 
   // ── State backups (#180) ─────────────────────────────────────────────────────────────────────
   // Automatic snapshots of SNAPSHOT_STATE_FILES before synthesis + on a timer.

--- a/companion/src/routes/encryptedImport.ts
+++ b/companion/src/routes/encryptedImport.ts
@@ -1,0 +1,103 @@
+import type { Express, Request, Response } from "express";
+import { getImportLimiter, getImportIpLimiter } from "../http/rateLimiter.js";
+import { importEncryptedCase, CaseImportConflictError } from "../analysis/caseExportArchive.js";
+import { DecryptionError } from "../analysis/caseEncryption.js";
+import { sanitizeCaseMeta } from "../analysis/casePassword.js";
+import type { RouteContext } from "./context.js";
+
+/**
+ * Encrypted whole-case import — POST /cases/import/encrypted.
+ *
+ * Split out of routes/caseLifecycle.ts when the request budget below was added (#424): that file
+ * is at its size-ledger cap, and this route's rate limiting is intricate enough to be worth
+ * reading in one piece.
+ */
+export function registerEncryptedImportRoutes(app: Express, ctx: RouteContext): void {
+  const { store, options } = ctx;
+
+  // Import a `.dfircase` encrypted archive into a NEW case (replaces issue #56's snapshot
+  // import). Body: { data: base64, password, targetCaseId? } — base64-in-JSON, matching this
+  // codebase's existing convention for binary uploads elsewhere (no multipart/multer). 409 if the
+  // target id already exists (the dashboard re-prompts with a new id), 400 on a wrong password,
+  // corrupt archive, or malformed payload.
+  //
+  // Rate-limited like /unlock, and for a sharper reason: opening an archive costs a deliberate
+  // ~1s scrypt derivation (caseEncryption.ts) on the SYNCHRONOUS path, so an unauthenticated
+  // caller looping wrong-password imports holds the event loop — the whole server, not just this
+  // route — for as long as it cares to. The origin guard doesn't stop it (a caller with no Origin
+  // header is allowed by design, see http/originGuard.ts) and in container mode the port is on the
+  // network. Keyed by client IP because an import names no case until it has been decrypted; the
+  // key is coarse behind a reverse proxy that doesn't strip its own address, where every caller
+  // shares one bucket. That's the deliberate trade: a shared 30s import lockout is a far smaller
+  // failure than a wedged event loop, and refusing to trust a spoofable X-Forwarded-For is worth
+  // more than a per-caller bucket.
+  app.post("/cases/import/encrypted", async (req: Request, res: Response) => {
+    const limiter = getImportLimiter();
+    const limiterKey = req.ip ?? "unknown";
+    try {
+      const remaining = limiter.remainingLockout(limiterKey);
+      if (remaining > 0) {
+        res.setHeader("Retry-After", String(Math.ceil(remaining / 1000)));
+        return res
+          .status(429)
+          .json({ error: "too many failed imports, try again later", retryAfterMs: remaining });
+      }
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const { data, password, targetCaseId } = body;
+      if (typeof data !== "string" || !data.trim()) {
+        return res.status(400).json({ error: "data (base64) is required" });
+      }
+      if (typeof password !== "string" || !password) {
+        return res.status(400).json({ error: "password is required" });
+      }
+      // Everything past here reaches decryptBuffer, whose scrypt derivation blocks the event loop
+      // for about a second. The failure limiter above cannot bound that on its own: it counts only
+      // outcomes the catch classifies as failures, and deliberately never counts a conflict. This
+      // budget is charged per REQUEST, so no outcome — conflict, malformed archive, or success —
+      // is an unmetered way to buy another derivation (#424).
+      if (!getImportIpLimiter().tryAcquire(limiterKey)) {
+        res.setHeader("Retry-After", "60");
+        return res.status(429).json({ error: "too many import attempts, try again later" });
+      }
+      const fileBuffer = Buffer.from(data, "base64");
+      const { meta, counts } = await importEncryptedCase(store, fileBuffer, password, {
+        targetCaseId:
+          typeof targetCaseId === "string" && targetCaseId.trim() ? targetCaseId.trim() : undefined,
+      });
+      options.teamAuth?.grantCreator(req, meta.caseId);
+      // An archived case.json is written back byte-for-byte on import (see
+      // caseExportArchive.ts), so an exported case that had a case-lock password carries
+      // its salt+hash into the archive. Sanitize before responding — never let it reach
+      // the client, same as every other route that serializes a CaseMeta.
+      limiter.clear(limiterKey);
+      return res.status(201).json({ ...sanitizeCaseMeta(meta), counts });
+    } catch (err) {
+      // A conflict means the archive DID open — a real analyst re-importing, not an attacker
+      // burning CPU. Deliberately not counted as a failure; the per-request budget above is what
+      // stops a loop of them from being free.
+      if (err instanceof CaseImportConflictError) {
+        return res.status(409).json({ error: err.message, caseId: err.caseId });
+      }
+      // Every remaining failure got here by paying for the derivation, and they cost the same:
+      // a wrong password (DecryptionError) and a correctly-encrypted archive whose ZIP is
+      // malformed are one scrypt pass each. Only the first used to be counted, so encrypting
+      // arbitrary bytes with a known password gave an unlimited supply of full derivations that
+      // never touched the limiter (#424).
+      const lockout = limiter.recordFailure(limiterKey);
+      const msg = (err as Error).message;
+      if (lockout > 0) {
+        res.setHeader("Retry-After", String(Math.ceil(lockout / 1000)));
+        return res.status(429).json({ error: "too many failed imports, locked out", retryAfterMs: lockout });
+      }
+      if (err instanceof DecryptionError) return res.status(400).json({ error: msg });
+      if (
+        /not a valid case archive|invalid target case id|not a ZIP archive|corrupt ZIP|zip entry|zip bomb/i.test(
+          msg,
+        )
+      ) {
+        return res.status(400).json({ error: msg });
+      }
+      return res.status(500).json({ error: msg });
+    }
+  });
+}

--- a/companion/tests/server/encryptedCaseRoutes.test.ts
+++ b/companion/tests/server/encryptedCaseRoutes.test.ts
@@ -9,6 +9,7 @@ import { createApp } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { CommentsStore } from "../../src/analysis/comments.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
+import { encryptBuffer } from "../../src/analysis/caseEncryption.js";
 
 const PASSWORD = "correct horse battery staple";
 
@@ -214,6 +215,64 @@ describe("POST /cases/import/encrypted", () => {
     for (let i = 0; i < 4; i++) {
       expect((await request(app).post("/cases/import/encrypted").send({ data: junk, password: "x" })).status).toBe(400);
     }
+  });
+
+  // #424: the limiter recorded a failure only for a DecryptionError. A CORRECTLY encrypted archive
+  // whose contents are not a ZIP pays exactly the same ~1s synchronous scrypt derivation and then
+  // throws an archive error instead — so it never touched the limiter, and looping it was an
+  // unmetered way to hold the event loop. (It answered 500 as well: a client-supplied archive that
+  // does not parse is a bad request, not a server fault.)
+  it("counts a correctly encrypted but malformed archive, which costs the same derivation", { timeout: 60_000 }, async () => {
+    const { app } = await harness();
+    // Valid container, correct password, contents that are not a ZIP. Decryption succeeds; the
+    // ZIP parse is what fails.
+    const data = encryptBuffer(Buffer.from("valid container, contents are not a ZIP"), PASSWORD).toString("base64");
+
+    for (let i = 0; i < 4; i++) {
+      const res = await request(app).post("/cases/import/encrypted").send({ data, password: PASSWORD });
+      expect(res.status).toBe(400);
+    }
+    const tripped = await request(app).post("/cases/import/encrypted").send({ data, password: PASSWORD });
+    expect(tripped.status).toBe(429);
+    expect(tripped.headers["retry-after"]).toBeDefined();
+  });
+
+  it("clears the failure state only on a successful import", { timeout: 60_000 }, async () => {
+    const { app, stateStore, store } = await harness();
+    await seedCase(app, stateStore, store);
+    const good = await exportArchive(app, "INC-1");
+    const bad = encryptBuffer(Buffer.from("not a ZIP"), PASSWORD).toString("base64");
+
+    for (let i = 0; i < 4; i++) {
+      expect((await request(app).post("/cases/import/encrypted").send({ data: bad, password: PASSWORD })).status).toBe(400);
+    }
+    // One good import resets the counter...
+    expect((await request(app).post("/cases/import/encrypted").send({ data: good, password: PASSWORD, targetCaseId: "INC-2" })).status).toBe(201);
+    // ...so four more failures fit again rather than tripping on the first.
+    for (let i = 0; i < 4; i++) {
+      expect((await request(app).post("/cases/import/encrypted").send({ data: bad, password: PASSWORD })).status).toBe(400);
+    }
+  });
+
+  // The conflict stays uncounted by the failure limiter — an analyst re-importing is not an
+  // attack — but it opens the archive, which means it pays for a derivation. The per-request
+  // budget is what stops a loop of them from being free.
+  it("stops repeated conflicts from being an unmetered derivation loop", { timeout: 120_000 }, async () => {
+    const { app, stateStore, store } = await harness();
+    await seedCase(app, stateStore, store);
+    const data = await exportArchive(app, "INC-1");
+
+    let budgetHit = 0;
+    for (let i = 0; i < 12; i++) {
+      const res = await request(app).post("/cases/import/encrypted").send({ data, password: PASSWORD });
+      if (res.status === 429) { budgetHit = i; break; }
+      expect(res.status).toBe(409);   // still a conflict, still not a "failed import"
+    }
+    expect(budgetHit).toBeGreaterThan(0);
+    // The bound came from the request budget, not the failure lockout — so the message is the
+    // budget's, and the failure limiter was never touched.
+    const res = await request(app).post("/cases/import/encrypted").send({ data, password: PASSWORD });
+    expect(res.body.error).toMatch(/too many import attempts/i);
   });
 
   it("400s on a malformed payload", async () => {


### PR DESCRIPTION
Closes #424.

`POST /cases/import/encrypted` recorded a rate-limit failure **only** for a `DecryptionError`. A *correctly encrypted* archive whose contents are not a ZIP costs exactly the same ~1s synchronous scrypt derivation and then throws an archive error instead — so it never touched the limiter.

Encrypting arbitrary bytes with a known password therefore gave an unlimited supply of full derivations, each one blocking the event loop, none of them ever producing a 429. The route's own comments name that synchronous KDF cost as the reason rate limiting exists here at all.

## Two ways to reach the derivation uncounted, two changes

**Failures.** The catch now records every outcome except a conflict, rather than only `DecryptionError`. A wrong password and a malformed archive are one scrypt pass each; they should cost the caller the same.

Those archive errors also answered **500** — a client-supplied archive that does not parse is a bad request, not a server fault — so they now answer 400 alongside the existing patterns. (The regression test catches this too: on master the malformed-archive request returns 500.)

**Conflicts.** Still deliberately *not* a failure — an analyst re-importing is not an attack — but no longer free. A per-IP **request budget** of 10/minute is charged *before* decryption, on every request that reaches it, so no outcome (conflict, malformed archive, or success) is an unmetered way to buy another derivation. Ten is far above real use for a whole-case import and still bounds what one client can force.

Failure state is still cleared only on a successful import, now with a test that says so.

## Route extraction

The route moves to `routes/encryptedImport.ts`, registered from the same point in `registerCaseLifecycleRoutes` so route ordering is unchanged and `tests/architecture` passes untouched. `caseLifecycle.ts` is at its `check:size` ledger cap, and this route's rate limiting is intricate enough to be worth reading in one piece.

## Tests

Three new tests in `tests/server/encryptedCaseRoutes.test.ts`, all failing on master:

- a correctly encrypted, non-ZIP archive: four 400s then a 429 lockout (master: five 500s, no lockout)
- failure state clears only on a successful import — four failures, one good import, four more failures fit again
- repeated conflicts reach the request budget instead of looping free; the response is the budget's message, proving the failure limiter was never touched

The existing tests for wrong passwords, cheap non-container junk, and the deliberate conflict behaviour all still pass unchanged.

## Gates

All seven clean; full suite **6860 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)