### PR TITLE
fix(captures): name and describe a screenshot by the format it actually is

### DIFF
--- a/companion/src/analysis/imageLoader.ts
+++ b/companion/src/analysis/imageLoader.ts
@@ -1,11 +1,19 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
+import { detectImageFormat } from "../ingest/imageFormat.js";
 import type { AnalyzeImage } from "../providers/provider.js";
 
 export function makeImageLoader(store: CaseStore) {
   return async (caseId: string, screenshotFile: string): Promise<AnalyzeImage> => {
     const bytes = await readFile(join(store.screenshotsDir(caseId), screenshotFile));
-    return { base64: bytes.toString("base64"), mimeType: "image/webp" };
+    // From the BYTES, not the filename. Capture ingest accepts PNG, JPEG and GIF as well as WebP,
+    // and this reported image/webp for all of them — a media type a provider can reject outright
+    // or quietly mis-decode (#425). Sniffing rather than reading the extension also heals the
+    // screenshots already on disk under the old fixed ".webp" suffix, with no migration.
+    // The fallback covers only bytes that are none of the four accepted formats, which ingest
+    // refuses — so it is unreachable for anything this app wrote.
+    const mimeType = detectImageFormat(bytes)?.mimeType ?? "image/webp";
+    return { base64: bytes.toString("base64"), mimeType };
   };
 }

--- a/companion/src/ingest/captureIngest.ts
+++ b/companion/src/ingest/captureIngest.ts
@@ -4,6 +4,7 @@ import type { CaseStore } from "../storage/caseStore.js";
 import { isValidCaseId } from "../storage/caseStore.js";
 import { computeContentHash } from "../dedup/contentHash.js";
 import { slugifyTitle } from "./titleSlug.js";
+import { detectImageFormat } from "./imageFormat.js";
 
 // Is deduplication enabled? Default on. `DFIR_DEDUP=off` (also false/no/0) turns it off so
 // EVERY capture is analyzed. Read per call so a restart picks up the change. When on, a capture
