### PR TITLE
fix(extension): cap decompression of a page-forgeable capture body

### DIFF
--- a/extension/src/adapters/bridge.ts
+++ b/extension/src/adapters/bridge.ts
@@ -10,6 +10,22 @@ export const DFIR_READY_MSG = "dfir-companion-hook-ready";
 export const DFIR_CONFIG_MSG = "dfir-companion-hook-config";
 export const DFIR_CAPTURE_MSG = "dfir-companion-hook-capture";
 
+/**
+ * Largest capture body the content script will accept, in characters.
+ *
+ * The MAIN-world hook applies the same bound before it forwards anything (pageHook.ts's MAX_BODY,
+ * re-declared there for the same standalone-bundle reason the message strings are — keep the two
+ * numbers in sync). That is not enough on its own: a script in the page can post a
+ * DFIR_CAPTURE_MSG itself and never goes through the hook, so the receiving side has to enforce
+ * the bound it relies on rather than assume the sender did (#430).
+ */
+export const MAX_CAPTURE_BODY = 8_000_000;
+
+/** Whether a DFIR_CAPTURE_MSG body is one the content script will accept at all. */
+export function isAcceptableCaptureBody(body: unknown): body is string {
+  return typeof body === "string" && body.length <= MAX_CAPTURE_BODY;
+}
+
 /** content → page: which response URLs to forward (regex sources matched case-insensitively). */
 export interface HookConfigMessage {
   source: typeof DFIR_CONFIG_MSG;

--- a/extension/src/adapters/extractUtils.ts
+++ b/extension/src/adapters/extractUtils.ts
@@ -51,8 +51,42 @@ const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
  * `deflate` first, then `gzip`/`deflate-raw` to be robust to encoder differences). Returns the parsed
  * JSON value, or null when the string isn't base64 / doesn't inflate to JSON. Async (the stream API
  * is async); a no-op on plain-JSON deployments.
+ *
+ * The output is capped. `raw` reaches here from a page-forgeable DFIR_CAPTURE_MSG — the same
+ * untrusted channel the DANGEROUS_KEYS guard below exists for — and the hook's own 8 MB cap does
+ * not apply, because a script in the page's MAIN world can post the message itself and never goes
+ * through the hook. A small high-ratio DEFLATE stream therefore used to inflate without limit
+ * (#430). `maxBytes` is a test seam; production callers use the default.
  */
-export async function inflateBase64Json(raw: string): Promise<unknown | null> {
+export const MAX_INFLATED_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Inflate to text, reading incrementally and giving up the moment the accumulated output passes
+ * `maxBytes`. Returns null for "too big" — distinct from a throw, which means these bytes are not
+ * this format. `new Response(stream).text()` cannot do this: it materializes the whole output
+ * first, so a check on the result runs after the allocation it was meant to prevent.
+ */
+async function inflateCapped(blob: Blob, format: "deflate" | "gzip" | "deflate-raw", maxBytes: number): Promise<string | null> {
+  const reader = blob.stream().pipeThrough(new DecompressionStream(format)).getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => { /* already closing */ });
+      return null;
+    }
+    chunks.push(value);
+  }
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) { merged.set(chunk, offset); offset += chunk.byteLength; }
+  return new TextDecoder().decode(merged);
+}
+
+export async function inflateBase64Json(raw: string, maxBytes = MAX_INFLATED_BYTES): Promise<unknown | null> {
   const compact = raw.replace(/\s+/g, "");
   if (compact.length < 8 || !BASE64_RE.test(compact)) return null;
   // Deliberately un-annotated: a bare `Uint8Array` widens to `Uint8Array<ArrayBufferLike>` under
@@ -65,13 +99,17 @@ export async function inflateBase64Json(raw: string): Promise<unknown | null> {
     bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
   } catch { return null; }
   for (const format of ["deflate", "gzip", "deflate-raw"] as const) {
+    let inflated: string | null;
     try {
-      const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream(format));
-      const text = (await new Response(stream).text()).trim();
-      if (text.startsWith("{") || text.startsWith("[")) {
-        try { return JSON.parse(text); } catch { /* inflated but not JSON — try next format */ }
-      }
-    } catch { /* wrong format for these bytes — try the next */ }
+      inflated = await inflateCapped(new Blob([bytes]), format, maxBytes);
+    } catch { continue; }   // wrong format for these bytes — try the next
+    // Over the cap. Not a format mismatch: only a stream these bytes really are produces output at
+    // all, so trying the remaining formats would just re-run the bomb. Give up on the payload.
+    if (inflated === null) return null;
+    const text = inflated.trim();
+    if (text.startsWith("{") || text.startsWith("[")) {
+      try { return JSON.parse(text); } catch { /* inflated but not JSON — try next format */ }
+    }
   }
   return null;
 }

