### PR TITLE
test(dashboard): rebuild the state gates on AST analysis, and make the parity test run the server (#415)

### DIFF
--- a/companion/tests/dashboard/dashboardFilters.test.ts
+++ b/companion/tests/dashboard/dashboardFilters.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { FiltersApi } from "./dashboardApi.js";
 import { loadDashboardModule } from "../helpers/dashboardModule.js";
+import { applyFalsePositive } from "../../src/analysis/falsePositive.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
 
 // public/js/dashboard-filters.js — the search, exclude and relevance predicates (#415).
 //
@@ -227,35 +229,70 @@ describe("ftOriginOf / originFacets", () => {
   });
 });
 
-// THE MIRROR ITSELF. isFindingFalsePositive exists to answer the same question as the server's
-// applyFalsePositive, so an analyst never sees a finding in the panel that the report has already
-// dropped, or vice versa. #457 was that mirror being broken in both directions at once — each side
-// guarded one empty-string case and not the other — so it is worth a test that runs the two
-// implementations against the same inputs rather than trusting a comment that says they agree.
+// THE MIRROR ITSELF, RUN RATHER THAN RESTATED.
+//
+// isFindingFalsePositive exists to answer the same question as the server's applyFalsePositive, so
+// an analyst never sees a finding the report has already dropped, or vice versa. #457 was that
+// mirror broken in both directions at once.
+//
+// The first version of this test transcribed the server's rule into a local `serverDrops` helper
+// and compared the client against that. An audit caught what that actually tests: a server-only
+// change leaves the transcription untouched, so the test stays green through exactly the
+// divergence it exists to prevent. It was checking the client against a copy of the server, which
+// is the same class of mistake as the bug.
+//
+// So it now imports applyFalsePositive and runs it against a real InvestigationState. If either
+// side changes alone, the two answers differ and this fails.
 describe("agrees with the server's applyFalsePositive", () => {
   const CASES: Array<[string, string | null, string[]]> = [
     ["an exact match", "SharpHound AD reconnaissance", ["sharphound ad reconnaissance"]],
     ["the marker inside the title", "Encoded PowerShell launched", ["powershell"]],
     ["the title inside the marker", "PowerShell", ["encoded powershell launched"]],
+    ["differing case and padding", "  ENCODED PowerShell  ", ["powershell"]],
     ["no relationship at all", "Persistence via run key", ["powershell"]],
     ["an untitled finding", "", ["powershell"]],
     ["a whitespace-only title", "   ", ["powershell"]],
-    ["a null title", null, ["powershell"]],
     ["an empty marker", "Encoded PowerShell", [""]],
-    ["no markers", "Encoded PowerShell", []],
+    ["an empty marker beside a real one", "Encoded PowerShell", ["", "powershell"]],
+    ["no markers at all", "Encoded PowerShell", []],
   ];
 
-  /** The server's rule, transcribed from src/analysis/falsePositive.ts. */
+  /** Does the SERVER drop this finding? Answered by running the server, not by describing it. */
   const serverDrops = (title: string | null, refs: string[]): boolean => {
-    const t = String(title ?? "")
-      .trim()
-      .toLowerCase();
-    const findingRefs = refs.map((r) => r.trim().toLowerCase()).filter(Boolean);
-    if (!t) return false;
-    return findingRefs.some((ref) => t === ref || t.includes(ref) || ref.includes(t));
+    const state = emptyState("parity");
+    state.findings.push({
+      id: "probe",
+      severity: "High",
+      title: title ?? "",
+      description: "",
+      relatedIocs: [],
+      mitreTechniques: [],
+      sourceScreenshots: [],
+      firstSeen: "",
+      lastUpdated: "",
+      status: "open",
+    });
+    const markers = refs.map((ref, i) => ({
+      id: `m${i}`,
+      kind: "finding" as const,
+      ref,
+      reason: "other" as const,
+      note: "",
+      markedAt: "2026-05-28T10:00:00Z",
+      markedBy: "anonymous",
+    }));
+    return !applyFalsePositive(state, markers).findings.some((f) => f.id === "probe");
   };
 
   it.each(CASES)("matches the server on %s", (_label, title, refs) => {
     expect(f.isFindingFalsePositive(title, refs)).toBe(serverDrops(title, refs));
+  });
+
+  // Guards the guard: if every case came out false on both sides the comparison would be vacuous.
+  // At least one input must actually be suppressed by both.
+  it("includes cases where both sides do suppress", () => {
+    const suppressing = CASES.filter(([, t, r]) => serverDrops(t, r));
+    expect(suppressing.length).toBeGreaterThanOrEqual(3);
+    for (const [, t, r] of suppressing) expect(f.isFindingFalsePositive(t, r)).toBe(true);
   });
 });