@@ -46,21 +47,6 @@ export class InvalidImageError extends Error {
 // In-memory cache of the last content hash per case, to decide duplicates without re-reading disk.
 const lastHashByCase = new Map<string, string>();
 
-// Magic-byte sniff: verify the captured bytes are a real image, not arbitrary binary.
-// WebP: RIFF....WEBP  |  PNG: 89 PNG\r\n  |  JPEG: FF D8 FF  |  GIF: GIF8
-function isImageMagic(bytes: Buffer): boolean {
-  if (bytes.length < 12) return false;
-  // WebP
-  if (bytes.subarray(0, 4).toString("ascii") === "RIFF" && bytes.subarray(8, 12).toString("ascii") === "WEBP") return true;
-  // PNG
-  if (bytes[0] === 0x89 && bytes.subarray(1, 4).toString("ascii") === "PNG") return true;
-  // JPEG
-  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return true;
-  // GIF
-  if (bytes.subarray(0, 4).toString("ascii") === "GIF8") return true;
-  return false;
-}
-
 export async function ingestCapture(
   store: CaseStore,
   rawPayload: unknown,
@@ -76,9 +62,10 @@ export async function ingestCapture(
 
   const bytes = Buffer.from(payload.imageBase64, "base64");
 
-  // Validate that the bytes are a real image (magic-byte sniff) — reject arbitrary binary
-  // stored as a .webp screenshot. Accepts WebP (RIFF....WEBP), PNG, JPEG, and GIF.
-  if (!isImageMagic(bytes)) {
+  // Validate that the bytes are a real image (magic-byte sniff) — reject arbitrary binary stored
+  // as a screenshot — and keep WHICH image it is, so the file on disk is named for what it holds.
+  const format = detectImageFormat(bytes);
+  if (!format) {
     throw new InvalidImageError();
   }
 
@@ -97,9 +84,12 @@ export async function ingestCapture(
   // an empty/all-unsafe title is omitted cleanly (no dangling underscore).
   const titleSlug = slugifyTitle(payload.tabTitle);
   const seq = String(sequenceNumber).padStart(6, "0");
+  // The extension is the DETECTED format, not a fixed ".webp". Every accepted buffer used to be
+  // stored as WebP whatever it was, which made the filename — part of the evidence record — wrong,
+  // and the evidence route derives its Content-Type from exactly this name (#425).
   const screenshotFile = titleSlug
-    ? `${seq}_${tsSafe}_${titleSlug}.webp`
-    : `${seq}_${tsSafe}.webp`;
+    ? `${seq}_${tsSafe}_${titleSlug}${format.ext}`
+    : `${seq}_${tsSafe}${format.ext}`;
 
   // Evidence first: write the image before recording metadata. The provenance goes with the write
   // because this is the only layer that still knows where the frame came from — the store below

--- a/companion/src/ingest/imageFormat.ts
+++ b/companion/src/ingest/imageFormat.ts
@@ -1,0 +1,42 @@
+/**
+ * What a buffer of image bytes actually is — the one place the answer is decided (#425).
+ *
+ * Capture ingest accepts PNG, JPEG, GIF and WebP, and used to store every one of them under a
+ * `.webp` filename. The image loader then reported `image/webp` to the AI provider whatever the
+ * bytes were, and the evidence route derived its Content-Type from that wrong extension. So a PNG
+ * capture was described incorrectly to every consumer, and its filename — which for evidence is
+ * part of the record — said something untrue about the file.
+ *
+ * The fix preserves the source format rather than transcoding to WebP. Transcoding would re-encode
+ * evidence before it is hashed, so the recorded content hash would cover bytes that never existed
+ * on the analyst's screen; for a forensic tool that is the worse of the two options.
+ *
+ * Sniffing beats trusting a name: it also heals the screenshots already on disk with the wrong
+ * suffix, without a migration.
+ */
+export interface ImageFormat {
+  /** Filename extension, including the dot. */
+  ext: string;
+  mimeType: string;
+}
+
+const WEBP: ImageFormat = { ext: ".webp", mimeType: "image/webp" };
+const PNG: ImageFormat = { ext: ".png", mimeType: "image/png" };
+const JPEG: ImageFormat = { ext: ".jpg", mimeType: "image/jpeg" };
+const GIF: ImageFormat = { ext: ".gif", mimeType: "image/gif" };
+
+/**
+ * Identify image bytes by their magic number, or null when they are not one of the four formats
+ * capture ingest accepts.
+ *
+ * WebP: `RIFF....WEBP` | PNG: `89 PNG\r\n` | JPEG: `FF D8 FF` | GIF: `GIF8`
+ */
+export function detectImageFormat(bytes: Buffer): ImageFormat | null {
+  if (bytes.length < 12) return null;
+  if (bytes.subarray(0, 4).toString("ascii") === "RIFF" && bytes.subarray(8, 12).toString("ascii") === "WEBP")
+    return WEBP;
+  if (bytes[0] === 0x89 && bytes.subarray(1, 4).toString("ascii") === "PNG") return PNG;
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return JPEG;
+  if (bytes.subarray(0, 4).toString("ascii") === "GIF8") return GIF;
+  return null;
+}

--- a/companion/src/routes/captures.ts
+++ b/companion/src/routes/captures.ts
@@ -5,6 +5,7 @@ import { ZodError } from "zod";
 import { ingestCapture, CaseNotFoundError, InvalidImageError } from "../ingest/captureIngest.js";
 import { searchOcrIndex, isOcrSearchEnabled } from "../analysis/ocrSearch.js";
 import { isValidCaseId } from "../storage/caseStore.js";
+import { detectImageFormat } from "../ingest/imageFormat.js";
 import { parseCookieHeader, unlockCookieName, verifyUnlockToken, verifyCasePassword } from "../analysis/casePassword.js";
 import { getUnlockLimiter } from "../http/rateLimiter.js";
 import type { RouteContext } from "./context.js";
@@ -179,7 +180,12 @@ export function registerCaptureRoutes(app: Express, ctx: RouteContext): void {
     for (const path of candidates) {
       try {
         const buf = await readFile(path);
-        res.type(evidenceContentType(file));
+        // Bytes first, name second. The extension map below is right for imports (csv/json/log),
+        // but a screenshot written before ingest preserved the source format carries a ".webp"
+        // suffix over PNG/JPEG/GIF bytes, and serving those as image/webp is how the browser gets
+        // told something untrue about the evidence (#425). Only the four image magic numbers are
+        // sniffed, so nothing textual can be re-typed by its content.
+        res.type(detectImageFormat(buf)?.mimeType ?? evidenceContentType(file));
         res.setHeader("Cache-Control", "private, max-age=300");
         return res.send(buf);
       } catch (err) {

--- a/companion/tests/fullPipeline.test.ts
+++ b/companion/tests/fullPipeline.test.ts
@@ -236,7 +236,9 @@ describe("full-pipeline integration (capture → import → synthesis → report
     // 10. Evidence files are preserved — in BOTH the original AND the restored case. This is the
     // whole point of the encrypted archive replacing the old JSON-only snapshot: screenshots and
     // raw imports now travel with the export, not just references to them.
-    expect(screenshotFile).toMatch(/\.webp$/);
+    // The fixture is a PNG, so the stored name says .png — ingest preserves the detected source
+    // format rather than labelling everything .webp (#425).
+    expect(screenshotFile).toMatch(/\.png$/);
     const evidence = await request(app).get(`/cases/pipeline-1/evidence/${screenshotFile}`);
     expect(evidence.status).toBe(200);
     expect(evidence.headers["content-type"]).toContain("image/");

--- a/companion/tests/ingest/captureIngest.test.ts
+++ b/companion/tests/ingest/captureIngest.test.ts
@@ -84,7 +84,8 @@ describe("ingestCapture", () => {
       store,
       payload({ imageBase64: img, tabTitle: "Velociraptor — Hunts" }),
     );
-    expect(meta.screenshotFile).toMatch(/^000001_.*_Velociraptor-Hunts\.webp$/);
+    // .png, not .webp: the extension follows the DETECTED format (#425), and this fixture is a PNG.
+    expect(meta.screenshotFile).toMatch(/^000001_.*_Velociraptor-Hunts\.png$/);
     const onDisk = await readFile(join(store.screenshotsDir("c1"), meta.screenshotFile));
     expect(onDisk.length).toBeGreaterThan(0);
   });
@@ -93,7 +94,7 @@ describe("ingestCapture", () => {
     const img = await pngBase64(40, 50, 60);
     const meta = await ingestCapture(store, payload({ imageBase64: img, tabTitle: "💀💀" }));
     // No trailing underscore, no title segment at all.
-    expect(meta.screenshotFile).toMatch(/^000001_[^_]+\.webp$/);
+    expect(meta.screenshotFile).toMatch(/^000001_[^_]+\.png$/);
   });
 
   it("rejects an invalid payload (missing url)", async () => {

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -114,7 +114,8 @@ describe("HTTP server", () => {
     });
     expect(res.status).toBe(201);
     expect(res.body.sequenceNumber).toBe(1);
-    expect(res.body.screenshotFile).toMatch(/\.webp$/);
+    // pngBase64() posts PNG bytes, so the stored name says .png (#425).
+    expect(res.body.screenshotFile).toMatch(/\.png$/);
   });
 
   it("POST /captures returns 400 on invalid payload", async () => {

--- a/companion/tests/server/captureFormats.test.ts
+++ b/companion/tests/server/captureFormats.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import sharp from "sharp";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { CommentsStore } from "../../src/analysis/comments.js";
+import { ingestCapture, _resetDedupCache } from "../../src/ingest/captureIngest.js";
+import { makeImageLoader } from "../../src/analysis/imageLoader.js";
+
+/**
+ * Every accepted capture format, end to end (#425).
+ *
+ * Ingest advertises PNG, JPEG, GIF and WebP, and used to store all four under a `.webp` filename.
+ * The image loader then reported `image/webp` whatever the bytes were, and the evidence route
+ * derived its Content-Type from that wrong extension — so for three of the four formats, the
+ * filename, the media type sent to the AI provider, and the response header all described the
+ * evidence incorrectly.
+ *
+ * The four things that must agree, per format: the saved bytes, the filename extension, the AI
+ * media type, and the evidence response header.
+ */
+const FORMATS = [
+  { format: "png" as const, ext: ".png", mime: "image/png" },
+  { format: "jpeg" as const, ext: ".jpg", mime: "image/jpeg" },
+  { format: "gif" as const, ext: ".gif", mime: "image/gif" },
+  { format: "webp" as const, ext: ".webp", mime: "image/webp" },
+];
+
+let store: CaseStore;
+let app: ReturnType<typeof createApp>;
+
+beforeEach(async () => {
+  _resetDedupCache();
+  const root = await mkdtemp(join(tmpdir(), "dfir-capfmt-"));
+  store = new CaseStore(root);
+  app = createApp(store, { stateStore: new StateStore(store), commentsStore: new CommentsStore(store) });
+  await store.createCase({ caseId: "c1", name: "Case", investigator: "alice", aiProvider: null });
+});
+
+async function encode(format: (typeof FORMATS)[number]["format"]): Promise<Buffer> {
+  return sharp({ create: { width: 24, height: 24, channels: 3, background: "#3366aa" } })
+    .toFormat(format)
+    .toBuffer();
+}
+
+describe.each(FORMATS)("capture ingest — $format", ({ format, ext, mime }) => {
+  it("stores the bytes verbatim under a filename that names the real format", async () => {
+    const bytes = await encode(format);
+    const meta = await ingestCapture(store, {
+      caseId: "c1",
+      timestamp: "2026-05-28T10:00:00.000Z",
+      url: "https://example.test/x",
+      tabTitle: "Evidence",
+      triggerType: "timer",
+      imageBase64: bytes.toString("base64"),
+    });
+
+    expect(meta.screenshotFile.endsWith(ext)).toBe(true);
+    const onDisk = await readFile(join(store.screenshotsDir("c1"), meta.screenshotFile));
+    // Verbatim: the fix preserves the source format rather than transcoding, so the content hash
+    // covers the bytes the analyst's browser actually sent.
+    expect(onDisk.equals(bytes)).toBe(true);
+  });
+
+  it("hands the AI provider the matching media type", async () => {
+    const bytes = await encode(format);
+    const meta = await ingestCapture(store, {
+      caseId: "c1",
+      timestamp: "2026-05-28T10:00:00.000Z",
+      url: "https://example.test/x",
+      tabTitle: "Evidence",
+      triggerType: "timer",
+      imageBase64: bytes.toString("base64"),
+    });
+
+    const loaded = await makeImageLoader(store)("c1", meta.screenshotFile);
+    expect(loaded.mimeType).toBe(mime);
+    expect(Buffer.from(loaded.base64, "base64").equals(bytes)).toBe(true);
+  });
+
+  it("serves the evidence with the matching Content-Type", async () => {
+    const bytes = await encode(format);
+    const meta = await ingestCapture(store, {
+      caseId: "c1",
+      timestamp: "2026-05-28T10:00:00.000Z",
+      url: "https://example.test/x",
+      tabTitle: "Evidence",
+      triggerType: "timer",
+      imageBase64: bytes.toString("base64"),
+    });
+
+    const res = await request(app).get(`/cases/c1/evidence/${meta.screenshotFile}`);
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain(mime);
+  });
+});
+
+describe("screenshots already on disk under the old fixed .webp suffix", () => {
+  it("are described by their bytes, not by the misleading name", async () => {
+    // No migration ships with the fix, so the loader and the evidence route have to cope with the
+    // files the old code wrote: PNG bytes in a .webp filename.
+    const bytes = await encode("png");
+    await store.saveScreenshot("c1", "000001_legacy.webp", bytes);
+
+    expect((await makeImageLoader(store)("c1", "000001_legacy.webp")).mimeType).toBe("image/png");
+    const res = await request(app).get("/cases/c1/evidence/000001_legacy.webp");
+    expect(res.headers["content-type"]).toContain("image/png");
+  });
+
+  it("does not re-type a non-image evidence file by its content", async () => {
+    // The sniff covers four image magic numbers only — an imported CSV stays text/plain.
+    await store.saveImport("c1", "hits.csv", "a,b\n1,2\n");
+    const res = await request(app).get("/cases/c1/evidence/hits.csv");
+    expect(res.headers["content-type"]).toContain("text/plain");
+  });
+});


### PR DESCRIPTION
Closes #425.

Capture ingest explicitly accepts PNG, JPEG, GIF and WebP — and stored every accepted buffer under a `.webp` filename:

```ts
const screenshotFile = titleSlug ? `${seq}_${tsSafe}_${titleSlug}.webp` : `${seq}_${tsSafe}.webp`;
```

`makeImageLoader` then reported `mimeType: "image/webp"` whatever the bytes were, and the evidence route derives its `Content-Type` from that filename. So for **three of the four accepted formats**, the filename, the media type sent to the AI provider, and the response header all described the evidence incorrectly. The existing ingest tests posted real PNG data and asserted a `.webp` suffix — the bug was documented, not caught.

## Which option

The issue offers transcode-to-WebP or preserve-the-source-format. **Preserve**, because transcoding would re-encode evidence *before* it is hashed, so the recorded content hash would cover bytes that never existed on the analyst's screen. For a forensic tool that is the worse trade.

## The change

The magic-byte sniff that already gate-kept ingest now returns *which* format it recognized, from one module — `ingest/imageFormat.ts` — shared by ingest, the image loader and the evidence route.

The loader and the route sniff the **bytes** rather than reading the extension. That costs nothing and heals the screenshots already on disk under the old fixed suffix: a PNG stored as `.webp` by the old code is now sent to the provider and served to the browser as `image/png`, **with no migration**. The route's sniff covers only the four image magic numbers, so an imported CSV is still `text/plain`.

`ingest/imageFormat.ts` sits in the platform layer so both `ingest/` (sideways) and `analysis/` (down) can import it without a boundary violation.

## Tests

`tests/server/captureFormats.test.ts` (new) runs all four formats through ingest → loader → evidence route, asserting the four things that must agree: saved bytes (byte-identical, proving no transcode), filename extension, AI media type, response `Content-Type`. Ten of its fourteen tests fail on master.

Plus two legacy cases: a PNG stored under the old `.webp` name is described by its bytes, and a non-image evidence file is not re-typed by its content.

Two existing assertions changed from `.webp` to `.png` (`tests/server.test.ts`, `tests/fullPipeline.test.ts`) — their fixtures were always PNGs.

## Gates

All seven clean; full suite **6871 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)