### PR TITLE
fix(memory): bound the pstree __children walk instead of exhausting the stack

### DIFF
--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -1,6 +1,6 @@
 {
   "analysis/caseSqliteWorker.ts": 812,
-  "analysis/memoryImport.ts": 1265,
+  "analysis/memoryImport.ts": 1264,
   "analysis/pipeline.ts": 3411,
   "analysis/seedDemoCase.ts": 822,
   "analysis/siemImport.ts": 1346,

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -305,6 +305,7 @@
     "m365Import.ts": "analysis/ingest",
     "manualEntry.ts": "analysis/workflow",
     "memoryImport.ts": "analysis/ingest",
+    "pstreeDepth.ts": "analysis/ingest",
     "memoryNextStep.ts": "analysis/ai",
     "mobileSummary.ts": "analysis/workflow",
     "networkImport.ts": "analysis/ingest",

--- a/companion/src/analysis/memoryImport.ts
+++ b/companion/src/analysis/memoryImport.ts
@@ -49,6 +49,7 @@ import {
   type SiemIoc,
   maxEventsDefault,
 } from "./siemImport.js";
+import { pstreeChildren } from "./pstreeDepth.js";
 import { parseCsv } from "./csvImport.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
 
@@ -224,18 +225,17 @@ function mapProcess(label: string, tool: string, rows: Row[], sink: Map<string, 
 
   // Index PID → name (across the whole tree) so a flat table resolves PPID → parent name.
   const pidIndex = new Map<string, string>();
-  const index = (list: Row[]): void => {
+  const index = (list: Row[], depth: number): void => {
     for (const r of list) {
       const pid = pickPid(r); const nm = procName(r);
       if (pid && nm) pidIndex.set(pid, nm);
-      const kids = getCI(r, "__children");
-      if (Array.isArray(kids)) index(kids.filter(isObject));
+      index(pstreeChildren(r, depth), depth + 1);
     }
   };
-  index(rows);
+  index(rows, 0);
   recordIndex = 0;
 
-  const walk = (list: Row[], parent: string): void => {
+  const walk = (list: Row[], parent: string, depth: number): void => {
     for (const r of list) {
       const locatorIndex = recordIndex++;
       const name = procName(r);
@@ -312,11 +312,10 @@ function mapProcess(label: string, tool: string, rows: Row[], sink: Map<string, 
           ...(path && /[\\/]/.test(path) ? { path } : {}),
         });
       }
-      const kids = getCI(r, "__children");
-      if (Array.isArray(kids)) walk(kids.filter(isObject), name || parent);
+      walk(pstreeChildren(r, depth), name || parent, depth + 1);
     }
   };
-  walk(rows, "");
+  walk(rows, "", 0);
   return out;
 }
 

--- a/companion/src/analysis/pstreeDepth.ts
+++ b/companion/src/analysis/pstreeDepth.ts
@@ -1,0 +1,42 @@
+import { isObject, getCI } from "./siemImport.js";
+
+type Row = Record<string, unknown>;
+
+/**
+ * How deep a Volatility pstree may nest before the file is treated as malformed.
+ *
+ * The nesting comes straight from evidence — a `vol -r json` array, a volatility-map, a jsonl dump
+ * — and mapProcess recurses over it twice, once to index PIDs and once to emit events. V8's
+ * JSON.parse is iterative, so it accepts arbitrarily deep JSON without complaint; the depth only
+ * becomes call frames during those walks. Measured on the Node version this project targets,
+ * JSON.parse takes 300k levels happily while a recursive walk over the same structure dies at
+ * about 20k — roughly a 1 MB crafted file. The import already failed safely (every call site
+ * catches), but it failed with a raw "Maximum call stack size exceeded" instead of saying what was
+ * wrong with the file (#429).
+ *
+ * 128 is far past any real process tree — a deep Windows tree is a dozen levels — so nothing
+ * forensic is lost, and far below the stack limit. Every other walker over untrusted input in this
+ * codebase is bounded the same way (siemImport's `flatten` returns past depth > 3,
+ * velociraptorImport's pickTime fallback stops at depth < 1); pstree was the exception.
+ */
+export const MAX_PSTREE_DEPTH = 128;
+
+/**
+ * The child rows of a pstree node, ready to recurse into — empty when it has none.
+ *
+ * `parentDepth` is the depth of `row` itself, so descending into the result costs one more level.
+ * Throws when that would pass the cap, rather than truncating: silently dropping a subtree would
+ * be evidence loss, and this shape of file is malformed either way.
+ */
+export function pstreeChildren(row: Row, parentDepth: number): Row[] {
+  const kids = getCI(row, "__children");
+  if (!Array.isArray(kids) || kids.length === 0) return [];
+  if (parentDepth >= MAX_PSTREE_DEPTH) {
+    throw new Error(
+      `pstree __children nesting is deeper than ${MAX_PSTREE_DEPTH} levels — no real process tree ` +
+        `is, so this file is malformed or crafted. Re-export the pstree output, or import the flat ` +
+        `pslist/psscan output instead.`,
+    );
+  }
+  return kids.filter(isObject);
+}

--- a/companion/tests/analysis/memoryImport.test.ts
+++ b/companion/tests/analysis/memoryImport.test.ts
@@ -44,6 +44,41 @@ describe("parseMemory — Volatility 3 pslist", () => {
   });
 });
 
