### PR TITLE
test(import): gate the re-import assertions on the second import's own cycle

### DIFF
--- a/companion/tests/server/importReimportIdempotence.test.ts
+++ b/companion/tests/server/importReimportIdempotence.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { Express } from "express";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,6 +9,7 @@ import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ImportMetaStore } from "../../src/analysis/importMeta.js";
 import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { pollFor } from "../helpers/poll.js";
 
 // #94 — characterization test: re-importing the SAME evidence file must stay idempotent.
 //
@@ -77,16 +79,15 @@ async function makeApp() {
   const store = new CaseStore(root);
   const stateStore = new StateStore(store);
   const superTimelineStore = new SuperTimelineStore(store);
+  const importMetaStore = new ImportMetaStore(store);
   // No-AI pipeline: the deterministic chainsaw importer populates the timeline with no model call.
   const pipeline = buildRuntimePipeline({
     provider: undefined, synthesisProvider: undefined, stateStore, store,
     imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
   });
-  const app = createApp(store, {
-    pipeline, stateStore, importMetaStore: new ImportMetaStore(store), superTimelineStore,
-  });
+  const app = createApp(store, { pipeline, stateStore, importMetaStore, superTimelineStore });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
-  return { app, store, stateStore, superTimelineStore };
+  return { app, store, stateStore, superTimelineStore, importMetaStore };
 }
 
 async function counts(stateStore: StateStore, superStore: SuperTimelineStore) {
@@ -95,30 +96,65 @@ async function counts(stateStore: StateStore, superStore: SuperTimelineStore) {
   return { forensic: state.forensicTimeline.length, super: sup.total ?? 0 };
 }
 
-// Poll until the background import has landed at least `atLeast` forensic events, then let it settle.
-async function settle(stateStore: StateStore, atLeast: number): Promise<void> {
-  for (let i = 0; i < 150; i++) {
-    const s = await stateStore.load("c1");
-    if (s.forensicTimeline.length >= atLeast) break;
-    await new Promise((r) => setTimeout(r, 20));
-  }
-  // Give any trailing super-timeline / tagging work a moment to finish before asserting.
+// Wait for the background work of ONE SPECIFIC import cycle, identified by the stored filename the
+// 202 response returned ("0001_hunt.json", "0002_hunt.json" — each import gets its own sequence).
+//
+// It must be a per-cycle signal, not a timeline threshold. A re-import is expected to add nothing, so
+// "poll until forensicTimeline.length >= N" is already satisfied by the PREVIOUS import's events: the
+// probe returns on its first attempt and the assertions can run before the re-import has even started,
+// passing vacuously. That was the flaw in this test's original hand-rolled loop, whose `break` fired on
+// iteration 0 for the same reason, leaving a fixed sleep as the only thing covering the re-import.
+//
+// import-meta.json is the right signal: routes/import.ts writes it AFTER the importer's events have
+// merged into the forensic timeline, been appended to the super-timeline and been demoted — and
+// lastImportFile carries that import's own sequence-numbered name, so it can only match once the
+// SECOND cycle is done. (The imports audit log is NOT usable here: it is written evidence-first,
+// BEFORE analysis runs, so its presence would prove nothing about the merge.)
+async function settle(importMetaStore: ImportMetaStore, storedFile: string): Promise<void> {
+  let seen = "(nothing)";
+  await pollFor(
+    () => `import-meta to record the '${storedFile}' import cycle (last saw '${seen}')`,
+    async () => {
+      seen = (await importMetaStore.load("c1")).lastImportFile || "(nothing)";
+      return seen === storedFile ? true : undefined;
+    },
+  );
+  // import-meta lands before the route's trailing best-effort passes (whitelist / NSRL / deobfuscation
+  // sweeps, re-synthesis). Those have no signal of their own in this app wiring — no jobManager is
+  // configured here — so give them a moment. Unlike before, this sleep is no longer what covers the
+  // import itself: the poll above already proved the timeline merge finished.
   await new Promise((r) => setTimeout(r, 300));
+}
+
+// Kick off an import and return the stored filename it will be recorded under (the 202 body's `file`),
+// which is what `settle` waits on.
+async function startImport(app: Express, file: { filename: string; text: string }): Promise<string> {
+  const res = await request(app).post("/cases/c1/import").send(file);
+  expect(res.status).toBe(202);
+  expect(typeof res.body.file).toBe("string");
+  return res.body.file as string;
 }
 
 describe("#94 — re-importing identical evidence is idempotent", () => {
   it("adds nothing to the forensic timeline or the super-timeline on a second identical import", async () => {
-    const { app, stateStore, superTimelineStore } = await makeApp();
+    const { app, stateStore, superTimelineStore, importMetaStore } = await makeApp();
 
-    expect((await request(app).post("/cases/c1/import").send(FILE_A)).status).toBe(202);
-    await settle(stateStore, 1);
+    const firstFile = await startImport(app, FILE_A);
+    await settle(importMetaStore, firstFile);
     const first = await counts(stateStore, superTimelineStore);
     expect(first.forensic).toBe(1);
     expect(first.super).toBe(1);
 
-    // The recovery path after an interrupted import: send the exact same bytes again.
-    expect((await request(app).post("/cases/c1/import").send(FILE_A)).status).toBe(202);
-    await settle(stateStore, 1);
+    // The recovery path after an interrupted import: send the exact same bytes again. Waiting on THIS
+    // cycle's stored name is what makes the assertions below mean something — the timeline already
+    // holds the first import's event, so any threshold on its length would be met before the re-import
+    // even started, and the test would report idempotence for work that never landed.
+    const reimportFile = await startImport(app, FILE_A);
+    // The same bytes under a different stored name: each import takes a fresh sequence number, which is
+    // what makes the wait above discriminating. Were the two names equal, matching lastImportFile would
+    // be satisfied by the FIRST import's record and be exactly as vacuous as a timeline threshold.
+    expect(reimportFile).not.toBe(firstFile);
+    await settle(importMetaStore, reimportFile);
     const second = await counts(stateStore, superTimelineStore);
 
     expect(second.forensic).toBe(first.forensic);
@@ -126,13 +162,10 @@ describe("#94 — re-importing identical evidence is idempotent", () => {
   }, 30000);
 
   it("still ingests genuinely different evidence as new events", async () => {
-    const { app, stateStore, superTimelineStore } = await makeApp();
+    const { app, stateStore, superTimelineStore, importMetaStore } = await makeApp();
 
-    expect((await request(app).post("/cases/c1/import").send(FILE_A)).status).toBe(202);
-    await settle(stateStore, 1);
-
-    expect((await request(app).post("/cases/c1/import").send(FILE_B)).status).toBe(202);
-    await settle(stateStore, 2);
+    await settle(importMetaStore, await startImport(app, FILE_A));
+    await settle(importMetaStore, await startImport(app, FILE_B));
 
     // Guards the test above: proves the idempotence it asserts is real dedup of identical evidence,
     // not the importer silently dropping every second import.


### PR DESCRIPTION
The first test in `companion/tests/server/importReimportIdempotence.test.ts` could pass without ever measuring a re-import.

## The problem

`settle(stateStore, atLeast)` polled until `forensicTimeline.length >= atLeast`. A re-import is *expected* to add nothing, so after the first import the threshold was already met — the probe returned on its first attempt and the only thing standing between posting the second import and asserting was the trailing 300 ms sleep. When that import took longer, `second.forensic === first.forensic` held and the test reported idempotence for work that had not landed.

Pre-existing: the old hand-rolled loop's `break` fired on iteration 0 for the same reason, and #408's `pollFor` conversion carried the behavior through unchanged.

## The fix

Wait on a signal specific to each import **cycle**: `import-meta.json`. `routes/import.ts` writes it *after* the importer's events merge into the forensic timeline, are appended to the super-timeline and are demoted, and its `lastImportFile` carries that import's own sequence-numbered stored name (`0001_hunt.json` vs `0002_hunt.json`). The 202 response returns that name, so the test waits for the exact cycle it just started.

Rejected alternatives:
- **The imports audit log** — written evidence-first, *before* analysis runs, so its presence proves nothing about the merge.
- **The job manager** — this test's `createApp` gets no `jobManager`, so no job is ever registered.

The test also asserts the two stored names differ. Were they equal, matching `lastImportFile` would be satisfied by the *first* import's record and be exactly as vacuous as the old threshold.

Kept as-is: the `pollFor` wall-clock style and the explanatory comment block at the top of the file.

## Verification

Passing after the change only shows the test wasn't broken, so it was mutation-tested. Keying correlation step 0 on `e.id` (`src/analysis/correlate.ts`) makes a re-import genuinely duplicate — but both versions caught that, because the duplication landed inside the 300 ms sleep. Adding a 1500 ms delay to the import's `run()`, simulating a loaded machine, separated them:

| | old `settle` | new `settle` |
|---|---|---|
| duplication + slow import | **passed** (vacuous) | **failed** — `expected 2 to be 1` |

Both mutations were reverted; this PR touches only the test file.

- `npx vitest run tests/server/importReimportIdempotence.test.ts` — 2 passed
- `npm run typecheck` — no errors in this file (`tests/e2e/workflows/*.spec.ts` and `tests/analysis/sharpVersion.test.ts` fail identically on untouched master)
- `npm run format:check` — ok; `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)