### PR TITLE
fix(dashboard): render a placeholder when an activity timestamp is missing (#458)

### DIFF
--- a/companion/tests/dashboard/dashboardTime.test.ts
+++ b/companion/tests/dashboard/dashboardTime.test.ts
@@ -43,7 +43,7 @@ describe("the six relative-time formatters disagree, on purpose recorded", () =>
     ["veloClientsAge", "never refreshed", "just now", "just now", "1m ago", "3h ago"],
     ["veloMonAge", "never", "just now", "30s ago", "1m ago", "3h ago"],
     ["relTime", "never", "unknown", "30s ago", "2m ago", "3h ago"],
-    ["activityTimeAgo", "20513d ago", "—", "just now", "1m ago", "3h ago"],
+    ["activityTimeAgo", "—", "—", "just now", "1m ago", "3h ago"],
     ["cockpitAge", "", "", "just now", "1m ago", "3h ago"],
   ])("%s: null=%j unparseable=%j 30s=%j 90s=%j 3h=%j", (name, onNull, onJunk, s30, s90, h3) => {
     const fn = FNS[name as keyof typeof FNS];
@@ -54,15 +54,27 @@ describe("the six relative-time formatters disagree, on purpose recorded", () =>
     expect(fn(ago(3 * 3_600_000))).toBe(h3);
   });
 
-  // A LATENT BUG, PINNED RATHER THAN FIXED — see #458, which owns the fix. `new Date(null)` is the
-  // epoch, not Invalid Date, so activityTimeAgo is the one of the six that reports a missing
-  // timestamp as 57 years ago instead of a placeholder. Its five siblings all guard with `!iso` or
-  // Number.isFinite first. Fixing it changes what the activity feed renders, which belongs in its
-  // own change with its own reasoning — this asserts the current behaviour so that change is
-  // deliberate when it happens. UPDATE THIS TEST AND THE TABLE ROW ABOVE when #458 lands.
-  it("activityTimeAgo(null) reports the epoch, unlike its five siblings", () => {
-    expect(activityTimeAgo(null)).toMatch(/^\d{5}d ago$/);
-    for (const fn of [lgAgo, veloClientsAge, veloMonAge, relTime, cockpitAge]) {
+  // THE BUG #415 PINNED HERE, FIXED BY #458 — this test and the table row above are the two places
+  // that pinned it. `new Date(null)` is the epoch, not Invalid Date, so activityTimeAgo was the one
+  // of the six that reported a missing timestamp as 57 years ago — a literal "20513d ago" in the
+  // activity feed — while its five siblings all guarded with `!iso` or Number.isFinite first. Only
+  // null ever hit it: `new Date(undefined)` IS Invalid Date, so undefined already returned "—".
+  //
+  // IT RETURNS "—", NOT A SIBLING'S PLACEHOLDER. Both call sites render this into a muted, nowrap
+  // table column with the row's raw timestamp already in a `title` tooltip: the Activity Log (#238)
+  // and the Chain of Custody event table (#231). "never"/"never refreshed" would claim the logged
+  // activity did not happen when it is only its timestamp that is missing, "just now" would invent
+  // one, and "" would leave a blank cell that reads as a broken render rather than as absent data.
+  // "—" is what this function already returned for an unparseable string, and what the custody
+  // table beside it already renders for an unknown verification state.
+  //
+  // The sibling sweep is kept and now covers all six: it is what catches a seventh formatter added
+  // without a guard, which is how this one got here.
+  it("renders a placeholder for a missing timestamp, like its five siblings", () => {
+    for (const missing of [null, undefined, ""]) {
+      expect(activityTimeAgo(missing)).toBe("—");
+    }
+    for (const fn of [lgAgo, veloClientsAge, veloMonAge, relTime, activityTimeAgo, cockpitAge]) {
       expect(fn(null)).not.toMatch(/d ago$/);
     }
   });

--- a/public/js/dashboard-time.js
+++ b/public/js/dashboard-time.js
@@ -89,6 +89,11 @@ function mcpJobDuration(ms) {
 }
 
 function activityTimeAgo(iso) {
+  // The Number.isNaN below does NOT cover a missing timestamp, which is why this looks redundant
+  // and is not (#458): `new Date(null)` is the epoch rather than Invalid Date, so a null
+  // collectedAt used to arrive here as a valid instant and render "20513d ago" — 57 years.
+  // `new Date(undefined)` IS Invalid Date, so only null ever reached that path.
+  if (!iso) return "—";
   const ms = Date.now() - new Date(iso).getTime();
   if (Number.isNaN(ms)) return "—";
   const mins = Math.floor(ms / 60000);


### PR DESCRIPTION
Closes #458.

A missing timestamp in the activity feed rendered as **"20513d ago"** — the Unix epoch, roughly 57
years — instead of a placeholder.

## The cause

`activityTimeAgo` was the only one of the dashboard's six relative-time formatters with no guard for
an absent input. `new Date(null)` is the **epoch**, not `Invalid Date`, so `ms` was a perfectly
finite ~1.77e12 and the existing `Number.isNaN` guard never fired.

Only `null` was ever affected — `new Date(undefined)` *is* Invalid Date, so `undefined` already
returned the placeholder, and so did `""`. Verified rather than assumed:

| input | `new Date(input)` |
|---|---|
| `null` | `1970-01-01T00:00:00.000Z` |
| `undefined` | Invalid Date |
| `""` | Invalid Date |

That asymmetry is why this survived: the obvious manual test passes.

## Why `"—"` and not a sibling's placeholder

The issue asked for the placeholder the activity feed should show rather than a blind copy, so I
worked from the two call sites — the Activity Log (#238) at `public/dashboard.html:12460` and the
Chain of Custody event table (#231) at `public/dashboard.html:12515`. Both render into a muted,
`white-space:nowrap` table column, with the row's raw timestamp already in a `title` tooltip.

Against that, none of the five sibling placeholders fit:

| sibling answer | why not here |
|---|---|
| `"never"` / `"never refreshed"` | claims the logged activity never happened, when only its timestamp is missing |
| `"just now"` | invents a timestamp we do not have |
| `"unknown"` | new vocabulary in a column of terse relative times |
| `""` | a blank cell in a bordered table reads as a broken render, not as absent data |

`"—"` is what this function **already** returned for an unparseable string, so the two absent-input
paths now agree; and it is already what the custody table beside it renders (`&mdash;`) for an
unknown verification state. No new vocabulary.

Unifying all six remains out of scope — that changes what six panels render, which is the product
decision #415 deliberately left alone.

## The fix

`public/js/dashboard-time.js` — a `!iso` guard, matching the veloClientsAge/veloMonAge idiom of
guarding first and keeping the follow-on finite check. I kept that over
`Number.isFinite(Date.parse(...))` because `Date.parse` stringifies a `Date` argument and loses
milliseconds; the smaller guard leaves every other input path byte-identical. The comment says why
it is not redundant with the `Number.isNaN` below it, so it does not get "cleaned up" later.

## Tests

Both pinned locations updated, as the issue and the in-file comment asked:

- the `it.each` table row for `activityTimeAgo` — `null` now expects `"—"`
- `it("activityTimeAgo(null) reports the epoch, unlike its five siblings")` → now
  `it("renders a placeholder for a missing timestamp, like its five siblings")`, covering `null`,
  `undefined` and `""`

The sibling sweep is kept and now covers all six formatters, since that is what would catch a
seventh added without a guard — which is how this one got here.

Done red-green: both locations were confirmed failing with `expected '20513d ago' to be '—'` on this
exact base before the guard went in.

## Verification

- `tests/dashboard/` — 339 passed
- Full suite as CI runs it (`npm test` in `companion/`) — **7270 passed, 2 failed**
- `check:size`, `check:imports`, `check:boundaries`, `check:us-map`, `format:check` — all pass

The 2 failures, plus the `lint` and `typecheck` errors, are all in `tests/analysis/sharpVersion.test.ts`,
`tests/e2e/**` and `landmarks.spec.ts` — artifacts of symlinking the main checkout's `node_modules`
into a worktree (installed sharp 0.33.5 vs the required ≥0.35.0; `@playwright/test` absent). None are
in files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
