### PR TITLE
refactor(dashboard): move the KEV catalog panel out whole (#415 tier 3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -295,7 +295,7 @@ the issue that owns the work, so no number is a blocker without an assignee:
 |---|---|---|---|
 | `analysis/pipeline.ts` | 800 | **591 — met** | [#418](https://github.com/hasamba/DFIR-Companion/issues/418) |
 | `server.ts` | 800 | **623 — met** | [#416](https://github.com/hasamba/DFIR-Companion/issues/416) |
-| `public/dashboard.html` inline JS | 2,000 | 18,182 | [#415](https://github.com/hasamba/DFIR-Companion/issues/415) |
+| `public/dashboard.html` inline JS | 2,000 | 18,138 | [#415](https://github.com/hasamba/DFIR-Companion/issues/415) |
 | `public/dashboard.html` inline CSS | 800 | **4 — met** | [#415](https://github.com/hasamba/DFIR-Companion/issues/415) |
 | `public/css/dashboard.css` | 800 | 3,261 | [#415](https://github.com/hasamba/DFIR-Companion/issues/415) |
 | Files in `src/` over 800 lines | 0 | 11 | the ledger below |

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -6,7 +6,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/css/dashboard.css": 3261,
-  "public/dashboard.html#inline-js": 18182,
+  "public/dashboard.html#inline-js": 18138,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,

--- a/companion/src/http/staticAssets.ts
+++ b/companion/src/http/staticAssets.ts
@@ -45,6 +45,7 @@ export const STATIC_ASSETS: Record<string, string> = {
   "/js/dashboard-fragments.js": "application/javascript; charset=utf-8",
   // The first whole FEATURE module of #415 tier 3, as opposed to the pure-helper modules above.
   "/js/dashboard-tagger.js": "application/javascript; charset=utf-8",
+  "/js/dashboard-kev.js": "application/javascript; charset=utf-8",
   // Accessibility primitives (#386). modal-autowire is the only one dashboard.html loads directly;
   // the other two are its static imports, and the browser fetches those by URL too — so all three
   // need an entry here or the import chain 404s exactly as described above.

--- a/companion/tests/architecture/route-inventory.json
+++ b/companion/tests/architecture/route-inventory.json
@@ -479,6 +479,7 @@
     "ROUTE GET /js/dashboard-values.js",
     "ROUTE GET /js/dashboard-fragments.js",
     "ROUTE GET /js/dashboard-tagger.js",
+    "ROUTE GET /js/dashboard-kev.js",
     "ROUTE GET /js/a11y/modal-autowire.js",
     "ROUTE GET /js/a11y/modal.js",
     "ROUTE GET /js/a11y/focus-trap.js",

--- a/companion/tests/dashboard/dashboardTagger.test.ts
+++ b/companion/tests/dashboard/dashboardTagger.test.ts
@@ -91,3 +91,50 @@ describe("the tagger feature is still reachable", () => {
     expect(functionsOf(tagger!).length).toBeGreaterThanOrEqual(TAGGER.length);
   });
 });
+
+// public/js/dashboard-kev.js — the second and last wholly-movable feature (#415 tier 3).
+//
+// Wired differently from the tagger, which is the point of testing it separately: KEV uses
+// `addEventListener("click", kevImportUrl)`, a function REFERENCE resolved when the listener is
+// registered, where the tagger goes through the ACTIONS table's late-bound arrows. Both work only
+// because the module is a synchronous classic script loaded before the inline script — but they
+// would fail differently, so both are pinned.
+describe("the KEV feature moved whole", () => {
+  const KEV = ["loadKev", "kevImportUrl", "kevImportFile", "kevClear"];
+
+  it("declares all four functions and publishes every one", () => {
+    expect(declaredFunctions("dashboard-kev.js").sort()).toEqual([...KEV].sort());
+  });
+
+  it("leaves no half of the feature behind in the inline script", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    const leftBehind = [...html.matchAll(/^\s*(?:async )?function (\w*[Kk]ev\w*)\s*\(/gm)].map((m) => m[1]);
+    expect(leftBehind).toEqual([]);
+  });
+
+  it("touches no shared dashboard state", async () => {
+    expect(
+      await readFile(new URL("../../../public/js/dashboard-kev.js", import.meta.url), "utf8"),
+    ).not.toMatch(/\bDfirState\b/);
+  });
+
+  // The listener registrations still name these functions. They resolve at registration time, in
+  // the inline script — so the module must load first, and the names must be real globals.
+  it("keeps the listener registrations resolving to functions the module publishes", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    const registered = [...html.matchAll(/addEventListener\("(?:click|keydown)",\s*(kev\w+)\)/g)].map(
+      (m) => m[1],
+    );
+    expect(registered.length, "no KEV listener is registered — the check is vacuous").toBeGreaterThan(0);
+    for (const name of registered) expect(declaredFunctions("dashboard-kev.js")).toContain(name);
+  });
+
+  it("is loaded synchronously ahead of the inline script, and served by the whitelist", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    const tag = /<script([^>]*)\ssrc="\/js\/dashboard-kev\.js"/.exec(html);
+    expect(tag).not.toBeNull();
+    expect(tag?.[1]).not.toMatch(/defer|type="module"|async/);
+    expect(html.indexOf('src="/js/dashboard-kev.js"')).toBeLessThan(html.lastIndexOf("<script nonce="));
+    expect(STATIC_ASSETS["/js/dashboard-kev.js"]).toBe("application/javascript; charset=utf-8");
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -123,6 +123,8 @@
   <!-- The AI tagger-rule feature (#415 tier 3). A whole feature, not the movable half of one —
        js/dashboard-tagger.js explains why that distinction decides what moves next. -->
   <script src="/js/dashboard-tagger.js"></script>
+  <!-- The CISA KEV catalog panel (#99), the second and last wholly-movable feature (#415 tier 3). -->
+  <script src="/js/dashboard-kev.js"></script>
   <script defer src="/vendor/leaflet/leaflet.js"></script>
   <script defer src="/vendor/cytoscape/cytoscape.min.js"></script>
   <script defer src="/vendor/cytoscape/dagre.min.js"></script>
@@ -20077,50 +20079,6 @@
           if (j.legitimate) renderFalsePositives(j.legitimate);
         })
         .catch(e => { msg.textContent = "failed: " + e.message + " — restart the server if the endpoint 404s."; });
-    }
-
-    // --- CISA KEV catalog (#99) — global CVE cross-reference, Settings → KEV ---------------------
-    function loadKev() {
-      const status = document.getElementById("kevStatus");
-      const cnt = document.getElementById("kevCount");
-      fetch("/kev").then(r => r.json()).then(j => {
-        if (j.count > 0) {
-          const ver = j.catalogVersion ? ` · version ${j.catalogVersion}` : "";
-          const rel = j.dateReleased ? ` · released ${j.dateReleased.slice(0, 10)}` : "";
-          cnt.textContent = `(${j.count.toLocaleString()} CVEs)`;
-          status.textContent = `Catalog loaded${ver}${rel}.`;
-        } else {
-          cnt.textContent = "";
-          status.textContent = "No catalog loaded yet — click \"Load from CISA feed\" or point to a local file.";
-        }
-      }).catch(() => { if (status) status.textContent = "Could not fetch KEV status — restart the server if this 404s."; });
-    }
-    function kevImportUrl() {
-      const msg = document.getElementById("kevUrlMsg");
-      msg.textContent = "fetching from CISA…";
-      fetch("/kev/import-url", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
-        .then(async r => { if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "HTTP " + r.status); return r.json(); })
-        .then(j => { msg.textContent = `loaded ${j.total.toLocaleString()} CVEs`; loadKev(); })
-        .catch(e => { msg.textContent = "failed: " + e.message + " — check server outbound connectivity or use a local file."; });
-    }
-    function kevImportFile() {
-      const path = document.getElementById("kevFilePath").value.trim();
-      const msg = document.getElementById("kevFileMsg");
-      if (!path) { msg.textContent = "enter a file path first"; return; }
-      msg.textContent = "loading…";
-      fetch("/kev/import-file", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ path }) })
-        .then(async r => { if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "HTTP " + r.status); return r.json(); })
-        .then(j => { msg.textContent = `loaded ${j.total.toLocaleString()} CVEs`; document.getElementById("kevFilePath").value = ""; loadKev(); })
-        .catch(e => { msg.textContent = "failed: " + e.message; });
-    }
-    function kevClear() {
-      if (!confirm("Clear the CISA KEV catalog? This is global (affects all cases).")) return;
-      const msg = document.getElementById("kevClearMsg");
-      msg.textContent = "clearing…";
-      fetch("/kev", { method: "DELETE" })
-        .then(async r => { if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "HTTP " + r.status); return r.json(); })
-        .then(() => { msg.textContent = "cleared"; loadKev(); })
-        .catch(e => { msg.textContent = "failed: " + e.message; });
     }
 
     // --- Update check (#127) — opt-in "newer release available" notice; Settings → Updates ----------

--- a/public/js/dashboard-kev.js
+++ b/public/js/dashboard-kev.js
@@ -1,0 +1,71 @@
+// The CISA KEV catalog panel (#99), lifted whole out of the inline script (#415, tier 3).
+//
+// The SECOND of the two features measured as wholly movable, and the last one until tier 2 lands.
+// Of fourteen features surveyed, eleven would have split across two files because part of each is
+// entangled with the shared timeline-filter state; the tagger and this are the two that are not.
+// See js/dashboard-tagger.js for why half a feature in a module is worse than none.
+//
+// Four functions, no shared dashboard state: each reads the DOM, calls a /kev route, and writes a
+// status line back. The catalog itself is global and lives on the server, which is precisely why
+// this panel never touched the per-case state everything else here is tangled with.
+//
+// A CLASSIC SCRIPT, like every js/dashboard-*.js file. These four are wired with
+// `addEventListener("click", kevImportUrl)` — a function REFERENCE resolved when the listener is
+// registered — and loadKev() is called by name when the Settings KEV tab opens. Both need the name
+// to be a real global by the time the inline script runs, which is what a synchronous classic
+// script in <head> guarantees. See js/dashboard-escape.js for the full argument.
+
+// --- CISA KEV catalog (#99) — global CVE cross-reference, Settings → KEV ---------------------
+function loadKev() {
+  const status = document.getElementById("kevStatus");
+  const cnt = document.getElementById("kevCount");
+  fetch("/kev").then(r => r.json()).then(j => {
+    if (j.count > 0) {
+      const ver = j.catalogVersion ? ` · version ${j.catalogVersion}` : "";
+      const rel = j.dateReleased ? ` · released ${j.dateReleased.slice(0, 10)}` : "";
+      cnt.textContent = `(${j.count.toLocaleString()} CVEs)`;
+      status.textContent = `Catalog loaded${ver}${rel}.`;
+    } else {
+      cnt.textContent = "";
+      status.textContent = "No catalog loaded yet — click \"Load from CISA feed\" or point to a local file.";
+    }
+  }).catch(() => { if (status) status.textContent = "Could not fetch KEV status — restart the server if this 404s."; });
+}
+
+function kevImportUrl() {
+  const msg = document.getElementById("kevUrlMsg");
+  msg.textContent = "fetching from CISA…";
+  fetch("/kev/import-url", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
+    .then(async r => { if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "HTTP " + r.status); return r.json(); })
+    .then(j => { msg.textContent = `loaded ${j.total.toLocaleString()} CVEs`; loadKev(); })
+    .catch(e => { msg.textContent = "failed: " + e.message + " — check server outbound connectivity or use a local file."; });
+}
+
+function kevImportFile() {
+  const path = document.getElementById("kevFilePath").value.trim();
+  const msg = document.getElementById("kevFileMsg");
+  if (!path) { msg.textContent = "enter a file path first"; return; }
+  msg.textContent = "loading…";
+  fetch("/kev/import-file", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ path }) })
+    .then(async r => { if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "HTTP " + r.status); return r.json(); })
+    .then(j => { msg.textContent = `loaded ${j.total.toLocaleString()} CVEs`; document.getElementById("kevFilePath").value = ""; loadKev(); })
+    .catch(e => { msg.textContent = "failed: " + e.message; });
+}
+
+function kevClear() {
+  if (!confirm("Clear the CISA KEV catalog? This is global (affects all cases).")) return;
+  const msg = document.getElementById("kevClearMsg");
+  msg.textContent = "clearing…";
+  fetch("/kev", { method: "DELETE" })
+    .then(async r => { if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "HTTP " + r.status); return r.json(); })
+    .then(() => { msg.textContent = "cleared"; loadKev(); })
+    .catch(e => { msg.textContent = "failed: " + e.message; });
+}
+
+// Published for the inline script, which registers the listeners and calls loadKev() on tab open.
+window.DfirKev = {
+  loadKev,
+  kevImportUrl,
+  kevImportFile,
+  kevClear,
+};


