### PR TITLE
test(dashboard): close three bypasses in the state gates (#415)

### DIFF
--- a/companion/tests/dashboard/dashboardState.test.ts
+++ b/companion/tests/dashboard/dashboardState.test.ts
@@ -8,7 +8,8 @@ import {
   cachedSnapshots,
   callsAfter,
   dashboardScripts,
-  dfirStateCalls,
+  setterRefs,
+  capturedByNestedFunction,
   functionsOf,
   reachableFrom,
   usesAfter,
@@ -168,17 +169,22 @@ describe("the single-writer rule", () => {
     { setter: "setLastSuperData", owner: "renderSuperTimeline" },
   ] as const;
 
-  it.each(CELLS)("$setter has exactly one call site anywhere in the client", ({ setter }) => {
-    const calls = dfirStateCalls(scripts, setter);
+  it.each(CELLS)("$setter is referenced exactly once, as a direct call", ({ setter }) => {
+    const refs = setterRefs(scripts, setter);
     expect(
-      calls,
-      `${setter} must have exactly one writer across all ${scripts.length} scripts; found ` +
-        calls.map((c) => `${c.script}:${c.line}`).join(", "),
+      refs,
+      `${setter} must be named exactly once across all ${scripts.length} scripts; found ` +
+        refs.map((r) => `${r.script}:${r.line} (${r.form})`).join(", "),
     ).toHaveLength(1);
+    // Not merely once, but in the one shape the gate can reason about. A destructured or computed
+    // reference hands the setter to code this analysis cannot follow.
+    expect(refs[0].form, `${setter} must be called directly, not stashed or accessed dynamically`).toBe(
+      "direct-call",
+    );
   });
 
   it.each(CELLS)("$setter is called from $owner", ({ setter, owner }) => {
-    const [call] = dfirStateCalls(scripts, setter);
+    const [call] = setterRefs(scripts, setter);
     const script = scripts.find((s) => s.name === call.script);
     const enclosing = functionsOf(script!)
       .filter((f) => {
@@ -221,6 +227,16 @@ describe("no snapshot is cached across a refresh", () => {
           const refreshers = callsAfter(fn.node, cached.pos).filter(
             (c) => c.name === writer || reachableFrom(graph, [c.name]).has(writer),
           );
+          if (refreshers.length === 0) continue;
+          // A value that escapes into a callback has no knowable execution position — see
+          // capturedByNestedFunction. Any refresher in the enclosing function is then a fault.
+          if (capturedByNestedFunction(fn.node, cached.name)) {
+            offenders.push(
+              `${script.name}:${fn.line} ${fn.name} captures \`${cached.name}\` in a callback, ` +
+                `and ${refreshers[0].name}() can replace it before that callback runs`,
+            );
+            continue;
+          }
           for (const r of refreshers) {
             if (usesAfter(fn.node, cached.name, r.end).length > 0) {
               offenders.push(

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -47,10 +47,27 @@ export function dashboardScripts(): DashboardScript[] {
   for (const m of html.matchAll(/<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g)) {
     out.push(makeScript(`dashboard.html#inline-${++n}`, m[1]));
   }
-  // Any `src="/js/…"`, classic or `type="module"` — the distinction is about load semantics, not
-  // about whether the code can write the store.
-  for (const m of html.matchAll(/<script[^>]*\ssrc="\/js\/([^"]+)"/g)) {
-    out.push(makeScript(`js/${m[1]}`, readFileSync(new URL(`js/${m[1]}`, PUBLIC), "utf8")));
+
+  // Tagged files, THEN everything they import, transitively.
+  //
+  // js/a11y/modal-autowire.js imports modal.js, which imports focus-trap.js. Neither is named by a
+  // script tag, so neither was scanned — the browser fetches them, they run on every page, and a
+  // second writer or a stale snapshot in either would have passed every gate. The same reasoning
+  // that put the whole import graph in the STATIC_ASSETS check (a transitive import 404s exactly as
+  // silently as a direct one) applies here: the gate has to see what the browser executes.
+  const seen = new Set<string>();
+  const queue = [...html.matchAll(/<script[^>]*\ssrc="\/js\/([^"]+)"/g)].map((m) => `js/${m[1]}`);
+  while (queue.length > 0) {
+    const rel = queue.shift() as string;
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    const source = readFileSync(new URL(rel, PUBLIC), "utf8");
+    out.push(makeScript(rel, source));
+    // Relative specifiers only — a bare specifier would be a bundler dependency, and this page has
+    // no bundler, so anything not starting with "." is not ours to scan.
+    for (const imp of source.matchAll(/^\s*(?:import|export)\s[^"']*["'](\.[^"']+)["']/gm)) {
+      queue.push(new URL(imp[1], `file:///${rel}`).pathname.replace(/^\//, ""));
+    }
   }
   return out;
 }
@@ -125,22 +142,68 @@ export function callsWithin(node: ts.Node): Set<string> {
   return out;
 }
 
-/** `DfirState.<member>(` call sites, as (script, line) pairs. Comments cannot reach this. */
-export function dfirStateCalls(
-  scripts: DashboardScript[],
-  member: string,
-): Array<{ script: string; line: number }> {
-  const hits: Array<{ script: string; line: number }> = [];
+/** One place a protected setter is named, and whether it is the one permitted shape. */
+export interface SetterRef {
+  script: string;
+  line: number;
+  /** `direct-call` is the only allowed form; everything else defeats the single-writer gate. */
+  form: "direct-call" | "property-reference" | "computed-access" | "destructured";
+}
+
+/**
+ * EVERY reference to `DfirState.<member>`, not just `DfirState.member(...)`.
+ *
+ * Counting direct dot-calls was a gate with three doors and a lock on one of them. All of these
+ * write the cell and none is a direct call:
+ *
+ *     const { setLastFt } = DfirState; setLastFt([]);   // destructured
+ *     DfirState["setLastFt"]([]);                       // computed
+ *     const w = DfirState.setLastFt; w([]);             // property reference
+ *
+ * A probe containing three real writes produced one gate hit. So the rule is not "one call" but
+ * "one reference, and it is a direct call" — anything that gets hold of the setter can write it,
+ * and the gate cannot follow where the reference goes afterwards.
+ */
+export function setterRefs(scripts: DashboardScript[], member: string): SetterRef[] {
+  const hits: SetterRef[] = [];
   for (const s of scripts) {
+    const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
     const visit = (n: ts.Node): void => {
+      // DfirState.member — a call, or a bare reference someone can stash.
       if (
-        ts.isCallExpression(n) &&
-        ts.isPropertyAccessExpression(n.expression) &&
-        ts.isIdentifier(n.expression.expression) &&
-        n.expression.expression.text === "DfirState" &&
-        n.expression.name.text === member
+        ts.isPropertyAccessExpression(n) &&
+        ts.isIdentifier(n.expression) &&
+        n.expression.text === "DfirState" &&
+        n.name.text === member
       ) {
-        hits.push({ script: s.name, line: s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1 });
+        const isCallee = n.parent && ts.isCallExpression(n.parent) && n.parent.expression === n;
+        hits.push({ script: s.name, line: at(n), form: isCallee ? "direct-call" : "property-reference" });
+      }
+      // DfirState["member"]
+      if (
+        ts.isElementAccessExpression(n) &&
+        ts.isIdentifier(n.expression) &&
+        n.expression.text === "DfirState" &&
+        n.argumentExpression &&
+        ts.isStringLiteral(n.argumentExpression) &&
+        n.argumentExpression.text === member
+      ) {
+        hits.push({ script: s.name, line: at(n), form: "computed-access" });
+      }
+      // const { member } = DfirState
+      if (
+        ts.isVariableDeclaration(n) &&
+        n.initializer &&
+        ts.isIdentifier(n.initializer) &&
+        n.initializer.text === "DfirState" &&
+        ts.isObjectBindingPattern(n.name)
+      ) {
+        for (const el of n.name.elements) {
+          const source = el.propertyName ?? el.name;
+          if (ts.isIdentifier(source) && source.text === member) {
+            hits.push({ script: s.name, line: at(el), form: "destructured" });
+          }
+        }
       }
       ts.forEachChild(n, visit);
     };
@@ -223,6 +286,39 @@ export function usesAfter(node: ts.Node, name: string, pos: number): number[] {
   };
   ts.forEachChild(node, visit);
   return out;
+}
+
+/**
+ * Is `name` captured by a function nested inside `node`?
+ *
+ * SOURCE ORDER IS NOT EXECUTION ORDER, and the positional check alone believes it is. This passes
+ * it:
+ *
+ *     const ft = DfirState.lastFt();
+ *     setTimeout(() => consume(ft), 0);   // captured here, RUNS later
+ *     render(lastState);                  // replaces lastFt in between
+ *
+ * Every use of `ft` precedes the refresh in the text, so nothing is "used after" it — while at
+ * runtime the order is cache, refresh, use. A loop body does the same thing by jumping backwards.
+ *
+ * A captured variable has no knowable execution position, so the honest treatment is to stop
+ * reasoning about position for it: if the value escapes into a callback and anything in the
+ * enclosing function can refresh the cell, that is a fault. Conservative by design — a deferred
+ * read of a snapshot is worth writing differently even when it happens to be safe.
+ */
+export function capturedByNestedFunction(node: ts.Node, name: string): boolean {
+  let captured = false;
+  const search = (n: ts.Node, insideNested: boolean): void => {
+    if (captured) return;
+    const nested = insideNested || (n !== node && isFunctionLike(n));
+    if (nested && ts.isIdentifier(n) && n.text === name) {
+      captured = true;
+      return;
+    }
+    ts.forEachChild(n, (c) => search(c, nested));
+  };
+  ts.forEachChild(node, (c) => search(c, false));
+  return captured;
 }
 
 /**


### PR DESCRIPTION
Three more holes in the gates #462 landed, all reproduced before fixing. #462 made them AST-based;
these are the cases the AST walk still didn't reach.

## Transitively imported modules were not scanned

`dashboardScripts()` read the inline blocks and the files named by script tags — not what those
files import. `js/a11y/modal-autowire.js` imports `modal.js`, which imports `focus-trap.js`. The
browser fetches and runs both; the gates saw neither.

Now walks the import graph: **26 scripts → 28**.

This is the same reasoning `tests/settings/settingsSearch.test.ts` already applies to the
`STATIC_ASSETS` whitelist — a transitive import 404s exactly as silently as a direct one — and the
gates should have had it from the start.

## The single-writer gate counted one shape of three

It matched `DfirState.setLastFt(...)`. All of these write the cell and none is a dot-call:

```js
const { setLastFt } = DfirState; setLastFt([]);
DfirState["setLastFt"]([]);
const w = DfirState.setLastFt; w([]);
```

A probe with three real writes produced **one** gate hit. The rule is now *referenced exactly once,
and that reference is a direct call* rather than *called once* — anything that gets hold of the
setter can write it, and the analysis can't follow where the reference goes next.

## Source order is not execution order

`callsAfter`/`usesAfter` compare AST positions, which assumes the text runs top to bottom:

```js
const ft = DfirState.lastFt();
setTimeout(() => consume(ft), 0);   // captured here, RUNS later
render(lastState);                  // replaces lastFt in between
```

Every use of `ft` precedes the refresh *in the text*, so nothing is "used after" it — while the
runtime order is cache → refresh → use. A loop body has the same shape by jumping backwards.

A captured variable has no knowable execution position, so the gate stops reasoning about position
for it: if the value escapes into a callback and anything in the enclosing function can refresh the
cell, that's a fault. Conservative by design — and it does **not** fire on `jumpToEvent`, the one
function that legitimately caches, because nothing nested captures its array.

## Mutation results — all four were previously invisible

| mutation | before | now |
|---|---|---|
| writer added in a **transitively imported** module | 0 | **1 failure** |
| destructured setter | 0 | **1 failure** |
| computed access `DfirState["setLastFt"]` | 0 | **1 failure** |
| snapshot captured by a deferred callback | 0 | **1 failure** |

Full suite green apart from the two pre-existing `sharpVersion` failures. Gates, lint, format,
`git diff --check` all pass; type-check count unchanged at 362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)