+// #429: mapProcess walked `__children` with no depth limit, in both the pid-indexing pass and the
+// event-emitting pass. The nesting comes straight from evidence, and V8's JSON.parse is iterative —
+// it accepts arbitrarily deep JSON without complaint — so the depth only became call frames during
+// those walks, and around 20k levels (a ~1 MB file) exhausted the stack. Every call site already
+// caught the RangeError, so the import failed safely; it just failed by telling the analyst
+// "Maximum call stack size exceeded" instead of what was wrong with the file.
+describe("parseMemory — pstree nesting depth", () => {
+  // Built as TEXT, not via JSON.stringify: stringify is recursive and dies well before JSON.parse
+  // does, and that asymmetry is the whole reason this input reaches the walkers at all.
+  function nestedJson(levels: number): string {
+    const parts: string[] = [];
+    for (let i = 1; i <= levels; i++) parts.push(`{"PID":${i},"PPID":${i - 1},"ImageFileName":"p${i}.exe","__children":[`);
+    parts.push('{"PID":0,"PPID":0,"ImageFileName":"leaf.exe","__children":[]}');
+    for (let i = 0; i < levels; i++) parts.push("]}");
+    return `[${parts.join("")}]`;
+  }
+
+  it("rejects an over-deep tree with an actionable message, not a RangeError", () => {
+    // 30k levels: JSON.parse takes it happily, an unbounded recursive walk does not.
+    const text = nestedJson(30_000);
+    expect(() => JSON.parse(text)).not.toThrow();
+    expect(() => parseMemory(text, { filename: "windows.pstree.json" })).toThrow(/nesting is deeper than/i);
+    expect(() => parseMemory(text, { filename: "windows.pstree.json" })).not.toThrow(RangeError);
+  });
+
+  it("still imports a tree of realistic depth", () => {
+    // A deep Windows process tree is a dozen levels; the cap is 128.
+    const r = parseMemory(nestedJson(20), { filename: "windows.pstree.json" });
+    expect(r.processes).toBe(1);                              // one root row in the table
+    expect(r.events.length).toBeGreaterThan(1);               // every level emitted an event
+    expect(r.events.some((e) => e.description.includes("leaf.exe"))).toBe(true);
+    expect(r.events.some((e) => e.parentName === "p20.exe")).toBe(true);
+  });
+});
+
 describe("parseMemory — Volatility 3 netscan", () => {
   it("maps connections, harvests the foreign IP, and grades an external ESTABLISHED conn Low", () => {
     const r = parseMemory(JSON.stringify(netscan()), { filename: "netscan.json" });


### PR DESCRIPTION
Closes #429.

`mapProcess` walked the Volatility 3 pstree tree with **no depth limit**, in both passes — `index()` (pid-indexing) and `walk()` (event-emitting). The nesting comes straight from evidence: a `vol -r json` array, a volatility-map, a jsonl dump.

The reason it is reachable at all: V8's `JSON.parse` is **iterative**, so it accepts arbitrarily deep JSON without complaint. The depth only becomes call frames once these walks recurse over the parsed structure — about 20k levels, a roughly 1 MB crafted file.

## Impact, stated precisely

**The server is not taken down.** `RangeError` from stack exhaustion is an ordinary catchable exception, and every call site already catches it — the synchronous preview `parseMemory` runs inside a `try/catch` that routes to `sendPipelineError`, and the unified import paths are `.catch`-handled into a failed job. So the outcome was one self-inflicted import failure that reported `Maximum call stack size exceeded` instead of saying what was wrong with the file. A robustness / error-quality gap, not a denial of service.

## The fix

Both recursions thread a depth and stop at **128** levels. A deep Windows process tree is a dozen levels, so nothing forensic is lost, and 128 is far below the stack limit.

Over-deep input **throws** a named importer error naming the limit and the alternative (import the flat `pslist`/`psscan` output) — it does not truncate. Silently dropping a subtree would be evidence loss, and a file this shape is malformed either way.

Every other walker over untrusted input here is already bounded — `siemImport`'s `flatten` returns past `depth > 3`, `velociraptorImport`'s `pickTime` fallback stops at `depth < 1`. pstree was the exception, not a deliberate carve-out.

The guard lives in `analysis/pstreeDepth.ts` because `memoryImport.ts` is at its `check:size` ledger cap — and it earns the module, since it also absorbs the `__children` lookup both passes were duplicating (`memoryImport.ts` 1265 → 1263, re-recorded down).

## Tests

Two, in `tests/analysis/memoryImport.test.ts`. The first fails on master with `Maximum call stack size exceeded`:

- a 30k-level `__children` chain: asserts `JSON.parse` accepts it, then that `parseMemory` rejects it with the actionable message and **not** a `RangeError`
- a 20-level tree still imports, with every level emitting an event and parent links intact

The fixture is built as JSON **text** rather than with `JSON.stringify` — stringify is recursive and dies well before `JSON.parse` does, and that asymmetry is the whole reason this input reaches the walkers, so the test asserts it rather than tripping over it.

## Gates

All seven clean; full suite **6859 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)