### PR TITLE
fix(findings): keep an untitled finding instead of matching every false-positive marker (#457)

### DIFF
--- a/companion/src/analysis/falsePositive.ts
+++ b/companion/src/analysis/falsePositive.ts
@@ -76,6 +76,16 @@ export function applyFalsePositive(state: InvestigationState, markers: FalsePosi
   const iocs = state.iocs.filter((i) => !iocRefs.has(i.value.trim().toLowerCase()));
   const findings = state.findings.filter((f) => {
     const title = f.title.trim().toLowerCase();
+    // KEEP AN UNTITLED FINDING (#457). The test below is two-way substring, and "" is a substring
+    // of every ref — so without this guard a finding with no title is dropped by whichever marker
+    // happens to be first in the list, whatever that marker says.
+    //
+    // This is the half that mattered: `findingRefs` is already `.filter(Boolean)`-ed, so an empty
+    // MARKER cannot match everything, but nothing guarded the empty TITLE. And this filter does not
+    // merely hide a row — it removes the finding from InvestigationState, which is what the report
+    // is generated from, so the finding is erased from the exported report rather than hidden in
+    // the UI. Hiding evidence is the wrong direction for this function to fail in.
+    if (!title) return true;
     return !findingRefs.some((ref) => title === ref || title.includes(ref) || ref.includes(title));
   });
   return { ...state, iocs, findings };

--- a/companion/tests/analysis/falsePositive.test.ts
+++ b/companion/tests/analysis/falsePositive.test.ts
@@ -47,6 +47,29 @@ describe("applyFalsePositive", () => {
     expect(filtered.findings.map((f) => f.title)).toEqual(["Mimikatz credential dumping"]);
   });
 
+  // #457. The match is two-way substring and "" is a substring of every ref, so an unguarded empty
+  // title matched the FIRST marker in the list whatever it said. This filter does not hide a row —
+  // it removes the finding from InvestigationState, which the report is generated from, so an
+  // untitled finding was erased from the exported report. Kept and left for a human to read.
+  it("keeps an untitled finding — an empty title must not match every marker", () => {
+    const state = emptyState("c1");
+    state.findings.push(
+      { id: "f1", severity: "High", title: "", description: "extractor produced no title", relatedIocs: [],
+        mitreTechniques: [], sourceScreenshots: [], firstSeen: "", lastUpdated: "", status: "open" },
+      { id: "f2", severity: "Low", title: "   ", description: "whitespace-only title", relatedIocs: [],
+        mitreTechniques: [], sourceScreenshots: [], firstSeen: "", lastUpdated: "", status: "open" },
+      { id: "f3", severity: "High", title: "SharpHound AD reconnaissance", description: "the real match",
+        relatedIocs: [], mitreTechniques: [], sourceScreenshots: [], firstSeen: "", lastUpdated: "", status: "open" },
+    );
+
+    const filtered = applyFalsePositive(state, [
+      marker("finding", "SharpHound AD reconnaissance", "authorized-test", "authorized pentest"),
+    ]);
+
+    // f3 is dropped because it genuinely matches; the two untitled ones survive.
+    expect(filtered.findings.map((f) => f.id)).toEqual(["f1", "f2"]);
+  });
+
   it("buildFalsePositiveContext lists finding/ioc markers with their reason, empty when none", () => {
     expect(buildFalsePositiveContext([])).toBe("");
     const ctx = buildFalsePositiveContext([marker("finding", "SharpHound recon", "authorized-test", "authorized")]);

--- a/companion/tests/dashboard/dashboardFilters.test.ts
+++ b/companion/tests/dashboard/dashboardFilters.test.ts
@@ -186,17 +186,28 @@ describe("isFindingFalsePositive", () => {
     expect(f.isFindingFalsePositive("Persistence", [])).toBe(false);
   });
 
-  // A SECOND LATENT BUG THE EXTRACTION MADE VISIBLE, pinned rather than fixed — see #457, which
-  // owns the fix. The match is `t.includes(ref) || ref.includes(t)`, and every string contains ""
-  // — so a finding with no title at all is suppressed by the FIRST false-positive entry in the
-  // list, whatever it says. The blast radius is small (findings normally have titles) but the
-  // direction is bad: the failure mode of this function is hiding evidence, not showing noise.
-  // Fixing it changes what the findings list renders, so it belongs in its own change; this
-  // records today's answer so that change is deliberate. INVERT THIS TEST when #457 lands.
-  it("treats an empty title as matching any entry", () => {
-    expect(f.isFindingFalsePositive(null, ["powershell"])).toBe(true);
-    expect(f.isFindingFalsePositive("   ", ["anything at all"])).toBe(true);
-    expect(f.isFindingFalsePositive("", [])).toBe(false); // ...unless there are no entries
+  // FIXED IN #457 — this test was the pin, and it is inverted rather than deleted so the fix has a
+  // permanent witness. The match is `t.includes(ref) || ref.includes(t)` and every string contains
+  // "", so an unguarded empty title matched the FIRST entry in the list whatever it said.
+  //
+  // The client half hid a row. The SERVER half — applyFalsePositive, which shares this match by
+  // design — removed the finding from InvestigationState, i.e. from the exported report. That is
+  // why this is guarded on both sides and why the priority went up once the second half surfaced.
+  it("keeps an untitled finding rather than matching every entry", () => {
+    expect(f.isFindingFalsePositive(null, ["powershell"])).toBe(false);
+    expect(f.isFindingFalsePositive("", ["anything at all"])).toBe(false);
+    expect(f.isFindingFalsePositive("   ", ["anything at all"])).toBe(false);
+  });
+
+  // The mirror-image hazard, in the other direction: an empty REF matches every title, which would
+  // empty the whole Findings panel. The server drops empty refs with `.filter(Boolean)`; this
+  // function is handed the set already built and cannot assume that happened, so it guards too.
+  // Not reachable through the API today (the route 400s a missing ref) — but "same match as the
+  // server" is the contract this function states, and a mirror that holds only for reachable
+  // inputs is not that.
+  it("ignores an empty entry rather than suppressing everything", () => {
+    expect(f.isFindingFalsePositive("Encoded PowerShell", [""])).toBe(false);
+    expect(f.isFindingFalsePositive("Encoded PowerShell", ["", "powershell"])).toBe(true);
   });
 });
 
@@ -213,5 +224,38 @@ describe("ftOriginOf / originFacets", () => {
       f.originFacets([{ artifactName: "MFT" }, { sources: ["evtx"] }, { artifactName: "MFT" }, {}]),
     ).toEqual(["evtx", "MFT", "Unknown"]);
     expect(f.originFacets(null)).toEqual([]);
+  });
+});
+
+// THE MIRROR ITSELF. isFindingFalsePositive exists to answer the same question as the server's
+// applyFalsePositive, so an analyst never sees a finding in the panel that the report has already
+// dropped, or vice versa. #457 was that mirror being broken in both directions at once — each side
+// guarded one empty-string case and not the other — so it is worth a test that runs the two
+// implementations against the same inputs rather than trusting a comment that says they agree.
+describe("agrees with the server's applyFalsePositive", () => {
+  const CASES: Array<[string, string | null, string[]]> = [
+    ["an exact match", "SharpHound AD reconnaissance", ["sharphound ad reconnaissance"]],
+    ["the marker inside the title", "Encoded PowerShell launched", ["powershell"]],
+    ["the title inside the marker", "PowerShell", ["encoded powershell launched"]],
+    ["no relationship at all", "Persistence via run key", ["powershell"]],
+    ["an untitled finding", "", ["powershell"]],
+    ["a whitespace-only title", "   ", ["powershell"]],
+    ["a null title", null, ["powershell"]],
+    ["an empty marker", "Encoded PowerShell", [""]],
+    ["no markers", "Encoded PowerShell", []],
+  ];
+
+  /** The server's rule, transcribed from src/analysis/falsePositive.ts. */
+  const serverDrops = (title: string | null, refs: string[]): boolean => {
+    const t = String(title ?? "")
+      .trim()
+      .toLowerCase();
+    const findingRefs = refs.map((r) => r.trim().toLowerCase()).filter(Boolean);
+    if (!t) return false;
+    return findingRefs.some((ref) => t === ref || t.includes(ref) || ref.includes(t));
+  };
+
+  it.each(CASES)("matches the server on %s", (_label, title, refs) => {
+    expect(f.isFindingFalsePositive(title, refs)).toBe(serverDrops(title, refs));
   });
 });

--- a/public/js/dashboard-filters.js
+++ b/public/js/dashboard-filters.js
@@ -75,9 +75,24 @@ function _evMatchesTimeRange(e, from, to) {
 
 // Same substring match the server's applyFalsePositive uses (companion/src/analysis/falsePositive.ts)
 // so a finding hides here under EXACTLY the conditions it will actually be dropped server-side.
+//
+// BOTH EMPTY-STRING GUARDS BELONG TO THAT MIRRORING (#457), and each covers a different direction
+// of the same hazard: the match is two-way substring, and "" is a substring of every string.
+//
+//   - an empty TITLE would match the first ref in the list, whatever it says -> the finding is
+//     hidden here and, until #457, dropped from InvestigationState and the report too.
+//   - an empty REF would match every title -> the whole Findings panel empties.
+//
+// The server guards the second by `.filter(Boolean)` on findingRefs and, since #457, the first by
+// an early return. This function has to guard both, because it is handed the ref set already built
+// and cannot assume it was filtered. The empty ref is not reachable through the API today —
+// POST /cases/:id/false-positive rejects a missing ref with a 400 — but the server defends against
+// it anyway for markers loaded from storage, and a mirror that only holds for reachable inputs is
+// not the claim the comment above makes.
 function isFindingFalsePositive(title, fpTitles) {
   const t = String(title || "").trim().toLowerCase();
-  for (const ref of fpTitles) if (t === ref || t.includes(ref) || ref.includes(t)) return true;
+  if (!t) return false;
+  for (const ref of fpTitles) if (ref && (t === ref || t.includes(ref) || ref.includes(t))) return true;
   return false;
 }
 


### PR DESCRIPTION
Closes #457.

A finding with no title was suppressed by whichever false-positive marker happened to be first in
the list, whatever that marker said. The match is two-way substring and `""` is a substring of every
string, so an unguarded empty title matched unconditionally.

## The server half is the serious one

`applyFalsePositive` does not hide a row — it filters the finding out of `InvestigationState`, which
is what the report is generated from. An untitled finding was **erased from the exported report**,
not merely hidden in the UI. That is why #457 went from `priority: medium` to `high` once this half
surfaced; the original report described only the client symptom.

## Both sides were broken, in opposite directions

`isFindingFalsePositive` exists to mirror `applyFalsePositive`, so a finding disappears from the
panel under exactly the conditions the report drops it. The two had diverged **both ways**:

| | empty **title** matches every marker | empty **marker** matches every finding |
|---|---|---|
| server `applyFalsePositive` | unguarded ❌ | guarded by `.filter(Boolean)` ✅ |
| client `isFindingFalsePositive` | unguarded ❌ | unguarded ❌ |

Each side guarded one case and not the other, so the mirror held for neither. Fixed on both: the
server gets the title guard, the client gets both.

The empty marker is not reachable through the API today — `POST /cases/:id/false-positive` returns
400 when `ref` is missing — but the server defends against it anyway for markers loaded from
storage, and a mirror that holds only for reachable inputs is not the claim the client's comment
makes.

## Tests

The two tests that **pinned** this behaviour in #456 are inverted rather than deleted, so the fix
has a permanent witness where the bug used to be recorded.

Added a test that runs both implementations against the same nine inputs and asserts they agree,
rather than trusting a comment that says they do. The server rule is transcribed into the test
beside the client call, so if either side changes alone the pair disagrees and the test says so —
that is the check that would have caught this class of divergence in the first place.

Mutation-tested all three guards:

| guard removed | assertions that fail |
|---|---|
| server title guard | 1 |
| client title guard | 4 |
| client marker guard | 2 |

Full suite green apart from the two pre-existing `sharpVersion` failures (local libvips, fails on
master too). `check:size`, `check:imports`, `check:boundaries`, `format:check`, lint all pass.

## Credit

The server-side half was found by the session spun off this issue, which also wrote the
`InvestigationState` test used here. Its client-side patch targeted the copy in
`public/dashboard.html`; #456 had already moved that function to `public/js/dashboard-filters.js`,
so the fix is applied there instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