--- a/companion/tests/dashboard/dashboardState.test.ts
+++ b/companion/tests/dashboard/dashboardState.test.ts
@@ -3,7 +3,17 @@ import { runInContext } from "node:vm";
 import { describe, expect, it, vi } from "vitest";
 import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
 import type { Cell, StateApi } from "./dashboardApi.js";
-import { dashboardClientSource, globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
+import {
+  buildCallGraph,
+  cachedSnapshots,
+  callsAfter,
+  dashboardScripts,
+  dfirStateCalls,
+  functionsOf,
+  reachableFrom,
+  usesAfter,
+} from "../helpers/dashboardAst.js";
+import { globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
 
 // public/js/dashboard-state.js — the store the rest of dashboard.html's 422 top-level bindings are
 // meant to migrate onto, and the answer to #415's actual question: who owns `lastState`.
@@ -107,61 +117,129 @@ describe("activeView", () => {
   });
 });
 
-// THE ACTUAL INVARIANT. Tier 1 and tier 2 in the module's header are defined by having very few
-// writers — `lastState` has exactly one across 43 readers — and the whole decision rests on that
-// staying true. A second writer appearing is the failure this design has to prevent, and the
-// cheapest place to prevent it is here, in the PR that would add it.
-describe("the single-writer rule", () => {
-  // Comment lines are dropped before counting. Not fastidiousness: the first run of this test
-  // failed because dashboard-state.js's own header described the rule using the literal string the
-  // regex looks for, so the module documenting the invariant counted as a violation of it. A gate
-  // that greps source has to decide what counts as source, and prose about the code is not it.
-  //
-  // Line-based rather than a real parser, because the haystack is HTML, CSS and JS concatenated,
-  // and stripping `//` from that would eat every `https://` in the markup.
-  const codeOnly = (source: string): string =>
-    source
-      .split("\n")
-      .filter((line) => !/^\s*(\/\/|\*|<!--)/.test(line))
-      .join("\n");
+// THE ARCHITECTURAL GATES, AST-BASED.
+//
+// These started as regexes over public/dashboard.html. An audit of #460 found three holes, all of
+// which mattered because #415's next phase moves hundreds of functions into modules:
+//
+//   - ONE FILE was scanned. The page loads 26 first-party scripts. A function that gained a second
+//     writer, or cached a snapshot across a refresh, was simply not in the text being searched.
+//   - ONE FUNCTION SHAPE was recognised: four-space-indented `function name(`. An injected
+//     `async function` that cached lastState() and called render() passed all 35 tests.
+//   - DIRECT CALLS ONLY. jumpToEvent reaches render() three hops away via
+//     resetTimelineViewFilters -> setExcludeTerms, and the direct check cleared it — wrongly.
+//
+// tests/helpers/dashboardAst.ts now parses every script the page tags and walks every function-like
+// node. The numbers below are the measure of the difference: 26 scripts, ~3,900 function nodes.
+describe("the state gates see the whole client", () => {
+  const scripts = dashboardScripts();
 
-  it("has exactly one call site that writes activeView", () => {
-    const writes = [...codeOnly(dashboardClientSource()).matchAll(/DfirState\.setActiveView\(/g)];
-    expect(
-      writes,
-      "activeView is owned by applyDashboardView(). A second writer means the cell is shared " +
-        "mutable state again, which is the thing js/dashboard-state.js exists to stop.",
-    ).toHaveLength(1);
+  it("scans every first-party script the page loads, not just the page", () => {
+    const names = scripts.map((s) => s.name);
+    expect(names.filter((n) => n.startsWith("dashboard.html#inline")).length).toBeGreaterThanOrEqual(5);
+    // The helpers AND the feature modules AND the a11y layer — the module half was the gap.
+    for (const required of [
+      "js/dashboard-state.js",
+      "js/dashboard-filters.js",
+      "js/hunt-workbench.js",
+      "js/a11y/modal-autowire.js",
+    ]) {
+      expect(names, `${required} is loaded by the dashboard but not scanned`).toContain(required);
+    }
+    expect(names.length).toBeGreaterThanOrEqual(20);
   });
 
-  it("puts that call site inside applyDashboardView", async () => {
-    const html = await readFile(DASHBOARD, "utf8");
-    const at = html.indexOf("DfirState.setActiveView(");
-    const owner = html.lastIndexOf("function applyDashboardView(", at);
-    const nextFn = html.indexOf("\n    function ", owner + 1);
-    expect(owner, "no applyDashboardView() before the write").toBeGreaterThan(-1);
-    expect(at, "the write escaped applyDashboardView()").toBeLessThan(nextFn);
-  });
-
-  // The bare identifier is gone from the page: `let activeView` no longer exists, so a stray
-  // `activeView = x` would be a ReferenceError rather than a silent second source of truth.
-  it("leaves no top-level activeView binding behind in the inline script", async () => {
-    const html = await readFile(DASHBOARD, "utf8");
-    expect(html).not.toMatch(/^\s*(let|var|const)\s+activeView\b/m);
+  it("walks every function form, not just top-level declarations", () => {
+    // ~3,900 against the ~800 the old four-space regex could see. The difference is arrows,
+    // methods, async functions and nested callbacks — where most of the dashboard's logic lives.
+    expect(scripts.flatMap(functionsOf).length).toBeGreaterThan(3000);
   });
 });
 
-// WHY COUNTING CALL SITES WAS NOT ENOUGH ON ITS OWN.
+// Each cell has exactly one writer, and that writer is the function that owned the variable.
+// Counted from the AST, so a comment quoting the setter cannot be mistaken for a call — which is
+// how the regex version first failed.
+describe("the single-writer rule", () => {
+  const scripts = dashboardScripts();
+  const CELLS = [
+    { setter: "setActiveView", owner: "applyDashboardView" },
+    { setter: "setLastState", owner: "render" },
+    { setter: "setLastFt", owner: "render" },
+    { setter: "setLastSuperData", owner: "renderSuperTimeline" },
+  ] as const;
+
+  it.each(CELLS)("$setter has exactly one call site anywhere in the client", ({ setter }) => {
+    const calls = dfirStateCalls(scripts, setter);
+    expect(
+      calls,
+      `${setter} must have exactly one writer across all ${scripts.length} scripts; found ` +
+        calls.map((c) => `${c.script}:${c.line}`).join(", "),
+    ).toHaveLength(1);
+  });
+
+  it.each(CELLS)("$setter is called from $owner", ({ setter, owner }) => {
+    const [call] = dfirStateCalls(scripts, setter);
+    const script = scripts.find((s) => s.name === call.script);
+    const enclosing = functionsOf(script!)
+      .filter((f) => {
+        const { line } = script!.ast.getLineAndCharacterOfPosition(f.node.getEnd());
+        return f.line <= call.line && line + 1 >= call.line;
+      })
+      .map((f) => f.name);
+    expect(enclosing, `${setter} is written outside ${owner}()`).toContain(owner);
+  });
+});
+
+// NO SNAPSHOT MAY BE CACHED ACROSS SOMETHING THAT CAN REPLACE IT.
 //
-// The first version of this file shipped with the cell as a top-level `const` in a classic script.
-// That reads as private — it never appears on the global object — but a classic script's top-level
-// `const` goes into the global LEXICAL environment, which every other script on the page shares.
-// `dfirActiveView.set(x)` from any later script therefore wrote the cell while the call-site count
-// above, which looks for `DfirState.setActiveView(`, stayed at one. The invariant this module's
-// whole argument rests on was decorative, and CI would have passed a second writer.
+// 16 of the 84 readers call their own writer. Reading a bare `let` always saw the current value; a
+// cached accessor result does not. But "never cache" is the wrong rule and the first draft of this
+// gate got it wrong: jumpToEvent reads the timeline once and renders that same array, and a
+// consistent snapshot across its body is the point.
 //
-// Both halves are now checked: the closure closes the hole, and these two tests are what notices
-// if a future edit hoists something back out of it.
+// So the rule is positional and transitive: a cache is a fault only when something reachable from
+// the writer runs AFTER it. That is the real invariant rather than a proxy for it, and it is why
+// this flags exactly the functions that are wrong instead of every function that caches.
+describe("no snapshot is cached across a refresh", () => {
+  const scripts = dashboardScripts();
+  const graph = buildCallGraph(scripts);
+  const CELLS = [
+    { cell: "lastState", writer: "render" },
+    { cell: "lastFt", writer: "render" },
+    { cell: "lastSuperData", writer: "renderSuperTimeline" },
+  ] as const;
+
+  it.each(CELLS)("$cell is never used after a refresh that followed caching it", ({ cell, writer }) => {
+    const offenders: string[] = [];
+    for (const script of scripts) {
+      for (const fn of functionsOf(script)) {
+        for (const cached of cachedSnapshots(fn.node, cell)) {
+          // A cache is only a fault when the value is READ again after something that can replace
+          // it has run. Passing the cached value INTO a refreshing renderer is the intended use —
+          // the refresh happens inside the callee, after the argument is already bound — so the
+          // rule is cache -> refresh -> use, not merely cache -> refresh.
+          const refreshers = callsAfter(fn.node, cached.pos).filter(
+            (c) => c.name === writer || reachableFrom(graph, [c.name]).has(writer),
+          );
+          for (const r of refreshers) {
+            if (usesAfter(fn.node, cached.name, r.end).length > 0) {
+              offenders.push(
+                `${script.name}:${fn.line} ${fn.name} reads \`${cached.name}\` after calling ${r.name}()`,
+              );
+              break;
+            }
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      `a snapshot cached before a refresh is stale by the time it is used. Read ${cell} after the ` +
+        "call that can replace it, or do not cache it.",
+    ).toEqual([]);
+  });
+});
+
 describe("nothing but the namespace escapes", () => {
   it("adds only DfirState to the global object", () => {
     expect(globalsAddedBy("dashboard-state.js")).toEqual(["DfirState"]);
@@ -232,97 +310,5 @@ describe("the snapshot cells", () => {
     s.onLastSuperDataChange(() => seen.push("super"));
     s.setLastFt([{ a: 1 }]);
     expect(seen).toEqual(["ft"]);
-  });
-});
-
-describe("the snapshot single-writer rule", () => {
-  const codeOnly = (source: string): string =>
-    source
-      .split("\n")
-      .filter((line) => !/^\s*(\/\/|\*|<!--)/.test(line))
-      .join("\n");
-
-  it.each(SNAPSHOT_CELLS)("$write has exactly one call site", ({ write, read }) => {
-    const calls = [...codeOnly(dashboardClientSource()).matchAll(new RegExp(`DfirState\\.${write}\\(`, "g"))];
-    expect(calls, `${read} must keep exactly one writer`).toHaveLength(1);
-  });
-
-  it.each(SNAPSHOT_CELLS)("$write is called from $owner", async ({ write, owner }) => {
-    const html = await readFile(DASHBOARD, "utf8");
-    const at = html.indexOf(`DfirState.${write}(`);
-    const ownerAt = html.lastIndexOf(`function ${owner}(`, at);
-    expect(ownerAt, `no ${owner}() before the write`).toBeGreaterThan(-1);
-    const nextFn = html.indexOf("\n    function ", ownerAt + 1);
-    expect(at, `the write escaped ${owner}()`).toBeLessThan(nextFn);
-  });
-
-  it.each(SNAPSHOT_CELLS)("leaves no top-level $read binding in the inline script", async ({ read }) => {
-    const html = await readFile(DASHBOARD, "utf8");
-    expect(html).not.toMatch(new RegExp(`^\\s*(let|var|const)\\s+${read}\\b`, "m"));
-  });
-});
-
-// THE RULE THIS MIGRATION TURNS ON.
-//
-// 16 of the 84 reader functions call their own writer — setExcludeTerms, loadTags, loadPins,
-// patchFindingWorkflow, applyDashboardView and eleven more all reach render() or
-// renderSuperTimeline(). Reading a bare `let` always saw the current value. Caching the accessor
-// result in a local does not, so `const s = DfirState.lastState()` at the top of one of THOSE
-// functions is a behaviour change on exactly the paths where a refetch happens mid-function.
-//
-// THE GATE IS NOT "NEVER CACHE", and the first draft of it was, which was wrong. jumpToEvent binds
-// `const ft = DfirState.lastFt() || []`, computes a page index into that array, and renders the
-// same array — a consistent snapshot across its body is the POINT, and re-reading the accessor
-// between the index and the render would be the bug. It is safe because nothing it calls reaches
-// render(), which was checked rather than assumed.
-//
-// So the rule is the intersection: do not cache a snapshot in a function that can rewrite it. That
-// is computed from the source below rather than from a list of names, because a list of sixteen
-// function names is exactly the kind of thing that is right on the day it is written.
-describe("no reader caches a snapshot it can invalidate", () => {
-  const WRITER_OF: Record<string, string> = {
-    lastState: "render",
-    lastFt: "render",
-    lastSuperData: "renderSuperTimeline",
-  };
-
-  /** Top-level functions of the inline script, by the 4-space indentation it is written at. */
-  const topLevelFunctions = (html: string): Array<{ name: string; body: string }> => {
-    const out: Array<{ name: string; body: string }> = [];
-    const re = /\n {4}function (\w+)\s*\([^)]*\)\s*\{/g;
-    for (const m of html.matchAll(re)) {
-      const from = m.index + m[0].length;
-      const end = html.indexOf("\n    }", from);
-      out.push({ name: m[1], body: html.slice(from, end < 0 ? undefined : end) });
-    }
-    return out;
-  };
-
-  it("finds the inline script's functions, so the check below is not vacuous", async () => {
-    expect(topLevelFunctions(await readFile(DASHBOARD, "utf8")).length).toBeGreaterThan(700);
-  });
-
-  it("never binds a snapshot local in a function that calls that cell's writer", async () => {
-    const html = await readFile(DASHBOARD, "utf8");
-    const offenders: string[] = [];
-    for (const fn of topLevelFunctions(html)) {
-      for (const [cell, writer] of Object.entries(WRITER_OF)) {
-        const binds = new RegExp(`(?:const|let|var)\\s+\\w+\\s*=\\s*DfirState\\.${cell}\\(\\)`).test(fn.body);
-        const calls = new RegExp(`(?:^|[^.\\w])${writer}\\(`).test(fn.body);
-        if (binds && calls) offenders.push(`${fn.name} caches ${cell} and calls ${writer}()`);
-      }
-    }
-    expect(
-      offenders,
-      "a cached snapshot goes stale the moment its writer runs. Call the accessor at each use in " +
-        "these functions, or stop them re-fetching mid-body.",
-    ).toEqual([]);
-  });
-
-  // Guards the guard: if the accessors were renamed, both regexes above would match nothing and
-  // the check would pass vacuously. There must be reads to police in the first place.
-  it("is policing a real population of reads", () => {
-    const reads = [...dashboardClientSource().matchAll(/DfirState\.(?:lastState|lastFt|lastSuperData)\(\)/g)];
-    expect(reads.length).toBeGreaterThan(100);
   });
 });

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -1,0 +1,258 @@
+// AST analysis of the dashboard's first-party client code (#415).
+//
+// WHY THIS EXISTS. The state gates in tests/dashboard/dashboardState.test.ts started as regexes over
+// public/dashboard.html. An audit of #460 showed both had holes that mattered:
+//
+//   - they read ONE file. The page loads ten classic scripts and seven modules besides, and tier 3
+//     of #415 moves hundreds more functions into modules. A function that gained a second writer or
+//     cached a snapshot across a refresh would not have been in the text being scanned.
+//   - the function pattern was `\n    function name(`. That misses `async function`, arrow
+//     callbacks, object methods and class methods. An `async function` that cached the snapshot and
+//     called render() was injected and all 35 tests passed.
+//   - "calls the writer" meant a DIRECT call. jumpToEvent reaches render() three hops away through
+//     resetTimelineViewFilters -> setExcludeTerms, and the direct check cleared it.
+//
+// A gate the architecture is supposed to rest on has to see all the code and all the shapes, so
+// this parses instead of matching.
+//
+// WHY THE TYPESCRIPT PARSER rather than acorn or espree: both are present in node_modules but only
+// as transitive dependencies, and a gate CI depends on should not rest on a package that any
+// unrelated dependency bump can remove. `typescript` is a direct devDependency and parses JS fine.
+
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+const PUBLIC = new URL("../../../public/", import.meta.url);
+
+/** One parseable unit of the dashboard's client code. */
+export interface DashboardScript {
+  /** Display name for assertion messages: a filename, or `dashboard.html#inline-3`. */
+  name: string;
+  source: string;
+  ast: ts.SourceFile;
+}
+
+/**
+ * EVERY first-party script the dashboard loads: its inline blocks plus each /js/ file it tags,
+ * whether classic or module.
+ *
+ * Read from the markup rather than hard-coded, so a script added tomorrow is covered the day it is
+ * added — the hard-coded list is exactly what left seven modules unscanned before.
+ */
+export function dashboardScripts(): DashboardScript[] {
+  const html = readFileSync(new URL("dashboard.html", PUBLIC), "utf8");
+  const out: DashboardScript[] = [];
+
+  let n = 0;
+  for (const m of html.matchAll(/<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g)) {
+    out.push(makeScript(`dashboard.html#inline-${++n}`, m[1]));
+  }
+  // Any `src="/js/…"`, classic or `type="module"` — the distinction is about load semantics, not
+  // about whether the code can write the store.
+  for (const m of html.matchAll(/<script[^>]*\ssrc="\/js\/([^"]+)"/g)) {
+    out.push(makeScript(`js/${m[1]}`, readFileSync(new URL(`js/${m[1]}`, PUBLIC), "utf8")));
+  }
+  return out;
+}
+
+function makeScript(name: string, source: string): DashboardScript {
+  return {
+    name,
+    source,
+    ast: ts.createSourceFile(name, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS),
+  };
+}
+
+/** Every function-like node, in any form the language offers. */
+export interface FunctionInfo {
+  script: string;
+  /** Declared name where there is one, else `<anonymous@line>`. */
+  name: string;
+  line: number;
+  node: ts.Node;
+}
+
+const isFunctionLike = (n: ts.Node): boolean =>
+  ts.isFunctionDeclaration(n) ||
+  ts.isFunctionExpression(n) ||
+  ts.isArrowFunction(n) ||
+  ts.isMethodDeclaration(n) ||
+  ts.isGetAccessor(n) ||
+  ts.isSetAccessor(n) ||
+  ts.isConstructorDeclaration(n);
+
+/**
+ * Name a function for a failure message.
+ *
+ * An arrow assigned to a variable or property takes that name, because `const foo = async () => …`
+ * is a named function to everyone except the parser, and a message saying `<anonymous@8231>` when
+ * the source plainly says `foo` wastes the reader's time.
+ */
+function nameOf(node: ts.Node, sf: ts.SourceFile): string {
+  const named = node as ts.FunctionDeclaration;
+  if (named.name && ts.isIdentifier(named.name)) return named.name.text;
+  const parent = node.parent;
+  if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+  return `<anonymous@${line + 1}>`;
+}
+
+export function functionsOf(script: DashboardScript): FunctionInfo[] {
+  const out: FunctionInfo[] = [];
+  const visit = (n: ts.Node): void => {
+    if (isFunctionLike(n)) {
+      const { line } = script.ast.getLineAndCharacterOfPosition(n.getStart(script.ast));
+      out.push({ script: script.name, name: nameOf(n, script.ast), line: line + 1, node: n });
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(script.ast, visit);
+  return out;
+}
+
+/** Names called from inside `node`, including from functions nested within it. */
+export function callsWithin(node: ts.Node): Set<string> {
+  const out = new Set<string>();
+  const visit = (n: ts.Node): void => {
+    if (ts.isCallExpression(n)) {
+      if (ts.isIdentifier(n.expression)) out.add(n.expression.text);
+      else if (ts.isPropertyAccessExpression(n.expression)) out.add(n.expression.name.text);
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(node, visit);
+  return out;
+}
+
+/** `DfirState.<member>(` call sites, as (script, line) pairs. Comments cannot reach this. */
+export function dfirStateCalls(
+  scripts: DashboardScript[],
+  member: string,
+): Array<{ script: string; line: number }> {
+  const hits: Array<{ script: string; line: number }> = [];
+  for (const s of scripts) {
+    const visit = (n: ts.Node): void => {
+      if (
+        ts.isCallExpression(n) &&
+        ts.isPropertyAccessExpression(n.expression) &&
+        ts.isIdentifier(n.expression.expression) &&
+        n.expression.expression.text === "DfirState" &&
+        n.expression.name.text === member
+      ) {
+        hits.push({ script: s.name, line: s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1 });
+      }
+      ts.forEachChild(n, visit);
+    };
+    ts.forEachChild(s.ast, visit);
+  }
+  return hits;
+}
+
+/** A local that caches a snapshot: its name, and where it was bound. */
+export interface CachedSnapshot {
+  name: string;
+  pos: number;
+}
+
+/**
+ * Locals whose initialiser IS `DfirState.<member>()` — optionally with a `|| fallback`.
+ *
+ * Only the accessor call itself counts. `const caseId = DfirState.lastState() && ….caseId` derives
+ * a scalar rather than caching the snapshot, and without that distinction the gate fires on every
+ * derived value.
+ */
+export function cachedSnapshots(node: ts.Node, member: string): CachedSnapshot[] {
+  const out: CachedSnapshot[] = [];
+  const isAccessorCall = (e: ts.Expression): boolean =>
+    ts.isCallExpression(e) &&
+    ts.isPropertyAccessExpression(e.expression) &&
+    ts.isIdentifier(e.expression.expression) &&
+    e.expression.expression.text === "DfirState" &&
+    e.expression.name.text === member;
+  const visit = (n: ts.Node): void => {
+    if (ts.isVariableDeclaration(n) && n.initializer && ts.isIdentifier(n.name)) {
+      let init: ts.Expression = n.initializer;
+      while (
+        ts.isBinaryExpression(init) &&
+        (init.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
+          init.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken)
+      ) {
+        init = init.left;
+      }
+      if (isAccessorCall(init)) out.push({ name: n.name.text, pos: n.end });
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(node, visit);
+  return out;
+}
+
+/**
+ * Calls made within `node` after `pos`, with both bounds.
+ *
+ * `end` matters as much as `pos`: the arguments of a call sit INSIDE it, so `renderTimelineEvents(ft)`
+ * contains a read of `ft` at a position after the call begins. Measuring a later use from the call's
+ * END is what distinguishes "passed the cached value into a renderer" — fine, the argument is bound
+ * before the callee runs — from "read it again after the renderer replaced it".
+ */
+export function callsAfter(node: ts.Node, pos: number): Array<{ name: string; pos: number; end: number }> {
+  const out: Array<{ name: string; pos: number; end: number }> = [];
+  const visit = (n: ts.Node): void => {
+    if (n.pos >= pos && ts.isCallExpression(n)) {
+      if (ts.isIdentifier(n.expression)) out.push({ name: n.expression.text, pos: n.pos, end: n.end });
+      else if (ts.isPropertyAccessExpression(n.expression))
+        out.push({ name: n.expression.name.text, pos: n.pos, end: n.end });
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(node, visit);
+  return out;
+}
+
+/** Positions where the identifier `name` is read within `node`, after `pos`. */
+export function usesAfter(node: ts.Node, name: string, pos: number): number[] {
+  const out: number[] = [];
+  const visit = (n: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(n)) {
+      visit(n.expression);
+      return;
+    } // `x.y` reads x, not y
+    if (ts.isIdentifier(n) && n.text === name && n.pos >= pos) out.push(n.pos);
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(node, visit);
+  return out;
+}
+
+/**
+ * Every name transitively reachable from `roots` through the call graph of named functions.
+ *
+ * The audit's third point: a direct-call check cleared jumpToEvent, which reaches render() three
+ * hops away via resetTimelineViewFilters -> setExcludeTerms. Reachability is the property that
+ * matters, because a snapshot cached before ANY of those hops is stale after it.
+ */
+export function buildCallGraph(scripts: DashboardScript[]): Map<string, Set<string>> {
+  const graph = new Map<string, Set<string>>();
+  for (const s of scripts) {
+    for (const fn of functionsOf(s)) {
+      if (fn.name.startsWith("<anonymous")) continue;
+      const existing = graph.get(fn.name) ?? new Set<string>();
+      for (const c of callsWithin(fn.node)) existing.add(c);
+      graph.set(fn.name, existing);
+    }
+  }
+  return graph;
+}
+
+export function reachableFrom(graph: Map<string, Set<string>>, start: Iterable<string>): Set<string> {
+  const seen = new Set<string>();
+  const queue = [...start];
+  while (queue.length > 0) {
+    const name = queue.shift() as string;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    for (const next of graph.get(name) ?? []) if (!seen.has(next)) queue.push(next);
+  }
+  return seen;
+}

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -13164,9 +13164,9 @@
       const sec = document.getElementById("sec-timeline");
       if (sec) sec.classList.remove("collapsed");
       if (swLocateInTable(id)) return;                                    // already on the current page
-      const ft = DfirState.lastFt() || [];
-      if (!ft.some(e => String(e.id) === id)) return;                    // not in the in-scope timeline
+      if (!(DfirState.lastFt() || []).some(e => String(e.id) === id)) return;  // not in the in-scope timeline
       resetTimelineViewFilters();                                         // unhide it if a filter excluded it
+      const ft = DfirState.lastFt() || [];   // AFTER the reset — it reaches render(), which replaces lastFt
       const sorted = sortTimelineEvents(ft.slice());                      // same order the table renders in
       const idx = sorted.findIndex(e => String(e.id) === id);
       if (idx >= 0 && tlPageSize > 0) tlPage = Math.floor(idx / tlPageSize);  // page the event lands on


### PR DESCRIPTION
Fixes the three audit findings against #460 and #461. No runtime behaviour changes; all three were
gates reporting success where they could not see. **Prerequisite for #415 tier 3**, which moves
hundreds of functions into modules — the scenario the gates were about to stop covering.

## 1 — The gates could not see the code they exist for

| | before | now |
|---|---|---|
| scripts scanned (stale-snapshot gate) | **1** (`dashboard.html`) | **26** |
| scripts scanned (single-writer gate) | 9 helpers | **26** |
| function forms recognised | `\n    function name(` | **every form** |
| function nodes visible | ~800 | **~3,900** |
| "calls the writer" | direct call only | **transitive** |

The script list is read from the markup, not hard-coded — a hard-coded list is what left seven
modules unscanned.

`tests/helpers/dashboardAst.ts` uses the **TypeScript** parser: acorn and espree are both in
`node_modules` but only transitively, and a gate CI rests on shouldn't rest on a package any
unrelated bump can remove.

## 2 — The rule is dataflow, not prohibition

"Never cache a snapshot" is wrong, and this gate got it wrong **twice** before landing:

1. *Never cache* — forbids `jumpToEvent`, which reads the timeline once and renders that same array. A consistent snapshot across its body is the point.
2. *Cache followed by a refresh* — still wrong. Passing the cached value **into** a refreshing renderer is the intended use; the argument binds before the callee runs.
3. **cache → refresh → use** — the rule that is actually true. A cached snapshot is a fault only when it is read *again* after something that can replace it has run. A use inside the refreshing call doesn't count, because it's measured from that call's end.

That precision is what lets the gate be absolute: it flags exactly one function today and no others, so there's no allowlist to rot.

## 3 — And `jumpToEvent` was that one function

It cached `lastFt`, called `resetTimelineViewFilters()`, then used the cached array. `resetTimelineViewFilters` reaches `render()` three hops away via `setExcludeTerms`.

It worked only because `render` recomputes `lastFt` from `state` + FP markers, which that reset doesn't touch — **an invariant nobody stated and nothing enforced.** It now reads after the reset: behaviour-identical today, no longer dependent on the accident.

I cleared this function in #460's commit message by checking one call level and describing it as "checked rather than assumed". It was assumed. The audit was right.

## 4 — The parity test was checking a copy of the server

#461 added a test claiming to run both implementations against the same inputs. It ran the client
against `serverDrops` — a hand-written transcription of the server rule. A server-only change leaves
the transcription untouched and the test green, through exactly the divergence it exists to prevent.
Same class of mistake as the bug it was written for.

It now imports `applyFalsePositive` and runs it against a real `InvestigationState`.

## Mutation results

A gate nobody has seen fail is a gate nobody should trust:

| mutation | before | now |
|---|---|---|
| `async function` caching then refreshing | 0 | **1 failure** |
| arrow function **in a module** doing the same | 0 | **1 failure** |
| a second writer added **in a module** | 0 | **1 failure** |
| server-only removal of the title guard | 0 | **3 failures** |

## Verification

Full suite green apart from the two pre-existing `sharpVersion` failures (local libvips; fails on
master, passes on CI). `check:size`, `check:imports`, `check:boundaries`, `format:check`, lint all
pass; `git diff --check` clean; type-check count unchanged at 362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
