### PR TITLE
fix(import): compare archive entry paths by the file they resolve to

### DIFF
--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -237,10 +237,45 @@ export async function exportEncryptedCase(
 // this guard means a malicious or corrupted entry path is rejected before ANY file is written.
 // The colon check also closes an NTFS alternate-data-stream gap: "shot.jpg:hidden.exe" doesn't
 // escape the case directory, but would silently write a hidden stream on Windows without it.
+//
+// It also fixes the archive to ONE path syntax, forward slashes, and rejects the segment spellings
+// Windows silently normalizes. Both exist for the same reason (#426): the duplicate check compares
+// raw path strings, but the write loop resolves them with the host platform's rules, and on Windows
+// several distinct strings resolve to one file. `state/a` and `state\a`, `EVIDENCE.BIN` and
+// `evidence.bin`, `notes` and `notes.` all pass a raw-string comparison and then have the later
+// entry silently overwrite the earlier one — evidence loss with no error, from a crafted archive or
+// from a legitimate one created on a case-sensitive filesystem. A reserved device name (CON, LPT1,
+// NUL — with or without an extension) is worse still: on Windows it does not resolve to a file at
+// all. Every case archive this tool writes uses forward slashes and ordinary names, so nothing
+// legitimate is refused.
+const WINDOWS_RESERVED_SEGMENT = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+
 function isSafeZipEntryPath(path: string): boolean {
   if (!path || isAbsolute(path) || /^[a-zA-Z]:/.test(path) || path.includes(":")) return false;
-  const segments = path.split(/[\\/]+/);
-  return segments.every((seg) => seg !== "" && seg !== "." && seg !== "..");
+  if (path.includes("\\")) return false;
+  return path.split("/").every(
+    (seg) =>
+      seg !== "" &&
+      seg !== "." &&
+      seg !== ".." &&
+      !/[.\s]$/.test(seg) && // Windows strips trailing dots and spaces
+      !/[\x00-\x1f]/.test(seg) && // control characters are not filenames anywhere
+      !WINDOWS_RESERVED_SEGMENT.test(seg),
+  );
+}
+
+/**
+ * The key two entry paths collide on, under the most collision-prone rules any supported platform
+ * applies — which is Windows, where the filesystem is case-insensitive. Compared on EVERY platform,
+ * not only Windows: an archive whose entries collide is malformed wherever it is opened, and an
+ * import that quietly succeeds on Linux and loses a file on Windows is the harder bug to find.
+ *
+ * Upper-cased because that is the direction Windows' own comparison folds. JS case mapping is
+ * locale-independent here (toUpperCase, not toLocaleUpperCase), so this does not shift under a
+ * Turkish locale.
+ */
+function destinationKey(path: string): string {
+  return path.toUpperCase();
 }
 
 function rewriteCaseIdInJson(data: Buffer, targetCaseId: string, indent: number | undefined): Buffer {
@@ -376,24 +411,34 @@ export async function importEncryptedCase(
   // needs rewriting has been proven to parse. A corrupt archive must fail cleanly here, not
   // partway through the write loop — a partial write would leave an orphaned case directory
   // that makes store.caseExists() return true for a case that never actually imported.
-  const seenPaths = new Set<string>();
+  const seenPaths = new Map<string, string>();
   for (const entry of entries) {
     if (!isSafeZipEntryPath(entry.path)) {
       throw new Error(`not a valid case archive: unsafe entry path "${entry.path}"`);
     }
-    if (seenPaths.has(entry.path)) {
+    // Keyed by the destination the path resolves to, not the raw string, so an alias cannot slip
+    // past and overwrite the file an earlier entry wrote (#426).
+    const key = destinationKey(entry.path);
+    const earlier = seenPaths.get(key);
+    if (earlier === entry.path) {
       throw new Error(`not a valid case archive: duplicate entry path "${entry.path}"`);
     }
-    seenPaths.add(entry.path);
+    if (earlier !== undefined) {
+      throw new Error(
+        `not a valid case archive: entry path "${entry.path}" resolves to the same file as ` +
+          `"${earlier}" on a case-insensitive filesystem`,
+      );
+    }
+    seenPaths.set(key, entry.path);
   }
 
   const rename = targetCaseId !== originalMeta.caseId;
   const rewrittenByPath = new Map<string, Buffer>();
   if (rename) {
     for (const entry of entries) {
-      // Match on a forward-slash-normalized path so a backslash-separated entry (however
-      // unlikely) still gets its caseId rewritten instead of silently keeping the old id.
-      const normalizedPath = entry.path.replace(/\\/g, "/");
+      // A plain match: entry paths are forward-slash only by the time they get here, because
+      // isSafeZipEntryPath rejects a backslash outright rather than normalizing one away (#426).
+      const normalizedPath = entry.path;
       try {
         if (CASE_ID_JSON_PATHS.has(normalizedPath)) {
           const indent = CASE_ID_JSON_PATHS.get(normalizedPath);

--- a/companion/tests/analysis/caseExportArchive.test.ts
+++ b/companion/tests/analysis/caseExportArchive.test.ts
@@ -275,6 +275,78 @@ describe("importEncryptedCase", () => {
     expect(await store.caseExists("INC-NOID")).toBe(false);
   });
 
+  // #426: the duplicate check compared raw path strings, but the write loop resolved them with the
+  // host platform's rules. On Windows several distinct strings name one file, so the later entry
+  // silently overwrote the earlier one — evidence loss with no error. These are checked on every
+  // platform: an archive whose entries collide is malformed wherever it is opened, and an import
+  // that succeeds on Linux while losing a file on Windows is the harder bug to find.
+  describe("path aliases that collide on a Windows destination", () => {
+    async function importAliased(paths: string[], targetCaseId: string) {
+      const store = await harness();
+      await seedCase(store, "INC-1");
+      const caseJson = await readFile(store.caseMetaPath("INC-1"));
+      const archive = encryptBuffer(
+        createZip([
+          { path: "case.json", data: caseJson },
+          ...paths.map((path, i) => ({ path, data: Buffer.from(`entry ${i}`) })),
+        ]),
+        PASSWORD,
+      );
+      return { store, run: () => importEncryptedCase(store, archive, PASSWORD, { targetCaseId }) };
+    }
+
+    it("rejects a backslash alias of a forward-slash path", async () => {
+      const { store, run } = await importAliased(["state/a.bin", "state\\a.bin"], "INC-BS");
+      await expect(run()).rejects.toThrow(/unsafe entry path/);
+      expect(await store.caseExists("INC-BS")).toBe(false);
+    });
+
+    it("rejects a case-only alias", async () => {
+      const { store, run } = await importAliased(
+        ["imports/EVIDENCE.bin", "imports/evidence.bin"],
+        "INC-CASE",
+      );
+      await expect(run()).rejects.toThrow(/same file as/i);
+      expect(await store.caseExists("INC-CASE")).toBe(false);
+    });
+
+    it("rejects a case-only alias in a DIRECTORY segment", async () => {
+      const { store, run } = await importAliased(["Imports/a.bin", "imports/a.bin"], "INC-DIR");
+      await expect(run()).rejects.toThrow(/same file as/i);
+      expect(await store.caseExists("INC-DIR")).toBe(false);
+    });
+
+    it("rejects a trailing-dot or trailing-space name, which Windows strips", async () => {
+      for (const [i, alias] of ["imports/notes.", "imports/notes ", "imports/dir./a.bin"].entries()) {
+        const { store, run } = await importAliased(["imports/notes", alias], `INC-TRIM${i}`);
+        await expect(run()).rejects.toThrow(/unsafe entry path/);
+        expect(await store.caseExists(`INC-TRIM${i}`)).toBe(false);
+      }
+    });
+
+    it("rejects a reserved Windows device name, with or without an extension", async () => {
+      for (const [i, reserved] of [
+        "imports/CON",
+        "imports/nul.txt",
+        "LPT1/a.bin",
+        "imports/com9.bin",
+      ].entries()) {
+        const { store, run } = await importAliased([reserved], `INC-DEV${i}`);
+        await expect(run()).rejects.toThrow(/unsafe entry path/);
+        expect(await store.caseExists(`INC-DEV${i}`)).toBe(false);
+      }
+    });
+
+    it("still accepts the ordinary paths a real export produces", async () => {
+      const { store, run } = await importAliased(
+        ["imports/thor-001.json", "screenshots/shot-001.webp", "state/notes.md", "reports/report.md"],
+        "INC-OK",
+      );
+      await expect(run()).resolves.toBeTruthy();
+      expect(await store.caseExists("INC-OK")).toBe(true);
+    });
+  });
+
   it("rejects an archive with duplicate entry paths", async () => {
     const store = await harness();
     await seedCase(store, "INC-1");


### PR DESCRIPTION
Closes #426.

Encrypted-case import detected duplicate ZIP entries by comparing **raw path strings**, then built destination paths with the **host platform's rules**. On Windows several distinct strings name one file, so an alias passed the duplicate check and the later entry silently overwrote the earlier one's evidence — no error, no trace.

Reachable two ways: a crafted archive bypassing the duplicate-path defense on purpose, and a legitimate archive created on a case-sensitive filesystem quietly losing files when an analyst restores it on Windows.

## Two changes

**One path syntax.** Entry paths must use forward slashes, and a segment may not:

| Rejected | Why |
|---|---|
| any `\` in the path | `state\a` and `state/a` are one destination on Windows |
| trailing `.` or space | Windows strips them: `notes.` and `notes` are one file |
| `CON`, `NUL`, `LPT1`, `com9.bin`, … | a reserved device name resolves to no file at all; an extension does not exempt it |
| control characters | not a filename on any platform |

Backslashes are now rejected outright rather than normalized away, which also lets the caseId-rewrite match drop its `.replace(/\\/g, "/")`. Every archive this tool writes already uses forward slashes and ordinary names — the export walker builds every path with `/` — so nothing legitimate is refused.

**Collision keyed by destination.** The seen-path set is keyed by the path **upper-cased** — the direction Windows' own comparison folds — so `imports/EVIDENCE.bin` and `imports/evidence.bin` collide before either is written, as do `Imports/a.bin` and `imports/a.bin`.

Compared on **every** platform, not only Windows: an archive whose entries collide is malformed wherever it is opened, and an import that succeeds on Linux while losing a file on Windows is the harder bug to find. A true duplicate and an alias get different messages, because they are different mistakes.

## No partial destination

All of it runs in the existing validation pass, before the first `mkdir`. Every new test asserts `caseExists(target) === false` after the rejection.

## Tests

Six new tests in `tests/analysis/caseExportArchive.test.ts`; the five rejection cases all import cleanly on master:

- backslash alias of a forward-slash path
- case-only alias, in a filename and in a directory segment
- trailing dot, trailing space, and a trailing dot on a directory segment
- reserved device names: `CON`, `nul.txt`, `LPT1/`, `com9.bin`
- and a positive case proving the ordinary paths a real export produces still import

## Gates

All seven clean; full suite **6863 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)