### PR TITLE
fix(ai): report the true matched count for a view summary

### DIFF
--- a/companion/src/analysis/ai/viewReports.ts
+++ b/companion/src/analysis/ai/viewReports.ts
@@ -296,10 +296,21 @@ export async function viewSummary(
     backoffMs,
   );
 
+  // `eventCount` is what MATCHED the filters, NOT what the row cap let through — the analyst is
+  // told the true denominator or the disclosure is worthless. Reporting `matched.length` here made
+  // a 750-row filter render as "500 matching events" with `truncated: false` whenever those 500
+  // happened to fit the AI budget: the 250 the cap excluded vanished from the panel and from the
+  // Activity Log line, which is exactly the silent-slice failure the cap exists to prevent.
+  //
+  // `truncated` therefore compares against `total` as well, so it covers BOTH reasons rows went
+  // unread: the VIEW_SUMMARY_MAX_ROWS cap and the AI input budget. Because the flag can no longer
+  // tell those two apart, the dashboard caption states the fact ("N of M matching events
+  // summarized") instead of naming a cause it cannot know — it used to say "(AI input budget)",
+  // which is the wrong reason whenever the row cap was what dropped them.
   return {
     markdown: result.markdown,
-    eventCount: matched.length,
+    eventCount: total,
     usedEvents: events.length,
-    truncated: events.length < matched.length,
+    truncated: events.length < total,
   };
 }

--- a/companion/tests/analysis/forensicBoundary.test.ts
+++ b/companion/tests/analysis/forensicBoundary.test.ts
@@ -146,4 +146,39 @@ describe("viewSummary is the documented exception", () => {
     await pipeline.viewSummary("c1", {});
     expect(provider.lastReq!.userPrompt).not.toContain("capped at");
   });
+
+  // The two tests above assert the MODEL is told about the cap. For a long time nothing asserted the
+  // ANALYST was, and they were not: the result reported `eventCount: matched.length` — the capped
+  // count, not the matched one — so a 750-row filter rendered as "500 matching events" with
+  // `truncated: false` whenever those 500 fit the AI budget. The dashboard caption and the Activity
+  // Log line both read from these fields, so the 250 excluded rows disappeared from every surface
+  // the analyst sees. Disclosing a cap to the model and hiding it from the investigator is the
+  // silent-slice failure with an extra step.
+  it("reports the TRUE matched count to the analyst, not the capped one", async () => {
+    const overCap = VIEW_SUMMARY_MAX_ROWS + 250;
+    const { pipeline } = await harness(
+      Array.from({ length: overCap }, (_, i) => ev({ id: `bulk${i}`, description: `row ${i}` })),
+    );
+
+    const result = await pipeline.viewSummary("c1", {});
+
+    expect(result.eventCount).toBe(overCap); // what MATCHED, not what the cap let through
+    expect(result.usedEvents).toBeLessThanOrEqual(VIEW_SUMMARY_MAX_ROWS);
+    expect(result.truncated).toBe(true); // true even when every read row fit the AI budget
+  });
+
+  it("reports no truncation when the whole matched view was read", async () => {
+    // Distinct descriptions: the store folds rows that share a timestamp AND description, so two
+    // bare ev() calls would land as one row and the assertion would be measuring the dedupe.
+    const { pipeline } = await harness([
+      ev({ id: "raw1", description: "prefetch: ONE.EXE" }),
+      ev({ id: "raw2", description: "amcache: TWO.EXE" }),
+    ]);
+
+    const result = await pipeline.viewSummary("c1", {});
+
+    expect(result.eventCount).toBe(2);
+    expect(result.usedEvents).toBe(2);
+    expect(result.truncated).toBe(false);
+  });
 });

--- a/companion/tests/analysis/synthesizeCharacterisation.test.ts
+++ b/companion/tests/analysis/synthesizeCharacterisation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -99,6 +99,12 @@ function spyProvider(rawText: string, during?: () => Promise<void>) {
   };
   return { provider, sent };
 }
