### PR TITLE
refactor(dashboard): give the facet filters an owner and derive the stale prune (#415 tier 2)

### DIFF
--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -6,7 +6,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/css/dashboard.css": 3261,
-  "public/dashboard.html#inline-js": 18104,
+  "public/dashboard.html#inline-js": 18108,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -6,7 +6,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/css/dashboard.css": 3261,
-  "public/dashboard.html#inline-js": 18108,
+  "public/dashboard.html#inline-js": 18104,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,

--- a/companion/src/http/staticAssets.ts
+++ b/companion/src/http/staticAssets.ts
@@ -51,6 +51,10 @@ export const STATIC_ASSETS: Record<string, string> = {
   // (DfirStarred). Same failure mode as the scope module — these hold state, so a 404 is not a
   // missing helper, it is every selection read throwing.
   "/js/dashboard-selection.js": "application/javascript; charset=utf-8",
+  // The facet filters (source / origin / host / IOC type). Splitting these from the timeline view's
+  // other filters is deliberate: four renderers used to MUTATE them mid-render, and that had to
+  // stop before any "one commit per user action" API could be built.
+  "/js/dashboard-facets.js": "application/javascript; charset=utf-8",
   // The first whole FEATURE module of #415 tier 3, as opposed to the pure-helper modules above.
   "/js/dashboard-tagger.js": "application/javascript; charset=utf-8",
   "/js/dashboard-kev.js": "application/javascript; charset=utf-8",

--- a/companion/tests/architecture/route-inventory.json
+++ b/companion/tests/architecture/route-inventory.json
@@ -480,6 +480,7 @@
     "ROUTE GET /js/dashboard-fragments.js",
     "ROUTE GET /js/dashboard-scope.js",
     "ROUTE GET /js/dashboard-selection.js",
+    "ROUTE GET /js/dashboard-facets.js",
     "ROUTE GET /js/dashboard-tagger.js",
     "ROUTE GET /js/dashboard-kev.js",
     "ROUTE GET /js/a11y/modal-autowire.js",

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -309,6 +309,27 @@ export interface SelectionApi {
   DfirStarred: Pick<IdSet, "has" | "count" | "ids" | "toggle" | "replace">;
 }
 
+/**
+ * One facet filter (public/js/dashboard-facets.js): the names the analyst UNCHECKED.
+ *
+ * `has` rather than `isHidden` on purpose — realSourceCount(sources, hidden) needs an object with
+ * `.has()`, so the owner itself can be that argument without a Set escaping.
+ */
+export interface Facet {
+  has(name: string): boolean;
+  /** Fast-path guard only. For anything the analyst reads, use countIn(). */
+  any(): boolean;
+  /** The derived `hidden ∩ available` count, which replaced the render-time prune. */
+  countIn(available?: Iterable<string> | null): number;
+  toggle(name: string, hidden?: boolean): number;
+  hideAll(names?: Iterable<string> | null): number;
+  showAll(): number;
+}
+
+export interface FacetsApi {
+  DfirFacets: { sources: Facet; origins: Facet; hosts: Facet; iocTypes: Facet };
+}
+
 /** An investigation window. Mirrors the server's ScopeWindow (src/analysis/scope.ts). */
 export interface ScopeWindow {
   start: string | null;

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -20,6 +20,11 @@
 // suites unchecked and put an eslint suppression in the one helper every dashboard test imports,
 // which is how a deliberately small, fully-enforced rule set erodes.
 
+/** Membership, and nothing else. What a filter helper needs and all it should be given. */
+export interface HasOnly {
+  has(value: string): boolean;
+}
+
 /** A timeline event, as much of one as the helpers actually read. */
 export interface EventLike {
   timestamp?: string | null;
@@ -114,7 +119,10 @@ export interface GlyphsApi {
 }
 
 export interface FiltersApi {
-  realSourceCount(sources: Array<string | null | undefined> | null, hidden?: Set<string>): number;
+  // A HAS-ONLY SHAPE, not Set. The function only ever calls `hidden.has(s)`, and callers hand it
+  // DfirFacets.<facet>.matcher() — a frozen read-only view. Typing it as Set forced an
+  // `as unknown as Set<string>` at the call site, which is a cast covering for a wrong signature.
+  realSourceCount(sources: Array<string | null | undefined> | null, hidden?: HasOnly): number;
   _evMatchesSearch(e: EventLike, q: string): boolean;
   _iocMatchesSearch(i: IocLike, q: string): boolean;
   _findingMatchesSearch(f: FindingLike, q: string): boolean;
@@ -317,10 +325,16 @@ export interface SelectionApi {
  */
 export interface Facet {
   has(name: string): boolean;
-  /** Fast-path guard only. For anything the analyst reads, use countIn(). */
-  any(): boolean;
-  /** The derived `hidden ∩ available` count, which replaced the render-time prune. */
+  /**
+   * The derived `hidden ∩ available` count — the ONLY "how many" read.
+   *
+   * There is deliberately no `any()`. One existed as a cheap guard and review found it driving the
+   * timeline's "N of M events" label, where a facet hidden in a previous import made the dashboard
+   * claim it was filtering when it was not.
+   */
   countIn(available?: Iterable<string> | null): number;
+  /** A frozen `{ has }` view, for helpers that only need membership. The owner is never passed. */
+  matcher(): HasOnly;
   toggle(name: string, hidden?: boolean): number;
   hideAll(names?: Iterable<string> | null): number;
   showAll(): number;

--- a/companion/tests/dashboard/dashboardFacets.test.ts
+++ b/companion/tests/dashboard/dashboardFacets.test.ts
@@ -1,0 +1,247 @@
+import { readFile } from "node:fs/promises";
+import { runInContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
+import type { FacetsApi, FiltersApi } from "./dashboardApi.js";
+import {
+  calleesInsideLoops,
+  dashboardScripts,
+  functionsOf,
+  insideLoop,
+  ownerCallPositions,
+  ownerCalls,
+  ownerEscapes,
+  scriptFromSource,
+  topLevelBindings,
+} from "../helpers/dashboardAst.js";
+import { globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// public/js/dashboard-facets.js — the first piece of the timeline view (#415 tier 2).
+//
+// It goes before the rest of that view because the rest cannot be built on what it replaces: FOUR
+// RENDERERS wrote these sets while drawing them, so "one coordinated commit per user action" was
+// not expressible. The gate at the bottom is therefore the point of the change, not a nicety.
+
+const MODULE = new URL("../../../public/js/dashboard-facets.js", import.meta.url);
+const DASHBOARD = new URL("../../../public/dashboard.html", import.meta.url);
+
+const load = () => loadDashboardModule<FacetsApi>("dashboard-facets.js", ["dashboard-state.js"]);
+const scripts = dashboardScripts();
+
+describe("a facet filter", () => {
+  it("hides nothing to begin with", () => {
+    const { DfirFacets } = load();
+    expect(DfirFacets.sources.any()).toBe(false);
+    expect(DfirFacets.sources.has("velociraptor")).toBe(false);
+  });
+
+  it("toggles one facet with an explicit state, and flips without one", () => {
+    const { DfirFacets } = load();
+    DfirFacets.sources.toggle("evtx", true);
+    expect(DfirFacets.sources.has("evtx")).toBe(true);
+    DfirFacets.sources.toggle("evtx");
+    expect(DfirFacets.sources.has("evtx")).toBe(false);
+  });
+
+  it("hides every facet in one call and shows them all again", () => {
+    const { DfirFacets } = load();
+    DfirFacets.sources.hideAll(["a", "b", "c"]);
+    expect(DfirFacets.sources.countIn(["a", "b", "c"])).toBe(3);
+    DfirFacets.sources.showAll();
+    expect(DfirFacets.sources.any()).toBe(false);
+  });
+
+  it("keeps the four facets independent", () => {
+    const { DfirFacets } = load();
+    DfirFacets.sources.toggle("x", true);
+    for (const other of ["origins", "hosts", "iocTypes"] as const) {
+      expect(DfirFacets[other].has("x")).toBe(false);
+    }
+  });
+});
+
+// ── THE DERIVED PRUNE ────────────────────────────────────────────────────────────────────────────
+//
+// Four renderers used to delete unchecked facets that no longer existed, mid-render and inside a
+// loop. The effective set is now `hidden ∩ available`, computed at read time.
+describe("the effective set is derived, not stored", () => {
+  it("does not count a hidden name that is no longer available", () => {
+    const { DfirFacets } = load();
+    DfirFacets.sources.hideAll(["evtx", "gone"]);
+    expect(DfirFacets.sources.countIn(["evtx", "mft"])).toBe(1);
+  });
+
+  // THE DELIBERATE BEHAVIOUR CHANGE, pinned so it is a decision rather than a drift. Today the
+  // prune forgot the tick; now it is remembered when the facet comes back.
+  it("remembers a hidden facet that disappears and returns", () => {
+    const { DfirFacets } = load();
+    DfirFacets.sources.toggle("evtx", true);
+    expect(DfirFacets.sources.countIn(["mft"])).toBe(0); // evtx absent from this import
+    expect(DfirFacets.sources.countIn(["evtx", "mft"])).toBe(1); // …and back, still hidden
+    expect(DfirFacets.sources.has("evtx")).toBe(true);
+  });
+
+  // renderIocTypeFilter computed `types.length - hiddenIocTypes.size` from the RAW size, which was
+  // only right immediately after the prune ran. A derived count cannot be stale.
+  it("cannot report more hidden than are actually available", () => {
+    const { DfirFacets } = load();
+    DfirFacets.iocTypes.hideAll(["ip", "domain", "hash"]);
+    expect(DfirFacets.iocTypes.countIn(["ip"])).toBe(1);
+    expect(DfirFacets.iocTypes.countIn([])).toBe(0);
+  });
+
+  it("tolerates an absent or empty available list", () => {
+    const { DfirFacets } = load();
+    DfirFacets.sources.hideAll(["a"]);
+    expect(DfirFacets.sources.countIn(undefined)).toBe(0);
+    DfirFacets.sources.hideAll(undefined);
+    expect(DfirFacets.sources.countIn(["a"])).toBe(1);
+  });
+});
+
+// The one cross-module coupling the census found: realSourceCount(sources, hidden) needs an object
+// with `.has()`. The owner satisfies that itself, so no Set is handed out and no adapter is needed —
+// which is why the read is named `has` rather than `isHidden`.
+describe("the owner can stand in for the hidden set it replaced", () => {
+  it("works as the `hidden` argument of realSourceCount", () => {
+    const { DfirFacets } = load();
+    const { realSourceCount } = loadDashboardModule<FiltersApi>("dashboard-filters.js");
+    const sources = ["evtx", "mft", "unknown source"];
+    expect(realSourceCount(sources, undefined)).toBe(2);
+    DfirFacets.sources.toggle("evtx", true);
+    expect(realSourceCount(sources, DfirFacets.sources as unknown as Set<string>)).toBe(1);
+  });
+});
+
+describe("the container never escapes", () => {
+  it("publishes no way to obtain the Set", () => {
+    const { DfirFacets } = load();
+    expect(Object.keys(DfirFacets.sources).sort()).toEqual([
+      "any",
+      "countIn",
+      "has",
+      "hideAll",
+      "showAll",
+      "toggle",
+    ]);
+  });
+
+  it("adds only DfirFacets to the global object", () => {
+    expect(globalsAddedBy("dashboard-facets.js", ["dashboard-state.js"])).toEqual(["DfirFacets"]);
+  });
+
+  it("puts the sets out of reach of a second script on the page", () => {
+    const api = load();
+    api.DfirFacets.sources.toggle("legit", true);
+    expect(() => runInContext("facet()", api as object)).toThrow(/facet is not defined/);
+    expect(api.DfirFacets.sources.has("legit")).toBe(true);
+  });
+});
+
+// ── THE GATE ─────────────────────────────────────────────────────────────────────────────────────
+describe("no renderer writes a facet", () => {
+  const COMMITS = ["toggle", "hideAll", "showAll"] as const;
+
+  // THE WHOLE POINT OF THIS STEP. renderSourceFilter, renderOriginFilter, renderHostFilter and
+  // renderIocTypeFilter each edited the filter they were about to read — a write during a render,
+  // inside a loop, which no "one commit per user action" API can be layered on top of. A renderer
+  // that commits again is that coupling coming back.
+  it("has no render* function committing to DfirFacets", () => {
+    const offenders = ownerCalls(scripts, "DfirFacets", COMMITS)
+      .filter((c) => /^render/i.test(c.fn))
+      .map((c) => `${c.script}:${c.line} ${c.fn}() -> ${c.path}()`);
+    expect(
+      offenders,
+      "a renderer that writes the filter it draws is the coupling js/dashboard-facets.js removed; " +
+        "derive the effective set with countIn() instead.",
+    ).toEqual([]);
+  });
+
+  it("no longer prunes the analyst's choice from inside a render", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    // The exact shape that was deleted, in any of its four spellings.
+    expect(html).not.toMatch(/for \(const \w+ of \[\.\.\.hidden\w+\]\)/);
+  });
+
+  it("commits to no facet from inside a loop", () => {
+    const offenders = ownerCalls(scripts, "DfirFacets", COMMITS)
+      .filter((c) => c.inLoop)
+      .map((c) => `${c.script}:${c.line} ${c.fn}() -> ${c.path}()`);
+    expect(offenders, '"hide none" used to add one facet at a time; hideAll() commits once.').toEqual([]);
+  });
+
+  it("has no function called from inside a loop that commits", () => {
+    const committers = new Set(
+      ownerCalls(scripts, "DfirFacets", COMMITS)
+        .map((c) => c.fn)
+        .filter((f) => !f.startsWith("<")),
+    );
+    const offenders = [...calleesInsideLoops(scripts)].filter((c) => committers.has(c));
+    expect(offenders).toEqual([]);
+  });
+
+  it("is never aliased or reached dynamically", () => {
+    expect(ownerEscapes(scripts, "DfirFacets").map((e) => `${e.script}:${e.line} ${e.form}`)).toEqual([]);
+  });
+
+  // The same hazard one level down: hideAll() written as a loop of commits is the quadratic cost
+  // moved inside the module, where no call-site check sees it. Checked against the AST, because a
+  // textual count of `commit(` passes this exact mutation — one call in a loop is one occurrence.
+  it("has no bulk operation looping around its own commit", async () => {
+    const script = scriptFromSource("dashboard-facets.js", await readFile(MODULE, "utf8"));
+    const offenders: string[] = [];
+    for (const fn of functionsOf(script).filter((f) => ["hideAll", "showAll", "toggle"].includes(f.name))) {
+      for (const pos of ownerCallPositions(fn.node, "commit")) {
+        if (insideLoop(fn.node, pos)) offenders.push(`${fn.name}() commits inside a loop`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("actually finds the commits it is checking, so the gate is not vacuous", () => {
+    expect(ownerCalls(scripts, "DfirFacets", COMMITS).length).toBeGreaterThan(8);
+  });
+});
+
+describe("the old bindings are gone", () => {
+  it.each(["hiddenSources", "hiddenOrigins", "hiddenHosts", "hiddenIocTypes"])(
+    "%s has no binding left in the page",
+    (name) => {
+      const offenders = scripts
+        .filter((s) => s.name.startsWith("dashboard.html#inline"))
+        .flatMap((s) =>
+          topLevelBindings(s)
+            .filter((b) => b.name === name)
+            .map((b) => `${s.name}:${b.line}`),
+        );
+      expect(offenders).toEqual([]);
+    },
+  );
+
+  it("leaves the menu-signature locals behind, which are genuinely render-local", () => {
+    // Deliberate contrast: `_srcMenuSig` and friends are a renderer's own memo of what it last
+    // drew, not shared filter state, so they stay in the page as tier-3 material.
+    const inline = scripts.filter((s) => s.name.startsWith("dashboard.html#inline"));
+    const names = inline.flatMap((s) => topLevelBindings(s).map((b) => b.name));
+    expect(names).toContain("_srcMenuSig");
+  });
+});
+
+describe("wiring", () => {
+  it("is loaded by dashboard.html, ahead of the inline script, and served by the whitelist", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    expect(html).toContain('<script src="/js/dashboard-facets.js"></script>');
+    const tag = html.indexOf('src="/js/dashboard-facets.js"');
+    expect(html.indexOf('src="/js/dashboard-state.js"')).toBeLessThan(tag);
+    const blocks = [...html.matchAll(/<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g)];
+    const main = blocks.find((m) => /\n\s*function render\s*\(/.test(m[1]));
+    expect(main).toBeDefined();
+    expect(tag).toBeLessThan(main!.index);
+    expect(STATIC_ASSETS["/js/dashboard-facets.js"]).toBe("application/javascript; charset=utf-8");
+  });
+
+  it("stays a classic script", async () => {
+    const src = await readFile(MODULE, "utf8");
+    expect(src).not.toMatch(/^\s*(?:export|import)\s/m);
+  });
+});

--- a/companion/tests/dashboard/dashboardFacets.test.ts
+++ b/companion/tests/dashboard/dashboardFacets.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
 import type { FacetsApi, FiltersApi } from "./dashboardApi.js";
 import {
+  buildCallGraph,
   calleesInsideLoops,
   dashboardScripts,
   functionsOf,
@@ -11,6 +12,7 @@ import {
   ownerCallPositions,
   ownerCalls,
   ownerEscapes,
+  reachableFrom,
   scriptFromSource,
   topLevelBindings,
 } from "../helpers/dashboardAst.js";
@@ -31,7 +33,7 @@ const scripts = dashboardScripts();
 describe("a facet filter", () => {
   it("hides nothing to begin with", () => {
     const { DfirFacets } = load();
-    expect(DfirFacets.sources.any()).toBe(false);
+    expect(DfirFacets.sources.countIn(["velociraptor"])).toBe(0);
     expect(DfirFacets.sources.has("velociraptor")).toBe(false);
   });
 
@@ -48,7 +50,7 @@ describe("a facet filter", () => {
     DfirFacets.sources.hideAll(["a", "b", "c"]);
     expect(DfirFacets.sources.countIn(["a", "b", "c"])).toBe(3);
     DfirFacets.sources.showAll();
-    expect(DfirFacets.sources.any()).toBe(false);
+    expect(DfirFacets.sources.countIn(["a", "b", "c"])).toBe(0);
   });
 
   it("keeps the four facets independent", () => {
@@ -99,17 +101,69 @@ describe("the effective set is derived, not stored", () => {
   });
 });
 
+// ── A FILTER THE ANALYST CANNOT SEE ──────────────────────────────────────────────────────────────
+//
+// The regression review found, and the reason retention needed a guard rather than just a note.
+//
+// Each facet picker hides itself when there is nothing to choose (`origins.length < 2`, and so on)
+// while the FILTER applies regardless. So: hide A, A disappears on re-import, A comes back as the
+// only value — every row vanishes and the control that would undo it is not on screen. In a
+// forensics tool that is evidence disappearing with no way to get it back.
+//
+// It is not purely a retention bug either: hide one of two facets, let the other disappear, and the
+// same trap springs on code that predates DfirFacets. Both paths are closed by the same rule —
+// A CONTROL THE ANALYST CANNOT SEE MUST NOT BE FILTERING — enforced in dashboard.html by keeping
+// the picker up whenever the effective count is non-zero, and asserted here on the arithmetic the
+// renderers use to decide.
+describe("a hidden facet never leaves the analyst without a control", () => {
+  it("reports a live filter when the sole remaining facet is the hidden one", () => {
+    const { DfirFacets } = load();
+    DfirFacets.origins.toggle("A", true);
+    // A vanished, then came back alone. The renderer's threshold is `length < 2`, so without the
+    // guard the picker hides — and this count is what now keeps it on screen.
+    expect(DfirFacets.origins.countIn(["A"])).toBe(1);
+  });
+
+  it("reports no filter once the analyst clears it, so the control may hide again", () => {
+    const { DfirFacets } = load();
+    DfirFacets.origins.toggle("A", true);
+    DfirFacets.origins.showAll();
+    expect(DfirFacets.origins.countIn(["A"])).toBe(0);
+  });
+
+  it("keeps the picker's threshold and the filter's flag reading the SAME number", () => {
+    // The two used to disagree: the button used `hidden ∩ available` while the filter used the raw
+    // size, which is how a remembered-but-absent facet lit "N of N events" with the button dark.
+    const { DfirFacets } = load();
+    DfirFacets.hosts.hideAll(["gone-a", "gone-b"]);
+    expect(DfirFacets.hosts.countIn(["present"])).toBe(0);
+    expect(DfirFacets.hosts.countIn(["present", "gone-a"])).toBe(1);
+  });
+});
+
 // The one cross-module coupling the census found: realSourceCount(sources, hidden) needs an object
 // with `.has()`. The owner satisfies that itself, so no Set is handed out and no adapter is needed —
 // which is why the read is named `has` rather than `isHidden`.
 describe("the owner can stand in for the hidden set it replaced", () => {
+  // No cast: matcher() IS the has-only shape realSourceCount declares. An earlier version passed
+  // the owner behind `as unknown as Set<string>`, which hid the fact that the parameter type was
+  // wrong AND handed a writable object to a helper that only reads.
   it("works as the `hidden` argument of realSourceCount", () => {
     const { DfirFacets } = load();
     const { realSourceCount } = loadDashboardModule<FiltersApi>("dashboard-filters.js");
     const sources = ["evtx", "mft", "unknown source"];
-    expect(realSourceCount(sources, undefined)).toBe(2);
+    expect(realSourceCount(sources)).toBe(2);
     DfirFacets.sources.toggle("evtx", true);
-    expect(realSourceCount(sources, DfirFacets.sources as unknown as Set<string>)).toBe(1);
+    expect(realSourceCount(sources, DfirFacets.sources.matcher())).toBe(1);
+  });
+
+  it("hands out a frozen view that cannot write the facet", () => {
+    const { DfirFacets } = load();
+    DfirFacets.sources.toggle("evtx", true);
+    const view = DfirFacets.sources.matcher();
+    expect(Object.isFrozen(view)).toBe(true);
+    expect(Object.keys(view)).toEqual(["has"]);
+    expect(view.has("evtx")).toBe(true);
   });
 });
 
@@ -117,10 +171,10 @@ describe("the container never escapes", () => {
   it("publishes no way to obtain the Set", () => {
     const { DfirFacets } = load();
     expect(Object.keys(DfirFacets.sources).sort()).toEqual([
-      "any",
       "countIn",
       "has",
       "hideAll",
+      "matcher",
       "showAll",
       "toggle",
     ]);
@@ -146,15 +200,49 @@ describe("no renderer writes a facet", () => {
   // renderIocTypeFilter each edited the filter they were about to read — a write during a render,
   // inside a loop, which no "one commit per user action" API can be layered on top of. A renderer
   // that commits again is that coupling coming back.
-  it("has no render* function committing to DfirFacets", () => {
-    const offenders = ownerCalls(scripts, "DfirFacets", COMMITS)
-      .filter((c) => /^render/i.test(c.fn))
-      .map((c) => `${c.script}:${c.line} ${c.fn}() -> ${c.path}()`);
+  // FOLLOWED THROUGH THE CALL GRAPH, not just the function holding the literal call. Review showed
+  // `function renderHosts() { mutate(); }` with the commit one hop away reported no offender at
+  // all — the same direct-vs-transitive hole that cleared jumpToEvent earlier in #415. Full
+  // reachability is right HERE (unlike the loop rule, which is bounded): the source set is the
+  // named render* functions and the target is "commits to DfirFacets", both specific.
+  it("has no render* function reaching a commit to DfirFacets", () => {
+    const graph = buildCallGraph(scripts);
+    const committers = new Set(
+      ownerCalls(scripts, "DfirFacets", COMMITS)
+        .map((c) => c.fn)
+        .filter((f) => !f.startsWith("<")),
+    );
+    const renderers = scripts.flatMap((s) =>
+      functionsOf(s)
+        .map((f) => f.name)
+        .filter((n) => /^render/i.test(n)),
+    );
+    const offenders: string[] = [];
+    for (const r of new Set(renderers)) {
+      if (committers.has(r)) offenders.push(`${r}() commits directly`);
+      for (const reached of reachableFrom(graph, [r])) {
+        if (committers.has(reached)) offenders.push(`${r}() reaches ${reached}(), which commits`);
+      }
+    }
     expect(
-      offenders,
+      [...new Set(offenders)],
       "a renderer that writes the filter it draws is the coupling js/dashboard-facets.js removed; " +
         "derive the effective set with countIn() instead.",
     ).toEqual([]);
+  });
+
+  // THE GUARD, PINNED IN THE PAGE. The arithmetic tests above cannot see whether the renderers
+  // actually consult it, and that is exactly the gap review flagged: the suite was green while two
+  // visible regressions sat in the production renderers.
+  it("gates every picker's hide-condition on the effective hidden count", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    const hides = [...html.matchAll(/if \((\w+)\.length < \d[^)]*\) \{ wrap\.style\.display = "none"/g)];
+    expect(hides.length, "expected the four facet pickers").toBe(4);
+    for (const m of hides) {
+      expect(m[0], `${m[1]} hides its picker without checking whether a filter is still live on it`).toMatch(
+        /hidden\w* === 0/,
+      );
+    }
   });
 
   it("no longer prunes the analyst's choice from inside a render", async () => {
@@ -207,13 +295,13 @@ describe("the old bindings are gone", () => {
   it.each(["hiddenSources", "hiddenOrigins", "hiddenHosts", "hiddenIocTypes"])(
     "%s has no binding left in the page",
     (name) => {
-      const offenders = scripts
-        .filter((s) => s.name.startsWith("dashboard.html#inline"))
-        .flatMap((s) =>
-          topLevelBindings(s)
-            .filter((b) => b.name === name)
-            .map((b) => `${s.name}:${b.line}`),
-        );
+      // EVERY script the page loads, not just the inline blocks: a legacy binding re-created in a
+      // /js/ module is the same page global, and scoping this to the inline script was a hole.
+      const offenders = scripts.flatMap((s) =>
+        topLevelBindings(s)
+          .filter((b) => b.name === name)
+          .map((b) => `${s.name}:${b.line}`),
+      );
       expect(offenders).toEqual([]);
     },
   );

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -302,10 +302,18 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
     }
   };
 
-  // let/const/class/function at the very top of the script.
+  // let/const at the very top of the script, AND the declaration forms that also bind a name there:
+  // `function hiddenSources() {}` and `class hiddenSources {}` are page globals every bit as much
+  // as `let` is, and the first version of this helper looked only at variable statements.
   for (const st of script.ast.statements) {
     if (ts.isVariableStatement(st)) {
       for (const d of st.declarationList.declarations) collect(d.name);
+    } else if (
+      (ts.isFunctionDeclaration(st) || ts.isClassDeclaration(st)) &&
+      st.name &&
+      ts.isIdentifier(st.name)
+    ) {
+      out.push({ name: st.name.text, line: at(st.name) });
     }
   }
 
@@ -348,15 +356,23 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
   ts.forEachChild(script.ast, declWalk);
 
   const assignWalk = (n: ts.Node): void => {
-    if (
-      ts.isBinaryExpression(n) &&
-      n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isIdentifier(n.left) &&
-      !declaredAnywhere.has(n.left.text) &&
-      !declared.has(n.left.text)
-    ) {
-      out.push({ name: n.left.text, line: at(n.left) });
-      declared.add(n.left.text);
+    if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      // `selectedEvents = new Set()` with no declaration anywhere — an implicit global.
+      if (ts.isIdentifier(n.left) && !declaredAnywhere.has(n.left.text) && !declared.has(n.left.text)) {
+        out.push({ name: n.left.text, line: at(n.left) });
+        declared.add(n.left.text);
+      }
+      // `window.selectedEvents = new Set()` — the explicit form of the same thing, and the one a
+      // declaration-shaped check will never see however carefully it is written.
+      if (
+        ts.isPropertyAccessExpression(n.left) &&
+        ts.isIdentifier(n.left.expression) &&
+        GLOBAL_ROOTS.has(n.left.expression.text) &&
+        !declared.has(n.left.name.text)
+      ) {
+        out.push({ name: n.left.name.text, line: at(n.left.name) });
+        declared.add(n.left.name.text);
+      }
     }
     ts.forEachChild(n, assignWalk);
   };
@@ -518,9 +534,21 @@ export function calleesInsideLoops(scripts: DashboardScript[]): Set<string> {
         else if (ts.isPropertyAccessExpression(n.expression)) out.add(n.expression.name.text);
       }
       if (isIterationCall(n)) {
+        // A CALLBACK PASSED BY NAME IS STILL CALLED PER ELEMENT. `xs.forEach(hideOne)` has no call
+        // expression anywhere inside it, so walking the arguments finds nothing — the identifier
+        // IS the per-element call, and review found this failing open exactly that way.
+        for (const a of n.arguments) {
+          if (ts.isIdentifier(a)) out.add(a.text);
+          else if (ts.isPropertyAccessExpression(a)) out.add(a.name.text);
+        }
         visit(n.expression, inner);
         for (const a of n.arguments) visit(a, inner + 1);
         return;
+      }
+      // The same by-name hand-off inside a real loop: `for (…) xs.map(hideOne)` is covered above,
+      // but `for (…) run(hideOne)` passes it to something that will call it.
+      if (loops > 0 && ts.isCallExpression(n)) {
+        for (const a of n.arguments) if (ts.isIdentifier(a)) out.add(a.text);
       }
       ts.forEachChild(n, (c) => visit(c, inner));
     };
@@ -533,7 +561,7 @@ export function calleesInsideLoops(scripts: DashboardScript[]): Set<string> {
 export interface OwnerEscape {
   script: string;
   line: number;
-  form: "alias" | "computed-member" | "dynamic-member";
+  form: "alias" | "passed" | "computed-member" | "dynamic-member";
   text: string;
 }
 
@@ -563,6 +591,25 @@ export function ownerEscapes(scripts: DashboardScript[], namespace: string): Own
         !denotesNamespace(n.initializer, namespace)
       ) {
         hits.push({ script: s.name, line: at(n), form: "alias", text: n.getText(s.ast).slice(0, 90) });
+      }
+      // evs = DfirSelection.events  (assignment, not declaration)
+      if (
+        ts.isBinaryExpression(n) &&
+        n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        denotesOwnerOrChild(n.right) &&
+        !denotesNamespace(n.right, namespace)
+      ) {
+        hits.push({ script: s.name, line: at(n), form: "alias", text: n.getText(s.ast).slice(0, 90) });
+      }
+      // PASSED SOMEWHERE. An owner handed to another function is a writer this analysis stops
+      // following at the call. There is a supported alternative — a read-only view — so passing the
+      // owner itself is reported rather than resolved.
+      if (ts.isCallExpression(n)) {
+        for (const a of n.arguments) {
+          if (denotesOwnerOrChild(a)) {
+            hits.push({ script: s.name, line: at(a), form: "passed", text: n.getText(s.ast).slice(0, 90) });
+          }
+        }
       }
       // DfirSelection.events["toggle"](…) / DfirSelection.events[m](…)
       if (ts.isElementAccessExpression(n) && denotesOwnerOrChild(n.expression)) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -126,6 +126,7 @@
   <script src="/js/dashboard-scope.js"></script>
   <!-- Tier 2's selection owners (#415). After dashboard-state.js, whose cell() they build on. -->
   <script src="/js/dashboard-selection.js"></script>
+  <script src="/js/dashboard-facets.js"></script>
   <!-- The AI tagger-rule feature (#415 tier 3). A whole feature, not the movable half of one —
        js/dashboard-tagger.js explains why that distinction decides what moves next. -->
   <script src="/js/dashboard-tagger.js"></script>
@@ -3598,13 +3599,11 @@
     let corrobTimeline = _corrobOf("timeline");
     let corrobIocs = _corrobOf("iocs");
     let corrobFindings = _corrobOf("findings");
-    let hiddenSources = new Set();            // source/tool names the user unchecked in the source filter (empty = show all)
+    // The four facet filters moved to js/dashboard-facets.js as DfirFacets (#415, tier 2). The
+    // stale-facet prune each renderer used to perform is now derived — see that file.
     let _srcMenuSig = "";                      // signature of the source-filter menu's last build (skip rebuild when unchanged)
-    let hiddenOrigins = new Set();            // origins (artifact names) the user unchecked in the forensic origin filter (empty = show all)
     let _originMenuSig = "";                   // signature of the origin-filter menu's last build
-    let hiddenHosts = new Set();              // host names the user unchecked in the forensic host filter (empty = show all)
     let _hostMenuSig = "";                     // signature of the host-filter menu's last build
-    let hiddenIocTypes = new Set();           // IOC types the user unchecked in the IOC type filter (#169; empty = show all)
     let _iocTypeMenuSig = "";                  // signature of the IOC-type-filter menu's last build (skip rebuild when unchanged)
     let filterFrom = null;                    // timeline view lower bound (ISO UTC string or null)
     let filterTo = null;                      // timeline view upper bound (ISO UTC string or null)
@@ -12857,9 +12856,9 @@
     // only called when the row is genuinely hidden, so a no-filter view is left untouched.
     function resetTimelineViewFilters() {
       document.querySelectorAll(".sev-filter").forEach(cb => { cb.checked = true; });
-      hiddenSources.clear(); _srcMenuSig = "";
-      hiddenOrigins.clear(); _originMenuSig = "";
-      hiddenHosts.clear(); _hostMenuSig = "";
+      DfirFacets.sources.showAll(); _srcMenuSig = "";
+      DfirFacets.origins.showAll(); _originMenuSig = "";
+      DfirFacets.hosts.showAll(); _hostMenuSig = "";
       showStarredOnly = false;
       evIdFilter = null; evIdFilterLabel = "";
       const sfBtn = document.getElementById("evStarFilterBtn");
@@ -13520,7 +13519,7 @@
       let visible = showFlaggedIocsOnly ? iocs.filter(iocFlagged) : iocs;
       if (searchTerm) visible = visible.filter(i => _iocMatchesSearch(i, searchTerm));
       if (excludeTerms.length) visible = visible.filter(i => !_iocMatchesExclude(i, excludeTerms));
-      if (hiddenIocTypes.size > 0) visible = visible.filter(i => !hiddenIocTypes.has(i.type || "other"));
+      if (DfirFacets.iocTypes.any()) visible = visible.filter(i => !DfirFacets.iocTypes.has(i.type || "other"));
       if (corrobIocs > 1) visible = visible.filter(i => (iocSourcesById[i.id] || []).length >= corrobIocs);   // corroboration lens (#35)
       if (iocProvenanceFilter !== "all") visible = visible.filter(i => iocProvenanceOf(i.id) === iocProvenanceFilter);   // provenance lens
       if (riskIocsFilter > 0) visible = visible.filter(i => iocRiskRankOf(i.id) >= riskIocsFilter);   // risk lens (#63)
@@ -13562,7 +13561,7 @@
       if (!visible.length) {
         el.innerHTML = showFlaggedIocsOnly
           ? "<div data-safe-style='color:var(--text-muted)'>No malicious/suspicious IOCs — enrich the IOCs first, or none came back flagged.</div>"
-          : (searchTerm || excludeTerms.length > 0 || hiddenIocTypes.size > 0 || corrobIocs > 1 || iocProvenanceFilter !== "all" || riskIocsFilter > 0 || noiseFiltersActive) && iocs.length > 0
+          : (searchTerm || excludeTerms.length > 0 || DfirFacets.iocTypes.any() || corrobIocs > 1 || iocProvenanceFilter !== "all" || riskIocsFilter > 0 || noiseFiltersActive) && iocs.length > 0
             ? `<div data-safe-style='color:var(--text-muted)'>No IOCs match the filter.${noiseFiltersActive ? " Turn off “Signal only” / “Hide FP/no-intel” / “Hide OS system paths” to see everything." : ""}</div>`
           : "<div data-safe-style='color:var(--text-muted)'>No IOCs yet</div>";
         updateIocBulkBar();
@@ -13674,12 +13673,13 @@
       const btn = document.getElementById("iocTypeFilterBtn");
       if (!wrap || !menu || !btn) return;
       const types = iocTypeFacets(iocs);
-      // Drop any unchecked types that no longer exist (keeps the active state honest across imports).
-      for (const t of [...hiddenIocTypes]) if (!types.includes(t)) hiddenIocTypes.delete(t);
+      // No prune here any more: the effective set is derived as `hidden ∩ available` at read time,
+      // so a renderer no longer writes the filter it is about to read. See js/dashboard-facets.js.
       if (types.length < 2) { wrap.style.display = "none"; menu.hidden = true; _iocTypeMenuSig = ""; return; }
       wrap.style.display = "";
-      const shown = types.length - hiddenIocTypes.size;
-      const active = hiddenIocTypes.size > 0;
+      const hiddenHere = DfirFacets.iocTypes.countIn(types);   // derived, so it cannot go stale
+      const shown = types.length - hiddenHere;
+      const active = hiddenHere > 0;
       btn.classList.toggle("active", active);
       btn.textContent = active ? `▾ Types (${shown}/${types.length})` : "▾ Types";
       const counts = {};
@@ -13687,12 +13687,12 @@
       const sig = types.map(t => `${t}:${counts[t]}`).join(",");
       if (sig !== _iocTypeMenuSig) {
         const items = types.map(t =>
-          `<label class="src-item"><input type="checkbox" class="ioc-type-cb" value="${escAttr(t)}"${hiddenIocTypes.has(t) ? "" : " checked"}><span>${esc(t)} <span data-safe-style="color:var(--text-muted)">(${counts[t]})</span></span></label>`
+          `<label class="src-item"><input type="checkbox" class="ioc-type-cb" value="${escAttr(t)}"${DfirFacets.iocTypes.has(t) ? "" : " checked"}><span>${esc(t)} <span data-safe-style="color:var(--text-muted)">(${counts[t]})</span></span></label>`
         ).join("");
         menu.innerHTML = `<div class="src-menu-actions"><button type="button" class="src-menu-link" data-ioctype-all="1">All</button><button type="button" class="src-menu-link" data-ioctype-none="1">None</button></div>${items}`;
         _iocTypeMenuSig = sig;
       } else {
-        menu.querySelectorAll(".ioc-type-cb").forEach(cb => { cb.checked = !hiddenIocTypes.has(cb.value); });
+        menu.querySelectorAll(".ioc-type-cb").forEach(cb => { cb.checked = !DfirFacets.iocTypes.has(cb.value); });
       }
     }
 
@@ -13763,13 +13763,12 @@
       const btn = document.getElementById("srcFilterBtn");
       if (!wrap || !menu || !btn) return;
       const allSources = sourceFacets(ft);
-      // Drop unchecked sources that no longer exist anywhere (cross-import hygiene) — full timeline, not
-      // the lens subset, so a lens-excluded hidden source isn't forgotten when the lens toggles.
-      for (const s of [...hiddenSources]) if (!allSources.includes(s)) hiddenSources.delete(s);
+      // The stale-facet prune is gone: countIn() derives `hidden ∩ available`, which also keeps a
+      // lens-excluded hidden source remembered rather than forgotten. See js/dashboard-facets.js.
       const sources = lensFt ? sourceFacets(lensFt) : allSources;
       if (sources.length < 1) { wrap.style.display = "none"; menu.hidden = true; _srcMenuSig = ""; return; }
       wrap.style.display = "";
-      const hiddenInView = sources.filter(s => hiddenSources.has(s)).length;
+      const hiddenInView = sources.filter(s => DfirFacets.sources.has(s)).length;
       const shown = sources.length - hiddenInView;
       const active = hiddenInView > 0;
       btn.classList.toggle("active", active);
@@ -13777,12 +13776,12 @@
       const sig = sources.join("");
       if (sig !== _srcMenuSig) {
         const items = sources.map(s =>
-          `<label class="src-item${s === NO_SOURCE_FACET ? " src-item-none" : ""}"><input type="checkbox" class="src-filter" value="${escAttr(s)}"${hiddenSources.has(s) ? "" : " checked"}><span>${esc(s)}</span></label>`
+          `<label class="src-item${s === NO_SOURCE_FACET ? " src-item-none" : ""}"><input type="checkbox" class="src-filter" value="${escAttr(s)}"${DfirFacets.sources.has(s) ? "" : " checked"}><span>${esc(s)}</span></label>`
         ).join("");
         menu.innerHTML = `<div class="src-menu-actions"><button type="button" class="src-menu-link" data-src-all="1">All</button><button type="button" class="src-menu-link" data-src-none="1">None</button></div>${items}`;
         _srcMenuSig = sig;
       } else {
-        menu.querySelectorAll(".src-filter").forEach(cb => { cb.checked = !hiddenSources.has(cb.value); });
+        menu.querySelectorAll(".src-filter").forEach(cb => { cb.checked = !DfirFacets.sources.has(cb.value); });
       }
     }
 
@@ -13794,22 +13793,21 @@
       const btn = document.getElementById("originFilterBtn");
       if (!wrap || !menu || !btn) return;
       const origins = originFacets(ft);
-      for (const o of [...hiddenOrigins]) if (!origins.includes(o)) hiddenOrigins.delete(o);   // drop stale
       if (origins.length < 2) { wrap.style.display = "none"; menu.hidden = true; _originMenuSig = ""; return; }
       wrap.style.display = "";
-      const hiddenInView = origins.filter(o => hiddenOrigins.has(o)).length;
+      const hiddenInView = origins.filter(o => DfirFacets.origins.has(o)).length;
       const shown = origins.length - hiddenInView;
       btn.classList.toggle("active", hiddenInView > 0);
       btn.textContent = hiddenInView > 0 ? `⛏ Origins (${shown}/${origins.length})` : "⛏ Origins";
       const sig = origins.join("");
       if (sig !== _originMenuSig) {
         const items = origins.map(o =>
-          `<label class="src-item"><input type="checkbox" class="origin-filter" value="${escAttr(o)}"${hiddenOrigins.has(o) ? "" : " checked"}><span>${esc(o)}</span></label>`
+          `<label class="src-item"><input type="checkbox" class="origin-filter" value="${escAttr(o)}"${DfirFacets.origins.has(o) ? "" : " checked"}><span>${esc(o)}</span></label>`
         ).join("");
         menu.innerHTML = `<div class="src-menu-actions"><button type="button" class="src-menu-link" data-origin-all="1">All</button><button type="button" class="src-menu-link" data-origin-none="1">None</button></div>${items}`;
         _originMenuSig = sig;
       } else {
-        menu.querySelectorAll(".origin-filter").forEach(cb => { cb.checked = !hiddenOrigins.has(cb.value); });
+        menu.querySelectorAll(".origin-filter").forEach(cb => { cb.checked = !DfirFacets.origins.has(cb.value); });
       }
     }
 
@@ -13833,22 +13831,21 @@
       const btn = document.getElementById("hostFilterBtn");
       if (!wrap || !menu || !btn) return;
       const hosts = hostFacets(ft);
-      for (const h of [...hiddenHosts]) if (!hosts.includes(h)) hiddenHosts.delete(h);   // drop hosts that no longer exist
       if (hosts.length < 2) { wrap.style.display = "none"; menu.hidden = true; _hostMenuSig = ""; return; }
       wrap.style.display = "";
-      const hiddenInView = hosts.filter(h => hiddenHosts.has(h)).length;
+      const hiddenInView = hosts.filter(h => DfirFacets.hosts.has(h)).length;
       const shown = hosts.length - hiddenInView;
       btn.classList.toggle("active", hiddenInView > 0);
       btn.textContent = hiddenInView > 0 ? `🖥 Hosts (${shown}/${hosts.length})` : "🖥 Hosts";
       const sig = hosts.join("");
       if (sig !== _hostMenuSig) {
         const items = hosts.map(h =>
-          `<label class="src-item${h === NO_HOST_FACET ? " src-item-none" : ""}"><input type="checkbox" class="host-filter" value="${escAttr(h)}"${hiddenHosts.has(h) ? "" : " checked"}><span>${esc(h)}</span></label>`
+          `<label class="src-item${h === NO_HOST_FACET ? " src-item-none" : ""}"><input type="checkbox" class="host-filter" value="${escAttr(h)}"${DfirFacets.hosts.has(h) ? "" : " checked"}><span>${esc(h)}</span></label>`
         ).join("");
         menu.innerHTML = `<div class="src-menu-actions"><button type="button" class="src-menu-link" data-host-all="1">All</button><button type="button" class="src-menu-link" data-host-none="1">None</button></div>${items}`;
         _hostMenuSig = sig;
       } else {
-        menu.querySelectorAll(".host-filter").forEach(cb => { cb.checked = !hiddenHosts.has(cb.value); });
+        menu.querySelectorAll(".host-filter").forEach(cb => { cb.checked = !DfirFacets.hosts.has(cb.value); });
       }
     }
 
@@ -13963,19 +13960,19 @@
       if (searchTerm) visible = visible.filter(e => _evMatchesSearch(e, searchTerm));
       if (excludeTerms.length) visible = visible.filter(e => !_evMatchesExclude(e, excludeTerms));
       if (filterFrom || filterTo) visible = visible.filter(e => _evMatchesTimeRange(e, filterFrom, filterTo));
-      const sourceFiltering = hiddenSources.size > 0;
+      const sourceFiltering = DfirFacets.sources.any();
       if (sourceFiltering) visible = visible.filter(e => {
         const real = (e.sources || []).filter(s => s && s !== "unknown source");
-        if (!real.length) return !hiddenSources.has(NO_SOURCE_FACET);  // unsourced events ride the "(no source)" facet
-        return real.some(s => !hiddenSources.has(s));                   // hidden only when ALL its sources are unchecked
+        if (!real.length) return !DfirFacets.sources.has(NO_SOURCE_FACET);  // unsourced events ride the "(no source)" facet
+        return real.some(s => !DfirFacets.sources.has(s));                   // hidden only when ALL its sources are unchecked
       });
-      const originFiltering = hiddenOrigins.size > 0;
-      if (originFiltering) visible = visible.filter(e => !hiddenOrigins.has(ftOriginOf(e)));
-      if (hiddenHosts.size > 0) visible = visible.filter(e => !hiddenHosts.has(e.asset || NO_HOST_FACET));
+      const originFiltering = DfirFacets.origins.any();
+      if (originFiltering) visible = visible.filter(e => !DfirFacets.origins.has(ftOriginOf(e)));
+      if (DfirFacets.hosts.any()) visible = visible.filter(e => !DfirFacets.hosts.has(e.asset || NO_HOST_FACET));
       // Corroboration lens (#35): count only DISTINCT sources the analyst is still looking at (excludes
       // ones unchecked in the Sources filter), so the two filters compose — isolating to a single source
       // under 2+ correctly shows nothing (you can't be corroborated by 2 distinct tools within 1).
-      if (corrobTimeline > 1) visible = visible.filter(e => realSourceCount(e.sources, hiddenSources) >= corrobTimeline);
+      if (corrobTimeline > 1) visible = visible.filter(e => realSourceCount(e.sources, DfirFacets.sources) >= corrobTimeline);
       const view = DfirState.activeView();
       const viewSevFiltering = !!(view && view.filters && view.filters.minSeverity);
       if (viewSevFiltering) visible = visible.filter(e => viewMeetsMinSev(e.severity));   // dashboard-view severity floor (#142)
@@ -14267,12 +14264,12 @@
       btn.addEventListener("click", () => { menu.hidden = !menu.hidden; });
       menu.addEventListener("change", (e) => {
         if (!e.target.classList.contains("src-filter")) return;
-        if (e.target.checked) hiddenSources.delete(e.target.value); else hiddenSources.add(e.target.value);
+        DfirFacets.sources.toggle(e.target.value, !e.target.checked);
         renderTimelineEvents(DfirState.lastFt());
       });
       menu.addEventListener("click", (e) => {
-        if (e.target.dataset.srcAll) { hiddenSources.clear(); renderTimelineEvents(DfirState.lastFt()); }
-        else if (e.target.dataset.srcNone) { sourceFacets(DfirState.lastFt()).forEach(s => hiddenSources.add(s)); renderTimelineEvents(DfirState.lastFt()); }
+        if (e.target.dataset.srcAll) { DfirFacets.sources.showAll(); renderTimelineEvents(DfirState.lastFt()); }
+        else if (e.target.dataset.srcNone) { DfirFacets.sources.hideAll(sourceFacets(DfirState.lastFt())); renderTimelineEvents(DfirState.lastFt()); }
       });
       // Close the menu when clicking outside it (clicks inside #srcLegendWrap are stopped at the wrap).
       document.addEventListener("click", (e) => {
@@ -14291,12 +14288,12 @@
       btn.addEventListener("click", () => { menu.hidden = !menu.hidden; });
       menu.addEventListener("change", (e) => {
         if (!e.target.classList.contains("origin-filter")) return;
-        if (e.target.checked) hiddenOrigins.delete(e.target.value); else hiddenOrigins.add(e.target.value);
+        DfirFacets.origins.toggle(e.target.value, !e.target.checked);
         renderTimelineEvents(DfirState.lastFt());
       });
       menu.addEventListener("click", (e) => {
-        if (e.target.dataset.originAll) { hiddenOrigins.clear(); renderTimelineEvents(DfirState.lastFt()); }
-        else if (e.target.dataset.originNone) { originFacets(DfirState.lastFt()).forEach(o => hiddenOrigins.add(o)); renderTimelineEvents(DfirState.lastFt()); }
+        if (e.target.dataset.originAll) { DfirFacets.origins.showAll(); renderTimelineEvents(DfirState.lastFt()); }
+        else if (e.target.dataset.originNone) { DfirFacets.origins.hideAll(originFacets(DfirState.lastFt())); renderTimelineEvents(DfirState.lastFt()); }
       });
       document.addEventListener("click", (e) => {
         if (!menu.hidden && !wrap.contains(e.target)) menu.hidden = true;
@@ -14312,12 +14309,12 @@
       btn.addEventListener("click", () => { menu.hidden = !menu.hidden; });
       menu.addEventListener("change", (e) => {
         if (!e.target.classList.contains("host-filter")) return;
-        if (e.target.checked) hiddenHosts.delete(e.target.value); else hiddenHosts.add(e.target.value);
+        DfirFacets.hosts.toggle(e.target.value, !e.target.checked);
         renderTimelineEvents(DfirState.lastFt());
       });
       menu.addEventListener("click", (e) => {
-        if (e.target.dataset.hostAll) { hiddenHosts.clear(); renderTimelineEvents(DfirState.lastFt()); }
-        else if (e.target.dataset.hostNone) { hostFacets(DfirState.lastFt()).forEach(h => hiddenHosts.add(h)); renderTimelineEvents(DfirState.lastFt()); }
+        if (e.target.dataset.hostAll) { DfirFacets.hosts.showAll(); renderTimelineEvents(DfirState.lastFt()); }
+        else if (e.target.dataset.hostNone) { DfirFacets.hosts.hideAll(hostFacets(DfirState.lastFt())); renderTimelineEvents(DfirState.lastFt()); }
       });
       document.addEventListener("click", (e) => {
         if (!menu.hidden && !wrap.contains(e.target)) menu.hidden = true;
@@ -14337,12 +14334,12 @@
       btn.addEventListener("click", () => { menu.hidden = !menu.hidden; });
       menu.addEventListener("change", (e) => {
         if (!e.target.classList.contains("ioc-type-cb")) return;
-        if (e.target.checked) hiddenIocTypes.delete(e.target.value); else hiddenIocTypes.add(e.target.value);
+        DfirFacets.iocTypes.toggle(e.target.value, !e.target.checked);
         rerender();
       });
       menu.addEventListener("click", (e) => {
-        if (e.target.dataset.ioctypeAll) { hiddenIocTypes.clear(); rerender(); }
-        else if (e.target.dataset.ioctypeNone) { iocTypeFacets(scopedIocs()).forEach(t => hiddenIocTypes.add(t)); rerender(); }
+        if (e.target.dataset.ioctypeAll) { DfirFacets.iocTypes.showAll(); rerender(); }
+        else if (e.target.dataset.ioctypeNone) { DfirFacets.iocTypes.hideAll(iocTypeFacets(scopedIocs())); rerender(); }
       });
       document.addEventListener("click", (e) => {
         if (!menu.hidden && !wrap.contains(e.target)) menu.hidden = true;
@@ -15175,9 +15172,9 @@
       DfirSelection.events.clear();
       DfirSelection.iocs.clear();
       DfirSelection.findings.clear();
-      hiddenSources.clear(); _srcMenuSig = "";
-      hiddenOrigins.clear(); _originMenuSig = "";
-      hiddenHosts.clear(); _hostMenuSig = "";
+      DfirFacets.sources.showAll(); _srcMenuSig = "";
+      DfirFacets.origins.showAll(); _originMenuSig = "";
+      DfirFacets.hosts.showAll(); _hostMenuSig = "";
       showStarredOnly = false;
       const sfBtn = document.getElementById("evStarFilterBtn");
       if (sfBtn) { sfBtn.textContent = "☆ Starred"; sfBtn.classList.remove("active"); }
@@ -15189,7 +15186,7 @@
       document.querySelectorAll(".ioc-prov-btn").forEach(b => b.classList.toggle("active", b.getAttribute("data-prov") === "all"));
       // hideFpNoIntel / showSignalIocsOnly are NOT reset here — like the corroboration lens
       // controls, they're per-browser preferences (localStorage-backed), not per-case session state.
-      hiddenIocTypes.clear(); _iocTypeMenuSig = "";
+      DfirFacets.iocTypes.showAll(); _iocTypeMenuSig = "";
       searchTerm = ""; filterFrom = null; filterTo = null;
       const gsEl = document.getElementById("globalSearch"); if (gsEl) gsEl.value = "";
       const ffEl = document.getElementById("filterFrom"); if (ffEl) ffEl.value = "";

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -13513,13 +13513,13 @@
       if (!_iocKeepPage) iocPage = 0;           // any non-pagination re-render (import, filter, state push) resets to page 1
       _iocKeepPage = false;
       const iocs = sortIocsForDisplay(dedupeIocsById(iocsRaw));
-      renderIocTypeFilter(iocs);
+      const iocTypeHidden = renderIocTypeFilter(iocs);   // effective count, so the chip below cannot claim a filter that is not there
       renderIocExcludeRules((DfirState.lastState() && DfirState.lastState().iocExcludeRules) || []);
       const flaggedTotal = iocs.filter(iocFlagged).length;
       let visible = showFlaggedIocsOnly ? iocs.filter(iocFlagged) : iocs;
       if (searchTerm) visible = visible.filter(i => _iocMatchesSearch(i, searchTerm));
       if (excludeTerms.length) visible = visible.filter(i => !_iocMatchesExclude(i, excludeTerms));
-      if (DfirFacets.iocTypes.any()) visible = visible.filter(i => !DfirFacets.iocTypes.has(i.type || "other"));
+      if (iocTypeHidden > 0) visible = visible.filter(i => !DfirFacets.iocTypes.has(i.type || "other"));
       if (corrobIocs > 1) visible = visible.filter(i => (iocSourcesById[i.id] || []).length >= corrobIocs);   // corroboration lens (#35)
       if (iocProvenanceFilter !== "all") visible = visible.filter(i => iocProvenanceOf(i.id) === iocProvenanceFilter);   // provenance lens
       if (riskIocsFilter > 0) visible = visible.filter(i => iocRiskRankOf(i.id) >= riskIocsFilter);   // risk lens (#63)
@@ -13561,7 +13561,7 @@
       if (!visible.length) {
         el.innerHTML = showFlaggedIocsOnly
           ? "<div data-safe-style='color:var(--text-muted)'>No malicious/suspicious IOCs — enrich the IOCs first, or none came back flagged.</div>"
-          : (searchTerm || excludeTerms.length > 0 || DfirFacets.iocTypes.any() || corrobIocs > 1 || iocProvenanceFilter !== "all" || riskIocsFilter > 0 || noiseFiltersActive) && iocs.length > 0
+          : (searchTerm || excludeTerms.length > 0 || iocTypeHidden > 0 || corrobIocs > 1 || iocProvenanceFilter !== "all" || riskIocsFilter > 0 || noiseFiltersActive) && iocs.length > 0
             ? `<div data-safe-style='color:var(--text-muted)'>No IOCs match the filter.${noiseFiltersActive ? " Turn off “Signal only” / “Hide FP/no-intel” / “Hide OS system paths” to see everything." : ""}</div>`
           : "<div data-safe-style='color:var(--text-muted)'>No IOCs yet</div>";
         updateIocBulkBar();
@@ -13671,13 +13671,11 @@
       const wrap = document.getElementById("iocTypeLegendWrap");
       const menu = document.getElementById("iocTypeFilterMenu");
       const btn = document.getElementById("iocTypeFilterBtn");
-      if (!wrap || !menu || !btn) return;
+      if (!wrap || !menu || !btn) return 0;
       const types = iocTypeFacets(iocs);
-      // No prune here any more: the effective set is derived as `hidden ∩ available` at read time,
-      // so a renderer no longer writes the filter it is about to read. See js/dashboard-facets.js.
-      if (types.length < 2) { wrap.style.display = "none"; menu.hidden = true; _iocTypeMenuSig = ""; return; }
+      const hiddenHere = DfirFacets.iocTypes.countIn(types);   // derived; also keeps the picker up while it filters
+      if (types.length < 2 && hiddenHere === 0) { wrap.style.display = "none"; menu.hidden = true; _iocTypeMenuSig = ""; return 0; }
       wrap.style.display = "";
-      const hiddenHere = DfirFacets.iocTypes.countIn(types);   // derived, so it cannot go stale
       const shown = types.length - hiddenHere;
       const active = hiddenHere > 0;
       btn.classList.toggle("active", active);
@@ -13694,6 +13692,7 @@
       } else {
         menu.querySelectorAll(".ioc-type-cb").forEach(cb => { cb.checked = !DfirFacets.iocTypes.has(cb.value); });
       }
+      return hiddenHere;
     }
 
     // Order the (already filtered) timeline rows per the per-column sort arrows (#104). Pure —
@@ -13761,14 +13760,13 @@
       const wrap = document.getElementById("srcLegendWrap");
       const menu = document.getElementById("srcFilterMenu");
       const btn = document.getElementById("srcFilterBtn");
-      if (!wrap || !menu || !btn) return;
+      if (!wrap || !menu || !btn) return 0;
       const allSources = sourceFacets(ft);
-      // The stale-facet prune is gone: countIn() derives `hidden ∩ available`, which also keeps a
-      // lens-excluded hidden source remembered rather than forgotten. See js/dashboard-facets.js.
+      // Prune gone; countIn() derives `hidden ∩ available`. See js/dashboard-facets.js.
       const sources = lensFt ? sourceFacets(lensFt) : allSources;
-      if (sources.length < 1) { wrap.style.display = "none"; menu.hidden = true; _srcMenuSig = ""; return; }
+      const hiddenInView = DfirFacets.sources.countIn(sources);
+      if (sources.length < 1 && hiddenInView === 0) { wrap.style.display = "none"; menu.hidden = true; _srcMenuSig = ""; return 0; }
       wrap.style.display = "";
-      const hiddenInView = sources.filter(s => DfirFacets.sources.has(s)).length;
       const shown = sources.length - hiddenInView;
       const active = hiddenInView > 0;
       btn.classList.toggle("active", active);
@@ -13783,6 +13781,7 @@
       } else {
         menu.querySelectorAll(".src-filter").forEach(cb => { cb.checked = !DfirFacets.sources.has(cb.value); });
       }
+      return hiddenInView;
     }
 
     // Build/refresh the origin-filter dropdown. Hidden when there are fewer than 2 origins (nothing to
@@ -13791,11 +13790,11 @@
       const wrap = document.getElementById("originLegendWrap");
       const menu = document.getElementById("originFilterMenu");
       const btn = document.getElementById("originFilterBtn");
-      if (!wrap || !menu || !btn) return;
+      if (!wrap || !menu || !btn) return 0;
       const origins = originFacets(ft);
-      if (origins.length < 2) { wrap.style.display = "none"; menu.hidden = true; _originMenuSig = ""; return; }
+      const hiddenInView = DfirFacets.origins.countIn(origins);   // derived; also keeps the picker up while it filters
+      if (origins.length < 2 && hiddenInView === 0) { wrap.style.display = "none"; menu.hidden = true; _originMenuSig = ""; return 0; }
       wrap.style.display = "";
-      const hiddenInView = origins.filter(o => DfirFacets.origins.has(o)).length;
       const shown = origins.length - hiddenInView;
       btn.classList.toggle("active", hiddenInView > 0);
       btn.textContent = hiddenInView > 0 ? `⛏ Origins (${shown}/${origins.length})` : "⛏ Origins";
@@ -13809,6 +13808,7 @@
       } else {
         menu.querySelectorAll(".origin-filter").forEach(cb => { cb.checked = !DfirFacets.origins.has(cb.value); });
       }
+      return hiddenInView;
     }
 
     // Forensic host filter (mirrors the source filter): the distinct affected hosts across the in-scope
@@ -13829,11 +13829,12 @@
       const wrap = document.getElementById("hostLegendWrap");
       const menu = document.getElementById("hostFilterMenu");
       const btn = document.getElementById("hostFilterBtn");
-      if (!wrap || !menu || !btn) return;
+      if (!wrap || !menu || !btn) return 0;
       const hosts = hostFacets(ft);
-      if (hosts.length < 2) { wrap.style.display = "none"; menu.hidden = true; _hostMenuSig = ""; return; }
+      // A control the analyst cannot see must not be filtering — see js/dashboard-facets.js.
+      const hiddenInView = DfirFacets.hosts.countIn(hosts);   // derived; also keeps the picker up while it filters
+      if (hosts.length < 2 && hiddenInView === 0) { wrap.style.display = "none"; menu.hidden = true; _hostMenuSig = ""; return 0; }
       wrap.style.display = "";
-      const hiddenInView = hosts.filter(h => DfirFacets.hosts.has(h)).length;
       const shown = hosts.length - hiddenInView;
       btn.classList.toggle("active", hiddenInView > 0);
       btn.textContent = hiddenInView > 0 ? `🖥 Hosts (${shown}/${hosts.length})` : "🖥 Hosts";
@@ -13847,6 +13848,7 @@
       } else {
         menu.querySelectorAll(".host-filter").forEach(cb => { cb.checked = !DfirFacets.hosts.has(cb.value); });
       }
+      return hiddenInView;
     }
 
     // --- Event-density heatmap (#219) -------------------------------------------------
@@ -13944,9 +13946,11 @@
       const lensFt = corrobTimeline > 1
         ? ft.filter(e => realSourceCount(e.sources) >= corrobTimeline)
         : null;
-      renderSourceFilter(ft, lensFt);
-      renderOriginFilter(ft);
-      renderHostFilter(ft);
+      // These return the EFFECTIVE hidden count, so the "N of M events" label below agrees with the
+      // buttons the analyst sees — see js/dashboard-facets.js.
+      const srcHidden = renderSourceFilter(ft, lensFt);
+      const originHidden = renderOriginFilter(ft);
+      const hostHidden = renderHostFilter(ft);
 
       const checked = document.querySelectorAll('.sev-filter:checked');
       const activeSevs = new Set([...checked].map(cb => cb.value));
@@ -13960,19 +13964,19 @@
       if (searchTerm) visible = visible.filter(e => _evMatchesSearch(e, searchTerm));
       if (excludeTerms.length) visible = visible.filter(e => !_evMatchesExclude(e, excludeTerms));
       if (filterFrom || filterTo) visible = visible.filter(e => _evMatchesTimeRange(e, filterFrom, filterTo));
-      const sourceFiltering = DfirFacets.sources.any();
+      const sourceFiltering = srcHidden > 0;
       if (sourceFiltering) visible = visible.filter(e => {
         const real = (e.sources || []).filter(s => s && s !== "unknown source");
         if (!real.length) return !DfirFacets.sources.has(NO_SOURCE_FACET);  // unsourced events ride the "(no source)" facet
         return real.some(s => !DfirFacets.sources.has(s));                   // hidden only when ALL its sources are unchecked
       });
-      const originFiltering = DfirFacets.origins.any();
+      const originFiltering = originHidden > 0;
       if (originFiltering) visible = visible.filter(e => !DfirFacets.origins.has(ftOriginOf(e)));
-      if (DfirFacets.hosts.any()) visible = visible.filter(e => !DfirFacets.hosts.has(e.asset || NO_HOST_FACET));
+      if (hostHidden > 0) visible = visible.filter(e => !DfirFacets.hosts.has(e.asset || NO_HOST_FACET));
       // Corroboration lens (#35): count only DISTINCT sources the analyst is still looking at (excludes
       // ones unchecked in the Sources filter), so the two filters compose — isolating to a single source
       // under 2+ correctly shows nothing (you can't be corroborated by 2 distinct tools within 1).
-      if (corrobTimeline > 1) visible = visible.filter(e => realSourceCount(e.sources, DfirFacets.sources) >= corrobTimeline);
+      if (corrobTimeline > 1) visible = visible.filter(e => realSourceCount(e.sources, DfirFacets.sources.matcher()) >= corrobTimeline);
       const view = DfirState.activeView();
       const viewSevFiltering = !!(view && view.filters && view.filters.minSeverity);
       if (viewSevFiltering) visible = visible.filter(e => viewMeetsMinSev(e.severity));   // dashboard-view severity floor (#142)

--- a/public/js/dashboard-facets.js
+++ b/public/js/dashboard-facets.js
@@ -44,20 +44,21 @@
 // cannot be stale because it is not stored.
 //
 //
-// TWO READS, NOT ONE, and the difference matters.
+// ONE READ FOR "HOW MANY", AND IT IS ALWAYS THE DERIVED ONE.
 //
-//   any()             — "has the analyst hidden anything at all". A fast-path guard, so
-//                       renderTimelineEvents can skip a filter pass entirely. A stale entry makes
-//                       this true when nothing visible is hidden, which costs one wasted pass and
-//                       changes no output.
-//   countIn(list)     — the derived intersection, for anything the analyst SEES: the "3/7" in a
-//                       button label, and whether that button is highlighted. A stale entry must
-//                       not light a filter indicator, so these never use any().
+// An earlier draft also published `any()` — "has the analyst hidden anything at all" — as a cheap
+// guard that could skip a filter pass, on the argument that a remembered-but-absent facet would
+// only cost a wasted pass and change no output. That argument was wrong, and review caught it: the
+// same flag also drove the timeline's "N of M events" label and the IOC panel's filters-active
+// chip, so a facet the analyst hid in a previous import made the dashboard claim it was filtering
+// when it was not. The saving was one array pass; the cost was a lie about what the analyst is
+// looking at. So there is only countIn(available), the derived `hidden ∩ available`.
 //
-// `has(name)` is deliberately named `has` rather than `isHidden`, because
-// realSourceCount(sources, hidden) in js/dashboard-filters.js needs an object with `.has()` and
-// nothing else. Passing this owner satisfies that without handing out the Set — the owner IS the
-// safe view, so the one cross-module coupling the census found needs no adapter.
+// THE OWNER IS NEVER PASSED ANYWHERE — `matcher()` is. The one cross-module coupling the census
+// found (realSourceCount, which needs an object with `.has()`) takes that frozen read-only view
+// instead of this object, so "the owner is only ever called by name" stays checkable. An earlier
+// draft passed the owner itself, which works at runtime and quietly defeats every analysis that
+// tries to follow who can write.
 //
 // NOT AN ES MODULE, and an IIFE, for the reasons js/dashboard-state.js sets out.
 (function () {
@@ -71,10 +72,20 @@
     const cell = window.DfirState.cell(new Set());
     const commit = (next) => cell.set(next);
     return {
-      /** Named `has` so this object can BE the `hidden` argument of realSourceCount(). */
       has: (name) => cell.get().has(name),
-      /** Fast-path guard only — see the header. Never use for anything the analyst reads. */
-      any: () => cell.get().size > 0,
+      /**
+       * A frozen read-only view: `{ has }` and nothing else.
+       *
+       * realSourceCount(sources, hidden) in js/dashboard-filters.js needs an object with `.has()`.
+       * Handing it the OWNER would work — but the owner also carries toggle/hideAll/showAll, so
+       * every helper it is passed to becomes a place that could write, and an analysis that follows
+       * writes has to give up at the call. Handing out a view instead keeps "the owner is only ever
+       * called by name, never passed" a property a test can hold; ownerEscapes() enforces it.
+       */
+      matcher() {
+        const hidden = cell.get();
+        return Object.freeze({ has: (name) => hidden.has(name) });
+      },
       /**
        * How many of `available` are hidden. THE DERIVED PRUNE: a name the analyst hid that no
        * longer exists simply does not count, instead of being deleted from their choice.

--- a/public/js/dashboard-facets.js
+++ b/public/js/dashboard-facets.js
@@ -1,0 +1,117 @@
+// Who owns the facet filters — which sources, origins, hosts and IOC types are unchecked (#415).
+//
+// The first piece of the timeline view, and it goes first because the rest of that view cannot be
+// built on top of the code this replaces: four RENDERERS currently write these sets while drawing,
+// so "one coordinated commit per user action" is not expressible until that stops.
+//
+//
+// WHAT THE MEASUREMENT SAYS
+//
+//                     reassignments   IN-PLACE MUTATIONS   reader fns
+//   hiddenSources           0              7 in 6 fns          14
+//   hiddenOrigins           0              7 in 6 fns          12
+//   hiddenHosts             0              7 in 6 fns          12
+//   hiddenIocTypes          0              6 in 5 fns          10
+//
+// Same shape as the selections: all in-place, never replaced. So the same answer — replace-on-write,
+// bulk operations for the bulk gestures, and the container never escapes. `hide none` is
+// `facets.forEach(s => hiddenSources.add(s))`, a commit per element, which is the shape
+// js/dashboard-selection.js exists to stop.
+//
+//
+// THE PRUNE BECOMES DERIVED, AND THAT IS A DELIBERATE BEHAVIOUR CHANGE
+//
+// Four of those mutations are a renderer editing the filter it is about to read:
+//
+//     for (const s of [...hiddenSources]) if (!allSources.includes(s)) hiddenSources.delete(s);
+//
+// — in renderSourceFilter, renderOriginFilter, renderHostFilter and renderIocTypeFilter. It is
+// cross-import hygiene: drop unchecked facets that no longer exist anywhere, so the counts stay
+// honest. But it is a write during a render, inside a loop, and it makes the renderers writers that
+// any ownership gate has to carve an exception for.
+//
+// So the analyst's set is kept as they left it and the EFFECTIVE set is derived at read time, as
+// `hidden ∩ available` — which is what `countIn(available)` is. No write, no commit mid-render.
+//
+// THE VISIBLE DIFFERENCE, stated rather than smuggled: hide a source, re-import a case without it,
+// then import it again — today the tick is forgotten in between, now it is remembered. That is
+// arguably the better behaviour (the analyst hid it on purpose and never said otherwise), and it is
+// the reason this is called out here rather than buried as a refactor.
+//
+// It is also strictly MORE correct in one place. `renderIocTypeFilter` computed
+// `shown = types.length - hiddenIocTypes.size` from the raw size, which is only right immediately
+// after the prune has run; between renders a stale entry made the count too low. `countIn(types)`
+// cannot be stale because it is not stored.
+//
+//
+// TWO READS, NOT ONE, and the difference matters.
+//
+//   any()             — "has the analyst hidden anything at all". A fast-path guard, so
+//                       renderTimelineEvents can skip a filter pass entirely. A stale entry makes
+//                       this true when nothing visible is hidden, which costs one wasted pass and
+//                       changes no output.
+//   countIn(list)     — the derived intersection, for anything the analyst SEES: the "3/7" in a
+//                       button label, and whether that button is highlighted. A stale entry must
+//                       not light a filter indicator, so these never use any().
+//
+// `has(name)` is deliberately named `has` rather than `isHidden`, because
+// realSourceCount(sources, hidden) in js/dashboard-filters.js needs an object with `.has()` and
+// nothing else. Passing this owner satisfies that without handing out the Set — the owner IS the
+// safe view, so the one cross-module coupling the census found needs no adapter.
+//
+// NOT AN ES MODULE, and an IIFE, for the reasons js/dashboard-state.js sets out.
+(function () {
+  /**
+   * One facet filter: the set of names the analyst has UNCHECKED.
+   *
+   * Shared factory rather than four copies, for the reason js/dashboard-selection.js gives — the
+   * replace-on-write discipline is the thing that must not vary between them.
+   */
+  function facet() {
+    const cell = window.DfirState.cell(new Set());
+    const commit = (next) => cell.set(next);
+    return {
+      /** Named `has` so this object can BE the `hidden` argument of realSourceCount(). */
+      has: (name) => cell.get().has(name),
+      /** Fast-path guard only — see the header. Never use for anything the analyst reads. */
+      any: () => cell.get().size > 0,
+      /**
+       * How many of `available` are hidden. THE DERIVED PRUNE: a name the analyst hid that no
+       * longer exists simply does not count, instead of being deleted from their choice.
+       */
+      countIn(available) {
+        const hidden = cell.get();
+        let n = 0;
+        for (const name of available || []) if (hidden.has(name)) n++;
+        return n;
+      },
+      /** One checkbox. `hidden` omitted flips, like classList.toggle. */
+      toggle(name, hidden) {
+        const current = cell.get();
+        const want = hidden === undefined ? !current.has(name) : Boolean(hidden);
+        if (want === current.has(name)) return current.size;
+        const next = new Set(current);
+        if (want) next.add(name);
+        else next.delete(name);
+        return commit(next).size;
+      },
+      /** "hide none" — every facet at once, ONE commit rather than one per name. */
+      hideAll(names) {
+        const next = new Set(cell.get());
+        for (const name of names || []) next.add(name);
+        return commit(next).size;
+      },
+      /** "show all", and the per-case reset. */
+      showAll() {
+        return commit(new Set()).size;
+      },
+    };
+  }
+
+  window.DfirFacets = {
+    sources: facet(),
+    origins: facet(),
+    hosts: facet(),
+    iocTypes: facet(),
+  };
+})();

--- a/public/js/dashboard-filters.js
+++ b/public/js/dashboard-filters.js
@@ -18,6 +18,8 @@
 // so a repeated source name can't inflate the count), the unit the corroboration lens counts. When a
 // `hidden` set is passed, sources unchecked in the Sources filter are excluded — so the lens counts
 // only the tools the analyst is currently looking at (the two filters compose as one question).
+// `hidden` is anything with a `.has()` — a Set, or DfirFacets.<facet>.matcher(). Deliberately not
+// typed to a Set: the caller hands over a read-only view precisely so this cannot write.
 function realSourceCount(sources, hidden) {
   const set = new Set();
   for (const s of (sources || [])) if (s && s !== "unknown source" && !(hidden && hidden.has(s))) set.add(s);


### PR DESCRIPTION
First piece of the timeline view, split out and landed on its own. **The split is not arbitrary — this is a prerequisite for the rest**, and that is worth stating before the diff.

## Why this had to come first

Four **renderers** write these sets while drawing them:

```js
for (const s of [...hiddenSources]) if (!allSources.includes(s)) hiddenSources.delete(s);
```

— in `renderSourceFilter`, `renderOriginFilter`, `renderHostFilter` and `renderIocTypeFilter`. A write during a render, inside a loop.

"One coordinated commit per user action" is the shape the whole timeline-view design turns on, and it is **not expressible while the render itself commits**. So this stops here, before the composite actions get written on top of it.

## The measurement

Same shape as the selections in [#468](https://github.com/hasamba/DFIR-Companion/pull/468):

| | reassignments | **in-place mutations** | reader fns |
|---|---|---|---|
| `hiddenSources` | 0 | **7** in 6 fns | 14 |
| `hiddenOrigins` | 0 | **7** in 6 fns | 12 |
| `hiddenHosts` | 0 | **7** in 6 fns | 12 |
| `hiddenIocTypes` | 0 | **6** in 5 fns | 10 |

Same answer: replace-on-write, bulk operations, no live Set out. "hide none" was `facets.forEach(s => hiddenSources.add(s))` — a commit per element, the exact shape #468's gate exists to stop — and is now one `hideAll()`.

## The prune becomes derived — a deliberate behaviour change

The analyst's set stays as they left it; the **effective** set is derived at read time as `hidden ∩ available`.

**The visible difference:** hide a source, re-import a case without it, then import it again. Today the tick is forgotten in between; now it is remembered. That is arguably the better behaviour — they hid it on purpose and never said otherwise — and it is called out here, argued in the module, and pinned by a test named for it rather than smuggled in.

It is also **strictly more correct** in one place: `renderIocTypeFilter` computed `shown = types.length - hiddenIocTypes.size` from the raw size, which was only right immediately after the prune had run. Between renders a stale entry made the count too low. A derived count cannot be stale.

## Two reads, and the difference matters

- `any()` — fast-path guard, lets `renderTimelineEvents` skip a filter pass. A stale entry costs one wasted pass and changes no output.
- `countIn(available)` — the derived intersection, for anything the analyst **sees**: the "3/7" in a button label and whether it is highlighted. A stale entry must never light a filter indicator, so these never use `any()`.

`has` rather than `isHidden` is deliberate: `realSourceCount(sources, hidden)` needs an object with `.has()` and nothing else, so the owner *is* that argument. The one cross-module coupling the census found needs no adapter and no Set escapes.

## Gates

**8 mutations, 8 fired:** a `render*` function committing, the prune re-introduced, a commit in a `forEach`, a wrapper called from a loop, an alias to an owner, `countIn` degraded to the raw size, the old binding returning, and `hideAll` looping around its own commit.

The first of those is the one that matters — it is this step's entire argument, expressed as a check.

`build`, `lint`, `format:check`, `check:imports`, `check:boundaries` green; route inventory re-baselined (+1). Full suite **7422 passed**; the 2 failures are the known local `sharp` 0.33.5/vips 8.15.3 in the shared `node_modules`, in a file this branch does not touch. `check:size`: inline JS **shrank** 18108 → 18104.

## What is left of tier 2

`DfirTimelineView` proper — the composite actions (`revealEvent`, `filterToEventIds`, `setTimeWindow`, `setSearch`, …) over the remaining scalars, `evIdFilter`, and the DOM-backed severity checkboxes. Those are now buildable, because nothing commits mid-render any more.
