### PR TITLE
refactor(dashboard): give the investigation scope window its own owner (#415 tier 2)

### DIFF
--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -6,7 +6,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/css/dashboard.css": 3261,
-  "public/dashboard.html#inline-js": 18138,
+  "public/dashboard.html#inline-js": 18108,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,

--- a/companion/src/http/staticAssets.ts
+++ b/companion/src/http/staticAssets.ts
@@ -43,6 +43,10 @@ export const STATIC_ASSETS: Record<string, string> = {
   "/js/dashboard-ioc.js": "application/javascript; charset=utf-8",
   "/js/dashboard-values.js": "application/javascript; charset=utf-8",
   "/js/dashboard-fragments.js": "application/javascript; charset=utf-8",
+  // Tier 2's first owner: the investigation scope window, its projection, and its controls (#415).
+  // Unlike the helpers above this one holds state, so a 404 here is not a missing helper — every
+  // scope read would throw and the dashboard would not render at all.
+  "/js/dashboard-scope.js": "application/javascript; charset=utf-8",
   // The first whole FEATURE module of #415 tier 3, as opposed to the pure-helper modules above.
   "/js/dashboard-tagger.js": "application/javascript; charset=utf-8",
   "/js/dashboard-kev.js": "application/javascript; charset=utf-8",

--- a/companion/tests/architecture/route-inventory.json
+++ b/companion/tests/architecture/route-inventory.json
@@ -478,6 +478,7 @@
     "ROUTE GET /js/dashboard-ioc.js",
     "ROUTE GET /js/dashboard-values.js",
     "ROUTE GET /js/dashboard-fragments.js",
+    "ROUTE GET /js/dashboard-scope.js",
     "ROUTE GET /js/dashboard-tagger.js",
     "ROUTE GET /js/dashboard-kev.js",
     "ROUTE GET /js/a11y/modal-autowire.js",

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -272,3 +272,32 @@ export interface StateApi {
     onLastSuperDataChange(fn: (data: Snapshot) => void): () => void;
   };
 }
+
+/** An investigation window. Mirrors the server's ScopeWindow (src/analysis/scope.ts). */
+export interface ScopeWindow {
+  start: string | null;
+  end: string | null;
+}
+
+/**
+ * public/js/dashboard-scope.js — tier 2's first owner (#415).
+ *
+ * Note what is NOT here: there is no `set`, and no `onScopeChange`. The three call sites that write
+ * this window want three different refreshes, so the module publishes the two COMMIT shapes they
+ * actually differ by — `receive` (the server told us; push into the controls) and `confirm` (the
+ * analyst typed it; leave the controls alone) — and leaves the redraw at the call site. A generic
+ * setter plus a subscriber would have to be the union of the three, which is the behaviour change
+ * this design exists to avoid. If a `set` or an `onScopeChange` ever appears here, that is the
+ * design being lost, not extended.
+ */
+export interface ScopeApi {
+  DfirScope: {
+    get(): Readonly<ScopeWindow>;
+    isEmpty(): boolean;
+    contains(ts: unknown): boolean;
+    /** The client-side mirror of the server's projectScope(). Same object back when no window is set. */
+    project<T>(state: T): T;
+    receive(start: unknown, end: unknown): void;
+    confirm(start: unknown, end: unknown): void;
+  };
+}

--- a/companion/tests/dashboard/dashboardScope.test.ts
+++ b/companion/tests/dashboard/dashboardScope.test.ts
@@ -1,0 +1,389 @@
+import { readFile } from "node:fs/promises";
+import { runInContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
+import { projectScope as serverProjectScope } from "../../src/analysis/scopeProject.js";
+import { NO_SCOPE, type ScopeWindow } from "../../src/analysis/scope.js";
+import { emptyState, type InvestigationState } from "../../src/analysis/stateTypes.js";
+import type { ScopeApi } from "./dashboardApi.js";
+import { dashboardScripts, functionsOf, setterRefs } from "../helpers/dashboardAst.js";
+import { globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// public/js/dashboard-scope.js — the first TIER 2 cell to move (#415).
+//
+// Tier 1 was a cache with one writer each, and its gate is a call-site count. This one is not that
+// shape and the gate cannot be that gate: the investigation window has THREE legitimate writers,
+// because it is server-persisted state that arrives by three routes (case-load GET, the analyst's
+// POST, another client's websocket broadcast) and each route refreshes something different.
+//
+// So the enforceable rule here is not "how many" but "WHICH". The allowlist below is the design
+// decision written down where CI can see it: a fourth writer, or one of these three moving to
+// another function, is a change to who owns the window and has to be argued for rather than
+// noticed later.
+//
+// The other reason this file exists is parity. src/analysis/scopeProject.ts is the same projection
+// written a second time, and the inline copy called itself "the client-side mirror" of it for as
+// long as it sat in dashboard.html, where nothing could execute it. Now something can.
+
+const MODULE = new URL("../../../public/js/dashboard-scope.js", import.meta.url);
+const DASHBOARD = new URL("../../../public/dashboard.html", import.meta.url);
+
+/** A stand-in for the three elements the module writes. */
+function stubDom() {
+  const els: Record<string, { value: string; textContent: string; style: { color: string } }> = {
+    scopeStart: { value: "", textContent: "", style: { color: "" } },
+    scopeEnd: { value: "", textContent: "", style: { color: "" } },
+    scopeInfo: { value: "", textContent: "", style: { color: "" } },
+  };
+  return { els, document: { getElementById: (id: string) => els[id] ?? null } };
+}
+
+/**
+ * The module as the browser loads it: after dashboard-state.js, whose cell() it builds on at load
+ * time, and after dashboard-time.js, whose isoToUtcInput() it calls.
+ */
+function loadScopeModule(dom = stubDom()) {
+  const api = loadDashboardModule<ScopeApi>(
+    "dashboard-scope.js",
+    ["dashboard-state.js", "dashboard-time.js"],
+    { document: dom.document },
+  );
+  return { api, dom };
+}
+
+describe("the window itself", () => {
+  it("starts empty, meaning every event is in scope", () => {
+    const { api } = loadScopeModule();
+    expect(api.DfirScope.get()).toEqual({ start: null, end: null });
+    expect(api.DfirScope.isEmpty()).toBe(true);
+  });
+
+  // The difference from tier 1, and a deliberate one. dashboard-state.js hands back the live
+  // snapshot and argues that deep-freezing a whole case state per fetch is not free. A two-field
+  // object written three times is a different trade, so the hazard tier 1 documented is closed.
+  it("hands back a frozen window, so a reader cannot edit it in place", () => {
+    const { api } = loadScopeModule();
+    api.DfirScope.confirm("2026-05-20T00:00:00.000Z", null);
+    const w = api.DfirScope.get();
+    expect(Object.isFrozen(w)).toBe(true);
+    try {
+      (w as { start: string | null }).start = "tampered";
+    } catch {
+      // A strict-mode realm throws; a sloppy one silently no-ops. Either is a rejected write.
+    }
+    expect(api.DfirScope.get().start).toBe("2026-05-20T00:00:00.000Z");
+  });
+
+  it("normalises every falsy bound to null", () => {
+    const { api } = loadScopeModule();
+    // The three former call sites spelled this two ways — `s.start || null` and `msg.start ?? null`.
+    // They differ only for "", which the server's norm() turns into null before sending.
+    api.DfirScope.confirm("", undefined);
+    expect(api.DfirScope.get()).toEqual({ start: null, end: null });
+  });
+});
+
+describe("contains", () => {
+  const withWindow = () => {
+    const { api } = loadScopeModule();
+    api.DfirScope.confirm("2026-05-15T00:00:00Z", "2026-05-25T00:00:00Z");
+    return api.DfirScope;
+  };
+
+  it("keeps everything when no window is set", () => {
+    const { api } = loadScopeModule();
+    expect(api.DfirScope.contains("1999-01-01T00:00:00Z")).toBe(true);
+  });
+
+  it("excludes timestamps outside the bounds and keeps the ones inside", () => {
+    const s = withWindow();
+    expect(s.contains("2026-05-10T00:00:00Z")).toBe(false);
+    expect(s.contains("2026-05-20T00:00:00Z")).toBe(true);
+    expect(s.contains("2026-05-30T00:00:00Z")).toBe(false);
+  });
+
+  // The rule that matters for real evidence: plenty of forensic artefacts have no usable timestamp,
+  // and dropping them from a scoped view would hide evidence rather than narrow it.
+  it("keeps an undated event, because it cannot be proven out of scope", () => {
+    const s = withWindow();
+    expect(s.contains("not-a-date")).toBe(true);
+    expect(s.contains("")).toBe(true);
+  });
+});
+
+// ── PARITY ───────────────────────────────────────────────────────────────────────────────────────
+//
+// The client projection and src/analysis/scopeProject.ts are the same rule written twice. This runs
+// the REAL server function — imported, not re-implemented — against the browser module loaded in a
+// vm, over the same inputs. Re-implementing the server's rule here is exactly the mistake this
+// issue already corrected once, for the false-positive filter.
+describe("the client projection matches the server's", () => {
+  function fixture(): InvestigationState {
+    return {
+      ...emptyState("c1"),
+      forensicTimeline: [
+        {
+          id: "e1",
+          timestamp: "2026-05-20T09:00:00Z",
+          description: "early phish",
+          severity: "High",
+          mitreTechniques: ["T1566"],
+          relatedFindingIds: ["f1"],
+          sourceScreenshots: [],
+        },
+        {
+          id: "e2",
+          timestamp: "2026-05-25T12:00:00Z",
+          description: "in-window exec",
+          severity: "Critical",
+          mitreTechniques: ["T1059"],
+          relatedFindingIds: ["f2"],
+          sourceScreenshots: [],
+        },
+        {
+          id: "e3",
+          timestamp: "not-a-date",
+          description: "undated artefact",
+          severity: "Medium",
+          mitreTechniques: [],
+          relatedFindingIds: [],
+          sourceScreenshots: [],
+        },
+      ],
+      findings: [
+        {
+          id: "f1",
+          severity: "High",
+          title: "phishing",
+          description: "out of window",
+          relatedIocs: ["i001"],
+          mitreTechniques: ["T1566"],
+          sourceScreenshots: [],
+          firstSeen: "",
+          lastUpdated: "",
+          status: "open",
+        },
+        {
+          id: "f2",
+          severity: "Critical",
+          title: "execution",
+          description: "in window",
+          relatedIocs: ["i002"],
+          mitreTechniques: ["T1059"],
+          sourceScreenshots: [],
+          firstSeen: "",
+          lastUpdated: "",
+          status: "confirmed",
+        },
+        {
+          id: "f3",
+          severity: "Low",
+          title: "unbacked",
+          description: "no event backs it",
+          relatedIocs: [],
+          mitreTechniques: [],
+          sourceScreenshots: [],
+          firstSeen: "",
+          lastUpdated: "",
+          status: "open",
+        },
+      ],
+      iocs: [
+        { id: "i001", type: "file", value: "phish.docx", firstSeen: "" },
+        { id: "i002", type: "process", value: "powershell.exe", firstSeen: "" },
+        { id: "i003", type: "ip", value: "10.0.0.9", firstSeen: "" },
+      ],
+      mitreTechniques: [
+        { id: "T1566", name: "Phishing", findingIds: ["f1"] },
+        { id: "T1059", name: "Command and Scripting Interpreter", findingIds: ["f2"] },
+        { id: "T1005", name: "Data from Local System", findingIds: [] },
+      ],
+    };
+  }
+
+  // Every shape that exercises a different branch, including the two degenerate ones.
+  const WINDOWS: Array<[string, ScopeWindow]> = [
+    ["no window", NO_SCOPE],
+    ["lower bound only", { start: "2026-05-22T00:00:00Z", end: null }],
+    ["upper bound only", { start: null, end: "2026-05-22T00:00:00Z" }],
+    ["both bounds", { start: "2026-05-19T00:00:00Z", end: "2026-05-26T00:00:00Z" }],
+    ["inverted, so nothing is in scope", { start: "2026-05-26T00:00:00Z", end: "2026-05-19T00:00:00Z" }],
+    ["an unparseable bound", { start: "garbage", end: null }],
+  ];
+
+  it.each(WINDOWS)("agrees with the server: %s", (_label, window) => {
+    const { api } = loadScopeModule();
+    api.DfirScope.confirm(window.start, window.end);
+    const client = api.DfirScope.project(fixture());
+    const server = serverProjectScope(fixture(), window);
+    expect(client).toEqual(server);
+  });
+
+  it("returns the very same object when no window is set, as the server does", () => {
+    const { api } = loadScopeModule();
+    const state = fixture();
+    expect(api.DfirScope.project(state)).toBe(state);
+    const s = fixture();
+    expect(serverProjectScope(s, NO_SCOPE)).toBe(s);
+  });
+
+  it("does not mutate the state it is given", () => {
+    const { api } = loadScopeModule();
+    const state = fixture();
+    api.DfirScope.confirm("2026-05-22T00:00:00Z", null);
+    api.DfirScope.project(state);
+    expect(state.findings).toHaveLength(3);
+    expect(state.iocs).toHaveLength(3);
+    expect(state.mitreTechniques[0].findingIds).toEqual(["f1"]);
+  });
+});
+
+// ── THE TWO COMMIT SHAPES ────────────────────────────────────────────────────────────────────────
+//
+// receive/confirm exist because the three writers disagree about the two <input> controls, and that
+// disagreement is not incidental: on the POST path the controls are where the window came FROM, so
+// writing them back would overwrite what the analyst typed with a round-tripped copy of it.
+describe("receive and confirm differ exactly where the call sites did", () => {
+  it("receive pushes the window into the two controls", () => {
+    const { api, dom } = loadScopeModule();
+    api.DfirScope.receive("2026-05-20T08:30:00.000Z", "2026-05-21T00:00:00.000Z");
+    expect(dom.els.scopeStart.value).toBe("2026-05-20T08:30");
+    expect(dom.els.scopeEnd.value).toBe("2026-05-21T00:00");
+  });
+
+  // THE CONTROL VALUES MUST NOT BE THE ROUND-TRIP OF THE COMMITTED WINDOW. The first version of
+  // this test pre-set them to "2026-05-20T08:30" and committed that same instant, so a confirm()
+  // that DID write the controls wrote back the identical string and the test still passed. It was
+  // asserting "the value is right" while claiming to assert "nothing wrote it". Mutation testing
+  // caught it; the sentinel is what makes the two distinguishable.
+  it("confirm leaves the controls exactly as the analyst left them", () => {
+    const { api, dom } = loadScopeModule();
+    dom.els.scopeStart.value = "TYPED-BY-THE-ANALYST";
+    dom.els.scopeEnd.value = "ALSO-UNTOUCHED";
+    api.DfirScope.confirm("2026-05-20T08:30:00.000Z", "2026-05-21T00:00:00.000Z");
+    expect(dom.els.scopeStart.value).toBe("TYPED-BY-THE-ANALYST");
+    expect(dom.els.scopeEnd.value).toBe("ALSO-UNTOUCHED");
+  });
+
+  // The reason renderScopeInfo() moved in rather than staying a function the writers must remember
+  // to call: an owner that can be written without repainting its own indicator is a bug waiting to
+  // be written, and its three former call sites were exactly these three writers.
+  it.each(["receive", "confirm"] as const)("%s repaints the indicator as part of committing", (op) => {
+    const { api, dom } = loadScopeModule();
+    api.DfirScope[op]("2026-05-20T00:00:00.000Z", null);
+    expect(dom.els.scopeInfo.textContent).toContain("active:");
+    expect(dom.els.scopeInfo.style.color).toBe("#ffd93b");
+
+    api.DfirScope[op](null, null);
+    expect(dom.els.scopeInfo.textContent).toBe("none (all events)");
+    expect(dom.els.scopeInfo.style.color).toBe("#9aa4b2");
+  });
+});
+
+// ── THE GATE ─────────────────────────────────────────────────────────────────────────────────────
+describe("who may write the window", () => {
+  const scripts = dashboardScripts();
+
+  // THE ALLOWLIST. Not a count — a count would let a writer move from applyScope into some other
+  // function without anyone noticing, and "which function owns this write" is the whole question
+  // for a cell with more than one writer.
+  const WRITERS = [
+    { op: "receive", owner: "loadScope", why: "the case-load GET" },
+    { op: "receive", owner: "proceedConnect", why: "another client's scope_changed broadcast" },
+    { op: "confirm", owner: "applyScope", why: "this analyst's POST" },
+  ] as const;
+
+  it.each(["receive", "confirm"] as const)(
+    "%s is only ever called directly, never stashed or reached dynamically",
+    (op) => {
+      const refs = setterRefs(scripts, op, "DfirScope");
+      expect(refs.length, `DfirScope.${op} is never called`).toBeGreaterThan(0);
+      const bad = refs.filter((r) => r.form !== "direct-call");
+      expect(
+        bad,
+        `a reference this analysis cannot follow defeats the allowlist below; found ` +
+          bad.map((r) => `${r.script}:${r.line} (${r.form})`).join(", "),
+      ).toEqual([]);
+    },
+  );
+
+  it("is written from exactly the three functions that own a refresh path", () => {
+    const found = (["receive", "confirm"] as const).flatMap((op) =>
+      setterRefs(scripts, op, "DfirScope").map((ref) => {
+        const script = scripts.find((s) => s.name === ref.script)!;
+        const owner = functionsOf(script)
+          .filter((f) => {
+            const end = script.ast.getLineAndCharacterOfPosition(f.node.getEnd()).line + 1;
+            return f.line <= ref.line && end >= ref.line;
+          })
+          // The innermost named function: these writes sit inside .then()/onmessage callbacks.
+          .map((f) => f.name)
+          .filter((n) => !n.startsWith("<"))
+          .pop();
+        return `${op} <- ${owner}`;
+      }),
+    );
+    expect(
+      found.sort(),
+      "the investigation window has three writers by design, one per refresh path " +
+        "(see js/dashboard-scope.js). A new one changes who owns the window.",
+    ).toEqual(WRITERS.map((w) => `${w.op} <- ${w.owner}`).sort());
+  });
+
+  // The binding is gone, not merely wrapped. While `let scope` still existed at the top of the
+  // inline script every one of the gates above could pass with the old variable still being read.
+  it("leaves no `scope` binding behind in the inline script", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    expect(html).not.toMatch(/^\s*let scope = \{/m);
+    expect(html).not.toMatch(/^\s*function (?:inScope|projectScope|renderScopeInfo)\s*\(/m);
+  });
+});
+
+describe("nothing but the namespace escapes", () => {
+  it("adds only DfirScope to the global object", () => {
+    // Baselined after its dependencies have run, so this is what THIS file added and nothing else.
+    expect(globalsAddedBy("dashboard-scope.js", ["dashboard-state.js", "dashboard-time.js"])).toEqual([
+      "DfirScope",
+    ]);
+  });
+
+  // The lexical half, invisible to globalsAddedBy: a top-level `const` in a classic script joins
+  // the shared lexical environment and is writable by name from any later script. This is the hole
+  // that made the tier-1 single-writer gate decorative until dashboard-state.js grew its IIFE.
+  it("puts the cell out of reach of a second script on the page", () => {
+    const { api } = loadScopeModule();
+    api.DfirScope.confirm("2026-05-20T00:00:00.000Z", null);
+    expect(() => runInContext("dfirScope.set({ start: 'smuggled', end: null })", api as object)).toThrow(
+      /dfirScope is not defined/,
+    );
+    expect(() => runInContext("commit('smuggled', null)", api as object)).toThrow(/commit is not defined/);
+    expect(api.DfirScope.get().start).toBe("2026-05-20T00:00:00.000Z");
+  });
+
+  // No `set`, and no `onScopeChange`. Both would re-open the design: one generic setter cannot
+  // express three refresh paths, and one subscriber would have to fire the union of them.
+  it("publishes no generic setter and no change subscription", () => {
+    const { api } = loadScopeModule();
+    const surface = Object.keys(api.DfirScope).sort();
+    expect(surface).toEqual(["confirm", "contains", "get", "isEmpty", "project", "receive"]);
+  });
+});
+
+describe("wiring", () => {
+  it("is loaded by dashboard.html, ahead of the inline script, and served by the whitelist", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    expect(html).toContain('<script src="/js/dashboard-scope.js"></script>');
+    // After the store it builds on at load time, and before the inline script that calls it.
+    expect(html.indexOf('src="/js/dashboard-state.js"')).toBeLessThan(
+      html.indexOf('src="/js/dashboard-scope.js"'),
+    );
+    expect(STATIC_ASSETS["/js/dashboard-scope.js"]).toBe("application/javascript; charset=utf-8");
+  });
+
+  it("stays a classic script, like the helpers the inline script calls by name", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    expect(html).not.toContain('<script type="module" src="/js/dashboard-scope.js">');
+    const src = await readFile(MODULE, "utf8");
+    expect(src).not.toMatch(/^\s*(?:export|import)\s/m);
+  });
+});

--- a/companion/tests/dashboard/dashboardScope.test.ts
+++ b/companion/tests/dashboard/dashboardScope.test.ts
@@ -6,7 +6,13 @@ import { projectScope as serverProjectScope } from "../../src/analysis/scopeProj
 import { NO_SCOPE, type ScopeWindow } from "../../src/analysis/scope.js";
 import { emptyState, type InvestigationState } from "../../src/analysis/stateTypes.js";
 import type { ScopeApi } from "./dashboardApi.js";
-import { dashboardScripts, functionsOf, setterRefs } from "../helpers/dashboardAst.js";
+import {
+  dashboardScripts,
+  functionsOf,
+  getterMutations,
+  setterRefs,
+  topLevelBindings,
+} from "../helpers/dashboardAst.js";
 import { globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
 
 // public/js/dashboard-scope.js — the first TIER 2 cell to move (#415).
@@ -330,12 +336,54 @@ describe("who may write the window", () => {
     ).toEqual(WRITERS.map((w) => `${w.op} <- ${w.owner}`).sort());
   });
 
-  // The binding is gone, not merely wrapped. While `let scope` still existed at the top of the
-  // inline script every one of the gates above could pass with the old variable still being read.
-  it("leaves no `scope` binding behind in the inline script", async () => {
-    const html = await readFile(DASHBOARD, "utf8");
-    expect(html).not.toMatch(/^\s*let scope = \{/m);
-    expect(html).not.toMatch(/^\s*function (?:inScope|projectScope|renderScopeInfo)\s*\(/m);
+  // The binding is GONE, not merely wrapped. While a top-level `scope` still existed every gate
+  // above could pass with the old variable still being read.
+  //
+  // Asked of the AST, not of the text. The first version of this was
+  // `expect(html).not.toMatch(/^\s*let scope = \{/m)` — one spelling of one initialiser. `let scope
+  // = null`, `let scope;`, `const scope = …` and `var scope` all passed it, and any of them is the
+  // second source of truth this migration exists to remove.
+  it("leaves no top-level `scope` binding behind, in any spelling", () => {
+    const offenders = scripts
+      .filter((s) => s.name.startsWith("dashboard.html#inline"))
+      .flatMap((s) =>
+        topLevelBindings(s)
+          .filter((b) => b.name === "scope")
+          .map((b) => `${s.name}:${b.line}`),
+      );
+    expect(
+      offenders,
+      "the investigation window is owned by js/dashboard-scope.js; a top-level `scope` in the page " +
+        "is a second source of truth regardless of how it is declared",
+    ).toEqual([]);
+  });
+
+  it("leaves none of the moved functions behind", () => {
+    const moved = new Set(["inScope", "projectScope", "renderScopeInfo"]);
+    const offenders = scripts
+      .filter((s) => s.name.startsWith("dashboard.html#inline"))
+      .flatMap((s) =>
+        functionsOf(s)
+          .filter((f) => moved.has(f.name))
+          .map((f) => `${s.name}:${f.line} ${f.name}`),
+      );
+    expect(offenders).toEqual([]);
+  });
+
+  // THE OTHER HALF OF FREEZING. Object.freeze stops the state being corrupted; it does NOT stop the
+  // code being written, because a classic script is not strict mode and the assignment silently
+  // no-ops. That is a caller whose intent vanished, every later read returning the old value, and a
+  // green CI — strictly worse than the throw a strict realm would have raised. The module's header
+  // claims this gate exists, so it had better.
+  it("never writes through get() to the window it returned", () => {
+    const offenders = getterMutations(scripts, "DfirScope", "get").map(
+      (m) => `${m.script}:${m.line} (${m.form}) ${m.text}`,
+    );
+    expect(
+      offenders,
+      "DfirScope.get() returns a frozen window; assigning to it silently does nothing in a " +
+        "non-strict classic script. Commit through receive()/confirm() instead.",
+    ).toEqual([]);
   });
 });
 
@@ -373,10 +421,21 @@ describe("wiring", () => {
   it("is loaded by dashboard.html, ahead of the inline script, and served by the whitelist", async () => {
     const html = await readFile(DASHBOARD, "utf8");
     expect(html).toContain('<script src="/js/dashboard-scope.js"></script>');
-    // After the store it builds on at load time, and before the inline script that calls it.
-    expect(html.indexOf('src="/js/dashboard-state.js"')).toBeLessThan(
-      html.indexOf('src="/js/dashboard-scope.js"'),
-    );
+    const tag = html.indexOf('src="/js/dashboard-scope.js"');
+    // AFTER the store whose cell() it builds on at load time.
+    expect(html.indexOf('src="/js/dashboard-state.js"')).toBeLessThan(tag);
+    // ...and BEFORE the inline script that calls it. Asserting only the first half let the tag move
+    // anywhere later in the document — including past the inline script, where every DfirScope call
+    // is a ReferenceError. These are synchronous classic scripts, so document order IS load order.
+    //
+    // The block is found by looking INSIDE each one, not with a single regex spanning the file: a
+    // pattern like /<script[^>]*>[\s\S]*?function render\s*\(/ happily starts at the first tiny
+    // bootstrap block in <head> and runs past its </script> to find render() in a later one, which
+    // is how the first version of this assertion pointed at offset 652 instead of the real script.
+    const blocks = [...html.matchAll(/<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g)];
+    const main = blocks.find((m) => /\n\s*function render\s*\(/.test(m[1]));
+    expect(main, "could not locate the inline dashboard script").toBeDefined();
+    expect(tag).toBeLessThan(main!.index);
     expect(STATIC_ASSETS["/js/dashboard-scope.js"]).toBe("application/javascript; charset=utf-8");
   });
 

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -180,7 +180,49 @@ export interface SetterRef {
  * to another name, or indexing it with anything but a string literal, is reported wherever it
  * appears. Both are one line to avoid and neither has a use here, so the cost of the blunt rule is
  * zero and the alternative is a gate that keeps being almost right.
+ *
+ *   round 3 — and it still was. `window.DfirScope.confirm(…)` is the SAME namespace by the spelling
+ *             the browser itself uses (these are classic scripts publishing onto `window`), and the
+ *             matcher required a bare Identifier, so it returned zero references and a fourth writer
+ *             would have passed CI. That is exactly the failure the two rounds above describe, found
+ *             a third time in review rather than by the gate. Hence `denotesNamespace` below: the
+ *             question "does this expression mean the store" now has ONE answer that every check
+ *             shares, instead of each check re-deciding it and stopping at a different spelling.
  */
+/**
+ * The roots a classic script's namespace is reachable through besides its bare name.
+ *
+ * These files publish onto `window`, so `window.DfirScope` is not a clever bypass — it is the
+ * spelling the module itself writes and the one any reader would consider equivalent. A check that
+ * accepts only the bare identifier is not being strict, it is being wrong.
+ */
+const GLOBAL_ROOTS = new Set(["window", "globalThis", "self"]);
+
+/**
+ * Does this expression denote the namespace itself?
+ *
+ * `DfirState` · `window.DfirState` · `globalThis["DfirState"]` — all the same object. ONE definition,
+ * shared by every check below, because the last three holes in these gates were each a check that
+ * had its own idea of what "the store" looks like.
+ */
+function denotesNamespace(n: ts.Node, namespace: string): boolean {
+  if (ts.isIdentifier(n)) return n.text === namespace;
+  if (ts.isPropertyAccessExpression(n)) {
+    return ts.isIdentifier(n.expression) && GLOBAL_ROOTS.has(n.expression.text) && n.name.text === namespace;
+  }
+  if (ts.isElementAccessExpression(n)) {
+    const arg = n.argumentExpression;
+    return (
+      ts.isIdentifier(n.expression) &&
+      GLOBAL_ROOTS.has(n.expression.text) &&
+      !!arg &&
+      ts.isStringLiteral(arg) &&
+      arg.text === namespace
+    );
+  }
+  return false;
+}
+
 export function setterRefs(scripts: DashboardScript[], member: string, namespace = "DfirState"): SetterRef[] {
   const hits: SetterRef[] = [];
   for (const s of scripts) {
@@ -189,18 +231,13 @@ export function setterRefs(scripts: DashboardScript[], member: string, namespace
       // <namespace>.member — a call, or a bare reference someone can stash.
       if (
         ts.isPropertyAccessExpression(n) &&
-        ts.isIdentifier(n.expression) &&
-        n.expression.text === namespace &&
+        denotesNamespace(n.expression, namespace) &&
         n.name.text === member
       ) {
         const isCallee = n.parent && ts.isCallExpression(n.parent) && n.parent.expression === n;
         hits.push({ script: s.name, line: at(n), form: isCallee ? "direct-call" : "property-reference" });
       }
-      if (
-        ts.isElementAccessExpression(n) &&
-        ts.isIdentifier(n.expression) &&
-        n.expression.text === namespace
-      ) {
+      if (ts.isElementAccessExpression(n) && denotesNamespace(n.expression, namespace)) {
         const arg = n.argumentExpression;
         if (arg && ts.isStringLiteral(arg) && arg.text === member) {
           hits.push({ script: s.name, line: at(n), form: "computed-access" });
@@ -210,12 +247,7 @@ export function setterRefs(scripts: DashboardScript[], member: string, namespace
         }
       }
       // const { member } = DfirState
-      if (
-        ts.isVariableDeclaration(n) &&
-        n.initializer &&
-        ts.isIdentifier(n.initializer) &&
-        n.initializer.text === namespace
-      ) {
+      if (ts.isVariableDeclaration(n) && n.initializer && denotesNamespace(n.initializer, namespace)) {
         if (ts.isObjectBindingPattern(n.name)) {
           for (const el of n.name.elements) {
             const source = el.propertyName ?? el.name;
@@ -226,6 +258,105 @@ export function setterRefs(scripts: DashboardScript[], member: string, namespace
         } else if (ts.isIdentifier(n.name)) {
           // const state = <namespace> — every member is now reachable under another name.
           hits.push({ script: s.name, line: at(n), form: "namespace-alias" });
+        }
+      }
+      ts.forEachChild(n, visit);
+    };
+    ts.forEachChild(s.ast, visit);
+  }
+  return hits;
+}
+
+/**
+ * Every name bound at the TOP LEVEL of a script — `let`/`const`/`var`, destructuring included.
+ *
+ * For asserting that a migrated binding is GONE rather than merely unused. The first version of that
+ * assertion was `expect(html).not.toMatch(/^\s*let scope = \{/m)`, which pinned one spelling of one
+ * initialiser: `let scope = null`, `let scope;`, `const scope = …` and `var scope` all sailed
+ * through, and any of them re-opens the second source of truth the migration existed to close.
+ * A declaration is an AST fact, so ask the AST.
+ */
+export function topLevelBindings(script: DashboardScript): Array<{ name: string; line: number }> {
+  const out: Array<{ name: string; line: number }> = [];
+  const at = (n: ts.Node): number =>
+    script.ast.getLineAndCharacterOfPosition(n.getStart(script.ast)).line + 1;
+  const collect = (name: ts.BindingName): void => {
+    if (ts.isIdentifier(name)) {
+      out.push({ name: name.text, line: at(name) });
+      return;
+    }
+    for (const el of name.elements) {
+      if (ts.isBindingElement(el)) collect(el.name);
+    }
+  };
+  for (const st of script.ast.statements) {
+    if (ts.isVariableStatement(st)) {
+      for (const d of st.declarationList.declarations) collect(d.name);
+    }
+  }
+  return out;
+}
+
+/** A property write through an owner's getter: `DfirScope.get().start = x`. */
+export interface GetterMutation {
+  script: string;
+  line: number;
+  /** `direct` is `owner.get().prop = v`; `via-alias` went through a local first. */
+  form: "direct" | "via-alias";
+  text: string;
+}
+
+/**
+ * Writes THROUGH an accessor to the object it returned.
+ *
+ * js/dashboard-scope.js hands back a frozen window and argues that closes the "a reader could mutate
+ * it in place" hazard tier 1 documented. Freezing alone does not close it: these are classic
+ * scripts, so they are not strict mode, so `DfirScope.get().start = x` silently does NOTHING. The
+ * caller's intent is lost and every subsequent read returns the old value — a wrong dashboard with a
+ * green CI, which is worse than the throw a strict realm would have given.
+ *
+ * So the runtime freeze stops the state from being corrupted and this stops the code from being
+ * written. Both halves are needed and neither substitutes for the other.
+ */
+export function getterMutations(
+  scripts: DashboardScript[],
+  namespace: string,
+  accessor: string,
+): GetterMutation[] {
+  const hits: GetterMutation[] = [];
+  const isAccessorCall = (e: ts.Node): boolean =>
+    ts.isCallExpression(e) &&
+    ts.isPropertyAccessExpression(e.expression) &&
+    denotesNamespace(e.expression.expression, namespace) &&
+    e.expression.name.text === accessor;
+
+  for (const s of scripts) {
+    const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
+    // Locals bound straight to the accessor's result, so the aliased form is reachable too.
+    const aliases = new Set<string>();
+    const findAliases = (n: ts.Node): void => {
+      if (ts.isVariableDeclaration(n) && n.initializer && ts.isIdentifier(n.name)) {
+        if (isAccessorCall(n.initializer)) aliases.add(n.name.text);
+      }
+      ts.forEachChild(n, findAliases);
+    };
+    ts.forEachChild(s.ast, findAliases);
+
+    const visit = (n: ts.Node): void => {
+      if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+        const lhs = n.left;
+        if (ts.isPropertyAccessExpression(lhs) || ts.isElementAccessExpression(lhs)) {
+          const target = lhs.expression;
+          if (isAccessorCall(target)) {
+            hits.push({ script: s.name, line: at(n), form: "direct", text: n.getText(s.ast).slice(0, 90) });
+          } else if (ts.isIdentifier(target) && aliases.has(target.text)) {
+            hits.push({
+              script: s.name,
+              line: at(n),
+              form: "via-alias",
+              text: n.getText(s.ast).slice(0, 90),
+            });
+          }
         }
       }
       ts.forEachChild(n, visit);
@@ -248,13 +379,12 @@ export interface CachedSnapshot {
  * a scalar rather than caching the snapshot, and without that distinction the gate fires on every
  * derived value.
  */
-export function cachedSnapshots(node: ts.Node, member: string): CachedSnapshot[] {
+export function cachedSnapshots(node: ts.Node, member: string, namespace = "DfirState"): CachedSnapshot[] {
   const out: CachedSnapshot[] = [];
   const isAccessorCall = (e: ts.Expression): boolean =>
     ts.isCallExpression(e) &&
     ts.isPropertyAccessExpression(e.expression) &&
-    ts.isIdentifier(e.expression.expression) &&
-    e.expression.expression.text === "DfirState" &&
+    denotesNamespace(e.expression.expression, namespace) &&
     e.expression.name.text === member;
   const visit = (n: ts.Node): void => {
     if (ts.isVariableDeclaration(n) && n.initializer && ts.isIdentifier(n.name)) {

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -157,8 +157,13 @@ export interface SetterRef {
 }
 
 /**
- * Every reference to `DfirState.<member>`, AND every construct that puts the setter out of reach
+ * Every reference to `<namespace>.<member>`, AND every construct that puts the setter out of reach
  * of that question.
+ *
+ * `namespace` defaults to DfirState because that was the only store when this was written. Tier 2
+ * added a second owner with its own namespace (DfirScope), and the alternative to a parameter here
+ * was a second copy of the rejection rules below — which is how two gates drift into checking
+ * different things while both claiming to check writers.
  *
  * This has been widened twice, and each time by the same discovery: the gate was answering "how
  * many times is it written this one way" while presenting itself as "how many writers are there".
@@ -176,16 +181,16 @@ export interface SetterRef {
  * appears. Both are one line to avoid and neither has a use here, so the cost of the blunt rule is
  * zero and the alternative is a gate that keeps being almost right.
  */
-export function setterRefs(scripts: DashboardScript[], member: string): SetterRef[] {
+export function setterRefs(scripts: DashboardScript[], member: string, namespace = "DfirState"): SetterRef[] {
   const hits: SetterRef[] = [];
   for (const s of scripts) {
     const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
     const visit = (n: ts.Node): void => {
-      // DfirState.member — a call, or a bare reference someone can stash.
+      // <namespace>.member — a call, or a bare reference someone can stash.
       if (
         ts.isPropertyAccessExpression(n) &&
         ts.isIdentifier(n.expression) &&
-        n.expression.text === "DfirState" &&
+        n.expression.text === namespace &&
         n.name.text === member
       ) {
         const isCallee = n.parent && ts.isCallExpression(n.parent) && n.parent.expression === n;
@@ -194,7 +199,7 @@ export function setterRefs(scripts: DashboardScript[], member: string): SetterRe
       if (
         ts.isElementAccessExpression(n) &&
         ts.isIdentifier(n.expression) &&
-        n.expression.text === "DfirState"
+        n.expression.text === namespace
       ) {
         const arg = n.argumentExpression;
         if (arg && ts.isStringLiteral(arg) && arg.text === member) {
@@ -209,7 +214,7 @@ export function setterRefs(scripts: DashboardScript[], member: string): SetterRe
         ts.isVariableDeclaration(n) &&
         n.initializer &&
         ts.isIdentifier(n.initializer) &&
-        n.initializer.text === "DfirState"
+        n.initializer.text === namespace
       ) {
         if (ts.isObjectBindingPattern(n.name)) {
           for (const el of n.name.elements) {
@@ -219,7 +224,7 @@ export function setterRefs(scripts: DashboardScript[], member: string): SetterRe
             }
           }
         } else if (ts.isIdentifier(n.name)) {
-          // const state = DfirState — every member is now reachable under another name.
+          // const state = <namespace> — every member is now reachable under another name.
           hits.push({ script: s.name, line: at(n), form: "namespace-alias" });
         }
       }

--- a/companion/tests/helpers/dashboardModule.ts
+++ b/companion/tests/helpers/dashboardModule.ts
@@ -184,9 +184,17 @@ function freshSandbox(extraGlobals: DashboardGlobals = {}): DashboardGlobals {
  * Lexical bindings are invisible here by construction, so this checks the property side and the
  * companion test proves the lexical side by trying the bypass and expecting a ReferenceError.
  */
-export function globalsAddedBy(file: string): string[] {
-  const before = new Set(Object.keys(freshSandbox()));
-  const after = loadDashboardModule<DashboardGlobals>(file);
+export function globalsAddedBy(file: string, preload: string[] = []): string[] {
+  // `preload` for the same reason loadDashboardModule takes one, and it is not optional for every
+  // module: js/dashboard-scope.js builds its cell from DfirState.cell at LOAD time, so without its
+  // dependency present it does not merely fail to publish — it throws while loading. Baselining
+  // AFTER the dependencies have run is what keeps the answer "what did THIS file add".
+  const before = new Set(
+    preload.length
+      ? Object.keys(loadDashboardModule<DashboardGlobals>(preload[preload.length - 1], preload.slice(0, -1)))
+      : Object.keys(freshSandbox()),
+  );
+  const after = loadDashboardModule<DashboardGlobals>(file, preload);
   return Object.keys(after).filter((name) => !before.has(name));
 }
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -120,6 +120,10 @@
   <script src="/js/dashboard-ioc.js"></script>
   <script src="/js/dashboard-values.js"></script>
   <script src="/js/dashboard-fragments.js"></script>
+  <!-- Tier 2's first owner (#415). After dashboard-state.js, whose cell() it builds on at load
+       time, and after dashboard-time.js, whose isoToUtcInput it calls (at call time, so this is
+       documentation rather than a constraint). -->
+  <script src="/js/dashboard-scope.js"></script>
   <!-- The AI tagger-rule feature (#415 tier 3). A whole feature, not the movable half of one —
        js/dashboard-tagger.js explains why that distinction decides what moves next. -->
   <script src="/js/dashboard-tagger.js"></script>
@@ -3539,7 +3543,9 @@
     let countTimer = null;
     let countUpdate = null;   // current capture-count poll fn (set by pollCount)
     let aiEnabled = false;   // AI defaults OFF per case; loadAiToggle() syncs the real state
-    let scope = { start: null, end: null };  // active investigation window (ISO or null)
+    // The investigation scope window moved to js/dashboard-scope.js (#415, tier 2) — it is
+    // server-persisted state with three different refresh paths, so it owns them rather than
+    // sharing a generic setter. Read it through DfirScope.
     // The case snapshot moved to js/dashboard-state.js (#415). Read it through DfirState; only
     // render() and renderSuperTimeline() may write, and never cache a snapshot in a local inside a
     // function that can re-fetch — 16 readers call their own writer, where a bare `let` never went stale.
@@ -3664,44 +3670,10 @@
       }
     }
 
-    function inScope(ts) {
-      if (!scope.start && !scope.end) return true;
-      const t = Date.parse(ts); if (isNaN(t)) return true;
-      if (scope.start && t < Date.parse(scope.start)) return false;
-      if (scope.end && t > Date.parse(scope.end)) return false;
-      return true;
-    }
-
-    // Deterministic scope projection — the client-side mirror of the server's
-    // projectScope(). Drops out-of-scope events AND the findings/IOCs/MITRE backed
-    // ONLY by them, so the dashboard is scope-consistent instantly, without waiting
-    // on (or depending on) AI re-synthesis. "No links → can't prove out of scope → keep".
-    function projectScope(state) {
-      if (!scope.start && !scope.end) return state;
-      const events = state.forensicTimeline || [];
-      const forensicTimeline = events.filter(e => inScope(e.timestamp));
-
-      const backedIn = new Set(), backedOut = new Set();
-      for (const e of events) {
-        const tgt = inScope(e.timestamp) ? backedIn : backedOut;
-        for (const fid of (e.relatedFindingIds || [])) tgt.add(fid);
-      }
-      const findings = (state.findings || []).filter(f => backedIn.has(f.id) || !backedOut.has(f.id));
-      const surviving = new Set(findings.map(f => f.id));
-
-      const citedBySurviving = new Set(), citedByAny = new Set();
-      for (const f of (state.findings || [])) for (const iid of (f.relatedIocs || [])) {
-        citedByAny.add(iid);
-        if (surviving.has(f.id)) citedBySurviving.add(iid);
-      }
-      const iocs = (state.iocs || []).filter(i => citedBySurviving.has(i.id) || !citedByAny.has(i.id));
-
-      const mitreTechniques = (state.mitreTechniques || [])
-        .map(t => ({ ...t, findingIds: (t.findingIds || []).filter(id => surviving.has(id)) }))
-        .filter((t, idx) => t.findingIds.length > 0 || (state.mitreTechniques[idx].findingIds || []).length === 0);
-
-      return { ...state, forensicTimeline, findings, iocs, mitreTechniques };
-    }
+    // inScope() and projectScope() moved to js/dashboard-scope.js (#415) — they are pure functions
+    // of (window, state), and moving them with the value is what leaves `scope` with no readers
+    // outside its owner. DfirScope.project() is the same function; a parity suite now checks it
+    // against companion/src/analysis/scopeProject.ts, the server copy it has always mirrored.
 
     // The latest forensic event time anchors the relative-scope presets (DFIR data
     // is historical, so "last 24h" means the last 24h of ACTIVITY, not of wall-clock).
@@ -3712,21 +3684,16 @@
       return isNaN(max) ? Date.now() : max;
     }
 
-    function renderScopeInfo() {
-      const el = document.getElementById("scopeInfo");
-      const utc = (iso) => isoToUtcInput(iso).replace("T", " ") + " UTC";
-      el.textContent = (scope.start || scope.end)
-        ? `active: ${scope.start ? utc(scope.start) : "−∞"} → ${scope.end ? utc(scope.end) : "now"}`
-        : "none (all events)";
-      el.style.color = (scope.start || scope.end) ? "#ffd93b" : "#9aa4b2";
-    }
+    // renderScopeInfo() moved into js/dashboard-scope.js: its three call sites were exactly the
+    // three writers, so an owner that could be written without repainting its own indicator was a
+    // bug waiting to be written. DfirScope.receive()/confirm() each repaint as part of committing.
 
     function loadScope(caseId) {
       fetch(`/cases/${caseId}/scope`).then(r => r.json()).then(s => {
-        scope = { start: s.start || null, end: s.end || null };
-        document.getElementById("scopeStart").value = isoToUtcInput(scope.start);
-        document.getElementById("scopeEnd").value = isoToUtcInput(scope.end);
-        renderScopeInfo();
+        // No redraw, deliberately — the case is still loading and render() arrives separately.
+        // The websocket branch performs the identical commit and then DOES redraw; that difference
+        // is real (see the scope_changed handler) and is preserved rather than levelled out.
+        DfirScope.receive(s.start, s.end);
       }).catch(() => {});
     }
 
@@ -9030,11 +8997,13 @@
       fetch(`/cases/${caseId}/scope`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) })
         .then(r => { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
         .then(s => {
-          scope = { start: s.start || null, end: s.end || null };
-          renderScopeInfo();
+          // confirm(), not receive(): the two inputs are where this window was READ from, so
+          // writing them back is not this path's business. (The server's own scope_changed echo
+          // does write them, with its normalised ISO form — see the handler.)
+          DfirScope.confirm(s.start, s.end);
           // The view is scope-consistent immediately (client-side projection); AI
           // re-synthesis continues in the background and is reported via AI status.
-          document.getElementById("status").textContent = (scope.start || scope.end)
+          document.getElementById("status").textContent = !DfirScope.isEmpty()
             ? "scope applied — AI re-synthesizing in background (see AI status)"
             : "scope cleared — AI re-synthesizing in background (see AI status)";
           fetch(`/cases/${caseId}/state`).then(r => r.json()).then(render).catch(() => {});
@@ -10670,7 +10639,7 @@
     function loadIocSources(caseId) {
       fetch(`/cases/${caseId}/ioc-sources`).then(r => r.json()).then(m => {
         iocSourcesById = (m && typeof m === "object") ? m : {};
-        if (DfirState.lastState()) renderIocs((projectScope(DfirState.lastState()).iocs) || []);
+        if (DfirState.lastState()) renderIocs((DfirScope.project(DfirState.lastState()).iocs) || []);
       }).catch(() => {});
     }
     function scheduleIocSourcesReload() {
@@ -10691,7 +10660,7 @@
     function loadIocProvenance(caseId) {
       fetch(`/cases/${caseId}/ioc-provenance`).then(r => r.json()).then(m => {
         iocProvenance = (m && typeof m === "object") ? m : {};
-        if (DfirState.lastState()) renderIocs((projectScope(DfirState.lastState()).iocs) || []);
+        if (DfirState.lastState()) renderIocs((DfirScope.project(DfirState.lastState()).iocs) || []);
       }).catch(() => {});
     }
     function scheduleIocProvenanceReload() {
@@ -10729,7 +10698,7 @@
     function loadIocRisk(caseId) {
       fetch(`/cases/${caseId}/ioc-risk`).then(r => r.json()).then(m => {
         iocRisk = (m && typeof m === "object") ? m : {};
-        if (DfirState.lastState()) renderIocs((projectScope(DfirState.lastState()).iocs) || []);
+        if (DfirState.lastState()) renderIocs((DfirScope.project(DfirState.lastState()).iocs) || []);
       }).catch(() => {});
     }
     function scheduleIocRiskReload() {
@@ -14361,7 +14330,7 @@
       const btn = document.getElementById("iocTypeFilterBtn");
       const menu = document.getElementById("iocTypeFilterMenu");
       if (!wrap || !btn || !menu) return;
-      const scopedIocs = () => (DfirState.lastState() ? (projectScope(DfirState.lastState()).iocs || []) : []);
+      const scopedIocs = () => (DfirState.lastState() ? (DfirScope.project(DfirState.lastState()).iocs || []) : []);
       const rerender = () => renderIocs(scopedIocs());
       btn.addEventListener("click", () => { menu.hidden = !menu.hidden; });
       menu.addEventListener("change", (e) => {
@@ -14737,7 +14706,7 @@
       renderCollectionPlan();
       // Keep the raw state so scope-preset clicks can re-project without a refetch.
       DfirState.setLastState(rawState);
-      const state = projectScope(rawState);
+      const state = DfirScope.project(rawState);
       document.getElementById("summary").textContent = state.lastSummary || "—";
       document.getElementById("attackerPath").textContent = state.attackerPath || "—";
       document.getElementById("narrativeView").textContent = state.narrativeTimeline || "—";
@@ -15393,13 +15362,18 @@
         else if (msg.type === "source_trust_changed") loadSourceTrust(caseId);
         else if (msg.type === "clock_skew_changed") loadClockSkew(caseId);
         else if (msg.type === "scope_changed") {
-          scope = { start: msg.start ?? null, end: msg.end ?? null };
-          document.getElementById("scopeStart").value = isoToUtcInput(scope.start);
-          document.getElementById("scopeEnd").value = isoToUtcInput(scope.end);
-          renderScopeInfo();
-          // render() projects with the freshly-updated `scope` global AND caches its argument
-          // as `DfirState.lastState()`, so pass the RAW state — passing projectScope(DfirState.lastState()) would cache
-          // a scope-narrowed subset, permanently dropping out-of-window events on the next
+          // The same commit loadScope makes — the window came from the server either way, so the
+          // two controls are a sink here. Unlike loadScope this path then redraws, because the
+          // change came from outside and nothing else is going to.
+          //
+          // The hub broadcasts to every subscriber with no sender exclusion (src/live/hub.ts:67-80),
+          // so applyScope receives its own echo and this runs a second time after it — which is why
+          // applying a scope renders twice and the analyst's typed input is replaced by the
+          // server's normalised form. Pre-existing behaviour, preserved.
+          DfirScope.receive(msg.start, msg.end);
+          // render() projects with the freshly-updated window AND caches its argument as
+          // `DfirState.lastState()`, so pass the RAW state — passing an already-projected one would
+          // cache a scope-narrowed subset, permanently dropping out-of-window events on the next
           // scope widen/clear until a fresh server state arrives.
           if (DfirState.lastState()) render(DfirState.lastState());
         }

--- a/public/js/dashboard-scope.js
+++ b/public/js/dashboard-scope.js
@@ -80,9 +80,15 @@
 // and accepted — "a reader could mutate the value in place" — is therefore just closed here.
 //
 // It closes it at runtime only in strict mode; a classic script is not strict, so a stray
-// `DfirScope.get().start = x` silently no-ops rather than throwing. That is why the AST gate checks
-// it statically as well. Belt and braces, because the whole point of freezing is that the "0
-// property mutations" measurement above stays true without anyone having to re-measure.
+// `DfirScope.get().start = x` silently NO-OPS rather than throwing — the caller's intent vanishes,
+// every later read returns the old value, and CI stays green. That is strictly worse than the throw
+// a strict realm would have raised, so freezing alone is not the guarantee.
+//
+// The other half is a gate: getterMutations() in tests/helpers/dashboardAst.ts, asserted by "never
+// writes through get() to the window it returned". It catches the direct form, the aliased form
+// (`const w = DfirScope.get(); w.start = x`) and the window-rooted spelling. Freezing stops the
+// state being corrupted; the gate stops the code being written. Both are needed — an earlier draft
+// of this comment promised the gate before it existed, which review caught.
 //
 //
 // NO onScopeChange. The cell has subscribe() and this module deliberately does not publish it.

--- a/public/js/dashboard-scope.js
+++ b/public/js/dashboard-scope.js
@@ -1,0 +1,222 @@
+// Who owns the investigation scope window (#415, tier 2).
+//
+// `scope` is the first tier-2 cell to move, and it moves FIRST because it is the one piece of
+// tier-2 state that is not really "view state" at all: it is server-persisted forensic state, with
+// a store (companion/src/analysis/scope.ts), a REST pair, and a websocket broadcast behind it.
+// That is also why it does not belong to the timeline-view owner that the rest of tier 2 is headed
+// for — see "THREE PATHS" below, which is the whole argument.
+//
+//
+// WHAT THE MEASUREMENT SAYS
+//
+// Resolved through a real lexical scope chain rather than by grepping the word — which matters
+// here, because three functions declare a LOCAL `scope` that has nothing to do with this one
+// (dashboard.html:11524 an HTML string, 13586 an IOC count label, 11732 a chain label), and
+// `p.scope` / `m.scope` / `data-scope` / `TAGGER_SCOPE` are unrelated besides:
+//
+//   33  occurrences of the identifier `scope` in the inline script
+//   26    resolve to the top-level binding
+//    7    resolve to a local shadow          -- a grep would have counted these as writers
+//    3  writes, ALL whole-value replacement
+//    0  property mutations (`scope.start = x`)  -- nothing mutates it in place
+//    4  reader functions besides the writers: inScope, projectScope, renderScopeInfo, and the
+//       writers reading it back for their own status text
+//
+// The published census for this issue listed renderHostRanking as a fourth writer. It is not; that
+// was the shadow at 11524. Three writers, and they are the three below.
+//
+//
+// THREE PATHS, AND WHY A GENERIC setScope() CANNOT EXPRESS THEM
+//
+// The three writers do NOT differ by accident, and flattening them into one setter with a redraw
+// flag was the first design's mistake:
+//
+//   loadScope (3724)        commit -> push into #scopeStart/#scopeEnd -> repaint #scopeInfo.
+//                           NO redraw. The case is still loading; render() comes separately.
+//   scope_changed (15395)   THE SAME THREE STEPS, then render(DfirState.lastState()).
+//                           Another analyst (or this one, in another tab) moved the window.
+//   applyScope (9022)       commit -> repaint #scopeInfo, and deliberately does NOT touch the two
+//                           inputs, because it READ the window out of them. Then its own refresh:
+//                           a /state refetch, twenty derived panels, the super-timeline.
+//
+// So there are two operations, not one and not three: `receive` (the server told us a window; push
+// it into the controls) and `confirm` (the analyst set the controls; the server accepted). The
+// redraw is NOT part of either, because the redraw is exactly what the three paths disagree about,
+// and hiding a disagreement behind a boolean is how the first design broke behaviour.
+//
+// A CONSEQUENCE WORTH STATING: because the server broadcasts to every subscriber of a case with no
+// sender exclusion (companion/src/live/hub.ts:67-80), applyScope receives its own echo, so applying
+// a scope renders twice and the echo overwrites the analyst's typed input with the server's
+// normalised ISO form. That is today's behaviour and this module preserves it rather than fixing
+// it; it is written up on the issue as found-not-fixed.
+//
+//
+// WHY THE PROJECTION LIVES HERE TOO
+//
+// projectScope() moved in with the value rather than staying behind, for three reasons. It is a
+// pure function of (window, state) — no DOM, no fetch. It is what the window MEANS, so leaving it
+// outside would make DfirScope an owner of a value whose interpretation someone else holds. And it
+// leaves the binding with zero readers outside this file, which is the difference between "behind
+// an accessor" and "encapsulated".
+//
+// The third reason is the useful one: companion/src/analysis/scopeProject.ts is the SAME RULE,
+// written a second time, and the inline copy's own comment calls itself "the client-side mirror of
+// the server's projectScope()". Nothing checked that the mirror still matched. It could not be
+// checked while the function was trapped in an inline script; now it can, and the parity suite does
+// exactly that against the real server module — the same correction made earlier in this issue for
+// the false-positive rule, which had drifted the same way.
+//
+// inScope() did NOT get published. Its only two call sites are inside projectScope, so it is
+// private here; `contains` is the published form, and it exists because the parity suite needs to
+// exercise the undated-timestamp rule directly.
+//
+//
+// THE VALUE IS FROZEN, WHICH TIER 1'S IS NOT
+//
+// dashboard-state.js hands back the live snapshot object and argues that deep-freezing a whole case
+// state on every fetch is not free, so the single-writer rule carries the weight instead. That
+// argument does not transfer, and the difference is worth being explicit about: this is a two-field
+// object written three times, so freezing it costs nothing measurable. The hazard tier 1 documented
+// and accepted — "a reader could mutate the value in place" — is therefore just closed here.
+//
+// It closes it at runtime only in strict mode; a classic script is not strict, so a stray
+// `DfirScope.get().start = x` silently no-ops rather than throwing. That is why the AST gate checks
+// it statically as well. Belt and braces, because the whole point of freezing is that the "0
+// property mutations" measurement above stays true without anyone having to re-measure.
+//
+//
+// NO onScopeChange. The cell has subscribe() and this module deliberately does not publish it.
+// Subscription is a single fixed reaction to a write, and the three paths above are three DIFFERENT
+// reactions — a subscriber would have to be the union of them, which is the generic redraw this
+// design exists to avoid. The machinery stays unused here on purpose.
+//
+// NOT AN ES MODULE, and an IIFE for the reason dashboard-state.js explains at length: a top-level
+// `const` in a classic script joins the shared global LEXICAL environment, so it is writable by
+// name from any later script even though it never appears on the global object. Nothing escapes
+// this closure but window.DfirScope, and a test asserts that by attempting the bypass for real.
+(function () {
+  // Built with DfirState.cell, which dashboard-state.js publishes for exactly this: "cell is
+  // exposed because the next migrations need to build their own cells". That is the only load-time
+  // dependency this file has, so its <script> tag must follow dashboard-state.js — everything else
+  // it calls (isoToUtcInput) resolves at call time, long after every tag has run.
+  const dfirScope = window.DfirState.cell(Object.freeze({ start: null, end: null }));
+
+  /**
+   * Commit a window. The single point every write goes through, so the gate has one thing to count.
+   *
+   * `|| null` normalises the three call sites' two spellings into one. loadScope and applyScope
+   * already wrote `s.start || null`; the websocket branch wrote `msg.start ?? null`, which differs
+   * only for an empty string — and the server's norm() (companion/src/routes/findings.ts:353-358)
+   * turns "" into null before it can ever be sent, so the two are the same on real traffic.
+   */
+  function commit(start, end) {
+    return dfirScope.set(Object.freeze({ start: start || null, end: end || null }));
+  }
+
+  /** No window set — every event is in scope. Was `!scope.start && !scope.end`, written four times. */
+  function isEmpty() {
+    const s = dfirScope.get();
+    return !s.start && !s.end;
+  }
+
+  /**
+   * Is this timestamp inside the window?
+   *
+   * "Can't prove it's out of scope" → keep it, which is why an unparseable timestamp returns true.
+   * That rule is load-bearing for undated events and is mirrored on the server in
+   * companion/src/analysis/scope.ts:22-29.
+   */
+  function contains(ts) {
+    const s = dfirScope.get();
+    if (!s.start && !s.end) return true;
+    const t = Date.parse(ts);
+    if (isNaN(t)) return true;
+    if (s.start && t < Date.parse(s.start)) return false;
+    if (s.end && t > Date.parse(s.end)) return false;
+    return true;
+  }
+
+  /**
+   * Deterministic scope projection — the client-side mirror of the server's projectScope().
+   *
+   * Drops out-of-scope events AND the findings/IOCs/MITRE backed ONLY by them, so the dashboard is
+   * scope-consistent instantly, without waiting on (or depending on) AI re-synthesis.
+   * "No links → can't prove out of scope → keep".
+   *
+   * The `|| []` guards are the one intended difference from the server's copy: the server owns the
+   * type and can index straight into it, this one is handed parsed JSON. On well-formed input the
+   * two produce identical output, and the parity suite pins that.
+   */
+  function project(state) {
+    if (isEmpty()) return state;
+    const events = state.forensicTimeline || [];
+    const forensicTimeline = events.filter((e) => contains(e.timestamp));
+
+    const backedIn = new Set(), backedOut = new Set();
+    for (const e of events) {
+      const tgt = contains(e.timestamp) ? backedIn : backedOut;
+      for (const fid of (e.relatedFindingIds || [])) tgt.add(fid);
+    }
+    const findings = (state.findings || []).filter((f) => backedIn.has(f.id) || !backedOut.has(f.id));
+    const surviving = new Set(findings.map((f) => f.id));
+
+    const citedBySurviving = new Set(), citedByAny = new Set();
+    for (const f of (state.findings || [])) for (const iid of (f.relatedIocs || [])) {
+      citedByAny.add(iid);
+      if (surviving.has(f.id)) citedBySurviving.add(iid);
+    }
+    const iocs = (state.iocs || []).filter((i) => citedBySurviving.has(i.id) || !citedByAny.has(i.id));
+
+    const mitreTechniques = (state.mitreTechniques || [])
+      .map((t) => ({ ...t, findingIds: (t.findingIds || []).filter((id) => surviving.has(id)) }))
+      .filter((t, idx) => t.findingIds.length > 0 || (state.mitreTechniques[idx].findingIds || []).length === 0);
+
+    return { ...state, forensicTimeline, findings, iocs, mitreTechniques };
+  }
+
+  /** The #scopeInfo chip. Was renderScopeInfo(), whose three call sites were the three writers. */
+  function renderInfo() {
+    const el = document.getElementById("scopeInfo");
+    const s = dfirScope.get();
+    const utc = (iso) => isoToUtcInput(iso).replace("T", " ") + " UTC";
+    el.textContent = (s.start || s.end)
+      ? `active: ${s.start ? utc(s.start) : "−∞"} → ${s.end ? utc(s.end) : "now"}`
+      : "none (all events)";
+    el.style.color = (s.start || s.end) ? "#ffd93b" : "#9aa4b2";
+  }
+
+  window.DfirScope = {
+    /**
+     * The window, frozen. Read it at the point of use — do not stash it across anything that can
+     * write, for the reason dashboard-state.js gives about cached snapshots and the gate enforces.
+     */
+    get: () => dfirScope.get(),
+    isEmpty,
+    contains,
+    project,
+
+    /**
+     * A window arrived FROM the server — the case-load GET, or another client's change over the
+     * websocket. Commit it and push it into the two controls, which are a sink on this path.
+     *
+     * Does not redraw. loadScope never did, and the websocket branch does its own render() straight
+     * after; that difference between the two callers is real and stays visible at the call sites.
+     */
+    receive(start, end) {
+      commit(start, end);
+      document.getElementById("scopeStart").value = isoToUtcInput(dfirScope.get().start);
+      document.getElementById("scopeEnd").value = isoToUtcInput(dfirScope.get().end);
+      renderInfo();
+    },
+
+    /**
+     * The server accepted a window the analyst typed. Commit and repaint the chip only — the two
+     * controls are the SOURCE on this path, so writing them back is not this operation's business.
+     * (The websocket echo of this same change does write them, with the server's normalised form.)
+     */
+    confirm(start, end) {
+      commit(start, end);
+      renderInfo();
+    },
+  };
+})();


### PR DESCRIPTION
First **tier 2** cell of #415. Tier 1 put the case snapshot behind `DfirState`; this puts the
investigation scope window behind a new owner, `DfirScope`.

Scope goes first because it is the one piece of tier-2 state that is not view state at all — it is
server-persisted, with a store, a REST pair and a websocket broadcast behind it. That is also why it
does **not** join the timeline-view owner the rest of tier 2 is headed for.

## The measurement

Resolved through a real lexical scope chain, not by name — three functions declare a *local* `scope`
that has nothing to do with this one (`11524` an HTML string, `13587` an IOC count label, `11732` a
chain label):

| | |
|---|---|
| occurrences of the identifier | 33 |
| → bind to the top-level declaration | **26** |
| → bind to a local shadow | 7 |
| **whole-value writes** | **3** |
| **property mutations** (`scope.start = x`) | **0** |
| reader functions | 3 — `inScope`, `projectScope`, `renderScopeInfo` |

> The census I posted to #415 listed `renderHostRanking` as a fourth writer. It is not — that was the
> shadow at 11524, matched by name. A correction is going on the issue.

Zero property mutations is what makes handing back the value safe, and it is now enforced rather than
measured once.

## Three paths, two commit shapes

The writers differ in what they refresh, so one setter with a redraw flag would change behaviour:

| path | commits | writes the two controls | repaints `#scopeInfo` | redraws |
|---|---|---|---|---|
| `loadScope` | ✓ | ✓ | ✓ | **nothing** |
| `scope_changed` | ✓ | ✓ | ✓ | `render(lastState())` |
| `applyScope` | ✓ | ✗ — it *read* them | ✓ | `/state` refetch → `render`, 20 loaders, super-timeline |

So the module publishes the two shapes they actually differ by — `receive` (the server told us; the
controls are a sink) and `confirm` (the analyst typed it; the controls are the source) — and leaves
the redraw at the call site, because the redraw is exactly what the three disagree about.

**No generic `set`, no `onScopeChange`.** A single subscriber would have to fire the union of all
three. A test pins the published surface so that stays true.

## The projection moves in, and becomes checkable

`projectScope()`/`inScope()` are pure functions of (window, state), so moving them leaves the binding
with no readers outside its owner — the difference between "behind an accessor" and "encapsulated".

The payoff is that they can now be *executed*: `src/analysis/scopeProject.ts` is the same rule written
a second time, the inline copy called itself "the client-side mirror" of it, and nothing checked the
mirror still matched. The parity suite runs the **real server function** — imported, not
re-implemented — against the browser module over six window shapes including inverted and unparseable
bounds. Same correction this issue already made once, for the false-positive rule.

Before committing the extraction I ran a differential test against the original inline function
lifted verbatim by line range: **2400/2400 identical projections**, object identity preserved for the
no-scope case, `contains()` identical on every case.

## The gate

A call-site count cannot express a cell with three legitimate writers, so the rule is not "how many"
but **which** — an allowlist pinning each commit to its owning function.

- `setterRefs()` gains a `namespace` parameter rather than being copied; two gates checking different
  things while both claiming to check writers is how they drift.
- `globalsAddedBy()` gains a `preload` list. This is the first module with a *load-time* dependency,
  so without it the module throws while loading rather than failing to publish.

**All ten new gates were mutation-tested.** One did not fire: the test that `confirm()` leaves the
controls alone pre-set them to the round-trip of the committed window, so a `confirm()` that *did*
write them wrote back the identical string and the test still passed — it was asserting "the value is
right" while claiming to assert "nothing wrote it". It is now a sentinel, and fires.

## Found, not fixed

Behaviour is reproduced exactly. Both are pre-existing and written up on the issue:

- **`applyScope` renders twice.** `broadcastTo` (`src/live/hub.ts:67-80`) iterates every subscriber
  with no sender exclusion, so the POSTing client receives its own echo — which also replaces the
  analyst's typed input with the server's normalised ISO form.
- **`loadScope` redraws nothing** while the websocket branch redraws after identical writes. A
  `/scope` response landing after the first `render()` leaves an unprojected view.

## Gates

`build`, `lint`, `format:check`, `check:size` (18138 → 18108), `check:imports`, `check:boundaries`,
`eval:change-gate`, `check:us-map` all green; route inventory re-baselined (+1 line, the new asset).
Full suite 7336 passed. Four failures are pre-existing and environmental — `sharpVersion` (local
node_modules has sharp 0.33.5/vips 8.15.3, below what the test requires) and one timing-sensitive
ReDoS assertion that **passes when run alone**; neither file is touched by this branch.