+
+// Env stubs are undone here, not at the end of the test that set them: an assertion failure throws
+// past an inline `unstubAllEnvs`, leaking a stubbed DFIR_* into every test that runs after it.
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 beforeEach(async () => {
   const root = await mkdtemp(join(tmpdir(), "dfir-synth-char-"));
@@ -213,7 +219,6 @@ describe("synthesize — scope selection", () => {
     expect(coverage.omittedHighSeverity).toBe(1);
     // The model returned one finding; the omitted Critical got one from the deterministic backfill.
     expect(state.findings.length).toBeGreaterThan(1);
-    vi.unstubAllEnvs();
   });
 });
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -9385,7 +9385,7 @@
         .then(d => {
           if (caseId !== superCaseId()) return;   // case switched mid-flight — drop the stale result
           stRenderAiPanel("✨ View summary", d.markdown || "(empty summary)",
-            d.truncated ? `${d.usedEvents} of ${d.eventCount} matching events (AI input budget)` : `${d.eventCount} matching event${d.eventCount !== 1 ? "s" : ""}`,
+            d.truncated ? `${d.usedEvents} of ${d.eventCount} matching events summarized` : `${d.eventCount} matching event${d.eventCount !== 1 ? "s" : ""}`,
             null);
         })
         .catch(e => stRenderNote(e.status === 501 ? "AI provider not configured (Settings → AI)." : "view summary failed: " + e.message, true))


### PR DESCRIPTION
Found in a code-level audit of #451. Carried forward unchanged through that refactor — the extraction preserved this behaviour rather than introducing it.

## The bug

`viewSummary` caps its read of the raw record at `VIEW_SUMMARY_MAX_ROWS` (500), then reported the **capped** count back as `eventCount`:

```ts
eventCount: matched.length,                     // 500 — what the cap let through
truncated: events.length < matched.length,      // false when all 500 fit the AI budget
```

A filter matching 750 rows therefore rendered as **"500 matching events"** with no truncation notice. The 250 rows the cap excluded were absent from the dashboard caption *and* from the Activity Log line (`aiSynthesis.ts:419`) — which is an audit record, not just a UI label.

## Why it matters more than a wrong number

It contradicts the third constraint `ARCHITECTURE.md` places on this path — the constraint that makes it a *sanctioned exception* to the forensic/super-timeline rule rather than a hole in it:

> 3. **Capped** at `VIEW_SUMMARY_MAX_ROWS` (500, was 10,000), and it *tells the analyst* when the cap truncated their view rather than silently summarizing a slice.

The disclosure did exist — but only in the **prompt**. The model was told `read from 750 matching (capped at 500)`; the investigator was told `500 matching events`. Disclosing a cap to the model and hiding it from the analyst is the silent-slice failure with an extra step.

`forensicBoundary.test.ts` asserted only the prompt half (`provider.lastReq.userPrompt`), which is exactly why this stayed green.

## The fix

- `eventCount` is now `total` — the true post-filter match count. Verified in `superTimelineStore.query`: `total` increments for every row passing the filter gauntlet, while `events` is bounded by `limit`.
- `truncated` compares against `total`, so it covers **both** reasons rows go unread: the row cap and the AI input budget.
- The dashboard caption drops `(AI input budget)` — the wrong cause whenever the cap was what dropped the rows — for a neutral `N of M matching events summarized`. Kept **net-zero in lines**: the `dashboard.html#inline-js` ledger only shrinks, so the reasoning lives in `viewReports.ts` instead of a comment there.
- Two regression tests assert the **returned result**, closing the gap that let this hide. Mutation-checked: restoring `matched.length` fails `reports the TRUE matched count to the analyst, not the capped one`.

One test-fixture note: the "no truncation" case uses distinct descriptions, because the super-timeline store folds rows sharing a timestamp *and* description — two bare `ev()` calls land as one row, and the assertion would be measuring the dedupe instead of the fix.

## Also included

From the same audit: the `DFIR_AI_SYNTH_MAX_EVENTS` stub in `synthesizeCharacterisation.test.ts` was undone at the end of the test body, so a failing assertion would throw past it and leak the stubbed cap into every later test. Moved to `afterEach`.

## Verification

`typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all clean. Full suite **546/547 files, 6,923 tests** — two more than master, the new regression tests. The single failure is `sharpVersion.test.ts`, an artefact of the worktree sharing the main checkout's `node_modules` (sharp 0.33.5 vs the required ≥0.35.0); it passes in CI.
