### PR TITLE
test: adopt pollFor in every file hand-rolling a bounded poll loop

### DIFF
--- a/companion/tests/fullPipeline.test.ts
+++ b/companion/tests/fullPipeline.test.ts
@@ -12,6 +12,8 @@ import { StateStore } from "../src/analysis/stateStore.js";
 import { MockProvider } from "../src/providers/provider.js";
 import { ReportWriter } from "../src/reports/reportWriter.js";
 import { ReportMetaStore } from "../src/reports/reportMeta.js";
+import { POLL_TIMEOUT_MS } from "./helpers/poll.js";
+import { pollState } from "./helpers/caseWaits.js";
 
 async function pngBase64(): Promise<string> {
   const buf = await sharp({
@@ -138,11 +140,8 @@ describe("full-pipeline integration (capture → import → synthesis → report
     const screenshotFile = capture.body.screenshotFile as string;
 
     // Wait for extraction + auto-synthesis to populate state
-    let state = await stateStore.load("pipeline-1");
-    for (let i = 0; i < 60 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("pipeline-1");
-    }
+    let state = await pollState(stateStore, "pipeline-1",
+      "extraction + auto-synthesis to produce a finding", (s) => s.findings.length > 0);
     expect(state.forensicTimeline.length).toBeGreaterThanOrEqual(1);
     expect(state.findings.length).toBe(1);
     expect(state.findings[0].title).toBe("Suspicious execution");
@@ -169,11 +168,8 @@ describe("full-pipeline integration (capture → import → synthesis → report
     expect(imp.body.kind).toBe("thor");
 
     // Wait for THOR import to land and re-synthesis to run
-    state = await stateStore.load("pipeline-1");
-    for (let i = 0; i < 80 && state.forensicTimeline.length < 2; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("pipeline-1");
-    }
+    state = await pollState(stateStore, "pipeline-1",
+      "the THOR import to bring the forensic timeline to 2 events", (s) => s.forensicTimeline.length >= 2);
     expect(state.forensicTimeline.some((e) => e.description.includes("mimikatz"))).toBe(true);
     expect(state.iocs.some((i) => i.value.includes("mimikatz.exe"))).toBe(true);
 
@@ -182,11 +178,8 @@ describe("full-pipeline integration (capture → import → synthesis → report
     const enrich = await request(app).post("/cases/pipeline-1/enrich").send({});
     expect(enrich.status).toBe(202);
 
-    state = await stateStore.load("pipeline-1");
-    for (let i = 0; i < 40 && !state.iocs.some((i) => i.enrichments); i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("pipeline-1");
-    }
+    state = await pollState(stateStore, "pipeline-1",
+      "the MockTI enrichment to annotate an IOC", (s) => s.iocs.some((i) => i.enrichments));
     const enrichedIoc = state.iocs.find((i) => i.enrichments?.some((e) => e.source === "MockTI"));
     expect(enrichedIoc).toBeDefined();
     expect(enrichedIoc!.enrichments).toEqual([
@@ -258,7 +251,8 @@ describe("full-pipeline integration (capture → import → synthesis → report
       .split("\n")
       .map((line) => JSON.parse(line));
     expect(restoredImportFiles.length).toBeGreaterThanOrEqual(1);
-  }, 60_000);
+    // THREE sequential pollState budgets, plus the export/restore/report legs after them.
+  }, POLL_TIMEOUT_MS * 6);
 
   it("does not leave AI or enrichment provider artifacts behind when AI is off", async () => {
     const { app, stateStore } = await freshFullPipelineApp();

--- a/companion/tests/helpers/caseWaits.ts
+++ b/companion/tests/helpers/caseWaits.ts
@@ -1,0 +1,86 @@
+/**
+ * Case-state waits, built on `pollFor` (issue #408).
+ *
+ * `poll.ts` stays domain-free — it knows only about budgets and probes. These are the DFIR-specific
+ * waits the server and pipeline tests share, and they live here so the wording of a failure is
+ * written once rather than copied per file.
+ *
+ * Every one of them replaced a hand-rolled `for (let i = 0; i < N; i++) { read(); await sleep(25) }`
+ * loop. That spelled a private sub-2s deadline, and on expiry it did not say so — it fell through to
+ * the caller's assertion, so a starved CI box reported `expected 0 to be 1` and read like a pipeline
+ * that produced nothing rather than a wait that ran out. An iteration count was not even a coherent
+ * budget: most of each iteration was the state read, not the sleep, so the wait got SHORTER exactly
+ * when the machine was slowest. The description closures below name what never happened and report
+ * the counts actually observed.
+ */
+import type { StateStore } from "../../src/analysis/stateStore.js";
+import type { InvestigationState } from "../../src/analysis/stateTypes.js";
+import { pollFor } from "./poll.js";
+
+/**
+ * Wait until `ready` accepts the case state, then return that state.
+ *
+ * Costs ONE poll budget — keep the calling test's timeout above the sum of its waits.
+ */
+export async function pollState(
+  stateStore: StateStore,
+  caseId: string,
+  what: string,
+  ready: (s: InvestigationState) => boolean,
+): Promise<InvestigationState> {
+  let last: InvestigationState | undefined;
+  return pollFor(
+    () =>
+      `${what} — last saw ${last?.forensicTimeline.length ?? 0} event(s), ` +
+      `${last?.findings.length ?? 0} finding(s), ${last?.iocs.length ?? 0} IOC(s)`,
+    async () => {
+      last = await stateStore.load(caseId);
+      return ready(last) ? last : undefined;
+    },
+  );
+}
+
+/** Wait for the background analysis (extraction → synthesis) to produce a finding. */
+export function pollForFinding(stateStore: StateStore, caseId: string): Promise<InvestigationState> {
+  return pollState(
+    stateStore,
+    caseId,
+    "the background analysis to produce a finding",
+    (s) => s.findings.length > 0,
+  );
+}
+
+/**
+ * Wait for a background import to land at least `atLeast` forensic events.
+ *
+ * Pass the count the test actually asserts on. Polling for "any event" and then asserting a count
+ * reintroduces the bug this helper exists to remove: the second event merely landing late reports
+ * as `expected 1 to be 2`.
+ */
+export function pollForForensicEvents(
+  stateStore: StateStore,
+  caseId: string,
+  atLeast = 1,
+): Promise<InvestigationState> {
+  return pollState(
+    stateStore,
+    caseId,
+    `the background import to land ${atLeast} forensic event(s)`,
+    (s) => s.forensicTimeline.length >= atLeast,
+  );
+}
+
+/** As `pollForForensicEvents`, but returns the event count for tests that assert on it directly. */
+export async function waitForEvents(stateStore: StateStore, caseId: string, atLeast = 1): Promise<number> {
+  return (await pollForForensicEvents(stateStore, caseId, atLeast)).forensicTimeline.length;
+}
+
+/** Wait for background enrichment to annotate the case's first IOC. */
+export function pollForFirstIocEnrichment(
+  stateStore: StateStore,
+  caseId: string,
+): Promise<InvestigationState> {
+  return pollState(stateStore, caseId, "the background enrichment to annotate the first IOC", (s) =>
+    Boolean(s.iocs[0]?.enrichments),
+  );
+}

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -23,6 +23,8 @@ import { emptyState, type InvestigationState } from "../src/analysis/stateTypes.
 import type { CustomerExposureProvider } from "../src/analysis/customerExposure.js";
 import { JobManager } from "../src/analysis/jobManager.js";
 import { DropStatusStore } from "../src/analysis/dropStatus.js";
+import { pollFor, POLL_TIMEOUT_MS } from "./helpers/poll.js";
+import { pollForFinding, pollForForensicEvents, pollForFirstIocEnrichment } from "./helpers/caseWaits.js";
 
 let app: ReturnType<typeof createApp>;
 
@@ -253,13 +255,9 @@ describe("server analysis wiring", () => {
     });
 
     // analysis runs async after the response; poll the state briefly.
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 20 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.findings).toHaveLength(1);
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   it("periodic flush analyzes a lone buffered capture that never fills a window", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-flush-"));
@@ -288,13 +286,9 @@ describe("server analysis wiring", () => {
 
     // No navigation/tab_switch and the window is far from full, so analysis only happens once
     // the periodic sweep fires. Poll the state until the finding lands.
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 40 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.findings).toHaveLength(1);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("auto-synthesizes (debounced) after a capture window when enabled", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-autosynth-"));
@@ -327,16 +321,12 @@ describe("server analysis wiring", () => {
       triggerType: "navigation", imageBase64: await pngBase64(),
     });
 
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 40 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.forensicTimeline.length).toBe(1);          // extraction ran
     expect(state.findings).toHaveLength(1);                  // auto-synthesis ran
     expect(state.findings[0].title).toBe("synth finding");
     expect(state.attackerPath).toBe("path");
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("imports a CSV: persists it as evidence, extracts events, then synthesizes findings", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-csv-"));
@@ -380,15 +370,11 @@ describe("server analysis wiring", () => {
     expect(stored).toBe(csv);
 
     // Background: extraction then synthesis populate the state.
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 60 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.forensicTimeline.length).toBeGreaterThanOrEqual(1); // extracted from rows
     expect(state.findings).toHaveLength(1);                          // synthesized
     expect(state.findings[0].title).toBe("finding from CSV");
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("serves screenshot + CSV evidence by filename and blocks traversal/invalid names", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-ev-"));
@@ -454,15 +440,11 @@ describe("server analysis wiring", () => {
     const stored = await readFile(join(store.importsDir("c1"), res.body.file), "utf8");
     expect(stored).toBe(log);
 
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 60 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.forensicTimeline.length).toBeGreaterThanOrEqual(1);
     expect(state.findings).toHaveLength(1);
     expect(state.findings[0].title).toBe("finding from log");
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("rejects a log import with empty text (no non-empty lines)", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-log-empty-"));
@@ -521,17 +503,13 @@ describe("server analysis wiring", () => {
     expect(auditLog.trim().split("\n")).toHaveLength(1);
 
     // Deterministic mapping populated the timeline; background synthesis adds findings.
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 60 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.forensicTimeline.length).toBe(1);
     expect(state.forensicTimeline[0].severity).toBe("Critical");
     expect(state.forensicTimeline[0].timestamp).toBe("2025-03-14T21:18:18Z"); // artifact time, not scan time
     expect(state.iocs.some((i) => i.value.includes("mimikatz.exe"))).toBe(true);
     expect(state.findings.length).toBeGreaterThanOrEqual(1);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("rejects a THOR import that has only info/lifecycle rows (no findings)", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-thor-empty-"));
@@ -580,16 +558,12 @@ describe("server analysis wiring", () => {
     expect(res.body.kind).toBe("thor");
     expect(res.body.minSeverity).toBe("Critical"); // normalized + echoed back
 
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 80 && state.forensicTimeline.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    let state = await pollForForensicEvents(stateStore, "c1");
     await new Promise((r) => setTimeout(r, 100)); // settle — the Medium Notice must never land
     state = await stateStore.load("c1");
     expect(state.forensicTimeline).toHaveLength(1);          // Alert(Critical) kept, Notice(Medium) dropped
     expect(state.forensicTimeline[0].severity).toBe("Critical");
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("unified /import keeps an ungraded (all-Info) import in full despite a high floor (the 'no severities → import everything' rule)", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-import-gate-"));
@@ -615,17 +589,16 @@ describe("server analysis wiring", () => {
     expect(res.status).toBe(202);
     expect(res.body.kind).toBe("kape");
 
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 80 && state.forensicTimeline.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
-    await new Promise((r) => setTimeout(r, 100));
+    // Waits for BOTH rows, not just the first: the assertion below is a count, so polling for
+    // ">0" and then sleeping 100ms would report a second row that merely landed late as
+    // `expected 1 to be 2` — the very failure shape this conversion exists to remove.
+    let state = await pollForForensicEvents(stateStore, "c1", 2);
+    await new Promise((r) => setTimeout(r, 100));   // settle — no third event may appear
     state = await stateStore.load("c1");
     // The floor was "high" but this import grades nothing (all Info) → it is kept whole.
     expect(state.forensicTimeline).toHaveLength(2);
     expect(state.forensicTimeline.every((e) => e.severity === "Info")).toBe(true);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("imports a SIEM/EDR JSON export (Elastic envelope): unwraps, maps Windows events, then synthesizes", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-siem-"));
@@ -664,16 +637,12 @@ describe("server analysis wiring", () => {
     expect(auditLog.trim().split("\n")).toHaveLength(1);
 
     // Deterministic mapping populated the timeline; the ::ffff: IP was unwrapped.
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 60 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.forensicTimeline.length).toBe(2);
     expect(state.forensicTimeline.some((e) => e.severity === "High" && e.description.includes("7045"))).toBe(true);
     expect(state.iocs.some((i) => i.type === "ip" && i.value === "10.10.200.11")).toBe(true);
     expect(state.findings.length).toBeGreaterThanOrEqual(1);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("import with AI OFF populates the timeline + IOCs deterministically but does NOT synthesize", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-import-aioff-"));
@@ -698,11 +667,7 @@ describe("server analysis wiring", () => {
 
     // Deterministic THOR mapping runs in the background; give it time, then confirm the
     // timeline + IOCs landed but synthesis never produced findings (AI is off).
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 60 && state.forensicTimeline.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    let state = await pollForForensicEvents(stateStore, "c1");
     // Settle: ensure no delayed synthesis sneaks a finding in afterwards.
     await new Promise((r) => setTimeout(r, 150));
     state = await stateStore.load("c1");
@@ -710,7 +675,7 @@ describe("server analysis wiring", () => {
     expect(state.forensicTimeline[0].severity).toBe("Critical");
     expect(state.iocs.some((i) => i.value.includes("mimikatz.exe"))).toBe(true);
     expect(state.findings).toHaveLength(0);                              // synthesis was gated off — no findings
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("CSV/log import via /import is gated by the AI toggle — saved as evidence, NOT sent to the model, when AI is off", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-import-csv-aioff-"));
@@ -914,14 +879,10 @@ describe("server analysis wiring", () => {
     expect(res.body.iocs).toBe(2);
 
     // Background enrichment annotates the hash (not the file) — poll until it lands.
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 40 && !state.iocs[0].enrichments; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFirstIocEnrichment(stateStore, "c1");
     expect(state.iocs[0].enrichments).toEqual([{ source: "VirusTotal", verdict: "malicious", score: "60/72", fetchedAt: expect.any(String) }]);
     expect(state.iocs[1].enrichments).toBeUndefined(); // file path not enrichable
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("returns 501 for enrich when no providers are configured", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-server-noenrich-"));
@@ -970,16 +931,12 @@ describe("server analysis wiring", () => {
     expect(on.status).toBe(200);
     expect(on.body.providers).toEqual(["VirusTotal"]);
 
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 40 && !state.iocs[0].enrichments; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFirstIocEnrichment(stateStore, "c1");
     expect(state.iocs[0].enrichments?.[0]).toMatchObject({ source: "VirusTotal", verdict: "malicious" });
 
     // Persisted ON.
     expect((await vtState()).enabled).toBe(true);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("rejects a log import when no AI pipeline is configured", async () => {
     await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
@@ -1026,11 +983,12 @@ describe("server analysis wiring", () => {
       const ai = events.findIndex((e) => e.status === "analyzing" && e.phase === "extracting");
       return ai >= 0 && events.slice(ai + 1).some((e) => e.status === "idle");
     };
-    for (let i = 0; i < 40 && !flushed(); i++) {
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    await pollFor(
+      () => `the window flush to report analyzing(extracting) → idle, saw [${events.map((e) => `${e.status}/${e.phase ?? "-"}`).join(", ")}]`,
+      async () => (flushed() ? true : undefined),
+    );
     expect(flushed()).toBe(true); // the window flush reported analyzing(extracting) → idle
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   it("GET /health reports aiEnabled false without a pipeline, true with one", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-ai-health-"));
@@ -1224,10 +1182,13 @@ describe("state and report routes", () => {
     expect(post.body.mentions).toEqual(["bob"]);
 
     // dispatchNotify is fire-and-forget AND the notifier loads its channel config from disk before
-    // it fetches, so one microtask tick isn't enough — poll until the send lands (or give up).
-    for (let i = 0; i < 200 && !sent.length; i++) await new Promise((r) => setTimeout(r, 10));
+    // it fetches, so one microtask tick isn't enough — poll until the send lands.
+    await pollFor(
+      "the @mention notification to reach the configured webhook",
+      async () => (sent.length ? sent : undefined),
+    );
     expect(sent).toEqual(["https://hooks.slack.com/services/mentions"]);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("false-positive: onFalsePositive callback fires on add, batch add, and remove", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-legit-cb-"));
@@ -1937,13 +1898,9 @@ describe("AI on/off control", () => {
 
     // turn AI ON → backfill analyzes the two captured-while-off screenshots
     await request(app).post("/cases/c1/ai-control").send({ enabled: true });
-    let state = await stateStore.load("c1");
-    for (let i = 0; i < 40 && state.findings.length === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      state = await stateStore.load("c1");
-    }
+    const state = await pollForFinding(stateStore, "c1");
     expect(state.findings).toHaveLength(1);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("emits a terminal idle status when AI is turned on with nothing to catch up on", async () => {
     // Regression: the dashboard optimistically shows "AI on — catching up on un-analyzed
@@ -1962,13 +1919,14 @@ describe("AI on/off control", () => {
 
     // Fresh case, zero captures → toggling AI on has nothing to analyze, but must still emit idle.
     await request(app).post("/cases/c1/ai-control").send({ enabled: true });
-    for (let i = 0; i < 40 && !events.some((e) => e.status === "idle"); i++) {
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    await pollFor(
+      () => `a terminal idle status after the AI toggle, saw [${events.map((e) => e.status).join(", ")}]`,
+      async () => (events.some((e) => e.status === "idle") ? true : undefined),
+    );
     expect(events.some((e) => e.status === "idle")).toBe(true);
     // …and it must not have falsely claimed it was analyzing when there was nothing to do.
     expect(events.some((e) => e.status === "analyzing")).toBe(false);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("synthesizes evidence imported while AI was off when AI is turned on (no screenshots)", async () => {
     // Bug: importing a Velociraptor table with AI off populates the timeline deterministically, but
@@ -1986,9 +1944,12 @@ describe("AI on/off control", () => {
     await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
     // No capture log at all (import-only case). Turning AI on must trigger synthesis, not idle.
     await request(app).post("/cases/c1/ai-control").send({ enabled: true });
-    for (let i = 0; i < 80 && !phases.includes("synthesizing"); i++) await new Promise((r) => setTimeout(r, 25));
+    await pollFor(
+      () => `the AI toggle to trigger synthesis, saw phases [${phases.join(", ")}]`,
+      async () => (phases.includes("synthesizing") ? true : undefined),
+    );
     expect(phases).toContain("synthesizing");
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("tracks AI off→on backfill synthesis as a job, not just an onAiStatus ping", async () => {
     // Bug: turning AI on ran synthesis via the debounced auto path (scheduleSynthesis), which never
@@ -2005,13 +1966,15 @@ describe("AI on/off control", () => {
     await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
     await request(app).post("/cases/c1/ai-control").send({ enabled: true });
     let jobs: { kind: string; status: string }[] = [];
-    for (let i = 0; i < 80; i++) {
-      jobs = jobManager.list("c1");
-      if (jobs.some((j) => j.kind === "synthesis")) break;
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    await pollFor(
+      () => `a synthesis job to be registered, saw kinds [${jobs.map((j) => j.kind).join(", ")}]`,
+      async () => {
+        jobs = jobManager.list("c1");
+        return jobs.some((j) => j.kind === "synthesis") ? jobs : undefined;
+      },
+    );
     expect(jobs.some((j) => j.kind === "synthesis")).toBe(true);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("tracks a drop-folder auto-import as a job so the Jobs panel shows it (parity with /import)", async () => {
     // Bug: the evidence drop-folder poller (scanCaseDrops) imported files through the SAME chain as
@@ -2036,16 +1999,21 @@ describe("AI on/off control", () => {
       await writeFile(join(dropDir, "evidence.json"), velo, "utf8");
 
       let jobs: { kind: string; label?: string }[] = [];
-      for (let i = 0; i < 200 && !jobs.some((j) => j.kind === "import"); i++) {
-        await new Promise((r) => setTimeout(r, 50));
-        jobs = jobManager.list("c1");
-      }
+      await pollFor(
+        () => `the drop-folder sweep to register an import job, saw kinds [${jobs.map((j) => j.kind).join(", ")}]`,
+        async () => {
+          jobs = jobManager.list("c1");
+          return jobs.some((j) => j.kind === "import") ? jobs : undefined;
+        },
+      );
       expect(jobs.some((j) => j.kind === "import" && /drop/i.test(j.label ?? ""))).toBe(true);
     } finally {
       if (prevPoll === undefined) delete process.env.DFIR_DROP_POLL_S;
       else process.env.DFIR_DROP_POLL_S = prevPoll;
     }
-  }, 15000);
+    // The drop poller needs ~4s to settle a file before importing it, so this poll genuinely uses
+    // most of its budget — leave a SECOND full poll budget on top (20s total), not the 15s default.
+  }, POLL_TIMEOUT_MS * 2);
 
   it("POST /import fires onImport(caseId) so dashboards can warn cross-case (parity with captures)", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-onimport-"));

--- a/companion/tests/server/deepPassRoutes.test.ts
+++ b/companion/tests/server/deepPassRoutes.test.ts
@@ -9,6 +9,7 @@ import { ActivityLogStore } from "../../src/analysis/activityLog.js";
 import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { emptyState, type ForensicEvent, type Severity } from "../../src/analysis/stateTypes.js";
 import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
 
 class ScriptedProvider implements AIProvider {
   readonly name = "scripted";
@@ -81,18 +82,24 @@ async function makeApp(opts: { aiConfigured?: boolean; failBatches?: boolean } =
 // Reading the log straight after the POST therefore races the write: it wins on a fast dev box and
 // loses on contended CI (seen live: `Cannot read properties of undefined (reading 'detail')`).
 // Poll for the entry instead of assuming it has arrived; the assertion is unchanged, only the wait.
+// The wait itself is a WALL-CLOCK budget: the 50x20ms loop this replaces returned `undefined` when
+// it expired, so the caller's `expect(entry).toBeTruthy()` reported the timeout as a missing log
+// entry — the same defect the fire-and-forget write would produce (issue #408).
 async function awaitActivityEntry(
   app: Parameters<typeof request>[0],
   caseId: string,
   action: string,
-): Promise<{ action: string; detail?: string } | undefined> {
-  for (let i = 0; i < 50; i++) {
-    const log = await request(app).get(`/cases/${caseId}/activity-log`);
-    const entry = (log.body as { action: string; detail?: string }[]).find((e) => e.action === action);
-    if (entry) return entry;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-  return undefined;
+): Promise<{ action: string; detail?: string }> {
+  let seen: string[] = [];
+  return pollFor(
+    () => `an activity-log entry for "${action}" on case ${caseId}, saw only [${seen.join(", ")}]`,
+    async () => {
+      const log = await request(app).get(`/cases/${caseId}/activity-log`);
+      const entries = log.body as { action: string; detail?: string }[];
+      seen = entries.map((e) => e.action);
+      return entries.find((e) => e.action === action);
+    },
+  );
 }
 
 describe("deep-pass routes", () => {
@@ -238,9 +245,8 @@ describe("deep-pass routes", () => {
     expect(res.body.batchesFailed).toBeGreaterThan(0);
 
     const entry = await awaitActivityEntry(app, "c1", "deep-pass");
-    expect(entry).toBeTruthy();
-    expect(String(entry!.detail)).toMatch(/fail/i);
-  });
+    expect(String(entry.detail)).toMatch(/fail/i);
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   // The dashboard must be able to DISABLE the Run button up front instead of letting the analyst
   // click into a 501. /health.aiEnabled is the VISION gate (hasAiProvider) and answers the wrong
@@ -267,7 +273,6 @@ describe("deep-pass routes", () => {
     await request(app).post("/cases/c1/deep-pass").send({ minSeverity: "High" });
 
     const entry = await awaitActivityEntry(app, "c1", "deep-pass");
-    expect(entry).toBeTruthy();
-    expect(String(entry!.detail)).not.toMatch(/fail/i);
-  });
+    expect(String(entry.detail)).not.toMatch(/fail/i);
+  }, POLL_TIMEOUT_MS * 2);
 });

--- a/companion/tests/server/importMissingCase.test.ts
+++ b/companion/tests/server/importMissingCase.test.ts
@@ -9,6 +9,8 @@ import { StateStore } from "../../src/analysis/stateStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { MockProvider } from "../../src/providers/provider.js";
 import { EVIDENCE_IMPORT_ROUTES } from "../../src/routes/importCaseGuard.js";
+import { POLL_TIMEOUT_MS } from "../helpers/poll.js";
+import { waitForEvents } from "../helpers/caseWaits.js";
 
 // Regression: POST /cases/:id/import — evidence imported into a case that does not exist.
 // Found by /qa on 2026-06-25.
@@ -77,18 +79,13 @@ async function makeApp(opts: { withSynthesis?: boolean } = {}) {
   return { app, store, stateStore };
 }
 
-async function waitForEvents(stateStore: StateStore, caseId: string): Promise<number> {
-  for (let i = 0; i < 100; i++) {
-    const s = await stateStore.load(caseId);
-    if (s.forensicTimeline.length > 0) return s.forensicTimeline.length;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-  return (await stateStore.load(caseId)).forensicTimeline.length;
-}
-
 const body = { filename: "hunt.json", text: JSON.stringify(CHAINSAW_HUNT) };
 
-describe("POST /cases/:id/import — case existence guard", () => {
+// One test below awaits waitForEvents (one poll budget), and poll.ts requires the test timeout to
+// exceed the SUM of its poll budgets. Stated on the suite rather than that one test because this
+// file is Prettier-gated: a third `it()` argument pushes the line past the print width and makes
+// Prettier reflow the whole test body, burying the change in unrelated formatting.
+describe("POST /cases/:id/import — case existence guard", { timeout: POLL_TIMEOUT_MS * 2 }, () => {
   it("404s a valid import into a case that does not exist (no silent 202 / orphaned evidence)", async () => {
     const { app, store } = await makeApp();
     const res = await request(app).post("/cases/does-not-exist/import").send(body);

--- a/companion/tests/server/importReimportIdempotence.test.ts
+++ b/companion/tests/server/importReimportIdempotence.test.ts
@@ -8,6 +8,7 @@ import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
 
 // #94 — characterization test: re-importing the SAME evidence file must stay idempotent.
 //
@@ -96,12 +97,18 @@ async function counts(stateStore: StateStore, superStore: SuperTimelineStore) {
 }
 
 // Poll until the background import has landed at least `atLeast` forensic events, then let it settle.
+// On a WALL-CLOCK budget: the 150x20ms loop this replaces `break`ed out on expiry and then let the
+// caller assert on whatever had landed, so a slow import and a broken one both reported
+// `expected 1 to be 2` (issue #408). Now a wait that runs out says so, and names the count it saw.
 async function settle(stateStore: StateStore, atLeast: number): Promise<void> {
-  for (let i = 0; i < 150; i++) {
-    const s = await stateStore.load("c1");
-    if (s.forensicTimeline.length >= atLeast) break;
-    await new Promise((r) => setTimeout(r, 20));
-  }
+  let last = 0;
+  await pollFor(
+    () => `case c1 to reach ${atLeast} forensic event(s) from the background import, last saw ${last}`,
+    async () => {
+      last = (await stateStore.load("c1")).forensicTimeline.length;
+      return last >= atLeast ? last : undefined;
+    },
+  );
   // Give any trailing super-timeline / tagging work a moment to finish before asserting.
   await new Promise((r) => setTimeout(r, 300));
 }
@@ -123,7 +130,11 @@ describe("#94 — re-importing identical evidence is idempotent", () => {
 
     expect(second.forensic).toBe(first.forensic);
     expect(second.super).toBe(first.super);
-  }, 30000);
+    // ONE real settle() budget: the second call asks for >=1 event, which the first import already
+    // satisfied, so it returns on its first probe and only the 300ms settle covers the re-import.
+    // Pre-existing (the old loop's `break` fired on iteration 0 too) — a weakness in what this test
+    // PROVES, not in how it reports failure. Tracked as a follow-up, not fixed in this refactor.
+  }, POLL_TIMEOUT_MS * 2);
 
   it("still ingests genuinely different evidence as new events", async () => {
     const { app, stateStore, superTimelineStore } = await makeApp();
@@ -139,5 +150,5 @@ describe("#94 — re-importing identical evidence is idempotent", () => {
     const after = await counts(stateStore, superTimelineStore);
     expect(after.forensic).toBe(2);
     expect(after.super).toBe(2);
-  }, 30000);
+  }, POLL_TIMEOUT_MS * 3);
 });

--- a/companion/tests/server/importerRoutes.test.ts
+++ b/companion/tests/server/importerRoutes.test.ts
@@ -8,6 +8,7 @@ import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ImporterStore } from "../../src/analysis/importerStore.js";
 import { EXAMPLE_IMPORTER_SPEC } from "../../src/analysis/importerSpec.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
 
 // Harness mirrors tests/server/veloBundle.test.ts: a real CaseStore + StateStore + a runtime pipeline
 // built via buildRuntimePipeline with NO AI provider (the declarative import path is deterministic and
@@ -54,18 +55,20 @@ describe("custom importer routes", () => {
     expect(imp.body.kind).toBe("mde-advanced-hunting");
 
     // Poll the case state until the deterministic import lands its forensic events (no AI involved).
-    let evs = 0;
-    for (let i = 0; i < 40 && evs === 0; i++) {
-      const st = await request(app).get("/cases/c1/state");
-      evs = (st.body.forensicTimeline ?? []).length;
-      if (evs === 0) await new Promise((r) => setTimeout(r, 25));
-    }
+    const evs = await pollFor(
+      "the custom importer to land a forensic event in the case state",
+      async () => {
+        const st = await request(app).get("/cases/c1/state");
+        const n = (st.body.forensicTimeline ?? []).length;
+        return n > 0 ? n : undefined;
+      },
+    );
     expect(evs).toBeGreaterThan(0);
 
     const del = await request(app).delete("/importers/mde-advanced-hunting");
     expect(del.status).toBe(200);
     expect((await request(app).get("/importers")).body.importers).toHaveLength(0);
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   it("toggles precedence", async () => {
     const { app } = await harness();
@@ -81,16 +84,20 @@ describe("custom importer routes", () => {
     await request(app).post("/importers").send({ spec: EXAMPLE_IMPORTER_SPEC });
     await request(app).post("/cases/c1/import").send({ text: MDE_CSV, filename: "advanced-hunting.csv" });
 
-    let row: { lastStatus?: string } | undefined;
-    for (let i = 0; i < 40 && row?.lastStatus == null; i++) {
-      const diag = await request(app).get("/diagnostics");
-      row = diag.body.report.importers.perImporter.find((p: { id: string }) => p.id === "mde-advanced-hunting");
-      if (row?.lastStatus == null) await new Promise((r) => setTimeout(r, 25));
-    }
-    expect(row).toBeTruthy();
-    expect(row!.lastStatus).toBe("ok");
-    expect((row as { kept?: number }).kept).toBeGreaterThan(0);
-    expect((row as { lastRunAt?: string }).lastRunAt).toBeTruthy();
-    expect((row as { lastError?: string | null }).lastError).toBeNull();
-  });
+    let seen: string[] = [];
+    const row = await pollFor<{ lastStatus?: string; kept?: number; lastRunAt?: string; lastError?: string | null }>(
+      () => `/diagnostics to report a run for mde-advanced-hunting, saw importers [${seen.join(", ")}]`,
+      async () => {
+        const diag = await request(app).get("/diagnostics");
+        const perImporter = diag.body.report.importers.perImporter as { id: string; lastStatus?: string }[];
+        seen = perImporter.map((p) => p.id);
+        const found = perImporter.find((p) => p.id === "mde-advanced-hunting");
+        return found?.lastStatus == null ? undefined : found;
+      },
+    );
+    expect(row.lastStatus).toBe("ok");
+    expect(row.kept).toBeGreaterThan(0);
+    expect(row.lastRunAt).toBeTruthy();
+    expect(row.lastError).toBeNull();
+  }, POLL_TIMEOUT_MS * 2);
 });

--- a/companion/tests/server/iocBulkRoutes.test.ts
+++ b/companion/tests/server/iocBulkRoutes.test.ts
@@ -9,6 +9,10 @@ import { StateStore } from "../../src/analysis/stateStore.js";
 import { TagsStore } from "../../src/analysis/tags.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
 import type { EnrichmentProvider, IocKind, EnrichmentResult } from "../../src/enrichment/provider.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
+
+/** The two IOC ids the bulk-enrich test selects; i2 is deliberately left out. */
+const SELECTED = ["i1", "i3"];
 
 async function freshStore(): Promise<CaseStore> {
   return new CaseStore(await mkdtemp(join(tmpdir(), "dfir-iocbulk-")));
@@ -53,17 +57,23 @@ describe("POST /cases/:id/iocs/bulk-enrich", () => {
     expect(res.body.iocCount).toBe(2);
 
     // Enrichment runs in the background; poll until the two selected IOCs are marked checked.
-    let iocs = (await stateStore.load("c1")).iocs;
-    for (let n = 0; n < 50 && !iocs.find((i) => i.id === "i1")?.enrichedBy; n++) {
-      await new Promise((r) => setTimeout(r, 20));
-      iocs = (await stateStore.load("c1")).iocs;
-    }
+    // Waits on BOTH selected ids, not just i1 — and on a wall-clock budget, so a wait that runs out
+    // says so instead of falling through to `expected undefined to contain "MockLocal"` (issue #408).
+    let pending = SELECTED;
+    const iocs = await pollFor(
+      () => `the bulk enrich to mark i1 and i3 enriched, still unenriched [${pending.join(", ")}]`,
+      async () => {
+        const current = (await stateStore.load("c1")).iocs;
+        pending = SELECTED.filter((id) => !current.find((i) => i.id === id)?.enrichedBy);
+        return pending.length === 0 ? current : undefined;
+      },
+    );
     const byId = Object.fromEntries(iocs.map((i) => [i.id, i]));
     expect(byId.i1.enrichedBy).toContain("MockLocal");
     expect(byId.i3.enrichedBy).toContain("MockLocal");
     expect(byId.i2.enrichedBy).toBeUndefined();             // not selected → untouched
     expect(seen.sort()).toEqual(["1.1.1.1", "3.3.3.3"]);    // only the selected values were queried
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   it("returns 400 when iocIds is empty", async () => {
     const store = await freshStore();

--- a/companion/tests/server/irisImportRoute.test.ts
+++ b/companion/tests/server/irisImportRoute.test.ts
@@ -7,6 +7,8 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import type { IrisClient } from "../../src/integrations/iris/irisClient.js";
+import { POLL_TIMEOUT_MS } from "../helpers/poll.js";
+import { waitForEvents } from "../helpers/caseWaits.js";
 
 // A lightweight stand-in for the IRIS client — only the read methods the import path calls.
 function mockIris(over: Partial<Record<string, unknown>> = {}): IrisClient {
@@ -38,15 +40,6 @@ async function makeApp(opts: { irisClient?: IrisClient; rebuildIrisClient?: () =
   const app = createApp(store, { pipeline, stateStore, irisClient: opts.irisClient, rebuildIrisClient: opts.rebuildIrisClient });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
   return { app, stateStore };
-}
-
-async function waitForEvents(stateStore: StateStore, caseId: string): Promise<number> {
-  for (let i = 0; i < 100; i++) {
-    const s = await stateStore.load(caseId);
-    if (s.forensicTimeline.length > 0) return s.forensicTimeline.length;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-  return (await stateStore.load(caseId)).forensicTimeline.length;
 }
 
 describe("DFIR-IRIS import routes (issue #88)", () => {
@@ -85,14 +78,14 @@ describe("DFIR-IRIS import routes (issue #88)", () => {
     const state = await stateStore.load("c1");
     expect(state.iocs.some((i) => i.value === "8.8.8.8")).toBe(true);
     expect(state.forensicTimeline.some((e) => (e.sources ?? []).includes("DFIR-IRIS"))).toBe(true);
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one waitForEvents budget, doubled to leave room for setup + assertions
 
   it("resolves the IRIS case by name", async () => {
     const { app, stateStore } = await makeApp({ irisClient: mockIris() });
     const res = await request(app).post("/cases/c1/iris-import").send({ irisCaseName: "Ransomware FS01" });
     expect(res.status).toBe(202);
     expect(await waitForEvents(stateStore, "c1")).toBeGreaterThan(0);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("502s when the IRIS case name does not resolve", async () => {
     const { app } = await makeApp({ irisClient: mockIris() });

--- a/companion/tests/server/mcpRunRoutes.test.ts
+++ b/companion/tests/server/mcpRunRoutes.test.ts
@@ -12,6 +12,14 @@ import { JobManager } from "../../src/analysis/jobManager.js";
 import { McpServerStore } from "../../src/integrations/mcp/mcpServerStore.js";
 import type { TransferRunner } from "../../src/integrations/mcp/mcpDelivery.js";
 import type { ClaudeRunner } from "../../src/providers/claudeRunner.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
+
+// Nearly every test here awaits `settle` (one poll budget) and a couple await two. Set the timeout
+// once at the suite level rather than on ~22 individual tests: poll.ts requires the caller's test
+// timeout to exceed the SUM of its poll budgets, and one stated figure is easier to keep true than
+// twenty-two copies of it. The trade is that the 8 tests here that never poll (pure request/response
+// 400/404/501 checks) also inherit it, so a hang in one of those surfaces in 30s instead of 15s.
+const MCP_TEST_TIMEOUT = POLL_TIMEOUT_MS * 3;
 
 // Output the existing importers recognize, so the run exercises the real ingest chain.
 const YARA_OUT = "EvilRule /x/a.bin\n0x10:$s: 4d 5a";
@@ -62,14 +70,25 @@ async function harness(opts: { text?: string } = {}) {
            pipeline, stateStore, importUndoStore, mcpTransferRunner };
 }
 
-/** The run is backgrounded, so wait for its job to reach a terminal state. */
+/**
+ * The run is backgrounded, so wait for its job to reach a terminal state.
+ *
+ * On a WALL-CLOCK budget: the 200x10ms loop this replaces spelled "2 seconds" but really meant
+ * "2 seconds of sleeping plus 200 JobManager reads", so it got shorter exactly when the machine was
+ * busiest (issue #408). Its `job never settled` message also never said which state the job was
+ * stuck in; pollFor's description closure does.
+ */
 async function settle(jobManager: JobManager, jobId: string) {
-  for (let i = 0; i < 200; i++) {
-    const job = jobManager.get(jobId);
-    if (job && (job.status === "succeeded" || job.status === "failed" || job.status === "cancelled")) return job;
-    await new Promise((r) => setTimeout(r, 10));
-  }
-  throw new Error("job never settled");
+  let last = "no job registered";
+  return pollFor(
+    () => `job ${jobId} to reach a terminal state, last saw "${last}"`,
+    async () => {
+      const job = jobManager.get(jobId);
+      if (!job) return undefined;
+      last = job.status;
+      return job.status === "succeeded" || job.status === "failed" || job.status === "cancelled" ? job : undefined;
+    },
+  );
 }
 
 const RUN_BODY = {
@@ -78,7 +97,7 @@ const RUN_BODY = {
   targetPath: "imports/mem.raw",
 };
 
-describe("POST /cases/:id/mcp/:serverId/run", () => {
+describe("POST /cases/:id/mcp/:serverId/run", { timeout: MCP_TEST_TIMEOUT }, () => {
   it("delivers, runs, and ingests the result into the case", async () => {
     const { app, jobManager, transfers } = await harness();
 
@@ -187,7 +206,7 @@ describe("POST /cases/:id/mcp/:serverId/run", () => {
 
 // A tool can return reference data as readily as evidence — a capability listing is structurally
 // identical to a Volatility table — so the analyst gets to look before any of it reaches the case.
-describe("preview before import", () => {
+describe("preview before import", { timeout: MCP_TEST_TIMEOUT }, () => {
   it("fetches the output without touching the case", async () => {
     const { app, jobManager } = await harness();
 
@@ -304,7 +323,7 @@ describe("preview before import", () => {
   });
 });
 
-describe("POST /cases/:id/mcp/agent", () => {
+describe("POST /cases/:id/mcp/agent", { timeout: MCP_TEST_TIMEOUT }, () => {
   const AGENT_JSON = '{"findings":[{"title":"Injected process","description":"malfind hit","severity":"High"}],"iocs":[{"type":"ip","value":"10.2.3.4"}]}';
   const agentRunner: ClaudeRunner = async () => ({
     code: 0, stderr: "",
@@ -362,15 +381,24 @@ describe("POST /cases/:id/mcp/agent", () => {
     const { app, jobManager } = await agentHarness({ runner });
     const res = await request(app).post("/cases/c1/mcp/agent").send({ prompt: "investigate" });
 
-    for (let i = 0; i < 50 && !jobManager.get(res.body.jobId)?.detail?.includes("windows.pslist"); i++) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
+    // The runner is parked on `await gate`, so `release()` has to run even if the poll times out
+    // or an assertion throws — otherwise the job stays pending for the rest of the file.
+    try {
+      let lastDetail = "no detail yet";
+      const running = await pollFor(
+        () => `the job to publish the windows.pslist tool activity, last saw detail "${lastDetail}"`,
+        async () => {
+          const job = jobManager.get(res.body.jobId);
+          lastDetail = job?.detail ?? "no detail yet";
+          return job?.detail?.includes("windows.pslist") ? job : undefined;
+        },
+      );
+      expect(running.detail).toContain("running windows.pslist");
+      expect(running.detail).not.toContain("secret");
+      expect(running.progress).toEqual({ done: 2, total: 4 });
+    } finally {
+      release();
     }
-    const running = jobManager.get(res.body.jobId)!;
-    expect(running.detail).toContain("running windows.pslist");
-    expect(running.detail).not.toContain("secret");
-    expect(running.progress).toEqual({ done: 2, total: 4 });
-
-    release();
     expect((await settle(jobManager, res.body.jobId)).status).toBe("succeeded");
   });
 
@@ -467,7 +495,7 @@ describe("POST /cases/:id/mcp/agent", () => {
   });
 });
 
-describe("POST /cases/:id/mcp/:serverId/run-upload", () => {
+describe("POST /cases/:id/mcp/:serverId/run-upload", { timeout: MCP_TEST_TIMEOUT }, () => {
   it("stages uploaded bytes, runs against them, and ingests", async () => {
     const { app, jobManager, transfers } = await harness();
 

--- a/companion/tests/server/ocrSearchRoute.test.ts
+++ b/companion/tests/server/ocrSearchRoute.test.ts
@@ -7,6 +7,7 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp } from "../../src/server.js";
 import { _resetDedupCache } from "../../src/ingest/captureIngest.js";
 import type { OcrRunner } from "../../src/analysis/ocrRedact.js";
+import { pollFor, POLL_TIMEOUT_MS, type PollOptions } from "../helpers/poll.js";
 
 // Stub OCR runner — "reads" a fixed line so the background-index path is exercised without tesseract.
 const stubOcr: OcrRunner = {
@@ -87,47 +88,73 @@ describe("POST /captures background OCR indexing", () => {
     ...over,
   });
 
-  // The 201 returns before background OCR finishes; poll the index briefly.
-  async function waitForIndex(file: string, tries = 40): Promise<boolean> {
-    for (let i = 0; i < tries; i++) {
-      const idx = await cases.loadOcrIndex("c1");
-      if (idx[file]) return true;
-      await new Promise((r) => setTimeout(r, 25));
-    }
-    return false;
+  // The 201 returns before background OCR finishes; poll the index on a WALL-CLOCK budget.
+  // The `for (i < tries)` loop this replaces returned `false` when it gave up, so the caller's
+  // `expect(...).toBe(true)` reported a wait that ran out as an index that never wrote — a timeout
+  // wearing the costume of a defect (issue #408). Now the failure names the files still missing.
+  //
+  // Takes the whole file list rather than one name, so the burst test below spends ONE budget for
+  // seven screenshots instead of seven sequential budgets that could outlast the test timeout.
+  // That collapse means the budget has to be sized for the WHOLE drain, not one file — the
+  // per-file waits it replaces summed to more tolerance than a single default budget carries.
+  async function waitForIndexed(files: string[], options?: PollOptions): Promise<void> {
+    let missing = files;
+    await pollFor(
+      () => `all ${files.length} screenshot(s) to be OCR-indexed, still missing [${missing.join(", ")}]`,
+      async () => {
+        const idx = await cases.loadOcrIndex("c1");
+        missing = files.filter((f) => !idx[f]);
+        return missing.length === 0 ? true : undefined;
+      },
+      options,
+    );
   }
 
-  it("indexes a captured screenshot's OCR text in the background", async () => {
-    const res = await request(app).post("/captures").send(capture());
-    expect(res.status).toBe(201);
-    const file = res.body.screenshotFile as string;
-
-    expect(await waitForIndex(file)).toBe(true);
-    const idx = await cases.loadOcrIndex("c1");
-    expect(idx[file].text).toBe("mimikatz.exe dumped creds");
-    expect(idx[file].wordCount).toBe(3);
-
-    // and it's searchable end-to-end
-    const search = await request(app).get("/cases/c1/ocr-search").query({ q: "mimikatz" });
-    expect(search.body.hits.map((h: { screenshotFile: string }) => h.screenshotFile)).toContain(file);
-  });
-
-  it("indexes EVERY screenshot in a burst (queued, not dropped past the concurrency cap)", async () => {
-    // Seven captures posted back-to-back, each with distinct bytes so none is a byte-dup.
-    const files: string[] = [];
-    for (let i = 0; i < 7; i++) {
-      const res = await request(app).post("/captures").send(capture({
-        imageBase64: pngBytes(i, i + 1, i + 2, i + 3),
-      }));
+  it(
+    "indexes a captured screenshot's OCR text in the background",
+    async () => {
+      const res = await request(app).post("/captures").send(capture());
       expect(res.status).toBe(201);
-      files.push(res.body.screenshotFile as string);
-    }
-    // All seven must eventually be indexed — the queue drains them, none is dropped.
-    // A generous per-file budget (160 tries × 25ms = 4s) absorbs CI-runner scheduling noise;
-    // a real drop/deadlock still fails well before the 20s test timeout below.
-    for (const f of files) expect(await waitForIndex(f, 160)).toBe(true);
-    expect(Object.keys(await cases.loadOcrIndex("c1"))).toHaveLength(7);
-  }, 20_000);
+      const file = res.body.screenshotFile as string;
+
+      await waitForIndexed([file]);
+      const idx = await cases.loadOcrIndex("c1");
+      expect(idx[file].text).toBe("mimikatz.exe dumped creds");
+      expect(idx[file].wordCount).toBe(3);
+
+      // and it's searchable end-to-end
+      const search = await request(app).get("/cases/c1/ocr-search").query({ q: "mimikatz" });
+      expect(search.body.hits.map((h: { screenshotFile: string }) => h.screenshotFile)).toContain(file);
+    },
+    POLL_TIMEOUT_MS * 2,
+  ); // one poll budget, doubled to leave room for setup + assertions
+
+  it(
+    "indexes EVERY screenshot in a burst (queued, not dropped past the concurrency cap)",
+    async () => {
+      // Seven captures posted back-to-back, each with distinct bytes so none is a byte-dup.
+      const files: string[] = [];
+      for (let i = 0; i < 7; i++) {
+        const res = await request(app)
+          .post("/captures")
+          .send(
+            capture({
+              imageBase64: pngBytes(i, i + 1, i + 2, i + 3),
+            }),
+          );
+        expect(res.status).toBe(201);
+        files.push(res.body.screenshotFile as string);
+      }
+      // All seven must eventually be indexed — the queue drains them, none is dropped. One shared
+      // budget covers the whole burst, and a drop/deadlock now names the files that never landed.
+      // Doubled because this is the slowest workload in the file: seven background OCR jobs behind a
+      // concurrency cap. The per-file waits this replaces gave each file its own 4s, so a single
+      // DEFAULT budget would have made the wait SHORTER than before — the opposite of the point.
+      await waitForIndexed(files, { timeoutMs: POLL_TIMEOUT_MS * 2 });
+      expect(Object.keys(await cases.loadOcrIndex("c1"))).toHaveLength(7);
+    },
+    POLL_TIMEOUT_MS * 3,
+  );
 
   it("does not index when DFIR_OCR_SEARCH is off", async () => {
     process.env.DFIR_OCR_SEARCH = "off";

--- a/companion/tests/server/pushRoute.test.ts
+++ b/companion/tests/server/pushRoute.test.ts
@@ -8,6 +8,8 @@ import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { PushTokenStore } from "../../src/analysis/pushTokenStore.js";
+import { POLL_TIMEOUT_MS } from "../helpers/poll.js";
+import { waitForEvents } from "../helpers/caseWaits.js";
 
 // A deterministic (no-AI) THOR alert the importer maps straight to a forensic event.
 const THOR_EVENT = {
@@ -32,15 +34,6 @@ async function makeApp(opts: { pushToken?: string; withTokenStore?: boolean } = 
   });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
   return { app, stateStore };
-}
-
-async function waitForEvents(stateStore: StateStore, caseId: string): Promise<number> {
-  for (let i = 0; i < 100; i++) {
-    const s = await stateStore.load(caseId);
-    if (s.forensicTimeline.length > 0) return s.forensicTimeline.length;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-  return (await stateStore.load(caseId)).forensicTimeline.length;
 }
 
 describe("POST /cases/:id/push — generic push ingest", () => {
@@ -71,7 +64,7 @@ describe("POST /cases/:id/push — generic push ingest", () => {
     expect(res.body.kind).toBe("thor");
     expect(res.body.source).toBe("siem-webhook");
     expect(await waitForEvents(stateStore, "c1")).toBeGreaterThan(0);
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one waitForEvents budget, doubled to leave room for setup + assertions
 
   it("accepts a Bearer token too", async () => {
     const { app } = await makeApp({ pushToken: "secret" });
@@ -91,7 +84,7 @@ describe("POST /cases/:id/push — generic push ingest", () => {
     expect(res.status).toBe(202);
     expect(res.body.kind).toBe("velociraptor");
     expect(await waitForEvents(stateStore, "c1")).toBeGreaterThan(0);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("authorizes with a per-case token generated via the API", async () => {
     const { app } = await makeApp({});   // no global token
@@ -138,5 +131,5 @@ describe("POST /cases/:id/push — generic push ingest", () => {
     const res = await request(app).post("/cases/c1/push").set("X-DFIR-Key", "secret").send({ source: "siem", events: [THOR_EVENT] });
     expect(res.status).toBe(202);
     expect(await waitForEvents(stateStore, "c1")).toBeGreaterThan(0);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 });

--- a/companion/tests/server/superTimeline.test.ts
+++ b/companion/tests/server/superTimeline.test.ts
@@ -17,7 +17,7 @@ import { ArtifactBundleStore } from "../../src/analysis/artifactBundleStore.js";
 import { VeloHuntStore } from "../../src/analysis/veloHuntStore.js";
 import { VelociraptorClient, type VqlRunner, type VelociraptorApiConfig } from "../../src/integrations/velociraptor/velociraptorApi.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
-import { pollFor } from "../helpers/poll.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
 
 // Fills the three array fields every ForensicEvent carries but no super-timeline assertion in
 // this file reads, so each literal below stays about the fields the route actually filters on.
@@ -400,17 +400,19 @@ describe("superTimelineOnly bundle routing", () => {
 
     // The collect runs in the background (huntResultsByArtifact → parse → super-timeline append).
     // Poll the super-timeline until the raw rows land.
-    let superRes = await request(app).get("/cases/c1/super-timeline");
-    for (let i = 0; i < 80 && (superRes.body.total ?? 0) === 0; i++) {
-      await new Promise((r) => setTimeout(r, 25));
-      superRes = await request(app).get("/cases/c1/super-timeline");
-    }
+    const superRes = await pollFor(
+      "the super-timeline to report a row from the background collect",
+      async () => {
+        const res = await request(app).get("/cases/c1/super-timeline");
+        return (res.body.total ?? 0) > 0 ? res : undefined;
+      },
+    );
     expect(superRes.status).toBe(200);
     expect(superRes.body.total).toBeGreaterThan(0);   // raw MFT row landed in the super-timeline
 
     const forensicAfter = (await stateStore.load("c1")).forensicTimeline.length;
     expect(forensicAfter).toBe(forensicBefore);       // forensic timeline untouched by the super-only bundle
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   it("a super-only bundle does NOT ingest uploaded reports into the forensic timeline", async () => {
     const { app, stateStore } = await makeSuperUploadApp();
@@ -424,21 +426,24 @@ describe("superTimelineOnly bundle routing", () => {
     // Drive the background collect to completion off the hunt job's terminal status (the MFT row lands in
     // the super-timeline). Only THEN can we assert the forensic timeline is still empty — proving the
     // uploaded thor.json was skipped, not dispatched into the forensic timeline.
-    let status: string | undefined;
-    for (let i = 0; i < 120 && status !== "imported"; i++) {
-      const jobs = await request(app).get("/cases/c1/velociraptor/hunt-jobs");
-      status = (jobs.body as Array<{ status?: string }>)[0]?.status;
-      if (status === "error") throw new Error("velo hunt collect errored");
-      if (status !== "imported") await new Promise((r) => setTimeout(r, 25));
-    }
-    expect(status).toBe("imported");
+    let lastStatus = "no job at all";
+    await pollFor(
+      () => `the hunt job to reach "imported", last saw "${lastStatus}"`,
+      async () => {
+        const jobs = await request(app).get("/cases/c1/velociraptor/hunt-jobs");
+        const status = (jobs.body as Array<{ status?: string }>)[0]?.status;
+        if (status === "error") throw new Error("velo hunt collect errored");
+        lastStatus = status ?? "no job at all";
+        return status === "imported" ? status : undefined;
+      },
+    );
 
     const superRes = await request(app).get("/cases/c1/super-timeline");
     expect(superRes.body.total).toBeGreaterThan(0);   // the raw MFT row still routed to the super-timeline
 
     const forensicAfter = (await stateStore.load("c1")).forensicTimeline.length;
     expect(forensicAfter).toBe(forensicBefore);       // the uploaded thor.json did NOT leak into forensic
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("re-collecting the same super-only hunt is idempotent (no duplicate events)", async () => {
     const { app } = await makeSuperBundleApp();
@@ -462,17 +467,32 @@ describe("superTimelineOnly bundle routing", () => {
     // Wait until the job reaches a terminal `imported` state with an `importedAt` newer than `prevImportedAt`
     // (so a re-collect is observed as its OWN completed cycle, not the previous one). Re-fires the collect
     // if it didn't take, then polls. Never a fixed sleep on the super-timeline — a stable status condition.
+    // The re-fire runs on a WALL-CLOCK cadence, and the whole wait on a wall-clock budget: the nested
+    // 40x80x25ms loops this replaces counted iterations, and under load those iterations were dominated
+    // by HTTP round-trips rather than the sleeps, so the wait shrank exactly when the machine was
+    // slowest (issue #408).
+    // Deliberately longer than a normal import cycle. The re-POST is belt-and-braces (see above),
+    // and this probe is the one converted site that performs a SIDE EFFECT rather than a read — so
+    // a tight cadence would pile redundant collects onto the coalescing importer under exactly the
+    // load this refactor targets. NOT "the old inner loop's cadence": that loop's 80 iterations were
+    // 80 HTTP round-trips plus 25ms each, so it re-fired every 5-10s on a busy box, not every 2s.
+    const RECOLLECT_EVERY_MS = 4_000;
     async function collectUntilImported(prevImportedAt?: string): Promise<void> {
-      for (let attempt = 0; attempt < 40; attempt++) {
-        expect((await request(app).post("/cases/c1/velociraptor/collect").send({})).status).toBe(202);
-        for (let i = 0; i < 80; i++) {
+      let last = "no job at all";
+      let nextCollectAt = 0;
+      await pollFor(
+        () => `an import cycle newer than importedAt=${prevImportedAt ?? "(none)"}, last saw status "${last}"`,
+        async () => {
+          if (Date.now() >= nextCollectAt) {
+            expect((await request(app).post("/cases/c1/velociraptor/collect").send({})).status).toBe(202);
+            nextCollectAt = Date.now() + RECOLLECT_EVERY_MS;
+          }
           const { status, importedAt } = await jobStatus();
-          if (status === "imported" && importedAt && importedAt !== prevImportedAt) return;
           if (status === "error") throw new Error("velo hunt collect errored");
-          await new Promise((r) => setTimeout(r, 25));
-        }
-      }
-      throw new Error("velo hunt collect never reached imported state");
+          last = status ?? "no job at all";
+          return status === "imported" && importedAt && importedAt !== prevImportedAt ? importedAt : undefined;
+        },
+      );
     }
 
     // First collect → wait for it to fully import; the row must have landed in the super-timeline.
@@ -489,7 +509,7 @@ describe("superTimelineOnly bundle routing", () => {
     await collectUntilImported(firstImportedAt);
     const second = await request(app).get("/cases/c1/super-timeline");
     expect(second.body.total).toBe(totalAfterFirst);   // NOT doubled — idempotent re-collect
-  });
+  }, POLL_TIMEOUT_MS * 3);   // TWO sequential collectUntilImported budgets, plus setup + assertions
 });
 
 // ── Bundle artifact validation against the server catalog ────────────────────────────────────────

--- a/companion/tests/server/veloBundle.test.ts
+++ b/companion/tests/server/veloBundle.test.ts
@@ -10,6 +10,7 @@ import { ArtifactBundleStore } from "../../src/analysis/artifactBundleStore.js";
 import { VeloHuntStore } from "../../src/analysis/veloHuntStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { VelociraptorClient, type VqlRunner, type VelociraptorApiConfig } from "../../src/integrations/velociraptor/velociraptorApi.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
 
 const veloCfg: VelociraptorApiConfig = {
   apiConfigPath: "/x/api.yaml", binary: "velociraptor", timeoutMs: 5000, maxRows: 1000, maxOutputBytes: 1024 * 1024,
@@ -55,6 +56,29 @@ async function makeApp(runnerOverride: VqlRunner = runner) {
   });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
   return { app, stateStore, store };
+}
+
+/**
+ * Wait for the case's hunt job to reach a TERMINAL status (issue #408).
+ *
+ * `error` counts as terminal so a genuine import failure still reports as
+ * `expected 'error' to be 'imported'` at the caller's assertion. The six loops this replaces
+ * spelled a private 100x20ms deadline instead, and on expiry fell through to that same assertion
+ * reporting `expected 'collecting' to be 'imported'` — a wait that ran out, wearing the costume of
+ * a state-machine defect. The description closure names the last status actually observed, so a
+ * real hang says what the job was stuck on.
+ */
+async function pollHuntJob<T extends { status: string }>(target: Parameters<typeof request>[0]): Promise<T> {
+  let last = "no job at all";
+  return pollFor<T>(
+    () => `the hunt job to reach a terminal status, last saw "${last}"`,
+    async () => {
+      const job = (await request(target).get("/cases/c1/velociraptor/hunt-jobs")).body[0] as T | undefined;
+      if (!job) return undefined;
+      last = job.status;
+      return job.status === "imported" || job.status === "error" ? job : undefined;
+    },
+  );
 }
 
 describe("Velociraptor triage bundles — routes", () => {
@@ -172,18 +196,13 @@ describe("Velociraptor triage bundles — routes", () => {
     const col = await request(app).post("/cases/c1/velociraptor/collect");
     expect(col.status).toBe(202);
 
-    let job: { status: string } | null = null;
-    for (let i = 0; i < 100; i++) {
-      job = (await request(app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
-      if (job && (job.status === "imported" || job.status === "error")) break;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    expect(job?.status).toBe("imported");
+    const job = await pollHuntJob<{ status: string }>(app);
+    expect(job.status).toBe("imported");
 
     // The Pstree rows the mock hunt returned became forensic-timeline events.
     const state = await stateStore.load("c1");
     expect(state.forensicTimeline.length).toBeGreaterThan(0);
-  });
+  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
 
   it("stamps veloUrl on the FORENSIC timeline events a bundle collect produces, not just super-only imports (#7 regression)", async () => {
     // Bug: importVeloHuntResults computed the hunt's GUI deep-link only inside the superTimelineOnly
@@ -192,17 +211,12 @@ describe("Velociraptor triage bundles — routes", () => {
     // timeline's "↗ Velociraptor" row link never rendered.
     await request(app).post("/cases/c1/velociraptor/run-bundle").send({ bundleId: "best-practice", waitMinutes: 30 });
     await request(app).post("/cases/c1/velociraptor/collect");
-    let job: { status: string } | null = null;
-    for (let i = 0; i < 100; i++) {
-      job = (await request(app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
-      if (job && (job.status === "imported" || job.status === "error")) break;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    expect(job?.status).toBe("imported");
+    const job = await pollHuntJob<{ status: string }>(app);
+    expect(job.status).toBe("imported");
     const state = await stateStore.load("c1");
     expect(state.forensicTimeline.length).toBeGreaterThan(0);
     expect(state.forensicTimeline.every((e) => e.veloUrl === "https://velo.example/app/index.html?org_id=root#/hunts/H.TEST1")).toBe(true);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("ingests an uploaded JSON report (THOR) from the hunt even when result rows are empty", async () => {
     const thorLine = JSON.stringify({
@@ -221,17 +235,12 @@ describe("Velociraptor triage bundles — routes", () => {
     await request(made.app).post("/cases/c1/velociraptor/run-bundle").send({ bundleId: "best-practice", waitMinutes: 30 });
     expect((await request(made.app).post("/cases/c1/velociraptor/collect")).status).toBe(202);
 
-    let job: { status: string } | null = null;
-    for (let i = 0; i < 100; i++) {
-      job = (await request(made.app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
-      if (job && (job.status === "imported" || job.status === "error")) break;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    expect(job?.status).toBe("imported");
+    const job = await pollHuntJob<{ status: string }>(made.app);
+    expect(job.status).toBe("imported");
     // The uploaded THOR JSON was detected + imported into the timeline (rows were empty).
     const state = await made.stateStore.load("c1");
     expect(state.forensicTimeline.length).toBeGreaterThan(0);
-  });
+  }, POLL_TIMEOUT_MS * 2);
 
   it("collect records skipped (failed) and empty (no findings) artifacts on the job — so a bundle where most artifacts fail isn't silently indistinguishable from one where they simply found nothing", async () => {
     const mixedRunner: VqlRunner = async (statements) => {
@@ -264,16 +273,11 @@ describe("Velociraptor triage bundles — routes", () => {
     await request(made.app).post("/cases/c1/velociraptor/run-bundle").send({ bundleId: "best-practice", waitMinutes: 30 });
     expect((await request(made.app).post("/cases/c1/velociraptor/collect")).status).toBe(202);
 
-    let job: { status: string; skippedArtifacts?: { name: string; error: string }[]; emptyArtifacts?: string[] } | null = null;
-    for (let i = 0; i < 100; i++) {
-      job = (await request(made.app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
-      if (job && (job.status === "imported" || job.status === "error")) break;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    expect(job?.status).toBe("imported");
-    expect(job?.skippedArtifacts).toEqual([{ name: "DetectRaptor.Windows.Detection.Amcache", error: "output exceeded 1048576 bytes" }]);
-    expect(job?.emptyArtifacts).toEqual(["Windows.System.Pslist"]);
-  });
+    const job = await pollHuntJob<{ status: string; skippedArtifacts?: { name: string; error: string }[]; emptyArtifacts?: string[] }>(made.app);
+    expect(job.status).toBe("imported");
+    expect(job.skippedArtifacts).toEqual([{ name: "DetectRaptor.Windows.Detection.Amcache", error: "output exceeded 1048576 bytes" }]);
+    expect(job.emptyArtifacts).toEqual(["Windows.System.Pslist"]);
+  }, POLL_TIMEOUT_MS * 2);
 
   it("run-bundle is 501 when Velociraptor is not configured", async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-velobundle-noclient-"));
@@ -300,14 +304,9 @@ describe("Velociraptor hunt status polling — routes", () => {
     expect(poll.status).toBe(200);
 
     // The poll triggered importVeloHuntResults in the background (fire-and-forget) — wait for it.
-    let job: { status: string } | null = null;
-    for (let i = 0; i < 100; i++) {
-      job = (await request(made.app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
-      if (job && (job.status === "imported" || job.status === "error")) break;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    expect(job?.status).toBe("imported");
-  });
+    const job = await pollHuntJob<{ status: string }>(made.app);
+    expect(job.status).toBe("imported");
+  }, POLL_TIMEOUT_MS * 2);
 
   // Deleting a hunt from the Velociraptor GUI does not make it disappear from hunts() (confirmed
   // against a live server) — it just reports STOPPED, same as a hunt that finished naturally. The only
@@ -327,16 +326,11 @@ describe("Velociraptor hunt status polling — routes", () => {
     await request(made.app).post("/cases/c1/velociraptor/run-bundle").send({ bundleId: "best-practice", waitMinutes: 30 });
     expect((await request(made.app).post("/cases/c1/velociraptor/collect")).status).toBe(202);
 
-    let job: { status: string; stoppedEarly?: boolean; addedEvents?: number } | null = null;
-    for (let i = 0; i < 100; i++) {
-      job = (await request(made.app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
-      if (job && (job.status === "imported" || job.status === "error")) break;
-      await new Promise((r) => setTimeout(r, 20));
-    }
-    expect(job?.status).toBe("imported");
-    expect(job?.stoppedEarly).toBe(true);
-    expect(job?.addedEvents ?? 0).toBe(0);
-  });
+    const job = await pollHuntJob<{ status: string; stoppedEarly?: boolean; addedEvents?: number }>(made.app);
+    expect(job.status).toBe("imported");
+    expect(job.stoppedEarly).toBe(true);
+    expect(job.addedEvents ?? 0).toBe(0);
+  }, POLL_TIMEOUT_MS * 2);
 
   it("poll-status marks the job deleted when Velociraptor has no record of the hunt", async () => {
     const runner: VqlRunner = async (statements) => {


### PR DESCRIPTION
Closes #408.

## The problem

Thirteen test files waited on background work with a hand-rolled bounded loop:

```ts
for (let i = 0; i < 100; i++) {
  job = (await request(app).get("/cases/c1/velociraptor/hunt-jobs")).body[0] ?? null;
  if (job && (job.status === "imported" || job.status === "error")) break;
  await new Promise((r) => setTimeout(r, 20));
}
expect(job?.status).toBe("imported");
```

That is a private 2-second deadline, and when it expires the loop does not say so — it falls through
to the assertion, which reports `expected 'collecting' to be 'imported'`. A state name where another
state name was expected reads like a state-machine defect. It is a timeout wearing a costume, and
the cost is the time spent looking for a logic bug that isn't there.

An iteration count is not even a coherent budget: 100 iterations is 2 seconds of *sleeping* plus 100
round-trips, and under a loaded parallel run the round-trips dominate — the wait gets **shorter**
exactly when the machine is slowest. Every budget here (0.2s–3s, one at 10s) sat far below the
suite's own 15s `testTimeout`, so #173's raised timeout could never save them: the loop was the
binding constraint, not Vitest.

## What changed

40 loops across 13 files now use `pollFor`, which takes a wall-clock budget and throws with the
observation. Verified by forcing a timeout:

```
timed out after 500ms (19 attempts) waiting for: the hunt job to reach a terminal status, last saw "imported"
```

Every description is a closure, so it reports what was actually seen — which is what `poll.ts`
resolves the description last for.

### Timeout arithmetic

`poll.ts` requires a test's timeout to exceed the **sum** of its poll budgets, so every converted
test states its own arithmetic (`POLL_TIMEOUT_MS * N`, with N = sequential budgets). Two files state
it once at the suite level instead:

- **`mcpRunRoutes`** — 22 of 30 tests share one `settle()` each; one figure is easier to keep true
  than 22 copies. Trade: the 8 non-polling tests inherit it, so a hang there surfaces in 30s not 15s.
- **`importMissingCase`** — this file is Prettier-gated, and a third `it()` argument pushes the line
  past the print width, reflowing the whole test body and burying the change in formatting noise.

### Semantics preserved

- `error` stays terminal in the hunt-job waits, so a genuine import failure still reports as
  `expected 'error' to be 'imported'` rather than as a hang.
- Negative-proof waits (`the Medium Notice must never land`, `AI off → no findings`) keep their fixed
  settle sleeps — `pollFor` cannot express "prove X never happens".
- `superTimeline`'s `collectUntilImported` is the only converted probe with a **side effect**, so its
  re-POST cadence is deliberately longer than an import cycle; a tight one would pile redundant
  collects onto the coalescing importer under exactly the load this targets.

## Two files #408's inventory missed

Review turned up the same pattern in `iocBulkRoutes` (`expected undefined to contain "MockLocal"`)
and `ocrSearchRoute` (`waitForIndex` returned `false` on expiry → `expected false to be true`). Both
are converted here, so the ESLint rule #408 proposes as a follow-up can land with no backlog.

## Bugs found and fixed during review

| File | Issue |
|---|---|
| `server.test.ts` | KAPE test polled for `>0` events then asserted `toHaveLength(2)` — a late second row reported as `expected 1 to be 2`. Now polls for both. |
| `mcpRunRoutes.test.ts` | `release()` sat outside a `finally`, so a failed assertion left a gated background job pending. |
| `ocrSearchRoute.test.ts` | Collapsing 7 per-file 4s waits into one default budget made the file's slowest test wait *less* than before. Given an explicit doubled budget. |
| `iocBulkRoutes.test.ts` | Waited on `i1` but asserted on `i1` and `i3`. Now waits on both. |

## Deliberate deviations

- **No version bump / no CHANGELOG entry.** This repo bumps on release, not per PR (see the
  maintainer note at the top of `CHANGELOG.md`), merged PR titles carry no version prefix, and the
  two most recent test-only commits (`5365878e`, `c2b831ad`) added no CHANGELOG line either.

## Known, deferred

- **`importReimportIdempotence`'s first test can pass vacuously.** Its second `settle(stateStore, 1)`
  returns on the first probe because the count is already satisfied, so only a 300ms sleep covers the
  re-import. Pre-existing — the old loop's `break` fired on iteration 0 for the same reason — and
  documented in the file. It is a weakness in what the test *proves*, not in how it *reports*, so it
  is out of scope here.
- **CI jobs have no `timeout-minutes`.** Raising per-test timeouts roughly doubles the worst-case
  cost of a systemic hang, and `.github/workflows/ci.yml` inherits GitHub's 360-minute default. Worth
  bounding, but it is workflow config rather than this PR's scope.

## Verification

- **Full suite: 546 files / 6913 tests pass**, re-run after every fix.
- `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`, `typecheck`, `build` —
  all pass.
- The 13 converted files also pass together under parallel load (291 tests), which is the condition
  that produced the original CI failure on #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