### PR DESCRIPTION
Part of #415. The **second and last** wholly-movable feature — four functions, 42 lines, into
`public/js/dashboard-kev.js`.

Of fourteen features surveyed, eleven split across the tier-2 tangle. This and the tagger are the
two that don't, so **tier 3 has no clean move left until tier 2 is resolved.**

It never touched per-case state because the KEV catalog is global and lives on the server: each
function reads the DOM, calls a `/kev` route, writes a status line back.

## Wired differently from the tagger, which is why it's tested separately

| | how it's reached | resolves at |
|---|---|---|
| tagger | `ACTIONS` table, arrow entries | click time |
| **KEV** | `addEventListener("click", kevImportUrl)` | listener-registration time |

Both work only because the module is a synchronous classic script loaded before the inline script —
but they'd fail differently, so both are pinned rather than one standing in for the other.

## Ledger and table updated in this commit

The tagger extraction shipped without running `--update` and needed a follow-up. The reduction here
(**18,182 → 18,138**) is locked in the same commit, and `ARCHITECTURE.md`'s target table matches the
ledger exactly — I typed 18,140 first and caught it by diffing the two rather than trusting the
number I'd written.

## Verification

- all 5 inline scripts parse; whole-page free-variable check shows the same 2 pre-existing
  unresolved names, no new ones
- AST gates now see 12 classic scripts / 127 provided globals
- route inventory regenerated
- full suite green apart from the two pre-existing `sharpVersion` failures
- `check:size`, `check:imports`, `check:boundaries`, `format:check`, lint, `git diff --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)