### PR TITLE
refactor(ai): decompose AnalysisPipeline (#418)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,7 +68,7 @@ today, not invented — `ai` importing `ingest` 39 times is why `ai` is at the t
 
 | Tier | Domain | Owns | Files | Lines |
 |---|---|---|---|---|
-| **5** | `ai/` | `pipeline`, the ~25 prompt constants, `synth*`, `deepPass*`, `hypothesis*`, `secondOpinion`, `secondLook`, `uncertainty`, `queryTranslate`, `aiCost` | 25 | 10,861 |
+| **5** | `ai/` | `pipeline`, the ~25 prompt constants, `synth*`, `deepPass*`, `hypothesis*`, `secondOpinion`, `secondLook`, `uncertainty`, `queryTranslate`, `aiCost` | 47 | 11,081 |
 | **4** | `workflow/` | `cockpit*`, `dashboardViews`, `collectionPlan*`, `scope*`, `presentation`, `notebook`, `activityLog`, `priorWork`, `summary` | 23 | 4,483 |
 | **3** | `ingest/` | the ~40 `*Import.ts` modules, `importDetect`, `importerSpec`, `importResume`, `importUndo`, `declarativeImporter`, `zip*` | 48 | 15,768 |
 | **2** | `findings/` | `ioc*`, `finding*`, `falsePositive*`, `fp*`, `tagger*`, `tags`, `confidence*`, `severityFloor` | 36 | 4,116 |
@@ -269,6 +269,14 @@ The order, by ascending risk:
    `tests/eval/checkChange.ts:36`, `tests/eval/identity.ts:21` (both read the file path directly), and
    `scripts/eject-prompts.ts:11` (imports the constants).
 7. The 35 `importX` methods → `analysis/ingest/` per-format modules.
+   **Done, and #418 finished the rest of `pipeline.ts` on the same pattern:** the AI-backed families
+   (the analyst reports, hunt generation, extraction, the provider-call gate, synthesis, Deep Pass,
+   second opinion) are free functions in `analysis/ai/` taking a narrow context interface, and the
+   class holds one-line delegations. `AnalysisPipeline` is now a facade — 591 lines, of which the 36
+   import delegations are the largest single block. What made this harder than the ingest extraction
+   is written up in the module headers: synthesis's context is deliberately wide because synthesis
+   genuinely touches most of `PipelineOptions`, and `tests/analysis/synthesizeCharacterisation.test.ts`
+   is the substitute for the machine attestation the prompt move could rely on.
 8. `mitreTactics.ts` → `intel/`; `correlate.ts` → `timeline/`; the five persistence modules →
    `storage/`; `stateTypes.ts` + `canonicalEvent.ts` → `src/eventTypes/`. Together these clear
    roughly a third of the ledger, because the map already files them where they belong and only the
@@ -284,11 +292,11 @@ the issue that owns the work, so no number is a blocker without an assignee:
 
 | Target | ≤ | Today | Owner |
 |---|---|---|---|
-| `analysis/pipeline.ts` | 800 | 3,410 | [#418](https://github.com/hasamba/DFIR-Companion/issues/418) |
+| `analysis/pipeline.ts` | 800 | **591 — met** | [#418](https://github.com/hasamba/DFIR-Companion/issues/418) |
 | `server.ts` | 800 | 4,077 | [#416](https://github.com/hasamba/DFIR-Companion/issues/416) |
 | `public/dashboard.html` inline JS | 2,000 | 19,201 | [#415](https://github.com/hasamba/DFIR-Companion/issues/415) |
 | `public/dashboard.html` inline CSS | 800 | 3,232 | [#415](https://github.com/hasamba/DFIR-Companion/issues/415) |
-| Files in `src/` over 800 lines | 0 | 13 | #416, #418, and the ledger below |
+| Files in `src/` over 800 lines | 0 | 12 | #416 and the ledger below |
 | Flat files in `src/analysis/` | 0 | 296 | whichever extraction touches them |
 | Boundary ledger | 10 | 47 | shrinks as the above land |
 

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -1,7 +1,6 @@
 {
   "analysis/caseSqliteWorker.ts": 812,
   "analysis/memoryImport.ts": 1264,
-  "analysis/pipeline.ts": 3411,
   "analysis/seedDemoCase.ts": 819,
   "analysis/siemImport.ts": 1346,
   "analysis/velociraptorImport.ts": 1503,

--- a/companion/src/analysis/ai/aiContext.ts
+++ b/companion/src/analysis/ai/aiContext.ts
@@ -1,0 +1,125 @@
+import type { AIProvider, AnalyzeRequest } from "../../providers/provider.js";
+import type { FalsePositiveMarker, FalsePositiveStore } from "../falsePositive.js";
+import { filterFalsePositiveEvents } from "../falsePositive.js";
+import { filterEventsByScope, NO_SCOPE, type ScopeStore, type ScopeWindow } from "../scope.js";
+import { selectSynthesisEvents } from "../synthSelect.js";
+import { maxPromptEvents } from "../synthGroup.js";
+import { estimateTokens, inputTokenBudget, fitItemsToBudget } from "../promptBudget.js";
+import type { StateStore } from "../stateStore.js";
+import type { ForensicEvent, InvestigationState } from "../stateTypes.js";
+import type { KevCatalog } from "../kev.js";
+
+/**
+ * What an AI-backed pipeline method needs from AnalysisPipeline, and nothing else (#418).
+ *
+ * This is the seam #384 established for the importers, widened to the shape the AI calls actually
+ * need. It is a WIDER interface than `ImportContext` because these methods genuinely reach further:
+ * an importer parses a file, but a report has to pick a provider, honour the anonymisation policy,
+ * count the tokens against a budget and retry a flaky model. The interface is still narrow where it
+ * counts — nothing here can synthesize, write state, or reach a store the method does not name.
+ *
+ * WHY THE PROVIDER CALL IS ONE METHOD. `analyzeRestored` is not a thin wrapper around
+ * `provider.analyze`. It is the gate: per-case anonymisation of the prompt, OCR redaction of the
+ * images, the Presidio approval check, cost accounting, usage logging, and restoring the real values
+ * into the parsed response before any schema sees it. Every extracted family calls the model through
+ * this one member precisely so none of them can accidentally skip a step of that chain.
+ */
+export interface AiCallContext {
+  /**
+   * The pipeline options an AI-backed report may read. Enumerated rather than widened to
+   * PipelineOptions for the reason ImportContext gives: the type states the real dependency, and a
+   * report that has no business touching the hypothesis store or the synthesis knobs cannot reach
+   * them because they are not on this type.
+   */
+  readonly opts: {
+    synthesisProvider?: AIProvider;
+    stateStore: StateStore;
+    falsePositiveStore?: FalsePositiveStore;
+    scopeStore?: ScopeStore;
+    retries?: number;
+    backoffMs?: number;
+  };
+
+  /** The vision provider, or a thrown error naming what the analyst was trying to do. */
+  requireProvider(purpose: string): AIProvider;
+
+  /** The CISA KEV catalog for `buildSynthesisContext`; undefined when no store is wired. */
+  getKevCatalog(): Promise<KevCatalog | undefined>;
+
+  /** The module-level retry, plus the per-attempt WARN and the ai_retry operational metric. */
+  withRetry<T>(
+    caseId: string,
+    label: string,
+    fn: () => Promise<T>,
+    retries: number,
+    backoffMs: number,
+  ): Promise<T>;
+
+  /** The anonymise → OCR-redact → Presidio-gate → call → restore chain. See the note above. */
+  analyzeRestored(
+    caseId: string,
+    state: InvestigationState,
+    provider: AIProvider,
+    req: AnalyzeRequest,
+    label?: string,
+    skipPresidioGate?: boolean,
+  ): Promise<unknown>;
+}
+
+/** `opts.retries` / `opts.backoffMs` with the defaults every AI call site repeated inline. */
+export function retryPolicy(ctx: AiCallContext): { retries: number; backoffMs: number } {
+  return { retries: ctx.opts.retries ?? 3, backoffMs: ctx.opts.backoffMs ?? 500 };
+}
+
+/**
+ * The two-stage event filter every case-wide AI call runs before building its prompt.
+ *
+ * Kept as one function because the two stages are not interchangeable and the order matters:
+ * `inWindow` is after the analyst's investigation scope (out-of-window activity is not part of this
+ * case), and `scoped` additionally drops what the analyst confirmed legitimate (so the model never
+ * reasons from benign activity). Synthesis needs both counts separately to attribute its coverage
+ * audit; every other caller wants only `scoped`.
+ *
+ * Nothing here mutates state — callers filter a COPY, so un-marking a false positive restores the
+ * event everywhere.
+ */
+export async function loadScopedEvents(
+  ctx: AiCallContext,
+  caseId: string,
+  state: InvestigationState,
+): Promise<{
+  markers: FalsePositiveMarker[];
+  scope: ScopeWindow;
+  inWindow: ForensicEvent[];
+  scoped: ForensicEvent[];
+}> {
+  const markers = ctx.opts.falsePositiveStore ? await ctx.opts.falsePositiveStore.load(caseId) : [];
+  const scope = ctx.opts.scopeStore ? await ctx.opts.scopeStore.load(caseId) : NO_SCOPE;
+  const inWindow = filterEventsByScope(state.forensicTimeline, scope);
+  return { markers, scope, inWindow, scoped: filterFalsePositiveEvents(inWindow, markers) };
+}
+
+/**
+ * Render the timeline into the prompt, trimmed so the WHOLE request fits the model's context.
+ *
+ * The dance is subtle enough to be worth having in one place: cap to the synthesis event budget,
+ * measure what the rendered rows cost against the budget left over after the fixed overhead, and —
+ * when they do not fit — RE-SELECT for the smaller count rather than truncating the list. Re-running
+ * the selector is what keeps the kept events the most significant ones; slicing would keep whichever
+ * happened to sort first.
+ */
+export function fitTimelineText(
+  scopedEvents: ForensicEvent[],
+  renderEvent: (e: ForensicEvent) => string,
+  overheadTokens: number,
+): string {
+  let events = selectSynthesisEvents(scopedEvents, maxPromptEvents());
+  const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overheadTokens));
+  if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
+  return events.map(renderEvent).join("\n") || "(no events yet)";
+}
+
+/** The fixed overhead of a report prompt: the system prompt plus its non-timeline blocks. */
+export function promptOverhead(systemPrompt: string, ...blocks: string[]): number {
+  return estimateTokens(systemPrompt) + estimateTokens(blocks.join("")) + 300;
+}

--- a/companion/src/analysis/ai/analystQueries.ts
+++ b/companion/src/analysis/ai/analystQueries.ts
@@ -1,0 +1,237 @@
+import { buildGraphContext, DEFAULT_MAX_GRAPH_EDGES } from "../graphContext.js";
+import {
+  askSchema,
+  explainEventSchema,
+  fpSimilaritySchema,
+  type AskAnswer,
+  type ExplainEventResult,
+} from "../responseSchema.js";
+import type { ForensicEvent, InvestigationState } from "../stateTypes.js";
+import type { SuperTimelineStore } from "../superTimelineStore.js";
+import { buildSynthesisContext } from "../synthSelect.js";
+import { getAskPrompt, getExplainEventPrompt, getFpSimilarityPrompt } from "./prompts/index.js";
+import {
+  fitTimelineText,
+  loadScopedEvents,
+  promptOverhead,
+  retryPolicy,
+  type AiCallContext,
+} from "./aiContext.js";
+
+/**
+ * The three "answer this specific question" AI calls (#418).
+ *
+ * Moved from AnalysisPipeline (see ai/caseReports.ts for the pattern). Unlike the case reports,
+ * which write a document about the whole case, each of these is pointed at something the analyst
+ * just clicked: a question they typed, an event they want explained, an item they just rejected.
+ * All three are single-shot, and only explainEvent can change the case — by promoting the one raw
+ * event it was asked about.
+ */
+
+/** What explainEvent needs on top of the shared AI-call seam, to reach the raw record. */
+export interface AnalystQueryContext extends AiCallContext {
+  readonly opts: AiCallContext["opts"] & { superTimelineStore?: SuperTimelineStore };
+  promoteSuperTimeline(
+    caseId: string,
+    events: ForensicEvent[],
+    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+  ): Promise<InvestigationState>;
+}
+
+// Answer a free-form analyst question from the case's own evidence. Text-only, EPHEMERAL — the
+// answer is returned for the analyst to act on, never written into the case.
+export async function ask(ctx: AiCallContext, caseId: string, question: string): Promise<AskAnswer> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("case questions");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+
+  const renderEvent = (e: ForensicEvent): string =>
+    `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}`;
+  const findingsText =
+    loaded.findings
+      .slice(0, 150)
+      .map((f) => `[${f.id}] [${f.severity}] ${f.title}`)
+      .join("\n") || "(none)";
+  const questionsText =
+    loaded.keyQuestions.map((q) => `- ${q.question}${q.answer ? ` → ${q.answer}` : " (open)"}`).join("\n") ||
+    "(none)";
+  const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog());
+  // GraphRAG (#98): serialize the deterministic evidence-chain graph (causal edges) so the model
+  // can trace multi-hop attack paths via the graph's relationships, not just the flat timeline.
+  const graphMaxEdges = Number(process.env.DFIR_ASK_GRAPH_MAX_EDGES) || DEFAULT_MAX_GRAPH_EDGES;
+  const graphBlock = buildGraphContext({ ...loaded, forensicTimeline: scoped }, { maxEdges: graphMaxEdges });
+
+  // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
+  const timelineText = fitTimelineText(
+    scoped,
+    renderEvent,
+    promptOverhead(
+      getAskPrompt(),
+      contextBlock,
+      graphBlock,
+      loaded.attackerPath || "",
+      findingsText,
+      questionsText,
+      question,
+    ),
+  );
+
+  const userPrompt =
+    contextBlock +
+    graphBlock +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `FINDINGS:\n${findingsText}\n\n` +
+    `FORENSIC TIMELINE (${scoped.length} in-scope events):\n${timelineText}\n\n` +
+    `CURRENT QUESTIONS:\n${questionsText}\n\n` +
+    `ANALYST QUESTION: ${question.trim()}\n\nAnswer it as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "ask",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getAskPrompt(), userPrompt, images: [] },
+        "ask",
+      );
+      return askSchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// Explain a single forensic event in context (issue #141). Single text-only AI call.
+//
+// NO LONGER EPHEMERAL, and that is the point. Asking about a raw super-timeline event PROMOTES it
+// into the forensic timeline first, so the model still only ever reads the forensic record — the
+// invariant forensicGate.ts states. Promotion is the same seam runSecondLook uses, and it is
+// honest: clicking "explain this" is the analyst declaring the event interesting, which is
+// precisely what the forensic timeline means. One event, recorded with a note saying why.
+export async function explainEvent(
+  ctx: AnalystQueryContext,
+  caseId: string,
+  eventId: string,
+): Promise<ExplainEventResult> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("event explanation");
+  let loaded = await ctx.opts.stateStore.load(caseId);
+
+  let event = loaded.forensicTimeline.find((e) => e.id === eventId);
+  if (!event && ctx.opts.superTimelineStore) {
+    // TARGETED lookup, not a paged scan (#406). The previous `query(caseId, {})` returned only the
+    // first DEFAULT_SUPER_QUERY_LIMIT (500) rows and searched those, so explaining an event past
+    // row 500 threw "event not found" for an event that plainly existed.
+    const raw = await ctx.opts.superTimelineStore.get(caseId, eventId);
+    if (raw) {
+      loaded = await ctx.promoteSuperTimeline(caseId, [raw], {
+        importedAt: new Date().toISOString(),
+        note: `Promoted 1 raw event for "explain this event"`,
+      });
+      event = loaded.forensicTimeline.find((e) => e.id === eventId);
+    }
+  }
+  if (!event) throw new Error(`event not found: ${eventId}`);
+  // The universe is the forensic timeline, always — including the event just promoted into it.
+  const universe = loaded.forensicTimeline;
+
+  // Context: events adjacent in time + events on the same asset (up to 15 total).
+  const sorted = [...universe].sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+  const focalIdx = sorted.findIndex((e) => e.id === eventId);
+  const nearby = [
+    ...sorted.slice(Math.max(0, focalIdx - 7), focalIdx),
+    ...sorted.slice(focalIdx + 1, focalIdx + 8),
+  ];
+  const sameAsset = event.asset
+    ? universe.filter((e) => e.id !== eventId && e.asset === event.asset).slice(0, 10)
+    : [];
+  const contextIds = new Set([...nearby.map((e) => e.id), ...sameAsset.map((e) => e.id)]);
+  const contextEvents = [...contextIds]
+    .map((id) => universe.find((e) => e.id === id)!)
+    .filter(Boolean)
+    .slice(0, 15);
+
+  const renderEv = (e: ForensicEvent, focal = false): string =>
+    `[${e.id}]${focal ? " *** FOCAL EVENT ***" : ""} ${e.timestamp || "(undated)"} [${e.severity}]` +
+    ` ${e.description.slice(0, 300)}` +
+    (e.asset ? ` | asset: ${e.asset}` : "") +
+    (e.processName ? ` | process: ${e.processName}` : "") +
+    (e.parentName ? ` | parent: ${e.parentName}` : "") +
+    (e.sha256 ? ` | sha256: ${e.sha256.slice(0, 16)}…` : "") +
+    (e.path ? ` | path: ${e.path}` : "") +
+    (e.mitreTechniques.length ? ` | MITRE: ${e.mitreTechniques.join(", ")}` : "");
+
+  const findingsText =
+    loaded.findings
+      .slice(0, 50)
+      .map((f) => `[${f.severity}] ${f.title}`)
+      .join("\n") || "(none)";
+  const contextBlock = buildSynthesisContext(loaded, [event, ...contextEvents], await ctx.getKevCatalog());
+
+  const userPrompt =
+    contextBlock +
+    `CASE FINDINGS (summary):\n${findingsText}\n\n` +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `FOCAL EVENT TO EXPLAIN:\n${renderEv(event, true)}\n\n` +
+    `CONTEXT EVENTS (nearby / same asset):\n` +
+    (contextEvents.map((e) => renderEv(e)).join("\n") || "(no context events)") +
+    `\n\nExplain the focal event as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "explain-event",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getExplainEventPrompt(), userPrompt, images: [] },
+        "explain-event",
+      );
+      return explainEventSchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// Optional AI-assisted extension of deterministic FP suggestions (#227). The caller narrows the
+// candidates and returned ids are validated against them, so hallucinated ids cannot be applied.
+export async function suggestFalsePositiveSimilarAi(
+  ctx: AiCallContext,
+  caseId: string,
+  anchorId: string,
+  anchorLabel: string,
+  candidateIds: string[],
+  candidateLabels: string[],
+): Promise<string[]> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("false positive suggestions");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const list = candidateIds.map((id, i) => `[${id}] ${candidateLabels[i] ?? ""}`).join("\n") || "(none)";
+  const userPrompt =
+    `ANCHOR ITEM (just marked false positive): [${anchorId}] ${anchorLabel}\n\n` +
+    `OTHER ITEMS IN THIS CASE:\n${list}\n\n` +
+    "Which of the other items are likely the same false-positive pattern?";
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "fp-similarity",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getFpSimilarityPrompt(), userPrompt, images: [] },
+        "fp-similarity",
+      );
+      const result = fpSimilaritySchema.parse(parsed);
+      const valid = new Set(candidateIds);
+      return result.candidateIds.filter((id) => valid.has(id));
+    },
+    retries,
+    backoffMs,
+  );
+}

--- a/companion/src/analysis/ai/caseReports.ts
+++ b/companion/src/analysis/ai/caseReports.ts
@@ -1,0 +1,307 @@
+import { z } from "zod";
+import { buildMitigationsResult } from "../attackMitigations.js";
+import { loadMitigationsDataset } from "../attackMitigationsData.js";
+import { buildD3fendResult } from "../d3fendMap.js";
+import { loadD3fendDataset, d3fendEnvOptions } from "../d3fendData.js";
+import type { HypothesisStore } from "../hypothesisStore.js";
+import { sanitizeHypothesisReviews, type HypothesisReviewItem } from "../hypothesis.js";
+import {
+  execSummarySchema,
+  hypothesisReviewSchema,
+  remediationPlanSchema,
+  type ExecSummary,
+  type RemediationPlan,
+} from "../responseSchema.js";
+import type { ForensicEvent, InvestigationState } from "../stateTypes.js";
+import { buildSynthesisContext } from "../synthSelect.js";
+import {
+  getExecSummaryPrompt,
+  getHypothesisReviewPrompt,
+  getNarrativePrompt,
+  getRemediationPrompt,
+} from "./prompts/index.js";
+import {
+  fitTimelineText,
+  loadScopedEvents,
+  promptOverhead,
+  retryPolicy,
+  type AiCallContext,
+} from "./aiContext.js";
+
+/**
+ * The four "write me a document about this case" AI calls (#418).
+ *
+ * Moved from AnalysisPipeline, which held them as methods; each is now a free function taking an
+ * AiCallContext, and the pipeline keeps a one-line delegation so every route and test is untouched.
+ *
+ * They belong together because they answer the same question with different audiences in mind —
+ * what happened, for the report / for management / for the team that has to fix it / for the analyst
+ * arguing with themselves. All four read the same in-scope, non-false-positive slice of the case,
+ * ground themselves in the same synthesis context block, and are single-shot. Only the narrative
+ * writes anything back, and only its own field.
+ */
+
+/** What the two hypothesis-aware reports need on top of the shared AI-call seam. */
+export interface CaseReportContext extends AiCallContext {
+  readonly opts: AiCallContext["opts"] & { hypothesisStore?: HypothesisStore };
+}
+
+/** `[timestamp] [severity] description` — the row shape for the two audience-facing reports. */
+const renderPlainEvent = (e: ForensicEvent): string =>
+  `[${e.timestamp || "(undated)"}] [${e.severity}] ${e.description.slice(0, 240)}`;
+
+/** The same row with its id, for the calls whose answer must cite specific events back. */
+const renderIdentifiedEvent = (e: ForensicEvent): string =>
+  `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}`;
+
+const findingsWithIds = (state: InvestigationState): string =>
+  state.findings
+    .slice(0, 150)
+    .map((f) => `[${f.id}] [${f.severity}] ${f.title}`)
+    .join("\n") || "(none)";
+
+const findingsPlain = (state: InvestigationState): string =>
+  state.findings
+    .slice(0, 150)
+    .map((f) => `[${f.severity}] ${f.title}`)
+    .join("\n") || "(none)";
+
+// Write the case's narrative timeline — the prose account that leads the report. The ONE report here
+// that persists: it re-reads state after the AI call so imports/edits that arrived during it aren't
+// clobbered, then saves only its own field.
+export async function generateNarrative(
+  ctx: AiCallContext,
+  caseId: string,
+): Promise<{ narrativeTimeline: string }> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("narrative generation");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+
+  const findingsText = findingsPlain(loaded);
+  const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog());
+  const narrativePrompt = getNarrativePrompt();
+  const timelineText = fitTimelineText(
+    scoped,
+    renderPlainEvent,
+    promptOverhead(narrativePrompt, contextBlock, loaded.attackerPath || "", findingsText),
+  );
+
+  const userPrompt =
+    contextBlock +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `FINDINGS:\n${findingsText}\n\n` +
+    `FORENSIC TIMELINE (${scoped.length} in-scope events):\n${timelineText}\n\n` +
+    `Write the narrative timeline as JSON.`;
+
+  const narrativeSchema = z.object({ narrativeTimeline: z.string().catch("") });
+  const { retries, backoffMs } = retryPolicy(ctx);
+  const result = await ctx.withRetry(
+    caseId,
+    "narrative",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: narrativePrompt, userPrompt, images: [] },
+        "narrative",
+      );
+      return narrativeSchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+
+  // Re-read state before saving so imports/edits that arrived during the AI call aren't clobbered.
+  const fresh = await ctx.opts.stateStore.load(caseId);
+  await ctx.opts.stateStore.save({ ...fresh, narrativeTimeline: result.narrativeTimeline });
+  return result;
+}
+
+// Generate a management-facing executive summary of the case (single-shot, no state change).
+// Text-only over the synthesized digest, like ask(); returns plain prose for the analyst to
+// review and save into the report's executive-summary section.
+export async function executiveSummary(ctx: AiCallContext, caseId: string): Promise<ExecSummary> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("executive summary");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+
+  const findingsText = findingsPlain(loaded);
+  const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog());
+  const timelineText = fitTimelineText(
+    scoped,
+    renderPlainEvent,
+    promptOverhead(getExecSummaryPrompt(), contextBlock, loaded.attackerPath || "", findingsText),
+  );
+
+  const userPrompt =
+    contextBlock +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `FINDINGS:\n${findingsText}\n\n` +
+    `FORENSIC TIMELINE (${scoped.length} in-scope events):\n${timelineText}\n\n` +
+    `Write the executive summary as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "exec-summary",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getExecSummaryPrompt(), userPrompt, images: [] },
+        "exec-summary",
+      );
+      return execSummarySchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// Incident-specific remediation plan (#178): a concrete, prioritized action list for the IR team,
+// GROUNDED in the deterministic ATT&CK Mitigations for the case's techniques so the model turns
+// generic guidance into specific steps instead of hallucinating. Single-shot, no state change.
+export async function remediationPlan(ctx: AiCallContext, caseId: string): Promise<RemediationPlan> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("remediation plan");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+  const filtered: InvestigationState = { ...loaded, forensicTimeline: scoped };
+
+  const findingsText =
+    loaded.findings
+      .slice(0, 100)
+      .map(
+        (f) =>
+          `[${f.severity}] ${f.title}${f.mitreTechniques?.length ? ` (${f.mitreTechniques.join(", ")})` : ""}`,
+      )
+      .join("\n") || "(none)";
+
+  // The deterministic ATT&CK mitigations for this case's techniques — the grounding facts.
+  const mit = buildMitigationsResult(filtered, loadMitigationsDataset());
+  const mitigationsText =
+    mit.byMitigation
+      .slice(0, 30)
+      .map((m) => `- ${m.id} ${m.name} (covers ${m.techniques.join(", ")}): ${m.description}`)
+      .join("\n") || "(no mapped ATT&CK mitigations)";
+
+  // The deterministic D3FEND countermeasures (defensive techniques/sensors) for the same
+  // techniques — so the plan can also cite the relevant D3FEND control alongside the M-code.
+  const d3f = buildD3fendResult(filtered, loadD3fendDataset(), d3fendEnvOptions());
+  const d3fendText =
+    d3f.byTactic
+      .flatMap((g) =>
+        g.countermeasures.map((c) => `- ${c.name} [${c.tactic}] (covers ${c.techniques.join(", ")})`),
+      )
+      .slice(0, 40)
+      .join("\n") || "(no mapped D3FEND countermeasures)";
+
+  const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog());
+
+  const userPrompt =
+    contextBlock +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `FINDINGS:\n${findingsText}\n\n` +
+    `RECOMMENDED ATT&CK MITIGATIONS (use these as the basis for concrete steps):\n${mitigationsText}\n\n` +
+    `RELEVANT D3FEND COUNTERMEASURES (the defensive technique/sensor for each — cite alongside the ATT&CK mitigation where it fits):\n${d3fendText}\n\n` +
+    `Write the incident-specific remediation plan as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "remediation",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getRemediationPrompt(), userPrompt, images: [] },
+        "remediation",
+      );
+      return remediationPlanSchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// On-demand hypothesis falsification review (issue #71). A focused, human-readable devil's-advocate
+// pass over the OPEN hypotheses: for each, the plain-English evidence FOR and AGAINST it plus an
+// ADVISORY recommended status. One text-only AI call; EPHEMERAL — no state change, and crucially it
+// NEVER mutates a hypothesis's status (the analyst-freeze contract); the recommendation is surfaced for
+// the analyst to apply. Returns { reviews: [] } with no AI call when there are no open hypotheses.
+export async function hypothesisReview(
+  ctx: CaseReportContext,
+  caseId: string,
+): Promise<{ reviews: HypothesisReviewItem[] }> {
+  if (!ctx.opts.hypothesisStore) throw new Error("hypotheses not configured");
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("hypothesis review");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+
+  const allHypotheses = await ctx.opts.hypothesisStore.load(caseId);
+  // Review OPEN, non-exhausted hypotheses (analyst- or synthesis-authored). Resolved/exhausted ones
+  // are already settled, so re-litigating them wastes tokens and invites status churn.
+  const open = allHypotheses.filter((h) => h.status === "open" && !h.exhausted);
+  if (!open.length) return { reviews: [] };
+
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+  const validEventIds = new Set(scoped.map((e) => e.id));
+
+  const findingsText = findingsWithIds(loaded);
+  const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog());
+
+  // Render the open hypotheses with the evidence already linked to them, so the model reviews the
+  // analyst's/synthesis's current picture rather than starting cold.
+  const hypothesesText = open
+    .map((h) => {
+      const parts = [`[${h.id}] ${h.title}`];
+      if (h.expectedOutcome) parts.push(`    decided by: ${h.expectedOutcome}`);
+      if (h.relatedEventIds.length)
+        parts.push(`    currently-supporting events: ${h.relatedEventIds.join(", ")}`);
+      if (h.contradictingEventIds.length)
+        parts.push(`    known contradicting events: ${h.contradictingEventIds.join(", ")}`);
+      return parts.join("\n");
+    })
+    .join("\n");
+
+  const timelineText = fitTimelineText(
+    scoped,
+    renderIdentifiedEvent,
+    promptOverhead(
+      getHypothesisReviewPrompt(),
+      contextBlock,
+      loaded.attackerPath || "",
+      findingsText,
+      hypothesesText,
+    ),
+  );
+
+  const userPrompt =
+    contextBlock +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `FINDINGS:\n${findingsText}\n\n` +
+    `FORENSIC TIMELINE (${scoped.length} in-scope events):\n${timelineText}\n\n` +
+    `OPEN HYPOTHESES TO REVIEW:\n${hypothesesText}\n\n` +
+    `Review each open hypothesis for supporting AND refuting evidence, and return the JSON.`;
+
+  const knownHypotheses = new Map(open.map((h) => [h.id, h.title] as const));
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "hypothesis-review",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getHypothesisReviewPrompt(), userPrompt, images: [] },
+        "hypothesis-review",
+      );
+      const result = hypothesisReviewSchema.parse(parsed);
+      return { reviews: sanitizeHypothesisReviews(result.reviews, knownHypotheses, validEventIds) };
+    },
+    retries,
+    backoffMs,
+  );
+}

--- a/companion/src/analysis/ai/deepPassRun.ts
+++ b/companion/src/analysis/ai/deepPassRun.ts
@@ -1,0 +1,202 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { AIProvider } from "../../providers/provider.js";
+import { recordDeepPassRun } from "../analysisRunRecorders.js";
+import {
+  previewFloors,
+  planBatches,
+  floorsWithinBudget,
+  renderObservationDigest,
+  DEFAULT_MAX_BATCHES,
+  type DeepPassCheckpoint,
+  type FloorOption,
+} from "../deepPass.js";
+import { executeDeepPassBatches } from "../deepPassExecution.js";
+import { filterFalsePositiveEvents } from "../falsePositive.js";
+import { filterEventsByScope, NO_SCOPE } from "../scope.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import type { ForensicEvent, Severity } from "../stateTypes.js";
+import { renderStructuredTags } from "../synthEvidence.js";
+import { collapseForPrompt, groupEnvOptions, maxPromptEvents, promptCandidates } from "../synthGroup.js";
+import { inputTokenBudget } from "../promptBudget.js";
+import { getObservePrompt, getSynthesisPrompt } from "./prompts/index.js";
+import { synthesize, type SynthesisContext } from "./synthesis.js";
+
+/**
+ * Deep Pass (#418): read the whole graded timeline in batches, then synthesize over the digest.
+ *
+ * Moved from AnalysisPipeline. Ordinary synthesis shows the model a stratified SAMPLE of the
+ * timeline — enough for the conclusions, but it means a detection that lost its prompt seat was
+ * never read at all. Deep Pass is the analyst spending real money to close that gap: every event at
+ * or above a chosen floor is observed in a bounded number of batches, and the observations become
+ * one `observationsBlock` fed into a forced synthesis.
+ *
+ * It sits in its own module rather than inside ai/synthesis.ts because the dependency runs one way:
+ * Deep Pass calls synthesis, synthesis knows nothing about Deep Pass beyond the block of text it is
+ * handed. Filing it here keeps that direction visible and the import graph acyclic.
+ */
+
+/** What one deep-pass run did, for the analyst and the route response. */
+export interface DeepPassResult {
+  aborted: boolean;
+  floor: Severity; // the minimum severity that was read
+  events: number; // graded events at or above the floor
+  rows: number; // prompt rows after detection-burst grouping
+  batches: number; // observation calls made
+  batchesFailed: number; // batches whose response never parsed — that slice went unread
+  observations: number; // observations that survived sanitising
+}
+
+/** Deep Pass drives a full synthesis at the end, so it needs everything synthesis needs. */
+export type DeepPassContext = SynthesisContext;
+
+// Observation rows match synthesis timeline rows, minus the selection-class prefix.
+function renderBatchRows(rows: readonly ForensicEvent[]): string {
+  return rows
+    .map(
+      (e) =>
+        `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}`,
+    )
+    .join("\n");
+}
+
+/** Estimate each Deep Pass severity floor against this case before the analyst spends credits. */
+export async function deepPassPreview(
+  ctx: DeepPassContext,
+  caseId: string,
+): Promise<{ cap: number; floors: FloorOption[] }> {
+  const state = await ctx.opts.stateStore.load(caseId);
+  const markers = ctx.opts.falsePositiveStore ? await ctx.opts.falsePositiveStore.load(caseId) : [];
+  const scope = ctx.opts.scopeStore ? await ctx.opts.scopeStore.load(caseId) : NO_SCOPE;
+  const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(state.forensicTimeline, scope), markers);
+  const cap = maxPromptEvents();
+  return { cap, floors: previewFloors(scopedEvents, { cap }) };
+}
+
+export async function deepPass(
+  ctx: DeepPassContext,
+  caseId: string,
+  opts: {
+    minSeverity: Severity;
+    provider?: AIProvider;
+    signal?: AbortSignal;
+    maxBatches?: number;
+    onProgress?: (done: number, total: number, detail: string) => void;
+    onCheckpoint?: (checkpoint: DeepPassCheckpoint) => Promise<void>;
+    resumeFrom?: DeepPassCheckpoint;
+    analysisParentRunId?: string;
+  },
+): Promise<DeepPassResult> {
+  const runStartedAt = new Date().toISOString();
+  const runId = `${runStartedAt.replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
+  const state = await ctx.opts.stateStore.load(caseId);
+  const provider = opts.provider ?? ctx.opts.synthesisProvider ?? ctx.opts.provider;
+  if (!provider) throw new Error("no synthesis provider configured");
+
+  const markers = ctx.opts.falsePositiveStore ? await ctx.opts.falsePositiveStore.load(caseId) : [];
+  const scope = ctx.opts.scopeStore ? await ctx.opts.scopeStore.load(caseId) : NO_SCOPE;
+  const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(state.forensicTimeline, scope), markers);
+
+  const cap = maxPromptEvents();
+  const floored = applySeverityFloor([...promptCandidates(scopedEvents)], opts.minSeverity);
+  const { events: rows } = collapseForPrompt(floored, groupEnvOptions());
+  const batches = planBatches(rows, cap);
+  const selectionHash = createHash("sha256")
+    .update(JSON.stringify(rows.map((event) => event.id)))
+    .digest("hex");
+
+  // Refuse rather than quietly starting a very expensive job — and name a floor that would fit.
+  const ceiling = opts.maxBatches ?? (Number(process.env.DFIR_DEEP_PASS_MAX_BATCHES) || DEFAULT_MAX_BATCHES);
+  if (batches.length > ceiling) {
+    const fits = floorsWithinBudget(previewFloors(scopedEvents, { cap }), ceiling);
+    throw new Error(
+      `deep pass needs ${batches.length} batches, above the ${ceiling} limit. ` +
+        (fits.length
+          ? `Raise the floor to ${fits[fits.length - 1]} or above.`
+          : "Raise DFIR_DEEP_PASS_MAX_BATCHES."),
+    );
+  }
+
+  const retries = ctx.opts.retries ?? 3;
+  const backoffMs = ctx.opts.backoffMs ?? 500;
+  const execution = await executeDeepPassBatches({
+    batches,
+    floor: opts.minSeverity,
+    selectionHash,
+    validEventIds: new Set(state.forensicTimeline.map((event) => event.id)),
+    digestBudget: Math.max(0, Math.floor(inputTokenBudget() * 0.25)),
+    ...(opts.resumeFrom ? { resumeFrom: opts.resumeFrom } : {}),
+    ...(opts.signal ? { signal: opts.signal } : {}),
+    ...(opts.onProgress ? { onProgress: opts.onProgress } : {}),
+    ...(opts.onCheckpoint ? { onCheckpoint: opts.onCheckpoint } : {}),
+    renderBatch: (batch) => renderBatchRows(batch),
+    observe: (userPrompt) =>
+      ctx.withRetry(
+        caseId,
+        "deep-pass-observe",
+        () =>
+          ctx.analyzeRestored(
+            caseId,
+            state,
+            provider,
+            {
+              systemPrompt: getObservePrompt(),
+              userPrompt,
+              images: [],
+              ...(opts.signal ? { signal: opts.signal } : {}),
+            },
+            "deep-pass-observe",
+          ),
+        retries,
+        backoffMs,
+      ),
+    onFailure: (message) => ctx.log.warn(`deep pass: ${message}`, { caseId }),
+  });
+  const { observations, batchesFailed, aborted } = execution;
+
+  const summary: DeepPassResult = {
+    aborted,
+    floor: opts.minSeverity,
+    events: floored.length,
+    rows: rows.length,
+    batches: batches.length,
+    batchesFailed,
+    observations: observations.length,
+  };
+  const runRecord = {
+    id: runId,
+    parentRunId: opts.analysisParentRunId,
+    startedAt: runStartedAt,
+    provider: provider.name,
+    model: provider.model,
+    eventIds: floored.map((event) => event.id),
+    minSeverity: opts.minSeverity,
+    maxBatches: ceiling,
+    rowsPerBatch: cap,
+    scope,
+    batchesFailed,
+    falsePositiveMarkers: markers.length,
+    observePrompt: getObservePrompt(),
+    synthesisPrompt: getSynthesisPrompt(),
+  };
+  if (aborted) {
+    await recordDeepPassRun(ctx.opts.analysisRunStore, caseId, {
+      ...runRecord,
+      status: "failed",
+      error: "cancelled before final synthesis",
+      output: state,
+    });
+    return summary;
+  }
+
+  opts.onProgress?.(batches.length, batches.length, "synthesizing");
+  await synthesize(ctx, caseId, {
+    force: true,
+    ...(opts.signal ? { signal: opts.signal } : {}),
+    ...(opts.provider ? { provider: opts.provider } : {}),
+    observationsBlock: renderObservationDigest(observations),
+    analysisParentRunId: runId,
+  });
+  const finalState = await ctx.opts.stateStore.load(caseId);
+  await recordDeepPassRun(ctx.opts.analysisRunStore, caseId, { ...runRecord, output: finalState });
+  return summary;
+}

--- a/companion/src/analysis/ai/extraction.ts
+++ b/companion/src/analysis/ai/extraction.ts
@@ -1,0 +1,355 @@
+import type { AIProvider, AnalyzeImage } from "../../providers/provider.js";
+import type { CaptureMetadata } from "../../types.js";
+import { chunkToCsvText, parseCsv } from "../csvImport.js";
+import { lastImportEventSequence } from "../importResume.js";
+import { aggregateLogLines, type AggregateStats } from "../logAggregate.js";
+import { parseLogLines } from "../logImport.js";
+import { batchByBudget, estimateTokens, inputTokenBudget } from "../promptBudget.js";
+import { deltaSchema, stripAiExtractedFrom } from "../responseSchema.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import { mergeDelta, type WindowContext } from "../stateMerge.js";
+import type { InvestigationState, Severity } from "../stateTypes.js";
+import { buildStateSummary } from "../summary.js";
+import { detectTool } from "../toolDetect.js";
+import { getCsvPrompt, getLogPrompt, getSystemPrompt } from "./prompts/index.js";
+import { type AiCallContext } from "./aiContext.js";
+import { buildImportAnonContext, presidioPreScan, type ProviderCallContext } from "./providerCall.js";
+
+/**
+ * The three AI EXTRACTION calls (#418): screenshots, CSV rows, log lines → forensic events.
+ *
+ * Moved from AnalysisPipeline (see ai/caseReports.ts for the pattern). These are the other half of
+ * ingest: `analysis/ingest/` holds the ~36 DETERMINISTIC importers, which parse a known format and
+ * need no model at all. These three are what is left when the format is not known in advance — a
+ * screenshot of someone else's console, an arbitrary CSV export, a log nobody wrote a parser for.
+ * They produce the SAME delta the deterministic importers do, and like them they produce only
+ * events and IOCs: findings, techniques and the attacker path come afterwards from synthesize().
+ *
+ * All three hold the state lock across their whole batch loop, and all three pre-scan the entire
+ * payload for Presidio once up front rather than per batch — one approval round trip per import.
+ */
+
+/** What an extraction call needs: the AI-call seam, the gate's own context, and the merge path. */
+export interface ExtractionContext extends AiCallContext, ProviderCallContext {
+  readonly opts: AiCallContext["opts"] &
+    ProviderCallContext["opts"] & {
+      provider?: AIProvider;
+      imageLoader: (caseId: string, screenshotFile: string) => Promise<AnalyzeImage>;
+      onState?: (state: InvestigationState) => void;
+    };
+  /** Serialise the load→merge→save critical section per case. Never nest for the same caseId. */
+  withStateLock<T>(caseId: string, fn: () => Promise<T>): Promise<T>;
+  /** mergeDelta plus the case's analyst IOC-merge aliases (#82). */
+  mergeWithAliases(
+    state: InvestigationState,
+    delta: Parameters<typeof mergeDelta>[1],
+    ctx: WindowContext,
+  ): Promise<InvestigationState>;
+  /** Side channel for analyzeLog's distinct-template cap; null clears a previous run's warning. */
+  recordImportTruncation(caseId: string, stats: AggregateStats | null): void;
+}
+
+/** Options common to the two file-import extractions; each adds its own batch-size knob. */
+interface ImportExtractionOptions {
+  label: string; // evidence label shown as the event source (stored filename)
+  idPrefix: string; // unique per import (e.g. "m3") so event ids never collide
+  importedAt: string; // ISO time used for timeline/firstSeen context
+  minSeverity?: Severity; // gate-aware import floor (unified Import button) — see applySeverityFloor
+  onProgress?: (done: number, total: number) => void | Promise<void>;
+  signal?: AbortSignal; // #225: analyst cancel — aborts the in-flight AI call + stops between batches
+  startBatch?: number;
+}
+
+export async function analyzeWindow(
+  ctx: ExtractionContext,
+  caseId: string,
+  captures: CaptureMetadata[],
+): Promise<InvestigationState> {
+  const provider = ctx.requireProvider("screenshot analysis");
+  const analyzable = captures.filter((c) => !c.isDuplicate);
+  if (analyzable.length === 0) return ctx.opts.stateStore.load(caseId);
+
+  return ctx.withStateLock(caseId, async () => {
+    const state = await ctx.opts.stateStore.load(caseId);
+    const images = await Promise.all(analyzable.map((c) => ctx.opts.imageLoader(caseId, c.screenshotFile)));
+    // Note: we deliberately do NOT put the capture time on these lines — the model
+    // would otherwise copy it into forensicEvents instead of reading the artifact's
+    // own timestamp column shown in the image.
+    const contextLines = analyzable
+      .map((c) => `Screenshot ${c.screenshotFile} — ${c.tabTitle} (${c.url})`)
+      .join("\n");
+    const userPrompt =
+      `${buildStateSummary(state)}\n\nNEW SCREENSHOTS (read each artifact's OWN timestamp column ` +
+      `for event times — do not use any capture/current time):\n${contextLines}\n\nReturn the JSON delta.`;
+
+    const retries = ctx.opts.retries ?? 3;
+    const backoffMs = ctx.opts.backoffMs ?? 500;
+
+    const delta = await ctx.withRetry(
+      caseId,
+      "extract",
+      async () => {
+        const parsed = await ctx.analyzeRestored(
+          caseId,
+          state,
+          provider,
+          { systemPrompt: getSystemPrompt(), userPrompt, images },
+          "extract",
+        );
+        return stripAiExtractedFrom(deltaSchema.parse(parsed));
+      },
+      retries,
+      backoffMs,
+    );
+
+    const windowSequence = analyzable[analyzable.length - 1].sequenceNumber;
+    // Tag each event's source for correlation/corroboration: detect the real tool from the
+    // captured tab titles (e.g. "Velociraptor", "CrowdStrike Falcon"), else generic "screenshot".
+    const winSource = detectTool(analyzable.map((c) => c.tabTitle).join(" ")) ?? "screenshot";
+    const tagged = {
+      ...delta,
+      forensicEvents: (delta.forensicEvents ?? []).map((e) => ({
+        ...e,
+        sources: e.sources?.length ? e.sources : [winSource],
+      })),
+    };
+    const next = await ctx.mergeWithAliases(state, tagged, {
+      windowSequence,
+      timestamp: analyzable[analyzable.length - 1].timestamp,
+      sourceScreenshots: analyzable.map((c) => c.screenshotFile),
+    });
+    await ctx.opts.stateStore.save(next);
+    ctx.opts.onState?.(next);
+    return next;
+  });
+}
+
+// Import an uploaded CSV (e.g. a Velociraptor result export) as evidence: extract
+// dated forensic events + IOCs from the rows, batch by batch, into the timeline —
+// the same delta the screenshot path produces. Findings/TTPs/attacker-path come
+// afterwards from synthesize() (call it after this resolves), exactly like capture.
+export async function analyzeCsv(
+  ctx: ExtractionContext,
+  caseId: string,
+  csvText: string,
+  opts: ImportExtractionOptions & { rowsPerBatch?: number },
+): Promise<InvestigationState> {
+  // Text model (same idiom as ask/explain/synthesis): CSV extraction is text reasoning, not OCR.
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("CSV analysis");
+  const { headers, rows } = parseCsv(csvText);
+  if (rows.length === 0) return ctx.opts.stateStore.load(caseId);
+
+  const retries = ctx.opts.retries ?? 3;
+  const backoffMs = ctx.opts.backoffMs ?? 500;
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    let evSeq = lastImportEventSequence(state.forensicTimeline, opts.idPrefix);
+
+    // Scan the WHOLE import once, up front, instead of letting the per-chunk batches below hit
+    // presidioGate repeatedly (which would stall-approve-restart on a large CSV with names
+    // scattered through it). One approval round trip per import, not one per chunk.
+    //
+    // The scan covers the STATE SUMMARY as well as the payload, because every batch prompt
+    // below is `buildStateSummary(state) + csvChunk`, and every batch passes
+    // skipPresidioGate=true. Scanning csvText alone left the summary — finding titles and
+    // descriptions, open threads, the last 12 forensic events and every known IOC value, all
+    // RESTORED to real values — reaching the provider having never been seen by Presidio: a
+    // fail-OPEN in a layer whose contract is fail-closed.
+    if (ctx.opts.presidio) {
+      const importAnonCtx = await buildImportAnonContext(ctx, caseId, state);
+      if (importAnonCtx)
+        await presidioPreScan(
+          ctx,
+          caseId,
+          `${buildStateSummary(state)}\n${csvText}`,
+          importAnonCtx.known,
+          importAnonCtx.anon,
+        );
+    }
+
+    // Batch by BOTH the row cap and a token budget: wide rows (long EDR/SIEM command-lines)
+    // could otherwise pack 50 rows into a prompt that overflows the model context. Reserve
+    // room for the system prompt + the state-summary that's prepended to every batch.
+    const csvOverhead =
+      estimateTokens(getCsvPrompt()) +
+      estimateTokens(buildStateSummary(state)) +
+      estimateTokens(chunkToCsvText(headers, [])) +
+      64;
+    const rowBudget = Math.max(0, inputTokenBudget() - csvOverhead);
+    const batches = batchByBudget(rows, opts.rowsPerBatch ?? 50, (r) => r.join(","), rowBudget);
+
+    for (let b = opts.startBatch ?? 0; b < batches.length; b++) {
+      if (opts.signal?.aborted) break; // #225: cancelled — stop before the next batch, keep prior batches
+      const csvChunk = chunkToCsvText(headers, batches[b]);
+      const userPrompt =
+        `${buildStateSummary(state)}\n\nCSV ARTIFACT ROWS (source: ${opts.label}; batch ${b + 1}/${batches.length}). ` +
+        `Read each row's OWN time column for event times — do not use the current time:\n\n${csvChunk}\n\n` +
+        `Return the JSON delta.`;
+
+      const delta = await ctx.withRetry(
+        caseId,
+        "csv",
+        async () => {
+          // skipPresidioGate=true: the pre-scan above already covered this whole import.
+          const parsed = await ctx.analyzeRestored(
+            caseId,
+            state,
+            provider,
+            {
+              systemPrompt: getCsvPrompt(),
+              userPrompt,
+              images: [],
+              ...(opts.signal ? { signal: opts.signal } : {}),
+            },
+            "csv",
+            true,
+          );
+          return stripAiExtractedFrom(deltaSchema.parse(parsed));
+        },
+        retries,
+        backoffMs,
+      );
+
+      // Renumber event ids so chunked imports don't overwrite each other (merge
+      // dedupes forensic events by id, and each batch independently emits e1, e2…).
+      const renumbered = {
+        ...delta,
+        forensicEvents: applySeverityFloor(delta.forensicEvents ?? [], opts.minSeverity).map((e) => ({
+          ...e,
+          id: `${opts.idPrefix}e${++evSeq}`,
+          sources: e.sources?.length ? e.sources : [detectTool(opts.label) ?? "CSV import"],
+        })),
+      };
+
+      state = await ctx.mergeWithAliases(state, renumbered, {
+        windowSequence: -(b + 1), // negative: distinguishes import batches from capture windows
+        timestamp: opts.importedAt,
+        sourceScreenshots: [opts.label], // evidence traceability: the CSV file
+      });
+      await ctx.opts.stateStore.save(state);
+      ctx.opts.onState?.(state);
+      await opts.onProgress?.(b + 1, batches.length);
+    }
+    return state;
+  });
+}
+
+// Import an uploaded generic log file (firewall logs, syslog, sshd, IIS, etc.)
+// as evidence. Logs are mostly repetition, so we DEDUPLICATE deterministically
+// first (aggregateLogLines collapses near-identical lines into counted patterns),
+// then ask the model to triage the PATTERNS — emitting one aggregated forensic
+// event only for the security-relevant ones and skipping routine noise. This
+// keeps the timeline signal-rich and cuts the analysis to ~one AI call.
+// Findings/TTPs/attacker-path come afterwards from synthesize().
+export async function analyzeLog(
+  ctx: ExtractionContext,
+  caseId: string,
+  logText: string,
+  opts: ImportExtractionOptions & { patternsPerBatch?: number },
+): Promise<InvestigationState> {
+  // Text model (same idiom as ask/explain/synthesis): log triage is text reasoning, not OCR.
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("log analysis");
+  const { lines } = parseLogLines(logText);
+  if (lines.length === 0) return ctx.opts.stateStore.load(caseId);
+
+  // Collapse the raw lines into distinct, counted patterns (most frequent first). Capture the
+  // aggregation stats so a cap-hit (more distinct patterns than the AI could be shown) is flagged
+  // as a coverage blind spot by the import route (#10 trigger b).
+  const aggStats: AggregateStats = { distinctTemplates: 0, keptTemplates: 0 };
+  const maxTemplates = Number(process.env.DFIR_LOG_MAX_TEMPLATES) || undefined; // else the built-in default
+  const templates = aggregateLogLines(lines, { maxTemplates }, aggStats);
+  ctx.recordImportTruncation(caseId, aggStats.distinctTemplates > aggStats.keptTemplates ? aggStats : null);
+  const retries = ctx.opts.retries ?? 3;
+  const backoffMs = ctx.opts.backoffMs ?? 500;
+
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    let evSeq = lastImportEventSequence(state.forensicTimeline, opts.idPrefix);
+
+    // Scan the WHOLE import once, up front — see analyzeCsv for why this must precede the
+    // per-pattern batch loop below rather than living inside it, and why the state summary is
+    // scanned alongside the payload (every batch prompt below prepends it and skips the gate).
+    if (ctx.opts.presidio) {
+      const importAnonCtx = await buildImportAnonContext(ctx, caseId, state);
+      if (importAnonCtx)
+        await presidioPreScan(
+          ctx,
+          caseId,
+          `${buildStateSummary(state)}\n${logText}`,
+          importAnonCtx.known,
+          importAnonCtx.anon,
+        );
+    }
+
+    // Batch by BOTH the pattern cap and a token budget — a few patterns with very long
+    // examples shouldn't form a prompt that overflows the model context.
+    const renderPattern = (t: (typeof templates)[number]) =>
+      `×${t.count} ${t.firstTimestamp ?? ""} ${t.lastTimestamp ?? ""} ${t.example}`;
+    const logOverhead = estimateTokens(getLogPrompt()) + estimateTokens(buildStateSummary(state)) + 96;
+    const patternBudget = Math.max(0, inputTokenBudget() - logOverhead);
+    const batches = batchByBudget(templates, opts.patternsPerBatch ?? 120, renderPattern, patternBudget);
+
+    for (let b = opts.startBatch ?? 0; b < batches.length; b++) {
+      if (opts.signal?.aborted) break; // #225: cancelled — stop before the next batch, keep prior batches
+      // Present each pattern with its occurrence count, time span, and an example.
+      const patternText = batches[b]
+        .map(
+          (t, i) =>
+            `[p${i + 1}] ×${t.count}` +
+            (t.firstTimestamp ? ` first=${t.firstTimestamp}` : "") +
+            (t.lastTimestamp && t.lastTimestamp !== t.firstTimestamp ? ` last=${t.lastTimestamp}` : "") +
+            `\n     e.g. ${t.example}`,
+        )
+        .join("\n");
+      const userPrompt =
+        `${buildStateSummary(state)}\n\nDEDUPLICATED LOG PATTERNS (source: ${opts.label}; ` +
+        `batch ${b + 1}/${batches.length}; ${lines.length} raw line(s) → ${templates.length} pattern(s)). ` +
+        `Emit an aggregated event ONLY for security-relevant patterns; skip routine noise:\n\n${patternText}\n\n` +
+        `Return the JSON delta.`;
+
+      const delta = await ctx.withRetry(
+        caseId,
+        "log",
+        async () => {
+          // skipPresidioGate=true: the pre-scan above already covered this whole import.
+          const parsed = await ctx.analyzeRestored(
+            caseId,
+            state,
+            provider,
+            {
+              systemPrompt: getLogPrompt(),
+              userPrompt,
+              images: [],
+              ...(opts.signal ? { signal: opts.signal } : {}),
+            },
+            "log",
+            true,
+          );
+          return stripAiExtractedFrom(deltaSchema.parse(parsed));
+        },
+        retries,
+        backoffMs,
+      );
+
+      const renumbered = {
+        ...delta,
+        forensicEvents: applySeverityFloor(delta.forensicEvents ?? [], opts.minSeverity).map((e) => ({
+          ...e,
+          id: `${opts.idPrefix}e${++evSeq}`,
+          sources: e.sources?.length ? e.sources : [detectTool(opts.label) ?? "Log import"],
+        })),
+      };
+
+      state = await ctx.mergeWithAliases(state, renumbered, {
+        windowSequence: -(b + 1),
+        timestamp: opts.importedAt,
+        sourceScreenshots: [opts.label],
+      });
+      await ctx.opts.stateStore.save(state);
+      ctx.opts.onState?.(state);
+      await opts.onProgress?.(b + 1, batches.length);
+    }
+    return state;
+  });
+}

--- a/companion/src/analysis/ai/hunts.ts
+++ b/companion/src/analysis/ai/hunts.ts
@@ -1,0 +1,413 @@
+import type { AIProvider } from "../../providers/provider.js";
+import { buildGraphContext, DEFAULT_MAX_GRAPH_EDGES } from "../graphContext.js";
+import {
+  deployedFingerprints,
+  renderPriorHuntsBlock,
+  renderHuntProductivityBlock,
+  vqlFingerprint,
+  type HuntOutcome,
+} from "../huntOutcomes.js";
+import type { HuntOutcomeStore } from "../huntOutcomeStore.js";
+import { HUNT_PLATFORMS, type HuntPlatform } from "../huntPlatforms.js";
+import {
+  huntSuggestionsResponseSchema,
+  sanitizeHuntSuggestions,
+  renderHuntFindings,
+  renderHuntIocs,
+  hasHuntMaterial,
+  HUNT_SUGGEST_MAX_DEFAULT,
+  type HuntSuggestion,
+} from "../huntSuggest.js";
+import type { PlaybookTask } from "../playbook.js";
+import {
+  playbookHuntResponseSchema,
+  sanitizePlaybookHuntSuggestions,
+  buildTaskEndpointsMap,
+  knownEndpoints,
+  renderPlaybookHuntTasks,
+  renderKnownEndpoints,
+  renderAvailableArtifacts,
+  hasPlaybookHuntMaterial,
+  PLAYBOOK_HUNT_SUGGEST_MAX_DEFAULT,
+  type PlaybookHuntSuggestion,
+} from "../playbookHunt.js";
+import { estimateTokens, inputTokenBudget, fitItemsToBudget } from "../promptBudget.js";
+import {
+  queryTranslationResponseSchema,
+  sanitizeQueryTranslations,
+  sanitizeInterpretation,
+  renderPlatformGuide,
+  renderCaseDataSources,
+  type QueryTranslationResult,
+} from "../queryTranslate.js";
+import type { ForensicEvent } from "../stateTypes.js";
+import { buildSynthesisContext, selectSynthesisEvents } from "../synthSelect.js";
+import { maxPromptEvents } from "../synthGroup.js";
+import { getHuntSuggestPrompt, getPlaybookHuntPrompt, getQueryTranslatePrompt } from "./prompts/index.js";
+import { loadScopedEvents, retryPolicy } from "./aiContext.js";
+import { knownUnknownsBlock, type PromptBlockContext } from "./promptBlocks.js";
+
+/**
+ * The four AI calls that produce something the analyst RUNS (#418).
+ *
+ * Moved from AnalysisPipeline (see ai/caseReports.ts for the pattern). Three of them write
+ * Velociraptor VQL and the fourth translates plain English into a SIEM query, but what actually
+ * groups them is the feedback loop underneath: every VQL suggestion is filtered against the hunts
+ * this case has already deployed, and every VQL prompt carries the hit/miss ledger so the model
+ * pivots on what worked. All four are EPHEMERAL — nothing here mutates the case.
+ */
+
+/** What a hunt generator needs beyond the shared AI-call seam and the derived prompt blocks. */
+export interface HuntContext extends PromptBlockContext {
+  readonly opts: PromptBlockContext["opts"] & {
+    velociraptorProvider?: AIProvider;
+    huntOutcomeStore?: HuntOutcomeStore;
+  };
+}
+
+// The hunting feedback loop's prior-hunt outcomes for a case (#157) — [] when no store is wired
+// (scripts/*) or the file is absent/corrupt, so the loop simply stays off without ever throwing.
+export async function loadHuntOutcomes(ctx: HuntContext, caseId: string): Promise<HuntOutcome[]> {
+  if (!ctx.opts.huntOutcomeStore) return [];
+  try {
+    return await ctx.opts.huntOutcomeStore.load(caseId);
+  } catch {
+    return [];
+  }
+}
+
+// Drop any suggestion whose VQL was already deployed in this case (#157) — the deterministic guarantee
+// that a hunt the analyst already ran is never re-proposed (the "PRIOR HUNTS" prompt block is the soft
+// signal; this is the hard one). Bundles contribute no fingerprint, so they never exclude a suggestion.
+function excludeDeployedHunts<T extends { vql: string }>(
+  suggestions: T[],
+  outcomes: readonly HuntOutcome[],
+): T[] {
+  const fps = deployedFingerprints(outcomes);
+  if (!fps.size) return suggestions;
+  return suggestions.filter((s) => !fps.has(vqlFingerprint(s.vql)));
+}
+
+/** The regenerate hook shared by the two hunt calls the analyst can ask for a different take on. */
+const excludeNote = (excludeVql?: string): string =>
+  excludeVql
+    ? `ALREADY SUGGESTED (this VQL was already shown to the analyst — generate something DIFFERENT that investigates from a different angle or uses different VQL plugins):\n${excludeVql}\n\n`
+    : "";
+
+// Propose proactive Velociraptor VQL fleet-hunts from the synthesized findings (issue #57).
+// Single text-only AI call; EPHEMERAL like ask()/executiveSummary() — it does NOT mutate state.
+// The analyst reviews each hunt's VQL + rationale, then one-click deploys it through the existing
+// launchHunt flow (POST /velociraptor/hunt). Returns [] without an AI call on an empty case.
+export async function suggestHunts(
+  ctx: HuntContext,
+  caseId: string,
+  opts?: { excludeVql?: string },
+): Promise<HuntSuggestion[]> {
+  const provider =
+    ctx.opts.velociraptorProvider ?? ctx.opts.synthesisProvider ?? ctx.requireProvider("hunt suggestions");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  if (!hasHuntMaterial(loaded)) return []; // nothing to pivot on — don't spend a call
+
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+
+  const max = maxPromptEvents();
+  let events = selectSynthesisEvents(scoped, max);
+  const renderEvent = (e: ForensicEvent) =>
+    `[${e.timestamp || "(undated)"}] [${e.severity}] ${e.description.slice(0, 240)}`;
+  const findingsText = renderHuntFindings(loaded.findings);
+  const iocText = renderHuntIocs(loaded.iocs);
+  const techText = loaded.mitreTechniques.map((t) => `${t.id} ${t.name}`).join(", ") || "(none)";
+  const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog());
+  // Causal grounding (#124): serialize the deterministic evidence-chain graph — process spawn
+  // chains, file lineage, lateral-movement edges — so the model hunts the RELATIONSHIP (the
+  // parent→child chain, the binary/account that moved between hosts) fleet-wide, not just the leaf
+  // indicator. The flat timeline drops processName/parentName; the graph carries them. Built from
+  // the SAME scoped+legitimate-filtered events as the rest of the prompt; "" when there are no edges.
+  // Capped at the shared default (the timeline trim below absorbs the block into the prompt budget).
+  const graphBlock = buildGraphContext(
+    { ...loaded, forensicTimeline: scoped },
+    { maxEdges: DEFAULT_MAX_GRAPH_EDGES },
+  );
+
+  // Feedback loop (#157): the prior hunts already run in this case (what hit / what missed), so the
+  // model proposes follow-ups that pivot on productive hunts and avoids repeating dead ones. "" when
+  // there are no recorded outcomes (or no store wired). Also drives the deterministic exclusion below.
+  const outcomes = await loadHuntOutcomes(ctx, caseId);
+  const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
+  // Productivity tuning (#72): the aggregate hit-rate by pivot class (hash/process/path/network/
+  // registry) across this case's hunt history, so the model biases toward classes that have found
+  // evidence rather than only avoiding exact repeats (priorHuntsBlock is the per-hunt signal; this
+  // is the aggregate one). "" until there's collected history to bias on.
+  const productivityBlock = renderHuntProductivityBlock(outcomes);
+  // Known unknowns (#165): the gaps in the story (silent windows, uncovered ATT&CK phases, likely-
+  // next techniques) so suggested hunts target what's MISSING, not just re-confirm what's known.
+  const unknownsBlock = await knownUnknownsBlock(ctx, loaded, scoped, caseId);
+
+  // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
+  const overhead =
+    estimateTokens(getHuntSuggestPrompt()) +
+    estimateTokens(
+      priorHuntsBlock +
+        productivityBlock +
+        contextBlock +
+        unknownsBlock +
+        graphBlock +
+        findingsText +
+        iocText +
+        techText +
+        (loaded.attackerPath || ""),
+    ) +
+    300;
+  const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
+  if (fit < events.length) events = selectSynthesisEvents(scoped, fit);
+  const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
+
+  const userPrompt =
+    priorHuntsBlock +
+    productivityBlock +
+    contextBlock +
+    unknownsBlock +
+    graphBlock +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `ATT&CK TECHNIQUES: ${techText}\n\n` +
+    `FINDINGS:\n${findingsText}\n\n` +
+    `PIVOTABLE INDICATORS:\n${iocText}\n\n` +
+    `FORENSIC TIMELINE (${scoped.length} in-scope events):\n${timelineText}\n\n` +
+    excludeNote(opts?.excludeVql) +
+    `Propose the fleet-hunts as JSON.`;
+
+  const limit = Number(process.env.DFIR_HUNT_SUGGEST_MAX) || HUNT_SUGGEST_MAX_DEFAULT;
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "suggest-hunts",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getHuntSuggestPrompt(), userPrompt, images: [] },
+        "suggest-hunts",
+      );
+      const { suggestions } = huntSuggestionsResponseSchema.parse(parsed);
+      return excludeDeployedHunts(sanitizeHuntSuggestions(suggestions, limit), outcomes);
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// Targeted hunt for ONE ATT&CK technique the adversary-emulation panel flagged as a likely next
+// move (issue #121). Unlike suggestHunts (findings-driven), this is technique-DRIVEN: the technique
+// has NOT been observed yet — the analyst wants VQL to detect it proactively if a lookalike actor
+// brings it here. Reuses the fleet-hunt system prompt + schema + sanitizer + deploy flow, with a
+// technique-focused user prompt grounded in the case's pivotable IOCs. EPHEMERAL like suggestHunts()
+// — no state change. Works on ANY case (the technique is by definition not in the timeline).
+export async function suggestTechniqueHunts(
+  ctx: HuntContext,
+  caseId: string,
+  techniqueId: string,
+  techniqueName?: string,
+): Promise<HuntSuggestion[]> {
+  const provider =
+    ctx.opts.velociraptorProvider ?? ctx.opts.synthesisProvider ?? ctx.requireProvider("technique hunt");
+  const id = String(techniqueId || "")
+    .trim()
+    .toUpperCase();
+  if (!/^T\d{4}(?:\.\d{3})?$/.test(id)) return []; // not a technique id — nothing to hunt
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const iocText = renderHuntIocs(loaded.iocs);
+  const label = techniqueName ? `${id} (${techniqueName})` : id;
+  const outcomes = await loadHuntOutcomes(ctx, caseId); // #157 feedback loop (exclude + prior-hunts context)
+  const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
+  const productivityBlock = renderHuntProductivityBlock(outcomes); // #72: aggregate hit-rate by pivot class
+  const userPrompt =
+    priorHuntsBlock +
+    productivityBlock +
+    `Focus EXCLUSIVELY on ONE ATT&CK technique the analyst wants to hunt for proactively across the fleet:\n` +
+    `  ${label}\n\n` +
+    `This technique has NOT yet been observed in this case. A group whose tradecraft resembles this case is known ` +
+    `to use it, so the goal is to DETECT it on any enrolled endpoint if it is being used here but missed.\n\n` +
+    `Propose 1–3 CLIENT-side Velociraptor VQL hunts that surface this technique's tradecraft generally (not tied to ` +
+    `one host). Where relevant, pivot on these case indicators, but do not depend on them:\n` +
+    `PIVOTABLE INDICATORS:\n${iocText}\n\n` +
+    `Set every suggestion's mitreTechniques to ["${id}"]. Propose the hunt(s) as JSON.`;
+  const limit = Number(process.env.DFIR_HUNT_SUGGEST_MAX) || HUNT_SUGGEST_MAX_DEFAULT;
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "hunt-technique",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getHuntSuggestPrompt(), userPrompt, images: [] },
+        "hunt-technique",
+      );
+      const { suggestions } = huntSuggestionsResponseSchema.parse(parsed);
+      return excludeDeployedHunts(sanitizeHuntSuggestions(suggestions, limit), outcomes);
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// Propose a Velociraptor hunt for each ENDPOINT-related PLAYBOOK task (issue #70). Single text-only
+// AI call; EPHEMERAL like suggestHunts() — it does NOT mutate state. The deploy MODE is decided here
+// deterministically from the case's observed endpoints: a task tied to exactly one host → a single
+// client COLLECTION on it; otherwise → a fleet HUNT. The playbook `tasks` are passed in by the route
+// (the pipeline has no PlaybookStore). Returns [] without an AI call when there's no endpoint task.
+export async function suggestPlaybookHunts(
+  ctx: HuntContext,
+  caseId: string,
+  tasks: PlaybookTask[],
+  availableArtifacts: string[] = [],
+  opts?: { excludeVql?: string },
+): Promise<PlaybookHuntSuggestion[]> {
+  const provider =
+    ctx.opts.velociraptorProvider ??
+    ctx.opts.synthesisProvider ??
+    ctx.requireProvider("playbook hunt suggestions");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  if (!hasPlaybookHuntMaterial(loaded, tasks)) return []; // empty/closed playbook → don't spend a call
+
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+
+  const endpointsByTaskId = buildTaskEndpointsMap(loaded, tasks);
+  const endpoints = knownEndpoints(loaded);
+  const tasksText = renderPlaybookHuntTasks(tasks, endpointsByTaskId);
+  const endpointsText = renderKnownEndpoints(endpoints);
+  // The server's REAL CLIENT artifacts (passed in by the route) — the model may reference an
+  // Artifact.<Name> only from this list (otherwise it hallucinates a name that won't compile).
+  const artifactsText = renderAvailableArtifacts(
+    availableArtifacts,
+    Number(process.env.DFIR_PBHUNT_MAX_ARTIFACTS) || 150,
+  );
+
+  // This call hunts PER TASK (grounded by the tasks + findings + IOCs + endpoints), so it does NOT
+  // need the full synthesis timeline — a smaller stratified event sample keeps the signal while
+  // cutting the prompt (the timeline dominates it). A leaner prompt is faster + cheaper and shrinks
+  // the window for a transient provider transport failure on a long generation. Tune via
+  // DFIR_PBHUNT_MAX_EVENTS (default 120, well below synthesis's 300).
+  const max = Number(process.env.DFIR_PBHUNT_MAX_EVENTS) || 120;
+  let events = selectSynthesisEvents(scoped, max);
+  const renderEvent = (e: ForensicEvent) =>
+    `[${e.timestamp || "(undated)"}] [${e.severity}]${e.asset ? ` <${e.asset}>` : ""} ${e.description.slice(0, 240)}`;
+  const findingsText = renderHuntFindings(loaded.findings);
+  const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog());
+  const outcomes = await loadHuntOutcomes(ctx, caseId); // #157 feedback loop (exclude + prior-hunts context)
+  const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
+  const productivityBlock = renderHuntProductivityBlock(outcomes); // #72: aggregate hit-rate by pivot class
+
+  // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
+  const overhead =
+    estimateTokens(getPlaybookHuntPrompt()) +
+    estimateTokens(
+      priorHuntsBlock +
+        productivityBlock +
+        contextBlock +
+        tasksText +
+        endpointsText +
+        artifactsText +
+        findingsText +
+        (loaded.attackerPath || ""),
+    ) +
+    300;
+  const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
+  if (fit < events.length) events = selectSynthesisEvents(scoped, fit);
+  const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
+
+  const userPrompt =
+    priorHuntsBlock +
+    productivityBlock +
+    contextBlock +
+    `KNOWN ENDPOINTS (hosts — pick a targetHost ONLY from these): ${endpointsText}\n\n` +
+    `AVAILABLE VELOCIRAPTOR ARTIFACTS (reference Artifact.<Name> ONLY if <Name> is in this list — else use a raw plugin):\n${artifactsText}\n\n` +
+    `PLAYBOOK TASKS:\n${tasksText}\n\n` +
+    `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
+    `FINDINGS:\n${findingsText}\n\n` +
+    `FORENSIC TIMELINE (${scoped.length} in-scope events):\n${timelineText}\n\n` +
+    excludeNote(opts?.excludeVql) +
+    `Propose the per-task hunts as JSON.`;
+
+  const limit = Number(process.env.DFIR_PBHUNT_SUGGEST_MAX) || PLAYBOOK_HUNT_SUGGEST_MAX_DEFAULT;
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "suggest-playbook-hunts",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getPlaybookHuntPrompt(), userPrompt, images: [] },
+        "suggest-playbook-hunts",
+      );
+      const { suggestions } = playbookHuntResponseSchema.parse(parsed);
+      return excludeDeployedHunts(
+        sanitizePlaybookHuntSuggestions(suggestions, endpointsByTaskId, endpoints, limit),
+        outcomes,
+      );
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// Translate a free-text analyst request into a runnable hunting query per platform (issue #100).
+// Unlike suggestHunts (findings-driven proposals), this is analyst-DRIVEN: the request is plain
+// English ("PowerShell downloading a file and executing it") and the model maps that intent onto
+// each requested platform's real schema. EPHEMERAL like ask()/suggestHunts() — no state change.
+// Works on an empty case (the analyst may translate before any evidence is imported); the case's
+// known data sources + pivotable IOCs are passed only as light grounding. Uses the strong
+// synthesisProvider like ask()/executiveSummary() — this spans MANY query languages (KQL/SPL/ES|QL/
+// Sigma/…) in one call, so the broad general model follows the multi-platform instruction far better
+// than the narrow VQL-tuned velociraptorProvider (which biases toward VQL and ignores the rest).
+export async function translateQuery(
+  ctx: HuntContext,
+  caseId: string,
+  request: string,
+  platforms?: readonly HuntPlatform[],
+): Promise<QueryTranslationResult> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("query translation");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+
+  // The caller's requested subset, intersected with the canonical platform set; empty → all.
+  const requested = (platforms ?? []).filter((p): p is HuntPlatform =>
+    (HUNT_PLATFORMS as readonly string[]).includes(p),
+  );
+  const targets: HuntPlatform[] = requested.length ? [...new Set(requested)] : [...HUNT_PLATFORMS];
+
+  const sourcesText = renderCaseDataSources(loaded);
+  const iocText = renderHuntIocs(loaded.iocs);
+  const guide = renderPlatformGuide(targets);
+
+  const userPrompt =
+    `KNOWN CASE DATA SOURCES (the tools/log sources this investigation already has data from):\n${sourcesText}\n\n` +
+    `PIVOTABLE INDICATORS observed in this case (use these exact values when the request refers to "this" host/IP/hash/etc.):\n${iocText}\n\n` +
+    `TARGET PLATFORMS (emit one query per key, grounded in the schema shown):\n${guide}\n\n` +
+    `ANALYST REQUEST: ${request.trim()}\n\nTranslate it as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "translate-query",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getQueryTranslatePrompt(), userPrompt, images: [] },
+        "translate-query",
+      );
+      const { interpretation, queries } = queryTranslationResponseSchema.parse(parsed);
+      return {
+        interpretation: sanitizeInterpretation(interpretation),
+        queries: sanitizeQueryTranslations(queries, targets),
+      };
+    },
+    retries,
+    backoffMs,
+  );
+}

--- a/companion/src/analysis/ai/nextSteps.ts
+++ b/companion/src/analysis/ai/nextSteps.ts
@@ -1,0 +1,183 @@
+import { detectTimelineGaps, gapEnvOptions } from "../gapDetect.js";
+import {
+  gapHypothesesResponseSchema,
+  sanitizeGapHypotheses,
+  buildGapHypotheses,
+  surroundingEvents,
+  renderGapsForPrompt,
+  hasGapMaterial,
+  GAP_HYPOTHESIS_MAX_DEFAULT,
+  SURROUNDING_EVENTS_DEFAULT,
+  GAP_HYPOTHESIS_CAVEAT,
+  type GapHypothesesResult,
+} from "../gapHypothesis.js";
+import {
+  memoryNextStepResponseSchema,
+  sanitizeMemoryNextSteps,
+  renderMemoryEvidence,
+  memoryPluginsPresent,
+  isMemoryEvent,
+  hasMemoryMaterial,
+  MEMORY_NEXTSTEP_MAX_DEFAULT,
+  type MemoryNextStep,
+} from "../memoryNextStep.js";
+import { estimateTokens, inputTokenBudget, fitItemsToBudget } from "../promptBudget.js";
+import { SHADOW_ARTIFACTS } from "../shadowArtifacts.js";
+import type { ForensicEvent } from "../stateTypes.js";
+import { MATCHABLE_FIELDS } from "../taggerRules.js";
+import {
+  suggestedRuleResponseSchema,
+  sanitizeSuggestedRule,
+  type SuggestOutcome,
+} from "../taggerRuleSuggest.js";
+import { getGapHypothesisPrompt, getMemoryNextStepPrompt, getTaggerRulePrompt } from "./prompts/index.js";
+import { loadScopedEvents, retryPolicy, type AiCallContext } from "./aiContext.js";
+
+/**
+ * The three AI calls that propose the analyst's NEXT move (#418).
+ *
+ * Moved from AnalysisPipeline (see ai/caseReports.ts for the pattern). Unlike ai/hunts.ts, which
+ * writes a query to run against the fleet, each of these answers "given what this case already has,
+ * what should I do about what it does NOT have?" — the next Volatility command, the collection that
+ * would fill a silent window, the tagger rule that would stop the noise. All three are EPHEMERAL,
+ * and each returns an empty result WITHOUT spending a call when the case has no material for it.
+ */
+
+// Memory-forensics "Next-Step" agent (issue #101). The case already has Volatility 3 / Rekall output
+// imported as forensic events; read that memory evidence (the process tree, connections, malfind,
+// command lines, services), identify the anomalies, and propose the EXACT next Volatility 3 command
+// the analyst should run to dig deeper. Single text-only AI call; EPHEMERAL like ask()/suggestHunts()
+// — it does NOT mutate state. Returns [] without an AI call when the case has no memory evidence.
+export async function suggestMemoryNextSteps(ctx: AiCallContext, caseId: string): Promise<MemoryNextStep[]> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("memory next-step suggestions");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  if (!hasMemoryMaterial(loaded)) return []; // no Volatility/Rekall evidence — don't spend a call
+
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+  const memEvents = scoped.filter(isMemoryEvent);
+  if (!memEvents.length) return []; // all memory evidence is out-of-scope / legitimate
+
+  const pluginsText = memoryPluginsPresent(memEvents).join(", ") || "(unknown)";
+
+  // Trim the memory evidence so the whole prompt fits the model context (the rest is fixed overhead).
+  const renderEvent = (e: ForensicEvent) =>
+    `[${e.severity}] ${(e.description ?? "").replace(/\s+/g, " ").trim().slice(0, 300)}`;
+  const overhead = estimateTokens(getMemoryNextStepPrompt()) + estimateTokens(pluginsText) + 300;
+  const fit = fitItemsToBudget(memEvents, renderEvent, Math.max(0, inputTokenBudget() - overhead));
+  const evidenceText = renderMemoryEvidence(memEvents, Math.max(1, fit));
+
+  const userPrompt =
+    `ALREADY-IMPORTED MEMORY PLUGINS (prefer suggesting plugins NOT in this list where they advance the case): ${pluginsText}\n\n` +
+    `MEMORY EVIDENCE (${memEvents.length} Volatility/Rekall events, worst-severity first):\n${evidenceText}\n\n` +
+    `Propose the next Volatility 3 commands as JSON.`;
+
+  const limit = Number(process.env.DFIR_MEMORY_NEXTSTEP_MAX) || MEMORY_NEXTSTEP_MAX_DEFAULT;
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "memory-next-steps",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getMemoryNextStepPrompt(), userPrompt, images: [] },
+        "memory-next-steps",
+      );
+      const { suggestions } = memoryNextStepResponseSchema.parse(parsed);
+      return sanitizeMemoryNextSteps(suggestions, limit);
+    },
+    retries,
+    backoffMs,
+  );
+}
+
+// Hypothesise what an attacker did during the timeline's SILENT periods (issue #96). Builds on the
+// deterministic gap detector: detect the suspicious gaps, then make ONE text-only AI call that reads
+// each gap's bounding events (before/after the silence) and infers the attacker activity that fits.
+// Each gap is also paired with the DETERMINISTIC shadow-artifact collections (USN journal, SRUM,
+// Prefetch, Amcache, …) that reconstruct the missing window — so even a gap the model skips still
+// carries deployable Velociraptor collections. EPHEMERAL like ask()/suggestHunts(): no state change.
+// Returns an empty result (no AI spend) when the timeline has no flagged gaps.
+export async function hypothesizeGaps(ctx: AiCallContext, caseId: string): Promise<GapHypothesesResult> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("gap hypothesis");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+
+  // Use the SAME gap detection (and thresholds) the panel/report use, so the analyst hypothesises
+  // about exactly the gaps they see flagged.
+  const gaps = detectTimelineGaps(scoped, gapEnvOptions());
+  if (!hasGapMaterial(gaps)) return { hypotheses: [], caveat: GAP_HYPOTHESIS_CAVEAT };
+
+  const cap = Number(process.env.DFIR_GAP_HYPOTHESIS_MAX) || GAP_HYPOTHESIS_MAX_DEFAULT;
+  const focusGaps = gaps.slice(0, Math.max(1, Math.floor(cap))); // worst-first → keep the most suspicious
+  const around = Number(process.env.DFIR_GAP_HYPOTHESIS_CONTEXT) || SURROUNDING_EVENTS_DEFAULT;
+  const surroundByGapId = new Map(focusGaps.map((g) => [g.id, surroundingEvents(g, scoped, around)]));
+  const validGapIds = new Set(focusGaps.map((g) => g.id));
+
+  const gapsText = renderGapsForPrompt(focusGaps, surroundByGapId);
+  // The shadow-artifact catalog the model ranks against (id → what it reconstructs). The catalog
+  // supplies the actual collection VQL deterministically; the model only picks the relevant ids.
+  const artifactsText = SHADOW_ARTIFACTS.map((a) => `- ${a.id}: ${a.name} — ${a.reconstructs}`).join("\n");
+  const userPrompt =
+    `SHADOW ARTIFACTS (reference recommendedArtifactIds ONLY from these ids):\n${artifactsText}\n\n` +
+    `TIMELINE GAPS (${focusGaps.length} of ${gaps.length} flagged; worst-first) with their surrounding events:\n\n` +
+    `${gapsText}\n\n` +
+    `Hypothesise the attacker activity for each gap as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  const aiHypotheses = await ctx.withRetry(
+    caseId,
+    "hypothesize-gaps",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getGapHypothesisPrompt(), userPrompt, images: [] },
+        "hypothesize-gaps",
+      );
+      const { hypotheses } = gapHypothesesResponseSchema.parse(parsed);
+      return sanitizeGapHypotheses(hypotheses, validGapIds, focusGaps.length);
+    },
+    retries,
+    backoffMs,
+  );
+
+  return buildGapHypotheses(aiHypotheses, focusGaps, surroundByGapId);
+}
+
+// Convert a plain-English description into ONE content-tagger rule (PR #112 follow-up), or a
+// decline reason when it can't be expressed as a single-event field-match rule. EPHEMERAL — this
+// returns a candidate for review; nothing is persisted here (the route's add step saves it). Uses
+// the strong synthesisProvider like translateQuery — authoring a schema-constrained rule benefits
+// from the general model over the VQL-tuned velociraptorProvider.
+export async function suggestTaggerRule(
+  ctx: AiCallContext,
+  caseId: string,
+  description: string,
+): Promise<SuggestOutcome> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("tagger rule suggestion");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const userPrompt =
+    `MATCHABLE FIELDS (use ONLY these): ${MATCHABLE_FIELDS.join(", ")}\n\n` +
+    `ANALYST REQUEST: ${description.trim()}\n\n` +
+    `Return the rule as JSON (or a decline).`;
+  const { retries, backoffMs } = retryPolicy(ctx);
+  return ctx.withRetry(
+    caseId,
+    "suggest-tagger-rule",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: getTaggerRulePrompt(), userPrompt, images: [] },
+        "suggest-tagger-rule",
+      );
+      return sanitizeSuggestedRule(suggestedRuleResponseSchema.parse(parsed));
+    },
+    retries,
+    backoffMs,
+  );
+}

--- a/companion/src/analysis/ai/pipelineOptions.ts
+++ b/companion/src/analysis/ai/pipelineOptions.ts
@@ -1,0 +1,176 @@
+import type { AIProvider, AnalyzeImage } from "../../providers/provider.js";
+import type { Logger } from "../../logging/logger.js";
+import type { AiControlStore } from "../aiControl.js";
+import { AiCostStore } from "../aiCost.js";
+import type { AnalysisRunStore } from "../analysisRunStore.js";
+import type { AnonControlStore } from "../anonControl.js";
+import type { DiscoveredEntitiesStore } from "../anonDiscovered.js";
+import type { CustomEntitiesStore } from "../anonEntities.js";
+import type { ClockSkewStore } from "../clockSkewStore.js";
+import { CorrelationProfileStore } from "../correlationProfile.js";
+import type { FalsePositiveStore } from "../falsePositive.js";
+import type { FindingsDiff } from "../findingsDiff.js";
+import type { HuntOutcomeStore } from "../huntOutcomeStore.js";
+import type { HypothesisStore } from "../hypothesisStore.js";
+import type { ImportMetaStore } from "../importMeta.js";
+import type { IncidentTypeStore } from "../incidentTypeStore.js";
+import type { IocAliasStore } from "../iocAlias.js";
+import type { KevStore } from "../kevStore.js";
+import type { LearnedPatternStore } from "../learnedPatternStore.js";
+import type { NotebookStore } from "../notebookStore.js";
+import type { OcrRunner } from "../ocrRedact.js";
+import type { OperationalMetricsStore } from "../operationalMetrics.js";
+import type { PresidioClient } from "../presidio.js";
+import type { PresidioPendingStore } from "../presidioPending.js";
+import type { PlaybookStore } from "../playbookStore.js";
+import type { ScopeStore } from "../scope.js";
+import type { SecondOpinionStore } from "../secondOpinionStore.js";
+import type { SourceTrustStore } from "../sourceTrustStore.js";
+import type { StateLock } from "../stateLock.js";
+import type { StateStore } from "../stateStore.js";
+import type { InvestigationState } from "../stateTypes.js";
+import type { SuperTimelineStore } from "../superTimelineStore.js";
+import type { SynthMetaStore } from "../synthMeta.js";
+
+/**
+ * Everything an AnalysisPipeline can be wired with (#418).
+ *
+ * Moved out of pipeline.ts, which is now a facade over src/analysis/ai/. Almost every field here is
+ * OPTIONAL and each one gates a feature: absent means the feature is simply off, which is how the
+ * CLI scripts and most tests run with a fraction of the server's wiring. That is why the comments
+ * matter more than usual — the type alone cannot tell you what NOT setting something costs you.
+ *
+ * The narrow context interfaces in this directory (AiCallContext, HuntContext, SynthesisContext, …)
+ * are views onto this type. Each names the handful of fields its family may touch, so this stays the
+ * single place a new option is declared while nothing gains access to it by accident.
+ */
+export interface PipelineOptions {
+  // The VISION model: screenshot analysis only (analyzeWindow). Screenshots need an image-capable
+  // model and are the one path a cheap/fast model is genuinely suited to.
+  provider?: AIProvider;
+  // The TEXT model: every text-only reasoning call — synthesis, ask/explain, memory next-steps, and
+  // (since #66-era model routing) CSV + log extraction. Falls back to `provider` when unset, so a
+  // single-model install is unaffected.
+  //
+  // CSV/log extraction moved here because it is a text-reasoning task, not an OCR one: measured on
+  // the eval harness (`npm run eval:real`), gpt-4o-mini returned ZERO events for a proxy log holding
+  // six large CONNECT-to-mega.nz transfers on every run, while gemini-2.5-pro found it every time on
+  // the identical input through the identical code path. The same silent-miss shows up in the
+  // northpeak benchmark, where a 27k-line proxy log and both web logs yielded zero forensic events.
+  synthesisProvider?: AIProvider;
+  // Optional DEDICATED model for Velociraptor VQL hunt generation (#70) — many models botch VQL,
+  // so the analyst can pin a known-good one just for suggestHunts/suggestPlaybookHunts. Falls back
+  // to synthesisProvider, then the main provider.
+  velociraptorProvider?: AIProvider;
+  // Per-case hunt outcomes (#157) — the hunting feedback loop. When set, suggestHunts /
+  // suggestTechniqueHunts / suggestPlaybookHunts read prior-hunt outcomes to (a) drop a suggestion
+  // whose VQL already ran and (b) feed a "PRIOR HUNTS" context block so the model pivots on what hit.
+  // Server-only (absent in scripts/* like the other Velociraptor features) → loop simply off.
+  huntOutcomeStore?: HuntOutcomeStore;
+  // Per-case super-timeline store (the raw imported host-triage events not in InvestigationState).
+  // When set, explainEvent falls back to it so an event that was only imported into the super-timeline
+  // (never promoted into the forensic timeline) can still be explained. Server-only (absent in scripts/*).
+  superTimelineStore?: SuperTimelineStore;
+  // Client-confirmed false-positive findings/IOCs to exclude from synthesis.
+  falsePositiveStore?: FalsePositiveStore;
+  // Learned dismissal patterns (issue #65): recurring reasoned dismissals distilled into a per-case
+  // ledger. When set, synthesis feeds a "PREVIOUSLY DISMISSED PATTERNS" block so NEW activity resembling
+  // one is surfaced with LOWER confidence unless corroborated (complements falsePositiveStore's EXCLUDE).
+  learnedPatternStore?: LearnedPatternStore;
+  // Per-source trust overrides (issue #66): steers cross-source merge description choice + caps confidence
+  // for low-trust-only findings. Absent → built-in DEFAULT_SOURCE_TRUST only (no per-case override).
+  sourceTrustStore?: SourceTrustStore;
+  // Per-host clock offsets + the alignment toggle (#228). Synthesis measures skew from the pre-merge
+  // timeline and stores it here; when alignment is on the corrected times steer correlation windows.
+  // Absent → no skew detection, correlation compares recorded times (pre-#228 behavior).
+  clockSkewStore?: ClockSkewStore;
+  // Analyst IOC merges (#82): duplicate value -> canonical IOC id. When set, every mergeDelta call
+  // resolves it first, so a later import/synthesis re-extracting the merged-away duplicate routes
+  // onto the canonical IOC instead of recreating it. Absent → no alias resolution (pre-#82 behavior).
+  iocAliasStore?: IocAliasStore;
+  // Optional investigation time-window — events outside it are excluded.
+  scopeStore?: ScopeStore;
+  // Per-case anonymization control. When a case has it enabled, the userPrompt is tokenized
+  // before the provider call and the response is restored before parsing. Optional: absent →
+  // no anonymization (used by older tests).
+  anonStore?: AnonControlStore;
+  // Per-case analyst-added entities to anonymize (exact-match), merged with the auto-derived ones.
+  customEntitiesStore?: CustomEntitiesStore;
+  // Per-case OCR-discovered entities + the analyst's suppression list. When set, the OCR pass feeds
+  // every entity it tokenizes out of a screenshot back here (so the auto-discovery list grows), and
+  // suppressed values are excluded from anonymization. Absent → no screenshot auto-discovery.
+  discoveredStore?: DiscoveredEntitiesStore;
+  stateStore: StateStore;
+  imageLoader: (caseId: string, screenshotFile: string) => Promise<AnalyzeImage>;
+  retries?: number;
+  backoffMs?: number;
+  onState?: (state: InvestigationState) => void;
+  // Optional: fired after a REAL synthesis run (not a skip) with the findings diff + the new state,
+  // so the server can dispatch notifications (issue #58 — new/escalated findings). Best-effort; the
+  // pipeline never awaits it. Absent → no notifications (used by CLI scripts/tests).
+  onSynth?: (caseId: string, diff: FindingsDiff, state: InvestigationState) => void;
+  // Optional: record when synthesis actually ran + what changed in the findings, so the
+  // dashboard can show "last synthesized N ago" and a what-changed diff. Absent → not recorded.
+  synthMetaStore?: SynthMetaStore;
+  analysisRunStore?: AnalysisRunStore; // append-only reproducibility ledger (#377)
+  // Per-case AI cost/token accounting (vision / synthesis / other buckets), read by the
+  // Diagnostics "AI cost — this case" card. Absent → cost tracking is skipped (CLI scripts).
+  aiCostStore?: AiCostStore;
+  operationalMetrics?: OperationalMetricsStore;
+  correlationProfileStore?: CorrelationProfileStore;
+  // When both notebookStore and aiControlStore are set, synthesis checks aiControl.includeNotebook
+  // and — when true — appends the analyst's notebook entries to the synthesis prompt.
+  notebookStore?: NotebookStore;
+  aiControlStore?: AiControlStore;
+  // When set (external AI provider only), each screenshot is OCR-redacted before the vision
+  // call: words the anonymizer would tokenize are covered with opaque rectangles. The original
+  // evidence file is never touched — only the in-memory buffer sent to the model is redacted.
+  ocrRunner?: OcrRunner;
+  // Optional Presidio layer. Runs AFTER the local anonymizer on already-masked text, so it only
+  // ever sees scrubbed data and reports only what the regex layer missed. Absent → skipped
+  // entirely. `url` is carried for the error message only.
+  presidio?: { client: PresidioClient; url: string; minScore: number };
+  // Holds findings awaiting analyst approval across the 409 round trip.
+  presidioPendingStore?: PresidioPendingStore;
+  // TEST-ONLY override for the import pre-scan's character-count caps (see
+  // AnalysisPipeline.presidioPreScan). Production code never sets this — the real caps are the
+  // PRESIDIO_SCAN_CHUNK_CHARS / PRESIDIO_SCAN_MAX_CHARS constants. Exists so a test can force the
+  // truncation-warning path (masked text exceeding the cap) without generating megabytes of
+  // synthetic text.
+  presidioScanCapsOverride?: { chunkChars: number; maxChars: number };
+  // Shared leveled logger. Absent → a console-only logger at DFIR_LOG_LEVEL (used by CLI scripts
+  // and tests). The server passes its file-backed logger so AI/OCR/anon traces land in the case log.
+  logger?: Logger;
+  // CISA KEV catalog (issue #99): when set, CVEs found in forensic events + IOCs are matched
+  // against the catalog and the hits are prepended to the synthesis context so the AI can flag
+  // actively-exploited CVEs as probable initial-access vectors. Opt-in (store starts empty).
+  kevStore?: KevStore;
+  // Second LLM opinion (issue #116): a DIFFERENT model that independently re-synthesizes the case
+  // for a QA cross-check. When set, secondOpinion() runs Pass 1 (independent synthesis through this
+  // provider) + Pass 2 (reconcile). Absent → the feature is disabled (route returns 501).
+  secondOpinionProvider?: AIProvider;
+  // Persists the last second-opinion run (deltas + analyst accept/reject). Also read by synthesize()
+  // so analyst-accepted deltas are re-applied after the wholesale findings rewrite (durability).
+  secondOpinionStore?: SecondOpinionStore;
+  // Human-readable model labels for the second-opinion comparison header (e.g. "claude-opus-4-8"
+  // vs "gpt-4o"). Fall back to the provider name when absent.
+  synthesisModelLabel?: string;
+  secondOpinionModelLabel?: string;
+  // Per-case mutex serializing load->save critical sections (manual adds, background
+  // enrichment, synthesis) so concurrent state writes cannot clobber each other (lost update).
+  // Absent -> no locking (CLI scripts/tests).
+  stateLock?: StateLock;
+  // Per-case hypothesis store (issue #140). When set, synthesis merges the model's auto-generated
+  // hypotheses into it (refresh-pristine / freeze-touched). Absent → no auto-generation (CLI/tests).
+  hypothesisStore?: HypothesisStore;
+  // Per-case playbook store. When set, synthesis reads DONE/SKIPPED task status so it can build on
+  // completed work instead of re-recommending it (investigation-guidance #2). Absent → no digest.
+  playbookStore?: PlaybookStore;
+  // Per-case import-meta store. When set, synthesis + the evidence-gap panel flag a zero-yield AI
+  // import (a source read as "clean" that actually dropped everything — investigation-guidance #10).
+  importMetaStore?: ImportMetaStore;
+  // Per-case incident-type store (#236). When set, synthesis prepends the chosen type's one-line
+  // hint so the model prioritizes the techniques that matter for a ransomware / BEC / exfil case.
+  // Absent → no hint (CLI/tests).
+  incidentTypeStore?: IncidentTypeStore;
+}

--- a/companion/src/analysis/ai/promptBlocks.ts
+++ b/companion/src/analysis/ai/promptBlocks.ts
@@ -1,0 +1,112 @@
+import { buildAdversaryHintsResult } from "../adversaryHints.js";
+import { loadAdversaryGroupsDataset, adversaryHintEnvOptions } from "../adversaryGroupsData.js";
+import { gapEnvOptions } from "../gapDetect.js";
+import { classifyImportYield, type ImportMetaStore, type ImportYieldWarning } from "../importMeta.js";
+import { buildKnownUnknownItems, renderKnownUnknowns, type KnownUnknownItem } from "../knownUnknowns.js";
+import { loadKnownPlaybooks } from "../knownPlaybooksData.js";
+import { buildPlaybookMatchResult, playbookMatchEnvOptions } from "../playbookMatch.js";
+import type { ForensicEvent, InvestigationState } from "../stateTypes.js";
+import { loadScopedEvents, type AiCallContext } from "./aiContext.js";
+
+/**
+ * The derived prompt blocks more than one AI call feeds into its prompt (#418).
+ *
+ * Extracted from AnalysisPipeline as their own module rather than filed with either consumer,
+ * because that is the point of them: synthesis and hunt suggestion must see the SAME gap list, and
+ * the known-unknowns panel must show the analyst the same one again. A copy in each caller is how
+ * those three drift apart.
+ *
+ * Everything here is DEFENSIVE by construction. A block is context, not evidence — a dataset that
+ * fails to load, a corrupt import-meta file or a playbook match that throws must degrade to an empty
+ * string, never fail the synthesis or the hunt call that was only decorating its prompt with it.
+ */
+
+/** What a block builder needs beyond the shared AI-call seam. */
+export interface PromptBlockContext extends AiCallContext {
+  readonly opts: AiCallContext["opts"] & { importMetaStore?: ImportMetaStore };
+}
+
+// The STRUCTURED known-unknowns for a case (investigation-guidance #9) — the SINGLE source the
+// synthesis prompt block AND the GET /cases/:id/known-unknowns panel both consume, so the model and
+// the analyst provably see the same gap list. Defensive: a failure here must never break synthesis.
+export function knownUnknownItems(
+  state: InvestigationState,
+  scopedEvents: ForensicEvent[],
+  yieldWarning?: ImportYieldWarning | null,
+): KnownUnknownItem[] {
+  try {
+    const hints = buildAdversaryHintsResult(state, loadAdversaryGroupsDataset(), adversaryHintEnvOptions());
+    // #230: the top playbook match, so an unobserved step of a chain the case otherwise follows
+    // becomes a named gap. Scored over the SCOPED events, exactly as the panel and report see them.
+    const playbook = buildPlaybookMatchResult(scopedEvents, loadKnownPlaybooks(), playbookMatchEnvOptions());
+    return buildKnownUnknownItems(state, scopedEvents, {
+      gapOptions: gapEnvOptions(),
+      nextTechniques: hints.nextTechniques,
+      playbookMatch: playbook.matches[0] ?? null,
+      yieldWarning,
+    });
+  } catch {
+    return [];
+  }
+}
+
+// The classified source-yield warning for the LAST import (investigation-guidance #10) — a large file
+// that yielded ZERO events via AI triage (the northpeak blind spot). Defensive: null when no store,
+// no import-meta, or nothing anomalous.
+export async function loadYieldWarning(
+  ctx: PromptBlockContext,
+  caseId: string,
+): Promise<ImportYieldWarning | null> {
+  if (!ctx.opts.importMetaStore) return null;
+  try {
+    return classifyImportYield(await ctx.opts.importMetaStore.load(caseId));
+  } catch {
+    return null;
+  }
+}
+
+// Known-unknowns preamble (#165): the gaps in the story (silent windows, uncovered ATT&CK phases,
+// the matched actors' likely-next techniques) so synthesis + hunts treat what's MISSING as open
+// questions, not just what the evidence shows. Pure block; the offline adversary dataset is cached.
+export async function knownUnknownsBlock(
+  ctx: PromptBlockContext,
+  state: InvestigationState,
+  scopedEvents: ForensicEvent[],
+  caseId: string,
+): Promise<string> {
+  const max = Math.max(0, Number(process.env.DFIR_SYNTH_KNOWN_UNKNOWNS_MAX) || 10);
+  return renderKnownUnknowns(
+    knownUnknownItems(state, scopedEvents, await loadYieldWarning(ctx, caseId)),
+    max,
+  );
+}
+
+// Read-only: the structured evidence-gap items for a case (scope + false-positive filtered, exactly
+// as synthesis sees them). Powers the "Evidence gaps" dashboard panel and the report section.
+export async function knownUnknownsForCase(
+  ctx: PromptBlockContext,
+  caseId: string,
+): Promise<KnownUnknownItem[]> {
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const { scoped } = await loadScopedEvents(ctx, caseId, loaded);
+  return knownUnknownItems(loaded, scoped, await loadYieldWarning(ctx, caseId));
+}
+
+// Candidate-threat-actor preamble (#165), OFF by default (DFIR_SYNTH_ADVERSARY_HINTS). Feeds the
+// technique-overlap hints (already shown in the report) into synthesis as LOW-CONFIDENCE candidates.
+// Gated because feeding model-derived attribution back into the model is a confirmation-bias loop;
+// labelled "NOT attribution". Pure + cached dataset; defensive — never breaks synthesis.
+export function adversaryHintBlock(state: InvestigationState): string {
+  if (!/^(1|true|on|yes)$/i.test(process.env.DFIR_SYNTH_ADVERSARY_HINTS ?? "")) return "";
+  try {
+    const r = buildAdversaryHintsResult(state, loadAdversaryGroupsDataset(), adversaryHintEnvOptions());
+    if (!r.hints.length) return "";
+    const top = r.hints
+      .slice(0, 5)
+      .map((h) => `${h.name} (${h.overlapCount}/${h.groupTechniqueCount} techniques)`)
+      .join(", ");
+    return `CANDIDATE THREAT ACTORS (technique-overlap hypothesis, NOT attribution — ${r.caveat}): ${top}\n\n`;
+  } catch {
+    return "";
+  }
+}

--- a/companion/src/analysis/ai/providerCall.ts
+++ b/companion/src/analysis/ai/providerCall.ts
@@ -1,0 +1,466 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join as joinPath } from "node:path";
+
+import {
+  ProviderError,
+  type AIProvider,
+  type AnalyzeRequest,
+  type AnalyzeResult,
+} from "../../providers/provider.js";
+import type { Logger } from "../../logging/logger.js";
+import {
+  createAnonymizer,
+  deriveKnownEntities,
+  isMaskableIpv4,
+  isInternalIp,
+  type Anonymizer,
+  type CustomEntity,
+  type KnownEntities,
+} from "../anonymize.js";
+import { toAnonPolicy, type AnonControlStore } from "../anonControl.js";
+import type { CustomEntitiesStore } from "../anonEntities.js";
+import type { DiscoveredEntitiesStore } from "../anonDiscovered.js";
+import { AiCostStore, bucketForLabel } from "../aiCost.js";
+import { parseJsonLoose } from "../extractJson.js";
+import { ocrRedactImage, type OcrRunner } from "../ocrRedact.js";
+import { safeAiErrorKind, safeAiPhase, type OperationalMetricsStore } from "../operationalMetrics.js";
+import {
+  mapFindings,
+  PresidioApprovalRequired,
+  type PresidioClient,
+  type PresidioFinding,
+} from "../presidio.js";
+import type { PresidioPendingStore } from "../presidioPending.js";
+import type { InvestigationState } from "../stateTypes.js";
+
+/**
+ * The AI-call gate (#418).
+ *
+ * Every model call in the companion goes through `analyzeRestored`, and this module is why that
+ * matters: it is not a wrapper around `provider.analyze` but a fixed chain — derive the case's known
+ * entities, mask the prompt, OCR-redact the images, hand the already-masked text to Presidio for
+ * approval, call the provider, record the cost and usage, and restore the real values into the
+ * parsed response before any schema sees it.
+ *
+ * Extracted as ONE unit rather than split across the callers, because the ordering IS the contract.
+ * Presidio must see masked text and only masked text; the response must be restored before parsing
+ * so a real value containing JSON metacharacters cannot corrupt it; a cost-recording failure must
+ * never fail the call it was accounting for. Those are the kind of invariants that survive being
+ * written down in one place and quietly rot when each call site re-implements them.
+ */
+
+/** What the gate needs. Deliberately no state store, no providers list, no synthesis knobs. */
+export interface ProviderCallContext {
+  readonly log: Logger;
+  readonly opts: {
+    anonStore?: AnonControlStore;
+    customEntitiesStore?: CustomEntitiesStore;
+    discoveredStore?: DiscoveredEntitiesStore;
+    ocrRunner?: OcrRunner;
+    presidio?: { client: PresidioClient; url: string; minScore: number };
+    presidioPendingStore?: PresidioPendingStore;
+    presidioScanCapsOverride?: { chunkChars: number; maxChars: number };
+    aiCostStore?: AiCostStore;
+    operationalMetrics?: OperationalMetricsStore;
+  };
+}
+
+// Presidio's /analyze cannot take an arbitrarily large body, and a big CSV would be many
+// requests. These bound it. They are module constants rather than env vars to keep the
+// settings surface small — the truncation is logged, so hitting the cap is visible.
+//
+// NAMED "_CHARS", NOT "_BYTES": both are compared against JS string .length, which counts
+// UTF-16 code units, not UTF-8 bytes. For non-ASCII PII (Hebrew, Cyrillic, accented names —
+// all plausible in a DFIR case) that undercounts real UTF-8 size by up to ~3-4x, so the
+// effective request-size cap is larger than a "_BYTES" name would imply. Left as a rough
+// request-size bound rather than switched to a real byte measure (e.g. Buffer.byteLength)
+// because the cap only needs to keep /analyze requests reasonably sized, not hit an exact
+// number — and the split/truncate arithmetic below is unit-tested against character counts.
+const PRESIDIO_SCAN_CHUNK_CHARS = 50_000;
+const PRESIDIO_SCAN_MAX_CHARS = 5_000_000;
+
+// Write a redacted screenshot copy to DFIR_OCR_DEBUG_DIR for visual inspection. The redacted
+// buffer keeps the source image format (sharp infers it from the input), so the extension is
+// derived from the source mime type. Best-effort: a dump failure must never break analysis, and
+// caseId is sanitized so it can't escape the debug dir. This never touches the evidence files.
+async function dumpRedactedImage(
+  dir: string,
+  caseId: string,
+  index: number,
+  mimeType: string,
+  buffer: Buffer,
+): Promise<void> {
+  try {
+    const ext = (mimeType.split("/")[1] ?? "png").replace(/[^a-z0-9]/gi, "") || "png";
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const safeCase = caseId.replace(/[^a-z0-9_-]/gi, "_");
+    const outDir = joinPath(dir, safeCase);
+    await mkdir(outDir, { recursive: true });
+    await writeFile(joinPath(outDir, `${stamp}-img${index + 1}.${ext}`), buffer);
+  } catch (err) {
+    console.warn(`[OCR dump] ${(err as Error).message}`);
+  }
+}
+
+/** The provider call itself, wrapped in the operational-metrics record for both outcomes. */
+async function analyzeProvider(
+  ctx: ProviderCallContext,
+  provider: AIProvider,
+  req: AnalyzeRequest,
+  label: string,
+): Promise<AnalyzeResult> {
+  const startedAt = Date.now();
+  try {
+    const result = await provider.analyze(req);
+    const usage = result.usage;
+    void ctx.opts.operationalMetrics?.record({
+      type: "ai",
+      phase: safeAiPhase(label),
+      durationMs: Date.now() - startedAt,
+      success: true,
+      inputTokens: usage?.inputTokens ?? 0,
+      outputTokens: usage?.outputTokens ?? 0,
+      costUsd: usage?.costUSD ?? 0,
+      errorKind: "none",
+    });
+    return result;
+  } catch (error) {
+    void ctx.opts.operationalMetrics?.record({
+      type: "ai",
+      phase: safeAiPhase(label),
+      durationMs: Date.now() - startedAt,
+      success: false,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      errorKind: safeAiErrorKind(error instanceof ProviderError ? error.kind : "other"),
+    });
+    throw error;
+  }
+}
+
+// Accumulate this call's tokens/cost into the case's running AI-cost totals (Settings →
+// Diagnostics). Best-effort: a write failure here must never fail the underlying AI call.
+async function recordAiCost(
+  ctx: ProviderCallContext,
+  caseId: string,
+  label: string,
+  provider: AIProvider,
+  result: AnalyzeResult,
+): Promise<void> {
+  if (!ctx.opts.aiCostStore) return;
+  try {
+    await ctx.opts.aiCostStore.record(
+      caseId,
+      bucketForLabel(label),
+      provider.name,
+      provider.model,
+      result.usage,
+    );
+  } catch (err) {
+    ctx.log.warn(`[ai-cost] could not record: ${(err as Error).message}`, { caseId });
+  }
+}
+
+// Log token usage at DEBUG after a provider call (surfaced with DFIR_LOG_LEVEL=debug).
+function logAiUsage(
+  ctx: ProviderCallContext,
+  caseId: string,
+  label: string,
+  provider: AIProvider,
+  result: AnalyzeResult,
+): void {
+  const u = result.usage;
+  if (!u) {
+    ctx.log.debug(`AI call [${label}] done provider=${provider.name} (no usage reported)`, { caseId });
+    return;
+  }
+  const cache =
+    (u.cacheReadTokens ? ` cacheRead=${u.cacheReadTokens}` : "") +
+    (u.cacheCreationTokens ? ` cacheWrite=${u.cacheCreationTokens}` : "");
+  // resolvedModel: the concrete model id actually served, when the provider reports one — e.g.
+  // claude-code's --model alias ("sonnet") resolves to "claude-sonnet-4-6" server-side; surfacing
+  // it here means DFIR_AI_SYNTH_MODEL=sonnet doesn't leave the exact version silently ambiguous.
+  const resolved =
+    u.resolvedModel && u.resolvedModel !== provider.model ? ` resolvedModel=${u.resolvedModel}` : "";
+  ctx.log.debug(
+    `AI call [${label}] done provider=${provider.name} model=${provider.model}${resolved} in=${u.inputTokens ?? "?"} out=${u.outputTokens ?? "?"}${cache}`,
+    { caseId },
+  );
+}
+
+/** The masked-text/known-entities pair the anonymised path is built from. */
+async function knownEntitiesFor(
+  ctx: ProviderCallContext,
+  caseId: string,
+  state: InvestigationState,
+): Promise<KnownEntities> {
+  const known = deriveKnownEntities(state);
+  const custom = ctx.opts.customEntitiesStore ? await ctx.opts.customEntitiesStore.load(caseId) : [];
+  // Auto-discovered screenshot entities are tokenized too; suppressed ones are never tokenized.
+  const disc = ctx.opts.discoveredStore
+    ? await ctx.opts.discoveredStore.load(caseId)
+    : { discovered: [], suppressed: [] };
+  known.custom = [...custom, ...disc.discovered];
+  known.suppressed = disc.suppressed;
+  return known;
+}
+
+/** Values the analyst has already vetted or vetoed, case-folded on both sides. */
+function alreadyApproved(known: KnownEntities): Set<string> {
+  // known.suppressed is DOCUMENTED as pre-lowercased (anonDiscovered.ts) and both writers
+  // enforce it today, but that invariant is easy to violate at a distance and this is the
+  // load-bearing case: a suppressed value is deliberately left UNMASKED, so Presidio sees it
+  // raw on every single call. A case-fold mismatch here would re-trigger the approval gate
+  // forever on a value the analyst already vetoed. Lower-case defensively rather than trust it.
+  return new Set<string>([
+    ...(known.custom ?? []).map((e) => e.value.toLowerCase()),
+    ...(known.suppressed ?? []).map((s) => s.toLowerCase()),
+  ]);
+}
+
+/** The one message shape for a Presidio scan that could not run — the analyst's next action. */
+function presidioUnreachable(url: string, err: unknown): Error {
+  return new Error(
+    `Presidio is enabled but the scan at ${url} failed (not reachable, or returned an ` +
+      `unusable response): ${(err as Error).message}. Start the container or clear ` +
+      `DFIR_PRESIDIO_URL to disable the layer.`,
+  );
+}
+
+/** Scan already-masked text with Presidio; fail closed on a scan error or unapproved value. */
+async function presidioGate(
+  ctx: ProviderCallContext,
+  caseId: string,
+  maskedText: string,
+  known: KnownEntities,
+): Promise<void> {
+  const presidio = ctx.opts.presidio;
+  if (!presidio) return;
+
+  let raw;
+  try {
+    raw = await presidio.client.analyze(maskedText);
+  } catch (err) {
+    throw presidioUnreachable(presidio.url, err);
+  }
+
+  const found = mapFindings(raw, presidio.minScore);
+  if (found.length === 0) return;
+
+  const alreadyKnown = alreadyApproved(known);
+  const fresh = found.filter((e) => !alreadyKnown.has(e.value.toLowerCase()));
+  if (fresh.length === 0) return;
+
+  ctx.log.warn(`[presidio] ${fresh.length} new PII value(s) need approval before this case can call the AI`, {
+    caseId,
+  });
+  await ctx.opts.presidioPendingStore?.save(caseId, fresh);
+  throw new PresidioApprovalRequired(fresh);
+}
+
+/** Scan one complete masked import up front so batched CSV/log analysis needs one approval round. */
+export async function presidioPreScan(
+  ctx: ProviderCallContext,
+  caseId: string,
+  text: string,
+  known: KnownEntities,
+  anon: Anonymizer,
+): Promise<void> {
+  const presidio = ctx.opts.presidio;
+  if (!presidio) return;
+
+  // TEST-ONLY seam (see PipelineOptions.presidioScanCapsOverride) so a test can force the
+  // truncation path with a tiny budget instead of generating megabytes of synthetic text.
+  // Production never sets this; the caps default to the real module constants.
+  const chunkChars = ctx.opts.presidioScanCapsOverride?.chunkChars ?? PRESIDIO_SCAN_CHUNK_CHARS;
+  const maxChars = ctx.opts.presidioScanCapsOverride?.maxChars ?? PRESIDIO_SCAN_MAX_CHARS;
+
+  // Mask FIRST, same as analyzeRestored — Presidio only ever sees already-scrubbed text.
+  const masked = anon.apply(text);
+  const scanned = masked.length > maxChars ? masked.slice(0, maxChars) : masked;
+  if (masked.length > maxChars) {
+    // A silent partial scan is worse than no scan: an analyst who sees "import scanned, no PII
+    // found" must be able to trust that claim. Name the unscanned character count so a
+    // truncated scan is never mistaken for a complete one.
+    ctx.log.warn(
+      `[presidio] import pre-scan truncated — ${masked.length - maxChars} character(s) of this ` +
+        `import were NOT scanned for PII (cap is ${maxChars} characters)`,
+      { caseId },
+    );
+  }
+
+  // Split on line boundaries so an entity is never cut in half across two /analyze requests.
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < scanned.length) {
+    let end = Math.min(start + chunkChars, scanned.length);
+    if (end < scanned.length) {
+      const nl = scanned.lastIndexOf("\n", end);
+      if (nl > start) end = nl + 1;
+    }
+    chunks.push(scanned.slice(start, end));
+    start = end;
+  }
+
+  const all: PresidioFinding[] = [];
+  for (const chunk of chunks) {
+    try {
+      all.push(...(await presidio.client.analyze(chunk)));
+    } catch (err) {
+      throw presidioUnreachable(presidio.url, err);
+    }
+  }
+
+  const found = mapFindings(all, presidio.minScore);
+  if (found.length === 0) return;
+
+  const alreadyKnown = alreadyApproved(known);
+  const fresh = found.filter((e) => !alreadyKnown.has(e.value.toLowerCase()));
+  if (fresh.length === 0) return;
+
+  ctx.log.warn(`[presidio] import pre-scan found ${fresh.length} new PII value(s) needing approval`, {
+    caseId,
+  });
+  await ctx.opts.presidioPendingStore?.save(caseId, fresh);
+  throw new PresidioApprovalRequired(fresh);
+}
+
+/**
+ * Build the same (known entities, anonymizer) pair analyzeRestored derives per call, so an
+ * import's pre-scan sees exactly the masked text the chunk loop would later produce. Returns
+ * null when anonymization is off case-wide (mirrors analyzeRestored's own early return for
+ * `!policy.enabled`) — with anonymization off there is no masked text for Presidio to see.
+ */
+export async function buildImportAnonContext(
+  ctx: ProviderCallContext,
+  caseId: string,
+  state: InvestigationState,
+): Promise<{ known: KnownEntities; anon: Anonymizer } | null> {
+  const control = ctx.opts.anonStore ? await ctx.opts.anonStore.load(caseId) : null;
+  const policy = toAnonPolicy(control);
+  if (!policy.enabled) return null;
+  const known = await knownEntitiesFor(ctx, caseId, state);
+  return { known, anon: createAnonymizer(policy, known) };
+}
+
+/** OCR-redact the image buffers when an external-provider runner is configured. */
+async function redactImages(
+  ctx: ProviderCallContext,
+  caseId: string,
+  images: AnalyzeRequest["images"],
+  policy: ReturnType<typeof toAnonPolicy>,
+  known: KnownEntities,
+  runner: OcrRunner,
+): Promise<AnalyzeRequest["images"]> {
+  // OCR-discovered entities to persist into the case's auto-discovery list after this pass.
+  const discoveredFromOcr: CustomEntity[] = [];
+  // DFIR_OCR_DEBUG forces the per-image detail to INFO (always shown); otherwise it is a
+  // DEBUG line, surfaced when DFIR_LOG_LEVEL=debug or the dashboard's Logging toggle is on.
+  const forceInfo = !!process.env.DFIR_OCR_DEBUG;
+  const dumpDir = process.env.DFIR_OCR_DEBUG_DIR; // write the redacted copy for inspection
+  const count = images.length;
+  let totalRedactions = 0;
+  let redactedImages = 0;
+  let publicIpsBoxed = 0;
+  const out = await Promise.all(
+    images.map(async (img, i) => {
+      try {
+        const buf = Buffer.from(img.base64, "base64");
+        const res = await ocrRedactImage(buf, policy, known, runner);
+        if (res.discovered.length) discoveredFromOcr.push(...res.discovered);
+        if (res.changed) {
+          redactedImages++;
+          totalRedactions += res.redactions.length;
+          publicIpsBoxed += res.redactions.filter(
+            (w) => isMaskableIpv4(w.text.trim()) && !isInternalIp(w.text.trim()),
+          ).length;
+          if (dumpDir) await dumpRedactedImage(dumpDir, caseId, i, img.mimeType, res.buffer);
+        }
+        const matched = res.redactions.map((w) => w.text).join(", ");
+        const line =
+          `[OCR] image ${i + 1}/${count}: read ${res.wordCount} word(s), ` +
+          `redacted ${res.redactions.length}${matched ? ` [${matched}]` : ""}`;
+        if (forceInfo) ctx.log.info(line, { caseId });
+        else ctx.log.debug(line, { caseId });
+        return res.changed ? { ...img, base64: res.buffer.toString("base64") } : img;
+      } catch (err) {
+        // OCR failure is non-fatal — log and forward the original image.
+        ctx.log.warn(`[OCR redact] ${(err as Error).message}`, { caseId });
+        return img;
+      }
+    }),
+  );
+  // Always-on confirmation that the OCR pre-pass ran (vs. images going to the model
+  // unredacted because anon is off or the provider is local). One line per analyze call.
+  ctx.log.info(
+    `[OCR] redaction ran on ${count} screenshot(s) — scrubbed ` +
+      `${totalRedactions} word(s) across ${redactedImages} image(s) before sending to the model`,
+    { caseId },
+  );
+  if (publicIpsBoxed > 0) {
+    ctx.log.warn(
+      `[OCR] ${publicIpsBoxed} public IP(s) were blacked out of the screenshot(s). Image ` +
+        `redaction is one-way, so these will NOT be extracted as IOCs from this capture.`,
+      { caseId },
+    );
+  }
+  // Feed what OCR tokenized back into the case's auto-discovery list (dedupe/suppress handled
+  // by the store). Best-effort — a write failure must not fail the analysis.
+  if (ctx.opts.discoveredStore && discoveredFromOcr.length > 0) {
+    try {
+      const added = await ctx.opts.discoveredStore.addDiscovered(caseId, discoveredFromOcr);
+      ctx.log.debug(`[OCR] auto-discovery now holds ${added.discovered.length} entit(y/ies)`, { caseId });
+    } catch (err) {
+      ctx.log.warn(`[OCR] could not persist discovered entities: ${(err as Error).message}`, { caseId });
+    }
+  }
+  return out;
+}
+
+// Apply per-case prompt/image anonymization in memory, then restore parsed JSON before schema
+// validation so real values containing JSON metacharacters cannot corrupt parsing.
+export async function analyzeRestored(
+  ctx: ProviderCallContext,
+  caseId: string,
+  state: InvestigationState,
+  provider: AIProvider,
+  req: AnalyzeRequest,
+  label = "ai",
+  skipPresidioGate = false,
+): Promise<unknown> {
+  const control = ctx.opts.anonStore ? await ctx.opts.anonStore.load(caseId) : null;
+  const policy = toAnonPolicy(control);
+  ctx.log.debug(
+    `AI call [${label}] provider=${provider.name} images=${req.images.length} ` +
+      `promptChars=${req.userPrompt.length} anonymize=${policy.enabled ? "on" : "off"}`,
+    { caseId },
+  );
+  if (!policy.enabled) {
+    const result = await analyzeProvider(ctx, provider, req, label);
+    logAiUsage(ctx, caseId, label, provider, result);
+    await recordAiCost(ctx, caseId, label, provider, result);
+    return parseJsonLoose(result.rawText);
+  }
+  const known = await knownEntitiesFor(ctx, caseId, state);
+  const anon = createAnonymizer(policy, known);
+  ctx.log.debug(`anonymized prompt before [${label}] AI call`, { caseId });
+
+  const images =
+    ctx.opts.ocrRunner && req.images.length > 0
+      ? await redactImages(ctx, caseId, req.images, policy, known, ctx.opts.ocrRunner)
+      : req.images;
+
+  // Mask FIRST, then let Presidio look at the result. It never sees a real hostname, IP,
+  // username, email, SID or secret — only what our own detectors could not find.
+  const maskedPrompt = anon.apply(req.userPrompt);
+  // Import call sites (analyzeCsv/analyzeLog) pre-scan the WHOLE payload once, up front, and
+  // pass skipPresidioGate=true so the loop that calls this per-chunk doesn't re-gate (and
+  // re-approve) the same import one chunk at a time.
+  if (!skipPresidioGate) await presidioGate(ctx, caseId, maskedPrompt, known);
+
+  const result = await analyzeProvider(ctx, provider, { ...req, userPrompt: maskedPrompt, images }, label);
+  logAiUsage(ctx, caseId, label, provider, result);
+  await recordAiCost(ctx, caseId, label, provider, result);
+  return anon.restoreDeep(parseJsonLoose(result.rawText));
+}

--- a/companion/src/analysis/ai/retry.ts
+++ b/companion/src/analysis/ai/retry.ts
@@ -1,0 +1,42 @@
+import { ProviderError, type ProviderErrorKind } from "../../providers/provider.js";
+import { PresidioApprovalRequired } from "../presidio.js";
+
+/**
+ * Retry policy for AI calls (#418).
+ *
+ * Extracted from pipeline.ts with the rest of the AI machinery. The interesting part is what is NOT
+ * retried: the point of the classification below is that some failures are a wall, not a blip, and
+ * retrying them only triples how long the analyst waits for the same error.
+ */
+
+// Error kinds where the failure is inherent to the call (bad/expired creds, exhausted quota, a hung
+// process) rather than a transient blip — retrying just re-runs into the same wall, tripling the wait
+// before the analyst sees the same error.
+const NON_RETRYABLE_KINDS = new Set<ProviderErrorKind>(["auth", "rate_limit", "timeout"]);
+
+function isRetryableError(err: unknown): boolean {
+  // An approval gate is not a transient failure. Retrying it re-runs the Presidio scan and delays
+  // the 409 the analyst is waiting on, so surface it on the first throw.
+  if (err instanceof PresidioApprovalRequired) return false;
+  return !(err instanceof ProviderError && NON_RETRYABLE_KINDS.has(err.kind));
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries: number,
+  backoffMs: number,
+  onError?: (err: unknown, attempt: number, willRetry: boolean) => void,
+): Promise<T> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (err) {
+      const willRetry = attempt < retries && isRetryableError(err);
+      onError?.(err, attempt, willRetry);
+      if (!willRetry) throw err;
+      await new Promise((r) => setTimeout(r, backoffMs * 2 ** attempt));
+      attempt++;
+    }
+  }
+}

--- a/companion/src/analysis/ai/secondOpinionRun.ts
+++ b/companion/src/analysis/ai/secondOpinionRun.ts
@@ -1,0 +1,164 @@
+import {
+  buildSecondOpinion,
+  buildReconcilePrompt,
+  reconcileResponseSchema,
+  mergeReconcileVerdicts,
+  applyAcceptedSecondOpinion,
+  setDeltaStatus,
+  setAllPendingStatus,
+  type SecondOpinion,
+} from "../secondOpinion.js";
+import type { InvestigationState } from "../stateTypes.js";
+import type { SynthThinkingInput } from "../synthThinking.js";
+import { getReconcilePrompt } from "./prompts/index.js";
+import type { AIProvider } from "../../providers/provider.js";
+import { synthesize, type SynthesisContext } from "./synthesis.js";
+
+/**
+ * The second-opinion QA cross-check (#418).
+ *
+ * Moved from AnalysisPipeline. A DIFFERENT model re-synthesizes the case independently and a
+ * reconcile pass annotates every disagreement, so the analyst adjudicates model-vs-model instead of
+ * taking one model's word for the case. Like ai/deepPassRun.ts it is a CONSUMER of synthesis — it
+ * runs it twice, once normally and once as a non-destructive `dryRun` — which is why it lives
+ * beside synthesis rather than inside it.
+ *
+ * Accepted deltas are durable: synthesize() re-applies them after its wholesale findings rewrite, so
+ * a confirmed model-B finding survives every later re-synthesis.
+ */
+
+/** Both passes run through synthesis, plus the model B this feature exists for. */
+export interface SecondOpinionContext extends SynthesisContext {
+  readonly opts: SynthesisContext["opts"] & {
+    secondOpinionProvider?: AIProvider;
+    secondOpinionModelLabel?: string;
+  };
+}
+
+export async function secondOpinion(
+  ctx: SecondOpinionContext,
+  caseId: string,
+  opts: SynthThinkingInput = {},
+): Promise<SecondOpinion> {
+  const provider = ctx.opts.secondOpinionProvider;
+  if (!provider) throw new Error("second-opinion model not configured (set DFIR_AI_SECOND_OPINION_MODEL)");
+  if (!ctx.opts.secondOpinionStore) throw new Error("second-opinion store not configured");
+  if ((await ctx.opts.stateStore.load(caseId)).forensicTimeline.length === 0) {
+    throw new Error("nothing to review — import evidence and synthesize the case first");
+  }
+  // Deep-reasoning toggle (#121) flows into BOTH synthesis passes below, so model A's freshened
+  // synthesis and model B's independent pass reason equally hard for the comparison.
+
+  // Pass 0 — freshen the PRIMARY synthesis so model A reflects the CURRENT timeline. Without this,
+  // a stale saved A vs a fresh model-B run produces deltas that are staleness artifacts (e.g. the
+  // deterministic gap-silence / high-severity backfill findings) rather than real model
+  // disagreements. Uses skip-if-unchanged (no `force`), so it's a NO-OP (no AI call) when A is
+  // already current — it only re-synthesizes when the in-scope timeline/IOCs/scope changed.
+  const a = await synthesize(ctx, caseId, {
+    deepReasoning: opts.deepReasoning,
+    thinkingTokens: opts.thinkingTokens,
+  });
+
+  // Pass 1 — independent synthesis with model B over the SAME current timeline/context, routed
+  // through a different model and NOT persisted (dryRun). This is model B's analysis.
+  const b = await synthesize(ctx, caseId, {
+    dryRun: true,
+    force: true,
+    provider,
+    deepReasoning: opts.deepReasoning,
+    thinkingTokens: opts.thinkingTokens,
+  });
+
+  const modelA =
+    ctx.opts.synthesisModelLabel ?? (ctx.opts.synthesisProvider ?? ctx.opts.provider)?.name ?? "model A";
+  const modelB = ctx.opts.secondOpinionModelLabel ?? provider.name;
+  let record = buildSecondOpinion({ a, b, modelA, modelB, now: () => new Date().toISOString() });
+
+  // Pass 2 — reconcile: annotate each disagreement with a rationale + recommendation. Best-effort:
+  // if the reconcile call fails, keep the deterministic deltas (no rationale) rather than failing.
+  if (record.deltas.length > 0) {
+    const userPrompt = buildReconcilePrompt(a, b, record.deltas);
+    const retries = ctx.opts.retries ?? 3;
+    const backoffMs = ctx.opts.backoffMs ?? 500;
+    try {
+      const parsed = await ctx.withRetry(
+        caseId,
+        "second-opinion-reconcile",
+        async () => {
+          const raw = await ctx.analyzeRestored(
+            caseId,
+            a,
+            provider,
+            { systemPrompt: getReconcilePrompt(), userPrompt, images: [] },
+            "second-opinion-reconcile",
+          );
+          return reconcileResponseSchema.parse(raw);
+        },
+        retries,
+        backoffMs,
+      );
+      record = mergeReconcileVerdicts(record, parsed);
+    } catch (err) {
+      ctx.log.warn(`[second-opinion] reconcile pass failed: ${(err as Error).message}`, { caseId });
+    }
+  }
+
+  await ctx.opts.secondOpinionStore.save(caseId, record);
+  // Per-model quality telemetry (#74): stamp the agreement rate onto synth-meta so modelA vs modelB
+  // can be compared empirically across runs, not just eyeballed on this one second-opinion panel.
+  const deltaCount = record.deltas.length;
+  const denom = record.agreementCount + deltaCount;
+  await ctx.opts.synthMetaStore?.recordSecondOpinionPerf(caseId, {
+    modelA,
+    modelB,
+    agreementCount: record.agreementCount,
+    deltaCount,
+    agreementRate: denom > 0 ? record.agreementCount / denom : 0,
+    at: record.generatedAt,
+  });
+  return record;
+}
+
+export async function applySecondOpinion(
+  ctx: SecondOpinionContext,
+  caseId: string,
+  deltaId: string,
+  accept: boolean,
+): Promise<{ record: SecondOpinion; state: InvestigationState }> {
+  if (!ctx.opts.secondOpinionStore) throw new Error("second-opinion store not configured");
+  const current = await ctx.opts.secondOpinionStore.load(caseId);
+  if (!current) throw new Error("no second opinion to act on — run a second opinion first");
+  if (!current.deltas.some((d) => d.id === deltaId))
+    throw new Error(`unknown second-opinion delta: ${deltaId}`);
+  return persistSecondOpinion(
+    ctx,
+    caseId,
+    setDeltaStatus(current, deltaId, accept ? "accepted" : "rejected"),
+  );
+}
+
+export async function applyAllSecondOpinion(
+  ctx: SecondOpinionContext,
+  caseId: string,
+  accept: boolean,
+): Promise<{ record: SecondOpinion; state: InvestigationState }> {
+  if (!ctx.opts.secondOpinionStore) throw new Error("second-opinion store not configured");
+  const current = await ctx.opts.secondOpinionStore.load(caseId);
+  if (!current) throw new Error("no second opinion to act on — run a second opinion first");
+  return persistSecondOpinion(ctx, caseId, setAllPendingStatus(current, accept ? "accepted" : "rejected"));
+}
+
+async function persistSecondOpinion(
+  ctx: SecondOpinionContext,
+  caseId: string,
+  record: SecondOpinion,
+): Promise<{ record: SecondOpinion; state: InvestigationState }> {
+  await ctx.opts.secondOpinionStore!.save(caseId, record);
+  const state = await ctx.opts.stateStore.load(caseId);
+  const applied = applyAcceptedSecondOpinion(state, record);
+  if (applied !== state) {
+    await ctx.opts.stateStore.save(applied);
+    ctx.opts.onState?.(applied);
+  }
+  return { record, state: applied };
+}

--- a/companion/src/analysis/ai/synthesis.ts
+++ b/companion/src/analysis/ai/synthesis.ts
@@ -1,0 +1,638 @@
+import { createHash } from "node:crypto";
+import type { AIProvider } from "../../providers/provider.js";
+import type { Logger } from "../../logging/logger.js";
+import { recordSynthesisRun } from "../analysisRunRecorders.js";
+import type { AnalysisRunStore } from "../analysisRunStore.js";
+import type { AiControlStore } from "../aiControl.js";
+import { toAnonPolicy, type AnonControlStore } from "../anonControl.js";
+import { alignedEpoch, detectClockSkew, effectiveOffsets } from "../clockSkew.js";
+import type { ClockSkewStore } from "../clockSkewStore.js";
+import { correlateEvents, correlationGroups, type CorrelateOptions } from "../correlate.js";
+import { CorrelationProfileStore } from "../correlationProfile.js";
+import { filterFalsePositiveEvents } from "../falsePositive.js";
+import { diffFindings, type FindingsDiff } from "../findingsDiff.js";
+import { sortByEventTime } from "../forensicSort.js";
+import { renderPriorHuntsBlock } from "../huntOutcomes.js";
+import { sanitizeHypotheses } from "../hypothesis.js";
+import type { HypothesisStore } from "../hypothesisStore.js";
+import type { IncidentTypeStore } from "../incidentTypeStore.js";
+import { renderIncidentTypeBlock } from "../incidentTypes.js";
+import { rankConnectiveIocs } from "../iocAnchors.js";
+import type { NotebookStore } from "../notebookStore.js";
+import type { PlaybookStore } from "../playbookStore.js";
+import { renderPlaybookProgressBlock, renderRefutedHypothesesBlock } from "../priorWork.js";
+import { deltaSchema, stripAiExtractedFrom } from "../responseSchema.js";
+import { filterEventsByScope, hasScope, NO_SCOPE, type ScopeWindow } from "../scope.js";
+import {
+  buildSecondLookPlan,
+  buildSecondLookRequests,
+  deriveWindow,
+  resolveSecondLookRequests,
+  summarizeSecondLook,
+  type ModelEvidenceRequest,
+} from "../secondLook.js";
+import { applyAcceptedSecondOpinion } from "../secondOpinion.js";
+import type { SecondOpinionStore } from "../secondOpinionStore.js";
+import { effectiveTrustMap } from "../sourceTrust.js";
+import type { SourceTrustStore } from "../sourceTrustStore.js";
+import type { StateLock } from "../stateLock.js";
+import { mergeDelta, type WindowContext } from "../stateMerge.js";
+import type { ForensicEvent, InvestigationState, TimelineEntry } from "../stateTypes.js";
+import type { SuperTimelineStore } from "../superTimelineStore.js";
+import type { SecondLookMeta, SynthMetaStore } from "../synthMeta.js";
+import { resolveSynthThinkingBudget, type SynthThinkingInput } from "../synthThinking.js";
+import { getSynthesisPrompt } from "./prompts/index.js";
+import type { AiCallContext } from "./aiContext.js";
+import { loadHuntOutcomes, type HuntContext } from "./hunts.js";
+import { buildSynthesisPrompt, type SynthesisPromptContext } from "./synthesisPrompt.js";
+import { foldSynthesisDelta, gradeFindings } from "./synthesisMerge.js";
+
+/**
+ * Synthesis: the AI call that turns the case's timeline into its conclusions (#418).
+ *
+ * The last and hardest of the extractions this issue owns, and the one #384 stopped short of. It is
+ * hard because this is not a report — it REWRITES the case. Findings and ATT&CK techniques are
+ * replaced wholesale, key questions are re-answered, IOCs are preserved and merged, and the write
+ * has to survive whatever an import or an analyst did during the seconds the model was thinking.
+ *
+ * Prompt construction and the coverage audit live in ai/synthesisPrompt.ts. What is left here is the
+ * orchestration: load, correlate, decide whether to run at all, call, fold the delta back in,
+ * persist under the lock, record, notify, and sweep once for what the sampler did not show.
+ *
+ * WHY THE CONTEXT IS SO WIDE. Every other family in this directory takes a narrow interface because
+ * a report genuinely touches little. Synthesis touches most of PipelineOptions, and pretending
+ * otherwise by threading twenty parameters would hide that rather than fix it. The interface still
+ * earns its place: it names exactly which stores participate, so adding one to synthesis becomes a
+ * visible edit here instead of an invisible reach through `this`.
+ */
+
+/** What synthesis needs. Wide by nature — see the note above. */
+export interface SynthesisContext extends AiCallContext, HuntContext, SynthesisPromptContext {
+  readonly log: Logger;
+  readonly opts: AiCallContext["opts"] &
+    HuntContext["opts"] &
+    SynthesisPromptContext["opts"] & {
+      provider?: AIProvider;
+      correlationProfileStore?: CorrelationProfileStore;
+      sourceTrustStore?: SourceTrustStore;
+      clockSkewStore?: ClockSkewStore;
+      notebookStore?: NotebookStore;
+      aiControlStore?: AiControlStore;
+      hypothesisStore?: HypothesisStore;
+      playbookStore?: PlaybookStore;
+      incidentTypeStore?: IncidentTypeStore;
+      secondOpinionStore?: SecondOpinionStore;
+      superTimelineStore?: SuperTimelineStore;
+      synthMetaStore?: SynthMetaStore;
+      analysisRunStore?: AnalysisRunStore;
+      anonStore?: AnonControlStore;
+      stateLock?: StateLock;
+      synthesisModelLabel?: string;
+      onSynth?: (caseId: string, diff: FindingsDiff, state: InvestigationState) => void;
+      onState?: (state: InvestigationState) => void;
+    };
+  /** mergeDelta plus the case's analyst IOC-merge aliases (#82). */
+  mergeWithAliases(
+    state: InvestigationState,
+    delta: Parameters<typeof mergeDelta>[1],
+    ctx: WindowContext,
+  ): Promise<InvestigationState>;
+  /** Promote raw super-timeline rows into the forensic timeline — the second-look sweep's seam. */
+  promoteSuperTimeline(
+    caseId: string,
+    events: ForensicEvent[],
+    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+  ): Promise<InvestigationState>;
+  /** Once per process: warn that a configured prompt override is missing shipped capabilities. */
+  warnOnPromptDrift(): void;
+  /**
+   * Hash of the last successfully-synthesized inputs per case. Owned by the pipeline so it lives as
+   * long as the process does: a fresh process (or an explicit `force`) always synthesizes.
+   */
+  readonly lastSynthHash: Map<string, string>;
+}
+
+async function detectSkew(
+  ctx: SynthesisContext,
+  caseId: string,
+  preMerge: ForensicEvent[],
+  opts: CorrelateOptions,
+): Promise<((e: ForensicEvent) => number | undefined) | undefined> {
+  const store = ctx.opts.clockSkewStore;
+  if (!store) return undefined;
+  let record;
+  try {
+    const report = detectClockSkew(correlationGroups(preMerge, { ...opts, crossHostArtifacts: true }), opts);
+    record = await store.recordDetection(caseId, report);
+  } catch {
+    try {
+      record = await store.load(caseId);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!record.alignEnabled) return undefined;
+  const offsets = effectiveOffsets(record.results, record.overrides);
+  if (offsets.size === 0) return undefined;
+  return (e: ForensicEvent) => alignedEpoch(e, offsets);
+}
+
+export async function synthesize(
+  ctx: SynthesisContext,
+  caseId: string,
+  opts: {
+    force?: boolean;
+    dryRun?: boolean;
+    provider?: AIProvider;
+    signal?: AbortSignal;
+    skipSecondLook?: boolean;
+    observationsBlock?: string;
+    analysisParentRunId?: string;
+  } & SynthThinkingInput = {},
+): Promise<InvestigationState> {
+  const observationsBlock = opts.observationsBlock ?? "";
+  const synthProvider = opts.provider ?? ctx.opts.synthesisProvider ?? ctx.requireProvider("synthesis");
+  ctx.warnOnPromptDrift(); // once per process: a stale synthesis-prompt override silently drops shipped capabilities
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  if (loaded.forensicTimeline.length === 0) return loaded;
+
+  // Correlate the same artifact across tools first: deduplicate into one corroborated event and
+  // one finding with both sources. This is idempotent and the correlated timeline is persisted.
+  const envWindow = Number(process.env.DFIR_CORRELATE_WINDOW_S);
+  const corrProfile = await ctx.opts.correlationProfileStore?.load(caseId);
+  const windowSeconds = Number.isFinite(envWindow) ? envWindow : (corrProfile?.windowSeconds ?? 2);
+  // Source trust (#66) selects merge wording and caps low-trust-only findings.
+  const trustOverrides = ctx.opts.sourceTrustStore ? await ctx.opts.sourceTrustStore.load(caseId) : undefined;
+  const sourceTrust = effectiveTrustMap(trustOverrides);
+  // Measure clock skew pre-merge (#228), before correlation erases the disagreeing anchors.
+  // Aligned times guide windows; persisted events retain recorded timestamps.
+  const skew = await detectSkew(ctx, caseId, loaded.forensicTimeline, { windowSeconds, sourceTrust });
+  const state: InvestigationState = {
+    ...loaded,
+    forensicTimeline: correlateEvents(loaded.forensicTimeline, { windowSeconds, sourceTrust, epochOf: skew }),
+  };
+
+  const markers = ctx.opts.falsePositiveStore ? await ctx.opts.falsePositiveStore.load(caseId) : [];
+
+  // Scope: only events inside the investigation window feed synthesis, so
+  // findings/IOCs/attacker-path/questions reflect only in-scope activity.
+  // Then drop events the client confirmed legitimate so the model never derives
+  // conclusions from benign activity (the raw events stay in state — reversible).
+  const scope = ctx.opts.scopeStore ? await ctx.opts.scopeStore.load(caseId) : NO_SCOPE;
+  // Split the two filter stages so the coverage audit (#62) can attribute omissions: `inWindowEvents`
+  // is after the scope filter (out-of-window events dropped); `scopedEvents` is after the additional
+  // false-positive/legitimate filter. The budget cap below drops the rest from the prompt.
+  const inWindowEvents = filterEventsByScope(state.forensicTimeline, scope);
+  const scopedEvents = filterFalsePositiveEvents(inWindowEvents, markers);
+
+  // Analyst notebook context: when both notebookStore and aiControlStore are wired and the
+  // analyst has opted in (includeNotebook: true in ai-control.json), append the notebook
+  // entries to the synthesis prompt so the AI incorporates investigator hypotheses.
+  // Loaded here (before the hash) so notebook changes also trigger a fresh synthesis.
+  let notebookBlock = "";
+  if (ctx.opts.notebookStore && ctx.opts.aiControlStore) {
+    const aiCtrl = await ctx.opts.aiControlStore.load(caseId);
+    if (aiCtrl.includeNotebook) {
+      const notebookEntries = await ctx.opts.notebookStore.load(caseId);
+      if (notebookEntries.length) {
+        notebookBlock =
+          "ANALYST NOTEBOOK (investigator notes and open questions — take these into account when synthesizing findings and the attacker path):\n" +
+          notebookEntries.map((e) => `[${e.type.toUpperCase()}] ${e.text}`).join("\n") +
+          "\n\n";
+      }
+    }
+  }
+
+  // Analyst hypotheses as steering (issue #140): feed the investigator's OPEN, analyst-owned
+  // hypotheses into the prompt so the model actively hunts evidence to support/refute them and
+  // reflects it in findings/events + its own hypotheses output. We do NOT ask it to flip the
+  // analyst's hypothesis status — those are frozen by mergeHypotheses (the analyst stays in
+  // control); the steering shows up as findings/events the analyst then uses to judge. Only
+  // analyst-authored or analyst-touched OPEN ones (pure inputs, never rewritten by synthesis),
+  // so including them in the hash below can't cause a re-synthesis loop. Bounded for prompt size.
+  let analystHypothesesBlock = "";
+  // Refuted hypotheses fed back as NEGATIVE KNOWLEDGE (investigation-guidance #2): a theory the
+  // analyst ruled out must not be re-asserted or re-opened. Loaded from the same store, once.
+  let refutedHypothesesBlock = "";
+  if (ctx.opts.hypothesisStore) {
+    // ACH exhaustion (investigation-guidance #14): before reading, flag hypotheses whose linked or
+    // technique-matched hunts have come back empty — so the negative-knowledge block below and the
+    // "to test" list reflect them. Derived from collected hunt outcomes; persisted; idempotent.
+    const exhaustionOutcomes = await loadHuntOutcomes(ctx, caseId);
+    const huntSignals = exhaustionOutcomes
+      .filter((o) => o.status === "collected")
+      .map((o) => ({
+        ...(o.relatedHypothesisId ? { relatedHypothesisId: o.relatedHypothesisId } : {}),
+        techniques: o.mitreTechniques ?? [],
+        missed: o.foundEvidence === false,
+        title: o.title,
+      }));
+    if (huntSignals.some((s) => s.missed))
+      await ctx.opts.hypothesisStore.applyExhaustion(caseId, huntSignals);
+
+    const allHypotheses = await ctx.opts.hypothesisStore.load(caseId);
+    const open = allHypotheses
+      .filter((h) => h.status === "open" && !h.exhausted && (h.source === "analyst" || h.analystTouched))
+      .slice(0, 15);
+    if (open.length) {
+      analystHypothesesBlock =
+        "ANALYST HYPOTHESES TO TEST (the investigator proposed these — actively look for evidence that " +
+        "SUPPORTS or REFUTES each and surface it in findings/events; you may add a corroborating hypothesis, " +
+        "but do NOT mark the analyst's own hypothesis resolved):\n" +
+        open
+          .map((h) => `- ${h.title}${h.expectedOutcome ? ` (decided by: ${h.expectedOutcome})` : ""}`)
+          .join("\n") +
+        "\n\n";
+    }
+    refutedHypothesesBlock = renderRefutedHypothesesBlock(allHypotheses);
+  }
+
+  // Prior-work feedback (investigation-guidance #2): the hunt hit/miss ledger (#157, previously fed
+  // only to the hunt prompts) and the playbook DONE/SKIPPED digest, so synthesis builds on completed
+  // work and dead hunts instead of re-recommending them. Loaded before the hash so completing a task
+  // or collecting a hunt triggers a fresh synthesis (a hit is a pivot; a miss is negative evidence).
+  const priorHuntsBlock = renderPriorHuntsBlock(await loadHuntOutcomes(ctx, caseId));
+  const playbookTasks = ctx.opts.playbookStore ? await ctx.opts.playbookStore.load(caseId) : [];
+  const playbookProgressBlock = renderPlaybookProgressBlock(playbookTasks);
+
+  // Incident-type framing (#236): the one-line hint for the type the analyst picked at case
+  // creation, so the model prioritizes ransomware / BEC / exfil techniques. A pure INPUT synthesis
+  // never rewrites, and cheap (one short line) — but changing the type must re-synthesize, so it
+  // joins the skip-if-unchanged hash below.
+  const incidentTypeBlock = renderIncidentTypeBlock(
+    ctx.opts.incidentTypeStore ? await ctx.opts.incidentTypeStore.loadType(caseId) : null,
+  );
+
+  // Skip-if-unchanged: hash only the STABLE INPUTS to synthesis — the in-scope timeline,
+  // the IOCs (value + intel verdicts), the scope, the legitimate markers, and (when opted
+  // in) the notebook entries. NOT the findings / MITRE / threads / summary, which synthesis
+  // itself rewrites (including those would make two consecutive runs hash differently and
+  // never skip). If the inputs are identical to the last successful run, return the saved
+  // state — no AI call.
+  const synthHash = createHash("sha1")
+    .update(
+      JSON.stringify({
+        ev: scopedEvents.map((e) => [e.id, e.severity, e.timestamp, e.description]),
+        io: state.iocs.map((i) => [i.id, i.value, (i.enrichments ?? []).map((e) => e.verdict).join(",")]),
+        sc: scope,
+        lg: markers.map((m) => m.id),
+        nb: notebookBlock,
+        hy: analystHypothesesBlock,
+        // Prior-work feedback (#2): completing a task, collecting a hunt, or refuting a hypothesis
+        // changes these strings, so an otherwise-identical timeline re-synthesizes to fold in the
+        // new negative knowledge instead of skipping. Pure inputs — synthesis never rewrites them.
+        pw: priorHuntsBlock + playbookProgressBlock + refutedHypothesesBlock,
+        // Re-picking the incident type reframes what the model should prioritize — an otherwise
+        // identical timeline must re-synthesize rather than skip.
+        it: incidentTypeBlock,
+        // Deep-pass observations are a pure INPUT synthesis never rewrites, but they change what the
+        // model can see — so a run carrying fresh ones must never be skipped as "inputs unchanged".
+        ob: observationsBlock,
+      }),
+    )
+    .digest("hex");
+  if (!opts.force && !opts.dryRun && ctx.lastSynthHash.get(caseId) === synthHash) return loaded;
+
+  // The prompt, and the coverage audit that describes exactly what it showed the model.
+  const {
+    userPrompt,
+    representedEvents,
+    shownIds,
+    selection,
+    coverage: synthCoverage,
+    maxEvents: SYNTH_MAX_EVENTS,
+    omittedInfo,
+  } = await buildSynthesisPrompt(ctx, {
+    caseId,
+    state,
+    scope,
+    markers,
+    inWindowEvents,
+    scopedEvents,
+    observationsBlock,
+    notebookBlock,
+    analystHypothesesBlock,
+    refutedHypothesesBlock,
+    priorHuntsBlock,
+    playbookProgressBlock,
+    incidentTypeBlock,
+  });
+
+  const synthStart = Date.now();
+  const retries = ctx.opts.retries ?? 3;
+  const backoffMs = ctx.opts.backoffMs ?? 500;
+  // Chain-of-Thought / extended thinking for the complex synthesis call (issue #121, feature 1).
+  // Budget resolved per-run: an explicit value or the dashboard "deep reasoning" toggle wins, else
+  // the global DFIR_AI_SYNTH_THINKING_TOKENS default (off when unset). The Anthropic provider maps
+  // it to extended thinking; OpenRouter to its unified `reasoning`; other providers ignore it. Only
+  // synthesis reasons step-by-step — extraction stays cheap.
+  const synthThinkingTokens = resolveSynthThinkingBudget(
+    opts,
+    Number(process.env.DFIR_AI_SYNTH_THINKING_TOKENS) || 0,
+  );
+  // Per-model quality telemetry (#74): count retries the synthesis call actually needed (a failed
+  // parse/schema-mismatch attempt increments this). Counted on catch INSIDE the retried closure
+  // rather than via ctx.withRetry's onRetry hook, because that hook is the shared server-logging
+  // callback — routing through ctx.withRetry keeps master's per-attempt WARN logging intact while
+  // the local catch keeps the count. Surfaced on synth-meta so a flaky model shows up empirically.
+  let synthParseRetries = 0;
+  const delta = await ctx.withRetry(
+    caseId,
+    "synthesis",
+    async () => {
+      try {
+        const parsed = await ctx.analyzeRestored(
+          caseId,
+          state,
+          synthProvider,
+          {
+            systemPrompt: getSynthesisPrompt(),
+            userPrompt,
+            images: [],
+            ...(synthThinkingTokens > 0 ? { thinkingTokens: synthThinkingTokens } : {}),
+            ...(opts.signal ? { signal: opts.signal } : {}),
+          },
+          "synthesis",
+        );
+        return stripAiExtractedFrom(deltaSchema.parse(parsed));
+      } catch (err) {
+        synthParseRetries++;
+        throw err;
+      }
+    },
+    retries,
+    backoffMs,
+  );
+
+  const {
+    next: folded,
+    highSeverityBackfillCount,
+    eligibleIds,
+    surviving,
+  } = await foldSynthesisDelta(ctx, {
+    caseId,
+    state,
+    delta,
+    markers,
+    scopedEvents,
+    playbookTasks,
+  });
+  let next = folded;
+  if (opts.dryRun) return next;
+
+  // Durability (issue #116): re-apply any analyst-ACCEPTED second-opinion deltas after the
+  // wholesale findings rewrite, so a confirmed model-B finding/severity/technique is never lost
+  // on re-synthesis. Pure + idempotent; a no-op when the store or record is absent/empty.
+  if (ctx.opts.secondOpinionStore) {
+    next = applyAcceptedSecondOpinion(next, await ctx.opts.secondOpinionStore.load(caseId));
+  }
+
+  // Per-finding grounding + corroboration (investigation-guidance #6): resolve each finding's
+  // supporting in-scope events (forward relatedEventIds AND reverse forensicTimeline links, so the
+  // deterministic backfill findings ground correctly), roll up { tools, hosts, intel, graph-linked },
+  // flag an uncited finding as `ungrounded`, and CAP an ungrounded/single-source finding's confidence.
+  // Also catches the subtler case where cited ids resolve but the finding's own claimed IP never
+  // appears in their text (`contentMismatch`) — floors High/Critical to Medium (veridia-deep-pass
+  // 2026-07-22). Deterministic + idempotent; only ever lowers confidence/severity. Runs last, so it
+  // grades the FINAL finding set (incl. backfills + accepted second-opinion deltas).
+  next = gradeFindings({
+    next,
+    delta,
+    surviving,
+    eligibleIds,
+    sourceTrust,
+    kevCatalog: await ctx.getKevCatalog(),
+  });
+
+  // What this run changed vs the pre-AI findings. Findings are FINAL here — neither persistLatest
+  // nor the hypothesis auto-gen below touch them — so it's computed once and reused for the
+  // Investigation-Log entry (#165), the synth-meta record, and the notify hook.
+  const findingsDiff = diffFindings(loaded.findings, next.findings);
+
+  // Lost-update guard (mirrors the pinned-questions re-load above): a manual event/IOC/thread
+  // added DURING the seconds-long AI call would otherwise be clobbered by this write, because
+  // `next` was derived from the snapshot taken before the call. Re-read the LATEST state and
+  // carry forward only items NEW since that snapshot (by id/value), so synthesis's conclusions
+  // and its correlation/legitimate work on the snapshot timeline are preserved while concurrent
+  // analyst additions survive. Reference the RAW snapshot (`loaded`), not the in-memory
+  // correlated `state`, so events deduped by correlateEvents aren't re-added.
+  const persistLatest = async () => {
+    const latest = await ctx.opts.stateStore.load(caseId);
+    const snapEventIds = new Set(loaded.forensicTimeline.map((e) => e.id));
+    const nextEventIds = new Set(next.forensicTimeline.map((e) => e.id));
+    const addedEvents = latest.forensicTimeline.filter(
+      (e) => !snapEventIds.has(e.id) && !nextEventIds.has(e.id),
+    );
+    const snapIocVals = new Set(loaded.iocs.map((i) => i.value.toLowerCase()));
+    const nextIocVals = new Set(next.iocs.map((i) => i.value.toLowerCase()));
+    const latestIocByVal = new Map(latest.iocs.map((i) => [i.value.toLowerCase(), i]));
+    const mergedIocs = [
+      ...next.iocs.map((i) => latestIocByVal.get(i.value.toLowerCase()) ?? i),
+      ...latest.iocs.filter(
+        (i) => !snapIocVals.has(i.value.toLowerCase()) && !nextIocVals.has(i.value.toLowerCase()),
+      ),
+    ];
+    const snapThreadIds = new Set(loaded.openThreads.map((t) => t.id));
+    const nextThreadIds = new Set(next.openThreads.map((t) => t.id));
+    const addedThreads = latest.openThreads.filter(
+      (t) => !snapThreadIds.has(t.id) && !nextThreadIds.has(t.id),
+    );
+    // Investigation Log (#165): carry forward any timeline line a CONCURRENT import appended during
+    // the AI call (dedupe by timestamp+sequence+text), so the synthesis write doesn't clobber it.
+    const tlKey = (t: TimelineEntry) => `${t.timestamp}|${t.windowSequence}|${t.description}`;
+    const snapTimeline = new Set(loaded.timeline.map(tlKey));
+    const nextTimeline = new Set(next.timeline.map(tlKey));
+    const addedTimeline = latest.timeline.filter(
+      (t) => !snapTimeline.has(tlKey(t)) && !nextTimeline.has(tlKey(t)),
+    );
+    next = {
+      ...next,
+      forensicTimeline: addedEvents.length
+        ? sortByEventTime([...next.forensicTimeline, ...addedEvents])
+        : next.forensicTimeline,
+      iocs: mergedIocs,
+      openThreads: addedThreads.length ? [...next.openThreads, ...addedThreads] : next.openThreads,
+      timeline: addedTimeline.length ? [...next.timeline, ...addedTimeline] : next.timeline,
+    };
+    // Record THIS synthesis run as a durable, cross-session Investigation-Log line (#165) — imports
+    // already log via timelineNote; synthesis didn't. Final merged counts; one entry per real run.
+    const synthLogEntry: TimelineEntry = {
+      timestamp: new Date().toISOString(),
+      windowSequence: 0,
+      description:
+        `Synthesis: ${next.findings.length} finding(s) (${findingsDiff.added.length} new, ` +
+        `${findingsDiff.severityChanged.length} reclassified), ${next.forensicTimeline.length} event(s), ` +
+        `${next.iocs.length} IOC(s)`,
+      sourceScreenshots: [],
+    };
+    next = { ...next, timeline: [...next.timeline, synthLogEntry] };
+    await ctx.opts.stateStore.save(next);
+  };
+  if (ctx.opts.stateLock) await ctx.opts.stateLock.runExclusive(caseId, persistLatest);
+  else await persistLatest();
+
+  // Auto-generate hypotheses (issue #140). Merge the model's hypotheses into the per-case store,
+  // refreshing pristine auto ones and FREEZING any the analyst touched (see mergeHypotheses). Only
+  // when the model actually returned some — an omitted field must never prune the analyst's set.
+  // Sanitized against the FINAL event/IOC ids so evidence links can't dangle. Side store, not
+  // InvestigationState; runs after the state is persisted so a failure here can't lose the synthesis.
+  if (ctx.opts.hypothesisStore && delta.hypotheses && delta.hypotheses.length) {
+    const validEventIds = new Set(next.forensicTimeline.map((e) => e.id));
+    const validIocIds = new Set(next.iocs.map((i) => i.id));
+    const seeds = sanitizeHypotheses(delta.hypotheses, validEventIds, validIocIds);
+    await ctx.opts.hypothesisStore.applyAutoGenerated(caseId, seeds, new Date().toISOString());
+  }
+
+  ctx.lastSynthHash.set(caseId, synthHash); // remember these inputs so an identical re-run skips the AI call
+  // Record what this run changed (findingsDiff computed above) and when it ran — surfaced on the
+  // dashboard. Only reached on a real run; skips return early above.
+  await ctx.opts.synthMetaStore?.record(caseId, findingsDiff, new Date().toISOString(), {
+    durationMs: Date.now() - synthStart,
+    eventCount: next.forensicTimeline.length,
+    iocCount: next.iocs.length,
+    selectionCounts: { ...selection.counts }, // #4: the evidence mix the model saw
+    coverage: synthCoverage, // #62: included/omitted coverage audit
+    synthModel: ctx.opts.synthesisModelLabel ?? `${synthProvider.name}/${synthProvider.model}`, // #74
+    findingsCount: next.findings.length, // #74
+    highSeverityBackfillCount, // #74
+    parseRetries: synthParseRetries, // #74
+  });
+  const anonPolicy = toAnonPolicy(ctx.opts.anonStore ? await ctx.opts.anonStore.load(caseId) : null);
+  await recordSynthesisRun(ctx.opts.analysisRunStore, caseId, {
+    parentRunId: opts.analysisParentRunId,
+    startedAt: new Date(synthStart).toISOString(),
+    provider: synthProvider.name,
+    model: synthProvider.model,
+    eventIds: [...shownIds],
+    inputState: state,
+    outputState: next,
+    prompt: getSynthesisPrompt(),
+    maxEvents: SYNTH_MAX_EVENTS,
+    thinkingTokens: synthThinkingTokens,
+    correlationWindowSeconds: windowSeconds,
+    anonymizationPolicy: anonPolicy,
+    scope,
+    falsePositiveMarkers: markers.length,
+    infoEventsExcluded: omittedInfo > 0,
+    observationsIncluded: observationsBlock.length > 0,
+    parseRetries: synthParseRetries,
+    coverage: synthCoverage,
+  });
+  // Notify on new/escalated findings (issue #58). Best-effort, fire-and-forget — never blocks or
+  // fails synthesis. Only on a real run, so a skipped (unchanged) re-synthesis sends nothing.
+  ctx.opts.onSynth?.(caseId, findingsDiff, next);
+  ctx.opts.onState?.(next);
+
+  // Second-look loop (investigation-guidance #11): now that this run has conclusions + (open)
+  // hypotheses + key questions, re-query the COMPLETE raw record (the super-timeline + the scoped
+  // events the sampler omitted) for the terms those open questions imply, promote the matches, and
+  // trigger EXACTLY ONE bounded re-synthesis so the conclusions fold them in. `skipSecondLook` on that
+  // re-synthesis (and on the second-opinion dryRun path, already returned above) is the one-iteration
+  // guard that makes this terminate. Best-effort: a sweep failure must never fail the synthesis.
+  if (!opts.skipSecondLook && ctx.opts.superTimelineStore) {
+    try {
+      const outcome = await runSecondLook(ctx, caseId, {
+        // The sweep treats anything not in `promptEvents` as a candidate to re-discover; events
+        // already covered by a grouped row HAVE been seen, so hand it the expanded set.
+        next,
+        scopedEvents,
+        promptEvents: representedEvents,
+        scope,
+        evidenceRequests: delta.evidenceRequests,
+      });
+      if (outcome) {
+        if (outcome.meta.promoted > 0) {
+          // Promotion changed the in-scope timeline → the synthHash differs → this re-synthesis runs
+          // (not skipped) and, with skipSecondLook, does NOT sweep again. Bounded to one extra AI call.
+          const resynth = await synthesize(ctx, caseId, {
+            force: true,
+            skipSecondLook: true,
+            ...(opts.signal ? { signal: opts.signal } : {}),
+          });
+          await ctx.opts.synthMetaStore?.recordSecondLook(caseId, outcome.meta);
+          return resynth;
+        }
+        // Nothing new to promote, but empty requests are still surfaced as collection leads.
+        await ctx.opts.synthMetaStore?.recordSecondLook(caseId, outcome.meta);
+      }
+    } catch (err) {
+      console.warn(`[DFIR] second-look sweep failed for case ${caseId}: ${(err as Error).message}`);
+    }
+  }
+  return next;
+}
+
+// Second-look sweep (investigation-guidance #11) — the impure orchestration around the pure secondLook
+// module. Mines the case's OPEN questions (open hypotheses, unknown/partial key questions with a
+// collect target, top connective IOCs) plus the model's own evidenceRequests into concrete searches,
+// resolves them against the omitted scoped events AND the super-timeline within the active window,
+// promotes the not-yet-analyzed matches (capped, tagged with provenance), and returns a meta summary.
+// Returns null when there was nothing to search for. Never re-synthesizes itself — the caller does.
+async function runSecondLook(
+  ctx: SynthesisContext,
+  caseId: string,
+  input: {
+    next: InvestigationState;
+    scopedEvents: ForensicEvent[];
+    promptEvents: ForensicEvent[];
+    scope: ScopeWindow;
+    evidenceRequests?: ModelEvidenceRequest[];
+  },
+): Promise<{ meta: SecondLookMeta } | null> {
+  const superStore = ctx.opts.superTimelineStore;
+  if (!superStore) return null;
+
+  // Active window: the explicit scope when set, else the span of the dated in-scope events. Bounds the
+  // raw re-query so a huge super-timeline is searched only over the incident window.
+  const window = hasScope(input.scope)
+    ? { from: input.scope.start ?? undefined, to: input.scope.end ?? undefined }
+    : deriveWindow(input.scopedEvents);
+
+  const hypotheses = ctx.opts.hypothesisStore ? await ctx.opts.hypothesisStore.load(caseId) : [];
+  const iocValueById = new Map(input.next.iocs.map((i) => [i.id, i.value] as const));
+  const connectiveIocs = rankConnectiveIocs(input.next, input.scopedEvents, { max: 5 });
+
+  const requests = buildSecondLookRequests({
+    hypotheses,
+    iocValueById,
+    keyQuestions: input.next.keyQuestions,
+    connectiveIocs,
+    modelRequests: input.evidenceRequests,
+    window,
+  });
+  if (!requests.length) return null;
+
+  // Candidate pool: the scoped events the sampler OMITTED from the prompt + the super-timeline rows in
+  // the window (deduped by id). A super row that is a copy of a forensic event shares its id, so
+  // `forensicEventIds` (below) correctly marks it non-promotable — only genuinely-new raw rows promote.
+  const shownIds = new Set(input.promptEvents.map((e) => e.id));
+  const omitted = input.scopedEvents.filter((e) => !shownIds.has(e.id));
+  const superRows = (await superStore.query(caseId, { from: window.from, to: window.to })).events;
+  const byId = new Map<string, ForensicEvent>();
+  for (const e of [...omitted, ...superRows]) if (!byId.has(e.id)) byId.set(e.id, e);
+  const candidates = [...byId.values()];
+
+  const forensicEventIds = new Set(input.next.forensicTimeline.map((e) => e.id));
+  const resolutions = resolveSecondLookRequests(requests, candidates, forensicEventIds);
+  const plan = buildSecondLookPlan(resolutions);
+
+  if (plan.promotions.length) {
+    await ctx.promoteSuperTimeline(caseId, plan.promotions, {
+      importedAt: new Date().toISOString(),
+      tagById: plan.tagById,
+      note: `Second look: promoted ${plan.promotions.length} raw event(s) matching open questions`,
+    });
+  }
+
+  const matched = resolutions.filter((r) => r.matchedEventIds.length > 0).length;
+  return {
+    meta: {
+      promoted: plan.promotions.length,
+      requests: requests.length,
+      matched,
+      leads: plan.leads.map((l) => l.reason).slice(0, 10),
+      summary: summarizeSecondLook(plan),
+      at: new Date().toISOString(),
+    },
+  };
+}

--- a/companion/src/analysis/ai/synthesisMerge.ts
+++ b/companion/src/analysis/ai/synthesisMerge.ts
@@ -1,0 +1,302 @@
+import { flagContradictedAnswers } from "../answerContradiction.js";
+import { buildAssetGraph } from "../assetGraph.js";
+import { buildEvidenceGraph } from "../evidenceGraph.js";
+import { applyFalsePositive, type FalsePositiveMarker } from "../falsePositive.js";
+import {
+  capIntelOnlyFindings,
+  buildIntelCorroborationSteps,
+  groundAndScoreFindings,
+} from "../findingGrounding.js";
+import { scoreFindingsRelevance } from "../findingRelevance.js";
+import { reconsiderKeyQuestions } from "../fpCascade.js";
+import { backfillSilenceGapFindings, detectTimelineGaps, gapEnvOptions } from "../gapDetect.js";
+import { backfillHighSeverityFindings } from "../highSeverityFindings.js";
+import { shortHost } from "../iocAnchors.js";
+import { extractCveIds, matchKevEntries, type KevCatalog } from "../kev.js";
+import type { PlaybookTask } from "../playbook.js";
+import { demoteCompletedNextSteps } from "../priorWork.js";
+import { unionEventTechniques } from "../reconTechniques.js";
+import type { deltaSchema } from "../responseSchema.js";
+import type { SourceTrustMap } from "../sourceTrust.js";
+import type { StateStore } from "../stateStore.js";
+import type { ForensicEvent, InvestigationQuestion, InvestigationState } from "../stateTypes.js";
+import { mergeDelta, type WindowContext } from "../stateMerge.js";
+
+/**
+ * Folding the model's delta back into the case (#418).
+ *
+ * The second half of `synthesize`, split out for the same reason the prompt builder was: it is a
+ * different kind of work. Nothing here talks to a model. It takes one parsed delta and applies a
+ * fixed sequence of DETERMINISTIC corrections to it — and each step in that sequence is a safety net
+ * someone added after the model got something wrong:
+ *
+ *   - findings and techniques are REPLACED, IOCs and events PRESERVED (a text-only pass cannot
+ *     re-derive 400 hashes a THOR import found)
+ *   - anything the analyst confirmed a false positive is dropped again even if the model re-added it
+ *   - every Critical/High event the model left uncovered gets a finding anyway
+ *   - a key question that still cites a rejected finding is forced back to "unknown"
+ *   - an answer asserting an absence the timeline contradicts is downgraded to "partial"
+ *   - an uncited, single-source or intel-only finding has its confidence and severity capped
+ *
+ * Every one of them only ever LOWERS a claim. That is the invariant worth protecting here: the
+ * deterministic passes can refuse to believe the model, never the other way round.
+ */
+
+/** Keep analyst-pinned questions across a synthesis (it replaces keyQuestions wholesale). */
+function mergePinnedQuestions(
+  pinned: InvestigationQuestion[],
+  current: InvestigationQuestion[],
+): InvestigationQuestion[] {
+  if (pinned.length === 0) return current;
+  const byId = new Map(current.map((q) => [q.id, q]));
+  for (const p of pinned) {
+    const cur = byId.get(p.id);
+    byId.set(p.id, cur ? { ...cur, pinned: true } : p);
+  }
+  return [...byId.values()];
+}
+
+/** What folding one delta needs. No providers and no AI — this half never calls a model. */
+export interface DeltaFoldContext {
+  readonly opts: { stateStore: StateStore };
+  mergeWithAliases(
+    state: InvestigationState,
+    delta: Parameters<typeof mergeDelta>[1],
+    ctx: WindowContext,
+  ): Promise<InvestigationState>;
+}
+
+export interface DeltaFoldInput {
+  caseId: string;
+  /** The correlated pre-call snapshot the model reasoned over. */
+  state: InvestigationState;
+  delta: ReturnType<typeof deltaSchema.parse>;
+  markers: FalsePositiveMarker[];
+  scopedEvents: ForensicEvent[];
+  playbookTasks: PlaybookTask[];
+}
+
+export interface DeltaFoldResult {
+  next: InvestigationState;
+  /** How many findings the safety net had to add — a proxy for what the model missed (#74). */
+  highSeverityBackfillCount: number;
+  /** The scoped event ids synthesis considered; the grading pass grounds against these. */
+  eligibleIds: Set<string>;
+  /** Delta finding ids that survived the false-positive filter. */
+  surviving: Set<string>;
+}
+
+export async function foldSynthesisDelta(
+  ctx: DeltaFoldContext,
+  input: DeltaFoldInput,
+): Promise<DeltaFoldResult> {
+  const { caseId, state, delta, markers, scopedEvents, playbookTasks } = input;
+  // Anchor finding timestamps to the last real event time (fallback: existing state time).
+  const ts = state.forensicTimeline[state.forensicTimeline.length - 1]?.timestamp || state.updatedAt;
+  // Synthesis is an authoritative holistic reassessment: replace the CONCLUSIONS
+  // (findings, MITRE techniques) rather than accumulate, so anything no longer
+  // supported by the in-scope timeline (e.g. out-of-scope or removed events) is
+  // dropped. IOCs are OBSERVED INDICATORS (often from deterministic imports like THOR
+  // — 100s of hashes the text-only synthesis can't re-derive), so they are PRESERVED
+  // and merged (deduped by value); scope/legitimate still filter them at projection.
+  // Threads and the forensic timeline are also preserved.
+  const base = { ...state, findings: [], mitreTechniques: [] };
+  const merged = await ctx.mergeWithAliases(base, delta, {
+    windowSequence: 0,
+    timestamp: ts,
+    sourceScreenshots: [],
+  });
+  // Safety net: drop anything confirmed false-positive even if the model re-introduced it.
+  const filtered = applyFalsePositive(merged, markers);
+
+  // Back-link forensic events to the CORRECT findings using the synthesis output
+  // (each finding lists the event ids it's based on). Replaces extraction guesses.
+  const surviving = new Set(filtered.findings.map((f) => f.id));
+  const eventToFindings = new Map<string, string[]>();
+  for (const f of delta.findings) {
+    if (!surviving.has(f.id)) continue;
+    for (const eid of f.relatedEventIds ?? []) {
+      const arr = eventToFindings.get(eid) ?? [];
+      if (!arr.includes(f.id)) arr.push(f.id);
+      eventToFindings.set(eid, arr);
+    }
+  }
+  const linked = {
+    ...filtered,
+    forensicTimeline: filtered.forensicTimeline.map((e) => ({
+      ...e,
+      relatedFindingIds: eventToFindings.get(e.id) ?? [],
+    })),
+  };
+
+  // Heuristic safety net: a Critical/High artifact row is almost always a finding.
+  // Any in-scope, non-legitimate high-severity event that synthesis left WITHOUT a
+  // finding gets one auto-created, so a severe detection can never be silently
+  // missed. Restricted to the events synthesis actually considered (scopedEvents).
+  const eligibleIds = new Set(scopedEvents.map((e) => e.id));
+  const backfilled = backfillHighSeverityFindings(linked, eligibleIds, ts);
+  // #74: how many findings the safety net had to add — a proxy for detections synthModel itself missed.
+  const highSeverityBackfillCount = backfilled.findings.length - linked.findings.length;
+  // Log gap analysis (#83): a COMPLETE-silence gap — a window where every source went dark — is the
+  // classic signature of cleared logs / a stopped collector, so escalate it to a finding here too.
+  // Gaps are derived on read (not persisted); only the complete ones earn a persisted finding, and
+  // the finding id is derived from the bounding events so re-synthesis over the same gap is idempotent.
+  const gapOpts = gapEnvOptions();
+  const gaps = detectTimelineGaps(scopedEvents, gapOpts);
+  const gapFilled = backfillSilenceGapFindings(backfilled, gaps, ts, gapOpts.maxFindings);
+  // Preserve analyst-pinned questions (synthesis replaces keyQuestions wholesale). Re-read
+  // the LATEST state here, not the pre-AI snapshot, so a question added DURING the
+  // seconds-long AI call isn't clobbered by this write (read-modify-write race).
+  const pinnedNow = (await ctx.opts.stateStore.load(caseId)).keyQuestions.filter((q) => q.pinned);
+  let next = pinnedNow.length
+    ? { ...gapFilled, keyQuestions: mergePinnedQuestions(pinnedNow, gapFilled.keyQuestions) }
+    : gapFilled;
+
+  // Deterministic backstop for the reanswerBlock instruction above: if the model still cited a
+  // now-dead finding (ignored the instruction) — whether via a structured relatedFindingIds link
+  // or only in the free-text pointer/answer prose (the only signal available for a question that
+  // predates relatedFindingIds) — force the question back to "unknown" (clearing the stale
+  // answer). ANY dependency on a rejected finding forces the reset, not just total loss of
+  // support: a partial answer that still names a finding the analyst just confirmed is NOT a
+  // threat is misleading even when another finding also backs it, and we can't safely guess what
+  // the finding-minus-the-FP'd-one answer should say without asking the model again. Guarantees a
+  // key question can never keep citing a finding that's already gone.
+  // Shared with the FP-mark route's synchronous cascade (investigation-guidance #12). Here it runs as
+  // the AUTHORITATIVE recompute (staleReSynth off → clears any interim stale badge), guaranteeing a key
+  // question can never keep citing a finding that's gone.
+  next = {
+    ...next,
+    keyQuestions: reconsiderKeyQuestions(next.keyQuestions, {
+      survivingFindingIds: new Set(next.findings.map((f) => f.id)),
+      priorFindingIds: state.findings.map((f) => f.id), // ids that existed going into this run
+    }).questions,
+  };
+
+  // Answer-contradiction validator (investigation-guidance #3): a key question whose answer asserts
+  // an ABSENCE ("no data exfiltration confirmed") while in-scope events carry the matching ATT&CK
+  // techniques is a dangerous false negative. Force such answers to "partial" and cite the
+  // contradicting events. Runs AFTER the FP reset (so a reset-to-unknown answer isn't re-flagged) over
+  // the same scoped, non-FP events the model saw. Pure + idempotent.
+  next = { ...next, keyQuestions: flagContradictedAnswers(next.keyQuestions, scopedEvents) };
+
+  // Union the deterministically-identified ATT&CK techniques carried by the (in-scope) timeline
+  // into the synthesized MITRE table, so techniques the model didn't echo — especially the Info/Low
+  // discovery phase (whoami/net group/findstr password/cat .env) tagged by the importers — still
+  // appear in the case's MITRE table and report. Same scoped events synthesis saw; pure + idempotent.
+  next = { ...next, mitreTechniques: unionEventTechniques(next.mitreTechniques, scopedEvents) };
+
+  // Prior-work safety net (investigation-guidance #2): even with the PLAYBOOK PROGRESS prompt block,
+  // the model may still echo a nextStep that repeats a COMPLETED task. Deterministically DEMOTE (not
+  // drop) any such step to priority "low" with an annotation, requiring a shared host/artifact token
+  // so a same-verb different-target step survives. Keeps the top of the next-steps list actionable.
+  if (playbookTasks.length) {
+    const doneTitles = playbookTasks.filter((t) => t.status === "done").map((t) => t.title);
+    if (doneTitles.length) {
+      const { steps, demotedIds } = demoteCompletedNextSteps(next.nextSteps, doneTitles);
+      if (demotedIds.length) next = { ...next, nextSteps: steps };
+    }
+  }
+
+  // Dry run (second-opinion Pass 1): return model B's conclusions WITHOUT persisting or any side
+  // effect — and WITHOUT folding in accepted deltas, so B stays an independent opinion.
+  return { next, highSeverityBackfillCount, eligibleIds, surviving };
+}
+
+export interface FindingGradeInput {
+  next: InvestigationState;
+  delta: ReturnType<typeof deltaSchema.parse>;
+  surviving: Set<string>;
+  eligibleIds: Set<string>;
+  sourceTrust: SourceTrustMap;
+  kevCatalog: KevCatalog | undefined;
+}
+
+/**
+ * Grade the FINAL finding set: ground each finding in its supporting events, roll up corroboration,
+ * cap what is uncited or intel-only, and place each one relative to the main attack component.
+ *
+ * Runs last so it sees the backfills and any accepted second-opinion deltas. Deterministic and
+ * idempotent, and — the property that makes it safe to run over model output — it only ever lowers
+ * a confidence or a severity. The AI's own relevance verdict can refine a disconnected finding into
+ * "a genuine separate issue", but it can never upgrade a rabbit hole into a lead.
+ */
+export function gradeFindings(input: FindingGradeInput): InvestigationState {
+  const { delta, surviving, eligibleIds, sourceTrust, kevCatalog } = input;
+  let next = input.next;
+  const evidenceGraph = buildEvidenceGraph(next);
+  const graphLinkedEventIds = new Set(evidenceGraph.edges.flatMap((e) => e.eventIds));
+  const inScope = next.forensicTimeline.filter((e) => eligibleIds.has(e.id));
+  // KEV-linked confidence signal (issue #61): the CVEs mentioned in-scope (events + IOCs) that match
+  // the CISA KEV catalog. Empty when no catalog is loaded, so the signal is simply never set then.
+  let kevCveIds: Set<string> | undefined;
+  if (kevCatalog && kevCatalog.size > 0) {
+    const cveIds = new Set<string>();
+    for (const e of inScope) {
+      extractCveIds(e.description).forEach((id) => cveIds.add(id));
+      if (e.message) extractCveIds(e.message).forEach((id) => cveIds.add(id));
+    }
+    for (const i of next.iocs) extractCveIds(i.value).forEach((id) => cveIds.add(id));
+    kevCveIds = new Set(matchKevEntries([...cveIds], kevCatalog).map((m) => m.cveID));
+  }
+  const grounded = groundAndScoreFindings({
+    findings: next.findings,
+    scopedEvents: inScope,
+    iocs: next.iocs,
+    graphLinkedEventIds,
+    kevCveIds,
+    sourceTrust,
+  });
+  // Intel-verdict gate (investigation-guidance #7): floor an intel-ONLY High/Critical finding (no
+  // behavioral corroboration, all its verdict IOCs lone-intel/conflicted) to Medium/≤60 — the
+  // northpeak stale-CTI-on-own-server class. Runs after grounding so it sees the corroboration rollup.
+  const hostNames = new Set(
+    buildAssetGraph(next)
+      .assets.filter((a) => a.type === "host")
+      .map((a) => shortHost(a.name)),
+  );
+  const capped = capIntelOnlyFindings({
+    findings: grounded,
+    iocs: next.iocs,
+    scopedEvents: inScope,
+    hostNames,
+  });
+  // Rabbit-hole detection (investigation-guidance #13): place each finding relative to the corroborated
+  // main attack component. A finding whose graph-modeled evidence sits in a SEPARATE component is a
+  // rabbit-hole candidate ('disconnected'); the model's per-finding relevance verdict refines a
+  // disconnected one into 'unrelated-but-real' (a genuine separate issue) vs undetermined noise. The
+  // deterministic linkage is authoritative; the AI never upgrades a rabbit hole into a lead.
+  const aiRelevanceById = new Map(
+    (delta.findings ?? [])
+      .filter(
+        (f): f is typeof f & { relevance: "connected" | "unrelated-but-real" | "undetermined" } =>
+          !!f.relevance && surviving.has(f.id),
+      )
+      .map((f) => [f.id, f.relevance] as const),
+  );
+  next = {
+    ...next,
+    findings: scoreFindingsRelevance({
+      findings: capped,
+      scopedEvents: inScope,
+      graph: evidenceGraph,
+      aiRelevanceById,
+    }),
+  };
+
+  // Auto "corroborate <ioc>" next-steps (investigation-guidance #7, deferred): for every finding the
+  // intel gate just floored to intel-only, add a concrete "go get the behavioral evidence" step so the
+  // capped lead becomes a directed action, not a dead end. Idempotent ids; prepend so the verification
+  // steps sit near the top, and don't duplicate a step the model already emitted with the same id.
+  const corroborateSteps = buildIntelCorroborationSteps({
+    findings: next.findings,
+    iocs: next.iocs,
+    scopedEvents: inScope,
+    hostNames,
+  });
+  if (corroborateSteps.length) {
+    const existing = new Set((next.nextSteps ?? []).map((s) => s.id));
+    const fresh = corroborateSteps.filter((s) => !existing.has(s.id));
+    if (fresh.length) next = { ...next, nextSteps: [...fresh, ...(next.nextSteps ?? [])] };
+  }
+  return next;
+}

--- a/companion/src/analysis/ai/synthesisPrompt.ts
+++ b/companion/src/analysis/ai/synthesisPrompt.ts
@@ -1,0 +1,405 @@
+import { buildAttackPhases } from "../burstDetect.js";
+import { detectBeacons, beaconEnvOptions } from "../beaconDetect.js";
+import { detectSatisfiedCollections, buildSatisfiedCollectionsBlock } from "../collectSatisfaction.js";
+import {
+  applyFalsePositive,
+  buildFalsePositiveContext,
+  buildAuthorizedContextBlock,
+  type FalsePositiveMarker,
+} from "../falsePositive.js";
+import { textMentionsFindingId } from "../fpCascade.js";
+import { corroborationLabel } from "../findingGrounding.js";
+import { buildGraphContext, DEFAULT_MAX_GRAPH_EDGES } from "../graphContext.js";
+import { buildLearnedPatternsBlock } from "../learnedPatterns.js";
+import type { LearnedPatternStore } from "../learnedPatternStore.js";
+import { buildPrevalenceIndex, eventPrevalence, prevalenceTag, rarityScore } from "../prevalence.js";
+import { estimateTokens, inputTokenBudget, fitItemsToBudget } from "../promptBudget.js";
+import { hasScope, type ScopeWindow } from "../scope.js";
+import type { ForensicEvent, InvestigationState } from "../stateTypes.js";
+import { renderStructuredTags, buildBeaconDigest, buildAttackPhaseDigest } from "../synthEvidence.js";
+import {
+  collapseForPrompt,
+  renderGroupSuffix,
+  groupEnvOptions,
+  groupingEnabled,
+  maxPromptEvents,
+  promptCandidates,
+  type CollapsedPrompt,
+} from "../synthGroup.js";
+import { buildSynthesisCoverage, type SynthesisCoverage } from "../synthMeta.js";
+import {
+  buildSynthesisContext,
+  selectSynthesisEventsAnnotated,
+  type SelectionClass,
+} from "../synthSelect.js";
+import { getSynthesisPrompt } from "./prompts/index.js";
+import type { AiCallContext } from "./aiContext.js";
+import { adversaryHintBlock, knownUnknownsBlock, type PromptBlockContext } from "./promptBlocks.js";
+
+/**
+ * Synthesis prompt construction and the coverage audit that describes it (#418).
+ *
+ * Split out of `synthesize` because it is a different KIND of work from the rest of that function:
+ * everything here is a pure-ish transformation of an already-loaded case into one string, whereas
+ * the orchestration around it loads stores, calls a model and writes state. Keeping them together is
+ * what made the 695-line version impossible to review — a change to how an event row renders sat 400
+ * lines away from the lock that protects the write.
+ *
+ * The coverage audit (#62) is computed HERE and not by the caller, and that is deliberate: it must
+ * describe the prompt that was actually sent. Every omission it reports — out of scope, confirmed
+ * legitimate, Info-severity, over the size budget — is a decision made in this file, and a
+ * denominator computed anywhere else would eventually stop matching them.
+ */
+
+/** Everything the prompt builder consumes. The blocks are loaded by the caller BEFORE the skip-hash. */
+export interface SynthesisPromptInput {
+  caseId: string;
+  /** The correlated state this run is reasoning over (not the raw snapshot). */
+  state: InvestigationState;
+  scope: ScopeWindow;
+  markers: FalsePositiveMarker[];
+  /** After the scope filter only — the coverage audit needs it separately from `scopedEvents`. */
+  inWindowEvents: ForensicEvent[];
+  scopedEvents: ForensicEvent[];
+  /** The blocks that are also hashed for skip-if-unchanged, so they are loaded before this runs. */
+  observationsBlock: string;
+  notebookBlock: string;
+  analystHypothesesBlock: string;
+  refutedHypothesesBlock: string;
+  priorHuntsBlock: string;
+  playbookProgressBlock: string;
+  incidentTypeBlock: string;
+}
+
+/** The prompt, plus what the run record and the second-look sweep need to describe it. */
+export interface SynthesisPromptResult {
+  userPrompt: string;
+  /** The rows the model was shown. A grouped row stands for its whole burst. */
+  promptEvents: ForensicEvent[];
+  /** Every scoped event the model saw, INCLUDING the members a grouped row represents. */
+  representedEvents: ForensicEvent[];
+  shownIds: Set<string>;
+  selection: ReturnType<typeof selectSynthesisEventsAnnotated>;
+  coverage: SynthesisCoverage;
+  maxEvents: number;
+  omittedInfo: number;
+}
+
+/** What the prompt builder needs: the KEV catalog, the learned-pattern store, and the gap blocks. */
+export interface SynthesisPromptContext extends PromptBlockContext {
+  readonly opts: PromptBlockContext["opts"] & { learnedPatternStore?: LearnedPatternStore };
+}
+
+export async function buildSynthesisPrompt(
+  ctx: SynthesisPromptContext,
+  input: SynthesisPromptInput,
+): Promise<SynthesisPromptResult> {
+  const {
+    caseId,
+    state,
+    scope,
+    markers,
+    inWindowEvents,
+    scopedEvents,
+    observationsBlock,
+    notebookBlock,
+    analystHypothesesBlock,
+    refutedHypothesesBlock,
+    priorHuntsBlock,
+    playbookProgressBlock,
+    incidentTypeBlock,
+  } = input;
+
+  // Detection-burst grouping (spec 2026-07-21): the same Sigma/YARA detection firing hundreds of
+  // times used to consume hundreds of prompt seats. Collapse each burst to ONE representative row so
+  // every DISTINCT detection reaches the model. Prompt-only and derived on read — `scopedEvents` (and
+  // therefore the case, the coverage denominators and the high-severity backfill) is untouched.
+  // The explicit CollapsedPrompt annotation matters: without it the disabled branch's bare `new Map()`
+  // infers Map<unknown, unknown> and every later `grouping.groupById.get(...)` fails to typecheck.
+  // Info-severity events don't get prompt seats (DFIR_SYNTH_INCLUDE_INFO=1 restores them): on a real
+  // case 213 Info rows pushed the prompt from 546 to 759 entries, past the cap, costing 26 GRADED
+  // detections their place. They remain in the case, the timeline and the coverage denominators —
+  // this only decides who gets budget.
+  const eligibleForPrompt = promptCandidates(scopedEvents);
+  const omittedInfo = scopedEvents.length - eligibleForPrompt.length;
+  const grouping: CollapsedPrompt = groupingEnabled()
+    ? collapseForPrompt(eligibleForPrompt, groupEnvOptions())
+    : { events: [...eligibleForPrompt], groupById: new Map(), memberIdsByRepresentative: new Map() };
+  const collapsedEvents = grouping.events;
+
+  // Bound the prompt for large imports (e.g. THOR: hundreds of events + auto-findings).
+  // Send the MOST SEVERE events (then most recent) up to a cap, and truncate each
+  // description — this keeps the request affordable (avoids OpenRouter 402 on a giant
+  // request) and inside the model's context. The deterministic high-severity backfill
+  // still creates findings for any Critical/High event NOT shown here (eligibleIds below
+  // is the full scoped set), so capping the prompt never loses a severe detection.
+  const SYNTH_MAX_EVENTS = maxPromptEvents();
+  // Per-case prevalence/baseline (investigation-guidance #15): how common each activity PATTERN is
+  // across the WHOLE case timeline (not just the scoped subset — the baseline is a property of the
+  // corpus). Feeds a rarity bias into the selection fill (a 1-off wins a seat over 500× noise) and a
+  // common/rare tag into each rendered event so the model gets explicit baseline context.
+  const prevalenceIndex = buildPrevalenceIndex(state.forensicTimeline);
+  const rarityOf = (e: ForensicEvent): number => rarityScore(e, prevalenceIndex);
+  // Stratified selection: all Critical/High + the earliest (initial-access) + an even
+  // time-spread sample, chronologically — better kill-chain coverage than severity-only. The ANNOTATED
+  // form (investigation-guidance #4) exposes which CLASS claimed each event, so renderEvent can prefix
+  // context-only rows with "~" (the model reads anchors vs supporting context) and the synth-meta card
+  // can show the analyst what evidence classes the model actually saw.
+  let selection = selectSynthesisEventsAnnotated(collapsedEvents, SYNTH_MAX_EVENTS, rarityOf);
+  let promptEvents = selection.events;
+  // Context classes: everything that is NOT a primary verdict-bearing anchor / initial-access event —
+  // these are the supporting rows the model should read as context, marked "~" in the timeline.
+  const CONTEXT_CLASSES = new Set<SelectionClass>([
+    "anchor_context",
+    "corroborated",
+    "technique",
+    "rare",
+    "spread",
+  ]);
+  const isContext = (id: string): boolean => CONTEXT_CLASSES.has(selection.classOf.get(id) as SelectionClass);
+
+  const scopeNote = hasScope(scope)
+    ? `INVESTIGATION SCOPE: only consider activity from ${scope.start ?? "the beginning"} to ${scope.end ?? "now"}. ` +
+      `Events outside this window have already been removed below.\n\n`
+    : "";
+  // Cap the existing-findings echo too (a big import can produce 100s of auto-findings). Append the
+  // prior run's corroboration label (investigation-guidance #6) so the model sees which of its own
+  // earlier claims were weak/uncorroborated and can strengthen or drop them this run.
+  const existingFindings =
+    state.findings
+      .slice(0, 150)
+      .map((f) => {
+        const corr = corroborationLabel(f);
+        return `[${f.id}] ${f.title}${corr ? ` — ${corr}` : ""}`;
+      })
+      .join("\n") || "(none yet)";
+  const openThreads =
+    state.openThreads
+      .filter((t) => t.status === "open")
+      .map((t) => `[${t.id}] ${t.description}`)
+      .join("\n") || "(none open)";
+  const falsePositiveBlock = buildFalsePositiveContext(markers);
+  // Rabbit-hole detection (#13): authorized-test / known-good-tool markers are RETAINED as shaping
+  // context (a sanctioned pentest during the window is signal, not just noise), not merely erased.
+  const authorizedContextBlock = buildAuthorizedContextBlock(markers);
+  // Learn from dismissals (#65): recurring reasoned dismissals → a "PREVIOUSLY DISMISSED PATTERNS" block
+  // that DOWN-WEIGHTS (not excludes) new look-alike activity. Distinct from the two blocks above: those
+  // act on EXACT current markers; this generalizes. Env-tunable recurrence floor. Best-effort/optional.
+  let learnedPatternsBlock = "";
+  if (ctx.opts.learnedPatternStore) {
+    const minCount = Number(process.env.DFIR_LEARNED_PATTERN_MIN_COUNT) || undefined;
+    learnedPatternsBlock = buildLearnedPatternsBlock(
+      await ctx.opts.learnedPatternStore.load(caseId),
+      minCount,
+    );
+  }
+  // Compact, corroborated context (compromised assets + threat-intel verdicts + KEV hits)
+  // so the model grounds findings/attacker-path in structure instead of inferring blind.
+  const kevCatalog = await ctx.getKevCatalog();
+  const contextBlock = buildSynthesisContext(state, scopedEvents, kevCatalog);
+  // Known unknowns (#165): the gaps in the story (silent windows, uncovered ATT&CK phases, likely-
+  // next techniques) so the model builds on what's MISSING instead of glossing over it. Plus the
+  // (env-gated, default OFF) candidate-actor block. Both DERIVED — computed AFTER the skip-hash
+  // above, so they never affect skip-if-unchanged.
+  const unknownsBlock = await knownUnknownsBlock(ctx, state, scopedEvents, caseId);
+  const adversaryBlock = adversaryHintBlock(state);
+  // Structured causal evidence (investigation-guidance #5), all DERIVED after the skip-hash so they
+  // never affect skip-if-unchanged: the deterministic ATTACK GRAPH (spawn/file-lineage/lateral/network
+  // edges with confidence+rule — previously fed only to ask()/suggestHunts(), never the call that
+  // writes findings), the statistically-confirmed periodic-beacon candidates, and the activity-phase
+  // digest. These give synthesis the cross-host structure it was inferring blind from truncated prose.
+  const graphBlock = buildGraphContext(
+    { ...state, forensicTimeline: scopedEvents },
+    { maxEdges: DEFAULT_MAX_GRAPH_EDGES },
+  );
+  const beaconBlock = buildBeaconDigest(detectBeacons(scopedEvents, beaconEnvOptions()));
+  const attackPhaseBlock = buildAttackPhaseDigest(buildAttackPhases(scopedEvents));
+  // Import-satisfaction (investigation-guidance #8, phase 2): a collection this case previously
+  // recommended (prior nextSteps / unknown questions carrying a structured collect target) whose host
+  // now HAS matching events was fulfilled — stop re-recommending it and re-evaluate the question it
+  // served. Derived from the PRIOR run's guidance vs the current events; the served questions are
+  // added to the re-answer set below so the model reconsiders them with the new evidence.
+  const satisfiedCollections = detectSatisfiedCollections(state, scopedEvents);
+  const satisfiedBlock = buildSatisfiedCollectionsBlock(satisfiedCollections);
+  const satisfiedQuestionIds = new Set(
+    satisfiedCollections.filter((s) => s.target.from === "question").map((s) => s.target.refId),
+  );
+  // Analyst-pinned open questions: tell the model to address each (answer when the evidence
+  // now supports it) and keep them. They're re-merged into the output below so they persist.
+  const pinnedQuestions = state.keyQuestions.filter((q) => q.pinned);
+  const pinnedBlock = pinnedQuestions.length
+    ? `OPEN QUESTIONS TO ADDRESS (include EACH in keyQuestions with the SAME id; answer with ` +
+      `status/answer + supporting relatedEventIds if the evidence now supports it, else status ` +
+      `"unknown" with a 'pointer' to the artifact to collect):\n` +
+      pinnedQuestions.map((q) => `[${q.id}] ${q.question}`).join("\n") +
+      "\n\n"
+    : "";
+  // A finding just confirmed false-positive forces a re-answer of any key question that cited it
+  // as support — otherwise a question "answered" from a finding the analyst just rejected would
+  // keep looking answered until the model happens to reconsider it unprompted. The sanitize pass
+  // after the AI call (below, near applyFalsePositive) is the deterministic backstop for when the
+  // model ignores this and echoes the stale answer back.
+  const droppedFindingIds = new Set(
+    state.findings
+      .filter((f) => !applyFalsePositive(state, markers).findings.some((k) => k.id === f.id))
+      .map((f) => f.id),
+  );
+  const questionsToReanswer = state.keyQuestions.filter((q) => {
+    if (q.pinned) return false;
+    // A question whose recommended collection was just satisfied (#8 phase 2) must be re-evaluated
+    // with the evidence now present, not left showing its old "unknown".
+    if (satisfiedQuestionIds.has(q.id)) return true;
+    if ((q.relatedFindingIds ?? []).some((id) => droppedFindingIds.has(id))) return true;
+    // Fallback for a question that predates relatedFindingIds (or whose answer only ever named
+    // the finding in prose): its free-text pointer/answer still cites the now-rejected finding.
+    return [...droppedFindingIds].some(
+      (id) => textMentionsFindingId(q.pointer, id) || textMentionsFindingId(q.answer, id),
+    );
+  });
+  const reanswerBlock = questionsToReanswer.length
+    ? `QUESTIONS TO RE-ANSWER (a finding backing this answer was just confirmed a FALSE POSITIVE — ` +
+      `re-evaluate using ONLY the CURRENT findings/evidence, ignoring the rejected finding entirely; ` +
+      `if nothing else supports it, set status "unknown", clear the answer, and set relatedFindingIds ` +
+      `to []):\n` +
+      questionsToReanswer.map((q) => `[${q.id}] ${q.question} (previously: "${q.answer}")`).join("\n") +
+      "\n\n"
+    : "";
+
+  // Token budget: trim the timeline so the WHOLE prompt fits the model context — the rest
+  // (context block, findings echo, system prompt) is the fixed overhead. Re-select for the
+  // smaller count so the kept events stay the most important; the high-severity backfill
+  // still creates findings for any Critical/High event dropped here.
+  // Each event carries its structured tags (host / process lineage / src→dst / corroborating-source
+  // count) after the prose (investigation-guidance #5) — only when set, so a bare event costs no extra
+  // tokens. This is what lets the model connect cross-host activity instead of guessing from prose.
+  const renderEvent = (e: ForensicEvent) => {
+    // Grouped rows carry their own count/host-spread/span suffix, which supersedes the prevalence
+    // tag — showing both would state the same repetition twice in different words.
+    const group = grouping.groupById.get(e.id);
+    const groupTag = group ? renderGroupSuffix(group) : "";
+    // Prevalence baseline tag (#15): only the informative extremes (clearly common / clearly rare) are
+    // tagged, so the model knows a 500× pattern is routine and a 1-off is anomalous.
+    const p = group ? null : eventPrevalence(e, prevalenceIndex);
+    const prevTag = p ? prevalenceTag(p) : "";
+    // "~" prefix (investigation-guidance #4): this row is supporting CONTEXT (pulled in to explain an
+    // anchor), not itself a primary verdict-bearing event — so the model weights it as background.
+    const ctx = isContext(e.id) ? "~" : "";
+    return `${ctx}[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}${groupTag}${prevTag ? ` ⟨${prevTag}⟩` : ""}`;
+  };
+  const synthOverhead =
+    estimateTokens(getSynthesisPrompt()) +
+    estimateTokens(
+      incidentTypeBlock +
+        scopeNote +
+        contextBlock +
+        graphBlock +
+        beaconBlock +
+        attackPhaseBlock +
+        unknownsBlock +
+        adversaryBlock +
+        notebookBlock +
+        analystHypothesesBlock +
+        refutedHypothesesBlock +
+        priorHuntsBlock +
+        playbookProgressBlock +
+        satisfiedBlock +
+        pinnedBlock +
+        reanswerBlock +
+        observationsBlock +
+        existingFindings +
+        openThreads +
+        falsePositiveBlock +
+        authorizedContextBlock +
+        learnedPatternsBlock +
+        (state.lastSummary || ""),
+    ) +
+    400;
+  const fit = fitItemsToBudget(promptEvents, renderEvent, Math.max(0, inputTokenBudget() - synthOverhead));
+  if (fit < promptEvents.length) {
+    selection = selectSynthesisEventsAnnotated(collapsedEvents, fit, rarityOf);
+    promptEvents = selection.events;
+  }
+
+  const timelineText = promptEvents.map(renderEvent).join("\n");
+  // Coverage audit (#62): what the model actually saw this run vs what was left out and why. Computed
+  // here where promptEvents + the token overhead are final. Of the budget-omitted events, the safety-net
+  // backfill (below) still guarantees a finding for any Critical/High, so surface that count too.
+  // A grouped row stands for every member of its burst, so all of those events were SEEN by the model —
+  // counting only the representative would report the rest as "omitted for the size limit", the
+  // opposite of the truth.
+  const shownIds = new Set<string>();
+  let groupEntries = 0;
+  let groupedEvents = 0;
+  for (const e of promptEvents) {
+    shownIds.add(e.id);
+    const members = grouping.memberIdsByRepresentative.get(e.id);
+    if (!members) continue;
+    groupEntries += 1;
+    groupedEvents += members.length;
+    for (const id of members) shownIds.add(id);
+  }
+  const representedEvents = scopedEvents.filter((e) => shownIds.has(e.id));
+  const omittedHighSeverity = scopedEvents.filter(
+    (e) => !shownIds.has(e.id) && (e.severity === "Critical" || e.severity === "High"),
+  ).length;
+  const synthCoverage: SynthesisCoverage = buildSynthesisCoverage({
+    totalEvents: state.forensicTimeline.length,
+    inWindow: inWindowEvents.length,
+    scoped: scopedEvents.length,
+    considered: shownIds.size,
+    groupEntries,
+    groupedEvents,
+    omittedInfo,
+    omittedHighSeverity,
+    promptTokensEstimate: synthOverhead + estimateTokens(timelineText),
+  });
+  const truncatedNote =
+    scopedEvents.length > shownIds.size
+      ? ` — showing ${shownIds.size} of ${scopedEvents.length}; ${scopedEvents.length - shownIds.size} event(s) omitted from this prompt but still in the case`
+      : "";
+  // Legend for the "~" context prefix (investigation-guidance #4) — only when at least one context row
+  // is present, so it costs nothing on a small case.
+  const contextLegend = promptEvents.some((e) => isContext(e.id))
+    ? ' Rows prefixed "~" are SUPPORTING CONTEXT (pulled in to explain a nearby anchor), not primary findings — weight them as background.'
+    : "";
+  const userPrompt =
+    incidentTypeBlock +
+    scopeNote +
+    contextBlock +
+    graphBlock +
+    beaconBlock +
+    attackPhaseBlock +
+    unknownsBlock +
+    adversaryBlock +
+    notebookBlock +
+    analystHypothesesBlock +
+    refutedHypothesesBlock +
+    priorHuntsBlock +
+    playbookProgressBlock +
+    satisfiedBlock +
+    pinnedBlock +
+    reanswerBlock +
+    observationsBlock +
+    `FORENSIC TIMELINE (${scopedEvents.length} dated events${truncatedNote}).${contextLegend}\n${timelineText}\n\n` +
+    `EXISTING FINDINGS (update by id, do not duplicate):\n${existingFindings}\n\n` +
+    `CURRENTLY OPEN THREADS (close by id in threadsClosed when the evidence resolves them):\n${openThreads}\n\n` +
+    (falsePositiveBlock ? `${falsePositiveBlock}\n\n` : "") +
+    (authorizedContextBlock ? `${authorizedContextBlock}\n\n` : "") +
+    (learnedPatternsBlock ? `${learnedPatternsBlock}\n\n` : "") +
+    `Running notes: ${state.lastSummary || "(none)"}\n\nReturn the JSON conclusions.`;
+
+  return {
+    userPrompt,
+    promptEvents,
+    representedEvents,
+    shownIds,
+    selection,
+    coverage: synthCoverage,
+    maxEvents: SYNTH_MAX_EVENTS,
+    omittedInfo,
+  };
+}
+
+// Satisfies the AiCallContext constraint without widening it here — the context this module
+// declares is a superset, and TypeScript checks the assignment at every call site.
+export type { AiCallContext };

--- a/companion/src/analysis/ai/viewReports.ts
+++ b/companion/src/analysis/ai/viewReports.ts
@@ -1,0 +1,305 @@
+import { z } from "zod";
+import { sortByEventTime } from "../forensicSort.js";
+import { estimateTokens, inputTokenBudget, fitItemsToBudget } from "../promptBudget.js";
+import { segmentSessions, sessionEnvOptions } from "../sessionSegmentation.js";
+import type { ForensicEvent, InvestigationState } from "../stateTypes.js";
+import type { SuperQuery, SuperLabelMap } from "../superTimeline.js";
+import type { SuperTimelineStore } from "../superTimelineStore.js";
+import { maxPromptEvents } from "../synthGroup.js";
+import { selectSynthesisEvents } from "../synthSelect.js";
+import { getSessionSummaryPrompt, getStarredReportPrompt, getViewSummaryPrompt } from "./prompts/index.js";
+import { retryPolicy, type AiCallContext } from "./aiContext.js";
+
+/**
+ * The three view-scoped AI summaries (#418).
+ *
+ * Moved from AnalysisPipeline (see ai/caseReports.ts for the pattern). These differ from the case
+ * reports in what defines their input: not the case, but a SLICE the analyst chose — the events they
+ * starred, the session they clicked, the filter they typed. So they share an event fitter rather
+ * than the case-wide scope/false-positive filter, and none of them applies that filter at all: the
+ * analyst hand-picked these rows and hiding some would misreport what the summary covered.
+ *
+ * Two of the three reach the raw super-timeline; starredReport PROMOTES what it reads and
+ * viewSummary is the codebase's one sanctioned exception to that rule (see its own note).
+ */
+
+// Result of the two view-scoped AI summaries (starred report / view summary). `eventCount` is the
+// full deduplicated match; `usedEvents` what actually fit the AI input budget.
+export interface StarredSummaryResult {
+  markdown: string;
+  eventCount: number;
+  usedEvents: number;
+  truncated: boolean;
+}
+
+/** One session's AI account (#342). Carries the session identity so a stale card can't mislabel it. */
+export interface SessionSummaryResult extends StarredSummaryResult {
+  sessionId: string;
+  label: string;
+}
+
+/**
+ * How many raw super-timeline rows viewSummary may read in one call (#384).
+ *
+ * Was 10,000. That is more than a model can usefully summarise and far more than the analyst can
+ * check, and it made the one sanctioned exception to the forensic/super-timeline rule the widest
+ * path into the raw record in the codebase. A few hundred rows is enough for "what am I looking
+ * at?" and small enough that the answer stays reviewable.
+ */
+export const VIEW_SUMMARY_MAX_ROWS = 500;
+
+/** What the two raw-record summaries need on top of the shared AI-call seam. */
+export interface ViewReportContext extends AiCallContext {
+  readonly opts: AiCallContext["opts"] & { superTimelineStore?: SuperTimelineStore };
+  promoteSuperTimeline(
+    caseId: string,
+    events: ForensicEvent[],
+    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+  ): Promise<InvestigationState>;
+}
+
+const markdownSchema = z.object({ markdown: z.string().min(1) });
+
+// Shared event-selection for the view-scoped summaries: cap to the synthesis event budget
+// (DFIR_AI_SYNTH_MAX_EVENTS, default 600), token-fit against the prompt overhead, keep the most
+// signal-bearing subset (selectSynthesisEvents) and re-sort it chronologically for the report.
+function fitViewEvents(
+  all: ForensicEvent[],
+  overheadTokens: number,
+): { events: ForensicEvent[]; render: (e: ForensicEvent) => string } {
+  const render = (e: ForensicEvent): string =>
+    `[${e.timestamp || "(undated)"}] [${e.severity}]` +
+    (e.asset ? ` [${e.asset}]` : "") +
+    ` ${e.description.slice(0, 240)}` +
+    (e.processName ? ` | process: ${e.processName}` : "") +
+    (e.srcIp || e.dstIp ? ` | net: ${[e.srcIp, e.dstIp].filter(Boolean).join(" → ")}` : "");
+  const max = maxPromptEvents();
+  let events = selectSynthesisEvents(all, max);
+  const fit = fitItemsToBudget(events, render, Math.max(0, inputTokenBudget() - overheadTokens));
+  if (fit < events.length) events = selectSynthesisEvents(all, fit);
+  return { events: sortByEventTime(events), render };
+}
+
+// TimeSketch-style Starred Events Report: ONE text-only AI call over ONLY the analyst-starred
+// events (ids resolved by the route from the reserved "starred" tags — the pipeline has no tags
+// store). Events resolve from the super-timeline store UNIONed with the forensic timeline
+// (manual/pushed events may exist only there), deduped by id. Deliberately NO scope / false-
+// positive filtering: the analyst hand-picked these events. EPHEMERAL — no state change.
+export async function starredReport(
+  ctx: ViewReportContext,
+  caseId: string,
+  starredIds: string[],
+): Promise<StarredSummaryResult> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("starred report");
+  let loaded = await ctx.opts.stateStore.load(caseId);
+  const wanted = new Set(starredIds);
+  // FORENSIC copies win: imports dual-write the same event ids to both stores, but all later
+  // severity/MITRE re-grades (content tagger, synthesis mergeDelta) land on the forensic copy
+  // only — the super copy is frozen at import time, so it must not shadow the re-graded one.
+  const byId = new Map<string, ForensicEvent>();
+  for (const e of loaded.forensicTimeline) if (wanted.has(e.id)) byId.set(e.id, e);
+
+  // Anything the analyst starred that lives only in the raw record is PROMOTED before the model
+  // sees it, so the report is still built from the forensic timeline alone. Starring an event is
+  // the analyst saying it matters; promotion is that judgement written down.
+  //
+  // Fetched by id rather than with `.all(caseId)`, which materialised the ENTIRE super-timeline —
+  // tens of thousands of rows — to resolve a handful of starred ones.
+  if (ctx.opts.superTimelineStore) {
+    const missing = starredIds.filter((id) => !byId.has(id));
+    const promotable: ForensicEvent[] = [];
+    for (const id of missing) {
+      const raw = await ctx.opts.superTimelineStore.get(caseId, id);
+      if (raw) promotable.push(raw);
+    }
+    if (promotable.length) {
+      loaded = await ctx.promoteSuperTimeline(caseId, promotable, {
+        importedAt: new Date().toISOString(),
+        note: `Promoted ${promotable.length} starred raw event(s) for the starred report`,
+      });
+      for (const e of loaded.forensicTimeline) if (wanted.has(e.id)) byId.set(e.id, e);
+    }
+  }
+  const all = sortByEventTime([...byId.values()]);
+  if (!all.length) throw new Error("no starred events");
+
+  // The provenance line is computed HERE (the model copies it verbatim, it never counts events
+  // itself) so the report's stated coverage is always accurate — including when the budget cap
+  // reduced the set.
+  const provenance = (used: number): string =>
+    used < all.length
+      ? `[*This report was generated based on the ${used} most significant of ${all.length} (deduplicated) starred events.*]`
+      : `[*This report was generated based on ${all.length} (deduplicated) starred events.*]`;
+
+  const prompt = getStarredReportPrompt();
+  const { events, render } = fitViewEvents(
+    all,
+    estimateTokens(prompt) + estimateTokens(provenance(all.length)) + 300,
+  );
+
+  const userPrompt =
+    `PROVENANCE LINE (copy verbatim directly under the title): ${provenance(events.length)}\n\n` +
+    `STARRED EVENTS (${events.length} of ${all.length}, chronological):\n` +
+    events.map(render).join("\n") +
+    `\n\nWrite the starred events report as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  const result = await ctx.withRetry(
+    caseId,
+    "starred-report",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: prompt, userPrompt, images: [] },
+        "starred-report",
+      );
+      return markdownSchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+
+  return {
+    markdown: result.markdown,
+    eventCount: all.length,
+    usedEvents: events.length,
+    truncated: events.length < all.length,
+  };
+}
+
+// Per-session summary (#342): ONE text-only AI call over just the events of a single attacker
+// session. Cheaper and more coherent than full synthesis — the events already share a host and a
+// tight window, so the model gets a focused slice instead of a 600-event wall.
+//
+// The session is re-derived HERE from the case's own timeline rather than trusting a caller-passed
+// event list: a session id is only meaningful relative to a segmentation run, and re-segmenting
+// with sessionEnvOptions() guarantees the summary covers exactly the session the dashboard and the
+// report call by that id. EPHEMERAL — no state change.
+export async function sessionSummary(
+  ctx: AiCallContext,
+  caseId: string,
+  sessionId: string,
+): Promise<SessionSummaryResult> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("session summary");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const sessions = segmentSessions(loaded.forensicTimeline, sessionEnvOptions());
+  const session = sessions.find((s) => s.id === sessionId);
+  if (!session) throw new Error(`session not found: ${sessionId}`);
+
+  const wanted = new Set(session.eventIds);
+  const all = sortByEventTime(loaded.forensicTimeline.filter((e) => wanted.has(e.id)));
+  if (!all.length) throw new Error(`session not found: ${sessionId}`);
+
+  const prompt = getSessionSummaryPrompt();
+  const { events, render } = fitViewEvents(all, estimateTokens(prompt) + 300);
+
+  const userPrompt =
+    `SESSION: ${session.label}\n` +
+    `HOST: ${session.host}\n` +
+    (session.account ? `ACCOUNT: ${session.account}\n` : "") +
+    `WINDOW: ${session.startTime} → ${session.endTime}\n\n` +
+    `EVENTS (${events.length} of ${all.length}, chronological):\n` +
+    events.map(render).join("\n") +
+    `\n\nWrite the session account as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  const result = await ctx.withRetry(
+    caseId,
+    "session-summary",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: prompt, userPrompt, images: [] },
+        "session-summary",
+      );
+      return markdownSchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+
+  return {
+    markdown: result.markdown,
+    sessionId: session.id,
+    label: session.label,
+    eventCount: all.length,
+    usedEvents: events.length,
+    truncated: events.length < all.length,
+  };
+}
+
+/**
+ * Summarize the analyst's CURRENT super-timeline view.
+ *
+ * THIS IS THE ONE SANCTIONED EXCEPTION to the rule that the model reads only the forensic
+ * timeline, and it is written down here so nobody has to infer it from the code.
+ *
+ * The other two raw-record paths — explainEvent and starredReport — promote before asking, so the
+ * invariant holds literally for them. This one cannot: it summarises whatever the analyst has
+ * filtered to, which can be thousands of rows. Promoting them would write thousands of Info-graded
+ * events into the forensic timeline permanently, drowning the record the rule exists to protect.
+ * Obeying the rule that way would cause exactly the harm the rule prevents.
+ *
+ * So it reads the raw record directly, under three constraints that keep it safe:
+ *   1. It only ever runs when the analyst presses the button. Nothing automatic reaches this.
+ *   2. It is EPHEMERAL — no promotion, no state change. Nothing it reads enters the case.
+ *   3. It is capped at VIEW_SUMMARY_MAX_ROWS, far below the old 10,000, and it tells the analyst
+ *      when the cap truncated their view rather than silently summarising a slice.
+ */
+export async function viewSummary(
+  ctx: ViewReportContext,
+  caseId: string,
+  filters: SuperQuery,
+  labelMap?: SuperLabelMap,
+): Promise<StarredSummaryResult> {
+  const provider = ctx.opts.synthesisProvider ?? ctx.requireProvider("view summary");
+  if (!ctx.opts.superTimelineStore) throw new Error("super-timeline not configured");
+  const loaded = await ctx.opts.stateStore.load(caseId);
+  const { events: matched, total } = await ctx.opts.superTimelineStore.query(
+    caseId,
+    { ...filters, offset: 0, limit: VIEW_SUMMARY_MAX_ROWS },
+    labelMap,
+  );
+  if (!matched.length) throw new Error("no events match the current filters");
+
+  const prompt = getViewSummaryPrompt();
+  const { events, render } = fitViewEvents(matched, estimateTokens(prompt) + 300);
+
+  // `total` is what MATCHED the filters; `matched.length` is what the cap let through. Reporting
+  // both means an analyst looking at a 40,000-row filter is told the summary covers a slice,
+  // rather than being left to assume it covered everything.
+  const capped = total > matched.length;
+  const userPrompt =
+    `EVENTS (${events.length} of ${matched.length}${capped ? ` read from ${total} matching (capped at ${VIEW_SUMMARY_MAX_ROWS})` : " matching the analyst's current filters"}, chronological):\n` +
+    events.map(render).join("\n") +
+    `\n\nWrite the overview as JSON.`;
+
+  const { retries, backoffMs } = retryPolicy(ctx);
+  const result = await ctx.withRetry(
+    caseId,
+    "view-summary",
+    async () => {
+      const parsed = await ctx.analyzeRestored(
+        caseId,
+        loaded,
+        provider,
+        { systemPrompt: prompt, userPrompt, images: [] },
+        "view-summary",
+      );
+      return markdownSchema.parse(parsed);
+    },
+    retries,
+    backoffMs,
+  );
+
+  return {
+    markdown: result.markdown,
+    eventCount: matched.length,
+    usedEvents: events.length,
+    truncated: events.length < matched.length,
+  };
+}

--- a/companion/src/analysis/ingest/cloudImports.ts
+++ b/companion/src/analysis/ingest/cloudImports.ts
@@ -6,6 +6,7 @@ import { parseOsqueryLog, type OsqueryImportOptions } from "../osqueryImport.js"
 import { deltaSchema } from "../responseSchema.js";
 import { applySeverityFloor } from "../severityFloor.js";
 import { type InvestigationState, type Severity } from "../stateTypes.js";
+import { noteEmptyImport } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
 
 /**
@@ -35,7 +36,7 @@ export async function importM365(
 ): Promise<InvestigationState> {
   const parsedRaw = parseM365Audit(text, opts.m365);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Microsoft 365", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Microsoft 365", parsed.total);
 
   const raw = {
     findings: [],
@@ -88,7 +89,7 @@ export async function importAws(
 ): Promise<InvestigationState> {
   const parsedRaw = parseCloudTrail(text, opts.aws);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "AWS CloudTrail", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "AWS CloudTrail", parsed.total);
 
   const raw = {
     findings: [],
@@ -141,7 +142,7 @@ export async function importCloudActivity(
 ): Promise<InvestigationState> {
   const parsedRaw = parseCloudActivity(text, opts.cloud);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Cloud activity", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Cloud activity", parsed.total);
 
   const raw = {
     findings: [],
@@ -195,7 +196,7 @@ export async function importK8sAudit(
 ): Promise<InvestigationState> {
   const parsedRaw = parseK8sAudit(text, opts.k8s);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Kubernetes audit", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Kubernetes audit", parsed.total);
 
   const raw = {
     findings: [],
@@ -248,7 +249,7 @@ export async function importOsquery(
 ): Promise<InvestigationState> {
   const parsedRaw = parseOsqueryLog(text, opts.osquery);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "osquery", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "osquery", parsed.total);
 
   const raw = {
     findings: [],

--- a/companion/src/analysis/ingest/endpointImports.ts
+++ b/companion/src/analysis/ingest/endpointImports.ts
@@ -9,6 +9,7 @@ import { resolveExtractedFrom } from "../siemImport.js";
 import { type InvestigationState, type Severity } from "../stateTypes.js";
 import { parseThorReport, type ThorImportOptions } from "../thorImport.js";
 import { parseVelociraptorJsonProgress, type VelociraptorImportOptions } from "../velociraptorImport.js";
+import { noteEmptyImport } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
 
 /**
@@ -39,7 +40,7 @@ export async function importThor(
 ): Promise<InvestigationState> {
   const parsedRaw = parseThorReport(jsonText, opts.thor);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "THOR", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "THOR", parsed.total);
 
   // Assign stable, collision-free ids and validate the delta against the schema
   // (fills defaults like relatedFindingIds). No model call — purely structural.
@@ -91,7 +92,7 @@ export async function importChainsaw(
 ): Promise<InvestigationState> {
   const parsedRaw = parseChainsawReport(jsonText, opts.chainsaw);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Chainsaw", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Chainsaw", parsed.total);
 
   const fallback = parsed.detections > 0 ? "Chainsaw" : "EVTX";
   const raw = {
@@ -147,7 +148,7 @@ export async function importHayabusa(
 ): Promise<InvestigationState> {
   const parsedRaw = parseHayabusaTimeline(text, opts.hayabusa);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Hayabusa", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Hayabusa", parsed.total);
 
   const raw = {
     findings: [],
@@ -218,7 +219,7 @@ export async function importVelociraptor(
     opts.onProgress,
   );
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Velociraptor", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Velociraptor", parsed.total);
 
   const eventIdByAggKey = new Map<string, string>();
   const forensicEvents = parsed.events.map((e, i) => {
@@ -288,7 +289,7 @@ export async function importEcar(
 ): Promise<InvestigationState> {
   const parsedRaw = parseEcarJson(text, { ...opts.ecar });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "ECAR", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "ECAR", parsed.total);
 
   const raw = {
     findings: [],
@@ -343,7 +344,7 @@ export async function importKape(
   const parsedRaw = parseKapeCsv(text, opts.kape);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, `KAPE/${parsed.artifact}`, parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, `KAPE/${parsed.artifact}`, parsed.total);
 
   const raw = {
     findings: [],
@@ -398,7 +399,7 @@ export async function importCybertriage(
   const parsedRaw = parseCybertriage(text, opts.cybertriage);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "Cyber Triage", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "Cyber Triage", parsed.total);
 
   const raw = {
     findings: [],

--- a/companion/src/analysis/ingest/importContext.ts
+++ b/companion/src/analysis/ingest/importContext.ts
@@ -1,6 +1,5 @@
 import type { WindowContext, mergeDelta } from "../stateMerge.js";
-import type { InvestigationState, Severity } from "../stateTypes.js";
-import type { PlasoParseResult } from "../plasoImport.js";
+import type { InvestigationState } from "../stateTypes.js";
 import type { StateStore } from "../stateStore.js";
 
 /**
@@ -20,6 +19,10 @@ import type { StateStore } from "../stateStore.js";
  * because they are not on this type — which is the boundary that keeps deterministic import
  * deterministic. `analysis/ingest` sits at tier 3 and `analysis/ai` at tier 5 for the same reason;
  * this interface is that rule expressed where the compiler can enforce it.
+ *
+ * THREE members now, not the five #384 counted: `noteEmptyImport` and `persistPlasoParsed` were
+ * import bookkeeping that only ingest ever called, so #418 moved them to `importState.ts` as free
+ * functions over this same context. A seam this narrow is worth keeping narrow.
  */
 export interface ImportContext {
   /**
@@ -49,30 +52,5 @@ export interface ImportContext {
     state: InvestigationState,
     delta: Parameters<typeof mergeDelta>[1],
     ctx: WindowContext,
-  ): Promise<InvestigationState>;
-
-  /**
-   * Record that an import produced nothing, with the importer's own record count so the note says
-   * how much was READ. "0 events from 0 records" (wrong format) and "0 events from 75,951 records"
-   * (understood but uninteresting) are very different problems.
-   */
-  noteEmptyImport(
-    caseId: string,
-    opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
-    kind: string,
-    total: number,
-  ): Promise<InvestigationState>;
-
-  /** Shared tail for the two Plaso entry points (text and file), which differ only in how they parse. */
-  persistPlasoParsed(
-    caseId: string,
-    parsed: PlasoParseResult,
-    opts: {
-      label: string;
-      idPrefix: string;
-      importedAt: string;
-      minSeverity?: Severity;
-      onProgress?: (done: number, total: number) => void;
-    },
   ): Promise<InvestigationState>;
 }

--- a/companion/src/analysis/ingest/importState.ts
+++ b/companion/src/analysis/ingest/importState.ts
@@ -1,0 +1,107 @@
+import type { PlasoParseResult } from "../plasoImport.js";
+import { deltaSchema } from "../responseSchema.js";
+import { applySeverityFloor } from "../severityFloor.js";
+import type { InvestigationState, Severity } from "../stateTypes.js";
+import type { ImportContext } from "./importContext.js";
+
+/**
+ * The two shared tails every deterministic importer ends in (#418).
+ *
+ * They were methods on AnalysisPipeline and members of ImportContext, which meant the AI-tier file
+ * carried a hundred lines of pure ingest bookkeeping and every importer's interface advertised two
+ * operations it mostly did not use. As free functions over the same ImportContext they read the
+ * same at the call site — `noteEmptyImport(ctx, …)` instead of `ctx.noteEmptyImport(…)` — and the
+ * code lives where the callers do.
+ */
+
+/** The load → merge → save → announce tail all deterministic imports share. */
+async function commitDelta(
+  ctx: ImportContext,
+  caseId: string,
+  delta: ReturnType<typeof deltaSchema.parse>,
+  opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
+): Promise<InvestigationState> {
+  return ctx.withStateLock(caseId, async () => {
+    let state = await ctx.opts.stateStore.load(caseId);
+    state = await ctx.mergeWithAliases(state, delta, {
+      windowSequence: -1,
+      timestamp: opts.importedAt,
+      sourceScreenshots: [opts.label],
+    });
+    await ctx.opts.stateStore.save(state);
+    ctx.opts.onState?.(state);
+    opts.onProgress?.(1, 1);
+    return state;
+  });
+}
+
+// Record an import that parsed cleanly but contributed nothing.
+//
+// Every deterministic importer guards on "no events (and no IOCs) → return the state unchanged".
+// That guard is correct — an empty delta must not be merged — but returning silently meant the
+// file was 202-accepted, stored under `imports/`, and left NO trace in the case: the analyst had
+// no way to tell "ingested and understood" from "silently dropped". On the northpeak benchmark
+// that hid Zeek conn.json contributing zero events out of 75,951 records, the largest artifact in
+// the case. A note costs one small timeline row and makes the outcome legible.
+//
+// `total` is the importer's own parsed-record count, so the note says how much was READ, not just
+// that nothing came out — "0 events from 0 records" (wrong format) and "0 events from 75,951
+// records" (understood but uninteresting) are very different problems.
+export async function noteEmptyImport(
+  ctx: ImportContext,
+  caseId: string,
+  opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
+  kind: string,
+  total: number,
+): Promise<InvestigationState> {
+  const delta = deltaSchema.parse({
+    findings: [],
+    iocs: [],
+    mitreTechniques: [],
+    forensicEvents: [],
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote: `${kind} import: no events from ${total} record(s) — nothing added to the case`,
+    summary: "",
+  });
+  return commitDelta(ctx, caseId, delta, opts);
+}
+
+// Shared tail of both Plaso entry points: apply the severity floor, build the delta and merge it
+// into the case state. (Keeping this in one place means the in-memory and streaming importers
+// produce identical timeline rows / IOCs / notes.)
+export async function persistPlasoParsed(
+  ctx: ImportContext,
+  caseId: string,
+  parsedRaw: PlasoParseResult,
+  opts: {
+    label: string;
+    idPrefix: string;
+    importedAt: string;
+    minSeverity?: Severity;
+    onProgress?: (done: number, total: number) => void;
+  },
+): Promise<InvestigationState> {
+  const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Plaso", parsed.total);
+
+  const raw = {
+    findings: [],
+    iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
+    mitreTechniques: [],
+    forensicEvents: parsed.events.map((e, i) => ({
+      ...e,
+      id: `${opts.idPrefix}e${i + 1}`,
+      sources: e.sources?.length ? e.sources : ["Plaso"],
+    })),
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote:
+      `Plaso import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
+      (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      `, ${parsed.iocs.length} IOC(s)`,
+    summary: "",
+  };
+
+  return commitDelta(ctx, caseId, deltaSchema.parse(raw), opts);
+}

--- a/companion/src/analysis/ingest/logImports.ts
+++ b/companion/src/analysis/ingest/logImports.ts
@@ -15,6 +15,7 @@ import { type InvestigationState, type Severity } from "../stateTypes.js";
 import { parseSysdig, type SysdigImportOptions } from "../sysdigImport.js";
 import { SYSLOG_SOURCE, parseSyslog, type SyslogImportOptions } from "../syslogImport.js";
 import { pickImportYear } from "../timeYearClamp.js";
+import { noteEmptyImport } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
 
 /**
@@ -44,7 +45,7 @@ export async function importBashHistory(
   const user = userFromHistoryFilename(opts.label);
   const parsedRaw = parseShellHistoryFile(text, { user });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Shell history", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Shell history", parsed.total);
 
   const raw = {
     findings: [],
@@ -97,7 +98,7 @@ export async function importCombinedLog(
   const parsedRaw = parseCombinedLog(text, { ...opts.combinedLog });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "Web/proxy access-log", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "Web/proxy access-log", parsed.total);
 
   const eventIdByAggKey = new Map<string, string>();
   const forensicEvents = parsed.events.map((e, i) => {
@@ -165,7 +166,7 @@ export async function importCiscoAsa(
     ...(assumeYear !== undefined ? { assumeYear } : {}),
   });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Cisco ASA", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Cisco ASA", parsed.total);
 
   const raw = {
     findings: [],
@@ -226,7 +227,7 @@ export async function importSyslog(
     ...(assumeYear !== undefined ? { assumeYear } : {}),
   });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Syslog", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Syslog", parsed.total);
 
   const raw = {
     findings: [],
@@ -280,7 +281,7 @@ export async function importAuditd(
   const parsedRaw = parseAuditdLog(text, opts.auditd);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "auditd", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "auditd", parsed.total);
 
   const raw = {
     findings: [],
@@ -336,7 +337,7 @@ export async function importJournald(
   const parsedRaw = parseJournald(text, opts.journald);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "journald", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "journald", parsed.total);
 
   const raw = {
     findings: [],
@@ -392,7 +393,7 @@ export async function importSysdig(
   const parsedRaw = parseSysdig(text, opts.sysdig);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "sysdig/Falco", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "sysdig/Falco", parsed.total);
 
   const raw = {
     findings: [],

--- a/companion/src/analysis/ingest/networkImports.ts
+++ b/companion/src/analysis/ingest/networkImports.ts
@@ -7,6 +7,7 @@ import { SNORT_SOURCE, parseSnortLog, type SnortImportOptions } from "../snortIm
 
 import { type InvestigationState, type Severity } from "../stateTypes.js";
 import { pickImportYear } from "../timeYearClamp.js";
+import { noteEmptyImport } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
 
 /**
@@ -43,7 +44,7 @@ export async function importSnort(
     ...(assumeYear !== undefined ? { assumeYear } : {}),
   });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Snort", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Snort", parsed.total);
 
   const raw = {
     findings: [],
@@ -102,7 +103,7 @@ export async function importNetwork(
   });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "Network", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "Network", parsed.total);
 
   const eventIdByAggKey = new Map<string, string>();
   const forensicEvents = parsed.events.map((e, i) => {
@@ -167,7 +168,7 @@ export async function importSecurityOnion(
   const parsedRaw = parseSecurityOnion(text, opts.securityOnion);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "Security Onion", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "Security Onion", parsed.total);
 
   const eventIdByAggKey = new Map<string, string>();
   const forensicEvents = parsed.events.map((e, i) => {

--- a/companion/src/analysis/ingest/platformImports.ts
+++ b/companion/src/analysis/ingest/platformImports.ts
@@ -19,6 +19,7 @@ import { parseTheHive, type TheHiveImportOptions } from "../theHiveImport.js";
 import { detectTool } from "../toolDetect.js";
 import { parseWazuhAlerts, type WazuhImportOptions } from "../wazuhImport.js";
 import { YARA_SOURCE, parseYaraOutput, type YaraImportOptions } from "../yaraImport.js";
+import { noteEmptyImport } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
 
 /**
@@ -49,7 +50,7 @@ export async function importSiem(
 ): Promise<InvestigationState> {
   const parsedRaw = parseSiemExport(jsonText, opts.siem);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "SIEM", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "SIEM", parsed.total);
 
   const source = detectTool(opts.label) ?? detectTool(parsed.format) ?? "SIEM import";
   const eventIdByAggKey = new Map<string, string>();
@@ -118,7 +119,7 @@ export async function importDeclarative(
   opts.onParsed?.(parsedRaw);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, opts.importer.label, parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, opts.importer.label, parsed.total);
 
   const raw = {
     findings: [],
@@ -171,7 +172,7 @@ export async function importSandbox(
 ): Promise<InvestigationState> {
   const parsedRaw = parseSandboxReport(text, opts.sandbox);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Sandbox", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Sandbox", parsed.total);
 
   const raw = {
     findings: [],
@@ -228,7 +229,7 @@ export async function importMemory(
   const parsedRaw = parseMemory(text, { ...opts.memory, filename: opts.label });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "Memory", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "Memory", parsed.total);
 
   const tool = parsed.tool || "Volatility";
   const raw = {
@@ -286,7 +287,7 @@ export async function importEmail(
   const parsedRaw = parseEmail(text, opts.email);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "Email", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "Email", parsed.total);
 
   const raw = {
     findings: [],
@@ -340,7 +341,7 @@ export async function importTheHive(
   const parsedRaw = parseTheHive(text, opts.thehive);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "TheHive", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "TheHive", parsed.total);
 
   const raw = {
     findings: [],
@@ -395,7 +396,7 @@ export async function importIris(
   const parsedRaw = parseIrisCase(data, opts.iris);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "DFIR-IRIS", parsed.timelineCount);
+    return noteEmptyImport(ctx, caseId, opts, "DFIR-IRIS", parsed.timelineCount);
 
   const raw = {
     findings: [],
@@ -448,7 +449,7 @@ export async function importWazuh(
 ): Promise<InvestigationState> {
   const parsedRaw = parseWazuhAlerts(text, opts.wazuh);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-  if (parsed.events.length === 0) return ctx.noteEmptyImport(caseId, opts, "Wazuh", parsed.total);
+  if (parsed.events.length === 0) return noteEmptyImport(ctx, caseId, opts, "Wazuh", parsed.total);
 
   const raw = {
     findings: [],
@@ -504,7 +505,7 @@ export async function importYara(
   const parsedRaw = parseYaraOutput(text, { ...opts.yara });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "YARA", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "YARA", parsed.total);
 
   const raw = {
     findings: [],
@@ -558,7 +559,7 @@ export async function importSocrates(
   const parsedRaw = parseSocrates(text, opts.socrates);
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "SO-CRATES", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "SO-CRATES", parsed.total);
 
   const raw = {
     findings: [],
@@ -627,7 +628,7 @@ export async function importEvtxXml(
   );
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0)
-    return ctx.noteEmptyImport(caseId, opts, "Windows Event Log (XML)", parsed.total);
+    return noteEmptyImport(ctx, caseId, opts, "Windows Event Log (XML)", parsed.total);
 
   const source = detectTool(opts.label) ?? "Windows Event Log";
   const raw = {

--- a/companion/src/analysis/ingest/timelineImports.ts
+++ b/companion/src/analysis/ingest/timelineImports.ts
@@ -9,6 +9,7 @@ import { deltaSchema } from "../responseSchema.js";
 import { type ForensicEvent, type InvestigationState, type Severity } from "../stateTypes.js";
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
+import { persistPlasoParsed } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
 
 /**
@@ -38,7 +39,7 @@ export async function importPlaso(
   },
 ): Promise<InvestigationState> {
   const parsedRaw = parsePlasoCsv(text, opts.plaso);
-  return ctx.persistPlasoParsed(caseId, parsedRaw, opts);
+  return persistPlasoParsed(ctx, caseId, parsedRaw, opts);
 }
 
 // Streaming-from-disk Plaso import: for super-timelines too large to hold as one JS string (a
@@ -69,7 +70,7 @@ export async function importPlasoFile(
   } finally {
     rl.close();
   }
-  return ctx.persistPlasoParsed(caseId, parsedRaw, opts);
+  return persistPlasoParsed(ctx, caseId, parsedRaw, opts);
 }
 
 // "Promote" copies already-imported super-timeline events UP into the forensic timeline so AI

--- a/companion/src/analysis/pipeline.ts
+++ b/companion/src/analysis/pipeline.ts
@@ -1,66 +1,25 @@
-
-import { mkdir, writeFile } from "node:fs/promises";
-
-import { join as joinPath } from "node:path";
-import { createHash, randomUUID } from "node:crypto";
-import { z } from "zod";
-import { ProviderError, type AIProvider, type AnalyzeImage, type AnalyzeRequest, type AnalyzeResult, type ProviderErrorKind } from "../providers/provider.js";
+import { ProviderError, type AIProvider } from "../providers/provider.js";
 import { createConsoleLogger, normalizeLogLevel, type Logger } from "../logging/logger.js";
-import { createAnonymizer, deriveKnownEntities, isMaskableIpv4, isInternalIp, type Anonymizer, type CustomEntity, type KnownEntities } from "./anonymize.js";
-import { mapFindings, PresidioApprovalRequired, type PresidioClient, type PresidioFinding } from "./presidio.js";
-import type { PresidioPendingStore } from "./presidioPending.js";
-import { toAnonPolicy, type AnonControlStore } from "./anonControl.js";
-import type { CustomEntitiesStore } from "./anonEntities.js";
-import type { DiscoveredEntitiesStore } from "./anonDiscovered.js";
 import type { CaptureMetadata } from "../types.js";
-import type { StateStore } from "./stateStore.js";
-import type { InvestigationState, InvestigationQuestion, ForensicEvent, Severity, TimelineEntry } from "./stateTypes.js";
-import { deltaSchema, askSchema, execSummarySchema, explainEventSchema, remediationPlanSchema, fpSimilaritySchema, hypothesisReviewSchema, stripAiExtractedFrom, type AskAnswer, type ExecSummary, type ExplainEventResult, type RemediationPlan } from "./responseSchema.js";
-import { buildMitigationsResult } from "./attackMitigations.js";
-import { loadMitigationsDataset } from "./attackMitigationsData.js";
-import { buildD3fendResult } from "./d3fendMap.js";
-import { loadD3fendDataset, d3fendEnvOptions } from "./d3fendData.js";
-import { buildStateSummary } from "./summary.js";
-import { mergeDelta, type WindowContext } from "./stateMerge.js";
-import type { IocAliasStore } from "./iocAlias.js";
-import type { StateLock } from "./stateLock.js";
-import { sortByEventTime } from "./forensicSort.js";
-import { segmentSessions, sessionEnvOptions } from "./sessionSegmentation.js";
-import { applySeverityFloor } from "./severityFloor.js";
-
-import { parseJsonLoose } from "./extractJson.js";
-import { applyFalsePositive, buildFalsePositiveContext, buildAuthorizedContextBlock, filterFalsePositiveEvents, type FalsePositiveStore } from "./falsePositive.js";
-import { buildLearnedPatternsBlock } from "./learnedPatterns.js";
-import type { LearnedPatternStore } from "./learnedPatternStore.js";
-import { backfillHighSeverityFindings } from "./highSeverityFindings.js";
-import { checkConfiguredPromptDrift } from "./promptCapabilities.js";
-import { MATCHABLE_FIELDS } from "./taggerRules.js";
-import { suggestedRuleResponseSchema, sanitizeSuggestedRule, type SuggestOutcome } from "./taggerRuleSuggest.js";
-import { resolveSynthThinkingBudget, type SynthThinkingInput } from "./synthThinking.js";
-import { detectTimelineGaps, backfillSilenceGapFindings, gapEnvOptions } from "./gapDetect.js";
+import type { InvestigationState } from "./stateTypes.js";
 import {
-  gapHypothesesResponseSchema,
-  sanitizeGapHypotheses,
-  buildGapHypotheses,
-  surroundingEvents,
-  renderGapsForPrompt,
-  hasGapMaterial,
-  GAP_HYPOTHESIS_MAX_DEFAULT,
-  SURROUNDING_EVENTS_DEFAULT,
-  GAP_HYPOTHESIS_CAVEAT,
-  type GapHypothesesResult,
-} from "./gapHypothesis.js";
-import { SHADOW_ARTIFACTS } from "./shadowArtifacts.js";
-import { diffFindings, type FindingsDiff } from "./findingsDiff.js";
-import { buildKnownUnknownItems, renderKnownUnknowns, type KnownUnknownItem } from "./knownUnknowns.js";
-import { classifyImportYield, type ImportMetaStore, type ImportYieldWarning } from "./importMeta.js";
-import { buildAdversaryHintsResult } from "./adversaryHints.js";
-import { loadAdversaryGroupsDataset, adversaryHintEnvOptions } from "./adversaryGroupsData.js";
-import { loadKnownPlaybooks } from "./knownPlaybooksData.js";
-import { buildPlaybookMatchResult, playbookMatchEnvOptions } from "./playbookMatch.js";
-import { buildSynthesisCoverage, type SynthMetaStore, type SynthesisCoverage } from "./synthMeta.js";
-import { AiCostStore, bucketForLabel } from "./aiCost.js";
+  type AskAnswer,
+  type ExecSummary,
+  type ExplainEventResult,
+  type RemediationPlan,
+} from "./responseSchema.js";
+import { mergeDelta, type WindowContext } from "./stateMerge.js";
+
+import { checkConfiguredPromptDrift } from "./promptCapabilities.js";
+import { type SuggestOutcome } from "./taggerRuleSuggest.js";
+import { type SynthThinkingInput } from "./synthThinking.js";
+import { type GapHypothesesResult } from "./gapHypothesis.js";
+import { type KnownUnknownItem } from "./knownUnknowns.js";
 import * as ingest from "./ingest/index.js";
+// The options bag and the retry policy moved out with the families that read them (#418).
+import type { PipelineOptions } from "./ai/pipelineOptions.js";
+export type { PipelineOptions } from "./ai/pipelineOptions.js";
+import { withRetry } from "./ai/retry.js";
 import type { ImportContext } from "./ingest/importContext.js";
 
 /**
@@ -71,368 +30,52 @@ import type { ImportContext } from "./ingest/importContext.js";
  * and the delegation stops compiling, which is the property a hand-copied signature would not have.
  */
 type ImporterArgs<F> = F extends (ctx: ImportContext, ...args: infer R) => unknown ? R : never;
+/** The same trick for the AI extraction calls, which take an ExtractionContext first (#418). */
+type AiExtractionArgs<F> = F extends (ctx: ExtractionContext, ...args: infer R) => unknown ? R : never;
+/** Ditto for the calls that take the widest context of all — synthesis and its two consumers. */
+type AiArgs<F> = F extends (ctx: SynthesisContext, ...args: infer R) => unknown ? R : never;
 // The prompt registry moved to ai/prompts/ (#384). Imported for the pipeline's own use and
 // re-exported below, because 23 modules and the eval harness import these names from here.
-import {
-  getAskPrompt, getCsvPrompt, getExecSummaryPrompt, getExplainEventPrompt, getFpSimilarityPrompt,
-  getGapHypothesisPrompt, getHuntSuggestPrompt, getHypothesisReviewPrompt,
-  getLogPrompt, getMemoryNextStepPrompt, getNarrativePrompt, getObservePrompt, getPlaybookHuntPrompt,
-  getQueryTranslatePrompt, getReconcilePrompt, getRemediationPrompt, getSessionSummaryPrompt,
-  getStarredReportPrompt, getSynthesisPrompt, getSystemPrompt, getTaggerRulePrompt,
-  getViewSummaryPrompt,
-} from "./ai/prompts/index.js";
 export * from "./ai/prompts/index.js";
-import { safeAiErrorKind, safeAiPhase, type OperationalMetricsStore } from "./operationalMetrics.js";
-import { CorrelationProfileStore } from "./correlationProfile.js";
-import type { SecondOpinionStore } from "./secondOpinionStore.js";
-import {
-  buildSecondOpinion,
-  buildReconcilePrompt,
-  reconcileResponseSchema,
-  mergeReconcileVerdicts,
-  applyAcceptedSecondOpinion,
-  setDeltaStatus,
-  setAllPendingStatus,
-  type SecondOpinion,
-} from "./secondOpinion.js";
-import { correlateEvents, correlationGroups, type CorrelateOptions } from "./correlate.js";
-import { detectClockSkew, effectiveOffsets, alignedEpoch } from "./clockSkew.js";
-import { effectiveTrustMap } from "./sourceTrust.js";
-import type { SourceTrustStore } from "./sourceTrustStore.js";
-import type { ClockSkewStore } from "./clockSkewStore.js";
-import { detectTool } from "./toolDetect.js";
-import { filterEventsByScope, hasScope, NO_SCOPE, type ScopeStore, type ScopeWindow } from "./scope.js";
-import { parseCsv, chunkToCsvText } from "./csvImport.js";
-import { parseLogLines } from "./logImport.js";
-import { aggregateLogLines, type AggregateStats } from "./logAggregate.js";
-
-import { type PlasoParseResult } from "./plasoImport.js";
-
-import { selectSynthesisEvents, selectSynthesisEventsAnnotated, buildSynthesisContext, type SelectionClass } from "./synthSelect.js";
-import { collapseForPrompt, renderGroupSuffix, groupEnvOptions, groupingEnabled, maxPromptEvents, promptCandidates, type CollapsedPrompt } from "./synthGroup.js";
-import {
-  previewFloors, planBatches, floorsWithinBudget, renderObservationDigest,
-  DEFAULT_MAX_BATCHES, type DeepPassCheckpoint, type FloorOption,
-} from "./deepPass.js";
-import { executeDeepPassBatches } from "./deepPassExecution.js";
-import { lastImportEventSequence } from "./importResume.js";
-import { unionEventTechniques } from "./reconTechniques.js";
-import { buildGraphContext, DEFAULT_MAX_GRAPH_EDGES } from "./graphContext.js";
-import type { KevStore } from "./kevStore.js";
-import { extractCveIds, matchKevEntries, type KevCatalog } from "./kev.js";
-import {
-  huntSuggestionsResponseSchema,
-  sanitizeHuntSuggestions,
-  renderHuntFindings,
-  renderHuntIocs,
-  hasHuntMaterial,
-  HUNT_SUGGEST_MAX_DEFAULT,
-  type HuntSuggestion,
-} from "./huntSuggest.js";
-import {
-  playbookHuntResponseSchema,
-  sanitizePlaybookHuntSuggestions,
-  buildTaskEndpointsMap,
-  knownEndpoints,
-  renderPlaybookHuntTasks,
-  renderKnownEndpoints,
-  renderAvailableArtifacts,
-  hasPlaybookHuntMaterial,
-  PLAYBOOK_HUNT_SUGGEST_MAX_DEFAULT,
-  type PlaybookHuntSuggestion,
-} from "./playbookHunt.js";
-import {
-  deployedFingerprints,
-  renderPriorHuntsBlock,
-  renderHuntProductivityBlock,
-  vqlFingerprint,
-  type HuntOutcome,
-} from "./huntOutcomes.js";
-import type { HuntOutcomeStore } from "./huntOutcomeStore.js";
-import type { SuperTimelineStore } from "./superTimelineStore.js";
+// The AI-backed families extracted in #418. Each method below is a one-line delegation; the result
+// types moved with them and are re-exported here, because routes/reports/tests import them from
+// this module and the extraction is not supposed to be visible to callers.
+import type { CaseReportContext } from "./ai/caseReports.js";
+import * as caseReports from "./ai/caseReports.js";
+import type { AnalystQueryContext } from "./ai/analystQueries.js";
+import * as analystQueries from "./ai/analystQueries.js";
+import type { SessionSummaryResult, StarredSummaryResult, ViewReportContext } from "./ai/viewReports.js";
+import * as viewReports from "./ai/viewReports.js";
+export { VIEW_SUMMARY_MAX_ROWS, type StarredSummaryResult, type SessionSummaryResult } from "./ai/viewReports.js";
+import type { ExtractionContext } from "./ai/extraction.js";
+import * as extraction from "./ai/extraction.js";
+import { analyzeRestored } from "./ai/providerCall.js";
+import type { HuntContext } from "./ai/hunts.js";
+import * as synthesis from "./ai/synthesis.js";
+import type { SynthesisContext } from "./ai/synthesis.js";
+import * as deepPassRun from "./ai/deepPassRun.js";
+import type { SecondOpinionContext } from "./ai/secondOpinionRun.js";
+import * as secondOpinionRun from "./ai/secondOpinionRun.js";
+import type { DeepPassResult } from "./ai/deepPassRun.js";
+export type { DeepPassResult } from "./ai/deepPassRun.js";
+import * as hunts from "./ai/hunts.js";
+import * as nextSteps from "./ai/nextSteps.js";
+import { type PromptBlockContext } from "./ai/promptBlocks.js";
+import * as promptBlocks from "./ai/promptBlocks.js";
+import { safeAiErrorKind, safeAiPhase } from "./operationalMetrics.js";
+import { type SecondOpinion } from "./secondOpinion.js";
+import { type AggregateStats } from "./logAggregate.js";
+import { type FloorOption } from "./deepPass.js";
+import { type KevCatalog } from "./kev.js";
+import { type HuntSuggestion } from "./huntSuggest.js";
+import { type PlaybookHuntSuggestion } from "./playbookHunt.js";
 import type { SuperQuery, SuperLabelMap } from "./superTimeline.js";
-import {
-  memoryNextStepResponseSchema,
-  sanitizeMemoryNextSteps,
-  renderMemoryEvidence,
-  memoryPluginsPresent,
-  isMemoryEvent,
-  hasMemoryMaterial,
-  MEMORY_NEXTSTEP_MAX_DEFAULT,
-  type MemoryNextStep,
-} from "./memoryNextStep.js";
-import {
-  queryTranslationResponseSchema,
-  sanitizeQueryTranslations,
-  sanitizeInterpretation,
-  renderPlatformGuide,
-  renderCaseDataSources,
-  type QueryTranslationResult,
-} from "./queryTranslate.js";
-import { HUNT_PLATFORMS, type HuntPlatform } from "./huntPlatforms.js";
+import { type MemoryNextStep } from "./memoryNextStep.js";
+import { type QueryTranslationResult } from "./queryTranslate.js";
+import { type HuntPlatform } from "./huntPlatforms.js";
 import type { PlaybookTask } from "./playbook.js";
-import type { PlaybookStore } from "./playbookStore.js";
-import type { IncidentTypeStore } from "./incidentTypeStore.js";
-import type { AnalysisRunStore } from "./analysisRunStore.js";
-import { recordDeepPassRun, recordSynthesisRun, uniqueProviderModels } from "./analysisRunRecorders.js";
-import { renderIncidentTypeBlock } from "./incidentTypes.js";
-import { renderPlaybookProgressBlock, renderRefutedHypothesesBlock, demoteCompletedNextSteps } from "./priorWork.js";
-import { flagContradictedAnswers } from "./answerContradiction.js";
-import { detectSatisfiedCollections, buildSatisfiedCollectionsBlock } from "./collectSatisfaction.js";
-import { renderStructuredTags, buildBeaconDigest, buildAttackPhaseDigest } from "./synthEvidence.js";
-import { detectBeacons, beaconEnvOptions } from "./beaconDetect.js";
-import { buildAttackPhases } from "./burstDetect.js";
-import { buildEvidenceGraph } from "./evidenceGraph.js";
-import { buildAssetGraph } from "./assetGraph.js";
-import { shortHost, rankConnectiveIocs } from "./iocAnchors.js";
-import {
-  buildSecondLookRequests, resolveSecondLookRequests, buildSecondLookPlan, summarizeSecondLook,
-  deriveWindow, type ModelEvidenceRequest,
-} from "./secondLook.js";
-import { groundAndScoreFindings, capIntelOnlyFindings, buildIntelCorroborationSteps, corroborationLabel } from "./findingGrounding.js";
-import { scoreFindingsRelevance } from "./findingRelevance.js";
-import { buildPrevalenceIndex, eventPrevalence, prevalenceTag, rarityScore } from "./prevalence.js";
-import { reconsiderKeyQuestions, textMentionsFindingId } from "./fpCascade.js";
-import { estimateTokens, inputTokenBudget, batchByBudget, fitItemsToBudget } from "./promptBudget.js";
-import type { AiControlStore } from "./aiControl.js";
-import type { NotebookStore } from "./notebookStore.js";
-import type { HypothesisStore } from "./hypothesisStore.js";
-import { sanitizeHypotheses, sanitizeHypothesisReviews, type HypothesisReviewItem } from "./hypothesis.js";
-import { ocrRedactImage, type OcrRunner } from "./ocrRedact.js";
-
-// Write a redacted screenshot copy to DFIR_OCR_DEBUG_DIR for visual inspection. The redacted
-// buffer keeps the source image format (sharp infers it from the input), so the extension is
-// derived from the source mime type. Best-effort: a dump failure must never break analysis, and
-// caseId is sanitized so it can't escape the debug dir. This never touches the evidence files.
-async function dumpRedactedImage(
-  dir: string,
-  caseId: string,
-  index: number,
-  mimeType: string,
-  buffer: Buffer,
-): Promise<void> {
-  try {
-    const ext = (mimeType.split("/")[1] ?? "png").replace(/[^a-z0-9]/gi, "") || "png";
-    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const safeCase = caseId.replace(/[^a-z0-9_-]/gi, "_");
-    const outDir = joinPath(dir, safeCase);
-    await mkdir(outDir, { recursive: true });
-    await writeFile(joinPath(outDir, `${stamp}-img${index + 1}.${ext}`), buffer);
-  } catch (err) {
-    console.warn(`[OCR dump] ${(err as Error).message}`);
-  }
-}
-
-/** What one deep-pass run did, for the analyst and the route response. */
-export interface DeepPassResult {
-  aborted: boolean;
-  floor: Severity;        // the minimum severity that was read
-  events: number;         // graded events at or above the floor
-  rows: number;           // prompt rows after detection-burst grouping
-  batches: number;        // observation calls made
-  batchesFailed: number;  // batches whose response never parsed — that slice went unread
-  observations: number;   // observations that survived sanitising
-}
-
-// Result of the two view-scoped AI summaries (starred report / view summary). `eventCount` is the
-// full deduplicated match; `usedEvents` what actually fit the AI input budget.
-export interface StarredSummaryResult {
-  markdown: string;
-  eventCount: number;
-  usedEvents: number;
-  truncated: boolean;
-}
-
-/** One session's AI account (#342). Carries the session identity so a stale card can't mislabel it. */
-export interface SessionSummaryResult extends StarredSummaryResult {
-  sessionId: string;
-  label: string;
-}
-
-export interface PipelineOptions {
-  // The VISION model: screenshot analysis only (analyzeWindow). Screenshots need an image-capable
-  // model and are the one path a cheap/fast model is genuinely suited to.
-  provider?: AIProvider;
-  // The TEXT model: every text-only reasoning call — synthesis, ask/explain, memory next-steps, and
-  // (since #66-era model routing) CSV + log extraction. Falls back to `provider` when unset, so a
-  // single-model install is unaffected.
-  //
-  // CSV/log extraction moved here because it is a text-reasoning task, not an OCR one: measured on
-  // the eval harness (`npm run eval:real`), gpt-4o-mini returned ZERO events for a proxy log holding
-  // six large CONNECT-to-mega.nz transfers on every run, while gemini-2.5-pro found it every time on
-  // the identical input through the identical code path. The same silent-miss shows up in the
-  // northpeak benchmark, where a 27k-line proxy log and both web logs yielded zero forensic events.
-  synthesisProvider?: AIProvider;
-  // Optional DEDICATED model for Velociraptor VQL hunt generation (#70) — many models botch VQL,
-  // so the analyst can pin a known-good one just for suggestHunts/suggestPlaybookHunts. Falls back
-  // to synthesisProvider, then the main provider.
-  velociraptorProvider?: AIProvider;
-  // Per-case hunt outcomes (#157) — the hunting feedback loop. When set, suggestHunts /
-  // suggestTechniqueHunts / suggestPlaybookHunts read prior-hunt outcomes to (a) drop a suggestion
-  // whose VQL already ran and (b) feed a "PRIOR HUNTS" context block so the model pivots on what hit.
-  // Server-only (absent in scripts/* like the other Velociraptor features) → loop simply off.
-  huntOutcomeStore?: HuntOutcomeStore;
-  // Per-case super-timeline store (the raw imported host-triage events not in InvestigationState).
-  // When set, explainEvent falls back to it so an event that was only imported into the super-timeline
-  // (never promoted into the forensic timeline) can still be explained. Server-only (absent in scripts/*).
-  superTimelineStore?: SuperTimelineStore;
-  // Client-confirmed false-positive findings/IOCs to exclude from synthesis.
-  falsePositiveStore?: FalsePositiveStore;
-  // Learned dismissal patterns (issue #65): recurring reasoned dismissals distilled into a per-case
-  // ledger. When set, synthesis feeds a "PREVIOUSLY DISMISSED PATTERNS" block so NEW activity resembling
-  // one is surfaced with LOWER confidence unless corroborated (complements falsePositiveStore's EXCLUDE).
-  learnedPatternStore?: LearnedPatternStore;
-  // Per-source trust overrides (issue #66): steers cross-source merge description choice + caps confidence
-  // for low-trust-only findings. Absent → built-in DEFAULT_SOURCE_TRUST only (no per-case override).
-  sourceTrustStore?: SourceTrustStore;
-  // Per-host clock offsets + the alignment toggle (#228). Synthesis measures skew from the pre-merge
-  // timeline and stores it here; when alignment is on the corrected times steer correlation windows.
-  // Absent → no skew detection, correlation compares recorded times (pre-#228 behavior).
-  clockSkewStore?: ClockSkewStore;
-  // Analyst IOC merges (#82): duplicate value -> canonical IOC id. When set, every mergeDelta call
-  // resolves it first, so a later import/synthesis re-extracting the merged-away duplicate routes
-  // onto the canonical IOC instead of recreating it. Absent → no alias resolution (pre-#82 behavior).
-  iocAliasStore?: IocAliasStore;
-  // Optional investigation time-window — events outside it are excluded.
-  scopeStore?: ScopeStore;
-  // Per-case anonymization control. When a case has it enabled, the userPrompt is tokenized
-  // before the provider call and the response is restored before parsing. Optional: absent →
-  // no anonymization (used by older tests).
-  anonStore?: AnonControlStore;
-  // Per-case analyst-added entities to anonymize (exact-match), merged with the auto-derived ones.
-  customEntitiesStore?: CustomEntitiesStore;
-  // Per-case OCR-discovered entities + the analyst's suppression list. When set, the OCR pass feeds
-  // every entity it tokenizes out of a screenshot back here (so the auto-discovery list grows), and
-  // suppressed values are excluded from anonymization. Absent → no screenshot auto-discovery.
-  discoveredStore?: DiscoveredEntitiesStore;
-  stateStore: StateStore;
-  imageLoader: (caseId: string, screenshotFile: string) => Promise<AnalyzeImage>;
-  retries?: number;
-  backoffMs?: number;
-  onState?: (state: InvestigationState) => void;
-  // Optional: fired after a REAL synthesis run (not a skip) with the findings diff + the new state,
-  // so the server can dispatch notifications (issue #58 — new/escalated findings). Best-effort; the
-  // pipeline never awaits it. Absent → no notifications (used by CLI scripts/tests).
-  onSynth?: (caseId: string, diff: FindingsDiff, state: InvestigationState) => void;
-  // Optional: record when synthesis actually ran + what changed in the findings, so the
-  // dashboard can show "last synthesized N ago" and a what-changed diff. Absent → not recorded.
-  synthMetaStore?: SynthMetaStore;
-  analysisRunStore?: AnalysisRunStore; // append-only reproducibility ledger (#377)
-  // Per-case AI cost/token accounting (vision / synthesis / other buckets), read by the
-  // Diagnostics "AI cost — this case" card. Absent → cost tracking is skipped (CLI scripts).
-  aiCostStore?: AiCostStore;
-  operationalMetrics?: OperationalMetricsStore;
-  correlationProfileStore?: CorrelationProfileStore;
-  // When both notebookStore and aiControlStore are set, synthesis checks aiControl.includeNotebook
-  // and — when true — appends the analyst's notebook entries to the synthesis prompt.
-  notebookStore?: NotebookStore;
-  aiControlStore?: AiControlStore;
-  // When set (external AI provider only), each screenshot is OCR-redacted before the vision
-  // call: words the anonymizer would tokenize are covered with opaque rectangles. The original
-  // evidence file is never touched — only the in-memory buffer sent to the model is redacted.
-  ocrRunner?: OcrRunner;
-  // Optional Presidio layer. Runs AFTER the local anonymizer on already-masked text, so it only
-  // ever sees scrubbed data and reports only what the regex layer missed. Absent → skipped
-  // entirely. `url` is carried for the error message only.
-  presidio?: { client: PresidioClient; url: string; minScore: number };
-  // Holds findings awaiting analyst approval across the 409 round trip.
-  presidioPendingStore?: PresidioPendingStore;
-  // TEST-ONLY override for the import pre-scan's character-count caps (see
-  // AnalysisPipeline.presidioPreScan). Production code never sets this — the real caps are the
-  // PRESIDIO_SCAN_CHUNK_CHARS / PRESIDIO_SCAN_MAX_CHARS constants. Exists so a test can force the
-  // truncation-warning path (masked text exceeding the cap) without generating megabytes of
-  // synthetic text.
-  presidioScanCapsOverride?: { chunkChars: number; maxChars: number };
-  // Shared leveled logger. Absent → a console-only logger at DFIR_LOG_LEVEL (used by CLI scripts
-  // and tests). The server passes its file-backed logger so AI/OCR/anon traces land in the case log.
-  logger?: Logger;
-  // CISA KEV catalog (issue #99): when set, CVEs found in forensic events + IOCs are matched
-  // against the catalog and the hits are prepended to the synthesis context so the AI can flag
-  // actively-exploited CVEs as probable initial-access vectors. Opt-in (store starts empty).
-  kevStore?: KevStore;
-  // Second LLM opinion (issue #116): a DIFFERENT model that independently re-synthesizes the case
-  // for a QA cross-check. When set, secondOpinion() runs Pass 1 (independent synthesis through this
-  // provider) + Pass 2 (reconcile). Absent → the feature is disabled (route returns 501).
-  secondOpinionProvider?: AIProvider;
-  // Persists the last second-opinion run (deltas + analyst accept/reject). Also read by synthesize()
-  // so analyst-accepted deltas are re-applied after the wholesale findings rewrite (durability).
-  secondOpinionStore?: SecondOpinionStore;
-  // Human-readable model labels for the second-opinion comparison header (e.g. "claude-opus-4-8"
-  // vs "gpt-4o"). Fall back to the provider name when absent.
-  synthesisModelLabel?: string;
-  secondOpinionModelLabel?: string;
-  // Per-case mutex serializing load->save critical sections (manual adds, background
-  // enrichment, synthesis) so concurrent state writes cannot clobber each other (lost update).
-  // Absent -> no locking (CLI scripts/tests).
-  stateLock?: StateLock;
-  // Per-case hypothesis store (issue #140). When set, synthesis merges the model's auto-generated
-  // hypotheses into it (refresh-pristine / freeze-touched). Absent → no auto-generation (CLI/tests).
-  hypothesisStore?: HypothesisStore;
-  // Per-case playbook store. When set, synthesis reads DONE/SKIPPED task status so it can build on
-  // completed work instead of re-recommending it (investigation-guidance #2). Absent → no digest.
-  playbookStore?: PlaybookStore;
-  // Per-case import-meta store. When set, synthesis + the evidence-gap panel flag a zero-yield AI
-  // import (a source read as "clean" that actually dropped everything — investigation-guidance #10).
-  importMetaStore?: ImportMetaStore;
-  // Per-case incident-type store (#236). When set, synthesis prepends the chosen type's one-line
-  // hint so the model prioritizes the techniques that matter for a ransomware / BEC / exfil case.
-  // Absent → no hint (CLI/tests).
-  incidentTypeStore?: IncidentTypeStore;
-}
-
-// Keep analyst-pinned questions across a synthesis. The model is told about them and may
-// answer one (same id) — keep that, flagged pinned; if it dropped one, re-add the original.
-function mergePinnedQuestions(pinned: InvestigationQuestion[], current: InvestigationQuestion[]): InvestigationQuestion[] {
-  if (pinned.length === 0) return current;
-  const byId = new Map(current.map((q) => [q.id, q]));
-  for (const p of pinned) {
-    const cur = byId.get(p.id);
-    byId.set(p.id, cur ? { ...cur, pinned: true } : p);
-  }
-  return [...byId.values()];
-}
-
-// Error kinds where the failure is inherent to the call (bad/expired creds, exhausted quota, a hung
-// process) rather than a transient blip — retrying just re-runs into the same wall, tripling the wait
-// before the analyst sees the same error.
-const NON_RETRYABLE_KINDS = new Set<ProviderErrorKind>(["auth", "rate_limit", "timeout"]);
-
-function isRetryableError(err: unknown): boolean {
-  // An approval gate is not a transient failure. Retrying it re-runs the Presidio scan and delays
-  // the 409 the analyst is waiting on, so surface it on the first throw.
-  if (err instanceof PresidioApprovalRequired) return false;
-  return !(err instanceof ProviderError && NON_RETRYABLE_KINDS.has(err.kind));
-}
-
-async function withRetry<T>(
-  fn: () => Promise<T>,
-  retries: number,
-  backoffMs: number,
-  onError?: (err: unknown, attempt: number, willRetry: boolean) => void,
-): Promise<T> {
-  let attempt = 0;
-  for (;;) {
-    try {
-      return await fn();
-    } catch (err) {
-      const willRetry = attempt < retries && isRetryableError(err);
-      onError?.(err, attempt, willRetry);
-      if (!willRetry) throw err;
-      await new Promise((r) => setTimeout(r, backoffMs * 2 ** attempt));
-      attempt++;
-    }
-  }
-}
-
-/**
- * How many raw super-timeline rows viewSummary may read in one call (#384).
- *
- * Was 10,000. That is more than a model can usefully summarise and far more than the analyst can
- * check, and it made the one sanctioned exception to the forensic/super-timeline rule the widest
- * path into the raw record in the codebase. A few hundred rows is enough for "what am I looking
- * at?" and small enough that the answer stays reviewable.
- */
-export const VIEW_SUMMARY_MAX_ROWS = 500;
+import { uniqueProviderModels } from "./analysisRunRecorders.js";
+import { type HypothesisReviewItem } from "./hypothesis.js";
 
 export class AnalysisPipeline {
   private readonly log: Logger;
@@ -448,13 +91,27 @@ export class AnalysisPipeline {
    * pipeline the entire options bag -- the AI providers, every store, every tuning knob. A boundary
    * that has to widen the class to exist is not much of a boundary.
    *
-   * This adapter closes over the five permitted operations instead, so the class members stay
-   * private and the importers still see nothing beyond what ImportContext declares. `opts` is
-   * exposed through getters rather than a snapshot because the settings-reload path rebuilds live
-   * options in place; a copy taken at construction would go stale the first time an operator saved
-   * a setting.
+   * This adapter closes over the permitted operations instead, so the class members stay private
+   * and the importers still see nothing beyond what ImportContext declares. `opts` is exposed
+   * through getters rather than a snapshot because the settings-reload path rebuilds live options
+   * in place; a copy taken at construction would go stale the first time an operator saved a
+   * setting.
+   *
+   * Down to three operations since #418 moved the two shared import tails — `noteEmptyImport` and
+   * `persistPlasoParsed` — into `ingest/importState.ts`, where their only callers already live.
    */
   private readonly importCtx: ImportContext;
+
+  /**
+   * The same adapter idea, for the AI-backed families extracted in #418.
+   *
+   * One object, several narrower views of it: `ai/caseReports.ts` takes a CaseReportContext,
+   * `ai/analystQueries.ts` an AnalystQueryContext, and so on. Each interface declares only the
+   * members that family may touch, so a report cannot reach the hypothesis store simply because
+   * hypothesisReview needs it. Live getters rather than a snapshot for the reason importCtx gives:
+   * the settings-reload path rebuilds these options in place.
+   */
+  private readonly aiCtx: CaseReportContext & AnalystQueryContext & ViewReportContext & HuntContext & PromptBlockContext & ExtractionContext & SynthesisContext & SecondOpinionContext;
 
   constructor(private readonly opts: PipelineOptions) {
     this.log = opts.logger ?? createConsoleLogger(normalizeLogLevel(process.env.DFIR_LOG_LEVEL));
@@ -469,8 +126,64 @@ export class AnalysisPipeline {
       },
       withStateLock: (caseId, fn) => this.withStateLock(caseId, fn),
       mergeWithAliases: (state, delta, ctx) => this.mergeWithAliases(state, delta, ctx),
-      noteEmptyImport: (caseId, o, kind, total) => this.noteEmptyImport(caseId, o, kind, total),
-      persistPlasoParsed: (caseId, parsed, o) => this.persistPlasoParsed(caseId, parsed, o),
+    };
+    this.aiCtx = {
+      opts: {
+        get synthesisProvider() { return opts.synthesisProvider; },
+        get stateStore() { return opts.stateStore; },
+        get falsePositiveStore() { return opts.falsePositiveStore; },
+        get scopeStore() { return opts.scopeStore; },
+        get superTimelineStore() { return opts.superTimelineStore; },
+        get hypothesisStore() { return opts.hypothesisStore; },
+        get velociraptorProvider() { return opts.velociraptorProvider; },
+        get huntOutcomeStore() { return opts.huntOutcomeStore; },
+        get importMetaStore() { return opts.importMetaStore; },
+        get provider() { return opts.provider; },
+        get imageLoader() { return opts.imageLoader; },
+        get onState() { return opts.onState; },
+        get anonStore() { return opts.anonStore; },
+        get customEntitiesStore() { return opts.customEntitiesStore; },
+        get discoveredStore() { return opts.discoveredStore; },
+        get ocrRunner() { return opts.ocrRunner; },
+        get presidio() { return opts.presidio; },
+        get presidioPendingStore() { return opts.presidioPendingStore; },
+        get presidioScanCapsOverride() { return opts.presidioScanCapsOverride; },
+        get aiCostStore() { return opts.aiCostStore; },
+        get operationalMetrics() { return opts.operationalMetrics; },
+        get correlationProfileStore() { return opts.correlationProfileStore; },
+        get sourceTrustStore() { return opts.sourceTrustStore; },
+        get clockSkewStore() { return opts.clockSkewStore; },
+        get notebookStore() { return opts.notebookStore; },
+        get aiControlStore() { return opts.aiControlStore; },
+        get playbookStore() { return opts.playbookStore; },
+        get incidentTypeStore() { return opts.incidentTypeStore; },
+        get learnedPatternStore() { return opts.learnedPatternStore; },
+        get secondOpinionStore() { return opts.secondOpinionStore; },
+        get secondOpinionProvider() { return opts.secondOpinionProvider; },
+        get secondOpinionModelLabel() { return opts.secondOpinionModelLabel; },
+        get synthesisModelLabel() { return opts.synthesisModelLabel; },
+        get synthMetaStore() { return opts.synthMetaStore; },
+        get analysisRunStore() { return opts.analysisRunStore; },
+        get stateLock() { return opts.stateLock; },
+        get onSynth() { return opts.onSynth; },
+        get retries() { return opts.retries; },
+        get backoffMs() { return opts.backoffMs; },
+      },
+      log: this.log,
+      requireProvider: (purpose) => this.requireProvider(purpose),
+      withStateLock: (caseId, fn) => this.withStateLock(caseId, fn),
+      mergeWithAliases: (state, delta, c) => this.mergeWithAliases(state, delta, c),
+      warnOnPromptDrift: () => this.warnOnPromptDrift(),
+      lastSynthHash: this.lastSynthHash,
+      recordImportTruncation: (caseId, stats) => {
+        if (stats) this.importTruncation.set(caseId, stats);
+        else this.importTruncation.delete(caseId);
+      },
+      getKevCatalog: () => this.getKevCatalog(),
+      withRetry: (caseId, label, fn, retries, backoffMs) => this.withRetry(caseId, label, fn, retries, backoffMs),
+      analyzeRestored: (caseId, state, provider, req, label, skipPresidioGate) =>
+        analyzeRestored(this.aiCtx, caseId, state, provider, req, label, skipPresidioGate),
+      promoteSuperTimeline: (caseId, events, o) => this.promoteSuperTimeline(caseId, events, o),
     };
   }
 
@@ -515,27 +228,6 @@ export class AnalysisPipeline {
     });
   }
 
-  private async analyzeProvider(provider: AIProvider, req: AnalyzeRequest, label: string): Promise<AnalyzeResult> {
-    const startedAt = Date.now();
-    try {
-      const result = await provider.analyze(req);
-      const usage = result.usage;
-      void this.opts.operationalMetrics?.record({
-        type: "ai", phase: safeAiPhase(label), durationMs: Date.now() - startedAt,
-        success: true, inputTokens: usage?.inputTokens ?? 0, outputTokens: usage?.outputTokens ?? 0,
-        costUsd: usage?.costUSD ?? 0, errorKind: "none",
-      });
-      return result;
-    } catch (error) {
-      void this.opts.operationalMetrics?.record({
-        type: "ai", phase: safeAiPhase(label), durationMs: Date.now() - startedAt,
-        success: false, inputTokens: 0, outputTokens: 0, costUsd: 0,
-        errorKind: safeAiErrorKind(error instanceof ProviderError ? error.kind : "other"),
-      });
-      throw error;
-    }
-  }
-
   /**
    * Measure per-host clock skew (#228) from the PRE-merge timeline and persist it, then return the
    * time function correlation should compare at — skew-corrected when the analyst has alignment on,
@@ -544,25 +236,6 @@ export class AnalysisPipeline {
    * Detection is best-effort: a case with no clock-skew store, or one whose evidence yields no
    * anchors, simply correlates on recorded times exactly as before.
    */
-  private async detectSkew(
-    caseId: string,
-    preMerge: ForensicEvent[],
-    opts: CorrelateOptions,
-  ): Promise<((e: ForensicEvent) => number | undefined) | undefined> {
-    const store = this.opts.clockSkewStore;
-    if (!store) return undefined;
-    let record;
-    try {
-      const report = detectClockSkew(correlationGroups(preMerge, { ...opts, crossHostArtifacts: true }), opts);
-      record = await store.recordDetection(caseId, report);
-    } catch {
-      try { record = await store.load(caseId); } catch { return undefined; }
-    }
-    if (!record.alignEnabled) return undefined;
-    const offsets = effectiveOffsets(record.results, record.overrides);
-    if (offsets.size === 0) return undefined;
-    return (e: ForensicEvent) => alignedEpoch(e, offsets);
-  }
 
   private async getKevCatalog(): Promise<KevCatalog | undefined> {
     if (!this.opts.kevStore) return undefined;
@@ -603,242 +276,9 @@ export class AnalysisPipeline {
     return this.opts.provider;
   }
 
-  // Apply per-case prompt/image anonymization in memory, then restore parsed JSON before schema
-  // validation so real values containing JSON metacharacters cannot corrupt parsing.
-  private async analyzeRestored(
-    caseId: string,
-    state: InvestigationState,
-    provider: AIProvider,
-    req: AnalyzeRequest,
-    label = "ai",
-    skipPresidioGate = false,
-  ): Promise<unknown> {
-    const control = this.opts.anonStore ? await this.opts.anonStore.load(caseId) : null;
-    const policy = toAnonPolicy(control);
-    this.log.debug(
-      `AI call [${label}] provider=${provider.name} images=${req.images.length} ` +
-        `promptChars=${req.userPrompt.length} anonymize=${policy.enabled ? "on" : "off"}`,
-      { caseId },
-    );
-    if (!policy.enabled) {
-      const result = await this.analyzeProvider(provider, req, label);
-      this.logAiUsage(caseId, label, provider, result);
-      await this.recordAiCost(caseId, label, provider, result);
-      return parseJsonLoose(result.rawText);
-    }
-    const known = deriveKnownEntities(state);
-    const custom = this.opts.customEntitiesStore ? await this.opts.customEntitiesStore.load(caseId) : [];
-    // Auto-discovered screenshot entities are tokenized too; suppressed ones are never tokenized.
-    const disc = this.opts.discoveredStore ? await this.opts.discoveredStore.load(caseId) : { discovered: [], suppressed: [] };
-    known.custom = [...custom, ...disc.discovered];
-    known.suppressed = disc.suppressed;
-    const anon = createAnonymizer(policy, known);
-    this.log.debug(`anonymized prompt before [${label}] AI call`, { caseId });
-
-    // OCR-discovered entities to persist into the case's auto-discovery list after this pass.
-    const discoveredFromOcr: CustomEntity[] = [];
-
-    // OCR-redact image buffers when an external-provider runner is configured.
-    let images = req.images;
-    if (this.opts.ocrRunner && images.length > 0) {
-      const runner = this.opts.ocrRunner;
-      // DFIR_OCR_DEBUG forces the per-image detail to INFO (always shown); otherwise it is a
-      // DEBUG line, surfaced when DFIR_LOG_LEVEL=debug or the dashboard's Logging toggle is on.
-      const forceInfo = !!process.env.DFIR_OCR_DEBUG;
-      const dumpDir = process.env.DFIR_OCR_DEBUG_DIR;      // write the redacted copy for inspection
-      const count = images.length;
-      let totalRedactions = 0;
-      let redactedImages = 0;
-      let publicIpsBoxed = 0;
-      images = await Promise.all(
-        images.map(async (img, i) => {
-          try {
-            const buf = Buffer.from(img.base64, "base64");
-            const res = await ocrRedactImage(buf, policy, known, runner);
-            if (res.discovered.length) discoveredFromOcr.push(...res.discovered);
-            if (res.changed) {
-              redactedImages++;
-              totalRedactions += res.redactions.length;
-              publicIpsBoxed += res.redactions.filter(
-                (w) => isMaskableIpv4(w.text.trim()) && !isInternalIp(w.text.trim()),
-              ).length;
-              if (dumpDir) await dumpRedactedImage(dumpDir, caseId, i, img.mimeType, res.buffer);
-            }
-            const matched = res.redactions.map((w) => w.text).join(", ");
-            const line =
-              `[OCR] image ${i + 1}/${count}: read ${res.wordCount} word(s), ` +
-              `redacted ${res.redactions.length}${matched ? ` [${matched}]` : ""}`;
-            if (forceInfo) this.log.info(line, { caseId });
-            else this.log.debug(line, { caseId });
-            return res.changed ? { ...img, base64: res.buffer.toString("base64") } : img;
-          } catch (err) {
-            // OCR failure is non-fatal — log and forward the original image.
-            this.log.warn(`[OCR redact] ${(err as Error).message}`, { caseId });
-            return img;
-          }
-        }),
-      );
-      // Always-on confirmation that the OCR pre-pass ran (vs. images going to the model
-      // unredacted because anon is off or the provider is local). One line per analyze call.
-      this.log.info(
-        `[OCR] redaction ran on ${count} screenshot(s) — scrubbed ` +
-          `${totalRedactions} word(s) across ${redactedImages} image(s) before sending to the model`,
-        { caseId },
-      );
-      if (publicIpsBoxed > 0) {
-        this.log.warn(
-          `[OCR] ${publicIpsBoxed} public IP(s) were blacked out of the screenshot(s). Image ` +
-            `redaction is one-way, so these will NOT be extracted as IOCs from this capture.`,
-          { caseId },
-        );
-      }
-      // Feed what OCR tokenized back into the case's auto-discovery list (dedupe/suppress handled
-      // by the store). Best-effort — a write failure must not fail the analysis.
-      if (this.opts.discoveredStore && discoveredFromOcr.length > 0) {
-        try {
-          const added = await this.opts.discoveredStore.addDiscovered(caseId, discoveredFromOcr);
-          this.log.debug(`[OCR] auto-discovery now holds ${added.discovered.length} entit(y/ies)`, { caseId });
-        } catch (err) {
-          this.log.warn(`[OCR] could not persist discovered entities: ${(err as Error).message}`, { caseId });
-        }
-      }
-    }
-
-    // Mask FIRST, then let Presidio look at the result. It never sees a real hostname, IP,
-    // username, email, SID or secret — only what our own detectors could not find.
-    const maskedPrompt = anon.apply(req.userPrompt);
-    // Import call sites (analyzeCsv/analyzeLog) pre-scan the WHOLE payload once, up front, and
-    // pass skipPresidioGate=true so the loop that calls this per-chunk doesn't re-gate (and
-    // re-approve) the same import one chunk at a time.
-    if (!skipPresidioGate) await this.presidioGate(caseId, maskedPrompt, known);
-
-    const result = await this.analyzeProvider(provider, { ...req, userPrompt: maskedPrompt, images }, label);
-    this.logAiUsage(caseId, label, provider, result);
-    await this.recordAiCost(caseId, label, provider, result);
-    return anon.restoreDeep(parseJsonLoose(result.rawText));
-  }
-
   /** Scan already-masked text with Presidio; fail closed on a scan error or unapproved value. */
-  private async presidioGate(caseId: string, maskedText: string, known: KnownEntities): Promise<void> {
-    const presidio = this.opts.presidio;
-    if (!presidio) return;
-
-    let raw;
-    try {
-      raw = await presidio.client.analyze(maskedText);
-    } catch (err) {
-      throw new Error(
-        `Presidio is enabled but the scan at ${presidio.url} failed (not reachable, or returned an ` +
-          `unusable response): ${(err as Error).message}. Start the container or clear ` +
-          `DFIR_PRESIDIO_URL to disable the layer.`,
-      );
-    }
-
-    const found = mapFindings(raw, presidio.minScore);
-    if (found.length === 0) return;
-
-    // known.suppressed is DOCUMENTED as pre-lowercased (anonDiscovered.ts) and both writers
-    // enforce it today, but that invariant is easy to violate at a distance and this is the
-    // load-bearing case: a suppressed value is deliberately left UNMASKED, so Presidio sees it
-    // raw on every single call. A case-fold mismatch here would re-trigger the approval gate
-    // forever on a value the analyst already vetoed. Lower-case defensively rather than trust it.
-    const alreadyKnown = new Set<string>([
-      ...(known.custom ?? []).map((e) => e.value.toLowerCase()),
-      ...(known.suppressed ?? []).map((s) => s.toLowerCase()),
-    ]);
-    const fresh = found.filter((e) => !alreadyKnown.has(e.value.toLowerCase()));
-    if (fresh.length === 0) return;
-
-    this.log.warn(
-      `[presidio] ${fresh.length} new PII value(s) need approval before this case can call the AI`,
-      { caseId },
-    );
-    await this.opts.presidioPendingStore?.save(caseId, fresh);
-    throw new PresidioApprovalRequired(fresh);
-  }
-
-  // Presidio's /analyze cannot take an arbitrarily large body, and a big CSV would be many
-  // requests. These bound it. They are module constants rather than env vars to keep the
-  // settings surface small — the truncation is logged, so hitting the cap is visible.
-  //
-  // NAMED "_CHARS", NOT "_BYTES": both are compared against JS string .length, which counts
-  // UTF-16 code units, not UTF-8 bytes. For non-ASCII PII (Hebrew, Cyrillic, accented names —
-  // all plausible in a DFIR case) that undercounts real UTF-8 size by up to ~3-4x, so the
-  // effective request-size cap is larger than a "_BYTES" name would imply. Left as a rough
-  // request-size bound rather than switched to a real byte measure (e.g. Buffer.byteLength)
-  // because the cap only needs to keep /analyze requests reasonably sized, not hit an exact
-  // number — and the split/truncate arithmetic below is unit-tested against character counts.
-  private static readonly PRESIDIO_SCAN_CHUNK_CHARS = 50_000;
-  private static readonly PRESIDIO_SCAN_MAX_CHARS = 5_000_000;
 
   /** Scan one complete masked import up front so batched CSV/log analysis needs one approval round. */
-  private async presidioPreScan(caseId: string, text: string, known: KnownEntities, anon: Anonymizer): Promise<void> {
-    const presidio = this.opts.presidio;
-    if (!presidio) return;
-
-    // TEST-ONLY seam (see PipelineOptions.presidioScanCapsOverride) so a test can force the
-    // truncation path with a tiny budget instead of generating megabytes of synthetic text.
-    // Production never sets this; the caps default to the real, class-wide constants.
-    const chunkChars = this.opts.presidioScanCapsOverride?.chunkChars ?? AnalysisPipeline.PRESIDIO_SCAN_CHUNK_CHARS;
-    const maxChars = this.opts.presidioScanCapsOverride?.maxChars ?? AnalysisPipeline.PRESIDIO_SCAN_MAX_CHARS;
-
-    // Mask FIRST, same as analyzeRestored — Presidio only ever sees already-scrubbed text.
-    const masked = anon.apply(text);
-    const scanned = masked.length > maxChars ? masked.slice(0, maxChars) : masked;
-    if (masked.length > maxChars) {
-      // A silent partial scan is worse than no scan: an analyst who sees "import scanned, no PII
-      // found" must be able to trust that claim. Name the unscanned character count so a
-      // truncated scan is never mistaken for a complete one.
-      this.log.warn(
-        `[presidio] import pre-scan truncated — ${masked.length - maxChars} character(s) of this ` +
-          `import were NOT scanned for PII (cap is ${maxChars} characters)`,
-        { caseId },
-      );
-    }
-
-    // Split on line boundaries so an entity is never cut in half across two /analyze requests.
-    const chunks: string[] = [];
-    let start = 0;
-    while (start < scanned.length) {
-      let end = Math.min(start + chunkChars, scanned.length);
-      if (end < scanned.length) {
-        const nl = scanned.lastIndexOf("\n", end);
-        if (nl > start) end = nl + 1;
-      }
-      chunks.push(scanned.slice(start, end));
-      start = end;
-    }
-
-    const all: PresidioFinding[] = [];
-    for (const chunk of chunks) {
-      try {
-        all.push(...(await presidio.client.analyze(chunk)));
-      } catch (err) {
-        throw new Error(
-          `Presidio is enabled but the scan at ${presidio.url} failed (not reachable, or returned ` +
-            `an unusable response): ${(err as Error).message}. Start the container or clear ` +
-            `DFIR_PRESIDIO_URL to disable the layer.`,
-        );
-      }
-    }
-
-    const found = mapFindings(all, presidio.minScore);
-    if (found.length === 0) return;
-
-    // Defensive lower-case on BOTH sides, same reasoning as presidioGate: known.suppressed is
-    // documented as pre-lowercased, but trusting that at a distance risks re-triggering approval
-    // forever on a value the analyst already vetoed.
-    const alreadyKnown = new Set<string>([
-      ...(known.custom ?? []).map((e) => e.value.toLowerCase()),
-      ...(known.suppressed ?? []).map((s) => s.toLowerCase()),
-    ]);
-    const fresh = found.filter((e) => !alreadyKnown.has(e.value.toLowerCase()));
-    if (fresh.length === 0) return;
-
-    this.log.warn(`[presidio] import pre-scan found ${fresh.length} new PII value(s) needing approval`, { caseId });
-    await this.opts.presidioPendingStore?.save(caseId, fresh);
-    throw new PresidioApprovalRequired(fresh);
-  }
 
   /**
    * Build the same (known entities, anonymizer) pair analyzeRestored derives per call, so an
@@ -846,49 +286,6 @@ export class AnalysisPipeline {
    * null when anonymization is off case-wide (mirrors analyzeRestored's own early return for
    * `!policy.enabled`) — with anonymization off there is no masked text for Presidio to see.
    */
-  private async buildImportAnonContext(caseId: string, state: InvestigationState): Promise<{ known: KnownEntities; anon: Anonymizer } | null> {
-    const control = this.opts.anonStore ? await this.opts.anonStore.load(caseId) : null;
-    const policy = toAnonPolicy(control);
-    if (!policy.enabled) return null;
-    const known = deriveKnownEntities(state);
-    const custom = this.opts.customEntitiesStore ? await this.opts.customEntitiesStore.load(caseId) : [];
-    const disc = this.opts.discoveredStore ? await this.opts.discoveredStore.load(caseId) : { discovered: [], suppressed: [] };
-    known.custom = [...custom, ...disc.discovered];
-    known.suppressed = disc.suppressed;
-    const anon = createAnonymizer(policy, known);
-    return { known, anon };
-  }
-
-  // Accumulate this call's tokens/cost into the case's running AI-cost totals (Settings →
-  // Diagnostics). Best-effort: a write failure here must never fail the underlying AI call.
-  private async recordAiCost(caseId: string, label: string, provider: AIProvider, result: AnalyzeResult): Promise<void> {
-    if (!this.opts.aiCostStore) return;
-    try {
-      await this.opts.aiCostStore.record(caseId, bucketForLabel(label), provider.name, provider.model, result.usage);
-    } catch (err) {
-      this.log.warn(`[ai-cost] could not record: ${(err as Error).message}`, { caseId });
-    }
-  }
-
-  // Log token usage at DEBUG after a provider call (surfaced with DFIR_LOG_LEVEL=debug).
-  private logAiUsage(caseId: string, label: string, provider: AIProvider, result: AnalyzeResult): void {
-    const u = result.usage;
-    if (!u) {
-      this.log.debug(`AI call [${label}] done provider=${provider.name} (no usage reported)`, { caseId });
-      return;
-    }
-    const cache =
-      (u.cacheReadTokens ? ` cacheRead=${u.cacheReadTokens}` : "") +
-      (u.cacheCreationTokens ? ` cacheWrite=${u.cacheCreationTokens}` : "");
-    // resolvedModel: the concrete model id actually served, when the provider reports one — e.g.
-    // claude-code's --model alias ("sonnet") resolves to "claude-sonnet-4-6" server-side; surfacing
-    // it here means DFIR_AI_SYNTH_MODEL=sonnet doesn't leave the exact version silently ambiguous.
-    const resolved = u.resolvedModel && u.resolvedModel !== provider.model ? ` resolvedModel=${u.resolvedModel}` : "";
-    this.log.debug(
-      `AI call [${label}] done provider=${provider.name} model=${provider.model}${resolved} in=${u.inputTokens ?? "?"} out=${u.outputTokens ?? "?"}${cache}`,
-      { caseId },
-    );
-  }
 
   // Hash of the last successfully-synthesized inputs per case. The live, debounced
   // synthesis fires after every capture window; this lets us skip the (expensive) AI call
@@ -921,2490 +318,274 @@ export class AnalysisPipeline {
     }
   }
 
-  async analyzeWindow(caseId: string, captures: CaptureMetadata[]): Promise<InvestigationState> {
-    const provider = this.requireProvider("screenshot analysis");
-    const analyzable = captures.filter((c) => !c.isDuplicate);
-    if (analyzable.length === 0) return this.opts.stateStore.load(caseId);
-
-    return this.withStateLock(caseId, async () => {
-      const state = await this.opts.stateStore.load(caseId);
-      const images = await Promise.all(
-        analyzable.map((c) => this.opts.imageLoader(caseId, c.screenshotFile)),
-      );
-      // Note: we deliberately do NOT put the capture time on these lines — the model
-      // would otherwise copy it into forensicEvents instead of reading the artifact's
-      // own timestamp column shown in the image.
-      const contextLines = analyzable
-        .map((c) => `Screenshot ${c.screenshotFile} — ${c.tabTitle} (${c.url})`)
-        .join("\n");
-      const userPrompt =
-        `${buildStateSummary(state)}\n\nNEW SCREENSHOTS (read each artifact's OWN timestamp column ` +
-        `for event times — do not use any capture/current time):\n${contextLines}\n\nReturn the JSON delta.`;
-
-      const retries = this.opts.retries ?? 3;
-      const backoffMs = this.opts.backoffMs ?? 500;
-
-      const delta = await this.withRetry(caseId, "extract", async () => {
-        const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getSystemPrompt(), userPrompt, images }, "extract");
-        return stripAiExtractedFrom(deltaSchema.parse(parsed));
-      }, retries, backoffMs);
-
-      const windowSequence = analyzable[analyzable.length - 1].sequenceNumber;
-      // Tag each event's source for correlation/corroboration: detect the real tool from the
-      // captured tab titles (e.g. "Velociraptor", "CrowdStrike Falcon"), else generic "screenshot".
-      const winSource = detectTool(analyzable.map((c) => c.tabTitle).join(" ")) ?? "screenshot";
-      const tagged = { ...delta, forensicEvents: (delta.forensicEvents ?? []).map((e) => ({ ...e, sources: e.sources?.length ? e.sources : [winSource] })) };
-      const next = await this.mergeWithAliases(state, tagged, {
-        windowSequence,
-        timestamp: analyzable[analyzable.length - 1].timestamp,
-        sourceScreenshots: analyzable.map((c) => c.screenshotFile),
-      });
-      await this.opts.stateStore.save(next);
-      this.opts.onState?.(next);
-      return next;
-    });
+  analyzeWindow(caseId: string, captures: CaptureMetadata[]): Promise<InvestigationState> {
+    return extraction.analyzeWindow(this.aiCtx, caseId, captures);
   }
 
-  // Import an uploaded CSV (e.g. a Velociraptor result export) as evidence: extract
-  // dated forensic events + IOCs from the rows, batch by batch, into the timeline —
-  // the same delta the screenshot path produces. Findings/TTPs/attacker-path come
-  // afterwards from synthesize() (call it after this resolves), exactly like capture.
-  async analyzeCsv(
-    caseId: string,
-    csvText: string,
-    opts: {
-      label: string;             // evidence label shown as the event source (stored filename)
-      idPrefix: string;          // unique per import (e.g. "m3") so event ids never collide
-      importedAt: string;        // ISO time used for timeline/firstSeen context
-      rowsPerBatch?: number;
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void | Promise<void>;
-      signal?: AbortSignal;      // #225: analyst cancel — aborts the in-flight AI call + stops between batches
-      startBatch?: number;
-    },
-  ): Promise<InvestigationState> {
-    // Text model (same idiom as ask/explain/synthesis): CSV extraction is text reasoning, not OCR.
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("CSV analysis");
-    const { headers, rows } = parseCsv(csvText);
-    if (rows.length === 0) return this.opts.stateStore.load(caseId);
-
-    const retries = this.opts.retries ?? 3;
-    const backoffMs = this.opts.backoffMs ?? 500;
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      let evSeq = lastImportEventSequence(state.forensicTimeline, opts.idPrefix);
-
-      // Scan the WHOLE import once, up front, instead of letting the per-chunk batches below hit
-      // presidioGate repeatedly (which would stall-approve-restart on a large CSV with names
-      // scattered through it). One approval round trip per import, not one per chunk.
-      //
-      // The scan covers the STATE SUMMARY as well as the payload, because every batch prompt
-      // below is `buildStateSummary(state) + csvChunk`, and every batch passes
-      // skipPresidioGate=true. Scanning csvText alone left the summary — finding titles and
-      // descriptions, open threads, the last 12 forensic events and every known IOC value, all
-      // RESTORED to real values — reaching the provider having never been seen by Presidio: a
-      // fail-OPEN in a layer whose contract is fail-closed.
-      if (this.opts.presidio) {
-        const importAnonCtx = await this.buildImportAnonContext(caseId, state);
-        if (importAnonCtx) await this.presidioPreScan(caseId, `${buildStateSummary(state)}\n${csvText}`, importAnonCtx.known, importAnonCtx.anon);
-      }
-
-      // Batch by BOTH the row cap and a token budget: wide rows (long EDR/SIEM command-lines)
-      // could otherwise pack 50 rows into a prompt that overflows the model context. Reserve
-      // room for the system prompt + the state-summary that's prepended to every batch.
-      const csvOverhead = estimateTokens(getCsvPrompt()) + estimateTokens(buildStateSummary(state))
-        + estimateTokens(chunkToCsvText(headers, [])) + 64;
-      const rowBudget = Math.max(0, inputTokenBudget() - csvOverhead);
-      const batches = batchByBudget(rows, opts.rowsPerBatch ?? 50, (r) => r.join(","), rowBudget);
-
-      for (let b = opts.startBatch ?? 0; b < batches.length; b++) {
-        if (opts.signal?.aborted) break;   // #225: cancelled — stop before the next batch, keep prior batches
-        const csvChunk = chunkToCsvText(headers, batches[b]);
-        const userPrompt =
-          `${buildStateSummary(state)}\n\nCSV ARTIFACT ROWS (source: ${opts.label}; batch ${b + 1}/${batches.length}). ` +
-          `Read each row's OWN time column for event times — do not use the current time:\n\n${csvChunk}\n\n` +
-          `Return the JSON delta.`;
-
-        const delta = await this.withRetry(caseId, "csv", async () => {
-          // skipPresidioGate=true: the pre-scan above already covered this whole import.
-          const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getCsvPrompt(), userPrompt, images: [], ...(opts.signal ? { signal: opts.signal } : {}) }, "csv", true);
-          return stripAiExtractedFrom(deltaSchema.parse(parsed));
-        }, retries, backoffMs);
-
-        // Renumber event ids so chunked imports don't overwrite each other (merge
-        // dedupes forensic events by id, and each batch independently emits e1, e2…).
-        const renumbered = {
-          ...delta,
-          forensicEvents: applySeverityFloor(delta.forensicEvents ?? [], opts.minSeverity).map((e) => ({ ...e, id: `${opts.idPrefix}e${++evSeq}`, sources: e.sources?.length ? e.sources : [detectTool(opts.label) ?? "CSV import"] })),
-        };
-
-        state = await this.mergeWithAliases(state, renumbered, {
-          windowSequence: -(b + 1), // negative: distinguishes import batches from capture windows
-          timestamp: opts.importedAt,
-          sourceScreenshots: [opts.label], // evidence traceability: the CSV file
-        });
-        await this.opts.stateStore.save(state);
-        this.opts.onState?.(state);
-        await opts.onProgress?.(b + 1, batches.length);
-      }
-      return state;
-    });
+  analyzeCsv(...args: AiExtractionArgs<typeof extraction.analyzeCsv>): Promise<InvestigationState> {
+    return extraction.analyzeCsv(this.aiCtx, ...args);
   }
 
-  // Import an uploaded generic log file (firewall logs, syslog, sshd, IIS, etc.)
-  // as evidence. Logs are mostly repetition, so we DEDUPLICATE deterministically
-  // first (aggregateLogLines collapses near-identical lines into counted patterns),
-  // then ask the model to triage the PATTERNS — emitting one aggregated forensic
-  // event only for the security-relevant ones and skipping routine noise. This
-  // keeps the timeline signal-rich and cuts the analysis to ~one AI call.
-  // Findings/TTPs/attacker-path come afterwards from synthesize().
-  async analyzeLog(
-    caseId: string,
-    logText: string,
-    opts: {
-      label: string;             // evidence label shown as the event source (stored filename)
-      idPrefix: string;          // unique per import (e.g. "l3") so event ids never collide
-      importedAt: string;        // ISO time used for timeline/firstSeen context
-      patternsPerBatch?: number; // how many distinct patterns to triage per AI call
-      minSeverity?: Severity;    // gate-aware import floor (unified Import button) — see applySeverityFloor
-      onProgress?: (done: number, total: number) => void | Promise<void>;
-      signal?: AbortSignal;      // #225: analyst cancel — aborts the in-flight AI call + stops between batches
-      startBatch?: number;
-    },
-  ): Promise<InvestigationState> {
-    // Text model (same idiom as ask/explain/synthesis): log triage is text reasoning, not OCR.
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("log analysis");
-    const { lines } = parseLogLines(logText);
-    if (lines.length === 0) return this.opts.stateStore.load(caseId);
-
-    // Collapse the raw lines into distinct, counted patterns (most frequent first). Capture the
-    // aggregation stats so a cap-hit (more distinct patterns than the AI could be shown) is flagged
-    // as a coverage blind spot by the import route (#10 trigger b).
-    const aggStats: AggregateStats = { distinctTemplates: 0, keptTemplates: 0 };
-    const maxTemplates = Number(process.env.DFIR_LOG_MAX_TEMPLATES) || undefined;   // else the built-in default
-    const templates = aggregateLogLines(lines, { maxTemplates }, aggStats);
-    if (aggStats.distinctTemplates > aggStats.keptTemplates) this.importTruncation.set(caseId, aggStats);
-    else this.importTruncation.delete(caseId);
-    const retries = this.opts.retries ?? 3;
-    const backoffMs = this.opts.backoffMs ?? 500;
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      let evSeq = lastImportEventSequence(state.forensicTimeline, opts.idPrefix);
-
-      // Scan the WHOLE import once, up front — see analyzeCsv for why this must precede the
-      // per-pattern batch loop below rather than living inside it, and why the state summary is
-      // scanned alongside the payload (every batch prompt below prepends it and skips the gate).
-      if (this.opts.presidio) {
-        const importAnonCtx = await this.buildImportAnonContext(caseId, state);
-        if (importAnonCtx) await this.presidioPreScan(caseId, `${buildStateSummary(state)}\n${logText}`, importAnonCtx.known, importAnonCtx.anon);
-      }
-
-      // Batch by BOTH the pattern cap and a token budget — a few patterns with very long
-      // examples shouldn't form a prompt that overflows the model context.
-      const renderPattern = (t: typeof templates[number]) =>
-        `×${t.count} ${t.firstTimestamp ?? ""} ${t.lastTimestamp ?? ""} ${t.example}`;
-      const logOverhead = estimateTokens(getLogPrompt()) + estimateTokens(buildStateSummary(state)) + 96;
-      const patternBudget = Math.max(0, inputTokenBudget() - logOverhead);
-      const batches = batchByBudget(templates, opts.patternsPerBatch ?? 120, renderPattern, patternBudget);
-
-      for (let b = opts.startBatch ?? 0; b < batches.length; b++) {
-        if (opts.signal?.aborted) break;   // #225: cancelled — stop before the next batch, keep prior batches
-        // Present each pattern with its occurrence count, time span, and an example.
-        const patternText = batches[b]
-          .map((t, i) =>
-            `[p${i + 1}] ×${t.count}` +
-            (t.firstTimestamp ? ` first=${t.firstTimestamp}` : "") +
-            (t.lastTimestamp && t.lastTimestamp !== t.firstTimestamp ? ` last=${t.lastTimestamp}` : "") +
-            `\n     e.g. ${t.example}`,
-          )
-          .join("\n");
-        const userPrompt =
-          `${buildStateSummary(state)}\n\nDEDUPLICATED LOG PATTERNS (source: ${opts.label}; ` +
-          `batch ${b + 1}/${batches.length}; ${lines.length} raw line(s) → ${templates.length} pattern(s)). ` +
-          `Emit an aggregated event ONLY for security-relevant patterns; skip routine noise:\n\n${patternText}\n\n` +
-          `Return the JSON delta.`;
-
-        const delta = await this.withRetry(caseId, "log", async () => {
-          // skipPresidioGate=true: the pre-scan above already covered this whole import.
-          const parsed = await this.analyzeRestored(caseId, state, provider, { systemPrompt: getLogPrompt(), userPrompt, images: [], ...(opts.signal ? { signal: opts.signal } : {}) }, "log", true);
-          return stripAiExtractedFrom(deltaSchema.parse(parsed));
-        }, retries, backoffMs);
-
-        const renumbered = {
-          ...delta,
-          forensicEvents: applySeverityFloor(delta.forensicEvents ?? [], opts.minSeverity).map((e) => ({ ...e, id: `${opts.idPrefix}e${++evSeq}`, sources: e.sources?.length ? e.sources : [detectTool(opts.label) ?? "Log import"] })),
-        };
-
-        state = await this.mergeWithAliases(state, renumbered, {
-          windowSequence: -(b + 1),
-          timestamp: opts.importedAt,
-          sourceScreenshots: [opts.label],
-        });
-        await this.opts.stateStore.save(state);
-        this.opts.onState?.(state);
-        await opts.onProgress?.(b + 1, batches.length);
-      }
-      return state;
-    });
+  analyzeLog(...args: AiExtractionArgs<typeof extraction.analyzeLog>): Promise<InvestigationState> {
+    return extraction.analyzeLog(this.aiCtx, ...args);
   }
 
-  // Record an import that parsed cleanly but contributed nothing.
-  //
-  // Every deterministic importer guards on "no events (and no IOCs) → return the state unchanged".
-  // That guard is correct — an empty delta must not be merged — but returning silently meant the
-  // file was 202-accepted, stored under `imports/`, and left NO trace in the case: the analyst had
-  // no way to tell "ingested and understood" from "silently dropped". On the northpeak benchmark
-  // that hid Zeek conn.json contributing zero events out of 75,951 records, the largest artifact in
-  // the case. A note costs one small timeline row and makes the outcome legible.
-  //
-  // `total` is the importer's own parsed-record count, so the note says how much was READ, not just
-  // that nothing came out — "0 events from 0 records" (wrong format) and "0 events from 75,951
-  // records" (understood but uninteresting) are very different problems.
-  private async noteEmptyImport(
-    caseId: string,
-    opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
-    kind: string,
-    total: number,
-  ): Promise<InvestigationState> {
-    const delta = deltaSchema.parse({
-      findings: [], iocs: [], mitreTechniques: [], forensicEvents: [],
-      threadsOpened: [], threadsClosed: [],
-      timelineNote: `${kind} import: no events from ${total} record(s) — nothing added to the case`,
-      summary: "",
-    });
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
-  }
-
-  // Import a THOR (Nextron) scanner report in JSON-Lines format. Unlike the CSV/log
-  // paths this is DETERMINISTIC — THOR's JSON is structured and stable, so each
-  // finding maps straight to a forensic event + IOCs with NO AI extraction call.
-  // Scan-lifecycle/info noise (module init, "Info" level) is dropped by default.
-  // Findings/attacker-path still come from a later synthesize().
   importThor(...args: ImporterArgs<typeof ingest.importThor>): Promise<InvestigationState> {
     return ingest.importThor(this.importCtx, ...args);
   }
 
-  // Import a SIEM / EDR JSON export (Elastic/Kibana, Splunk, an EDR console, a raw
-  // winlogbeat dump…). Like THOR, the mapping is DETERMINISTIC (no AI call): the
-  // container is unwrapped, Windows/Sysmon events get a per-EID mapping, other records
-  // fall back to field auto-detection, and repetitive events are aggregated. The
-  // detected tool name (from the filename / source) tags each event's `sources`.
   importSiem(...args: ImporterArgs<typeof ingest.importSiem>): Promise<InvestigationState> {
     return ingest.importSiem(this.importCtx, ...args);
   }
 
-  // Import Windows Event XML through the shared deterministic SIEM/EVTX mapping.
   importEvtxXml(...args: ImporterArgs<typeof ingest.importEvtxXml>): Promise<InvestigationState> {
     return ingest.importEvtxXml(this.importCtx, ...args);
   }
 
-  // Import a Linux/Unix shell history file (.bash_history / .zsh_history / …). Deterministic
-  // host-triage: one forensic event per command at the artifact's own time (bash HISTTIMEFORMAT
-  // `#<epoch>` / zsh extended history), Info by default with a conservative tradecraft bump. The
-  // account is derived from the filename and shown in each event.
   importBashHistory(...args: ImporterArgs<typeof ingest.importBashHistory>): Promise<InvestigationState> {
     return ingest.importBashHistory(this.importCtx, ...args);
   }
 
-  // Run a USER-authored declarative importer (the external plugin path). Mirrors the built-in
-  // deterministic wrappers exactly: parse -> severity floor -> standard delta (findings/MITRE empty,
-  // MITRE rides inside each event) -> mergeDelta -> save -> notify. Does NOT depend on any shared-runner
-  // refactor of the built-ins.
   importDeclarative(...args: ImporterArgs<typeof ingest.importDeclarative>): Promise<InvestigationState> {
     return ingest.importDeclarative(this.importCtx, ...args);
   }
 
-  // "Promote" copies already-imported super-timeline events UP into the forensic timeline so AI
-  // synthesis runs over them. The raw super-timeline is a complete record (incl. host-triage artifacts
-  // routed there exclusively) that is never synthesized; this is how the analyst pulls the events that
-  // matter into the analyzed timeline. Reuses mergeDelta (dedups forensic events by id) — a stored super
-  // event keeps its id, so a double-promote is a no-op. No AI here; the caller re-synthesizes.
   promoteSuperTimeline(...args: ImporterArgs<typeof ingest.promoteSuperTimeline>): Promise<InvestigationState> {
     return ingest.promoteSuperTimeline(this.importCtx, ...args);
   }
 
-  // Import Chainsaw (WithSecure) hunt output or a raw EVTX-as-JSON dump. Like THOR/SIEM
-  // the mapping is DETERMINISTIC (no AI call): the embedded EVTX events get the same
-  // per-EID Windows mapping as the SIEM import, and — for Chainsaw — the matched Sigma
-  // rule's level drives severity while its `attack.tXXXX` tags become MITRE techniques.
-  // Each event is tagged Chainsaw / EVTX as its source for cross-source correlation.
   importChainsaw(...args: ImporterArgs<typeof ingest.importChainsaw>): Promise<InvestigationState> {
     return ingest.importChainsaw(this.importCtx, ...args);
   }
 
-  // Import a Hayabusa (Yamato Security) detection timeline — JSON/JSONL or CSV. Like the
-  // other deterministic paths there is no AI call: the matched Sigma rule's level drives
-  // severity, its title leads the description, its tactics/tags become MITRE, and IOCs /
-  // asset / process-chain come from the rendered detail fields. Tagged Hayabusa as source.
   importHayabusa(...args: ImporterArgs<typeof ingest.importHayabusa>): Promise<InvestigationState> {
     return ingest.importHayabusa(this.importCtx, ...args);
   }
 
-  // Import Velociraptor native JSON output (collection results / hunt export). Like the
-  // other deterministic paths there is no AI call: each row is classified (Sigma / YARA /
-  // EventLog / generic) and mapped — detection rows are verdict-driven, the rest auto-detect
-  // the artifact's own time + IOCs. Every event is tagged Velociraptor as its source.
   importVelociraptor(...args: ImporterArgs<typeof ingest.importVelociraptor>): Promise<InvestigationState> {
     return ingest.importVelociraptor(this.importCtx, ...args);
   }
 
-  // Import ECAR — EDR Common Activity Record telemetry (NDJSON of (object, action) endpoint events).
-  // Deterministic (no AI call): maps each record's object/action/properties into a forensic event,
-  // reads `timestamp_ms`, scrapes PUBLIC IPs as IOCs, and keeps severity conservative (Info evidence,
-  // bumped only on real tradecraft) so high-volume raw telemetry doesn't flood the timeline. See
-  // ecarImport.ts for the mapping (and the lsass-access false-positive rationale).
   importEcar(...args: ImporterArgs<typeof ingest.importEcar>): Promise<InvestigationState> {
     return ingest.importEcar(this.importCtx, ...args);
   }
 
-  // Import an Apache/Nginx/Squid combined access log (web server or forward-proxy). Deterministic
-  // (no AI): raw web/proxy telemetry, Info by default with a conservative bump only for an
-  // access-denied response; git smart-HTTP clone/push tagged T1213. See combinedLogImport.ts.
   importCombinedLog(...args: ImporterArgs<typeof ingest.importCombinedLog>): Promise<InvestigationState> {
     return ingest.importCombinedLog(this.importCtx, ...args);
   }
 
-  // Import a Cisco ASA firewall syslog export. Deterministic (no AI): Built/Teardown telemetry
-  // stays Info, an explicit Deny bumps to Low, dynamic-NAT-translation noise is dropped,
-  // year-less timestamps are re-anchored by the mergeDelta year-clamp. See ciscoAsaImport.ts.
   importCiscoAsa(...args: ImporterArgs<typeof ingest.importCiscoAsa>): Promise<InvestigationState> {
     return ingest.importCiscoAsa(this.importCtx, ...args);
   }
 
-  // Import a Snort / Suricata "fast" alert log — a real IDS verdict feed. Deterministic (no AI):
-  // severity is the rule's Priority verdict, public src/dst IPs become IOCs, year-less timestamps are
-  // re-anchored by the mergeDelta year-clamp. See snortImport.ts.
   importSnort(...args: ImporterArgs<typeof ingest.importSnort>): Promise<InvestigationState> {
     return ingest.importSnort(this.importCtx, ...args);
   }
 
-  // Import YARA CLI scan output (`yara -s -m <rules> <target>`). Deterministic (no AI): each rule
-  // match becomes a file-match event (default Medium, bumped only on an explicit rule-meta signal),
-  // matched file + hash meta become IOCs. YARA output is undated, so mergeDelta stamps events at import
-  // time. Used by the external-tools run path (#211). See yaraImport.ts.
   importYara(...args: ImporterArgs<typeof ingest.importYara>): Promise<InvestigationState> {
     return ingest.importYara(this.importCtx, ...args);
   }
 
-  // Import a plain Linux/Unix syslog export (RFC 5424 / RFC 3164). Deterministic (no AI): host
-  // telemetry stays Info, an auth-failure or crit/alert/emerg PRI bumps to Low, the host is carried
-  // as the event's asset, RFC-3164 year-less timestamps are re-anchored by the mergeDelta year-clamp.
-  // See syslogImport.ts.
   importSyslog(...args: ImporterArgs<typeof ingest.importSyslog>): Promise<InvestigationState> {
     return ingest.importSyslog(this.importCtx, ...args);
   }
 
-  // Import network-monitor logs — Suricata `eve.json` and Zeek JSON (Security Onion's
-  // network side). Deterministic (no AI call): the timeline is built from the detections
-  // (Suricata alerts + Zeek notices); surrounding telemetry (dns/http/tls/files/conn)
-  // contributes IOCs only. Events are tagged Suricata / Zeek.
   importNetwork(...args: ImporterArgs<typeof ingest.importNetwork>): Promise<InvestigationState> {
     return ingest.importNetwork(this.importCtx, ...args);
   }
 
-  // Import SO-CRATES (dougburks/so-crates) verdicts — Suricata IDS alerts, YARA file matches, and
-  // Sigma log detections — as the browser extension pushes them (or a raw export). Deterministic
-  // (no AI). Events are tagged "SO-CRATES" (+ the underlying engine) for cross-source correlation.
   importSocrates(...args: ImporterArgs<typeof ingest.importSocrates>): Promise<InvestigationState> {
     return ingest.importSocrates(this.importCtx, ...args);
   }
 
-  // Import Security Onion Console (SOC) events — the Alerts / Hunt views the browser extension
-  // pushes. Deterministic (no AI call), verdict-first per the post-detection principle: the
-  // event's own `event.severity_label` drives severity, `rule.name` leads the description, ECS
-  // threat fields become MITRE, and source/destination IPs + app-layer fields become IOCs.
-  // Events are tagged "Security Onion".
   importSecurityOnion(...args: ImporterArgs<typeof ingest.importSecurityOnion>): Promise<InvestigationState> {
     return ingest.importSecurityOnion(this.importCtx, ...args);
   }
 
-  // Import a KAPE / Eric Zimmerman Tools CSV (Prefetch, Amcache, ShimCache, LNK, JumpLists,
-  // UsnJrnl, MFT, SRUM, Recycle Bin, Shellbags). Deterministic (no AI call): the EZ tool is
-  // detected from the CSV header, then each row maps to a forensic event reading the
-  // artifact's own time + file/hash/process IOCs. Events are tagged by artifact name.
   importKape(...args: ImporterArgs<typeof ingest.importKape>): Promise<InvestigationState> {
     return ingest.importKape(this.importCtx, ...args);
   }
 
-  // Import a Cyber Triage timeline export (JSONL / JSON array / CSV). Deterministic (no AI call):
-  // scored rows map verdict-first (severity from the Bad/Suspicious verdict + reason keywords),
-  // unscored process/task rows become Info evidence, the bulk File super-timeline is dropped
-  // (unless `fileTelemetry`), and Active-Connection remote IPs become IOCs. Events tagged
-  // "Cyber Triage".
   importCybertriage(...args: ImporterArgs<typeof ingest.importCybertriage>): Promise<InvestigationState> {
     return ingest.importCybertriage(this.importCtx, ...args);
   }
 
-  // Import Microsoft 365 Unified Audit Log + Entra ID (sign-in / directory audit) data.
-  // Deterministic (no AI call): each record is classified (UAL / sign-in / audit) and mapped,
-  // severity derived from the operation (BEC tradecraft) or Entra's own risk verdict; the
-  // source IP becomes an IOC and the UPN is surfaced for the asset graph.
   importM365(...args: ImporterArgs<typeof ingest.importM365>): Promise<InvestigationState> {
     return ingest.importM365(this.importCtx, ...args);
   }
 
-  // Import AWS CloudTrail logs. Deterministic (no AI call): each API-call record is mapped,
-  // severity derived from the action (IAM persistence, logging/detection tampering, S3
-  // exposure, secrets access) + denied/root/console-failure bumps; the caller IP → IOC.
   importAws(...args: ImporterArgs<typeof ingest.importAws>): Promise<InvestigationState> {
     return ingest.importAws(this.importCtx, ...args);
   }
 
-  // Import GCP Cloud Audit Logs + Azure Activity Log. Deterministic (no AI call): each record
-  // is routed (GCP / Azure) and mapped, severity derived from the action (+ denied bump); the
-  // caller IP → IOC and the principal email is surfaced for the asset graph.
   importCloudActivity(...args: ImporterArgs<typeof ingest.importCloudActivity>): Promise<InvestigationState> {
     return ingest.importCloudActivity(this.importCtx, ...args);
   }
 
-  // Import Kubernetes API-server audit logs (audit.k8s.io). Deterministic (no AI call): each audit
-  // Event → a forensic event whose severity is derived from the (verb, resource, subresource) tuple
-  // (pod exec/attach, secret access, RBAC change, privileged-pod create, anonymous access), Info by
-  // default. Source IP → IOC. Tagged Kubernetes Audit.
   importK8sAudit(...args: ImporterArgs<typeof ingest.importK8sAudit>): Promise<InvestigationState> {
     return ingest.importK8sAudit(this.importCtx, ...args);
   }
 
-  // Import osquery scheduled-query result logs (differential `columns` rows + `snapshot` sets).
-  // Deterministic (no AI call): Info-by-default endpoint telemetry, with a conservative tradecraft
-  // bump on a command-line column; columns → IOCs (path/hash/ip/process). Tagged osquery.
   importOsquery(...args: ImporterArgs<typeof ingest.importOsquery>): Promise<InvestigationState> {
     return ingest.importOsquery(this.importCtx, ...args);
   }
 
-  // Import a Plaso / log2timeline super-timeline (psort CSV — dynamic or l2tcsv). Deterministic
-  // (no AI call): each row is an Info evidence event read at its own time, with IOCs scraped
-  // from the message (hashes/URLs/IPs) and the source file path. Tagged Plaso.
   importPlaso(...args: ImporterArgs<typeof ingest.importPlaso>): Promise<InvestigationState> {
     return ingest.importPlaso(this.importCtx, ...args);
   }
 
-  // Streaming-from-disk Plaso import: for super-timelines too large to hold as one JS string (a
-  // 555 MB export EXCEEDS V8's ~512 MB max string length, so readFile(utf8) throws "Invalid string
-  // length"). Reads the file line-by-line via node:readline and feeds parsePlasoFromLines, which
-  // keeps memory bounded by the distinct-key set, not the row count. Same downstream merge as
-  // importPlaso. The route persists the evidence file separately (by copy, not as a string).
   importPlasoFile(...args: ImporterArgs<typeof ingest.importPlasoFile>): Promise<InvestigationState> {
     return ingest.importPlasoFile(this.importCtx, ...args);
   }
 
-  // Shared tail of both Plaso entry points: apply the severity floor, build the delta and merge it
-  // into the case state. (Keeping this in one place means the in-memory and streaming importers
-  // produce identical timeline rows / IOCs / notes.)
-  private async persistPlasoParsed(
-    caseId: string,
-    parsedRaw: PlasoParseResult,
-    opts: { label: string; idPrefix: string; importedAt: string; minSeverity?: Severity; onProgress?: (done: number, total: number) => void },
-  ): Promise<InvestigationState> {
-    const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
-    if (parsed.events.length === 0) return this.noteEmptyImport(caseId, opts, "Plaso", parsed.total);
-
-    const raw = {
-      findings: [],
-      iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
-      mitreTechniques: [],
-      forensicEvents: parsed.events.map((e, i) => ({
-        ...e, id: `${opts.idPrefix}e${i + 1}`, sources: e.sources?.length ? e.sources : ["Plaso"],
-      })),
-      threadsOpened: [],
-      threadsClosed: [],
-      timelineNote: `Plaso import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
-        (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-        `, ${parsed.iocs.length} IOC(s)`,
-      summary: "",
-    };
-    const delta = deltaSchema.parse(raw);
-
-    return this.withStateLock(caseId, async () => {
-      let state = await this.opts.stateStore.load(caseId);
-      state = await this.mergeWithAliases(state, delta, {
-        windowSequence: -1,
-        timestamp: opts.importedAt,
-        sourceScreenshots: [opts.label],
-      });
-      await this.opts.stateStore.save(state);
-      this.opts.onState?.(state);
-      opts.onProgress?.(1, 1);
-      return state;
-    });
-  }
-
-  // Import a Linux auditd log (raw audit.log / `ausearch` record format, or an `aureport` table).
-  // Deterministic (no AI call): records sharing a serial collapse into one logical event, mapped
-  // to severity/MITRE by record type (logins, account/group mgmt, sudo, SELinux denials, audit-config
-  // tampering), bumped on a failed auth or a suspicious command. Read at the audit() epoch. Tagged auditd.
   importAuditd(...args: ImporterArgs<typeof ingest.importAuditd>): Promise<InvestigationState> {
     return ingest.importAuditd(this.importCtx, ...args);
   }
 
-  // Import a systemd-journald structured log (`journalctl -o json` / `-o json-pretty`). Deterministic
-  // (no AI call): each entry is read at its own time (_SOURCE/__REALTIME µs epoch), severity derived
-  // from PRIORITY then bumped from the message (sshd auth, sudo, useradd, kernel), with IOCs scraped
-  // from _EXE/_COMM and the MESSAGE. Tagged journald.
   importJournald(...args: ImporterArgs<typeof ingest.importJournald>): Promise<InvestigationState> {
     return ingest.importJournald(this.importCtx, ...args);
   }
 
-  // Import a sysdig / Falco export (Falco alert JSON and/or sysdig `-j` event JSON). Deterministic
-  // (no AI call): Falco rule hits are the DETECTIONS (verdict-first: priority → severity, tags →
-  // MITRE) and surface on the timeline; raw sysdig syscall events are telemetry → Info evidence;
-  // both contribute proc/file/network IOCs. Tagged Falco / sysdig.
   importSysdig(...args: ImporterArgs<typeof ingest.importSysdig>): Promise<InvestigationState> {
     return ingest.importSysdig(this.importCtx, ...args);
   }
 
-  // Import Wazuh SIEM/EDR alert exports (alerts.json / NDJSON / API export). Deterministic
-  // (no AI call): rule.level drives severity (≥13 Critical, ≥10 High, ≥7 Medium, else Info),
-  // rule.mitre.technique → MITRE, agent.name → asset, data.srcip/dstip/md5/sha256/url → IOCs.
   importWazuh(...args: ImporterArgs<typeof ingest.importWazuh>): Promise<InvestigationState> {
     return ingest.importWazuh(this.importCtx, ...args);
   }
 
-  // Import a malware-sandbox detonation report (CAPEv2 or CrowdStrike Falcon Sandbox).
-  // Deterministic (no AI call): the sample verdict + each behavioural signature map to events
-  // (severity from the report's own score/verdict, MITRE from its ATT&CK), and every
-  // dropped/extracted file hash + network host/domain/URL is harvested as an IOC.
   importSandbox(...args: ImporterArgs<typeof ingest.importSandbox>): Promise<InvestigationState> {
     return ingest.importSandbox(this.importCtx, ...args);
   }
 
-  // Import memory-forensics tool output (Volatility 3 or Rekall). Deterministic (no AI call): each
-  // plugin table is identified by its columns and mapped — pslist/psscan/pstree → process-tree
-  // events (with parent→child links), netscan/netstat → network-connection events (+ foreign IP/
-  // port IOCs), malfind → High injected-code events (ATT&CK T1055), cmdline → command-line events
-  // (bumped on LOLBin/encoded tradecraft), svcscan/modules → service/driver evidence. Tagged
-  // "Volatility" / "Rekall" for cross-source correlation; reads the artifact's own time.
   importMemory(...args: ImporterArgs<typeof ingest.importMemory>): Promise<InvestigationState> {
     return ingest.importMemory(this.importCtx, ...args);
   }
 
-  // Import an email artifact (.eml RFC 2822, or best-effort .msg). Deterministic (no AI call):
-  // ONE forensic event dated at the message's own Date: header, severity DERIVED from the email's
-  // SPF/DKIM/DMARC verdict + sender heuristics; URLs, sender/reply-to domains, originating IP and
-  // attachment names/hashes become IOCs. Covers ATT&CK T1566 (Phishing). Tagged "Email".
   importEmail(...args: ImporterArgs<typeof ingest.importEmail>): Promise<InvestigationState> {
     return ingest.importEmail(this.importCtx, ...args);
   }
 
-  // Import a TheHive 5 case, alert, or observable export. Deterministic (no AI call):
-  // case/alert records → forensic events (severity from TheHive's own 1–4 scale, MITRE from
-  // ATT&CK-tagged tags, TLP/PAP labels prepended); observable records → IOCs by dataType.
   importTheHive(...args: ImporterArgs<typeof ingest.importTheHive>): Promise<InvestigationState> {
     return ingest.importTheHive(this.importCtx, ...args);
   }
 
-  // Import an existing DFIR-IRIS case (issue #88) — the reverse of the IRIS push. Takes the raw
-  // case rows already fetched from the IRIS API (analysis/irisImport.ts parses them deterministically,
-  // NO AI call): timeline → forensic events, IOCs → IOCs, assets → evidence events. All feed the
-  // same forensic timeline via mergeDelta, exactly like the other importers.
   importIris(...args: ImporterArgs<typeof ingest.importIris>): Promise<InvestigationState> {
     return ingest.importIris(this.importCtx, ...args);
   }
 
-  // Holistic pass: read the whole forensic timeline and produce findings, MITRE
-  // mapping, and the attacker-path narrative. Text-only (no images), one call.
-  // Answer a free-form analyst question about the case from its evidence (single-shot, no
-  // state change). Returns a grounded answer + status + collection guidance (`pointer`).
-  async ask(caseId: string, question: string): Promise<AskAnswer> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("case questions");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-
-    const max = maxPromptEvents();
-    let events = selectSynthesisEvents(scopedEvents, max);
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}`;
-    const findingsText = loaded.findings.slice(0, 150).map((f) => `[${f.id}] [${f.severity}] ${f.title}`).join("\n") || "(none)";
-    const questionsText = loaded.keyQuestions.map((q) => `- ${q.question}${q.answer ? ` → ${q.answer}` : " (open)"}`).join("\n") || "(none)";
-    const kevCatalog = await this.getKevCatalog();
-    const contextBlock = buildSynthesisContext(loaded, scopedEvents, kevCatalog);
-    // GraphRAG (#98): serialize the deterministic evidence-chain graph (causal edges) so the model
-    // can trace multi-hop attack paths via the graph's relationships, not just the flat timeline.
-    const graphMaxEdges = Number(process.env.DFIR_ASK_GRAPH_MAX_EDGES) || DEFAULT_MAX_GRAPH_EDGES;
-    const graphBlock = buildGraphContext({ ...loaded, forensicTimeline: scopedEvents }, { maxEdges: graphMaxEdges });
-
-    // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
-    const askOverhead = estimateTokens(getAskPrompt())
-      + estimateTokens(contextBlock + graphBlock + (loaded.attackerPath || "") + findingsText + questionsText + question) + 300;
-    const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - askOverhead));
-    if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
-    const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
-
-    const userPrompt =
-      contextBlock +
-      graphBlock +
-      `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
-      `FINDINGS:\n${findingsText}\n\n` +
-      `FORENSIC TIMELINE (${scopedEvents.length} in-scope events):\n${timelineText}\n\n` +
-      `CURRENT QUESTIONS:\n${questionsText}\n\n` +
-      `ANALYST QUESTION: ${question.trim()}\n\nAnswer it as JSON.`;
-
-    return this.withRetry(caseId, "ask", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getAskPrompt(), userPrompt, images: [] }, "ask");
-      return askSchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  // Everything below is a one-line delegation into src/analysis/ai/ (#418). Each method's
+  // documentation lives with its implementation there, so there is only ever one copy to keep true.
+  ask(caseId: string, question: string): Promise<AskAnswer> {
+    return analystQueries.ask(this.aiCtx, caseId, question);
   }
 
-  // Explain a single forensic event in context (issue #141). Single text-only AI call.
-  //
-  // NO LONGER EPHEMERAL, and that is the point. Asking about a raw super-timeline event PROMOTES it
-  // into the forensic timeline first, so the model still only ever reads the forensic record — the
-  // invariant forensicGate.ts states. Promotion is the same seam runSecondLook uses, and it is
-  // honest: clicking "explain this" is the analyst declaring the event interesting, which is
-  // precisely what the forensic timeline means. One event, recorded with a note saying why.
-  async explainEvent(caseId: string, eventId: string): Promise<ExplainEventResult> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("event explanation");
-    let loaded = await this.opts.stateStore.load(caseId);
-
-    let event = loaded.forensicTimeline.find((e) => e.id === eventId);
-    if (!event && this.opts.superTimelineStore) {
-      // TARGETED lookup, not a paged scan (#406). The previous `query(caseId, {})` returned only the
-      // first DEFAULT_SUPER_QUERY_LIMIT (500) rows and searched those, so explaining an event past
-      // row 500 threw "event not found" for an event that plainly existed.
-      const raw = await this.opts.superTimelineStore.get(caseId, eventId);
-      if (raw) {
-        loaded = await this.promoteSuperTimeline(caseId, [raw], {
-          importedAt: new Date().toISOString(),
-          note: `Promoted 1 raw event for "explain this event"`,
-        });
-        event = loaded.forensicTimeline.find((e) => e.id === eventId);
-      }
-    }
-    if (!event) throw new Error(`event not found: ${eventId}`);
-    // The universe is the forensic timeline, always — including the event just promoted into it.
-    const universe = loaded.forensicTimeline;
-
-    // Context: events adjacent in time + events on the same asset (up to 15 total).
-    const sorted = [...universe].sort((a, b) =>
-      (a.timestamp || "").localeCompare(b.timestamp || ""),
-    );
-    const focalIdx = sorted.findIndex((e) => e.id === eventId);
-    const nearby = [
-      ...sorted.slice(Math.max(0, focalIdx - 7), focalIdx),
-      ...sorted.slice(focalIdx + 1, focalIdx + 8),
-    ];
-    const sameAsset = event.asset
-      ? universe.filter((e) => e.id !== eventId && e.asset === event.asset).slice(0, 10)
-      : [];
-    const contextIds = new Set([...nearby.map((e) => e.id), ...sameAsset.map((e) => e.id)]);
-    const contextEvents = [...contextIds]
-      .map((id) => universe.find((e) => e.id === id)!)
-      .filter(Boolean)
-      .slice(0, 15);
-
-    const renderEv = (e: ForensicEvent, focal = false): string =>
-      `[${e.id}]${focal ? " *** FOCAL EVENT ***" : ""} ${e.timestamp || "(undated)"} [${e.severity}]`
-      + ` ${e.description.slice(0, 300)}`
-      + (e.asset ? ` | asset: ${e.asset}` : "")
-      + (e.processName ? ` | process: ${e.processName}` : "")
-      + (e.parentName ? ` | parent: ${e.parentName}` : "")
-      + (e.sha256 ? ` | sha256: ${e.sha256.slice(0, 16)}…` : "")
-      + (e.path ? ` | path: ${e.path}` : "")
-      + (e.mitreTechniques.length ? ` | MITRE: ${e.mitreTechniques.join(", ")}` : "");
-
-    const findingsText = loaded.findings.slice(0, 50)
-      .map((f) => `[${f.severity}] ${f.title}`).join("\n") || "(none)";
-    const kevCatalog = await this.getKevCatalog();
-    const contextBlock = buildSynthesisContext(loaded, [event, ...contextEvents], kevCatalog);
-
-    const userPrompt =
-      contextBlock
-      + `CASE FINDINGS (summary):\n${findingsText}\n\n`
-      + `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n`
-      + `FOCAL EVENT TO EXPLAIN:\n${renderEv(event, true)}\n\n`
-      + `CONTEXT EVENTS (nearby / same asset):\n`
-      + (contextEvents.map((e) => renderEv(e)).join("\n") || "(no context events)")
-      + `\n\nExplain the focal event as JSON.`;
-
-    return this.withRetry(caseId, "explain-event", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getExplainEventPrompt(), userPrompt, images: [] }, "explain-event");
-      return explainEventSchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  explainEvent(caseId: string, eventId: string): Promise<ExplainEventResult> {
+    return analystQueries.explainEvent(this.aiCtx, caseId, eventId);
   }
 
-  // The hunting feedback loop's prior-hunt outcomes for a case (#157) — [] when no store is wired
-  // (scripts/*) or the file is absent/corrupt, so the loop simply stays off without ever throwing.
-  private async loadHuntOutcomes(caseId: string): Promise<HuntOutcome[]> {
-    if (!this.opts.huntOutcomeStore) return [];
-    try {
-      return await this.opts.huntOutcomeStore.load(caseId);
-    } catch {
-      return [];
-    }
+  knownUnknownsForCase(caseId: string): Promise<KnownUnknownItem[]> {
+    return promptBlocks.knownUnknownsForCase(this.aiCtx, caseId);
   }
 
-  // Known-unknowns preamble (#165): the gaps in the story (silent windows, uncovered ATT&CK phases,
-  // the matched actors' likely-next techniques) so synthesis + hunts treat what's MISSING as open
-  // questions, not just what the evidence shows. Pure block; the offline adversary dataset is cached.
-  // Wrapped defensively — a known-unknowns failure must never break synthesis or hunt suggestions.
-  // The STRUCTURED known-unknowns for a case (investigation-guidance #9) — the SINGLE source the
-  // synthesis prompt block AND the GET /cases/:id/known-unknowns panel both consume, so the model and
-  // the analyst provably see the same gap list. Defensive: a failure here must never break synthesis.
-  private knownUnknownItems(state: InvestigationState, scopedEvents: ForensicEvent[], yieldWarning?: ImportYieldWarning | null): KnownUnknownItem[] {
-    try {
-      const hints = buildAdversaryHintsResult(state, loadAdversaryGroupsDataset(), adversaryHintEnvOptions());
-      // #230: the top playbook match, so an unobserved step of a chain the case otherwise follows
-      // becomes a named gap. Scored over the SCOPED events, exactly as the panel and report see them.
-      const playbook = buildPlaybookMatchResult(scopedEvents, loadKnownPlaybooks(), playbookMatchEnvOptions());
-      return buildKnownUnknownItems(state, scopedEvents, {
-        gapOptions: gapEnvOptions(),
-        nextTechniques: hints.nextTechniques,
-        playbookMatch: playbook.matches[0] ?? null,
-        yieldWarning,
-      });
-    } catch {
-      return [];
-    }
+  suggestHunts(caseId: string, opts?: { excludeVql?: string }): Promise<HuntSuggestion[]> {
+    return hunts.suggestHunts(this.aiCtx, caseId, opts);
   }
 
-  // The classified source-yield warning for the LAST import (investigation-guidance #10) — a large file
-  // that yielded ZERO events via AI triage (the northpeak blind spot). Defensive: null when no store,
-  // no import-meta, or nothing anomalous.
-  private async loadYieldWarning(caseId: string): Promise<ImportYieldWarning | null> {
-    if (!this.opts.importMetaStore) return null;
-    try {
-      return classifyImportYield(await this.opts.importMetaStore.load(caseId));
-    } catch {
-      return null;
-    }
+  suggestTechniqueHunts(caseId: string, techniqueId: string, techniqueName?: string): Promise<HuntSuggestion[]> {
+    return hunts.suggestTechniqueHunts(this.aiCtx, caseId, techniqueId, techniqueName);
   }
 
-  private async knownUnknownsBlock(state: InvestigationState, scopedEvents: ForensicEvent[], caseId: string): Promise<string> {
-    const max = Math.max(0, Number(process.env.DFIR_SYNTH_KNOWN_UNKNOWNS_MAX) || 10);
-    return renderKnownUnknowns(this.knownUnknownItems(state, scopedEvents, await this.loadYieldWarning(caseId)), max);
+  suggestMemoryNextSteps(caseId: string): Promise<MemoryNextStep[]> {
+    return nextSteps.suggestMemoryNextSteps(this.aiCtx, caseId);
   }
 
-  // Read-only: the structured evidence-gap items for a case (scope + false-positive filtered, exactly
-  // as synthesis sees them). Powers the "Evidence gaps" dashboard panel and the report section.
-  async knownUnknownsForCase(caseId: string): Promise<KnownUnknownItem[]> {
-    const loaded = await this.opts.stateStore.load(caseId);
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-    return this.knownUnknownItems(loaded, scopedEvents, await this.loadYieldWarning(caseId));
+  translateQuery(caseId: string, request: string, platforms?: readonly HuntPlatform[]): Promise<QueryTranslationResult> {
+    return hunts.translateQuery(this.aiCtx, caseId, request, platforms);
   }
 
-  // Candidate-threat-actor preamble (#165), OFF by default (DFIR_SYNTH_ADVERSARY_HINTS). Feeds the
-  // technique-overlap hints (already shown in the report) into synthesis as LOW-CONFIDENCE candidates.
-  // Gated because feeding model-derived attribution back into the model is a confirmation-bias loop;
-  // labelled "NOT attribution". Pure + cached dataset; defensive — never breaks synthesis.
-  private adversaryHintBlock(state: InvestigationState): string {
-    if (!/^(1|true|on|yes)$/i.test(process.env.DFIR_SYNTH_ADVERSARY_HINTS ?? "")) return "";
-    try {
-      const r = buildAdversaryHintsResult(state, loadAdversaryGroupsDataset(), adversaryHintEnvOptions());
-      if (!r.hints.length) return "";
-      const top = r.hints.slice(0, 5).map((h) => `${h.name} (${h.overlapCount}/${h.groupTechniqueCount} techniques)`).join(", ");
-      return `CANDIDATE THREAT ACTORS (technique-overlap hypothesis, NOT attribution — ${r.caveat}): ${top}\n\n`;
-    } catch {
-      return "";
-    }
+  suggestTaggerRule(caseId: string, description: string): Promise<SuggestOutcome> {
+    return nextSteps.suggestTaggerRule(this.aiCtx, caseId, description);
   }
 
-  // Drop any suggestion whose VQL was already deployed in this case (#157) — the deterministic guarantee
-  // that a hunt the analyst already ran is never re-proposed (the "PRIOR HUNTS" prompt block is the soft
-  // signal; this is the hard one). Bundles contribute no fingerprint, so they never exclude a suggestion.
-  private excludeDeployedHunts<T extends { vql: string }>(suggestions: T[], outcomes: readonly HuntOutcome[]): T[] {
-    const fps = deployedFingerprints(outcomes);
-    if (!fps.size) return suggestions;
-    return suggestions.filter((s) => !fps.has(vqlFingerprint(s.vql)));
+  hypothesizeGaps(caseId: string): Promise<GapHypothesesResult> {
+    return nextSteps.hypothesizeGaps(this.aiCtx, caseId);
   }
 
-  // Propose proactive Velociraptor VQL fleet-hunts from the synthesized findings (issue #57).
-  // Single text-only AI call; EPHEMERAL like ask()/executiveSummary() — it does NOT mutate state.
-  // The analyst reviews each hunt's VQL + rationale, then one-click deploys it through the existing
-  // launchHunt flow (POST /velociraptor/hunt). Returns [] without an AI call on an empty case.
-  async suggestHunts(caseId: string, opts?: { excludeVql?: string }): Promise<HuntSuggestion[]> {
-    const provider = this.opts.velociraptorProvider ?? this.opts.synthesisProvider ?? this.requireProvider("hunt suggestions");
-    const loaded = await this.opts.stateStore.load(caseId);
-    if (!hasHuntMaterial(loaded)) return [];   // nothing to pivot on — don't spend a call
-
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-
-    const max = maxPromptEvents();
-    let events = selectSynthesisEvents(scopedEvents, max);
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.timestamp || "(undated)"}] [${e.severity}] ${e.description.slice(0, 240)}`;
-    const findingsText = renderHuntFindings(loaded.findings);
-    const iocText = renderHuntIocs(loaded.iocs);
-    const techText = loaded.mitreTechniques.map((t) => `${t.id} ${t.name}`).join(", ") || "(none)";
-    const kevCatalog = await this.getKevCatalog();
-    const contextBlock = buildSynthesisContext(loaded, scopedEvents, kevCatalog);
-    // Causal grounding (#124): serialize the deterministic evidence-chain graph — process spawn
-    // chains, file lineage, lateral-movement edges — so the model hunts the RELATIONSHIP (the
-    // parent→child chain, the binary/account that moved between hosts) fleet-wide, not just the leaf
-    // indicator. The flat timeline drops processName/parentName; the graph carries them. Built from
-    // the SAME scoped+legitimate-filtered events as the rest of the prompt; "" when there are no edges.
-    // Capped at the shared default (the timeline trim below absorbs the block into the prompt budget).
-    const graphBlock = buildGraphContext({ ...loaded, forensicTimeline: scopedEvents }, { maxEdges: DEFAULT_MAX_GRAPH_EDGES });
-
-    // Feedback loop (#157): the prior hunts already run in this case (what hit / what missed), so the
-    // model proposes follow-ups that pivot on productive hunts and avoids repeating dead ones. "" when
-    // there are no recorded outcomes (or no store wired). Also drives the deterministic exclusion below.
-    const outcomes = await this.loadHuntOutcomes(caseId);
-    const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
-    // Productivity tuning (#72): the aggregate hit-rate by pivot class (hash/process/path/network/
-    // registry) across this case's hunt history, so the model biases toward classes that have found
-    // evidence rather than only avoiding exact repeats (priorHuntsBlock is the per-hunt signal; this
-    // is the aggregate one). "" until there's collected history to bias on.
-    const productivityBlock = renderHuntProductivityBlock(outcomes);
-    // Known unknowns (#165): the gaps in the story (silent windows, uncovered ATT&CK phases, likely-
-    // next techniques) so suggested hunts target what's MISSING, not just re-confirm what's known.
-    const knownUnknownsBlock = await this.knownUnknownsBlock(loaded, scopedEvents, caseId);
-
-    // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
-    const overhead = estimateTokens(getHuntSuggestPrompt())
-      + estimateTokens(priorHuntsBlock + productivityBlock + contextBlock + knownUnknownsBlock + graphBlock + findingsText + iocText + techText + (loaded.attackerPath || "")) + 300;
-    const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
-    if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
-    const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
-
-    // Regenerate hook (mirrors suggestPlaybookHunts): when the analyst asks for a DIFFERENT take on a
-    // hunt whose VQL was bad/unwanted, the excluded query is shown so the model varies the approach.
-    const excludeNote = opts?.excludeVql
-      ? `ALREADY SUGGESTED (this VQL was already shown to the analyst — generate something DIFFERENT that investigates from a different angle or uses different VQL plugins):\n${opts.excludeVql}\n\n`
-      : "";
-    const userPrompt =
-      priorHuntsBlock +
-      productivityBlock +
-      contextBlock +
-      knownUnknownsBlock +
-      graphBlock +
-      `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
-      `ATT&CK TECHNIQUES: ${techText}\n\n` +
-      `FINDINGS:\n${findingsText}\n\n` +
-      `PIVOTABLE INDICATORS:\n${iocText}\n\n` +
-      `FORENSIC TIMELINE (${scopedEvents.length} in-scope events):\n${timelineText}\n\n` +
-      excludeNote +
-      `Propose the fleet-hunts as JSON.`;
-
-    const limit = Number(process.env.DFIR_HUNT_SUGGEST_MAX) || HUNT_SUGGEST_MAX_DEFAULT;
-    return this.withRetry(caseId, "suggest-hunts", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getHuntSuggestPrompt(), userPrompt, images: [] }, "suggest-hunts");
-      const { suggestions } = huntSuggestionsResponseSchema.parse(parsed);
-      return this.excludeDeployedHunts(sanitizeHuntSuggestions(suggestions, limit), outcomes);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  suggestPlaybookHunts(caseId: string, tasks: PlaybookTask[], availableArtifacts: string[] = [], opts?: { excludeVql?: string }): Promise<PlaybookHuntSuggestion[]> {
+    return hunts.suggestPlaybookHunts(this.aiCtx, caseId, tasks, availableArtifacts, opts);
   }
 
-  // Targeted hunt for ONE ATT&CK technique the adversary-emulation panel flagged as a likely next
-  // move (issue #121). Unlike suggestHunts (findings-driven), this is technique-DRIVEN: the technique
-  // has NOT been observed yet — the analyst wants VQL to detect it proactively if a lookalike actor
-  // brings it here. Reuses the fleet-hunt system prompt + schema + sanitizer + deploy flow, with a
-  // technique-focused user prompt grounded in the case's pivotable IOCs. EPHEMERAL like suggestHunts()
-  // — no state change. Works on ANY case (the technique is by definition not in the timeline).
-  async suggestTechniqueHunts(caseId: string, techniqueId: string, techniqueName?: string): Promise<HuntSuggestion[]> {
-    const provider = this.opts.velociraptorProvider ?? this.opts.synthesisProvider ?? this.requireProvider("technique hunt");
-    const id = String(techniqueId || "").trim().toUpperCase();
-    if (!/^T\d{4}(?:\.\d{3})?$/.test(id)) return []; // not a technique id — nothing to hunt
-    const loaded = await this.opts.stateStore.load(caseId);
-    const iocText = renderHuntIocs(loaded.iocs);
-    const label = techniqueName ? `${id} (${techniqueName})` : id;
-    const outcomes = await this.loadHuntOutcomes(caseId);   // #157 feedback loop (exclude + prior-hunts context)
-    const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
-    const productivityBlock = renderHuntProductivityBlock(outcomes);   // #72: aggregate hit-rate by pivot class
-    const userPrompt =
-      priorHuntsBlock +
-      productivityBlock +
-      `Focus EXCLUSIVELY on ONE ATT&CK technique the analyst wants to hunt for proactively across the fleet:\n` +
-      `  ${label}\n\n` +
-      `This technique has NOT yet been observed in this case. A group whose tradecraft resembles this case is known ` +
-      `to use it, so the goal is to DETECT it on any enrolled endpoint if it is being used here but missed.\n\n` +
-      `Propose 1–3 CLIENT-side Velociraptor VQL hunts that surface this technique's tradecraft generally (not tied to ` +
-      `one host). Where relevant, pivot on these case indicators, but do not depend on them:\n` +
-      `PIVOTABLE INDICATORS:\n${iocText}\n\n` +
-      `Set every suggestion's mitreTechniques to ["${id}"]. Propose the hunt(s) as JSON.`;
-    const limit = Number(process.env.DFIR_HUNT_SUGGEST_MAX) || HUNT_SUGGEST_MAX_DEFAULT;
-    return this.withRetry(caseId, "hunt-technique", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getHuntSuggestPrompt(), userPrompt, images: [] }, "hunt-technique");
-      const { suggestions } = huntSuggestionsResponseSchema.parse(parsed);
-      return this.excludeDeployedHunts(sanitizeHuntSuggestions(suggestions, limit), outcomes);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  generateNarrative(caseId: string): Promise<{ narrativeTimeline: string }> {
+    return caseReports.generateNarrative(this.aiCtx, caseId);
   }
 
-  // Memory-forensics "Next-Step" agent (issue #101). The case already has Volatility 3 / Rekall output
-  // imported as forensic events; read that memory evidence (the process tree, connections, malfind,
-  // command lines, services), identify the anomalies, and propose the EXACT next Volatility 3 command
-  // the analyst should run to dig deeper. Single text-only AI call; EPHEMERAL like ask()/suggestHunts()
-  // — it does NOT mutate state. Returns [] without an AI call when the case has no memory evidence.
-  async suggestMemoryNextSteps(caseId: string): Promise<MemoryNextStep[]> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("memory next-step suggestions");
-    const loaded = await this.opts.stateStore.load(caseId);
-    if (!hasMemoryMaterial(loaded)) return [];   // no Volatility/Rekall evidence — don't spend a call
-
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-    const memEvents = scopedEvents.filter(isMemoryEvent);
-    if (!memEvents.length) return [];            // all memory evidence is out-of-scope / legitimate
-
-    const pluginsText = memoryPluginsPresent(memEvents).join(", ") || "(unknown)";
-
-    // Trim the memory evidence so the whole prompt fits the model context (the rest is fixed overhead).
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.severity}] ${(e.description ?? "").replace(/\s+/g, " ").trim().slice(0, 300)}`;
-    const overhead = estimateTokens(getMemoryNextStepPrompt()) + estimateTokens(pluginsText) + 300;
-    const fit = fitItemsToBudget(memEvents, renderEvent, Math.max(0, inputTokenBudget() - overhead));
-    const evidenceText = renderMemoryEvidence(memEvents, Math.max(1, fit));
-
-    const userPrompt =
-      `ALREADY-IMPORTED MEMORY PLUGINS (prefer suggesting plugins NOT in this list where they advance the case): ${pluginsText}\n\n` +
-      `MEMORY EVIDENCE (${memEvents.length} Volatility/Rekall events, worst-severity first):\n${evidenceText}\n\n` +
-      `Propose the next Volatility 3 commands as JSON.`;
-
-    const limit = Number(process.env.DFIR_MEMORY_NEXTSTEP_MAX) || MEMORY_NEXTSTEP_MAX_DEFAULT;
-    return this.withRetry(caseId, "memory-next-steps", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getMemoryNextStepPrompt(), userPrompt, images: [] }, "memory-next-steps");
-      const { suggestions } = memoryNextStepResponseSchema.parse(parsed);
-      return sanitizeMemoryNextSteps(suggestions, limit);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  executiveSummary(caseId: string): Promise<ExecSummary> {
+    return caseReports.executiveSummary(this.aiCtx, caseId);
   }
 
-  // Translate a free-text analyst request into a runnable hunting query per platform (issue #100).
-  // Unlike suggestHunts (findings-driven proposals), this is analyst-DRIVEN: the request is plain
-  // English ("PowerShell downloading a file and executing it") and the model maps that intent onto
-  // each requested platform's real schema. EPHEMERAL like ask()/suggestHunts() — no state change.
-  // Works on an empty case (the analyst may translate before any evidence is imported); the case's
-  // known data sources + pivotable IOCs are passed only as light grounding. Uses the strong
-  // synthesisProvider like ask()/executiveSummary() — this spans MANY query languages (KQL/SPL/ES|QL/
-  // Sigma/…) in one call, so the broad general model follows the multi-platform instruction far better
-  // than the narrow VQL-tuned velociraptorProvider (which biases toward VQL and ignores the rest).
-  async translateQuery(caseId: string, request: string, platforms?: readonly HuntPlatform[]): Promise<QueryTranslationResult> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("query translation");
-    const loaded = await this.opts.stateStore.load(caseId);
-
-    // The caller's requested subset, intersected with the canonical platform set; empty → all.
-    const requested = (platforms ?? []).filter((p): p is HuntPlatform => (HUNT_PLATFORMS as readonly string[]).includes(p));
-    const targets: HuntPlatform[] = requested.length ? [...new Set(requested)] : [...HUNT_PLATFORMS];
-
-    const sourcesText = renderCaseDataSources(loaded);
-    const iocText = renderHuntIocs(loaded.iocs);
-    const guide = renderPlatformGuide(targets);
-
-    const userPrompt =
-      `KNOWN CASE DATA SOURCES (the tools/log sources this investigation already has data from):\n${sourcesText}\n\n` +
-      `PIVOTABLE INDICATORS observed in this case (use these exact values when the request refers to "this" host/IP/hash/etc.):\n${iocText}\n\n` +
-      `TARGET PLATFORMS (emit one query per key, grounded in the schema shown):\n${guide}\n\n` +
-      `ANALYST REQUEST: ${request.trim()}\n\nTranslate it as JSON.`;
-
-    return this.withRetry(caseId, "translate-query", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getQueryTranslatePrompt(), userPrompt, images: [] }, "translate-query");
-      const { interpretation, queries } = queryTranslationResponseSchema.parse(parsed);
-      return { interpretation: sanitizeInterpretation(interpretation), queries: sanitizeQueryTranslations(queries, targets) };
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  starredReport(caseId: string, starredIds: string[]): Promise<StarredSummaryResult> {
+    return viewReports.starredReport(this.aiCtx, caseId, starredIds);
   }
 
-  // Convert a plain-English description into ONE content-tagger rule (PR #112 follow-up), or a
-  // decline reason when it can't be expressed as a single-event field-match rule. EPHEMERAL — this
-  // returns a candidate for review; nothing is persisted here (the route's add step saves it). Uses
-  // the strong synthesisProvider like translateQuery — authoring a schema-constrained rule benefits
-  // from the general model over the VQL-tuned velociraptorProvider.
-  async suggestTaggerRule(caseId: string, description: string): Promise<SuggestOutcome> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("tagger rule suggestion");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const userPrompt =
-      `MATCHABLE FIELDS (use ONLY these): ${MATCHABLE_FIELDS.join(", ")}\n\n` +
-      `ANALYST REQUEST: ${description.trim()}\n\n` +
-      `Return the rule as JSON (or a decline).`;
-    return this.withRetry(caseId, "suggest-tagger-rule", async () => {
-      const parsed = await this.analyzeRestored(
-        caseId, loaded, provider,
-        { systemPrompt: getTaggerRulePrompt(), userPrompt, images: [] },
-        "suggest-tagger-rule",
-      );
-      return sanitizeSuggestedRule(suggestedRuleResponseSchema.parse(parsed));
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  sessionSummary(caseId: string, sessionId: string): Promise<SessionSummaryResult> {
+    return viewReports.sessionSummary(this.aiCtx, caseId, sessionId);
   }
 
-  // Hypothesise what an attacker did during the timeline's SILENT periods (issue #96). Builds on the
-  // deterministic gap detector: detect the suspicious gaps, then make ONE text-only AI call that reads
-  // each gap's bounding events (before/after the silence) and infers the attacker activity that fits.
-  // Each gap is also paired with the DETERMINISTIC shadow-artifact collections (USN journal, SRUM,
-  // Prefetch, Amcache, …) that reconstruct the missing window — so even a gap the model skips still
-  // carries deployable Velociraptor collections. EPHEMERAL like ask()/suggestHunts(): no state change.
-  // Returns an empty result (no AI spend) when the timeline has no flagged gaps.
-  async hypothesizeGaps(caseId: string): Promise<GapHypothesesResult> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("gap hypothesis");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-
-    // Use the SAME gap detection (and thresholds) the panel/report use, so the analyst hypothesises
-    // about exactly the gaps they see flagged.
-    const gaps = detectTimelineGaps(scopedEvents, gapEnvOptions());
-    if (!hasGapMaterial(gaps)) return { hypotheses: [], caveat: GAP_HYPOTHESIS_CAVEAT };
-
-    const cap = Number(process.env.DFIR_GAP_HYPOTHESIS_MAX) || GAP_HYPOTHESIS_MAX_DEFAULT;
-    const focusGaps = gaps.slice(0, Math.max(1, Math.floor(cap)));   // worst-first → keep the most suspicious
-    const around = Number(process.env.DFIR_GAP_HYPOTHESIS_CONTEXT) || SURROUNDING_EVENTS_DEFAULT;
-    const surroundByGapId = new Map(focusGaps.map((g) => [g.id, surroundingEvents(g, scopedEvents, around)]));
-    const validGapIds = new Set(focusGaps.map((g) => g.id));
-
-    const gapsText = renderGapsForPrompt(focusGaps, surroundByGapId);
-    // The shadow-artifact catalog the model ranks against (id → what it reconstructs). The catalog
-    // supplies the actual collection VQL deterministically; the model only picks the relevant ids.
-    const artifactsText = SHADOW_ARTIFACTS.map((a) => `- ${a.id}: ${a.name} — ${a.reconstructs}`).join("\n");
-    const userPrompt =
-      `SHADOW ARTIFACTS (reference recommendedArtifactIds ONLY from these ids):\n${artifactsText}\n\n` +
-      `TIMELINE GAPS (${focusGaps.length} of ${gaps.length} flagged; worst-first) with their surrounding events:\n\n` +
-      `${gapsText}\n\n` +
-      `Hypothesise the attacker activity for each gap as JSON.`;
-
-    const aiHypotheses = await this.withRetry(caseId, "hypothesize-gaps", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getGapHypothesisPrompt(), userPrompt, images: [] }, "hypothesize-gaps");
-      const { hypotheses } = gapHypothesesResponseSchema.parse(parsed);
-      return sanitizeGapHypotheses(hypotheses, validGapIds, focusGaps.length);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-
-    return buildGapHypotheses(aiHypotheses, focusGaps, surroundByGapId);
+  viewSummary(caseId: string, filters: SuperQuery, labelMap?: SuperLabelMap): Promise<StarredSummaryResult> {
+    return viewReports.viewSummary(this.aiCtx, caseId, filters, labelMap);
   }
 
-  // Propose a Velociraptor hunt for each ENDPOINT-related PLAYBOOK task (issue #70). Single text-only
-  // AI call; EPHEMERAL like suggestHunts() — it does NOT mutate state. The deploy MODE is decided here
-  // deterministically from the case's observed endpoints: a task tied to exactly one host → a single
-  // client COLLECTION on it; otherwise → a fleet HUNT. The playbook `tasks` are passed in by the route
-  // (the pipeline has no PlaybookStore). Returns [] without an AI call when there's no endpoint task.
-  async suggestPlaybookHunts(caseId: string, tasks: PlaybookTask[], availableArtifacts: string[] = [], opts?: { excludeVql?: string }): Promise<PlaybookHuntSuggestion[]> {
-    const provider = this.opts.velociraptorProvider ?? this.opts.synthesisProvider ?? this.requireProvider("playbook hunt suggestions");
-    const loaded = await this.opts.stateStore.load(caseId);
-    if (!hasPlaybookHuntMaterial(loaded, tasks)) return [];   // empty/closed playbook → don't spend a call
-
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-
-    const endpointsByTaskId = buildTaskEndpointsMap(loaded, tasks);
-    const endpoints = knownEndpoints(loaded);
-    const tasksText = renderPlaybookHuntTasks(tasks, endpointsByTaskId);
-    const endpointsText = renderKnownEndpoints(endpoints);
-    // The server's REAL CLIENT artifacts (passed in by the route) — the model may reference an
-    // Artifact.<Name> only from this list (otherwise it hallucinates a name that won't compile).
-    const artifactsText = renderAvailableArtifacts(availableArtifacts, Number(process.env.DFIR_PBHUNT_MAX_ARTIFACTS) || 150);
-
-    // This call hunts PER TASK (grounded by the tasks + findings + IOCs + endpoints), so it does NOT
-    // need the full synthesis timeline — a smaller stratified event sample keeps the signal while
-    // cutting the prompt (the timeline dominates it). A leaner prompt is faster + cheaper and shrinks
-    // the window for a transient provider transport failure on a long generation. Tune via
-    // DFIR_PBHUNT_MAX_EVENTS (default 120, well below synthesis's 300).
-    const max = Number(process.env.DFIR_PBHUNT_MAX_EVENTS) || 120;
-    let events = selectSynthesisEvents(scopedEvents, max);
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.timestamp || "(undated)"}] [${e.severity}]${e.asset ? ` <${e.asset}>` : ""} ${e.description.slice(0, 240)}`;
-    const findingsText = renderHuntFindings(loaded.findings);
-    const kevCatalog = await this.getKevCatalog();
-    const contextBlock = buildSynthesisContext(loaded, scopedEvents, kevCatalog);
-    const outcomes = await this.loadHuntOutcomes(caseId);   // #157 feedback loop (exclude + prior-hunts context)
-    const priorHuntsBlock = renderPriorHuntsBlock(outcomes);
-    const productivityBlock = renderHuntProductivityBlock(outcomes);   // #72: aggregate hit-rate by pivot class
-
-    // Trim the timeline so the whole prompt fits the model context (the rest is fixed overhead).
-    const overhead = estimateTokens(getPlaybookHuntPrompt())
-      + estimateTokens(priorHuntsBlock + productivityBlock + contextBlock + tasksText + endpointsText + artifactsText + findingsText + (loaded.attackerPath || "")) + 300;
-    const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
-    if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
-    const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
-
-    const excludeNote = opts?.excludeVql
-      ? `ALREADY SUGGESTED (this VQL was already shown to the analyst — generate something DIFFERENT that investigates from a different angle or uses different VQL plugins):\n${opts.excludeVql}\n\n`
-      : "";
-    const userPrompt =
-      priorHuntsBlock +
-      productivityBlock +
-      contextBlock +
-      `KNOWN ENDPOINTS (hosts — pick a targetHost ONLY from these): ${endpointsText}\n\n` +
-      `AVAILABLE VELOCIRAPTOR ARTIFACTS (reference Artifact.<Name> ONLY if <Name> is in this list — else use a raw plugin):\n${artifactsText}\n\n` +
-      `PLAYBOOK TASKS:\n${tasksText}\n\n` +
-      `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
-      `FINDINGS:\n${findingsText}\n\n` +
-      `FORENSIC TIMELINE (${scopedEvents.length} in-scope events):\n${timelineText}\n\n` +
-      excludeNote +
-      `Propose the per-task hunts as JSON.`;
-
-    const limit = Number(process.env.DFIR_PBHUNT_SUGGEST_MAX) || PLAYBOOK_HUNT_SUGGEST_MAX_DEFAULT;
-    return this.withRetry(caseId, "suggest-playbook-hunts", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getPlaybookHuntPrompt(), userPrompt, images: [] }, "suggest-playbook-hunts");
-      const { suggestions } = playbookHuntResponseSchema.parse(parsed);
-      return this.excludeDeployedHunts(sanitizePlaybookHuntSuggestions(suggestions, endpointsByTaskId, endpoints, limit), outcomes);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+  remediationPlan(caseId: string): Promise<RemediationPlan> {
+    return caseReports.remediationPlan(this.aiCtx, caseId);
   }
 
-  // Generate a chronological prose narrative of the incident for management/stakeholders
-  // (single AI call). The result is saved to state.narrativeTimeline so it persists and
-  // appears in the report and dashboard immediately without a manual copy step.
-  async generateNarrative(caseId: string): Promise<{ narrativeTimeline: string }> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("narrative generation");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-
-    const max = maxPromptEvents();
-    let events = selectSynthesisEvents(scopedEvents, max);
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.timestamp || "(undated)"}] [${e.severity}] ${e.description.slice(0, 240)}`;
-    const findingsText = loaded.findings.slice(0, 150).map((f) => `[${f.severity}] ${f.title}`).join("\n") || "(none)";
-    const kevCatalog = await this.getKevCatalog();
-    const contextBlock = buildSynthesisContext(loaded, scopedEvents, kevCatalog);
-
-    const narrativePrompt = getNarrativePrompt();
-    const overhead = estimateTokens(narrativePrompt)
-      + estimateTokens(contextBlock + (loaded.attackerPath || "") + findingsText) + 300;
-    const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
-    if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
-    const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
-
-    const userPrompt =
-      contextBlock +
-      `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
-      `FINDINGS:\n${findingsText}\n\n` +
-      `FORENSIC TIMELINE (${scopedEvents.length} in-scope events):\n${timelineText}\n\n` +
-      `Write the narrative timeline as JSON.`;
-
-    const narrativeSchema = z.object({ narrativeTimeline: z.string().catch("") });
-    const result = await this.withRetry(caseId, "narrative", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: narrativePrompt, userPrompt, images: [] }, "narrative");
-      return narrativeSchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-
-    // Re-read state before saving so imports/edits that arrived during the AI call aren't clobbered.
-    const fresh = await this.opts.stateStore.load(caseId);
-    await this.opts.stateStore.save({ ...fresh, narrativeTimeline: result.narrativeTimeline });
-    return result;
+  hypothesisReview(caseId: string): Promise<{ reviews: HypothesisReviewItem[] }> {
+    return caseReports.hypothesisReview(this.aiCtx, caseId);
   }
 
-  // Generate a management-facing executive summary of the case (single-shot, no state change).
-  // Text-only over the synthesized digest, like ask(); returns plain prose for the analyst to
-  // review and save into the report's executive-summary section.
-  async executiveSummary(caseId: string): Promise<ExecSummary> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("executive summary");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-
-    const max = maxPromptEvents();
-    let events = selectSynthesisEvents(scopedEvents, max);
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.timestamp || "(undated)"}] [${e.severity}] ${e.description.slice(0, 240)}`;
-    const findingsText = loaded.findings.slice(0, 150).map((f) => `[${f.severity}] ${f.title}`).join("\n") || "(none)";
-    const kevCatalog = await this.getKevCatalog();
-    const contextBlock = buildSynthesisContext(loaded, scopedEvents, kevCatalog);
-
-    const overhead = estimateTokens(getExecSummaryPrompt())
-      + estimateTokens(contextBlock + (loaded.attackerPath || "") + findingsText) + 300;
-    const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
-    if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
-    const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
-
-    const userPrompt =
-      contextBlock +
-      `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
-      `FINDINGS:\n${findingsText}\n\n` +
-      `FORENSIC TIMELINE (${scopedEvents.length} in-scope events):\n${timelineText}\n\n` +
-      `Write the executive summary as JSON.`;
-
-    return this.withRetry(caseId, "exec-summary", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getExecSummaryPrompt(), userPrompt, images: [] }, "exec-summary");
-      return execSummarySchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-  }
-
-  // TimeSketch-style Starred Events Report: ONE text-only AI call over ONLY the analyst-starred
-  // events (ids resolved by the route from the reserved "starred" tags — the pipeline has no tags
-  // store). Events resolve from the super-timeline store UNIONed with the forensic timeline
-  // (manual/pushed events may exist only there), deduped by id. Deliberately NO scope / false-
-  // positive filtering: the analyst hand-picked these events. EPHEMERAL — no state change.
-  async starredReport(caseId: string, starredIds: string[]): Promise<StarredSummaryResult> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("starred report");
-    let loaded = await this.opts.stateStore.load(caseId);
-    const wanted = new Set(starredIds);
-    // FORENSIC copies win: imports dual-write the same event ids to both stores, but all later
-    // severity/MITRE re-grades (content tagger, synthesis mergeDelta) land on the forensic copy
-    // only — the super copy is frozen at import time, so it must not shadow the re-graded one.
-    const byId = new Map<string, ForensicEvent>();
-    for (const e of loaded.forensicTimeline) if (wanted.has(e.id)) byId.set(e.id, e);
-
-    // Anything the analyst starred that lives only in the raw record is PROMOTED before the model
-    // sees it, so the report is still built from the forensic timeline alone. Starring an event is
-    // the analyst saying it matters; promotion is that judgement written down.
-    //
-    // Fetched by id rather than with `.all(caseId)`, which materialised the ENTIRE super-timeline —
-    // tens of thousands of rows — to resolve a handful of starred ones.
-    if (this.opts.superTimelineStore) {
-      const missing = starredIds.filter((id) => !byId.has(id));
-      const promotable: ForensicEvent[] = [];
-      for (const id of missing) {
-        const raw = await this.opts.superTimelineStore.get(caseId, id);
-        if (raw) promotable.push(raw);
-      }
-      if (promotable.length) {
-        loaded = await this.promoteSuperTimeline(caseId, promotable, {
-          importedAt: new Date().toISOString(),
-          note: `Promoted ${promotable.length} starred raw event(s) for the starred report`,
-        });
-        for (const e of loaded.forensicTimeline) if (wanted.has(e.id)) byId.set(e.id, e);
-      }
-    }
-    const all = sortByEventTime([...byId.values()]);
-    if (!all.length) throw new Error("no starred events");
-
-    // The provenance line is computed HERE (the model copies it verbatim, it never counts events
-    // itself) so the report's stated coverage is always accurate — including when the budget cap
-    // reduced the set.
-    const provenance = (used: number): string => used < all.length
-      ? `[*This report was generated based on the ${used} most significant of ${all.length} (deduplicated) starred events.*]`
-      : `[*This report was generated based on ${all.length} (deduplicated) starred events.*]`;
-
-    const prompt = getStarredReportPrompt();
-    const { events, render } = this.fitViewEvents(all, estimateTokens(prompt) + estimateTokens(provenance(all.length)) + 300);
-
-    const userPrompt =
-      `PROVENANCE LINE (copy verbatim directly under the title): ${provenance(events.length)}\n\n` +
-      `STARRED EVENTS (${events.length} of ${all.length}, chronological):\n` +
-      events.map(render).join("\n") +
-      `\n\nWrite the starred events report as JSON.`;
-
-    const mdSchema = z.object({ markdown: z.string().min(1) });
-    const result = await this.withRetry(caseId, "starred-report", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "starred-report");
-      return mdSchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-
-    return { markdown: result.markdown, eventCount: all.length, usedEvents: events.length, truncated: events.length < all.length };
-  }
-
-  // Per-session summary (#342): ONE text-only AI call over just the events of a single attacker
-  // session. Cheaper and more coherent than full synthesis — the events already share a host and a
-  // tight window, so the model gets a focused slice instead of a 600-event wall.
-  //
-  // The session is re-derived HERE from the case's own timeline rather than trusting a caller-passed
-  // event list: a session id is only meaningful relative to a segmentation run, and re-segmenting
-  // with sessionEnvOptions() guarantees the summary covers exactly the session the dashboard and the
-  // report call by that id. EPHEMERAL — no state change.
-  async sessionSummary(caseId: string, sessionId: string): Promise<SessionSummaryResult> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("session summary");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const sessions = segmentSessions(loaded.forensicTimeline, sessionEnvOptions());
-    const session = sessions.find((s) => s.id === sessionId);
-    if (!session) throw new Error(`session not found: ${sessionId}`);
-
-    const wanted = new Set(session.eventIds);
-    const all = sortByEventTime(loaded.forensicTimeline.filter((e) => wanted.has(e.id)));
-    if (!all.length) throw new Error(`session not found: ${sessionId}`);
-
-    const prompt = getSessionSummaryPrompt();
-    const { events, render } = this.fitViewEvents(all, estimateTokens(prompt) + 300);
-
-    const userPrompt =
-      `SESSION: ${session.label}\n` +
-      `HOST: ${session.host}\n` +
-      (session.account ? `ACCOUNT: ${session.account}\n` : "") +
-      `WINDOW: ${session.startTime} → ${session.endTime}\n\n` +
-      `EVENTS (${events.length} of ${all.length}, chronological):\n` +
-      events.map(render).join("\n") +
-      `\n\nWrite the session account as JSON.`;
-
-    const mdSchema = z.object({ markdown: z.string().min(1) });
-    const result = await this.withRetry(caseId, "session-summary", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "session-summary");
-      return mdSchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-
-    return {
-      markdown: result.markdown,
-      sessionId: session.id,
-      label: session.label,
-      eventCount: all.length,
-      usedEvents: events.length,
-      truncated: events.length < all.length,
-    };
-  }
-
-  /**
-   * Summarize the analyst's CURRENT super-timeline view.
-   *
-   * THIS IS THE ONE SANCTIONED EXCEPTION to the rule that the model reads only the forensic
-   * timeline, and it is written down here so nobody has to infer it from the code.
-   *
-   * The other two raw-record paths — explainEvent and starredReport — promote before asking, so the
-   * invariant holds literally for them. This one cannot: it summarises whatever the analyst has
-   * filtered to, which can be thousands of rows. Promoting them would write thousands of Info-graded
-   * events into the forensic timeline permanently, drowning the record the rule exists to protect.
-   * Obeying the rule that way would cause exactly the harm the rule prevents.
-   *
-   * So it reads the raw record directly, under three constraints that keep it safe:
-   *   1. It only ever runs when the analyst presses the button. Nothing automatic reaches this.
-   *   2. It is EPHEMERAL — no promotion, no state change. Nothing it reads enters the case.
-   *   3. It is capped at VIEW_SUMMARY_MAX_ROWS, far below the old 10,000, and it tells the analyst
-   *      when the cap truncated their view rather than silently summarising a slice.
-   */
-  async viewSummary(caseId: string, filters: SuperQuery, labelMap?: SuperLabelMap): Promise<StarredSummaryResult> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("view summary");
-    if (!this.opts.superTimelineStore) throw new Error("super-timeline not configured");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const { events: matched, total } = await this.opts.superTimelineStore.query(
-      caseId, { ...filters, offset: 0, limit: VIEW_SUMMARY_MAX_ROWS }, labelMap);
-    if (!matched.length) throw new Error("no events match the current filters");
-
-    const prompt = getViewSummaryPrompt();
-    const { events, render } = this.fitViewEvents(matched, estimateTokens(prompt) + 300);
-
-    // `total` is what MATCHED the filters; `matched.length` is what the cap let through. Reporting
-    // both means an analyst looking at a 40,000-row filter is told the summary covers a slice,
-    // rather than being left to assume it covered everything.
-    const capped = total > matched.length;
-    const userPrompt =
-      `EVENTS (${events.length} of ${matched.length}${capped ? ` read from ${total} matching (capped at ${VIEW_SUMMARY_MAX_ROWS})` : " matching the analyst's current filters"}, chronological):\n` +
-      events.map(render).join("\n") +
-      `\n\nWrite the overview as JSON.`;
-
-    const mdSchema = z.object({ markdown: z.string().min(1) });
-    const result = await this.withRetry(caseId, "view-summary", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: prompt, userPrompt, images: [] }, "view-summary");
-      return mdSchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-
-    return { markdown: result.markdown, eventCount: matched.length, usedEvents: events.length, truncated: events.length < matched.length };
-  }
-
-  // Shared event-selection for the two view-scoped summaries: cap to the synthesis event budget
-  // (DFIR_AI_SYNTH_MAX_EVENTS, default 600), token-fit against the prompt overhead, keep the most
-  // signal-bearing subset (selectSynthesisEvents) and re-sort it chronologically for the report.
-  private fitViewEvents(all: ForensicEvent[], overheadTokens: number): { events: ForensicEvent[]; render: (e: ForensicEvent) => string } {
-    const render = (e: ForensicEvent): string =>
-      `[${e.timestamp || "(undated)"}] [${e.severity}]` +
-      (e.asset ? ` [${e.asset}]` : "") +
-      ` ${e.description.slice(0, 240)}` +
-      (e.processName ? ` | process: ${e.processName}` : "") +
-      (e.srcIp || e.dstIp ? ` | net: ${[e.srcIp, e.dstIp].filter(Boolean).join(" → ")}` : "");
-    const max = maxPromptEvents();
-    let events = selectSynthesisEvents(all, max);
-    const fit = fitItemsToBudget(events, render, Math.max(0, inputTokenBudget() - overheadTokens));
-    if (fit < events.length) events = selectSynthesisEvents(all, fit);
-    return { events: sortByEventTime(events), render };
-  }
-
-  // Incident-specific remediation plan (#178): a concrete, prioritized action list for the IR team,
-  // GROUNDED in the deterministic ATT&CK Mitigations for the case's techniques so the model turns
-  // generic guidance into specific steps instead of hallucinating. Single-shot, no state change.
-  async remediationPlan(caseId: string): Promise<RemediationPlan> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("remediation plan");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-    const filtered: InvestigationState = { ...loaded, forensicTimeline: scopedEvents };
-
-    const findingsText =
-      loaded.findings.slice(0, 100).map((f) => `[${f.severity}] ${f.title}${f.mitreTechniques?.length ? ` (${f.mitreTechniques.join(", ")})` : ""}`).join("\n") || "(none)";
-
-    // The deterministic ATT&CK mitigations for this case's techniques — the grounding facts.
-    const mit = buildMitigationsResult(filtered, loadMitigationsDataset());
-    const mitigationsText =
-      mit.byMitigation
-        .slice(0, 30)
-        .map((m) => `- ${m.id} ${m.name} (covers ${m.techniques.join(", ")}): ${m.description}`)
-        .join("\n") || "(no mapped ATT&CK mitigations)";
-
-    // The deterministic D3FEND countermeasures (defensive techniques/sensors) for the same
-    // techniques — so the plan can also cite the relevant D3FEND control alongside the M-code.
-    const d3f = buildD3fendResult(filtered, loadD3fendDataset(), d3fendEnvOptions());
-    const d3fendText =
-      d3f.byTactic
-        .flatMap((g) => g.countermeasures.map((c) => `- ${c.name} [${c.tactic}] (covers ${c.techniques.join(", ")})`))
-        .slice(0, 40)
-        .join("\n") || "(no mapped D3FEND countermeasures)";
-
-    const contextBlock = buildSynthesisContext(loaded, scopedEvents, await this.getKevCatalog());
-
-    const userPrompt =
-      contextBlock +
-      `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
-      `FINDINGS:\n${findingsText}\n\n` +
-      `RECOMMENDED ATT&CK MITIGATIONS (use these as the basis for concrete steps):\n${mitigationsText}\n\n` +
-      `RELEVANT D3FEND COUNTERMEASURES (the defensive technique/sensor for each — cite alongside the ATT&CK mitigation where it fits):\n${d3fendText}\n\n` +
-      `Write the incident-specific remediation plan as JSON.`;
-
-    return this.withRetry(caseId, "remediation", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getRemediationPrompt(), userPrompt, images: [] }, "remediation");
-      return remediationPlanSchema.parse(parsed);
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-  }
-
-  // On-demand hypothesis falsification review (issue #71). A focused, human-readable devil's-advocate
-  // pass over the OPEN hypotheses: for each, the plain-English evidence FOR and AGAINST it plus an
-  // ADVISORY recommended status. One text-only AI call; EPHEMERAL — no state change, and crucially it
-  // NEVER mutates a hypothesis's status (the analyst-freeze contract); the recommendation is surfaced for
-  // the analyst to apply. Returns { reviews: [] } with no AI call when there are no open hypotheses.
-  async hypothesisReview(caseId: string): Promise<{ reviews: HypothesisReviewItem[] }> {
-    if (!this.opts.hypothesisStore) throw new Error("hypotheses not configured");
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("hypothesis review");
-    const loaded = await this.opts.stateStore.load(caseId);
-
-    const allHypotheses = await this.opts.hypothesisStore.load(caseId);
-    // Review OPEN, non-exhausted hypotheses (analyst- or synthesis-authored). Resolved/exhausted ones
-    // are already settled, so re-litigating them wastes tokens and invites status churn.
-    const open = allHypotheses.filter((h) => h.status === "open" && !h.exhausted);
-    if (!open.length) return { reviews: [] };
-
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(loaded.forensicTimeline, scope), markers);
-    const validEventIds = new Set(scopedEvents.map((e) => e.id));
-
-    const max = maxPromptEvents();
-    let events = selectSynthesisEvents(scopedEvents, max);
-    const renderEvent = (e: ForensicEvent) =>
-      `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}`;
-    const findingsText = loaded.findings.slice(0, 150).map((f) => `[${f.id}] [${f.severity}] ${f.title}`).join("\n") || "(none)";
-    const contextBlock = buildSynthesisContext(loaded, scopedEvents, await this.getKevCatalog());
-
-    // Render the open hypotheses with the evidence already linked to them, so the model reviews the
-    // analyst's/synthesis's current picture rather than starting cold.
-    const hypothesesText = open.map((h) => {
-      const parts = [`[${h.id}] ${h.title}`];
-      if (h.expectedOutcome) parts.push(`    decided by: ${h.expectedOutcome}`);
-      if (h.relatedEventIds.length) parts.push(`    currently-supporting events: ${h.relatedEventIds.join(", ")}`);
-      if (h.contradictingEventIds.length) parts.push(`    known contradicting events: ${h.contradictingEventIds.join(", ")}`);
-      return parts.join("\n");
-    }).join("\n");
-
-    // Trim the timeline so the whole prompt fits the model context.
-    const overhead = estimateTokens(getHypothesisReviewPrompt())
-      + estimateTokens(contextBlock + (loaded.attackerPath || "") + findingsText + hypothesesText) + 300;
-    const fit = fitItemsToBudget(events, renderEvent, Math.max(0, inputTokenBudget() - overhead));
-    if (fit < events.length) events = selectSynthesisEvents(scopedEvents, fit);
-    const timelineText = events.map(renderEvent).join("\n") || "(no events yet)";
-
-    const userPrompt =
-      contextBlock +
-      `ATTACKER PATH: ${loaded.attackerPath || "(not reconstructed)"}\n\n` +
-      `FINDINGS:\n${findingsText}\n\n` +
-      `FORENSIC TIMELINE (${scopedEvents.length} in-scope events):\n${timelineText}\n\n` +
-      `OPEN HYPOTHESES TO REVIEW:\n${hypothesesText}\n\n` +
-      `Review each open hypothesis for supporting AND refuting evidence, and return the JSON.`;
-
-    const knownHypotheses = new Map(open.map((h) => [h.id, h.title] as const));
-    return this.withRetry(caseId, "hypothesis-review", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getHypothesisReviewPrompt(), userPrompt, images: [] }, "hypothesis-review");
-      const result = hypothesisReviewSchema.parse(parsed);
-      return { reviews: sanitizeHypothesisReviews(result.reviews, knownHypotheses, validEventIds) };
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
-  }
-
-  // Optional AI-assisted extension of deterministic FP suggestions (#227). The caller narrows the
-  // candidates and returned ids are validated against them, so hallucinated ids cannot be applied.
-  async suggestFalsePositiveSimilarAi(
+  suggestFalsePositiveSimilarAi(
     caseId: string,
     anchorId: string,
     anchorLabel: string,
     candidateIds: string[],
     candidateLabels: string[],
   ): Promise<string[]> {
-    const provider = this.opts.synthesisProvider ?? this.requireProvider("false positive suggestions");
-    const loaded = await this.opts.stateStore.load(caseId);
-    const list = candidateIds.map((id, i) => `[${id}] ${candidateLabels[i] ?? ""}`).join("\n") || "(none)";
-    const userPrompt =
-      `ANCHOR ITEM (just marked false positive): [${anchorId}] ${anchorLabel}\n\n` +
-      `OTHER ITEMS IN THIS CASE:\n${list}\n\n` +
-      "Which of the other items are likely the same false-positive pattern?";
-    return this.withRetry(caseId, "fp-similarity", async () => {
-      const parsed = await this.analyzeRestored(caseId, loaded, provider, { systemPrompt: getFpSimilarityPrompt(), userPrompt, images: [] }, "fp-similarity");
-      const result = fpSimilaritySchema.parse(parsed);
-      const valid = new Set(candidateIds);
-      return result.candidateIds.filter((id) => valid.has(id));
-    }, this.opts.retries ?? 3, this.opts.backoffMs ?? 500);
+    return analystQueries.suggestFalsePositiveSimilarAi(this.aiCtx, caseId, anchorId, anchorLabel, candidateIds, candidateLabels);
   }
 
-  // `dryRun` returns conclusions without persistence or side effects; second opinion uses it for
-  // model B (#116). `provider` overrides the synthesis model. Both default off for a normal run.
-  /** Estimate each Deep Pass severity floor against this case before the analyst spends credits. */
-  async deepPassPreview(caseId: string): Promise<{ cap: number; floors: FloorOption[] }> {
-    const state = await this.opts.stateStore.load(caseId);
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(state.forensicTimeline, scope), markers);
-    const cap = maxPromptEvents();
-    return { cap, floors: previewFloors(scopedEvents, { cap }) };
+  deepPassPreview(caseId: string): Promise<{ cap: number; floors: FloorOption[] }> {
+    return deepPassRun.deepPassPreview(this.aiCtx, caseId);
   }
 
   /** Read every graded event at the chosen floor in batches, then fold observations into one
    * synthesis. Preview uses the same ordering; cancellation records a failed run but changes no case data. */
-  async deepPass(caseId: string, opts: {
-    minSeverity: Severity;
-    provider?: AIProvider;
-    signal?: AbortSignal;
-    maxBatches?: number;
-    onProgress?: (done: number, total: number, detail: string) => void;
-    onCheckpoint?: (checkpoint: DeepPassCheckpoint) => Promise<void>;
-    resumeFrom?: DeepPassCheckpoint;
-    analysisParentRunId?: string;
-  }): Promise<DeepPassResult> {
-    const runStartedAt = new Date().toISOString();
-    const runId = `${runStartedAt.replace(/[:.]/g, "-")}-${randomUUID().slice(0, 8)}`;
-    const state = await this.opts.stateStore.load(caseId);
-    const provider = opts.provider ?? this.opts.synthesisProvider ?? this.opts.provider;
-    if (!provider) throw new Error("no synthesis provider configured");
-
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    const scopedEvents = filterFalsePositiveEvents(filterEventsByScope(state.forensicTimeline, scope), markers);
-
-    const cap = maxPromptEvents();
-    const floored = applySeverityFloor([...promptCandidates(scopedEvents)], opts.minSeverity);
-    const { events: rows } = collapseForPrompt(floored, groupEnvOptions());
-    const batches = planBatches(rows, cap);
-    const selectionHash = createHash("sha256")
-      .update(JSON.stringify(rows.map((event) => event.id)))
-      .digest("hex");
-
-    // Refuse rather than quietly starting a very expensive job — and name a floor that would fit.
-    const ceiling = opts.maxBatches ?? (Number(process.env.DFIR_DEEP_PASS_MAX_BATCHES) || DEFAULT_MAX_BATCHES);
-    if (batches.length > ceiling) {
-      const fits = floorsWithinBudget(previewFloors(scopedEvents, { cap }), ceiling);
-      throw new Error(
-        `deep pass needs ${batches.length} batches, above the ${ceiling} limit. ` +
-        (fits.length ? `Raise the floor to ${fits[fits.length - 1]} or above.` : "Raise DFIR_DEEP_PASS_MAX_BATCHES."),
-      );
-    }
-
-    const retries = this.opts.retries ?? 3;
-    const backoffMs = this.opts.backoffMs ?? 500;
-    const execution = await executeDeepPassBatches({
-      batches, floor: opts.minSeverity, selectionHash,
-      validEventIds: new Set(state.forensicTimeline.map((event) => event.id)),
-      digestBudget: Math.max(0, Math.floor(inputTokenBudget() * 0.25)),
-      ...(opts.resumeFrom ? { resumeFrom: opts.resumeFrom } : {}),
-      ...(opts.signal ? { signal: opts.signal } : {}),
-      ...(opts.onProgress ? { onProgress: opts.onProgress } : {}),
-      ...(opts.onCheckpoint ? { onCheckpoint: opts.onCheckpoint } : {}),
-      renderBatch: (batch) => this.renderBatchRows(batch),
-      observe: (userPrompt) => this.withRetry(
-        caseId, "deep-pass-observe", () => this.analyzeRestored(
-          caseId, state, provider,
-          { systemPrompt: getObservePrompt(), userPrompt, images: [], ...(opts.signal ? { signal: opts.signal } : {}) },
-          "deep-pass-observe",
-        ), retries, backoffMs,
-      ),
-      onFailure: (message) => this.log.warn(`deep pass: ${message}`, { caseId }),
-    });
-    const { observations, batchesFailed, aborted } = execution;
-
-    const summary: DeepPassResult = {
-      aborted,
-      floor: opts.minSeverity,
-      events: floored.length,
-      rows: rows.length,
-      batches: batches.length,
-      batchesFailed,
-      observations: observations.length,
-    };
-    const runRecord = {
-      id: runId, parentRunId: opts.analysisParentRunId, startedAt: runStartedAt,
-      provider: provider.name, model: provider.model, eventIds: floored.map((event) => event.id),
-      minSeverity: opts.minSeverity, maxBatches: ceiling, rowsPerBatch: cap, scope, batchesFailed,
-      falsePositiveMarkers: markers.length,
-      observePrompt: getObservePrompt(), synthesisPrompt: getSynthesisPrompt(),
-    };
-    if (aborted) {
-      await recordDeepPassRun(this.opts.analysisRunStore, caseId, { ...runRecord, status: "failed", error: "cancelled before final synthesis", output: state });
-      return summary;
-    }
-
-    opts.onProgress?.(batches.length, batches.length, "synthesizing");
-    await this.synthesize(caseId, {
-      force: true,
-      ...(opts.signal ? { signal: opts.signal } : {}),
-      ...(opts.provider ? { provider: opts.provider } : {}),
-      observationsBlock: renderObservationDigest(observations),
-      analysisParentRunId: runId,
-    });
-    const finalState = await this.opts.stateStore.load(caseId);
-    await recordDeepPassRun(this.opts.analysisRunStore, caseId, { ...runRecord, output: finalState });
-    return summary;
+  deepPass(...args: AiArgs<typeof deepPassRun.deepPass>): Promise<DeepPassResult> {
+    return deepPassRun.deepPass(this.aiCtx, ...args);
   }
 
-  // Observation rows match synthesis timeline rows, minus the selection-class prefix.
-  private renderBatchRows(rows: readonly ForensicEvent[]): string {
-    return rows
-      .map((e) => `[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}`)
-      .join("\n");
+  synthesize(...args: AiArgs<typeof synthesis.synthesize>): Promise<InvestigationState> {
+    return synthesis.synthesize(this.aiCtx, ...args);
   }
 
-  async synthesize(caseId: string, opts: { force?: boolean; dryRun?: boolean; provider?: AIProvider; signal?: AbortSignal; skipSecondLook?: boolean; observationsBlock?: string; analysisParentRunId?: string } & SynthThinkingInput = {}): Promise<InvestigationState> {
-    // Deep Pass supplies observations for events this prompt will not show row by row.
-    const observationsBlock = opts.observationsBlock ?? "";
-    const synthProvider = opts.provider ?? this.opts.synthesisProvider ?? this.requireProvider("synthesis");
-    this.warnOnPromptDrift();   // once per process: a stale synthesis-prompt override silently drops shipped capabilities
-    const loaded = await this.opts.stateStore.load(caseId);
-    if (loaded.forensicTimeline.length === 0) return loaded;
-
-    // Correlate the same artifact across tools first: deduplicate into one corroborated event and
-    // one finding with both sources. This is idempotent and the correlated timeline is persisted.
-    const envWindow = Number(process.env.DFIR_CORRELATE_WINDOW_S);
-    const corrProfile = await this.opts.correlationProfileStore?.load(caseId);
-    const windowSeconds = Number.isFinite(envWindow) ? envWindow : (corrProfile?.windowSeconds ?? 2);
-    // Source trust (#66) selects merge wording and caps low-trust-only findings.
-    const trustOverrides = this.opts.sourceTrustStore ? await this.opts.sourceTrustStore.load(caseId) : undefined;
-    const sourceTrust = effectiveTrustMap(trustOverrides);
-    // Measure clock skew pre-merge (#228), before correlation erases the disagreeing anchors.
-    // Aligned times guide windows; persisted events retain recorded timestamps.
-    const skew = await this.detectSkew(caseId, loaded.forensicTimeline, { windowSeconds, sourceTrust });
-    const state: InvestigationState = {
-      ...loaded,
-      forensicTimeline: correlateEvents(loaded.forensicTimeline, { windowSeconds, sourceTrust, epochOf: skew }),
-    };
-
-    const markers = this.opts.falsePositiveStore ? await this.opts.falsePositiveStore.load(caseId) : [];
-
-    // Scope: only events inside the investigation window feed synthesis, so
-    // findings/IOCs/attacker-path/questions reflect only in-scope activity.
-    // Then drop events the client confirmed legitimate so the model never derives
-    // conclusions from benign activity (the raw events stay in state — reversible).
-    const scope = this.opts.scopeStore ? await this.opts.scopeStore.load(caseId) : NO_SCOPE;
-    // Split the two filter stages so the coverage audit (#62) can attribute omissions: `inWindowEvents`
-    // is after the scope filter (out-of-window events dropped); `scopedEvents` is after the additional
-    // false-positive/legitimate filter. The budget cap below drops the rest from the prompt.
-    const inWindowEvents = filterEventsByScope(state.forensicTimeline, scope);
-    const scopedEvents = filterFalsePositiveEvents(inWindowEvents, markers);
-
-    // Detection-burst grouping (spec 2026-07-21): the same Sigma/YARA detection firing hundreds of
-    // times used to consume hundreds of prompt seats. Collapse each burst to ONE representative row so
-    // every DISTINCT detection reaches the model. Prompt-only and derived on read — `scopedEvents` (and
-    // therefore the case, the coverage denominators and the high-severity backfill) is untouched.
-    // The explicit CollapsedPrompt annotation matters: without it the disabled branch's bare `new Map()`
-    // infers Map<unknown, unknown> and every later `grouping.groupById.get(...)` fails to typecheck.
-    // Info-severity events don't get prompt seats (DFIR_SYNTH_INCLUDE_INFO=1 restores them): on a real
-    // case 213 Info rows pushed the prompt from 546 to 759 entries, past the cap, costing 26 GRADED
-    // detections their place. They remain in the case, the timeline and the coverage denominators —
-    // this only decides who gets budget.
-    const eligibleForPrompt = promptCandidates(scopedEvents);
-    const omittedInfo = scopedEvents.length - eligibleForPrompt.length;
-    const grouping: CollapsedPrompt = groupingEnabled()
-      ? collapseForPrompt(eligibleForPrompt, groupEnvOptions())
-      : { events: [...eligibleForPrompt], groupById: new Map(), memberIdsByRepresentative: new Map() };
-    const collapsedEvents = grouping.events;
-
-    // Bound the prompt for large imports (e.g. THOR: hundreds of events + auto-findings).
-    // Send the MOST SEVERE events (then most recent) up to a cap, and truncate each
-    // description — this keeps the request affordable (avoids OpenRouter 402 on a giant
-    // request) and inside the model's context. The deterministic high-severity backfill
-    // still creates findings for any Critical/High event NOT shown here (eligibleIds below
-    // is the full scoped set), so capping the prompt never loses a severe detection.
-    const SYNTH_MAX_EVENTS = maxPromptEvents();
-    // Per-case prevalence/baseline (investigation-guidance #15): how common each activity PATTERN is
-    // across the WHOLE case timeline (not just the scoped subset — the baseline is a property of the
-    // corpus). Feeds a rarity bias into the selection fill (a 1-off wins a seat over 500× noise) and a
-    // common/rare tag into each rendered event so the model gets explicit baseline context.
-    const prevalenceIndex = buildPrevalenceIndex(state.forensicTimeline);
-    const rarityOf = (e: ForensicEvent): number => rarityScore(e, prevalenceIndex);
-    // Stratified selection: all Critical/High + the earliest (initial-access) + an even
-    // time-spread sample, chronologically — better kill-chain coverage than severity-only. The ANNOTATED
-    // form (investigation-guidance #4) exposes which CLASS claimed each event, so renderEvent can prefix
-    // context-only rows with "~" (the model reads anchors vs supporting context) and the synth-meta card
-    // can show the analyst what evidence classes the model actually saw.
-    let selection = selectSynthesisEventsAnnotated(collapsedEvents, SYNTH_MAX_EVENTS, rarityOf);
-    let promptEvents = selection.events;
-    // Context classes: everything that is NOT a primary verdict-bearing anchor / initial-access event —
-    // these are the supporting rows the model should read as context, marked "~" in the timeline.
-    const CONTEXT_CLASSES = new Set<SelectionClass>(["anchor_context", "corroborated", "technique", "rare", "spread"]);
-    const isContext = (id: string): boolean => CONTEXT_CLASSES.has(selection.classOf.get(id) as SelectionClass);
-
-    // Analyst notebook context: when both notebookStore and aiControlStore are wired and the
-    // analyst has opted in (includeNotebook: true in ai-control.json), append the notebook
-    // entries to the synthesis prompt so the AI incorporates investigator hypotheses.
-    // Loaded here (before the hash) so notebook changes also trigger a fresh synthesis.
-    let notebookBlock = "";
-    if (this.opts.notebookStore && this.opts.aiControlStore) {
-      const aiCtrl = await this.opts.aiControlStore.load(caseId);
-      if (aiCtrl.includeNotebook) {
-        const notebookEntries = await this.opts.notebookStore.load(caseId);
-        if (notebookEntries.length) {
-          notebookBlock =
-            "ANALYST NOTEBOOK (investigator notes and open questions — take these into account when synthesizing findings and the attacker path):\n" +
-            notebookEntries.map((e) => `[${e.type.toUpperCase()}] ${e.text}`).join("\n") +
-            "\n\n";
-        }
-      }
-    }
-
-    // Analyst hypotheses as steering (issue #140): feed the investigator's OPEN, analyst-owned
-    // hypotheses into the prompt so the model actively hunts evidence to support/refute them and
-    // reflects it in findings/events + its own hypotheses output. We do NOT ask it to flip the
-    // analyst's hypothesis status — those are frozen by mergeHypotheses (the analyst stays in
-    // control); the steering shows up as findings/events the analyst then uses to judge. Only
-    // analyst-authored or analyst-touched OPEN ones (pure inputs, never rewritten by synthesis),
-    // so including them in the hash below can't cause a re-synthesis loop. Bounded for prompt size.
-    let analystHypothesesBlock = "";
-    // Refuted hypotheses fed back as NEGATIVE KNOWLEDGE (investigation-guidance #2): a theory the
-    // analyst ruled out must not be re-asserted or re-opened. Loaded from the same store, once.
-    let refutedHypothesesBlock = "";
-    if (this.opts.hypothesisStore) {
-      // ACH exhaustion (investigation-guidance #14): before reading, flag hypotheses whose linked or
-      // technique-matched hunts have come back empty — so the negative-knowledge block below and the
-      // "to test" list reflect them. Derived from collected hunt outcomes; persisted; idempotent.
-      const exhaustionOutcomes = await this.loadHuntOutcomes(caseId);
-      const huntSignals = exhaustionOutcomes
-        .filter((o) => o.status === "collected")
-        .map((o) => ({
-          ...(o.relatedHypothesisId ? { relatedHypothesisId: o.relatedHypothesisId } : {}),
-          techniques: o.mitreTechniques ?? [],
-          missed: o.foundEvidence === false,
-          title: o.title,
-        }));
-      if (huntSignals.some((s) => s.missed)) await this.opts.hypothesisStore.applyExhaustion(caseId, huntSignals);
-
-      const allHypotheses = await this.opts.hypothesisStore.load(caseId);
-      const open = allHypotheses
-        .filter((h) => h.status === "open" && !h.exhausted && (h.source === "analyst" || h.analystTouched))
-        .slice(0, 15);
-      if (open.length) {
-        analystHypothesesBlock =
-          "ANALYST HYPOTHESES TO TEST (the investigator proposed these — actively look for evidence that " +
-          "SUPPORTS or REFUTES each and surface it in findings/events; you may add a corroborating hypothesis, " +
-          "but do NOT mark the analyst's own hypothesis resolved):\n" +
-          open.map((h) => `- ${h.title}${h.expectedOutcome ? ` (decided by: ${h.expectedOutcome})` : ""}`).join("\n") +
-          "\n\n";
-      }
-      refutedHypothesesBlock = renderRefutedHypothesesBlock(allHypotheses);
-    }
-
-    // Prior-work feedback (investigation-guidance #2): the hunt hit/miss ledger (#157, previously fed
-    // only to the hunt prompts) and the playbook DONE/SKIPPED digest, so synthesis builds on completed
-    // work and dead hunts instead of re-recommending them. Loaded before the hash so completing a task
-    // or collecting a hunt triggers a fresh synthesis (a hit is a pivot; a miss is negative evidence).
-    const priorHuntsBlock = renderPriorHuntsBlock(await this.loadHuntOutcomes(caseId));
-    const playbookTasks = this.opts.playbookStore ? await this.opts.playbookStore.load(caseId) : [];
-    const playbookProgressBlock = renderPlaybookProgressBlock(playbookTasks);
-
-    // Incident-type framing (#236): the one-line hint for the type the analyst picked at case
-    // creation, so the model prioritizes ransomware / BEC / exfil techniques. A pure INPUT synthesis
-    // never rewrites, and cheap (one short line) — but changing the type must re-synthesize, so it
-    // joins the skip-if-unchanged hash below.
-    const incidentTypeBlock = renderIncidentTypeBlock(
-      this.opts.incidentTypeStore ? await this.opts.incidentTypeStore.loadType(caseId) : null,
-    );
-
-    // Skip-if-unchanged: hash only the STABLE INPUTS to synthesis — the in-scope timeline,
-    // the IOCs (value + intel verdicts), the scope, the legitimate markers, and (when opted
-    // in) the notebook entries. NOT the findings / MITRE / threads / summary, which synthesis
-    // itself rewrites (including those would make two consecutive runs hash differently and
-    // never skip). If the inputs are identical to the last successful run, return the saved
-    // state — no AI call.
-    const synthHash = createHash("sha1").update(JSON.stringify({
-      ev: scopedEvents.map((e) => [e.id, e.severity, e.timestamp, e.description]),
-      io: state.iocs.map((i) => [i.id, i.value, (i.enrichments ?? []).map((e) => e.verdict).join(",")]),
-      sc: scope, lg: markers.map((m) => m.id),
-      nb: notebookBlock,
-      hy: analystHypothesesBlock,
-      // Prior-work feedback (#2): completing a task, collecting a hunt, or refuting a hypothesis
-      // changes these strings, so an otherwise-identical timeline re-synthesizes to fold in the
-      // new negative knowledge instead of skipping. Pure inputs — synthesis never rewrites them.
-      pw: priorHuntsBlock + playbookProgressBlock + refutedHypothesesBlock,
-      // Re-picking the incident type reframes what the model should prioritize — an otherwise
-      // identical timeline must re-synthesize rather than skip.
-      it: incidentTypeBlock,
-      // Deep-pass observations are a pure INPUT synthesis never rewrites, but they change what the
-      // model can see — so a run carrying fresh ones must never be skipped as "inputs unchanged".
-      ob: observationsBlock,
-    })).digest("hex");
-    if (!opts.force && !opts.dryRun && this.lastSynthHash.get(caseId) === synthHash) return loaded;
-
-    const scopeNote = hasScope(scope)
-      ? `INVESTIGATION SCOPE: only consider activity from ${scope.start ?? "the beginning"} to ${scope.end ?? "now"}. ` +
-        `Events outside this window have already been removed below.\n\n`
-      : "";
-    // Cap the existing-findings echo too (a big import can produce 100s of auto-findings). Append the
-    // prior run's corroboration label (investigation-guidance #6) so the model sees which of its own
-    // earlier claims were weak/uncorroborated and can strengthen or drop them this run.
-    const existingFindings = state.findings.slice(0, 150).map((f) => {
-      const corr = corroborationLabel(f);
-      return `[${f.id}] ${f.title}${corr ? ` — ${corr}` : ""}`;
-    }).join("\n") || "(none yet)";
-    const openThreads = state.openThreads
-      .filter((t) => t.status === "open")
-      .map((t) => `[${t.id}] ${t.description}`)
-      .join("\n") || "(none open)";
-    const falsePositiveBlock = buildFalsePositiveContext(markers);
-    // Rabbit-hole detection (#13): authorized-test / known-good-tool markers are RETAINED as shaping
-    // context (a sanctioned pentest during the window is signal, not just noise), not merely erased.
-    const authorizedContextBlock = buildAuthorizedContextBlock(markers);
-    // Learn from dismissals (#65): recurring reasoned dismissals → a "PREVIOUSLY DISMISSED PATTERNS" block
-    // that DOWN-WEIGHTS (not excludes) new look-alike activity. Distinct from the two blocks above: those
-    // act on EXACT current markers; this generalizes. Env-tunable recurrence floor. Best-effort/optional.
-    let learnedPatternsBlock = "";
-    if (this.opts.learnedPatternStore) {
-      const minCount = Number(process.env.DFIR_LEARNED_PATTERN_MIN_COUNT) || undefined;
-      learnedPatternsBlock = buildLearnedPatternsBlock(await this.opts.learnedPatternStore.load(caseId), minCount);
-    }
-    // Compact, corroborated context (compromised assets + threat-intel verdicts + KEV hits)
-    // so the model grounds findings/attacker-path in structure instead of inferring blind.
-    const kevCatalog = await this.getKevCatalog();
-    const contextBlock = buildSynthesisContext(state, scopedEvents, kevCatalog);
-    // Known unknowns (#165): the gaps in the story (silent windows, uncovered ATT&CK phases, likely-
-    // next techniques) so the model builds on what's MISSING instead of glossing over it. Plus the
-    // (env-gated, default OFF) candidate-actor block. Both DERIVED — computed AFTER the skip-hash
-    // above, so they never affect skip-if-unchanged.
-    const knownUnknownsBlock = await this.knownUnknownsBlock(state, scopedEvents, caseId);
-    const adversaryBlock = this.adversaryHintBlock(state);
-    // Structured causal evidence (investigation-guidance #5), all DERIVED after the skip-hash so they
-    // never affect skip-if-unchanged: the deterministic ATTACK GRAPH (spawn/file-lineage/lateral/network
-    // edges with confidence+rule — previously fed only to ask()/suggestHunts(), never the call that
-    // writes findings), the statistically-confirmed periodic-beacon candidates, and the activity-phase
-    // digest. These give synthesis the cross-host structure it was inferring blind from truncated prose.
-    const graphBlock = buildGraphContext({ ...state, forensicTimeline: scopedEvents }, { maxEdges: DEFAULT_MAX_GRAPH_EDGES });
-    const beaconBlock = buildBeaconDigest(detectBeacons(scopedEvents, beaconEnvOptions()));
-    const attackPhaseBlock = buildAttackPhaseDigest(buildAttackPhases(scopedEvents));
-    // Import-satisfaction (investigation-guidance #8, phase 2): a collection this case previously
-    // recommended (prior nextSteps / unknown questions carrying a structured collect target) whose host
-    // now HAS matching events was fulfilled — stop re-recommending it and re-evaluate the question it
-    // served. Derived from the PRIOR run's guidance vs the current events; the served questions are
-    // added to the re-answer set below so the model reconsiders them with the new evidence.
-    const satisfiedCollections = detectSatisfiedCollections(state, scopedEvents);
-    const satisfiedBlock = buildSatisfiedCollectionsBlock(satisfiedCollections);
-    const satisfiedQuestionIds = new Set(
-      satisfiedCollections.filter((s) => s.target.from === "question").map((s) => s.target.refId),
-    );
-    // Analyst-pinned open questions: tell the model to address each (answer when the evidence
-    // now supports it) and keep them. They're re-merged into the output below so they persist.
-    const pinnedQuestions = state.keyQuestions.filter((q) => q.pinned);
-    const pinnedBlock = pinnedQuestions.length
-      ? `OPEN QUESTIONS TO ADDRESS (include EACH in keyQuestions with the SAME id; answer with ` +
-        `status/answer + supporting relatedEventIds if the evidence now supports it, else status ` +
-        `"unknown" with a 'pointer' to the artifact to collect):\n` +
-        pinnedQuestions.map((q) => `[${q.id}] ${q.question}`).join("\n") + "\n\n"
-      : "";
-    // A finding just confirmed false-positive forces a re-answer of any key question that cited it
-    // as support — otherwise a question "answered" from a finding the analyst just rejected would
-    // keep looking answered until the model happens to reconsider it unprompted. The sanitize pass
-    // after the AI call (below, near applyFalsePositive) is the deterministic backstop for when the
-    // model ignores this and echoes the stale answer back.
-    const droppedFindingIds = new Set(
-      state.findings
-        .filter((f) => !applyFalsePositive(state, markers).findings.some((k) => k.id === f.id))
-        .map((f) => f.id),
-    );
-    const questionsToReanswer = state.keyQuestions.filter((q) => {
-      if (q.pinned) return false;
-      // A question whose recommended collection was just satisfied (#8 phase 2) must be re-evaluated
-      // with the evidence now present, not left showing its old "unknown".
-      if (satisfiedQuestionIds.has(q.id)) return true;
-      if ((q.relatedFindingIds ?? []).some((id) => droppedFindingIds.has(id))) return true;
-      // Fallback for a question that predates relatedFindingIds (or whose answer only ever named
-      // the finding in prose): its free-text pointer/answer still cites the now-rejected finding.
-      return [...droppedFindingIds].some(
-        (id) => textMentionsFindingId(q.pointer, id) || textMentionsFindingId(q.answer, id),
-      );
-    });
-    const reanswerBlock = questionsToReanswer.length
-      ? `QUESTIONS TO RE-ANSWER (a finding backing this answer was just confirmed a FALSE POSITIVE — ` +
-        `re-evaluate using ONLY the CURRENT findings/evidence, ignoring the rejected finding entirely; ` +
-        `if nothing else supports it, set status "unknown", clear the answer, and set relatedFindingIds ` +
-        `to []):\n` +
-        questionsToReanswer.map((q) => `[${q.id}] ${q.question} (previously: "${q.answer}")`).join("\n") + "\n\n"
-      : "";
-
-    // Token budget: trim the timeline so the WHOLE prompt fits the model context — the rest
-    // (context block, findings echo, system prompt) is the fixed overhead. Re-select for the
-    // smaller count so the kept events stay the most important; the high-severity backfill
-    // still creates findings for any Critical/High event dropped here.
-    // Each event carries its structured tags (host / process lineage / src→dst / corroborating-source
-    // count) after the prose (investigation-guidance #5) — only when set, so a bare event costs no extra
-    // tokens. This is what lets the model connect cross-host activity instead of guessing from prose.
-    const renderEvent = (e: ForensicEvent) => {
-      // Grouped rows carry their own count/host-spread/span suffix, which supersedes the prevalence
-      // tag — showing both would state the same repetition twice in different words.
-      const group = grouping.groupById.get(e.id);
-      const groupTag = group ? renderGroupSuffix(group) : "";
-      // Prevalence baseline tag (#15): only the informative extremes (clearly common / clearly rare) are
-      // tagged, so the model knows a 500× pattern is routine and a 1-off is anomalous.
-      const p = group ? null : eventPrevalence(e, prevalenceIndex);
-      const prevTag = p ? prevalenceTag(p) : "";
-      // "~" prefix (investigation-guidance #4): this row is supporting CONTEXT (pulled in to explain an
-      // anchor), not itself a primary verdict-bearing event — so the model weights it as background.
-      const ctx = isContext(e.id) ? "~" : "";
-      return `${ctx}[${e.id}] ${e.timestamp || "(undated)"} [${e.severity}] ${e.description.slice(0, 240)}${renderStructuredTags(e)}${groupTag}${prevTag ? ` ⟨${prevTag}⟩` : ""}`;
-    };
-    const synthOverhead = estimateTokens(getSynthesisPrompt())
-      + estimateTokens(incidentTypeBlock + scopeNote + contextBlock + graphBlock + beaconBlock + attackPhaseBlock + knownUnknownsBlock + adversaryBlock + notebookBlock + analystHypothesesBlock + refutedHypothesesBlock + priorHuntsBlock + playbookProgressBlock + satisfiedBlock + pinnedBlock + reanswerBlock + observationsBlock + existingFindings + openThreads + falsePositiveBlock + authorizedContextBlock + learnedPatternsBlock + (state.lastSummary || "")) + 400;
-    const fit = fitItemsToBudget(promptEvents, renderEvent, Math.max(0, inputTokenBudget() - synthOverhead));
-    if (fit < promptEvents.length) { selection = selectSynthesisEventsAnnotated(collapsedEvents, fit, rarityOf); promptEvents = selection.events; }
-
-    const timelineText = promptEvents.map(renderEvent).join("\n");
-    // Coverage audit (#62): what the model actually saw this run vs what was left out and why. Computed
-    // here where promptEvents + the token overhead are final. Of the budget-omitted events, the safety-net
-    // backfill (below) still guarantees a finding for any Critical/High, so surface that count too.
-    // A grouped row stands for every member of its burst, so all of those events were SEEN by the model —
-    // counting only the representative would report the rest as "omitted for the size limit", the
-    // opposite of the truth.
-    const shownIds = new Set<string>();
-    let groupEntries = 0;
-    let groupedEvents = 0;
-    for (const e of promptEvents) {
-      shownIds.add(e.id);
-      const members = grouping.memberIdsByRepresentative.get(e.id);
-      if (!members) continue;
-      groupEntries += 1;
-      groupedEvents += members.length;
-      for (const id of members) shownIds.add(id);
-    }
-    const representedEvents = scopedEvents.filter((e) => shownIds.has(e.id));
-    const omittedHighSeverity = scopedEvents.filter(
-      (e) => !shownIds.has(e.id) && (e.severity === "Critical" || e.severity === "High"),
-    ).length;
-    const synthCoverage: SynthesisCoverage = buildSynthesisCoverage({
-      totalEvents: state.forensicTimeline.length,
-      inWindow: inWindowEvents.length,
-      scoped: scopedEvents.length,
-      considered: shownIds.size,
-      groupEntries,
-      groupedEvents,
-      omittedInfo,
-      omittedHighSeverity,
-      promptTokensEstimate: synthOverhead + estimateTokens(timelineText),
-    });
-    const truncatedNote = scopedEvents.length > shownIds.size
-      ? ` — showing ${shownIds.size} of ${scopedEvents.length}; ${scopedEvents.length - shownIds.size} event(s) omitted from this prompt but still in the case`
-      : "";
-    // Legend for the "~" context prefix (investigation-guidance #4) — only when at least one context row
-    // is present, so it costs nothing on a small case.
-    const contextLegend = promptEvents.some((e) => isContext(e.id))
-      ? " Rows prefixed \"~\" are SUPPORTING CONTEXT (pulled in to explain a nearby anchor), not primary findings — weight them as background."
-      : "";
-    const userPrompt =
-      incidentTypeBlock +
-      scopeNote +
-      contextBlock +
-      graphBlock +
-      beaconBlock +
-      attackPhaseBlock +
-      knownUnknownsBlock +
-      adversaryBlock +
-      notebookBlock +
-      analystHypothesesBlock +
-      refutedHypothesesBlock +
-      priorHuntsBlock +
-      playbookProgressBlock +
-      satisfiedBlock +
-      pinnedBlock +
-      reanswerBlock +
-      observationsBlock +
-      `FORENSIC TIMELINE (${scopedEvents.length} dated events${truncatedNote}).${contextLegend}\n${timelineText}\n\n` +
-      `EXISTING FINDINGS (update by id, do not duplicate):\n${existingFindings}\n\n` +
-      `CURRENTLY OPEN THREADS (close by id in threadsClosed when the evidence resolves them):\n${openThreads}\n\n` +
-      (falsePositiveBlock ? `${falsePositiveBlock}\n\n` : "") +
-      (authorizedContextBlock ? `${authorizedContextBlock}\n\n` : "") +
-      (learnedPatternsBlock ? `${learnedPatternsBlock}\n\n` : "") +
-      `Running notes: ${state.lastSummary || "(none)"}\n\nReturn the JSON conclusions.`;
-
-    const synthStart = Date.now();
-    const retries = this.opts.retries ?? 3;
-    const backoffMs = this.opts.backoffMs ?? 500;
-    // Chain-of-Thought / extended thinking for the complex synthesis call (issue #121, feature 1).
-    // Budget resolved per-run: an explicit value or the dashboard "deep reasoning" toggle wins, else
-    // the global DFIR_AI_SYNTH_THINKING_TOKENS default (off when unset). The Anthropic provider maps
-    // it to extended thinking; OpenRouter to its unified `reasoning`; other providers ignore it. Only
-    // synthesis reasons step-by-step — extraction stays cheap.
-    const synthThinkingTokens = resolveSynthThinkingBudget(opts, Number(process.env.DFIR_AI_SYNTH_THINKING_TOKENS) || 0);
-    // Per-model quality telemetry (#74): count retries the synthesis call actually needed (a failed
-    // parse/schema-mismatch attempt increments this). Counted on catch INSIDE the retried closure
-    // rather than via this.withRetry's onRetry hook, because that hook is the shared server-logging
-    // callback — routing through this.withRetry keeps master's per-attempt WARN logging intact while
-    // the local catch keeps the count. Surfaced on synth-meta so a flaky model shows up empirically.
-    let synthParseRetries = 0;
-    const delta = await this.withRetry(caseId, "synthesis", async () => {
-      try {
-        const parsed = await this.analyzeRestored(
-          caseId,
-          state,
-          synthProvider,
-          { systemPrompt: getSynthesisPrompt(), userPrompt, images: [], ...(synthThinkingTokens > 0 ? { thinkingTokens: synthThinkingTokens } : {}), ...(opts.signal ? { signal: opts.signal } : {}) },
-          "synthesis",
-        );
-        return stripAiExtractedFrom(deltaSchema.parse(parsed));
-      } catch (err) {
-        synthParseRetries++;
-        throw err;
-      }
-    }, retries, backoffMs);
-
-    // Anchor finding timestamps to the last real event time (fallback: existing state time).
-    const ts = state.forensicTimeline[state.forensicTimeline.length - 1]?.timestamp || state.updatedAt;
-    // Synthesis is an authoritative holistic reassessment: replace the CONCLUSIONS
-    // (findings, MITRE techniques) rather than accumulate, so anything no longer
-    // supported by the in-scope timeline (e.g. out-of-scope or removed events) is
-    // dropped. IOCs are OBSERVED INDICATORS (often from deterministic imports like THOR
-    // — 100s of hashes the text-only synthesis can't re-derive), so they are PRESERVED
-    // and merged (deduped by value); scope/legitimate still filter them at projection.
-    // Threads and the forensic timeline are also preserved.
-    const base = { ...state, findings: [], mitreTechniques: [] };
-    const merged = await this.mergeWithAliases(base, delta, { windowSequence: 0, timestamp: ts, sourceScreenshots: [] });
-    // Safety net: drop anything confirmed false-positive even if the model re-introduced it.
-    const filtered = applyFalsePositive(merged, markers);
-
-    // Back-link forensic events to the CORRECT findings using the synthesis output
-    // (each finding lists the event ids it's based on). Replaces extraction guesses.
-    const surviving = new Set(filtered.findings.map((f) => f.id));
-    const eventToFindings = new Map<string, string[]>();
-    for (const f of delta.findings) {
-      if (!surviving.has(f.id)) continue;
-      for (const eid of f.relatedEventIds ?? []) {
-        const arr = eventToFindings.get(eid) ?? [];
-        if (!arr.includes(f.id)) arr.push(f.id);
-        eventToFindings.set(eid, arr);
-      }
-    }
-    const linked = {
-      ...filtered,
-      forensicTimeline: filtered.forensicTimeline.map((e) => ({ ...e, relatedFindingIds: eventToFindings.get(e.id) ?? [] })),
-    };
-
-    // Heuristic safety net: a Critical/High artifact row is almost always a finding.
-    // Any in-scope, non-legitimate high-severity event that synthesis left WITHOUT a
-    // finding gets one auto-created, so a severe detection can never be silently
-    // missed. Restricted to the events synthesis actually considered (scopedEvents).
-    const eligibleIds = new Set(scopedEvents.map((e) => e.id));
-    const backfilled = backfillHighSeverityFindings(linked, eligibleIds, ts);
-    // #74: how many findings the safety net had to add — a proxy for detections synthModel itself missed.
-    const highSeverityBackfillCount = backfilled.findings.length - linked.findings.length;
-    // Log gap analysis (#83): a COMPLETE-silence gap — a window where every source went dark — is the
-    // classic signature of cleared logs / a stopped collector, so escalate it to a finding here too.
-    // Gaps are derived on read (not persisted); only the complete ones earn a persisted finding, and
-    // the finding id is derived from the bounding events so re-synthesis over the same gap is idempotent.
-    const gapOpts = gapEnvOptions();
-    const gaps = detectTimelineGaps(scopedEvents, gapOpts);
-    const gapFilled = backfillSilenceGapFindings(backfilled, gaps, ts, gapOpts.maxFindings);
-    // Preserve analyst-pinned questions (synthesis replaces keyQuestions wholesale). Re-read
-    // the LATEST state here, not the pre-AI snapshot, so a question added DURING the
-    // seconds-long AI call isn't clobbered by this write (read-modify-write race).
-    const pinnedNow = (await this.opts.stateStore.load(caseId)).keyQuestions.filter((q) => q.pinned);
-    let next = pinnedNow.length
-      ? { ...gapFilled, keyQuestions: mergePinnedQuestions(pinnedNow, gapFilled.keyQuestions) }
-      : gapFilled;
-
-    // Deterministic backstop for the reanswerBlock instruction above: if the model still cited a
-    // now-dead finding (ignored the instruction) — whether via a structured relatedFindingIds link
-    // or only in the free-text pointer/answer prose (the only signal available for a question that
-    // predates relatedFindingIds) — force the question back to "unknown" (clearing the stale
-    // answer). ANY dependency on a rejected finding forces the reset, not just total loss of
-    // support: a partial answer that still names a finding the analyst just confirmed is NOT a
-    // threat is misleading even when another finding also backs it, and we can't safely guess what
-    // the finding-minus-the-FP'd-one answer should say without asking the model again. Guarantees a
-    // key question can never keep citing a finding that's already gone.
-    // Shared with the FP-mark route's synchronous cascade (investigation-guidance #12). Here it runs as
-    // the AUTHORITATIVE recompute (staleReSynth off → clears any interim stale badge), guaranteeing a key
-    // question can never keep citing a finding that's gone.
-    next = {
-      ...next,
-      keyQuestions: reconsiderKeyQuestions(next.keyQuestions, {
-        survivingFindingIds: new Set(next.findings.map((f) => f.id)),
-        priorFindingIds: state.findings.map((f) => f.id), // ids that existed going into this run
-      }).questions,
-    };
-
-    // Answer-contradiction validator (investigation-guidance #3): a key question whose answer asserts
-    // an ABSENCE ("no data exfiltration confirmed") while in-scope events carry the matching ATT&CK
-    // techniques is a dangerous false negative. Force such answers to "partial" and cite the
-    // contradicting events. Runs AFTER the FP reset (so a reset-to-unknown answer isn't re-flagged) over
-    // the same scoped, non-FP events the model saw. Pure + idempotent.
-    next = { ...next, keyQuestions: flagContradictedAnswers(next.keyQuestions, scopedEvents) };
-
-    // Union the deterministically-identified ATT&CK techniques carried by the (in-scope) timeline
-    // into the synthesized MITRE table, so techniques the model didn't echo — especially the Info/Low
-    // discovery phase (whoami/net group/findstr password/cat .env) tagged by the importers — still
-    // appear in the case's MITRE table and report. Same scoped events synthesis saw; pure + idempotent.
-    next = { ...next, mitreTechniques: unionEventTechniques(next.mitreTechniques, scopedEvents) };
-
-    // Prior-work safety net (investigation-guidance #2): even with the PLAYBOOK PROGRESS prompt block,
-    // the model may still echo a nextStep that repeats a COMPLETED task. Deterministically DEMOTE (not
-    // drop) any such step to priority "low" with an annotation, requiring a shared host/artifact token
-    // so a same-verb different-target step survives. Keeps the top of the next-steps list actionable.
-    if (playbookTasks.length) {
-      const doneTitles = playbookTasks.filter((t) => t.status === "done").map((t) => t.title);
-      if (doneTitles.length) {
-        const { steps, demotedIds } = demoteCompletedNextSteps(next.nextSteps, doneTitles);
-        if (demotedIds.length) next = { ...next, nextSteps: steps };
-      }
-    }
-
-    // Dry run (second-opinion Pass 1): return model B's conclusions WITHOUT persisting or any side
-    // effect — and WITHOUT folding in accepted deltas, so B stays an independent opinion.
-    if (opts.dryRun) return next;
-
-    // Durability (issue #116): re-apply any analyst-ACCEPTED second-opinion deltas after the
-    // wholesale findings rewrite, so a confirmed model-B finding/severity/technique is never lost
-    // on re-synthesis. Pure + idempotent; a no-op when the store or record is absent/empty.
-    if (this.opts.secondOpinionStore) {
-      next = applyAcceptedSecondOpinion(next, await this.opts.secondOpinionStore.load(caseId));
-    }
-
-    // Per-finding grounding + corroboration (investigation-guidance #6): resolve each finding's
-    // supporting in-scope events (forward relatedEventIds AND reverse forensicTimeline links, so the
-    // deterministic backfill findings ground correctly), roll up { tools, hosts, intel, graph-linked },
-    // flag an uncited finding as `ungrounded`, and CAP an ungrounded/single-source finding's confidence.
-    // Also catches the subtler case where cited ids resolve but the finding's own claimed IP never
-    // appears in their text (`contentMismatch`) — floors High/Critical to Medium (veridia-deep-pass
-    // 2026-07-22). Deterministic + idempotent; only ever lowers confidence/severity. Runs last, so it
-    // grades the FINAL finding set (incl. backfills + accepted second-opinion deltas).
-    {
-      const evidenceGraph = buildEvidenceGraph(next);
-      const graphLinkedEventIds = new Set(evidenceGraph.edges.flatMap((e) => e.eventIds));
-      const inScope = next.forensicTimeline.filter((e) => eligibleIds.has(e.id));
-      // KEV-linked confidence signal (issue #61): the CVEs mentioned in-scope (events + IOCs) that match
-      // the CISA KEV catalog. Empty when no catalog is loaded, so the signal is simply never set then.
-      const kevCatalog = await this.getKevCatalog();
-      let kevCveIds: Set<string> | undefined;
-      if (kevCatalog && kevCatalog.size > 0) {
-        const cveIds = new Set<string>();
-        for (const e of inScope) { extractCveIds(e.description).forEach((id) => cveIds.add(id)); if (e.message) extractCveIds(e.message).forEach((id) => cveIds.add(id)); }
-        for (const i of next.iocs) extractCveIds(i.value).forEach((id) => cveIds.add(id));
-        kevCveIds = new Set(matchKevEntries([...cveIds], kevCatalog).map((m) => m.cveID));
-      }
-      const grounded = groundAndScoreFindings({ findings: next.findings, scopedEvents: inScope, iocs: next.iocs, graphLinkedEventIds, kevCveIds, sourceTrust });
-      // Intel-verdict gate (investigation-guidance #7): floor an intel-ONLY High/Critical finding (no
-      // behavioral corroboration, all its verdict IOCs lone-intel/conflicted) to Medium/≤60 — the
-      // northpeak stale-CTI-on-own-server class. Runs after grounding so it sees the corroboration rollup.
-      const hostNames = new Set(buildAssetGraph(next).assets.filter((a) => a.type === "host").map((a) => shortHost(a.name)));
-      const capped = capIntelOnlyFindings({ findings: grounded, iocs: next.iocs, scopedEvents: inScope, hostNames });
-      // Rabbit-hole detection (investigation-guidance #13): place each finding relative to the corroborated
-      // main attack component. A finding whose graph-modeled evidence sits in a SEPARATE component is a
-      // rabbit-hole candidate ('disconnected'); the model's per-finding relevance verdict refines a
-      // disconnected one into 'unrelated-but-real' (a genuine separate issue) vs undetermined noise. The
-      // deterministic linkage is authoritative; the AI never upgrades a rabbit hole into a lead.
-      const aiRelevanceById = new Map(
-        (delta.findings ?? [])
-          .filter((f): f is typeof f & { relevance: "connected" | "unrelated-but-real" | "undetermined" } => !!f.relevance && surviving.has(f.id))
-          .map((f) => [f.id, f.relevance] as const),
-      );
-      next = { ...next, findings: scoreFindingsRelevance({ findings: capped, scopedEvents: inScope, graph: evidenceGraph, aiRelevanceById }) };
-
-      // Auto "corroborate <ioc>" next-steps (investigation-guidance #7, deferred): for every finding the
-      // intel gate just floored to intel-only, add a concrete "go get the behavioral evidence" step so the
-      // capped lead becomes a directed action, not a dead end. Idempotent ids; prepend so the verification
-      // steps sit near the top, and don't duplicate a step the model already emitted with the same id.
-      const corroborateSteps = buildIntelCorroborationSteps({ findings: next.findings, iocs: next.iocs, scopedEvents: inScope, hostNames });
-      if (corroborateSteps.length) {
-        const existing = new Set((next.nextSteps ?? []).map((s) => s.id));
-        const fresh = corroborateSteps.filter((s) => !existing.has(s.id));
-        if (fresh.length) next = { ...next, nextSteps: [...fresh, ...(next.nextSteps ?? [])] };
-      }
-    }
-
-    // What this run changed vs the pre-AI findings. Findings are FINAL here — neither persistLatest
-    // nor the hypothesis auto-gen below touch them — so it's computed once and reused for the
-    // Investigation-Log entry (#165), the synth-meta record, and the notify hook.
-    const findingsDiff = diffFindings(loaded.findings, next.findings);
-
-    // Lost-update guard (mirrors the pinned-questions re-load above): a manual event/IOC/thread
-    // added DURING the seconds-long AI call would otherwise be clobbered by this write, because
-    // `next` was derived from the snapshot taken before the call. Re-read the LATEST state and
-    // carry forward only items NEW since that snapshot (by id/value), so synthesis's conclusions
-    // and its correlation/legitimate work on the snapshot timeline are preserved while concurrent
-    // analyst additions survive. Reference the RAW snapshot (`loaded`), not the in-memory
-    // correlated `state`, so events deduped by correlateEvents aren't re-added.
-    const persistLatest = async () => {
-      const latest = await this.opts.stateStore.load(caseId);
-      const snapEventIds = new Set(loaded.forensicTimeline.map((e) => e.id));
-      const nextEventIds = new Set(next.forensicTimeline.map((e) => e.id));
-      const addedEvents = latest.forensicTimeline.filter((e) => !snapEventIds.has(e.id) && !nextEventIds.has(e.id));
-      const snapIocVals = new Set(loaded.iocs.map((i) => i.value.toLowerCase()));
-      const nextIocVals = new Set(next.iocs.map((i) => i.value.toLowerCase()));
-      const latestIocByVal = new Map(latest.iocs.map((i) => [i.value.toLowerCase(), i]));
-      const mergedIocs = [
-        ...next.iocs.map((i) => latestIocByVal.get(i.value.toLowerCase()) ?? i),
-        ...latest.iocs.filter((i) => !snapIocVals.has(i.value.toLowerCase()) && !nextIocVals.has(i.value.toLowerCase())),
-      ];
-      const snapThreadIds = new Set(loaded.openThreads.map((t) => t.id));
-      const nextThreadIds = new Set(next.openThreads.map((t) => t.id));
-      const addedThreads = latest.openThreads.filter((t) => !snapThreadIds.has(t.id) && !nextThreadIds.has(t.id));
-      // Investigation Log (#165): carry forward any timeline line a CONCURRENT import appended during
-      // the AI call (dedupe by timestamp+sequence+text), so the synthesis write doesn't clobber it.
-      const tlKey = (t: TimelineEntry) => `${t.timestamp}|${t.windowSequence}|${t.description}`;
-      const snapTimeline = new Set(loaded.timeline.map(tlKey));
-      const nextTimeline = new Set(next.timeline.map(tlKey));
-      const addedTimeline = latest.timeline.filter((t) => !snapTimeline.has(tlKey(t)) && !nextTimeline.has(tlKey(t)));
-      next = {
-        ...next,
-        forensicTimeline: addedEvents.length ? sortByEventTime([...next.forensicTimeline, ...addedEvents]) : next.forensicTimeline,
-        iocs: mergedIocs,
-        openThreads: addedThreads.length ? [...next.openThreads, ...addedThreads] : next.openThreads,
-        timeline: addedTimeline.length ? [...next.timeline, ...addedTimeline] : next.timeline,
-      };
-      // Record THIS synthesis run as a durable, cross-session Investigation-Log line (#165) — imports
-      // already log via timelineNote; synthesis didn't. Final merged counts; one entry per real run.
-      const synthLogEntry: TimelineEntry = {
-        timestamp: new Date().toISOString(),
-        windowSequence: 0,
-        description:
-          `Synthesis: ${next.findings.length} finding(s) (${findingsDiff.added.length} new, ` +
-          `${findingsDiff.severityChanged.length} reclassified), ${next.forensicTimeline.length} event(s), ` +
-          `${next.iocs.length} IOC(s)`,
-        sourceScreenshots: [],
-      };
-      next = { ...next, timeline: [...next.timeline, synthLogEntry] };
-      await this.opts.stateStore.save(next);
-    };
-    if (this.opts.stateLock) await this.opts.stateLock.runExclusive(caseId, persistLatest);
-    else await persistLatest();
-
-    // Auto-generate hypotheses (issue #140). Merge the model's hypotheses into the per-case store,
-    // refreshing pristine auto ones and FREEZING any the analyst touched (see mergeHypotheses). Only
-    // when the model actually returned some — an omitted field must never prune the analyst's set.
-    // Sanitized against the FINAL event/IOC ids so evidence links can't dangle. Side store, not
-    // InvestigationState; runs after the state is persisted so a failure here can't lose the synthesis.
-    if (this.opts.hypothesisStore && delta.hypotheses && delta.hypotheses.length) {
-      const validEventIds = new Set(next.forensicTimeline.map((e) => e.id));
-      const validIocIds = new Set(next.iocs.map((i) => i.id));
-      const seeds = sanitizeHypotheses(delta.hypotheses, validEventIds, validIocIds);
-      await this.opts.hypothesisStore.applyAutoGenerated(caseId, seeds, new Date().toISOString());
-    }
-
-    this.lastSynthHash.set(caseId, synthHash);   // remember these inputs so an identical re-run skips the AI call
-    // Record what this run changed (findingsDiff computed above) and when it ran — surfaced on the
-    // dashboard. Only reached on a real run; skips return early above.
-    await this.opts.synthMetaStore?.record(caseId, findingsDiff, new Date().toISOString(), {
-      durationMs: Date.now() - synthStart,
-      eventCount: next.forensicTimeline.length,
-      iocCount: next.iocs.length,
-      selectionCounts: { ...selection.counts },   // #4: the evidence mix the model saw
-      coverage: synthCoverage,                     // #62: included/omitted coverage audit
-      synthModel: this.opts.synthesisModelLabel ?? `${synthProvider.name}/${synthProvider.model}`, // #74
-      findingsCount: next.findings.length,          // #74
-      highSeverityBackfillCount,                    // #74
-      parseRetries: synthParseRetries,              // #74
-    });
-    const anonPolicy = toAnonPolicy(this.opts.anonStore ? await this.opts.anonStore.load(caseId) : null);
-    await recordSynthesisRun(this.opts.analysisRunStore, caseId, {
-      parentRunId: opts.analysisParentRunId, startedAt: new Date(synthStart).toISOString(),
-      provider: synthProvider.name, model: synthProvider.model, eventIds: [...shownIds],
-      inputState: state, outputState: next, prompt: getSynthesisPrompt(), maxEvents: SYNTH_MAX_EVENTS,
-      thinkingTokens: synthThinkingTokens, correlationWindowSeconds: windowSeconds, anonymizationPolicy: anonPolicy,
-      scope, falsePositiveMarkers: markers.length, infoEventsExcluded: omittedInfo > 0,
-      observationsIncluded: observationsBlock.length > 0, parseRetries: synthParseRetries, coverage: synthCoverage,
-    });
-    // Notify on new/escalated findings (issue #58). Best-effort, fire-and-forget — never blocks or
-    // fails synthesis. Only on a real run, so a skipped (unchanged) re-synthesis sends nothing.
-    this.opts.onSynth?.(caseId, findingsDiff, next);
-    this.opts.onState?.(next);
-
-    // Second-look loop (investigation-guidance #11): now that this run has conclusions + (open)
-    // hypotheses + key questions, re-query the COMPLETE raw record (the super-timeline + the scoped
-    // events the sampler omitted) for the terms those open questions imply, promote the matches, and
-    // trigger EXACTLY ONE bounded re-synthesis so the conclusions fold them in. `skipSecondLook` on that
-    // re-synthesis (and on the second-opinion dryRun path, already returned above) is the one-iteration
-    // guard that makes this terminate. Best-effort: a sweep failure must never fail the synthesis.
-    if (!opts.skipSecondLook && this.opts.superTimelineStore) {
-      try {
-        const outcome = await this.runSecondLook(caseId, {
-          // The sweep treats anything not in `promptEvents` as a candidate to re-discover; events
-          // already covered by a grouped row HAVE been seen, so hand it the expanded set.
-          next, scopedEvents, promptEvents: representedEvents, scope, evidenceRequests: delta.evidenceRequests,
-        });
-        if (outcome) {
-          if (outcome.meta.promoted > 0) {
-            // Promotion changed the in-scope timeline → the synthHash differs → this re-synthesis runs
-            // (not skipped) and, with skipSecondLook, does NOT sweep again. Bounded to one extra AI call.
-            const resynth = await this.synthesize(caseId, {
-              force: true, skipSecondLook: true, ...(opts.signal ? { signal: opts.signal } : {}),
-            });
-            await this.opts.synthMetaStore?.recordSecondLook(caseId, outcome.meta);
-            return resynth;
-          }
-          // Nothing new to promote, but empty requests are still surfaced as collection leads.
-          await this.opts.synthMetaStore?.recordSecondLook(caseId, outcome.meta);
-        }
-      } catch (err) {
-        console.warn(`[DFIR] second-look sweep failed for case ${caseId}: ${(err as Error).message}`);
-      }
-    }
-    return next;
-  }
-
-  // Second-look sweep (investigation-guidance #11) — the impure orchestration around the pure secondLook
-  // module. Mines the case's OPEN questions (open hypotheses, unknown/partial key questions with a
-  // collect target, top connective IOCs) plus the model's own evidenceRequests into concrete searches,
-  // resolves them against the omitted scoped events AND the super-timeline within the active window,
-  // promotes the not-yet-analyzed matches (capped, tagged with provenance), and returns a meta summary.
-  // Returns null when there was nothing to search for. Never re-synthesizes itself — the caller does.
-  private async runSecondLook(
-    caseId: string,
-    ctx: {
-      next: InvestigationState;
-      scopedEvents: ForensicEvent[];
-      promptEvents: ForensicEvent[];
-      scope: ScopeWindow;
-      evidenceRequests?: ModelEvidenceRequest[];
-    },
-  ): Promise<{ meta: import("./synthMeta.js").SecondLookMeta } | null> {
-    const superStore = this.opts.superTimelineStore;
-    if (!superStore) return null;
-
-    // Active window: the explicit scope when set, else the span of the dated in-scope events. Bounds the
-    // raw re-query so a huge super-timeline is searched only over the incident window.
-    const window = hasScope(ctx.scope)
-      ? { from: ctx.scope.start ?? undefined, to: ctx.scope.end ?? undefined }
-      : deriveWindow(ctx.scopedEvents);
-
-    const hypotheses = this.opts.hypothesisStore ? await this.opts.hypothesisStore.load(caseId) : [];
-    const iocValueById = new Map(ctx.next.iocs.map((i) => [i.id, i.value] as const));
-    const connectiveIocs = rankConnectiveIocs(ctx.next, ctx.scopedEvents, { max: 5 });
-
-    const requests = buildSecondLookRequests({
-      hypotheses,
-      iocValueById,
-      keyQuestions: ctx.next.keyQuestions,
-      connectiveIocs,
-      modelRequests: ctx.evidenceRequests,
-      window,
-    });
-    if (!requests.length) return null;
-
-    // Candidate pool: the scoped events the sampler OMITTED from the prompt + the super-timeline rows in
-    // the window (deduped by id). A super row that is a copy of a forensic event shares its id, so
-    // `forensicEventIds` (below) correctly marks it non-promotable — only genuinely-new raw rows promote.
-    const shownIds = new Set(ctx.promptEvents.map((e) => e.id));
-    const omitted = ctx.scopedEvents.filter((e) => !shownIds.has(e.id));
-    const superRows = (await superStore.query(caseId, { from: window.from, to: window.to })).events;
-    const byId = new Map<string, ForensicEvent>();
-    for (const e of [...omitted, ...superRows]) if (!byId.has(e.id)) byId.set(e.id, e);
-    const candidates = [...byId.values()];
-
-    const forensicEventIds = new Set(ctx.next.forensicTimeline.map((e) => e.id));
-    const resolutions = resolveSecondLookRequests(requests, candidates, forensicEventIds);
-    const plan = buildSecondLookPlan(resolutions);
-
-    if (plan.promotions.length) {
-      await this.promoteSuperTimeline(caseId, plan.promotions, {
-        importedAt: new Date().toISOString(),
-        tagById: plan.tagById,
-        note: `Second look: promoted ${plan.promotions.length} raw event(s) matching open questions`,
-      });
-    }
-
-    const matched = resolutions.filter((r) => r.matchedEventIds.length > 0).length;
-    return {
-      meta: {
-        promoted: plan.promotions.length,
-        requests: requests.length,
-        matched,
-        leads: plan.leads.map((l) => l.reason).slice(0, 10),
-        summary: summarizeSecondLook(plan),
-        at: new Date().toISOString(),
-      },
-    };
-  }
-
-  // Second LLM opinion (issue #116). On-demand QA cross-check: a DIFFERENT model independently
-  // re-synthesizes the case (Pass 1, non-destructive `dryRun`), then a reconcile pass (Pass 2)
-  // annotates each disagreement (B-only / A-only finding, severity, ATT&CK technique) with a
-  // rationale + recommendation. Returns the saved record; never mutates the case state — the
-  // analyst adjudicates per delta via applySecondOpinion(). Throws (→ route 501/500) when the
-  // second-opinion model isn't configured.
-  async secondOpinion(caseId: string, opts: SynthThinkingInput = {}): Promise<SecondOpinion> {
-    const provider = this.opts.secondOpinionProvider;
-    if (!provider) throw new Error("second-opinion model not configured (set DFIR_AI_SECOND_OPINION_MODEL)");
-    if (!this.opts.secondOpinionStore) throw new Error("second-opinion store not configured");
-    if ((await this.opts.stateStore.load(caseId)).forensicTimeline.length === 0) {
-      throw new Error("nothing to review — import evidence and synthesize the case first");
-    }
-    // Deep-reasoning toggle (#121) flows into BOTH synthesis passes below, so model A's freshened
-    // synthesis and model B's independent pass reason equally hard for the comparison.
-
-    // Pass 0 — freshen the PRIMARY synthesis so model A reflects the CURRENT timeline. Without this,
-    // a stale saved A vs a fresh model-B run produces deltas that are staleness artifacts (e.g. the
-    // deterministic gap-silence / high-severity backfill findings) rather than real model
-    // disagreements. Uses skip-if-unchanged (no `force`), so it's a NO-OP (no AI call) when A is
-    // already current — it only re-synthesizes when the in-scope timeline/IOCs/scope changed.
-    const a = await this.synthesize(caseId, { deepReasoning: opts.deepReasoning, thinkingTokens: opts.thinkingTokens });
-
-    // Pass 1 — independent synthesis with model B over the SAME current timeline/context, routed
-    // through a different model and NOT persisted (dryRun). This is model B's analysis.
-    const b = await this.synthesize(caseId, { dryRun: true, force: true, provider, deepReasoning: opts.deepReasoning, thinkingTokens: opts.thinkingTokens });
-
-    const modelA = this.opts.synthesisModelLabel ?? (this.opts.synthesisProvider ?? this.opts.provider)?.name ?? "model A";
-    const modelB = this.opts.secondOpinionModelLabel ?? provider.name;
-    let record = buildSecondOpinion({ a, b, modelA, modelB, now: () => new Date().toISOString() });
-
-    // Pass 2 — reconcile: annotate each disagreement with a rationale + recommendation. Best-effort:
-    // if the reconcile call fails, keep the deterministic deltas (no rationale) rather than failing.
-    if (record.deltas.length > 0) {
-      const userPrompt = buildReconcilePrompt(a, b, record.deltas);
-      const retries = this.opts.retries ?? 3;
-      const backoffMs = this.opts.backoffMs ?? 500;
-      try {
-        const parsed = await this.withRetry(caseId, "second-opinion-reconcile", async () => {
-          const raw = await this.analyzeRestored(caseId, a, provider, { systemPrompt: getReconcilePrompt(), userPrompt, images: [] }, "second-opinion-reconcile");
-          return reconcileResponseSchema.parse(raw);
-        }, retries, backoffMs);
-        record = mergeReconcileVerdicts(record, parsed);
-      } catch (err) {
-        this.log.warn(`[second-opinion] reconcile pass failed: ${(err as Error).message}`, { caseId });
-      }
-    }
-
-    await this.opts.secondOpinionStore.save(caseId, record);
-    // Per-model quality telemetry (#74): stamp the agreement rate onto synth-meta so modelA vs modelB
-    // can be compared empirically across runs, not just eyeballed on this one second-opinion panel.
-    const deltaCount = record.deltas.length;
-    const denom = record.agreementCount + deltaCount;
-    await this.opts.synthMetaStore?.recordSecondOpinionPerf(caseId, {
-      modelA,
-      modelB,
-      agreementCount: record.agreementCount,
-      deltaCount,
-      agreementRate: denom > 0 ? record.agreementCount / denom : 0,
-      at: record.generatedAt,
-    });
-    return record;
+  secondOpinion(caseId: string, opts: SynthThinkingInput = {}): Promise<SecondOpinion> {
+    return secondOpinionRun.secondOpinion(this.aiCtx, caseId, opts);
   }
 
   // Accept or reject ONE second-opinion delta. The analyst's decision is recorded on the delta, and
   // ALL currently-accepted deltas are (re-)applied onto the live case state (idempotent) — so an
   // accept adds/edits the finding/severity/technique now and survives the next synthesis (the same
   // re-apply runs in synthesize()). A reject just records the decision; state is unchanged.
-  async applySecondOpinion(caseId: string, deltaId: string, accept: boolean): Promise<{ record: SecondOpinion; state: InvestigationState }> {
-    if (!this.opts.secondOpinionStore) throw new Error("second-opinion store not configured");
-    const current = await this.opts.secondOpinionStore.load(caseId);
-    if (!current) throw new Error("no second opinion to act on — run a second opinion first");
-    if (!current.deltas.some((d) => d.id === deltaId)) throw new Error(`unknown second-opinion delta: ${deltaId}`);
-    return this.persistSecondOpinion(caseId, setDeltaStatus(current, deltaId, accept ? "accepted" : "rejected"));
+  applySecondOpinion(caseId: string, deltaId: string, accept: boolean): Promise<{ record: SecondOpinion; state: InvestigationState }> {
+    return secondOpinionRun.applySecondOpinion(this.aiCtx, caseId, deltaId, accept);
   }
 
   // Bulk accept-all / reject-all: decide every still-PENDING delta at once (already-decided deltas
   // are left as the analyst set them), persist, and apply the accepted set to the case in ONE pass.
-  async applyAllSecondOpinion(caseId: string, accept: boolean): Promise<{ record: SecondOpinion; state: InvestigationState }> {
-    if (!this.opts.secondOpinionStore) throw new Error("second-opinion store not configured");
-    const current = await this.opts.secondOpinionStore.load(caseId);
-    if (!current) throw new Error("no second opinion to act on — run a second opinion first");
-    return this.persistSecondOpinion(caseId, setAllPendingStatus(current, accept ? "accepted" : "rejected"));
+  applyAllSecondOpinion(caseId: string, accept: boolean): Promise<{ record: SecondOpinion; state: InvestigationState }> {
+    return secondOpinionRun.applyAllSecondOpinion(this.aiCtx, caseId, accept);
   }
 
   // Save the (re)decided record, then re-apply ALL accepted deltas onto the live state (idempotent).
   // Shared by the single + bulk apply methods so both persist and broadcast identically.
-  private async persistSecondOpinion(caseId: string, record: SecondOpinion): Promise<{ record: SecondOpinion; state: InvestigationState }> {
-    await this.opts.secondOpinionStore!.save(caseId, record);
-    const state = await this.opts.stateStore.load(caseId);
-    const applied = applyAcceptedSecondOpinion(state, record);
-    if (applied !== state) {
-      await this.opts.stateStore.save(applied);
-      this.opts.onState?.(applied);
-    }
-    return { record, state: applied };
-  }
 }

--- a/companion/tests/analysis/synthesizeCharacterisation.test.ts
+++ b/companion/tests/analysis/synthesizeCharacterisation.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ScopeStore } from "../../src/analysis/scope.js";
+import { SynthMetaStore } from "../../src/analysis/synthMeta.js";
+import { FalsePositiveStore, markerId } from "../../src/analysis/falsePositive.js";
+import { HuntOutcomeStore } from "../../src/analysis/huntOutcomeStore.js";
+import { IncidentTypeStore } from "../../src/analysis/incidentTypeStore.js";
+import { MockProvider } from "../../src/providers/provider.js";
+import type { AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { emptyState, type ForensicEvent, type InvestigationState } from "../../src/analysis/stateTypes.js";
+
+/**
+ * Characterisation tests for synthesize (#418).
+ *
+ * `synthesize` is 695 lines and its output is a MODEL CALL, so "unchanged behaviour" cannot be
+ * proved the way #384 proved its two extractions — no prompt hash, no five-member interface. These
+ * tests are the substitute: they pin the ORCHESTRATION around the model call, which is what an
+ * extraction actually moves. Four seams, named by the issue:
+ *
+ *   1. scope selection  — which events reach the prompt, and how each omission is attributed
+ *   2. the delta merge  — what survives the wholesale findings rewrite, and the lost-update guard
+ *   3. second-look      — covered end-to-end in secondLookLoop.test.ts; not repeated here
+ *   4. skip-when-unchanged — exactly which inputs are in the hash
+ *
+ * Everything here asserts on state the pipeline persisted or on the prompt text it sent, never on a
+ * private method, so the same assertions hold after synthesize becomes a free function.
+ */
+
+let caseStore: CaseStore;
+let stateStore: StateStore;
+
+// Medium by default: high enough to earn a prompt seat, low enough that the Critical/High backfill
+// stays out of the way. A test that wants the backfill asks for Critical explicitly.
+function event(
+  id: string,
+  timestamp: string,
+  description: string,
+  severity: ForensicEvent["severity"] = "Medium",
+  extra: Partial<ForensicEvent> = {},
+): ForensicEvent {
+  return {
+    id,
+    timestamp,
+    description,
+    severity,
+    mitreTechniques: [],
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+    ...extra,
+  };
+}
+
+// A synthesis delta that returns ONE finding and nothing else, so every assertion below is about
+// what the pipeline preserved around the model rather than what the model said.
+function delta(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    findings: [
+      {
+        id: "f1",
+        severity: "High",
+        title: "synth finding",
+        description: "d",
+        relatedIocs: [],
+        mitreTechniques: [],
+        status: "open",
+        relatedEventIds: [],
+      },
+    ],
+    iocs: [],
+    mitreTechniques: [],
+    attackerPath: "p",
+    summary: "s",
+    forensicEvents: [],
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote: "",
+    ...overrides,
+  });
+}
+
+// A provider that records the prompt it was sent and can run a side effect DURING the call — the
+// only way to exercise the lost-update guard, which exists precisely for writes that land while the
+// model is thinking.
+function spyProvider(rawText: string, during?: () => Promise<void>) {
+  const sent: string[] = [];
+  const provider = {
+    name: "spy",
+    model: "spy-model",
+    analyze: async (req: AnalyzeRequest): Promise<AnalyzeResult> => {
+      sent.push(req.userPrompt);
+      if (during) await during();
+      return { rawText };
+    },
+  };
+  return { provider, sent };
+}
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-synth-char-"));
+  caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+  stateStore = new StateStore(caseStore);
+});
+
+describe("synthesize — scope selection", () => {
+  it("attributes each omitted event to its own coverage bucket: scope, legitimate, then Info", async () => {
+    // One event per omission reason plus one that reaches the prompt, so every bucket is non-zero
+    // and a mis-attribution shows up as a specific number rather than a total that happens to match.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("out", "2024-01-01T00:00:00.000Z", "before the window"),
+      event("fp", "2026-01-02T00:00:00.000Z", "analyst says benign"),
+      event("info", "2026-01-03T00:00:00.000Z", "routine chatter", "Info"),
+      event("keep", "2026-01-04T00:00:00.000Z", "the real lead"),
+    );
+    await stateStore.save(seeded);
+
+    const scopeStore = new ScopeStore(caseStore);
+    await scopeStore.save("c1", { start: "2026-01-01T00:00:00.000Z", end: "2026-12-31T00:00:00.000Z" });
+    const falsePositiveStore = new FalsePositiveStore(caseStore);
+    await falsePositiveStore.save("c1", [
+      {
+        id: markerId("event", "fp"),
+        kind: "event",
+        ref: "fp",
+        reason: "known-good-tool",
+        note: "",
+        markedAt: "2026-01-05T00:00:00.000Z",
+        markedBy: "analyst",
+      },
+    ]);
+    const synthMetaStore = new SynthMetaStore(caseStore);
+
+    const { provider, sent } = spyProvider(delta());
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      scopeStore,
+      falsePositiveStore,
+      synthMetaStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+
+    expect(sent[0]).toContain("the real lead");
+    expect(sent[0]).not.toContain("before the window");
+    expect(sent[0]).not.toContain("analyst says benign");
+    expect(sent[0]).not.toContain("routine chatter");
+
+    const coverage = (await synthMetaStore.load("c1")).coverage!;
+    expect(coverage.omittedScope).toBe(1); // the scope filter dropped "out"
+    expect(coverage.omittedLegitimate).toBe(1); // the false-positive filter dropped "fp"
+    expect(coverage.omittedInfo).toBe(1); // Info gets no prompt seat …
+    expect(coverage.omittedBudget).toBe(0); // … and is NOT blamed on the size limit
+    expect(coverage.considered).toBe(1);
+    expect(coverage.inWindow).toBe(3);
+  });
+
+  it("keeps Info events in the case even though they never reach the prompt", async () => {
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("i1", "2026-01-01T00:00:00.000Z", "routine chatter", "Info"),
+      event("h1", "2026-01-02T00:00:00.000Z", "the real lead"),
+    );
+    await stateStore.save(seeded);
+
+    const { provider, sent } = spyProvider(delta());
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+
+    expect(sent[0]).not.toContain("routine chatter");
+    const state = await stateStore.load("c1");
+    expect(state.forensicTimeline.map((e) => e.id).sort()).toEqual(["h1", "i1"]);
+  });
+
+  it("counts an in-scope Critical event the prompt could not fit as an omittedHighSeverity, and still gives it a finding", async () => {
+    // A cap of one prompt seat forces the second Critical out of the prompt. The backfill is the
+    // safety net that makes capping the prompt safe, so the two are asserted together.
+    vi.stubEnv("DFIR_AI_SYNTH_MAX_EVENTS", "1");
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("c1e", "2026-01-01T00:00:00.000Z", "ransomware note dropped", "Critical"),
+      event("c2e", "2026-01-02T00:00:00.000Z", "shadow copies deleted", "Critical"),
+    );
+    await stateStore.save(seeded);
+    const synthMetaStore = new SynthMetaStore(caseStore);
+
+    const { provider, sent } = spyProvider(delta());
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      synthMetaStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    const state = await pipeline.synthesize("c1");
+
+    const shown = ["ransomware note dropped", "shadow copies deleted"].filter((d) => sent[0].includes(d));
+    expect(shown).toHaveLength(1);
+    const coverage = (await synthMetaStore.load("c1")).coverage!;
+    expect(coverage.considered).toBe(1);
+    expect(coverage.omittedHighSeverity).toBe(1);
+    // The model returned one finding; the omitted Critical got one from the deterministic backfill.
+    expect(state.findings.length).toBeGreaterThan(1);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("synthesize — the delta merge", () => {
+  it("preserves IOCs the model did not re-derive, while replacing findings wholesale", async () => {
+    // The asymmetry is the point: findings are CONCLUSIONS (rewritten every run) but IOCs are
+    // OBSERVED INDICATORS a text-only synthesis cannot re-derive from a truncated timeline.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(event("e1", "2026-01-01T00:00:00.000Z", "beacon to 203.0.113.9"));
+    seeded.iocs.push({ id: "i1", type: "ip", value: "203.0.113.9", firstSeen: "2026-01-01T00:00:00.000Z" });
+    seeded.findings.push({
+      id: "stale",
+      severity: "Low",
+      title: "previous run's conclusion",
+      description: "",
+      relatedIocs: [],
+      mitreTechniques: [],
+      sourceScreenshots: [],
+      firstSeen: "",
+      lastUpdated: "",
+      status: "open",
+    });
+    await stateStore.save(seeded);
+
+    const { provider } = spyProvider(delta());
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    const state = await pipeline.synthesize("c1");
+
+    expect(state.iocs.map((i) => i.value)).toEqual(["203.0.113.9"]); // preserved
+    expect(state.findings.map((f) => f.title)).toEqual(["synth finding"]); // replaced
+  });
+
+  it("carries forward an event, IOC and thread added DURING the AI call instead of clobbering them", async () => {
+    // The lost-update guard. `next` is derived from a snapshot taken before a call that takes
+    // seconds; without the re-read, everything an import or a manual add wrote in that window is
+    // lost on save. Nothing else in the suite covers this.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(event("e1", "2026-01-01T00:00:00.000Z", "the analyzed event"));
+    await stateStore.save(seeded);
+
+    const concurrentWrite = async (): Promise<void> => {
+      const live = await stateStore.load("c1");
+      live.forensicTimeline.push(event("late", "2026-01-02T00:00:00.000Z", "imported mid-call"));
+      live.iocs.push({
+        id: "lateIoc",
+        type: "domain",
+        value: "late.example",
+        firstSeen: "2026-01-02T00:00:00.000Z",
+      });
+      live.openThreads.push({
+        id: "lateThread",
+        description: "opened mid-call",
+        status: "open",
+        openedAt: "2026-01-02T00:00:00.000Z",
+        closedAt: null,
+      });
+      await stateStore.save(live);
+    };
+
+    const { provider } = spyProvider(delta(), concurrentWrite);
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+
+    const state = await stateStore.load("c1");
+    expect(state.forensicTimeline.map((e) => e.id)).toContain("late");
+    expect(state.iocs.map((i) => i.id)).toContain("lateIoc");
+    expect(state.openThreads.map((t) => t.id)).toContain("lateThread");
+    expect(state.forensicTimeline.map((e) => e.id)).toContain("e1"); // and the analyzed event stays
+  });
+
+  it("unions the techniques the timeline already carries into the synthesized MITRE table", async () => {
+    // Importers tag Info/Low discovery activity with techniques the model never echoes back. If the
+    // union is lost the case's MITRE table silently shrinks to whatever the model happened to name.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("e1", "2026-01-01T00:00:00.000Z", "whoami /all", "Low", { mitreTechniques: ["T1033"] }),
+    );
+    await stateStore.save(seeded);
+
+    const { provider } = spyProvider(
+      delta({ mitreTechniques: [{ id: "T1059", name: "Command Interpreter" }] }),
+    );
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    const state = await pipeline.synthesize("c1");
+
+    expect(state.mitreTechniques.map((t) => t.id).sort()).toEqual(["T1033", "T1059"]);
+  });
+
+  it("dryRun returns the conclusions without persisting them or arming the skip hash", async () => {
+    // Second-opinion Pass 1 runs through here. If a dry run persisted, model B's independent
+    // opinion would overwrite the case; if it armed the hash, the next real run would skip.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(event("e1", "2026-01-01T00:00:00.000Z", "the analyzed event"));
+    await stateStore.save(seeded);
+
+    const provider = new MockProvider("mock", delta());
+    const analyze = vi.spyOn(provider, "analyze");
+    const synthMetaStore = new SynthMetaStore(caseStore);
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      synthMetaStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    const dry = await pipeline.synthesize("c1", { dryRun: true });
+    expect(dry.findings.map((f) => f.title)).toEqual(["synth finding"]);
+
+    expect((await stateStore.load("c1")).findings).toHaveLength(0); // nothing written
+    expect((await synthMetaStore.load("c1")).lastSynthesizedAt).toBeFalsy();
+
+    await pipeline.synthesize("c1"); // a real run still happens
+    expect(analyze).toHaveBeenCalledTimes(2);
+    expect((await stateStore.load("c1")).findings).toHaveLength(1);
+  });
+});
+
+describe("synthesize — skip-when-unchanged", () => {
+  async function seedOneEvent(): Promise<void> {
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(event("e1", "2026-01-01T00:00:00.000Z", "the analyzed event"));
+    await stateStore.save(seeded);
+  }
+
+  it("re-synthesizes when a hunt outcome is collected, even though the timeline is identical", async () => {
+    // Prior-work feedback is a pure INPUT: a hunt that came back empty is negative knowledge the
+    // model has not seen yet. Leaving it out of the hash would skip the run that folds it in.
+    await seedOneEvent();
+    const huntOutcomeStore = new HuntOutcomeStore(caseStore);
+    const provider = new MockProvider("mock", delta());
+    const analyze = vi.spyOn(provider, "analyze");
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      huntOutcomeStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+    await pipeline.synthesize("c1");
+    expect(analyze).toHaveBeenCalledTimes(1); // unchanged → skipped
+
+    await huntOutcomeStore.save("c1", [
+      {
+        id: "h1",
+        source: "fleet",
+        title: "Hunt for staged archives",
+        vqlFingerprint: "abc",
+        vqlPreview: "SELECT * FROM glob()",
+        mitreTechniques: ["T1560"],
+        deployedAt: "2026-01-02T00:00:00.000Z",
+        status: "collected",
+        foundEvidence: false,
+        resultSummary: "no results",
+      },
+    ]);
+
+    await pipeline.synthesize("c1");
+    expect(analyze).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-synthesizes when the analyst re-picks the incident type", async () => {
+    await seedOneEvent();
+    const incidentTypeStore = new IncidentTypeStore(
+      caseStore,
+      join(caseStore.stateDir("c1"), "incident-types"),
+    );
+    const provider = new MockProvider("mock", delta());
+    const analyze = vi.spyOn(provider, "analyze");
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      incidentTypeStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+    await pipeline.synthesize("c1");
+    expect(analyze).toHaveBeenCalledTimes(1);
+
+    await incidentTypeStore.saveRecord("c1", "ransomware");
+
+    await pipeline.synthesize("c1");
+    expect(analyze).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips on a re-run whose only difference is a finding synthesis itself wrote", async () => {
+    // The other half of the hash contract: findings/MITRE/threads/summary are OUTPUTS. Hashing them
+    // would make two consecutive runs differ and the skip would never fire at all.
+    await seedOneEvent();
+    const provider = new MockProvider("mock", delta());
+    const analyze = vi.spyOn(provider, "analyze");
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+    const afterFirst: InvestigationState = await stateStore.load("c1");
+    expect(afterFirst.findings).toHaveLength(1); // the run DID change stored state …
+
+    await pipeline.synthesize("c1");
+    expect(analyze).toHaveBeenCalledTimes(1); // … and the next run still skips
+  });
+});


### PR DESCRIPTION
Closes #418.

Takes `analysis/pipeline.ts` from **3,410 to 591 lines**, meeting the ≤800 target `ARCHITECTURE.md`'s closing conditions have carried since #384. `AnalysisPipeline` is now a facade: 88 members, all one-line delegations plus two context adapters.

## Why this needed a different kind of proof

#384 succeeded twice because each extraction was *provably* behaviour-preserving — the AI change gate hashed the prompts, and the importers' five-member `ImportContext` made the boundary compiler-enforced. Neither lever exists here: these methods reach across most of `PipelineOptions`, and their output is a model call.

So the substitute came first, exactly in the order the issue asked for.

## 1. Characterisation tests, proven to have teeth

[`tests/analysis/synthesizeCharacterisation.test.ts`](companion/tests/analysis/synthesizeCharacterisation.test.ts) — 10 tests over the seams the issue names: scope selection (which events reach the prompt and how each omission is attributed), the delta merge (what survives the wholesale findings rewrite, and the lost-update guard), and skip-when-unchanged (exactly which inputs are hashed). Second-look was already covered end-to-end in `secondLookLoop.test.ts` and is not duplicated.

Every assertion is on persisted state or on the prompt text sent — never a private method — so the same assertions hold after `synthesize` becomes a free function.

**These were not assumed to work.** Eight regressions were introduced deliberately and the suite re-run each time:

| Mutation | Before extraction | After extraction |
|---|---|---|
| Info events get prompt seats | caught (2) | caught (2) |
| IOCs wiped with findings | caught | caught |
| lost-update guard removed | caught | caught |
| MITRE union dropped | caught | caught |
| `dryRun` persists | caught | caught |
| prior-work dropped from the hash | caught | caught |
| incident type dropped from the hash | caught | caught |
| findings added to the hash | caught (3) | caught (3) |

## 2–5. The moves

Free functions over a named context interface, class keeps delegations, so no route, script or test changes:

| Family | Modules |
|---|---|
| analyst reports | `caseReports.ts`, `analystQueries.ts`, `viewReports.ts` |
| hunt generation | `hunts.ts`, `nextSteps.ts`, `promptBlocks.ts` |
| extraction + the AI-call gate | `extraction.ts`, `providerCall.ts` |
| synthesis | `synthesis.ts`, `synthesisPrompt.ts`, `synthesisMerge.ts`, `deepPassRun.ts`, `secondOpinionRun.ts` |
| shared | `aiContext.ts`, `pipelineOptions.ts`, `retry.ts` |

`providerCall.ts` moved as **one unit** — anonymise → OCR-redact → Presidio-gate → call → restore — because the ordering *is* the contract. Presidio must see masked text and only masked text; the response must be restored before parsing so a real value containing JSON metacharacters cannot corrupt it. Those invariants survive being written once and rot when each call site re-implements them.

## Three departures from a literal move

Each is argued in the code rather than left to be inferred:

- **`SynthesisContext` is deliberately wide.** Synthesis genuinely touches most of `PipelineOptions`. Threading twenty parameters would hide that rather than fix it. The interface still earns its place — it names which stores participate, so adding one becomes a visible edit instead of an invisible reach through `this`.
- **`synthesize` split three ways** (orchestration / prompt construction / delta fold). A straight move left one 839-line file, over `check:size`'s own 800-line limit for new files.
- **The 36 import delegations' comments were byte-identical copies** of the comments already in `analysis/ingest/` — verified duplicate-by-duplicate before removal. Two copies of one doc is a drift hazard. `noteEmptyImport` and `persistPlasoParsed` moved to `ingest/importState.ts` where their only callers already live; `ImportContext` is down from five members to three.

## Verification

`typecheck`, `lint`, `check:size` (re-recorded), `check:imports`, `check:boundaries`, `format:check` — all clean. **546/547 test files, 6,921 tests.**

The one failing file is `sharpVersion.test.ts`, an artefact of the worktree sharing the main checkout's `node_modules` (sharp 0.33.5 against a required ≥0.35.0). It touches nothing in this diff and should pass in CI — worth confirming on the run.

`ARCHITECTURE.md` is updated: the target is marked met, the `ai/` domain counts refreshed (25 → 47 files), and migration step 7 records the shape this followed.

No CHANGELOG entry — #384, the equivalent decomposition, has none, so the precedent is that internal refactors are not user-facing. Happy to add one if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
