### PR TITLE
ci: bound every job with timeout-minutes

### DIFF
--- a/.github/workflows/betterleaks-scan.yml
+++ b/.github/workflows/betterleaks-scan.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   betterleaks-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
   companion-quality:
     name: Companion lint + format + structure
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,6 +98,11 @@ jobs:
   companion:
     name: Companion build + test
     runs-on: ubuntu-latest
+    # ~4 min observed. The generous multiple is deliberate: #408 moved per-test
+    # timeouts from vitest's 15s default to 20-30s, so a systemic break (the background
+    # pipeline not running at all) now reddens the suite in roughly twice the wall-clock
+    # it used to. This bounds that without being tight enough to fail a merely slow runner.
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -131,6 +137,7 @@ jobs:
   extension:
     name: Extension build + test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,6 +28,9 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    # An agentic run that implements a change and opens a PR, so it is legitimately
+    # long-running. Bounded only to stop a wedged run burning the 6h default.
+    timeout-minutes: 60
     permissions:
       contents: write          # push the implementation branch
       pull-requests: write      # open the PR

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # ~5.5 min observed; a cold layer cache is the slow case.
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,8 @@ jobs:
   companion-e2e:
     name: Companion browser E2E
     runs-on: ubuntu-latest
+    # ~4 min observed; browser downloads and real page loads make the tail long.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,6 +56,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -22,6 +22,8 @@ jobs:
   windows-exe:
     name: Build Windows EXE (Node SEA)
     runs-on: windows-latest
+    # ~9 min observed — Windows runners are the slowest and most variable here.
+    timeout-minutes: 30
     outputs:
       # SHA256 of the portable zip, consumed by the `chocolatey` job so its package embeds the
       # exact checksum of the same artifact the release publishes.
@@ -75,6 +77,7 @@ jobs:
   linux-appimage:
     name: Build Linux AppImage (Node SEA)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -128,6 +131,7 @@ jobs:
     # either zip fails the release, which is the intent — a tag should never publish half the
     # extension.
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       # SHA256 of the CHROME extension zip, consumed by the `chocolatey` job which bundles it for
       # offline "Load unpacked". Keep this pointing at the Chrome zip: the Chocolatey package
@@ -217,6 +221,7 @@ jobs:
     # so it's safe to merge before the developer account / credentials exist (#138).
     if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.tag != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check for Web Store credentials
         id: creds
@@ -331,6 +336,7 @@ jobs:
     # but does NOT create a junk release named after the branch.
     if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.tag != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -387,6 +393,7 @@ jobs:
     needs: [windows-exe, extension-zip, release]
     if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.tag != ''
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   trufflehog:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## The gap

`grep -rn timeout-minutes .github/workflows/` returned exactly one hit repo-wide — `ai-evaluation.yml`.
The other **16 jobs inherited GitHub's 360-minute default**, so a wedged job (a hung test, a runner
that loses its network, a registry pull that never returns) could burn up to six hours before
anything reported.

## Why now

#408 made this more likely to matter. Moving per-test budgets from vitest's 15s default to a 10s
wall-clock poll (plus a 20–30s test timeout) means a *systemic* break — the background pipeline not
running at all — now reddens the companion suite in roughly twice the wall-clock it used to. Wall-clock
budgets were the right trade for diagnosability; this is the ceiling that trade wants.

## Sizing

Every value comes from **measured durations of recent successful runs**, not a guess. A too-tight CI
timeout would reintroduce exactly the flaky-failure class #408 set out to remove, so the multiples
err generous:

| Job | Observed | Timeout | ~x |
|---|---|---|---|
| Companion lint + format + structure | 0m57s | 15m | 15x |
| **Companion build + test** | 4m03s | **25m** | 6x |
| Extension build + test | 0m24s | 15m | 37x |
| Companion browser E2E | 3m58s | 30m | 7x |
| betterleaks-scan | 0m13s | 10m | 46x |
| trufflehog | 0m21s | 10m | 28x |
| docker build-and-push | 5m35s | 30m | 5x |
| pages build / deploy | 0m20s | 10m | 30x |
| Build Windows EXE (Node SEA) | 8m48s | 30m | 3.4x |
| Build Linux AppImage | 3m31s | 20m | 5.7x |
| extension-zip | — | 20m | — |
| chocolatey | 1m14s | 20m | 16x |
| chrome-webstore | 0m14s | 15m | 64x |
| release | — | 15m | — |
| claude (agentic) | — | 60m | — |

Two judgment calls worth flagging:

- **Windows EXE gets the narrowest multiple (3.4x)** because those runners are the slowest and most
  variable — 2m59s to 8m48s across three runs. 30m still leaves real room.
- **`claude` gets 60m** because it is an agentic run that implements a change and opens a PR. It is
  legitimately long-running, so the bound exists only to stop a wedged run, not to pace a working one.

## Verification

- All nine workflow files parse (`yaml.safe_load`), and every one of the 17 jobs now resolves an
  integer `timeout-minutes`.
- Diff is **25 added lines, zero deletions** — nothing else in any workflow changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