--- a/extension/src/artifactCapture.ts
+++ b/extension/src/artifactCapture.ts
@@ -22,7 +22,7 @@ import type { Adapter, CapturedArtifact } from "./adapters/types.js";
 import { resolveActiveAdapter } from "./adapters/override.js";
 import { matrixToRows } from "./adapters/domTable.js";
 import { decodeCapturedBodies } from "./adapters/extractUtils.js";
-import { DFIR_CAPTURE_MSG, DFIR_CONFIG_MSG, DFIR_READY_MSG } from "./adapters/bridge.js";
+import { DFIR_CAPTURE_MSG, DFIR_CONFIG_MSG, DFIR_READY_MSG, isAcceptableCaptureBody } from "./adapters/bridge.js";
 import { clampButtonPosition, isDrag, parseButtonPos, type ButtonPos } from "./buttonPosition.js";
 import type { EnsureHookMessage, PushArtifactMessage, PushArtifactResult, CaptureStatusResult } from "./types.js";
 import { browserApi } from "./browser.js";
@@ -197,7 +197,10 @@ function onPageMessage(ev: MessageEvent): void {
 
   if (d.source === DFIR_READY_MSG) { sendConfig(); return; }
 
-  if (d.source === DFIR_CAPTURE_MSG && typeof d.body === "string") {
+  // isAcceptableCaptureBody, not a bare typeof: the hook caps what it forwards, but this message is
+  // page-forgeable and can arrive without having gone through it, so the receiving side enforces
+  // the bound rather than assuming the sender did (#430).
+  if (d.source === DFIR_CAPTURE_MSG && isAcceptableCaptureBody(d.body)) {
     // Decoding may be async (compressed bfetch) — kick it off and don't block the message handler.
     void ingestCapturedBody(String(d.url ?? ""), d.body);
   }

--- a/extension/src/pageHook.ts
+++ b/extension/src/pageHook.ts
@@ -21,7 +21,7 @@
 
   // Don't forward absurdly large bodies across the postMessage bridge (the companion can still
   // ingest big files via the dashboard; this just keeps the in-page channel sane). ~8 MB of text.
-  const MAX_BODY = 8_000_000;
+  const MAX_BODY = 8_000_000;   // keep in sync with MAX_CAPTURE_BODY in adapters/bridge.ts (#430)
 
   const w = window as unknown as { __dfirHookInstalled?: boolean };
   if (w.__dfirHookInstalled) return; // idempotent — survive double injection (SPA re-navigations)

--- a/extension/tests/adapters.test.ts
+++ b/extension/tests/adapters.test.ts
@@ -7,7 +7,7 @@ import { crowdstrikeAdapter } from "../src/adapters/crowdstrike.js";
 import { securityOnionAdapter } from "../src/adapters/securityonion.js";
 import { socratesAdapter } from "../src/adapters/socrates.js";
 import { volwebAdapter, volwebSourceLabel } from "../src/adapters/volweb.js";
-import { parseResponseBodies, decodeCapturedBodies, zipColumnsRows, unflattenDotted } from "../src/adapters/extractUtils.js";
+import { parseResponseBodies, decodeCapturedBodies, zipColumnsRows, unflattenDotted, inflateBase64Json, MAX_INFLATED_BYTES } from "../src/adapters/extractUtils.js";
 import { deflateSync, gzipSync } from "node:zlib";
 
 describe("adapterForUrl", () => {
@@ -510,6 +510,42 @@ describe("decodeCapturedBodies (compressed bfetch — remote/Cloud Kibana)", () 
     const line = gzipSync(Buffer.from(JSON.stringify(item(0, { g: 1 })))).toString("base64");
     const rows = (await decodeCapturedBodies(line)).flatMap((b) => elasticAdapter.extractRows("u", b) ?? []);
     expect(rows).toEqual([{ _id: "0", _index: undefined, g: 1 }]);
+  });
+
+  // #430: inflateBase64Json read the whole DecompressionStream with `new Response(stream).text()`,
+  // which materializes the entire output before anything can look at its size. The input reaches
+  // it from a page-forgeable DFIR_CAPTURE_MSG — the same untrusted channel the DANGEROUS_KEYS
+  // guard exists for — and the hook's 8 MB cap does not apply, because a script in the page's MAIN
+  // world can post the message itself and never goes through the hook.
+  describe("decompression bomb guard", () => {
+    // ~800 KB of JSON from a ~2 KB input: high ratio, and deliberately VALID JSON so that without
+    // the cap it inflates and parses successfully. A bomb of nulls would return null either way
+    // and the test would pass for the wrong reason.
+    const inflatesTo = JSON.stringify(new Array(400_000).fill(0));
+    const bomb = deflateSync(Buffer.from(inflatesTo)).toString("base64");
+
+    it("aborts past the cap and returns null instead of materializing the output", async () => {
+      expect(bomb.length).toBeLessThan(16 * 1024);              // tiny input...
+      expect(inflatesTo.length).toBeGreaterThan(500 * 1024);    // ...large output
+      expect(await inflateBase64Json(bomb, 64 * 1024)).toBeNull();
+    });
+
+    it("is the cap doing it, not the payload — the same bytes decode under a larger cap", async () => {
+      const decoded = await inflateBase64Json(bomb, 4 * 1024 * 1024);
+      expect(Array.isArray(decoded)).toBe(true);
+      expect((decoded as unknown[]).length).toBe(400_000);
+    });
+
+    it("still decodes an ordinary payload, at a small cap and at the production one", async () => {
+      const payload = { rawResponse: { hits: { hits: [{ _id: "1", _source: { ok: true } }] } } };
+      const line = deflateSync(Buffer.from(JSON.stringify(payload))).toString("base64");
+      expect(await inflateBase64Json(line, 64 * 1024)).toEqual(payload);
+      expect(await inflateBase64Json(line)).toEqual(payload);
+    });
+
+    it("caps at 64 MB by default — far above a real bfetch response, far below a heap", () => {
+      expect(MAX_INFLATED_BYTES).toBe(64 * 1024 * 1024);
+    });
   });
 
   it("returns [] for empty input and skips undecodable lines", async () => {

--- a/extension/tests/pageHook.test.ts
+++ b/extension/tests/pageHook.test.ts
@@ -17,6 +17,28 @@ function compiledPageHook(): string {
   }).outputText;
 }
 
+// #430: the hook's forward() cap and the content script's accept cap are the same bound, written
+// twice — pageHook.ts is bundled standalone and cannot import bridge.ts, the same reason the
+// message-name strings are duplicated. A drift test is what keeps "keep the two in sync" true.
+describe("capture body cap", () => {
+  it("pageHook's MAX_BODY matches MAX_CAPTURE_BODY in adapters/bridge.ts", async () => {
+    const source = readFileSync(resolve(testDir, "../src/pageHook.ts"), "utf8");
+    const declared = /const MAX_BODY = ([0-9_]+);/.exec(source);
+    expect(declared).not.toBeNull();
+    const { MAX_CAPTURE_BODY } = await import("../src/adapters/bridge.js");
+    expect(Number(declared![1].replace(/_/g, ""))).toBe(MAX_CAPTURE_BODY);
+  });
+
+  it("rejects a body over the cap at the content script's boundary", async () => {
+    const { isAcceptableCaptureBody, MAX_CAPTURE_BODY } = await import("../src/adapters/bridge.js");
+    expect(isAcceptableCaptureBody("a".repeat(MAX_CAPTURE_BODY))).toBe(true);
+    expect(isAcceptableCaptureBody("a".repeat(MAX_CAPTURE_BODY + 1))).toBe(false);
+    // Still the type guard the call site relied on before the length check joined it.
+    expect(isAcceptableCaptureBody(undefined)).toBe(false);
+    expect(isAcceptableCaptureBody({ length: 1 })).toBe(false);
+  });
+});
+
 describe("pageHook", () => {
   it("can be injected repeatedly into the same page", () => {
     const addEventListener = vi.fn();


### PR DESCRIPTION
Closes #430.

`inflateBase64Json` decompressed a page-supplied base64 payload with `new Response(stream).text()` and **no cap on the output**, and `onPageMessage` passed `d.body` into it with **no length guard**. The 8 MB `MAX_BODY` cap in `pageHook`'s `forward()` does not cover this: a script in the page's MAIN world can post the `DFIR_CAPTURE_MSG` itself and never goes through the hook.

## Scoped honestly

This is a hardening gap, not an exploitable vulnerability with a distinct victim. The only party who can trigger it is a page the analyst has granted persistent site access to, and that page shares the same renderer process as the isolated-world content script — any page running JS can already exhaust its own renderer directly. No process, origin, or tab boundary is crossed, and output past V8's ~1 GiB string limit throws a `RangeError` the surrounding `catch` already handles.

It is still worth fixing, because the authors already treat this exact channel as hostile: the `DANGEROUS_KEYS` prototype-pollution guard a few lines away exists *precisely because* `DFIR_CAPTURE_MSG` is page-forgeable. Unbounded decompression on the same input is inconsistent with that stance.

## Two bounds, one at each end

**At the message boundary.** The content script rejects an oversized body before ingest via `isAcceptableCaptureBody` in `adapters/bridge.ts` — the receiving side enforcing the bound rather than assuming the sender applied it. It replaces the bare `typeof` check and is still a type guard, so the call site is unchanged in shape.

`pageHook.ts` cannot import `bridge.ts` (it is bundled standalone as a web-accessible resource — the same reason the message-name strings are duplicated), so a **drift test** now asserts the two numbers match, rather than relying on the "keep the two in sync" comment.

**At the decompressor.** `inflateBase64Json` reads the `DecompressionStream` incrementally via `getReader()` and cancels the moment accumulated output passes **64 MB** — far above any real bfetch response, far below a heap. `new Response(stream).text()` cannot do this: it materializes the whole output first, so a size check on the result runs *after* the allocation it was meant to prevent.

Hitting the cap stops the whole payload rather than retrying the remaining formats: a bomb is a bomb in whichever format decoded it, and only a stream the bytes really are produces output at all.

## Tests

Six new tests; four fail on master:

- a ~2 KB DEFLATE input inflating to ~800 KB is refused at a 64 KB cap. The fixture inflates to **valid JSON on purpose** — a bomb of nulls returns `null` with or without the fix, so that test would pass for the wrong reason. This one parses successfully without the cap (4.6s on master) and returns `null` with it.
- the same bytes decode fine under a larger cap, proving it is the cap and not the payload
- ordinary payloads still decode, at a small cap and at the production one
- `MAX_INFLATED_BYTES` is 64 MB
- `pageHook`'s `MAX_BODY` matches `MAX_CAPTURE_BODY`
- the boundary predicate accepts exactly-at-cap, rejects over-cap, and still rejects non-strings

Extension build, typecheck and suite: **212 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)