### PR TITLE
refactor(dashboard): give the selections and the star cache their own owners (#415 tier 2)

### DIFF
--- a/companion/src/http/staticAssets.ts
+++ b/companion/src/http/staticAssets.ts
@@ -47,6 +47,10 @@ export const STATIC_ASSETS: Record<string, string> = {
   // Unlike the helpers above this one holds state, so a 404 here is not a missing helper — every
   // scope read would throw and the dashboard would not render at all.
   "/js/dashboard-scope.js": "application/javascript; charset=utf-8",
+  // Tier 2's selection owners: what the analyst has ticked (DfirSelection) and starred
+  // (DfirStarred). Same failure mode as the scope module — these hold state, so a 404 is not a
+  // missing helper, it is every selection read throwing.
+  "/js/dashboard-selection.js": "application/javascript; charset=utf-8",
   // The first whole FEATURE module of #415 tier 3, as opposed to the pure-helper modules above.
   "/js/dashboard-tagger.js": "application/javascript; charset=utf-8",
   "/js/dashboard-kev.js": "application/javascript; charset=utf-8",

--- a/companion/tests/architecture/route-inventory.json
+++ b/companion/tests/architecture/route-inventory.json
@@ -479,6 +479,7 @@
     "ROUTE GET /js/dashboard-values.js",
     "ROUTE GET /js/dashboard-fragments.js",
     "ROUTE GET /js/dashboard-scope.js",
+    "ROUTE GET /js/dashboard-selection.js",
     "ROUTE GET /js/dashboard-tagger.js",
     "ROUTE GET /js/dashboard-kev.js",
     "ROUTE GET /js/a11y/modal-autowire.js",

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -273,6 +273,32 @@ export interface StateApi {
   };
 }
 
+/**
+ * One owned set of ids (public/js/dashboard-selection.js).
+ *
+ * Note the absence of anything returning a Set. Every read is a copy or a scalar, which is the
+ * whole point: replace-on-write is only enforceable if the container never leaves the owner.
+ */
+export interface IdSet {
+  has(id: string): boolean;
+  count(): number;
+  /** A frozen COPY, fresh each call. */
+  ids(): readonly string[];
+  /** `on` omitted flips, like classList.toggle. Returns the new size. */
+  toggle(id: string, on?: boolean): number;
+  /** Union in a batch — select-all, the rubber band. ONE commit. */
+  addAll(ids: Iterable<string>): number;
+  removeAll(ids: Iterable<string>): number;
+  replace(ids?: Iterable<string>): number;
+  clear(): number;
+}
+
+export interface SelectionApi {
+  DfirSelection: { events: IdSet; iocs: IdSet; findings: IdSet };
+  /** Starred is a CACHE of server tags, not view state, so it is a separate owner. */
+  DfirStarred: Pick<IdSet, "has" | "count" | "ids" | "toggle" | "replace">;
+}
+
 /** An investigation window. Mirrors the server's ScopeWindow (src/analysis/scope.ts). */
 export interface ScopeWindow {
   start: string | null;

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -286,15 +286,25 @@ export interface IdSet {
   ids(): readonly string[];
   /** `on` omitted flips, like classList.toggle. Returns the new size. */
   toggle(id: string, on?: boolean): number;
+  // All three guard with `ids || []`, so the parameter is optional and nullable here to match.
+  // Tightening it would make the "tolerates an empty or absent batch" case fail to compile, which
+  // is the type lying about the code rather than checking it.
   /** Union in a batch — select-all, the rubber band. ONE commit. */
-  addAll(ids: Iterable<string>): number;
-  removeAll(ids: Iterable<string>): number;
-  replace(ids?: Iterable<string>): number;
+  addAll(ids?: Iterable<string> | null): number;
+  removeAll(ids?: Iterable<string> | null): number;
+  replace(ids?: Iterable<string> | null): number;
   clear(): number;
 }
 
+/**
+ * A selection cannot be replaced wholesale — see js/dashboard-selection.js. Select-all ticks the
+ * rendered rows, so an operation that drops the rest would silently lose off-page ticks, and no
+ * caller wants one.
+ */
+export type SelectionSet = Omit<IdSet, "replace">;
+
 export interface SelectionApi {
-  DfirSelection: { events: IdSet; iocs: IdSet; findings: IdSet };
+  DfirSelection: { events: SelectionSet; iocs: SelectionSet; findings: SelectionSet };
   /** Starred is a CACHE of server tags, not view state, so it is a separate owner. */
   DfirStarred: Pick<IdSet, "has" | "count" | "ids" | "toggle" | "replace">;
 }

--- a/companion/tests/dashboard/dashboardSelection.test.ts
+++ b/companion/tests/dashboard/dashboardSelection.test.ts
@@ -1,0 +1,278 @@
+import { readFile } from "node:fs/promises";
+import { runInContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
+import type { SelectionApi } from "./dashboardApi.js";
+import { dashboardScripts, ownerCalls, topLevelBindings } from "../helpers/dashboardAst.js";
+import { globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// public/js/dashboard-selection.js — tier 2's second and third owners (#415).
+//
+// The scope window before it was three whole-value writes and zero in-place mutations, so putting
+// it behind an accessor was a rename. These four sets are the opposite: 33 in-place mutations, zero
+// replacements, and four of those mutations inside a loop. Replace-on-write is therefore a real
+// change of mechanism here, and the tests below are aimed at the two things that change can break —
+// the SEMANTICS of the bulk gestures, and the COST of committing one id at a time.
+
+const MODULE = new URL("../../../public/js/dashboard-selection.js", import.meta.url);
+const DASHBOARD = new URL("../../../public/dashboard.html", import.meta.url);
+
+const load = () => loadDashboardModule<SelectionApi>("dashboard-selection.js", ["dashboard-state.js"]);
+
+describe("a selection set", () => {
+  it("starts empty", () => {
+    const { DfirSelection } = load();
+    expect(DfirSelection.events.count()).toBe(0);
+    expect(DfirSelection.events.ids()).toEqual([]);
+    expect(DfirSelection.events.has("e1")).toBe(false);
+  });
+
+  it("toggles one id on and off with an explicit state", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.toggle("e1", true);
+    expect(DfirSelection.events.has("e1")).toBe(true);
+    DfirSelection.events.toggle("e1", false);
+    expect(DfirSelection.events.has("e1")).toBe(false);
+  });
+
+  // The swimlane's click-to-select is a genuine flip, unlike the checkboxes which know their state.
+  it("flips when no state is given, like classList.toggle", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.toggle("e1");
+    expect(DfirSelection.events.has("e1")).toBe(true);
+    DfirSelection.events.toggle("e1");
+    expect(DfirSelection.events.has("e1")).toBe(false);
+  });
+
+  it("keeps the three selections independent", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.toggle("x", true);
+    expect(DfirSelection.iocs.has("x")).toBe(false);
+    expect(DfirSelection.findings.has("x")).toBe(false);
+  });
+});
+
+// THE SEMANTIC THAT REPLACE-ON-WRITE COULD SILENTLY LOSE.
+//
+// Select-all ticks the RENDERED rows, and the timeline paginates, so rows selected on another page
+// have to survive it. The per-row `.add()` loop this replaced did that for free. `replace()` would
+// not — which is why select-all uses addAll/removeAll, and why this is a test rather than a comment.
+describe("bulk gestures union and subtract rather than replace", () => {
+  it("addAll keeps ids that were already selected off-screen", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.toggle("offpage", true);
+    DfirSelection.events.addAll(["a", "b"]);
+    expect(DfirSelection.events.ids().slice().sort()).toEqual(["a", "b", "offpage"]);
+  });
+
+  it("removeAll subtracts only the ids it is given", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.addAll(["offpage", "a", "b"]);
+    DfirSelection.events.removeAll(["a", "b"]);
+    expect(DfirSelection.events.ids()).toEqual(["offpage"]);
+  });
+
+  it("replace and clear DO drop everything, which is why select-all does not use them", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.addAll(["a", "b"]);
+    DfirSelection.events.replace(["c"]);
+    expect(DfirSelection.events.ids()).toEqual(["c"]);
+    DfirSelection.events.clear();
+    expect(DfirSelection.events.count()).toBe(0);
+  });
+
+  it("tolerates an empty or absent batch", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.addAll([]);
+    DfirSelection.events.replace(undefined);
+    expect(DfirSelection.events.count()).toBe(0);
+  });
+});
+
+// NO LIVE SET LEAVES THE CLOSURE.
+//
+// Note what is NOT done here: the internal Set is not frozen, because freezing one would be
+// theatre — Object.freeze touches own properties and a Set's contents are internal slots, so a
+// "frozen" Set still accepts .add(). The container simply never escapes, and ids() hands back a
+// frozen array copy.
+describe("the container never escapes", () => {
+  it("hands back a frozen array, not the Set", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.addAll(["a"]);
+    const ids = DfirSelection.events.ids();
+    expect(Array.isArray(ids)).toBe(true);
+    expect(Object.isFrozen(ids)).toBe(true);
+  });
+
+  it("is unaffected by anything done to a previously returned array", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.addAll(["a", "b"]);
+    const ids = DfirSelection.events.ids();
+    try {
+      (ids as string[]).push("smuggled");
+    } catch {
+      // frozen arrays throw in strict mode and no-op otherwise; either is a rejected write
+    }
+    expect(DfirSelection.events.count()).toBe(2);
+    expect(DfirSelection.events.has("smuggled")).toBe(false);
+  });
+
+  it("returns a fresh array each time, so callers cannot alias the state", () => {
+    const { DfirSelection } = load();
+    DfirSelection.events.addAll(["a"]);
+    expect(DfirSelection.events.ids()).not.toBe(DfirSelection.events.ids());
+  });
+});
+
+describe("DfirStarred is a separate owner", () => {
+  it("does not share a set with the event selection", () => {
+    const { DfirSelection, DfirStarred } = load();
+    DfirStarred.toggle("e1", true);
+    expect(DfirSelection.events.has("e1")).toBe(false);
+    DfirSelection.events.toggle("e2", true);
+    expect(DfirStarred.has("e2")).toBe(false);
+  });
+
+  // deriveStarred() rebuilds from the server's tags, so it replaces wholesale.
+  it("replaces wholesale when re-derived from tags", () => {
+    const { DfirStarred } = load();
+    DfirStarred.replace(["a", "b"]);
+    DfirStarred.replace(["c"]);
+    expect(DfirStarred.ids()).toEqual(["c"]);
+  });
+
+  // toggleStar flips optimistically and reverts on failure. The revert re-reads the CURRENT set
+  // rather than restoring a snapshot, so a concurrent change is not clobbered.
+  it("round-trips an optimistic flip and its revert", () => {
+    const { DfirStarred } = load();
+    DfirStarred.replace(["a"]);
+    const wasStarred = DfirStarred.has("a");
+    DfirStarred.toggle("a", !wasStarred);
+    expect(DfirStarred.has("a")).toBe(false);
+    DfirStarred.toggle("a", wasStarred);
+    expect(DfirStarred.has("a")).toBe(true);
+  });
+
+  it("exposes no way to write it that the selections do not need", () => {
+    const { DfirStarred } = load();
+    expect(Object.keys(DfirStarred).sort()).toEqual(["count", "has", "ids", "replace", "toggle"]);
+  });
+});
+
+// ── THE GATE ─────────────────────────────────────────────────────────────────────────────────────
+describe("no commit happens inside a loop", () => {
+  const scripts = dashboardScripts();
+  const COMMITS = ["toggle", "addAll", "removeAll", "replace", "clear"] as const;
+
+  // THE INVARIANT THIS MIGRATION TURNS ON. Replace-on-write is O(n) per commit, so committing per
+  // iteration is O(n^2) for the gesture — and `tlPageSize` is analyst-selectable with 0 meaning
+  // "every row", so select-all is not bounded by a page. The four sites that used to do this are
+  // why addAll/removeAll exist; without this test, the next one reads as perfectly ordinary code.
+  // THE ONE DOCUMENTED EXCEPTION, pinned by name rather than by narrowing the gate to miss it.
+  //
+  // bulkStarIds awaits ONE HTTP REQUEST PER ID — the tags store is read-modify-write on tags.json,
+  // which is why the requests are serialised in the first place. A Set copy next to a network
+  // round-trip is not the cost, and batching would be actively wrong: each id is applied as its
+  // request succeeds, so a failure halfway leaves the successful ones starred, which is what the
+  // analyst sees and what loadTags() then reconciles.
+  const ALLOWED_IN_LOOP = ["bulkStarIds"];
+
+  it.each(["DfirSelection", "DfirStarred"])("%s is never committed to from within a loop", (ns) => {
+    const offenders = ownerCalls(scripts, ns, COMMITS)
+      .filter((c) => c.inLoop && !ALLOWED_IN_LOOP.includes(c.fn))
+      .map((c) => `${c.script}:${c.line} ${c.fn}() -> ${c.path}()`);
+    expect(
+      offenders,
+      "collect the ids first and commit once — addAll/removeAll/replace exist for this. See " +
+        "js/dashboard-selection.js. If the loop awaits a request per id, add it to ALLOWED_IN_LOOP " +
+        "with the reason.",
+    ).toEqual([]);
+  });
+
+  // The allowlist must not outlive what it excuses: an entry that no longer matches anything is a
+  // stale exemption that would silently cover a future commit-in-loop in a function of that name.
+  it("has no stale entry in the loop allowlist", () => {
+    const inLoop = new Set(
+      ["DfirSelection", "DfirStarred"].flatMap((ns) =>
+        ownerCalls(scripts, ns, COMMITS)
+          .filter((c) => c.inLoop)
+          .map((c) => c.fn),
+      ),
+    );
+    expect([...ALLOWED_IN_LOOP].filter((f) => !inLoop.has(f))).toEqual([]);
+  });
+
+  it("actually finds the commits it is checking, so the gate is not vacuous", () => {
+    const found = ownerCalls(scripts, "DfirSelection", COMMITS);
+    expect(found.length).toBeGreaterThan(10);
+    expect(ownerCalls(scripts, "DfirStarred", COMMITS).length).toBeGreaterThan(2);
+  });
+});
+
+describe("the old bindings are gone", () => {
+  const scripts = dashboardScripts();
+  const MOVED = ["selectedEvents", "selectedIocs", "selectedFindings", "starredEvents"];
+
+  it.each(MOVED)("%s has no top-level binding left in the page", (name) => {
+    const offenders = scripts
+      .filter((s) => s.name.startsWith("dashboard.html#inline"))
+      .flatMap((s) =>
+        topLevelBindings(s)
+          .filter((b) => b.name === name)
+          .map((b) => `${s.name}:${b.line}`),
+      );
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("nothing but the namespaces escapes", () => {
+  it("adds only DfirSelection and DfirStarred to the global object", () => {
+    expect(globalsAddedBy("dashboard-selection.js", ["dashboard-state.js"]).sort()).toEqual([
+      "DfirSelection",
+      "DfirStarred",
+    ]);
+  });
+
+  it("puts the sets out of reach of a second script on the page", () => {
+    const api = load();
+    api.DfirSelection.events.toggle("legit", true);
+    expect(() => runInContext("idSet()", api as object)).toThrow(/idSet is not defined/);
+    expect(api.DfirSelection.events.has("legit")).toBe(true);
+  });
+
+  it("publishes no change subscription", () => {
+    const api = load();
+    expect(Object.keys(api.DfirSelection).sort()).toEqual(["events", "findings", "iocs"]);
+    for (const set of [api.DfirSelection.events, api.DfirSelection.iocs, api.DfirSelection.findings]) {
+      expect(Object.keys(set).sort()).toEqual([
+        "addAll",
+        "clear",
+        "count",
+        "has",
+        "ids",
+        "removeAll",
+        "replace",
+        "toggle",
+      ]);
+    }
+  });
+});
+
+describe("wiring", () => {
+  it("is loaded by dashboard.html, ahead of the inline script, and served by the whitelist", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    expect(html).toContain('<script src="/js/dashboard-selection.js"></script>');
+    const tag = html.indexOf('src="/js/dashboard-selection.js"');
+    expect(html.indexOf('src="/js/dashboard-state.js"')).toBeLessThan(tag);
+    const blocks = [...html.matchAll(/<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g)];
+    const main = blocks.find((m) => /\n\s*function render\s*\(/.test(m[1]));
+    expect(main, "could not locate the inline dashboard script").toBeDefined();
+    expect(tag).toBeLessThan(main!.index);
+    expect(STATIC_ASSETS["/js/dashboard-selection.js"]).toBe("application/javascript; charset=utf-8");
+  });
+
+  it("stays a classic script", async () => {
+    const src = await readFile(MODULE, "utf8");
+    expect(src).not.toMatch(/^\s*(?:export|import)\s/m);
+  });
+});

--- a/companion/tests/dashboard/dashboardSelection.test.ts
+++ b/companion/tests/dashboard/dashboardSelection.test.ts
@@ -3,7 +3,17 @@ import { runInContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
 import type { SelectionApi } from "./dashboardApi.js";
-import { dashboardScripts, ownerCalls, topLevelBindings } from "../helpers/dashboardAst.js";
+import {
+  calleesInsideLoops,
+  functionsOf,
+  insideLoop,
+  ownerCallPositions,
+  dashboardScripts,
+  ownerCalls,
+  ownerEscapes,
+  scriptFromSource,
+  topLevelBindings,
+} from "../helpers/dashboardAst.js";
 import { globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
 
 // public/js/dashboard-selection.js — tier 2's second and third owners (#415).
@@ -18,6 +28,9 @@ const MODULE = new URL("../../../public/js/dashboard-selection.js", import.meta.
 const DASHBOARD = new URL("../../../public/dashboard.html", import.meta.url);
 
 const load = () => loadDashboardModule<SelectionApi>("dashboard-selection.js", ["dashboard-state.js"]);
+
+/** Parsed once — the call-site pins and the loop gate both read it. */
+const scriptsForPins = dashboardScripts();
 
 describe("a selection set", () => {
   it("starts empty", () => {
@@ -72,20 +85,54 @@ describe("bulk gestures union and subtract rather than replace", () => {
     expect(DfirSelection.events.ids()).toEqual(["offpage"]);
   });
 
-  it("replace and clear DO drop everything, which is why select-all does not use them", () => {
+  it("clear DOES drop everything, which is why select-all does not use it", () => {
     const { DfirSelection } = load();
     DfirSelection.events.addAll(["a", "b"]);
-    DfirSelection.events.replace(["c"]);
-    expect(DfirSelection.events.ids()).toEqual(["c"]);
     DfirSelection.events.clear();
     expect(DfirSelection.events.count()).toBe(0);
+  });
+
+  // A replace() on a selection could only ever lose an off-page tick, and nothing calls one, so it
+  // is not published. Removing the operation is stronger than testing that nobody uses it.
+  it("publishes no replace() on a selection, only on the star cache", () => {
+    const { DfirSelection, DfirStarred } = load();
+    for (const set of [DfirSelection.events, DfirSelection.iocs, DfirSelection.findings]) {
+      expect(set).not.toHaveProperty("replace");
+    }
+    expect(DfirStarred).toHaveProperty("replace");
   });
 
   it("tolerates an empty or absent batch", () => {
     const { DfirSelection } = load();
     DfirSelection.events.addAll([]);
-    DfirSelection.events.replace(undefined);
+    DfirSelection.events.removeAll(undefined);
     expect(DfirSelection.events.count()).toBe(0);
+  });
+
+  // PIN THE PRODUCTION CALL SITES, not just the API. The off-page semantic lives in which operation
+  // the three select-all handlers call, and an API-level test alone would pass if one of them were
+  // switched to a set-clearing operation.
+  it("has all three select-all handlers committing through addAll and removeAll", () => {
+    for (const panel of ["events", "iocs", "findings"]) {
+      // `events` legitimately has TWO addAll sites — select-all and the swimlane rubber band — so
+      // this pins the OPERATIONS each panel reaches for, not how many times.
+      const methods = new Set(
+        ownerCalls(scriptsForPins, "DfirSelection", ["addAll", "removeAll"])
+          .filter((c) => c.path.startsWith(`DfirSelection.${panel}.`))
+          .map((c) => c.method),
+      );
+      expect(
+        [...methods].sort(),
+        `select-all for ${panel} must union and subtract, never drop the rest`,
+      ).toEqual(["addAll", "removeAll"]);
+    }
+  });
+
+  it("never calls a replace() on a selection anywhere in the page", () => {
+    const calls = ownerCalls(scriptsForPins, "DfirSelection", ["replace"]).map(
+      (c) => `${c.script}:${c.line} ${c.path}()`,
+    );
+    expect(calls, "selections publish no replace(); such a call would throw at runtime").toEqual([]);
   });
 });
 
@@ -189,6 +236,107 @@ describe("no commit happens inside a loop", () => {
     ).toEqual([]);
   });
 
+  // A CALLBACK LOOP IS A LOOP, asserted against the analyser directly.
+  //
+  // The first version of this gate recognised only `for`/`while`, so
+  // `ids.forEach(id => DfirSelection.events.toggle(id))` — the exact shape of three of the four
+  // sites this migration replaced — reported inLoop: false. The gate could not see the regression
+  // it exists to prevent. These cases are the analyser's own contract, and they are here rather
+  // than in a page assertion because the page currently contains none of them, so a page-level
+  // check would pass whether the analyser worked or not.
+  const probe = (body: string) => ownerCalls([scriptFromSource("probe.js", body)], "DfirSelection", COMMITS);
+
+  it.each([
+    ["a for-of loop", "for (const id of ids) DfirSelection.events.toggle(id);"],
+    ["a while loop", "while (n--) DfirSelection.events.toggle('x');"],
+    ["a forEach callback", "ids.forEach((id) => DfirSelection.events.toggle(id));"],
+    ["a map callback", "ids.map((id) => DfirSelection.events.toggle(id));"],
+    ["a sort comparator", "ids.sort((a, b) => DfirSelection.events.toggle(a));"],
+    [
+      "a nested callback inside a loop",
+      "for (const g of gs) g.ids.forEach((id) => DfirSelection.events.toggle(id));",
+    ],
+  ])("counts a commit in %s as in-loop", (_label, body) => {
+    const [call] = probe(body);
+    expect(call, "the analyser did not see the commit at all").toBeDefined();
+    expect(call.inLoop).toBe(true);
+  });
+
+  it.each([
+    ["a plain statement", "DfirSelection.events.toggle('a', true);"],
+    ["the receiver of a forEach", "DfirSelection.events.ids().forEach((x) => x);"],
+    ["a callback that commits nothing", "ids.forEach((id) => other.toggle(id));"],
+  ])("does not count %s as in-loop", (_label, body) => {
+    for (const call of probe(body)) expect(call.inLoop).toBe(false);
+  });
+
+  it("sees a commit at top level, outside any function", () => {
+    expect(probe("DfirSelection.events.clear();")).toHaveLength(1);
+  });
+
+  it.each([
+    ["an alias", "const evs = DfirSelection.events; evs.toggle('a');"],
+    ["a computed member", "DfirSelection.events['toggle']('a');"],
+    ["a dynamic member", "DfirSelection.events[m]('a');"],
+  ])("reports %s as an escape the loop gate cannot follow", (_label, body) => {
+    expect(ownerEscapes([scriptFromSource("probe.js", body)], "DfirSelection").length).toBeGreaterThan(0);
+  });
+
+  // Reaching an owner by a name this analysis cannot follow defeats every rule above, so those
+  // spellings are rejected outright rather than resolved — the same trade setterRefs makes.
+  it.each(["DfirSelection", "DfirStarred"])("%s is never aliased or reached dynamically", (ns) => {
+    const escapes = ownerEscapes(scripts, ns).map((e) => `${e.script}:${e.line} (${e.form}) ${e.text}`);
+    expect(
+      escapes,
+      "an alias or a computed member puts the commit beyond the loop gate. Call the owner by name.",
+    ).toEqual([]);
+  });
+
+  // THE INDIRECT HALF, and its deliberate limit.
+  //
+  // A commit does not stop being per-iteration because a thin wrapper sits between it and the loop:
+  // `for (const id of ids) selectOne(id)` is the shape this catches.
+  //
+  // ONE HOP, NOT FULL REACHABILITY, and that is a judgement rather than an oversight. Run
+  // transitively over this call graph it reports four things today, and not one is a per-element
+  // cost: addTag()/deleteTag() reach deriveStarred() only through loadTags(), which is a fetch, so
+  // each iteration is already a network round-trip (the same reason bulkStarIds is allowlisted);
+  // and createNewCase() reaches proceedConnect(), a whole case connect. In a 19,000-line script
+  // with names this generic, "can eventually reach" stops predicting "runs per iteration", and a
+  // gate whose output is mostly allowlist teaches people to extend the allowlist. The bound is
+  // stated here so the next reader knows what is NOT covered rather than assuming it is.
+  it("no function called directly from inside a loop commits", () => {
+    const committers = new Set(
+      ["DfirSelection", "DfirStarred"]
+        .flatMap((ns) => ownerCalls(scriptsForPins, ns, COMMITS))
+        .map((c) => c.fn)
+        .filter((f) => !f.startsWith("<")),
+    );
+    const offenders = [...calleesInsideLoops(scriptsForPins)]
+      .filter((callee) => committers.has(callee) && !ALLOWED_IN_LOOP.includes(callee))
+      .map((callee) => `${callee}() commits and is called from inside a loop`);
+    expect(offenders).toEqual([]);
+  });
+
+  // THE MODULE'S OWN BULK OPERATIONS MUST NOT LOOP AROUND A COMMIT.
+  //
+  // `addAll` implemented as `for (const id of ids) commit(...)` is the same quadratic cost moved one
+  // level down, where no call-site check sees it: the API would look right and behave exactly as
+  // badly as what it replaced. Checked against the AST rather than by counting `commit(` in the
+  // text, because the counting version passed this exact mutation — one call, inside a loop, is
+  // still one occurrence.
+  it("has no bulk operation looping around its own commit", async () => {
+    const script = scriptFromSource("dashboard-selection.js", await readFile(MODULE, "utf8"));
+    const BULK = ["addAll", "removeAll", "replace", "clear", "toggle"];
+    const offenders: string[] = [];
+    for (const fn of functionsOf(script).filter((f) => BULK.includes(f.name))) {
+      for (const call of ownerCallPositions(fn.node, "commit")) {
+        if (insideLoop(fn.node, call)) offenders.push(`${fn.name}() commits inside a loop`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
   // The allowlist must not outlive what it excuses: an entry that no longer matches anything is a
   // stale exemption that would silently cover a future commit-in-loop in a function of that name.
   it("has no stale entry in the loop allowlist", () => {
@@ -210,8 +358,32 @@ describe("no commit happens inside a loop", () => {
 });
 
 describe("the old bindings are gone", () => {
-  const scripts = dashboardScripts();
+  const scripts = scriptsForPins;
   const MOVED = ["selectedEvents", "selectedIocs", "selectedFindings", "starredEvents"];
+
+  // THE HELPER'S OWN CONTRACT. "Top level" is not the same as "written at the top": in a classic
+  // non-strict script a `var` inside a block hoists to the script, and a bare assignment with no
+  // declaration creates a global outright. Both are the binding this migration removed, wearing a
+  // different hat, and both were invisible to the first version of this check.
+  it.each([
+    ["a plain let", "let selectedEvents = new Set();"],
+    ["a const", "const selectedEvents = new Set();"],
+    ["a bare let", "let selectedEvents;"],
+    ["a var in a block", "if (ready) { var selectedEvents = new Set(); }"],
+    ["a var in a loop body", "for (;;) { var selectedEvents = new Set(); }"],
+    ["an implicit global", "function f() { selectedEvents = new Set(); }"],
+  ])("counts %s as a binding", (_label, src) => {
+    const found = topLevelBindings(scriptFromSource("probe.js", src)).map((b) => b.name);
+    expect(found).toContain("selectedEvents");
+  });
+
+  it.each([
+    ["a let inside a function", "function f() { let selectedEvents = new Set(); }"],
+    ["a parameter", "function f(selectedEvents) { return selectedEvents; }"],
+  ])("does not count %s", (_label, src) => {
+    const found = topLevelBindings(scriptFromSource("probe.js", src)).map((b) => b.name);
+    expect(found).not.toContain("selectedEvents");
+  });
 
   it.each(MOVED)("%s has no top-level binding left in the page", (name) => {
     const offenders = scripts
@@ -251,7 +423,6 @@ describe("nothing but the namespaces escapes", () => {
         "has",
         "ids",
         "removeAll",
-        "replace",
         "toggle",
       ]);
     }

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -297,6 +297,93 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
   return out;
 }
 
+/** One call of an owner's method, and whether a loop encloses it. */
+export interface OwnerCall {
+  script: string;
+  line: number;
+  /** The dotted path as written, e.g. `DfirSelection.events.addAll`. */
+  path: string;
+  method: string;
+  inLoop: boolean;
+  /** The innermost NAMED enclosing function, for allowlisting a documented exception. */
+  fn: string;
+}
+
+/**
+ * Every call to `<namespace>.….<method>` for the named methods, flagged if a loop encloses it.
+ *
+ * THE LOOP FLAG IS THE POINT, and it is specific to replace-on-write owners. A set behind
+ * replace-on-write costs O(n) per commit, so a commit inside a loop is O(n^2) for the gesture —
+ * and js/dashboard-selection.js exists partly because four of the sites it replaced were exactly
+ * that, over data no page size bounds. The bulk operations (addAll/removeAll/replace) are the
+ * supported way to write many ids, so "no commit in a loop" is a rule a test can hold, unlike
+ * "remember that this is O(n)".
+ *
+ * Matches at any depth under the namespace, so `DfirSelection.events.toggle` and a hypothetical
+ * `DfirSelection.toggle` both count; `denotesNamespace` handles the window-rooted spelling.
+ */
+export function ownerCalls(
+  scripts: DashboardScript[],
+  namespace: string,
+  methods: readonly string[],
+): OwnerCall[] {
+  const want = new Set(methods);
+  const out: Array<{ call: OwnerCall; depth: number }> = [];
+  // Walk down a property-access chain to its root, collecting the names on the way.
+  const chain = (n: ts.Node): string[] | null => {
+    if (denotesNamespace(n, namespace)) return [namespace];
+    if (ts.isPropertyAccessExpression(n)) {
+      const head = chain(n.expression);
+      return head ? [...head, n.name.text] : null;
+    }
+    return null;
+  };
+  for (const s of scripts) {
+    const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
+    for (const fn of functionsOf(s)) {
+      const visit = (n: ts.Node): void => {
+        if (ts.isCallExpression(n) && ts.isPropertyAccessExpression(n.expression)) {
+          const path = chain(n.expression);
+          if (path && want.has(path[path.length - 1])) {
+            out.push({
+              call: {
+                script: s.name,
+                line: at(n),
+                path: path.join("."),
+                method: path[path.length - 1],
+                inLoop: insideLoop(fn.node, n.getStart(s.ast)),
+                fn: fn.name,
+              },
+              // How deeply nested the enclosing function is, so the innermost NAMED one wins below.
+              depth: fn.node.getStart(s.ast),
+            });
+          }
+        }
+        ts.forEachChild(n, visit);
+      };
+      ts.forEachChild(fn.node, visit);
+    }
+  }
+  // functionsOf() yields nested functions too, so the same call is seen once per enclosing
+  // function. Collapse them: the loop flag is true if ANY enclosing scope saw a loop (a call in an
+  // arrow inside a for-loop is still in a loop), and the reported function is the innermost NAMED
+  // one, which is what an allowlist entry has to be written against.
+  const byKey = new Map<string, { call: OwnerCall; depth: number }>();
+  for (const c of out) {
+    const key = `${c.call.script}:${c.call.line}:${c.call.path}`;
+    const prev = byKey.get(key);
+    if (!prev) {
+      byKey.set(key, c);
+      continue;
+    }
+    if (c.call.inLoop) prev.call.inLoop = true;
+    const named = (n: string): boolean => !n.startsWith("<");
+    if (c.depth > prev.depth && named(c.call.fn)) prev.call.fn = c.call.fn;
+    else if (!named(prev.call.fn) && named(c.call.fn)) prev.call.fn = c.call.fn;
+  }
+  return [...byKey.values()].map((c) => c.call);
+}
+
 /** A property write through an owner's getter: `DfirScope.get().start = x`. */
 export interface GetterMutation {
   script: string;

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -72,6 +72,18 @@ export function dashboardScripts(): DashboardScript[] {
   return out;
 }
 
+/**
+ * Parse a snippet as if it were one of the dashboard's scripts.
+ *
+ * Exported so the ANALYSER can be tested directly. Every hole found in these gates so far — the
+ * `async function` shape, the transitive call, the window-rooted namespace, the callback loop — was
+ * found by a human reading the code, never by a test, because there was no way to ask "what does
+ * this helper say about this snippet". There is now.
+ */
+export function scriptFromSource(name: string, source: string): DashboardScript {
+  return makeScript(name, source);
+}
+
 function makeScript(name: string, source: string): DashboardScript {
   return {
     name,
@@ -289,12 +301,79 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
       if (ts.isBindingElement(el)) collect(el.name);
     }
   };
+
+  // let/const/class/function at the very top of the script.
   for (const st of script.ast.statements) {
     if (ts.isVariableStatement(st)) {
       for (const d of st.declarationList.declarations) collect(d.name);
     }
   }
+
+  // `var` ANYWHERE outside a function, because it hoists to the script scope regardless of the
+  // block it is written in. `if (ready) { var selectedEvents = new Set(); }` is a script-level
+  // binding, and the first version of this helper — which looked only at direct children of the
+  // SourceFile — reported nothing for it.
+  const declared = new Set(out.map((b) => b.name));
+  const varWalk = (n: ts.Node): void => {
+    if (isFunctionLike(n)) return; // `var` inside a function is that function's, not the script's
+    if (ts.isVariableStatement(n) && n.declarationList.flags & ts.NodeFlags.Let) {
+      // let/const in a nested block is genuinely block-scoped; not ours.
+    } else if (ts.isVariableStatement(n) && !(n.declarationList.flags & ts.NodeFlags.BlockScoped)) {
+      for (const d of n.declarationList.declarations) {
+        const before = out.length;
+        collect(d.name);
+        for (const b of out.slice(before)) declared.add(b.name);
+      }
+    }
+    ts.forEachChild(n, varWalk);
+  };
+  ts.forEachChild(script.ast, varWalk);
+
+  // IMPLICIT GLOBALS. These scripts are not strict, so a bare `selectedEvents = new Set()` with no
+  // declaration anywhere creates a property on the global object — a binding by any useful
+  // definition, and invisible to every declaration-shaped check. Collected by finding assignments
+  // whose target is declared NOWHERE in this script (parameters and nested `let`s included).
+  const declaredAnywhere = new Set<string>();
+  const declWalk = (n: ts.Node): void => {
+    if (ts.isVariableDeclaration(n)) collectInto(n.name, declaredAnywhere);
+    if (isFunctionLike(n)) {
+      const fn = n as ts.FunctionLikeDeclaration;
+      if (fn.name && ts.isIdentifier(fn.name)) declaredAnywhere.add(fn.name.text);
+      for (const p of fn.parameters) collectInto(p.name, declaredAnywhere);
+    }
+    if (ts.isCatchClause(n) && n.variableDeclaration)
+      collectInto(n.variableDeclaration.name, declaredAnywhere);
+    ts.forEachChild(n, declWalk);
+  };
+  ts.forEachChild(script.ast, declWalk);
+
+  const assignWalk = (n: ts.Node): void => {
+    if (
+      ts.isBinaryExpression(n) &&
+      n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(n.left) &&
+      !declaredAnywhere.has(n.left.text) &&
+      !declared.has(n.left.text)
+    ) {
+      out.push({ name: n.left.text, line: at(n.left) });
+      declared.add(n.left.text);
+    }
+    ts.forEachChild(n, assignWalk);
+  };
+  ts.forEachChild(script.ast, assignWalk);
+
   return out;
+}
+
+/** Names bound by a binding pattern, into an existing set. */
+function collectInto(name: ts.BindingName, into: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    into.add(name.text);
+    return;
+  }
+  for (const el of name.elements) {
+    if (ts.isBindingElement(el)) collectInto(el.name, into);
+  }
 }
 
 /** One call of an owner's method, and whether a loop encloses it. */
@@ -328,7 +407,7 @@ export function ownerCalls(
   methods: readonly string[],
 ): OwnerCall[] {
   const want = new Set(methods);
-  const out: Array<{ call: OwnerCall; depth: number }> = [];
+  const out: OwnerCall[] = [];
   // Walk down a property-access chain to its root, collecting the names on the way.
   const chain = (n: ts.Node): string[] | null => {
     if (denotesNamespace(n, namespace)) return [namespace];
@@ -338,50 +417,168 @@ export function ownerCalls(
     }
     return null;
   };
+
   for (const s of scripts) {
     const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
-    for (const fn of functionsOf(s)) {
-      const visit = (n: ts.Node): void => {
-        if (ts.isCallExpression(n) && ts.isPropertyAccessExpression(n.expression)) {
-          const path = chain(n.expression);
-          if (path && want.has(path[path.length - 1])) {
-            out.push({
-              call: {
-                script: s.name,
-                line: at(n),
-                path: path.join("."),
-                method: path[path.length - 1],
-                inLoop: insideLoop(fn.node, n.getStart(s.ast)),
-                fn: fn.name,
-              },
-              // How deeply nested the enclosing function is, so the innermost NAMED one wins below.
-              depth: fn.node.getStart(s.ast),
-            });
-          }
+    // Innermost NAMED function enclosing a position, for allowlisting a documented exception.
+    const named = functionsOf(s).filter((f) => !f.name.startsWith("<"));
+    const enclosing = (n: ts.Node): string => {
+      let best: FunctionInfo | null = null;
+      const p = n.getStart(s.ast);
+      for (const f of named) {
+        if (f.node.getStart(s.ast) <= p && f.node.getEnd() >= p) {
+          if (!best || f.node.getStart(s.ast) > best.node.getStart(s.ast)) best = f;
         }
-        ts.forEachChild(n, visit);
-      };
-      ts.forEachChild(fn.node, visit);
-    }
+      }
+      return best ? best.name : "<top-level>";
+    };
+
+    // ONE walk from the SourceFile, carrying loop depth. Walking per-function (the first version)
+    // skipped every commit at top level, where a classic script does most of its wiring.
+    const visit = (n: ts.Node, loops: number): void => {
+      let inner = loops;
+      if (
+        ts.isForStatement(n) ||
+        ts.isForOfStatement(n) ||
+        ts.isForInStatement(n) ||
+        ts.isWhileStatement(n) ||
+        ts.isDoStatement(n)
+      ) {
+        inner = loops + 1;
+      }
+      if (ts.isCallExpression(n) && ts.isPropertyAccessExpression(n.expression)) {
+        const path = chain(n.expression);
+        if (path && want.has(path[path.length - 1])) {
+          out.push({
+            script: s.name,
+            line: at(n),
+            path: path.join("."),
+            method: path[path.length - 1],
+            inLoop: loops > 0,
+            fn: enclosing(n),
+          });
+        }
+      }
+      // An iteration callback is a loop body, so its ARGUMENTS are walked at depth+1 while the
+      // receiver is not: in `xs.forEach(cb)` the `xs` expression runs once.
+      if (isIterationCall(n)) {
+        visit(n.expression, inner);
+        for (const a of n.arguments) visit(a, inner + 1);
+        return;
+      }
+      ts.forEachChild(n, (c) => visit(c, inner));
+    };
+    ts.forEachChild(s.ast, (c) => visit(c, 0));
   }
-  // functionsOf() yields nested functions too, so the same call is seen once per enclosing
-  // function. Collapse them: the loop flag is true if ANY enclosing scope saw a loop (a call in an
-  // arrow inside a for-loop is still in a loop), and the reported function is the innermost NAMED
-  // one, which is what an allowlist entry has to be written against.
-  const byKey = new Map<string, { call: OwnerCall; depth: number }>();
-  for (const c of out) {
-    const key = `${c.call.script}:${c.call.line}:${c.call.path}`;
-    const prev = byKey.get(key);
-    if (!prev) {
-      byKey.set(key, c);
-      continue;
+  return out;
+}
+
+/**
+ * Positions of every call to a bare `name(...)` within `node`.
+ *
+ * For asking questions about a module's INTERNALS — specifically whether an owner's own bulk
+ * operation loops around its private commit, which no call-site analysis can see.
+ */
+export function ownerCallPositions(node: ts.Node, name: string): number[] {
+  const out: number[] = [];
+  const visit = (n: ts.Node): void => {
+    if (ts.isCallExpression(n) && ts.isIdentifier(n.expression) && n.expression.text === name) {
+      out.push(n.getStart());
     }
-    if (c.call.inLoop) prev.call.inLoop = true;
-    const named = (n: string): boolean => !n.startsWith("<");
-    if (c.depth > prev.depth && named(c.call.fn)) prev.call.fn = c.call.fn;
-    else if (!named(prev.call.fn) && named(c.call.fn)) prev.call.fn = c.call.fn;
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(node, visit);
+  return out;
+}
+
+/**
+ * Names called from inside a loop body, anywhere in these scripts.
+ *
+ * The indirect half of the loop rule: a commit does not stop being per-iteration because a function
+ * call sits between it and the loop. Feed these to reachableFrom() against the set of functions
+ * that commit, and `for (const id of ids) selectOne(id)` is caught even though the commit is a hop
+ * away — the same direct-vs-transitive distinction that cleared jumpToEvent earlier in #415.
+ */
+export function calleesInsideLoops(scripts: DashboardScript[]): Set<string> {
+  const out = new Set<string>();
+  for (const s of scripts) {
+    const visit = (n: ts.Node, loops: number): void => {
+      let inner = loops;
+      if (
+        ts.isForStatement(n) ||
+        ts.isForOfStatement(n) ||
+        ts.isForInStatement(n) ||
+        ts.isWhileStatement(n) ||
+        ts.isDoStatement(n)
+      ) {
+        inner = loops + 1;
+      }
+      if (loops > 0 && ts.isCallExpression(n)) {
+        if (ts.isIdentifier(n.expression)) out.add(n.expression.text);
+        else if (ts.isPropertyAccessExpression(n.expression)) out.add(n.expression.name.text);
+      }
+      if (isIterationCall(n)) {
+        visit(n.expression, inner);
+        for (const a of n.arguments) visit(a, inner + 1);
+        return;
+      }
+      ts.forEachChild(n, (c) => visit(c, inner));
+    };
+    ts.forEachChild(s.ast, (c) => visit(c, 0));
   }
-  return [...byKey.values()].map((c) => c.call);
+  return out;
+}
+
+/** A construct that puts an owner's methods beyond what ownerCalls() can follow. */
+export interface OwnerEscape {
+  script: string;
+  line: number;
+  form: "alias" | "computed-member" | "dynamic-member";
+  text: string;
+}
+
+/**
+ * Ways of reaching an owner that defeat ownerCalls(), reported so they can be REJECTED.
+ *
+ * Same argument as setterRefs' rejection list, for the same reason. `const events =
+ * DfirSelection.events; ids.forEach(id => events.toggle(id))` is a commit in a loop that no
+ * path-matching analysis sees, and `DfirSelection.events["toggle"](id)` is another. Following
+ * either needs binding-aware analysis; neither has a use in this page, and both are one line to
+ * avoid — so they are reported wherever they appear rather than resolved.
+ */
+export function ownerEscapes(scripts: DashboardScript[], namespace: string): OwnerEscape[] {
+  const hits: OwnerEscape[] = [];
+  const denotesOwnerOrChild = (n: ts.Node): boolean => {
+    if (denotesNamespace(n, namespace)) return true;
+    return ts.isPropertyAccessExpression(n) && denotesOwnerOrChild(n.expression);
+  };
+  for (const s of scripts) {
+    const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
+    const visit = (n: ts.Node): void => {
+      // const events = DfirSelection.events
+      if (
+        ts.isVariableDeclaration(n) &&
+        n.initializer &&
+        denotesOwnerOrChild(n.initializer) &&
+        !denotesNamespace(n.initializer, namespace)
+      ) {
+        hits.push({ script: s.name, line: at(n), form: "alias", text: n.getText(s.ast).slice(0, 90) });
+      }
+      // DfirSelection.events["toggle"](…) / DfirSelection.events[m](…)
+      if (ts.isElementAccessExpression(n) && denotesOwnerOrChild(n.expression)) {
+        const arg = n.argumentExpression;
+        hits.push({
+          script: s.name,
+          line: at(n),
+          form: arg && ts.isStringLiteral(arg) ? "computed-member" : "dynamic-member",
+          text: n.getText(s.ast).slice(0, 90),
+        });
+      }
+      ts.forEachChild(n, visit);
+    };
+    ts.forEachChild(s.ast, visit);
+  }
+  return hits;
 }
 
 /** A property write through an owner's getter: `DfirScope.get().start = x`. */
@@ -557,6 +754,40 @@ export function usesAfter(node: ts.Node, name: string, pos: number): number[] {
  * enclosing function can refresh the cell, that is a fault. Conservative by design — a deferred
  * read of a snapshot is worth writing differently even when it happens to be safe.
  */
+/**
+ * Array methods whose callback runs once per element — a loop written as a call.
+ *
+ * These are here because leaving them out made the loop check miss the very shape it was written
+ * for. Three of the four sites js/dashboard-selection.js replaced were `.forEach(cb => …)`, so a
+ * gate that recognised only `for`/`while` reported `inLoop: false` for a re-introduction of the
+ * exact quadratic regression it exists to prevent. Syntax is not the property being tested;
+ * "does this run once per element" is.
+ */
+const ITERATION_METHODS = new Set([
+  "forEach",
+  "map",
+  "filter",
+  "reduce",
+  "reduceRight",
+  "some",
+  "every",
+  "flatMap",
+  "find",
+  "findLast",
+  "findIndex",
+  "findLastIndex",
+  "sort",
+]);
+
+/** Is this node a call whose callback argument runs per element? */
+function isIterationCall(n: ts.Node): n is ts.CallExpression {
+  return (
+    ts.isCallExpression(n) &&
+    ts.isPropertyAccessExpression(n.expression) &&
+    ITERATION_METHODS.has(n.expression.name.text)
+  );
+}
+
 export function insideLoop(node: ts.Node, pos: number): boolean {
   let found = false;
   const visit = (n: ts.Node): void => {
@@ -566,7 +797,10 @@ export function insideLoop(node: ts.Node, pos: number): boolean {
       ts.isForOfStatement(n) ||
       ts.isForInStatement(n) ||
       ts.isWhileStatement(n) ||
-      ts.isDoStatement(n);
+      ts.isDoStatement(n) ||
+      // `xs.forEach(x => …)` — the callback body is a loop body. Only the ARGUMENTS count, not the
+      // receiver: `getIds().forEach(…)` does not put getIds() itself in a loop.
+      (isIterationCall(n) && n.arguments.some((a) => a.pos <= pos && a.end >= pos));
     if (isLoop && n.pos <= pos && n.end >= pos) {
       found = true;
       return;

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -124,6 +124,8 @@
        time, and after dashboard-time.js, whose isoToUtcInput it calls (at call time, so this is
        documentation rather than a constraint). -->
   <script src="/js/dashboard-scope.js"></script>
+  <!-- Tier 2's selection owners (#415). After dashboard-state.js, whose cell() they build on. -->
+  <script src="/js/dashboard-selection.js"></script>
   <!-- The AI tagger-rule feature (#415 tier 3). A whole feature, not the movable half of one —
        js/dashboard-tagger.js explains why that distinction decides what moves next. -->
   <script src="/js/dashboard-tagger.js"></script>
@@ -5480,7 +5482,7 @@
       el.innerHTML = rows.map(e => {
         const origin = e.artifactName || (Array.isArray(e.sources) && e.sources[0]) || "Unknown";
         const sev = e.severity || "Info";
-        const starred = starredEvents.has(e.id);
+        const starred = DfirStarred.has(e.id);
         // Affected host as a leading chip (like the forensic timeline), with the redundant trailing
         // "@ <host>" many importers append stripped off the description.
         let desc = String(e.description || "");
@@ -5700,7 +5702,7 @@
     function genStarredReport() {
       const caseId = superCaseId();
       if (!caseId) return;
-      if (!starredEvents.size) {
+      if (!DfirStarred.count()) {
         stRenderNote("No starred events yet — star rows (☆) in the timeline first; the report runs over only the starred set.");
         return;
       }
@@ -6357,7 +6359,7 @@
     // browsers/analysts (TimeSketch's model: its star is the __ts_star label). starredEvents /
     // starredTagIds are DERIVED from tagsByTarget in loadTags(); legacy localStorage stars are
     // migrated up once per case, then the key is deleted.
-    let starredEvents = new Set();
+    // starredEvents moved to js/dashboard-selection.js as DfirStarred (#415).
     let starredTagIds = new Map();   // eventId -> tag id (needed for DELETE /cases/:id/tags/:tagId)
     let showStarredOnly = false;
     // Transient "show only this set of event ids" filter — set by the Timeline Anomalies
@@ -6389,14 +6391,14 @@
 
     // Rebuild the star lookup from the freshly-loaded tags (called by loadTags()).
     function deriveStarred() {
-      starredEvents = new Set();
-      starredTagIds = new Map();
+      const starred = []; starredTagIds = new Map();
       tagsByTarget.forEach(list => list.forEach(t => {
         if (t.targetType === "event" && t.label === "starred") {
-          starredEvents.add(t.targetId);
+          starred.push(t.targetId);
           starredTagIds.set(t.targetId, t.id);
         }
       }));
+      DfirStarred.replace(starred);
     }
 
     // One-time migration: pre-server-side stars lived in localStorage — push any not already
@@ -6408,7 +6410,7 @@
       let legacy = [];
       try { legacy = JSON.parse(localStorage.getItem(starredKey(caseId)) || "[]"); } catch {}
       if (!legacy.length) return;
-      const toMigrate = legacy.filter(id => !starredEvents.has(id));
+      const toMigrate = legacy.filter(id => !DfirStarred.has(id));
       try {
         for (const id of toMigrate) {
           const r = await fetch(`/cases/${caseId}/tags`, { method: "POST", headers: { "content-type": "application/json" },
@@ -6421,13 +6423,13 @@
     }
 
     function toggleStar(caseId, id) {
-      const wasStarred = starredEvents.has(id);
+      const wasStarred = DfirStarred.has(id);
       // Optimistic flip for instant feedback; loadTags() re-derives the truth after the server call.
-      if (wasStarred) starredEvents.delete(id); else starredEvents.add(id);
+      DfirStarred.toggle(id, !wasStarred);
       renderTimelineEvents(DfirState.lastFt());
       refreshSuperRows();   // the star may belong to a super-timeline row (shared ("event", id) key)
       const revert = () => {
-        if (wasStarred) starredEvents.add(id); else starredEvents.delete(id);
+        DfirStarred.toggle(id, wasStarred);
         renderTimelineEvents(DfirState.lastFt()); refreshSuperRows();
       };
       const req = wasStarred
@@ -6441,50 +6443,48 @@
     }
 
     // --- Multi-select (session-only, cleared on re-render) ----------------------
-    let selectedEvents = new Set();
-    let selectedIocs = new Set();
-    let selectedFindings = new Set();
+    // The three selections moved to js/dashboard-selection.js as DfirSelection (#415, tier 2).
     function updateBulkBar() {
       const bar = document.getElementById("evBulkBar");
       if (!bar) return;
-      if (selectedEvents.size > 0) {
+      if (DfirSelection.events.count() > 0) {
         bar.classList.add("active");
-        document.getElementById("evBulkCount").textContent = `${selectedEvents.size} event${selectedEvents.size !== 1 ? "s" : ""} selected`;
+        document.getElementById("evBulkCount").textContent = `${DfirSelection.events.count()} event${DfirSelection.events.count() !== 1 ? "s" : ""} selected`;
       } else {
         bar.classList.remove("active");
       }
     }
-    function clearSelection() { selectedEvents.clear(); updateBulkBar(); renderTimelineEvents(DfirState.lastFt()); swSelToolbar(); swRenderCanvas(); }
+    function clearSelection() { DfirSelection.events.clear(); updateBulkBar(); renderTimelineEvents(DfirState.lastFt()); swSelToolbar(); swRenderCanvas(); }
     function updateIocBulkBar() {
       const bar = document.getElementById("iocBulkBar");
       if (!bar) return;
-      if (selectedIocs.size > 0) {
+      if (DfirSelection.iocs.count() > 0) {
         bar.classList.add("active");
-        document.getElementById("iocBulkCount").textContent = `${selectedIocs.size} IOC${selectedIocs.size !== 1 ? "s" : ""} selected`;
+        document.getElementById("iocBulkCount").textContent = `${DfirSelection.iocs.count()} IOC${DfirSelection.iocs.count() !== 1 ? "s" : ""} selected`;
       } else {
         bar.classList.remove("active");
       }
     }
-    function clearIocSelection() { selectedIocs.clear(); if (DfirState.lastState()) renderIocs(DfirState.lastState().iocs || []); }
+    function clearIocSelection() { DfirSelection.iocs.clear(); if (DfirState.lastState()) renderIocs(DfirState.lastState().iocs || []); }
     // Bulk star/unstar N events: any unstarred → star all, else unstar all. SERIALIZED requests —
     // TagsStore.add() is read-modify-write on tags.json (same reason addTag()'s bulk mode awaits
     // each call). Set updates are reconciled into the UI by the per-tag ws broadcasts and the final loadTags().
     async function bulkStarIds(caseId, ids, msgEl) {
       if (!caseId || !ids.length) return;
-      const anyUnstarred = ids.some(id => !starredEvents.has(id));
+      const anyUnstarred = ids.some(id => !DfirStarred.has(id));
       try {
         for (let i = 0; i < ids.length; i++) {
           const id = ids[i];
           if (msgEl) { msgEl.style.color = "var(--text-muted)"; msgEl.textContent = `${anyUnstarred ? "starring" : "unstarring"}… (${i + 1}/${ids.length})`; }
-          if (anyUnstarred && !starredEvents.has(id)) {
+          if (anyUnstarred && !DfirStarred.has(id)) {
             const r = await fetch(`/cases/${caseId}/tags`, { method: "POST", headers: { "content-type": "application/json" },
               body: JSON.stringify({ targetType: "event", targetId: id, author: investigatorName(), label: "starred" }) });
             if (!r.ok) throw new Error("HTTP " + r.status);
-            starredEvents.add(id);
+            DfirStarred.toggle(id, true);
           } else if (!anyUnstarred && starredTagIds.has(id)) {
             const r = await fetch(`/cases/${caseId}/tags/${encodeURIComponent(starredTagIds.get(id))}`, { method: "DELETE" });
             if (!r.ok && r.status !== 404) throw new Error("HTTP " + r.status);   // 404 = already gone
-            starredEvents.delete(id);
+            DfirStarred.toggle(id, false);
           }
         }
         if (msgEl) msgEl.textContent = "";
@@ -6495,7 +6495,7 @@
     }
     function bulkToggleStar() {
       const caseId = document.getElementById("caseId").value.trim();
-      bulkStarIds(caseId, [...selectedEvents], document.getElementById("evBulkCount"));
+      bulkStarIds(caseId, DfirSelection.events.ids(), document.getElementById("evBulkCount"));
     }
     function openBulkTagModal(ids, targetType) {
       tagTarget = { bulk: true, ids, targetType: targetType || "event" };
@@ -6511,13 +6511,13 @@
     // what's checked in the modal.
     function bulkMarkFalsePositive() {
       const caseId = document.getElementById("caseId").value.trim();
-      if (!caseId || !selectedEvents.size) return;
-      const ids = [...selectedEvents];
+      if (!caseId || !DfirSelection.events.count()) return;
+      const ids = DfirSelection.events.ids();
       const descById = new Map((DfirState.lastFt() || []).map(e => [String(e.id), String(e.description || "")]));
       const [firstId, ...restIds] = ids;
       const extraRefs = restIds.map(id => ({ kind: "event", ref: id, label: descById.get(id) ?? "" }));
       openFalsePositiveModal("event", firstId, descById.get(firstId) ?? "", extraRefs, () => {
-        selectedEvents.clear();
+        DfirSelection.events.clear();
         renderTimelineEvents(DfirState.lastFt());
         swSelToolbar(); swRenderCanvas();   // clear the rings + hide the swimlane selection bar
       });
@@ -6526,8 +6526,8 @@
     // --- Bulk IOC operations -------------------------------------------------------
     async function bulkEnrichIocs() {
       const caseId = document.getElementById("caseId").value.trim();
-      if (!caseId || !selectedIocs.size) return;
-      const ids = [...selectedIocs];
+      if (!caseId || !DfirSelection.iocs.count()) return;
+      const ids = DfirSelection.iocs.ids();
       const statusEl = document.getElementById("status");
       statusEl.textContent = `enriching ${ids.length} IOC${ids.length !== 1 ? "s" : ""}…`;
       try {
@@ -6543,21 +6543,21 @@
       }
     }
     function bulkTagIocs() {
-      if (selectedIocs.size) openBulkTagModal([...selectedIocs], "ioc");
+      if (DfirSelection.iocs.count()) openBulkTagModal(DfirSelection.iocs.ids(), "ioc");
     }
     // Opens the mark-FP modal on the first selected IOC as the anchor; the rest ride along as
     // extraRefs regardless of what's checked in the modal (bulk IOC marking has no per-item
     // whitelist-promotion — see the "Confirm" handler's addToWhitelist note).
     function bulkMarkIocsFalsePositive() {
       const caseId = document.getElementById("caseId").value.trim();
-      if (!caseId || !selectedIocs.size) return;
-      const ids = [...selectedIocs];
+      if (!caseId || !DfirSelection.iocs.count()) return;
+      const ids = DfirSelection.iocs.ids();
       const iocById = new Map((DfirState.lastState()?.iocs || []).map(i => [i.id, i.value]));
       const [firstId, ...restIds] = ids;
       const firstVal = iocById.get(firstId) ?? firstId;
       const extraRefs = restIds.map(id => ({ kind: "ioc", ref: iocById.get(id) ?? id, label: iocById.get(id) ?? id }));
       openFalsePositiveModal("ioc", firstVal, firstVal, extraRefs, () => {
-        selectedIocs.clear();
+        DfirSelection.iocs.clear();
         if (DfirState.lastState()) renderIocs(DfirState.lastState().iocs || []);
       });
     }
@@ -6566,15 +6566,15 @@
     function updateFindingBulkBar() {
       const bar = document.getElementById("findingBulkBar");
       if (!bar) return;
-      if (selectedFindings.size > 0) {
+      if (DfirSelection.findings.count() > 0) {
         bar.classList.add("active");
-        document.getElementById("findingBulkCount").textContent = `${selectedFindings.size} finding${selectedFindings.size !== 1 ? "s" : ""} selected`;
+        document.getElementById("findingBulkCount").textContent = `${DfirSelection.findings.count()} finding${DfirSelection.findings.count() !== 1 ? "s" : ""} selected`;
       } else {
         bar.classList.remove("active");
       }
     }
     function clearFindingSelection() {
-      selectedFindings.clear();
+      DfirSelection.findings.clear();
       document.querySelectorAll(".finding-row-cb").forEach(cb => {
         cb.checked = false;
         const row = cb.closest(".finding");
@@ -6585,21 +6585,21 @@
       updateFindingBulkBar();
     }
     function bulkTagFindings() {
-      if (selectedFindings.size) openBulkTagModal([...selectedFindings], "finding");
+      if (DfirSelection.findings.count()) openBulkTagModal(DfirSelection.findings.ids(), "finding");
     }
     // Opens the mark-FP modal on the first selected finding as the anchor; the rest ride along as
     // extraRefs. Findings are marked by TITLE (not id) — see fpBtn("finding", f.title) above and
     // buildFalsePositiveMarker on the server, which uses `ref` as the marker key for this kind.
     function bulkMarkFindingsFalsePositive() {
       const caseId = document.getElementById("caseId").value.trim();
-      if (!caseId || !selectedFindings.size) return;
-      const ids = [...selectedFindings];
+      if (!caseId || !DfirSelection.findings.count()) return;
+      const ids = DfirSelection.findings.ids();
       const titleById = new Map((DfirState.lastState()?.findings || []).map(f => [f.id, f.title]));
       const [firstId, ...restIds] = ids;
       const firstTitle = titleById.get(firstId) ?? firstId;
       const extraRefs = restIds.map(id => ({ kind: "finding", ref: titleById.get(id) ?? id, label: titleById.get(id) ?? id }));
       openFalsePositiveModal("finding", firstTitle, firstTitle, extraRefs, () => {
-        selectedFindings.clear();
+        DfirSelection.findings.clear();
         if (DfirState.lastState()) render(DfirState.lastState());
       });
     }
@@ -6625,8 +6625,8 @@
     // to name the skipped ones — otherwise a half-pushed selection reads as a clean success.
     function bulkPushFindingsToTicket(target) {
       const caseId = document.getElementById("caseId").value.trim();
-      if (!caseId || !selectedFindings.size) return;
-      const findingIds = [...selectedFindings];
+      if (!caseId || !DfirSelection.findings.count()) return;
+      const findingIds = DfirSelection.findings.ids();
       const label = ticketLabel(target);
       showToast(`pushing ${findingIds.length} finding(s) to ${label}…`);
       fetch(`/cases/${encodeURIComponent(caseId)}/push/${target}/bulk`, {
@@ -6649,9 +6649,9 @@
     // has no dedicated batch route either). The server purges + pushes updated state per call.
     async function bulkExcludeIocs() {
       const caseId = document.getElementById("caseId").value.trim();
-      if (!caseId || !selectedIocs.size) return;
+      if (!caseId || !DfirSelection.iocs.count()) return;
       const iocById = new Map((DfirState.lastState()?.iocs || []).map(i => [i.id, i.value]));
-      const values = [...selectedIocs].map(id => iocById.get(id)).filter(Boolean);
+      const values = DfirSelection.iocs.ids().map(id => iocById.get(id)).filter(Boolean);
       if (!values.length) return;
       if (!confirm(`Permanently exclude ${values.length} IOC value(s) from this case?\n\nThey are removed now and will never be re-imported or enriched. This cannot be undone (deleting the exclude rule later will not bring them back).`)) return;
       const statusEl = document.getElementById("status");
@@ -6670,15 +6670,15 @@
       statusEl.textContent = succeeded === values.length
         ? `excluded ${succeeded} value(s), purged ${purged} IOC(s) total`
         : `excluded ${succeeded} of ${values.length} value(s) (${values.length - succeeded} failed), purged ${purged} IOC(s) total`;
-      selectedIocs.clear();
+      DfirSelection.iocs.clear();
       if (DfirState.lastState()) renderIocs(DfirState.lastState().iocs || []);
     }
     function bulkCopyIocs() {
       const iocById = new Map((DfirState.lastState()?.iocs || []).map(i => [i.id, i.value]));
-      const text = [...selectedIocs].map(id => iocById.get(id) ?? id).join("\n");
+      const text = DfirSelection.iocs.ids().map(id => iocById.get(id) ?? id).join("\n");
       navigator.clipboard.writeText(text).then(() => {
         const statusEl = document.getElementById("status");
-        statusEl.textContent = `copied ${selectedIocs.size} IOC value${selectedIocs.size !== 1 ? "s" : ""} to clipboard`;
+        statusEl.textContent = `copied ${DfirSelection.iocs.count()} IOC value${DfirSelection.iocs.count() !== 1 ? "s" : ""} to clipboard`;
       }).catch(() => {});
     }
 
@@ -12726,7 +12726,7 @@
             ctx.strokeStyle = themeColor("--text-bright"); ctx.lineWidth = 1.5; ctx.stroke();
           }
           // Multi-select ring (events chosen for a batch action; bidirectional with the table).
-          if (selectedEvents.has(e.id)) {
+          if (DfirSelection.events.has(e.id)) {
             ctx.beginPath(); ctx.arc(x, cy, r+3, 0, 2*Math.PI);
             ctx.strokeStyle = themeColor("--accent"); ctx.lineWidth = 2; ctx.stroke();
           }
@@ -12794,7 +12794,7 @@
     function swSelToolbar() {
       const bar = document.getElementById("swimlaneSelBar");
       if (!bar) return;
-      const n = selectedEvents.size;
+      const n = DfirSelection.events.count();
       if (n > 0) {
         bar.classList.add("active");
         document.getElementById("swimlaneSelCount").textContent = `${n} event${n !== 1 ? "s" : ""} selected`;
@@ -12819,17 +12819,19 @@
       const y0 = Math.min(swRubber.y0, swRubber.y1), y1 = Math.max(swRubber.y0, swRubber.y1);
       if ((x1 - x0) < 4 && (y1 - y0) < 4) {
         const hit = swHitTest(canvas, swRubber.x1, swRubber.y1);
-        if (hit) { selectedEvents.has(hit.id) ? selectedEvents.delete(hit.id) : selectedEvents.add(hit.id); }
+        if (hit) DfirSelection.events.toggle(hit.id);
       } else {
+        const hits = [];   // collected first, committed once — see js/dashboard-selection.js
         swLanes.forEach((lane, i) => {
           const cy = i * SW_LANE_H + SW_LANE_H / 2;
           if (cy < y0 || cy > y1) return;
           for (const e of lane.events) {
             const ms = Date.parse(e.timestamp); if (Number.isNaN(ms)) continue;
             const x = swTsToX(ms, canvas.width);
-            if (x >= x0 && x <= x1) selectedEvents.add(e.id);
+            if (x >= x0 && x <= x1) hits.push(e.id);
           }
         });
+        DfirSelection.events.addAll(hits);
       }
       swSelectionChanged();
     }
@@ -13170,10 +13172,10 @@
       document.getElementById("swimlaneScopeView").addEventListener("click", swScopeToView);
       document.getElementById("swimlanePng").addEventListener("click", swExportPng);
       document.getElementById("swimlaneSelFp").addEventListener("click", function() {
-        if (selectedEvents.size) bulkMarkFalsePositive();   // shared with the table's bulk bar
+        if (DfirSelection.events.count()) bulkMarkFalsePositive();   // shared with the table's bulk bar
       });
       document.getElementById("swimlaneSelClear").addEventListener("click", function() {
-        selectedEvents.clear(); swSelectionChanged();
+        DfirSelection.events.clear(); swSelectionChanged();
       });
       if (typeof ResizeObserver !== "undefined") {
         new ResizeObserver(() => swRenderCanvas()).observe(document.getElementById("swimlaneWrap"));
@@ -13569,8 +13571,8 @@
       // Select-all is page-scoped (matches the forensic timeline): the header checkbox reflects only the
       // rows actually rendered on this page, since the select-all click handler acts on the rendered rows.
       const allIds = pageVisible.map(i => i.id);
-      const allSel = allIds.length > 0 && allIds.every(id => selectedIocs.has(id));
-      const someSel = allIds.some(id => selectedIocs.has(id));
+      const allSel = allIds.length > 0 && allIds.every(id => DfirSelection.iocs.has(id));
+      const someSel = allIds.some(id => DfirSelection.iocs.has(id));
       const countLabel = visible.length === iocs.length
         ? `${visible.length} IOC${visible.length !== 1 ? "s" : ""}`
         : `${visible.length} of ${iocs.length} IOC${iocs.length !== 1 ? "s" : ""} shown`;
@@ -13590,7 +13592,7 @@
         + `</div>`;
       const rows = pageVisible.map(i => {
         const isNew = newIocKeys.has(i.value);
-        const isSel = selectedIocs.has(i.id);
+        const isSel = DfirSelection.iocs.has(i.id);
         const isFp = fpVals.has(String(i.value).trim().toLowerCase());
         const newBadge = isNew ? ` <span class="ev-new-badge" title="Added by the last import">NEW</span>` : "";
         // Already marked false-positive: show it (strikethrough) even when the "Hide FP/no-intel"
@@ -13957,7 +13959,7 @@
       const filtering = activeSevs.size < allSevs.length;
       let visible = filtering ? ft.filter(e => activeSevs.has(e.severity)) : ft;
       if (evIdFilter) visible = visible.filter(e => evIdFilter.has(String(e.id)));
-      if (showStarredOnly) visible = visible.filter(e => starredEvents.has(String(e.id)));
+      if (showStarredOnly) visible = visible.filter(e => DfirStarred.has(String(e.id)));
       if (searchTerm) visible = visible.filter(e => _evMatchesSearch(e, searchTerm));
       if (excludeTerms.length) visible = visible.filter(e => !_evMatchesExclude(e, excludeTerms));
       if (filterFrom || filterTo) visible = visible.filter(e => _evMatchesTimeRange(e, filterFrom, filterTo));
@@ -14010,8 +14012,8 @@
       }
 
       const allIds = pageVisible.map(e => String(e.id));
-      const allSelected = allIds.length > 0 && allIds.every(id => selectedEvents.has(id));
-      const someSelected = allIds.some(id => selectedEvents.has(id));
+      const allSelected = allIds.length > 0 && allIds.every(id => DfirSelection.events.has(id));
+      const someSelected = allIds.some(id => DfirSelection.events.has(id));
 
       // Pagination controls bar (shown only when content exceeds one page).
       const pageSizes = [50, 100, 250, 500, 0];
@@ -14036,8 +14038,8 @@
       const tld = loadTlDisplay();   // per-browser timeline-row display toggles (Settings → General)
       const rows = pageVisible.map(e => {
         const id = String(e.id);
-        const starred = starredEvents.has(id);
-        const isSelected = selectedEvents.has(id);
+        const starred = DfirStarred.has(id);
+        const isSelected = DfirSelection.events.has(id);
         const isNew = newEventKeys.has(evKey(e));   // added by the last import (see #importMeta)
         const newBadge = isNew ? ` <span class="ev-new-badge" title="Added by the last import">NEW</span>` : "";
 
@@ -14864,8 +14866,8 @@
           : `(${totalFindings} finding${totalFindings !== 1 ? "s" : ""})`;
       }
       const findingAllIds = capped.map(f => f.id);
-      const findingAllSel = findingAllIds.length > 0 && findingAllIds.every(id => selectedFindings.has(id));
-      const findingSomeSel = findingAllIds.some(id => selectedFindings.has(id));
+      const findingAllSel = findingAllIds.length > 0 && findingAllIds.every(id => DfirSelection.findings.has(id));
+      const findingSomeSel = findingAllIds.some(id => DfirSelection.findings.has(id));
       const findingHeaderRow = capped.length
         ? `<div class="finding-header-row">` +
             `<span data-safe-style="grid-column:1/3;display:flex;align-items:center;gap:6px">` +
@@ -14893,7 +14895,7 @@
             const confTitle = `AI confidence: ${f.confidence}%` + (f.confidenceReason ? ` — ${f.confidenceReason}` : "");
             confMeter = `<span class="fcbar" title="${escAttr(confTitle)}"><span data-safe-style="width:${f.confidence}%;background:${barColor}"></span></span><span class="fcpct">${f.confidence}%</span>`;
           }
-          const isSelFinding = selectedFindings.has(f.id);
+          const isSelFinding = DfirSelection.findings.has(f.id);
           const evidenceBody = findingEvidenceDetails(f, state.caseId, evidence, suppEventsByFinding[f.id] || [], state.iocs, citeIds);
           const hasEvidence = !!evidenceBody;
           // A plain <button>, not a native <summary> — <details> hides ALL non-summary children
@@ -15169,10 +15171,10 @@
       })();
       verifyCustodyOnOpen(caseId);
       applySavedViewForCase();   // restore this case's dashboard-view preset (#142)
-      starredEvents = new Set(); starredTagIds = new Map();   // reset synchronously; loadTags re-derives for the new case
-      selectedEvents.clear();
-      selectedIocs.clear();
-      selectedFindings.clear();
+      DfirStarred.replace([]); starredTagIds = new Map();   // reset synchronously; loadTags re-derives for the new case
+      DfirSelection.events.clear();
+      DfirSelection.iocs.clear();
+      DfirSelection.findings.clear();
       hiddenSources.clear(); _srcMenuSig = "";
       hiddenOrigins.clear(); _originMenuSig = "";
       hiddenHosts.clear(); _hostMenuSig = "";
@@ -16337,7 +16339,7 @@
       if (geoLi) { geoFocusIp(geoLi.getAttribute("data-geo-ip")); return; }
       // Bulk action bar buttons (events)
       if (e.target.id === "evBulkStarBtn") { bulkToggleStar(); return; }
-      if (e.target.id === "evBulkTagBtn") { if (selectedEvents.size) openBulkTagModal([...selectedEvents]); return; }
+      if (e.target.id === "evBulkTagBtn") { if (DfirSelection.events.count()) openBulkTagModal(DfirSelection.events.ids()); return; }
       if (e.target.id === "evBulkFpBtn") { bulkMarkFalsePositive(); return; }
       if (e.target.id === "evBulkClearBtn") { clearSelection(); return; }
       // Super-timeline bulk actions + filter toggles
@@ -16519,14 +16521,14 @@
       const rowCb = e.target.classList.contains("ev-row-cb") && e.target;
       if (rowCb) {
         const id = rowCb.getAttribute("data-evid");
-        if (e.target.checked) selectedEvents.add(id); else selectedEvents.delete(id);
+        DfirSelection.events.toggle(id, e.target.checked);
         const row = rowCb.closest(".ev-row");
         if (row) row.classList.toggle("ev-selected", e.target.checked);
         updateBulkBar();
         // keep select-all checkbox in sync
         const allIds = [...document.querySelectorAll(".ev-row-cb")].map(cb => cb.getAttribute("data-evid"));
-        const allSel = allIds.every(id => selectedEvents.has(id));
-        const someSel = allIds.some(id => selectedEvents.has(id));
+        const allSel = allIds.every(id => DfirSelection.events.has(id));
+        const someSel = allIds.some(id => DfirSelection.events.has(id));
         const sa = document.getElementById("evSelectAll");
         if (sa) { sa.checked = allSel; sa.indeterminate = someSel && !allSel; }
         swReflectSelection();   // mirror onto the swimlane dots
@@ -16534,12 +16536,12 @@
       }
       if (e.target.id === "stSelectAll") { toggleSuperSelectAll(e.target.checked); return; }
       if (e.target.id === "evSelectAll") {
-        document.querySelectorAll(".ev-row-cb").forEach(cb => {
-          const id = cb.getAttribute("data-evid");
-          if (e.target.checked) selectedEvents.add(id); else selectedEvents.delete(id);
+        const boxes = [...document.querySelectorAll(".ev-row-cb")];
+        const ids = boxes.map((cb) => cb.getAttribute("data-evid"));
+        if (e.target.checked) DfirSelection.events.addAll(ids); else DfirSelection.events.removeAll(ids);
+        boxes.forEach((cb) => {
           cb.checked = e.target.checked;
-          const row = cb.closest(".ev-row");
-          if (row) row.classList.toggle("ev-selected", e.target.checked);
+          const row = cb.closest(".ev-row"); if (row) row.classList.toggle("ev-selected", e.target.checked);
         });
         updateBulkBar();
         swReflectSelection();   // mirror onto the swimlane dots
@@ -16548,25 +16550,25 @@
       const iocRowCb = e.target.closest && e.target.closest(".ioc-row-cb");
       if (iocRowCb) {
         const id = iocRowCb.getAttribute("data-iocid");
-        if (e.target.checked) selectedIocs.add(id); else selectedIocs.delete(id);
+        DfirSelection.iocs.toggle(id, e.target.checked);
         const row = iocRowCb.closest(".ioc-row");
         if (row) row.classList.toggle("ioc-selected", e.target.checked);
         updateIocBulkBar();
         const allIds = [...document.querySelectorAll(".ioc-row-cb")].map(cb => cb.getAttribute("data-iocid"));
-        const allSel = allIds.every(id => selectedIocs.has(id));
-        const someSel = allIds.some(id => selectedIocs.has(id));
+        const allSel = allIds.every(id => DfirSelection.iocs.has(id));
+        const someSel = allIds.some(id => DfirSelection.iocs.has(id));
         const sa = document.getElementById("iocSelectAll");
         if (sa) { sa.checked = allSel; sa.indeterminate = someSel && !allSel; }
         return;
       }
       // IOC select-all checkbox
       if (e.target.id === "iocSelectAll") {
-        document.querySelectorAll(".ioc-row-cb").forEach(cb => {
-          const id = cb.getAttribute("data-iocid");
-          if (e.target.checked) selectedIocs.add(id); else selectedIocs.delete(id);
+        const boxes = [...document.querySelectorAll(".ioc-row-cb")];
+        const ids = boxes.map((cb) => cb.getAttribute("data-iocid"));
+        if (e.target.checked) DfirSelection.iocs.addAll(ids); else DfirSelection.iocs.removeAll(ids);
+        boxes.forEach((cb) => {
           cb.checked = e.target.checked;
-          const row = cb.closest(".ioc-row");
-          if (row) row.classList.toggle("ioc-selected", e.target.checked);
+          const row = cb.closest(".ioc-row"); if (row) row.classList.toggle("ioc-selected", e.target.checked);
         });
         updateIocBulkBar();
       }
@@ -16574,25 +16576,25 @@
       const findingRowCb = e.target.closest && e.target.closest(".finding-row-cb");
       if (findingRowCb) {
         const id = findingRowCb.getAttribute("data-fid");
-        if (e.target.checked) selectedFindings.add(id); else selectedFindings.delete(id);
+        DfirSelection.findings.toggle(id, e.target.checked);
         const row = findingRowCb.closest(".finding");
         if (row) row.classList.toggle("finding-selected", e.target.checked);
         updateFindingBulkBar();
         const allIds = [...document.querySelectorAll(".finding-row-cb")].map(cb => cb.getAttribute("data-fid"));
-        const allSel = allIds.every(id => selectedFindings.has(id));
-        const someSel = allIds.some(id => selectedFindings.has(id));
+        const allSel = allIds.every(id => DfirSelection.findings.has(id));
+        const someSel = allIds.some(id => DfirSelection.findings.has(id));
         const sa = document.getElementById("findingSelectAll");
         if (sa) { sa.checked = allSel; sa.indeterminate = someSel && !allSel; }
         return;
       }
       // Finding select-all checkbox
       if (e.target.id === "findingSelectAll") {
-        document.querySelectorAll(".finding-row-cb").forEach(cb => {
-          const id = cb.getAttribute("data-fid");
-          if (e.target.checked) selectedFindings.add(id); else selectedFindings.delete(id);
+        const boxes = [...document.querySelectorAll(".finding-row-cb")];
+        const ids = boxes.map((cb) => cb.getAttribute("data-fid"));
+        if (e.target.checked) DfirSelection.findings.addAll(ids); else DfirSelection.findings.removeAll(ids);
+        boxes.forEach((cb) => {
           cb.checked = e.target.checked;
-          const row = cb.closest(".finding");
-          if (row) row.classList.toggle("finding-selected", e.target.checked);
+          const row = cb.closest(".finding"); if (row) row.classList.toggle("finding-selected", e.target.checked);
         });
         updateFindingBulkBar();
       }

--- a/public/js/dashboard-selection.js
+++ b/public/js/dashboard-selection.js
@@ -1,0 +1,152 @@
+// Who owns what the analyst has selected, and what they have starred (#415, tier 2).
+//
+// Two owners, not one, and the split is deliberate: DfirSelection is ephemeral view state that dies
+// with the page, while DfirStarred is a local cache of server-side tags that loadTags() re-derives
+// from the truth. They look alike — both are sets of ids — and that is exactly why merging them
+// would be a mistake: a "clear everything" on the selection owner would silently unstar the case.
+//
+//
+// WHAT THE MEASUREMENT SAYS, AND WHY IT CHANGED THE DESIGN
+//
+// Resolved through a real lexical scope chain over the inline script:
+//
+//                      reassignments   IN-PLACE MUTATIONS   reader functions
+//   selectedEvents           0              11 in 8 fns          21
+//   selectedIocs             0               8 in 6 fns          18
+//   selectedFindings         0               7 in 5 fns          15
+//   starredEvents            2               7 in 4 fns          13
+//
+// Compare the scope window, which moved first: three whole-value writes and ZERO in-place
+// mutations, so putting it behind an accessor was a rename. This is the opposite. Every selection
+// Set is mutated in place and never replaced, so "replace-on-write" is a real change of mechanism
+// and had to be designed rather than assumed.
+//
+// THE LOOP IS THE REASON THIS API HAS BULK OPERATIONS. Four of those mutation sites are inside a
+// loop:
+//
+//   - select-all for events / IOCs / findings — `document.querySelectorAll(".ev-row-cb")
+//     .forEach(cb => { if (checked) selectedEvents.add(id); else selectedEvents.delete(id); })`
+//   - the swimlane rubber-band, which adds every event inside the dragged rectangle.
+//
+// Turning each of those `.add()` calls into its own replace-on-write commit is O(n) per iteration,
+// so O(n^2) for the gesture. That is not a micro-optimisation worry: `tlPageSize` is analyst-
+// selectable and 0 means "show every row" (see renderTimelineEvents), so select-all is NOT bounded
+// by a page, and neither is the swimlane's lane data. On a real case that is a hung tab, not a slow
+// one. So the bulk gestures commit ONCE, through replace(), and the loops build a plain collection
+// first. That is also fewer commits than today, not more.
+//
+//
+// NO LIVE SET LEAVES THIS CLOSURE, AND FREEZING IS NOT HOW THAT IS ACHIEVED
+//
+// Worth stating because the obvious hardening does nothing: `Object.freeze(new Set())` freezes the
+// object's own properties, and a Set's contents live in internal slots, so a frozen Set still
+// accepts `.add()`. Freezing one would look like protection while providing none — the trap the
+// scope window avoids only because a plain `{start, end}` object genuinely does freeze.
+//
+// So the Set simply never escapes. Reads are `has(id)`, `count()` and `ids()`, and `ids()` hands
+// back a frozen ARRAY copy. Those three cover every read form in the page today (24 `.has(`,
+// 17 `.size`, 11 `[...set]`), so nothing needs the container itself.
+//
+//
+// NO REFRESH IN HERE. The three selections cost wildly different amounts to repaint — clearing the
+// event selection repaints the whole timeline and the swimlane canvas, clearing the finding
+// selection is pure in-place class toggling that deliberately preserves scroll and focus. An owner
+// that redrew on commit would have to pick one, so refresh stays at the call sites where that
+// difference already lives. Same conclusion as js/dashboard-scope.js, reached from the same
+// measurement, and the reason neither publishes a change subscription.
+//
+// NOT AN ES MODULE, and an IIFE, for the reasons js/dashboard-state.js sets out at length.
+(function () {
+  /**
+   * One set of ids, owned: replace-on-write, and the container never escapes.
+   *
+   * A shared factory rather than four hand-written copies — the replace-on-write discipline is the
+   * thing that must not vary between them, and four copies is how one of them quietly keeps a
+   * mutation. It is an implementation detail, not a published generic cell: callers only ever see
+   * the named surfaces at the bottom of this file.
+   */
+  function idSet() {
+    const cell = window.DfirState.cell(new Set());
+    // Every write goes through here, so there is one place where a new Set is built and committed.
+    const commit = (next) => cell.set(next);
+    return {
+      has: (id) => cell.get().has(id),
+      count: () => cell.get().size,
+      /** A frozen COPY. The live Set is not handed out; see the header. */
+      ids: () => Object.freeze([...cell.get()]),
+      /**
+       * Add or remove one id. `on` omitted means flip, matching classList.toggle — which is the
+       * shape the call sites already use, since most of them are driven by a checkbox's checked
+       * state and one (the swimlane's click-to-toggle) is a genuine flip.
+       */
+      toggle(id, on) {
+        const current = cell.get();
+        const want = on === undefined ? !current.has(id) : Boolean(on);
+        if (want === current.has(id)) return current.size; // no commit for a no-op write
+        const next = new Set(current);
+        if (want) next.add(id);
+        else next.delete(id);
+        return commit(next).size;
+      },
+      /** The whole set at once — deriving from the server, and resetting for a new case. ONE commit. */
+      replace(ids) {
+        return commit(new Set(ids || [])).size;
+      },
+      /**
+       * Union in a batch — select-all, and the swimlane rubber band. ONE commit.
+       *
+       * NOT `replace()`, and the difference is a behaviour the page already has: select-all ticks
+       * the RENDERED rows, and `tlPageSize` paginates, so rows selected on another page must stay
+       * selected. Replacing would silently drop them. Union is what the per-row `.add()` loop did.
+       */
+      addAll(ids) {
+        const next = new Set(cell.get());
+        for (const id of ids || []) next.add(id);
+        return commit(next).size;
+      },
+      /** The mirror image: un-ticking select-all removed only the rendered rows. ONE commit. */
+      removeAll(ids) {
+        const next = new Set(cell.get());
+        for (const id of ids || []) next.delete(id);
+        return commit(next).size;
+      },
+      clear() {
+        return commit(new Set()).size;
+      },
+    };
+  }
+
+  /**
+   * What the analyst has ticked, per panel.
+   *
+   * Three separate sets rather than one keyed by kind, because that is what they are: an event id
+   * and a finding id are different namespaces, the bulk bars are three different elements, and the
+   * three "clear" gestures already cost three different amounts to repaint.
+   */
+  window.DfirSelection = {
+    events: idSet(),
+    iocs: idSet(),
+    findings: idSet(),
+  };
+
+  /**
+   * Which events carry the "starred" tag.
+   *
+   * A CACHE, unlike the selections — the truth is tags.json on the server, and loadTags() calls
+   * deriveStarred() to rebuild this from it. toggleStar() flips it optimistically for instant
+   * feedback and reverts on failure, which is why `toggle` is here and why the revert re-reads the
+   * current set rather than restoring a snapshot it captured beforehand.
+   */
+  window.DfirStarred = (() => {
+    const set = idSet();
+    return {
+      has: set.has,
+      count: set.count,
+      ids: set.ids,
+      /** Optimistic flip, and its revert. */
+      toggle: (id, on) => set.toggle(id, on),
+      /** Rebuild from the server's tags — deriveStarred's one commit at the end of its loop. */
+      replace: (ids) => set.replace(ids),
+    };
+  })();
+})();

--- a/public/js/dashboard-selection.js
+++ b/public/js/dashboard-selection.js
@@ -32,8 +32,15 @@
 // so O(n^2) for the gesture. That is not a micro-optimisation worry: `tlPageSize` is analyst-
 // selectable and 0 means "show every row" (see renderTimelineEvents), so select-all is NOT bounded
 // by a page, and neither is the swimlane's lane data. On a real case that is a hung tab, not a slow
-// one. So the bulk gestures commit ONCE, through replace(), and the loops build a plain collection
-// first. That is also fewer commits than today, not more.
+// one. So the bulk gestures collect the ids first and commit ONCE, through addAll()/removeAll().
+// That is also fewer commits than today, not more.
+//
+// addAll/removeAll and NOT replace, which is why the selections do not publish a replace() at all.
+// Select-all ticks the RENDERED rows and the timeline paginates, so rows ticked on another page
+// have to survive the gesture — the per-row `.add()` loop did that for free and `replace()` would
+// silently drop them. An operation with no caller that can quietly lose the analyst's selection is
+// not worth having on the surface, so it is not on it. DfirStarred keeps replace() because
+// deriveStarred() genuinely does rebuild the whole set from the server's tags.
 //
 //
 // NO LIVE SET LEAVES THIS CLOSURE, AND FREEZING IS NOT HOW THAT IS ACHIEVED
@@ -123,10 +130,17 @@
    * and a finding id are different namespaces, the bulk bars are three different elements, and the
    * three "clear" gestures already cost three different amounts to repaint.
    */
+  const selection = () => {
+    // Everything the factory offers EXCEPT replace(): see the header. Spelled out rather than
+    // deleted from the factory because DfirStarred does need it.
+    const { has, count, ids, toggle, addAll, removeAll, clear } = idSet();
+    return { has, count, ids, toggle, addAll, removeAll, clear };
+  };
+
   window.DfirSelection = {
-    events: idSet(),
-    iocs: idSet(),
-    findings: idSet(),
+    events: selection(),
+    iocs: selection(),
+    findings: selection(),
   };
 
   /**

--- a/public/js/dashboard-state.js
+++ b/public/js/dashboard-state.js
@@ -51,9 +51,25 @@
 //   2. THE SELECTION — the filter and selection cells that genuinely cross features: filterFrom,
 //      filterTo, searchTerm, excludeTerms, scope, selectedEvents/Iocs/Findings, starredEvents,
 //      hiddenSources/Origins/Hosts, activeView. Roughly fifteen bindings, 4-6 writers and 6-13
-//      readers each. Owned here too, but as cells with change notification, because a write has to
-//      make other panels re-render and today that is done by each writer remembering to call the
-//      right render function.
+//      readers each.
+//
+//      THIS PARAGRAPH USED TO SAY "owned here too, but as cells with change notification". Both
+//      halves turned out to be wrong once the tier was measured rather than sketched, and the note
+//      is kept rather than quietly rewritten because the reasoning is the useful part:
+//
+//        - NOT HERE. Each of these cells has its own domain, its own refresh cost and its own
+//          server contract. `scope` is server-persisted with three distinct refresh paths;
+//          the selections are ephemeral; starred is a cache of server tags. They live in
+//          js/dashboard-scope.js and js/dashboard-selection.js, as named owners.
+//        - NOT CHANGE NOTIFICATION. A subscriber is ONE fixed reaction to a write, and the
+//          measurement says these writes want different ones: loadScope commits without
+//          redrawing, the websocket branch redraws, applyScope refetches and reloads twenty
+//          panels. A single subscriber would have to be the union of all three, which is a
+//          behaviour change wearing a refactor's clothes. So refresh stays at the call sites and
+//          neither owner publishes a subscription.
+//
+//      What tier 2 kept from this file is `cell` itself — the factory below — which is exactly
+//      what it is exported for.
 //
 //   3. EVERYTHING ELSE — the 231 bindings read by five functions or fewer. NOT owned here. They
 //      are feature-local variables that look global because the whole page shares one scope; they
@@ -97,11 +113,15 @@
 //
 // WHAT IS LEFT, in order:
 //
-//   TIER 2, the ~15 selection cells. Harder than tier 1 despite being smaller: 4-6 writers each,
-//   so migrating one means deciding which of its writers is the owner, or accepting that some cells
-//   have several and the single-writer gate does not apply to them. The subscriber list exists for
-//   this tier and is still unused — today every writer re-renders by remembering to call the right
-//   function, which is the coupling `onLastStateChange` is meant to replace.
+//   TIER 2 IS UNDER WAY, in its own modules rather than here. `scope` moved first
+//   (js/dashboard-scope.js): three writers, one per refresh path, gated by an allowlist rather than
+//   by a count, because the single-writer rule cannot express a cell that three routes legitimately
+//   write. The three selections and the star cache followed (js/dashboard-selection.js) as
+//   replace-on-write owners, where the gate is "no commit inside a loop" — the cost of the
+//   mechanism rather than the number of writers. What is left of tier 2 is the timeline view.
+//
+//   The subscriber list is still unused, and the tier-2 work is the reason it will stay that way:
+//   see the note in tier 2 above.
 //
 //   TIER 3, the 231 feature-local bindings. The bulk of the remaining inline script, and the reason
 //   tiers 1 and 2 came first: a function that reads only its own feature's state can move into that


### PR DESCRIPTION
Second **tier 2** step of #415, after [#467](https://github.com/hasamba/DFIR-Companion/pull/467) moved the scope window. Four sets move behind two owners: `DfirSelection` (events / IOCs / findings) and `DfirStarred`.

## Why this one is not a rename

Scope was three whole-value writes and **zero** in-place mutations, so an accessor was a rename. These are the opposite:

| | reassignments | **in-place mutations** | reader fns |
|---|---|---|---|
| `selectedEvents` | 0 | **11** in 8 fns | 21 |
| `selectedIocs` | 0 | **8** in 6 fns | 18 |
| `selectedFindings` | 0 | **7** in 5 fns | 15 |
| `starredEvents` | 2 | **7** in 4 fns | 13 |

Replace-on-write is a real change of mechanism here, so the design had to follow the measurement rather than the plan.

## The loop is why there are bulk operations

Four mutation sites are **inside a loop** — select-all for each of the three panels, and the swimlane rubber band. One commit per iteration is O(n) each, so O(n²) for the gesture. That is not a micro-concern: `tlPageSize` is analyst-selectable and **0 means "show every row"**, so select-all is not bounded by a page, and the swimlane's lane data isn't either. On a real case that is a hung tab, not a slow one.

So the bulk gestures collect first and commit **once** — which is also *fewer* commits than today.

**`addAll`/`removeAll`, not `replace`/`clear`,** and that distinction is load-bearing: select-all ticks the *rendered* rows, so rows selected on another page must survive it. The per-row `.add()` loop did that for free; `replace()` would silently drop them. There is a test, and it fires when `addAll` is degraded to `replace`.

## Two owners, not one

`DfirSelection` is ephemeral view state; `DfirStarred` is a local cache of server-side tags that `loadTags()` re-derives. They look alike, which is exactly the risk — a "clear everything" on the selection owner would otherwise unstar the case.

## No live Set escapes, and freezing is not how

Worth stating because the obvious hardening does nothing: `Object.freeze(new Set())` freezes own properties, and a Set's contents live in internal slots, so a "frozen" Set still accepts `.add()`. The container simply never leaves the closure; `ids()` returns a frozen **array** copy. The three published reads cover every read form the page had — 24 `.has(`, 17 `.size`, 11 `[...set]`.

No refresh in the module, for the same reason as `dashboard-scope.js`: clearing the event selection repaints the timeline and swimlane canvas, clearing the finding selection is pure in-place class toggling that preserves scroll and focus. An owner that redrew on commit would have to pick one.

## The gate

New and specific to replace-on-write: `ownerCalls()` reports every commit and whether a loop encloses it, and **no commit may sit in one**.

`bulkStarIds` is the single allowlisted exception, pinned **by name with its reason** rather than by narrowing the gate to miss it — it awaits one HTTP request per id (`TagsStore.add` is read-modify-write on `tags.json`), so a Set copy is not the cost there, and batching would be actively wrong because each id must land as its own request succeeds. A companion test fails if that allowlist entry ever stops matching anything, so the exemption cannot outlive what it excuses.

**7 mutations, 7 gates fired:** a commit in a loop, a stranded allowlist entry, the old binding returning, `addAll` degraded to `replace`, `ids()` handing back the live Set, the IIFE removed, and a `subscribe()` appearing on the surface.

## Gates

`build`, `lint`, `format:check`, `check:imports`, `check:boundaries` green; route inventory re-baselined (+1 line, the new asset). Full suite **7368 passed**; the 2 failures are the known local `sharp` 0.33.5/vips 8.15.3 in the shared `node_modules`, below what `sharpVersion.test.ts` requires — that file is untouched here and CI installs fresh.

`check:size` is worth a note: it caught this change **growing** the inline script by 15 lines, all of it commentary I had added to the page. The argument moved into the module that owns the rule, which is where it belonged, and the inline script ends up not growing at all.
