### PR TITLE
refactor(dashboard): give the timeline view its composite actions (#415 tier 2 complete)

### DIFF
--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -6,7 +6,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/css/dashboard.css": 3261,
-  "public/dashboard.html#inline-js": 18097,
+  "public/dashboard.html#inline-js": 18104,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -6,7 +6,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/css/dashboard.css": 3261,
-  "public/dashboard.html#inline-js": 18108,
+  "public/dashboard.html#inline-js": 18097,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,

--- a/companion/src/http/staticAssets.ts
+++ b/companion/src/http/staticAssets.ts
@@ -55,6 +55,9 @@ export const STATIC_ASSETS: Record<string, string> = {
   // other filters is deliberate: four renderers used to MUTATE them mid-render, and that had to
   // stop before any "one commit per user action" API could be built.
   "/js/dashboard-facets.js": "application/javascript; charset=utf-8",
+  // The timeline view's composite actions — the last tier-2 owner (#415). Unlike the others this
+  // one takes injected painters, so a 404 leaves every filter gesture committing to nothing.
+  "/js/dashboard-timeline-view.js": "application/javascript; charset=utf-8",
   // The first whole FEATURE module of #415 tier 3, as opposed to the pure-helper modules above.
   "/js/dashboard-tagger.js": "application/javascript; charset=utf-8",
   "/js/dashboard-kev.js": "application/javascript; charset=utf-8",

--- a/companion/tests/architecture/route-inventory.json
+++ b/companion/tests/architecture/route-inventory.json
@@ -481,6 +481,7 @@
     "ROUTE GET /js/dashboard-scope.js",
     "ROUTE GET /js/dashboard-selection.js",
     "ROUTE GET /js/dashboard-facets.js",
+    "ROUTE GET /js/dashboard-timeline-view.js",
     "ROUTE GET /js/dashboard-tagger.js",
     "ROUTE GET /js/dashboard-kev.js",
     "ROUTE GET /js/a11y/modal-autowire.js",

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -318,6 +318,43 @@ export interface SelectionApi {
 }
 
 /**
+ * public/js/dashboard-timeline-view.js — the timeline's view filters, as ACTIONS.
+ *
+ * The reads are scalars and membership tests; no Set or array the caller can write ever comes out.
+ * The actions each declare their own refresh set, which is why there is no generic setter and no
+ * subscription — see the module header.
+ */
+export interface TimelineViewApi {
+  DfirTimelineView: {
+    wire(handlers: Record<string, () => void>): void;
+    hydrate(state?: { excludeTerms?: string[]; corroboration?: Record<string, number> }): void;
+
+    search(): string;
+    excludeTerms(): readonly string[];
+    from(): string | null;
+    to(): string | null;
+    starredOnly(): boolean;
+    hasEventId(id: unknown): boolean;
+    eventIdFilterActive(): boolean;
+    eventIdCount(): number;
+    eventIdLabel(): string;
+    corrobTimeline(): number;
+    corrobIocs(): number;
+    corrobFindings(): number;
+
+    setSearch(term: unknown): void;
+    setExcludeTerms(terms?: Iterable<string> | null): void;
+    setTimeWindow(from: string | null, to: string | null): void;
+    showOnlyStarred(on: boolean): void;
+    setCorroboration(which: string, value: unknown): number;
+    filterToEventIds(ids?: Iterable<unknown> | null, label?: string): number;
+    clearEventIds(): void;
+    clearFilters(): void;
+    resetForCase(): void;
+  };
+}
+
+/**
  * One facet filter (public/js/dashboard-facets.js): the names the analyst UNCHECKED.
  *
  * `has` rather than `isHidden` on purpose — realSourceCount(sources, hidden) needs an object with

--- a/companion/tests/dashboard/dashboardTimelineView.test.ts
+++ b/companion/tests/dashboard/dashboardTimelineView.test.ts
@@ -28,6 +28,10 @@ const PANELS = [
   "timeInputs",
   "severityBoxes",
   "starButton",
+  // The IOC lens has its OWN painter. Routing it to `all` (an earlier draft did) refetched the
+  // collection plan, rebuilt every panel and reset the timeline to page one for a change that only
+  // affects the IOC list.
+  "iocs",
 ] as const;
 
 /** Load the module with a counting spy registered for every painter. */
@@ -35,10 +39,24 @@ function load() {
   const api = loadDashboardModule<TimelineViewApi>("dashboard-timeline-view.js", ["dashboard-state.js"]);
   const painted: Record<string, number> = {};
   const handlers: Record<string, () => void> = {};
+  // EVERY spy snapshots the state it can see. Review found that only filterToEventIds checked this,
+  // so moving refresh() above the write in any other action left its test green — a painter that
+  // runs before the commit repaints the OLD value, which is the whole class of bug this owner
+  // exists to prevent.
+  const seenDuring: Record<string, unknown[]> = {};
   for (const p of PANELS) {
     painted[p] = 0;
+    seenDuring[p] = [];
     handlers[p] = () => {
       painted[p] += 1;
+      seenDuring[p].push({
+        search: api.DfirTimelineView.search(),
+        from: api.DfirTimelineView.from(),
+        starred: api.DfirTimelineView.starredOnly(),
+        exclude: [...api.DfirTimelineView.excludeTerms()],
+        ids: api.DfirTimelineView.eventIdCount(),
+        corrobIocs: api.DfirTimelineView.corrobIocs(),
+      });
     };
   }
   api.DfirTimelineView.wire(handlers);
@@ -47,7 +65,7 @@ function load() {
       .filter(([, n]) => n > 0)
       .map(([k]) => k)
       .sort();
-  return { view: api.DfirTimelineView, painted, refreshed };
+  return { view: api.DfirTimelineView, painted, refreshed, seenDuring };
 }
 
 describe("reads round-trip what the actions commit", () => {
@@ -129,14 +147,31 @@ describe("each action refreshes exactly what it declares, once", () => {
     expect(after.refreshed()).toEqual(["timeline"]);
   });
 
-  // The lenses differ from each other, which is why setCorroboration branches.
-  it("routes the timeline lens to the timeline and the other two to the page", () => {
-    const a = load();
-    a.view.setCorroboration("timeline", 2);
-    expect(a.refreshed()).toEqual(["timeline"]);
-    const b = load();
-    b.view.setCorroboration("findings", 2);
-    expect(b.refreshed()).toEqual(["all"]);
+  // THREE LENSES, THREE COSTS — which is why setCorroboration branches rather than being one
+  // setter. Collapsing the IOC lens into the full-page painter (an earlier draft did) refetched the
+  // collection plan and reset the timeline to page one for a change that only affects the IOC list.
+  it.each([
+    ["timeline", ["timeline"]],
+    ["iocs", ["iocs"]],
+    ["findings", ["all"]],
+  ] as const)("routes the %s lens to exactly its own panel", (which, expected) => {
+    const { view, refreshed } = load();
+    view.setCorroboration(which, 2);
+    expect(refreshed()).toEqual([...expected]);
+  });
+
+  // "Off" is 0 in the <select> and in localStorage. Normalising it to 1 (an earlier draft did) made
+  // `sel.value = String(get())` select an option that does not exist, so all three lenses rendered
+  // blank on load.
+  it("keeps 0 as off, matching the control's own values", () => {
+    const { view } = load();
+    expect(view.corrobTimeline()).toBe(0);
+    view.setCorroboration("timeline", 2);
+    expect(view.corrobTimeline()).toBe(2);
+    view.setCorroboration("timeline", 0);
+    expect(view.corrobTimeline()).toBe(0);
+    view.hydrate({ corroboration: { iocs: 0 } });
+    expect(view.corrobIocs()).toBe(0);
   });
 
   it("ignores an unknown lens rather than committing one", () => {
@@ -146,14 +181,46 @@ describe("each action refreshes exactly what it declares, once", () => {
   });
 });
 
+// EVERY action commits BEFORE it paints, not just the one that had a test for it.
+describe("no painter ever runs before the state it is painting", () => {
+  it.each([
+    ["setSearch", (v: TimelineViewApi["DfirTimelineView"]) => v.setSearch("psexec"), "search", "psexec"],
+    [
+      "setTimeWindow",
+      (v: TimelineViewApi["DfirTimelineView"]) => v.setTimeWindow("2026-05-01T00:00:00Z", null),
+      "from",
+      "2026-05-01T00:00:00Z",
+    ],
+    ["showOnlyStarred", (v: TimelineViewApi["DfirTimelineView"]) => v.showOnlyStarred(true), "starred", true],
+    [
+      "setCorroboration",
+      (v: TimelineViewApi["DfirTimelineView"]) => v.setCorroboration("iocs", 2),
+      "corrobIocs",
+      2,
+    ],
+  ] as const)("%s", (_label, act, field, expected) => {
+    const { view, seenDuring } = load();
+    act(view);
+    const observations = Object.values(seenDuring).flat() as Array<Record<string, unknown>>;
+    expect(observations.length, "the action painted nothing at all").toBeGreaterThan(0);
+    for (const seen of observations) {
+      expect(seen[field], `a painter ran before ${_label} committed`).toEqual(expected);
+    }
+  });
+});
+
 // ── THE ORDERING BUG THE DESIGN EXISTS TO FIX ────────────────────────────────────────────────────
 describe("revealing a group of events paints once, with the filter already applied", () => {
   it("has the id filter committed BEFORE the first repaint", () => {
     const api = loadDashboardModule<TimelineViewApi>("dashboard-timeline-view.js", ["dashboard-state.js"]);
     const view = api.DfirTimelineView;
     const seen: Array<{ active: boolean; count: number }> = [];
+    // `all`, not `timeline`: revealing a group clears filters that Findings, IOCs, False Positives
+    // and the super-timeline also read, so it refreshes the page — and render() paints the event
+    // list. An earlier draft refreshed the timeline alone, leaving every other panel showing
+    // filters the controls now said were cleared.
     view.wire({
-      timeline: () => seen.push({ active: view.eventIdFilterActive(), count: view.eventIdCount() }),
+      all: () => seen.push({ active: view.eventIdFilterActive(), count: view.eventIdCount() }),
     });
     view.filterToEventIds(["e1", "e2", "e3"], "bucket");
     // ONE paint, and it already sees the filter. filterTimelineToEventIds used to render TWICE
@@ -181,13 +248,92 @@ describe("revealing a group of events paints once, with the filter already appli
   });
 });
 
+// ── THE PRODUCTION NESTING ───────────────────────────────────────────────────────────────────────
+//
+// THE TEST THAT SHOULD HAVE EXISTED FIRST. The spies above are independent, which is convenient and
+// was, on its own, misleading: in the page `renderFalsePositives()` ends with its own
+// `render(lastState())`, so wiring it directly meant `refresh("all", "falsePositives")` ran TWO
+// full renders — the very double render this module claims to collapse — while a suite of
+// independent spies reported one. Review caught it; this models the nesting instead.
+describe("the collapse holds against the page's real handler nesting", () => {
+  /** Wire painters the way dashboard.html does, including any nesting the page has. */
+  function loadNested(opts: { falsePositivesRedraws: boolean }) {
+    const api = loadDashboardModule<TimelineViewApi>("dashboard-timeline-view.js", ["dashboard-state.js"]);
+    let renders = 0;
+    const all = () => {
+      renders += 1;
+    };
+    api.DfirTimelineView.wire({
+      all,
+      // The page wires the PANEL-ONLY form. Passing true here reproduces the bug: a False Positives
+      // painter that redraws the page behind the action's back.
+      falsePositives: () => {
+        if (opts.falsePositivesRedraws) all();
+      },
+      timeline: () => {},
+      superTimeline: () => {},
+      excludeChips: () => {},
+      searchBox: () => {},
+      timeInputs: () => {},
+      severityBoxes: () => {},
+      starButton: () => {},
+      derivedViews: () => {},
+      iocs: () => {},
+    });
+    return { view: api.DfirTimelineView, renders: () => renders };
+  }
+
+  it.each(["setSearch", "setExcludeTerms"] as const)(
+    "%s produces exactly one full render with the page's own wiring",
+    (action) => {
+      const { view, renders } = loadNested({ falsePositivesRedraws: false });
+      if (action === "setSearch") view.setSearch("psexec");
+      else view.setExcludeTerms(["noise"]);
+      expect(renders()).toBe(1);
+    },
+  );
+
+  // The bug, reproduced: this is what the page did before the panel-only painter existed.
+  it("would render twice if the False Positives painter redrew the page", () => {
+    const { view, renders } = loadNested({ falsePositivesRedraws: true });
+    view.setSearch("psexec");
+    expect(renders()).toBe(2);
+  });
+
+  // AND THE PAGE MUST ACTUALLY WIRE THE PANEL-ONLY FORM.
+  //
+  // The tests above prove the MODULE collapses correctly given a non-redrawing False Positives
+  // painter. They cannot prove dashboard.html supplies one — they register their own handlers — so
+  // reverting the page to `renderFalsePositives(fpMarkers)` left them green. That is finding 2 over
+  // again at one remove, and this is the assertion that closes it.
+  it("wires False Positives to the panel-only form, not the redrawing one", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    const wired = html.match(/falsePositives:\s*\(\)\s*=>\s*renderFalsePositives\(([^)]*)\)/);
+    expect(wired, "no falsePositives painter registered").not.toBeNull();
+    expect(
+      wired![1],
+      "the painter must suppress renderFalsePositives' own render(), or every search and exclude " +
+        "action runs TWO full renders again",
+    ).toMatch(/,\s*false\s*$/);
+    // ...and the renderer must still HAVE that parameter for the suppression to mean anything.
+    expect(html).toMatch(/function renderFalsePositives\(markers, redraw\)/);
+    expect(html).toMatch(/if \(redraw !== false && DfirState\.lastState\(\)\) render\(/);
+  });
+
+  it("clearFilters also settles on one full render", () => {
+    const { view, renders } = loadNested({ falsePositivesRedraws: false });
+    view.clearFilters();
+    expect(renders()).toBe(1);
+  });
+});
+
 // ── resetForCase IS NOT clearFilters ─────────────────────────────────────────────────────────────
 //
 // Connecting to a case deliberately keeps the id filter, the severity boxes and the analyst's
 // exclude terms. Routing both through one helper would wipe persisted exclude terms on every
 // connect — the asymmetry the census found, preserved on purpose.
 describe("a case connect is not a filter clear", () => {
-  it("keeps the exclude terms and the id filter", () => {
+  it("keeps the analyst's standing preferences", () => {
     const { view } = load();
     // Order matters and is itself behaviour: filterToEventIds clears the exclude terms, exactly as
     // filterTimelineToEventIds does today via resetTimelineViewFilters. So the terms are set AFTER,
@@ -197,8 +343,21 @@ describe("a case connect is not a filter clear", () => {
     view.setSearch("noise");
     view.resetForCase();
     expect(view.search()).toBe("");
+    // Exclude terms survive: they are the analyst's standing preference, not this case's.
     expect(view.excludeTerms()).toEqual(["keep-me"]);
-    expect(view.eventIdFilterActive()).toBe(true);
+  });
+
+  // THE ID FILTER IS DIFFERENT, and an earlier draft of this file asserted the opposite — it
+  // documented proceedConnect's omission as intended and pinned it. An id filter is DERIVED FROM A
+  // CASE (an anomaly bucket, a session's rows), so carrying it across a case switch either blanks
+  // the new timeline or, on an id collision, shows unrelated evidence under the old case's label.
+  it("drops the event-group filter, which belongs to the case being left", () => {
+    const { view } = load();
+    view.filterToEventIds(["e1", "e2"], "anomaly bucket");
+    view.resetForCase();
+    expect(view.eventIdFilterActive()).toBe(false);
+    expect(view.eventIdCount()).toBe(0);
+    expect(view.eventIdLabel()).toBe("");
   });
 
   it("clearFilters DOES drop both, and repaints everything they touch", () => {

--- a/companion/tests/dashboard/dashboardTimelineView.test.ts
+++ b/companion/tests/dashboard/dashboardTimelineView.test.ts
@@ -1,0 +1,329 @@
+import { readFile } from "node:fs/promises";
+import { runInContext } from "node:vm";
+import { describe, expect, it } from "vitest";
+import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
+import type { TimelineViewApi } from "./dashboardApi.js";
+import { dashboardScripts, ownerEscapes, topLevelBindings } from "../helpers/dashboardAst.js";
+import { globalsAddedBy, loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// public/js/dashboard-timeline-view.js — the last tier-2 owner (#415).
+//
+// THESE TESTS EXIST IN THIS SHAPE BECAUSE OF WHAT THE PREVIOUS ONES MISSED. Every audit of this
+// tier landed on the same gap: the suites tested an owner's arithmetic and never the renderer
+// interaction, so two analyst-visible regressions sat behind a green suite. The refresh handlers
+// here are injected, which makes "which panels did this action repaint, and how many times" an
+// assertion rather than something only a browser could tell you — so that is what most of this
+// file checks.
+
+const MODULE = new URL("../../../public/js/dashboard-timeline-view.js", import.meta.url);
+const DASHBOARD = new URL("../../../public/dashboard.html", import.meta.url);
+const PANELS = [
+  "timeline",
+  "all",
+  "superTimeline",
+  "falsePositives",
+  "derivedViews",
+  "excludeChips",
+  "searchBox",
+  "timeInputs",
+  "severityBoxes",
+  "starButton",
+] as const;
+
+/** Load the module with a counting spy registered for every painter. */
+function load() {
+  const api = loadDashboardModule<TimelineViewApi>("dashboard-timeline-view.js", ["dashboard-state.js"]);
+  const painted: Record<string, number> = {};
+  const handlers: Record<string, () => void> = {};
+  for (const p of PANELS) {
+    painted[p] = 0;
+    handlers[p] = () => {
+      painted[p] += 1;
+    };
+  }
+  api.DfirTimelineView.wire(handlers);
+  const refreshed = () =>
+    Object.entries(painted)
+      .filter(([, n]) => n > 0)
+      .map(([k]) => k)
+      .sort();
+  return { view: api.DfirTimelineView, painted, refreshed };
+}
+
+describe("reads round-trip what the actions commit", () => {
+  it("starts with no filter of any kind", () => {
+    const { view } = load();
+    expect(view.search()).toBe("");
+    expect(view.excludeTerms()).toEqual([]);
+    expect(view.from()).toBeNull();
+    expect(view.to()).toBeNull();
+    expect(view.starredOnly()).toBe(false);
+    expect(view.eventIdFilterActive()).toBe(false);
+  });
+
+  it("normalises the search term the way the input handler used to", () => {
+    const { view } = load();
+    view.setSearch("  MiMiKatz  ");
+    expect(view.search()).toBe("mimikatz");
+  });
+
+  it("hands back a frozen exclude list", () => {
+    const { view } = load();
+    view.setExcludeTerms(["noisy"]);
+    expect(Object.isFrozen(view.excludeTerms())).toBe(true);
+  });
+
+  it("exposes id membership without letting the Set out", () => {
+    const { view } = load();
+    view.filterToEventIds(["e1", "e2"], "anomaly bucket");
+    expect(view.eventIdFilterActive()).toBe(true);
+    expect(view.eventIdCount()).toBe(2);
+    expect(view.hasEventId("e1")).toBe(true);
+    expect(view.hasEventId(1)).toBe(false);
+    expect(view.eventIdLabel()).toBe("anomaly bucket");
+    expect(Object.values(view)).not.toContainEqual(expect.any(Set));
+  });
+});
+
+// ── THE REFRESH SETS ─────────────────────────────────────────────────────────────────────────────
+//
+// One commit, one redraw. The set differs per action — that is the whole reason the handlers are
+// declared per action rather than one fixed callback — so each is pinned by name.
+describe("each action refreshes exactly what it declares, once", () => {
+  it("setSearch repaints the page, super-timeline and False Positives ONCE each", () => {
+    const { view, painted, refreshed } = load();
+    view.setSearch("psexec");
+    expect(refreshed()).toEqual(["all", "falsePositives", "searchBox", "superTimeline"]);
+    // THE COLLAPSE. This used to render() at its own site and again through renderFalsePositives()'s
+    // tail: two full renders, two /collection-plan fetches and four section sweeps per keystroke.
+    expect(painted.all).toBe(1);
+  });
+
+  it("setExcludeTerms repaints the chips, page, super-timeline and False Positives ONCE each", () => {
+    const { view, painted, refreshed } = load();
+    view.setExcludeTerms(["noise"]);
+    expect(refreshed()).toEqual(["all", "excludeChips", "falsePositives", "superTimeline"]);
+    expect(painted.all).toBe(1);
+  });
+
+  // The time window reaches further than the other filters: Kill Chain and Attack Phases are derived
+  // from the same filtered timeline. It does NOT do a full render.
+  it("setTimeWindow reaches the derived views but not the whole page", () => {
+    const { view, painted, refreshed } = load();
+    view.setTimeWindow("2026-05-01T00:00:00Z", null);
+    expect(refreshed()).toEqual(["derivedViews", "superTimeline", "timeInputs", "timeline"]);
+    expect(painted.all).toBe(0);
+  });
+
+  it("showOnlyStarred stays timeline-local", () => {
+    const { view, refreshed } = load();
+    view.showOnlyStarred(true);
+    expect(refreshed()).toEqual(["starButton", "timeline"]);
+  });
+
+  it("clearEventIds repaints the timeline only", () => {
+    const { view } = load();
+    view.filterToEventIds(["e1"], "");
+    const after = load();
+    after.view.clearEventIds();
+    expect(after.refreshed()).toEqual(["timeline"]);
+  });
+
+  // The lenses differ from each other, which is why setCorroboration branches.
+  it("routes the timeline lens to the timeline and the other two to the page", () => {
+    const a = load();
+    a.view.setCorroboration("timeline", 2);
+    expect(a.refreshed()).toEqual(["timeline"]);
+    const b = load();
+    b.view.setCorroboration("findings", 2);
+    expect(b.refreshed()).toEqual(["all"]);
+  });
+
+  it("ignores an unknown lens rather than committing one", () => {
+    const { view, refreshed } = load();
+    expect(view.setCorroboration("nonsense", 3)).toBe(0);
+    expect(refreshed()).toEqual([]);
+  });
+});
+
+// ── THE ORDERING BUG THE DESIGN EXISTS TO FIX ────────────────────────────────────────────────────
+describe("revealing a group of events paints once, with the filter already applied", () => {
+  it("has the id filter committed BEFORE the first repaint", () => {
+    const api = loadDashboardModule<TimelineViewApi>("dashboard-timeline-view.js", ["dashboard-state.js"]);
+    const view = api.DfirTimelineView;
+    const seen: Array<{ active: boolean; count: number }> = [];
+    view.wire({
+      timeline: () => seen.push({ active: view.eventIdFilterActive(), count: view.eventIdCount() }),
+    });
+    view.filterToEventIds(["e1", "e2", "e3"], "bucket");
+    // ONE paint, and it already sees the filter. filterTimelineToEventIds used to render TWICE
+    // through its reset — both showing the filter it had just cleared — and only apply the ids on a
+    // third paint.
+    expect(seen).toEqual([{ active: true, count: 3 }]);
+  });
+
+  it("clears the other view filters as part of the same action", () => {
+    const { view } = load();
+    view.setSearch("noise");
+    view.setTimeWindow("2026-05-01T00:00:00Z", null);
+    view.showOnlyStarred(true);
+    view.filterToEventIds(["e1"], "");
+    expect(view.search()).toBe("");
+    expect(view.from()).toBeNull();
+    expect(view.starredOnly()).toBe(false);
+    expect(view.hasEventId("e1")).toBe(true);
+  });
+
+  it("does nothing at all when given no ids", () => {
+    const { view, refreshed } = load();
+    expect(view.filterToEventIds([], "x")).toBe(0);
+    expect(refreshed()).toEqual([]);
+  });
+});
+
+// ── resetForCase IS NOT clearFilters ─────────────────────────────────────────────────────────────
+//
+// Connecting to a case deliberately keeps the id filter, the severity boxes and the analyst's
+// exclude terms. Routing both through one helper would wipe persisted exclude terms on every
+// connect — the asymmetry the census found, preserved on purpose.
+describe("a case connect is not a filter clear", () => {
+  it("keeps the exclude terms and the id filter", () => {
+    const { view } = load();
+    // Order matters and is itself behaviour: filterToEventIds clears the exclude terms, exactly as
+    // filterTimelineToEventIds does today via resetTimelineViewFilters. So the terms are set AFTER,
+    // which is the state a real analyst is in when they connect to another case.
+    view.filterToEventIds(["e1"], "bucket");
+    view.setExcludeTerms(["keep-me"]);
+    view.setSearch("noise");
+    view.resetForCase();
+    expect(view.search()).toBe("");
+    expect(view.excludeTerms()).toEqual(["keep-me"]);
+    expect(view.eventIdFilterActive()).toBe(true);
+  });
+
+  it("clearFilters DOES drop both, and repaints everything they touch", () => {
+    const { view, refreshed } = load();
+    view.setExcludeTerms(["drop-me"]);
+    view.filterToEventIds(["e1"], "bucket");
+    const after = load();
+    after.view.setExcludeTerms(["drop-me"]);
+    after.view.filterToEventIds(["e1"], "bucket");
+    after.view.clearFilters();
+    expect(after.view.excludeTerms()).toEqual([]);
+    expect(after.view.eventIdFilterActive()).toBe(false);
+    expect(after.refreshed()).toContain("all");
+    void refreshed;
+  });
+
+  it("refreshes NOTHING on a case connect, because proceedConnect paints in its own order", () => {
+    const { view, refreshed } = load();
+    view.resetForCase();
+    expect(refreshed()).toEqual([]);
+  });
+});
+
+// Restoring persisted state at bootstrap is not a user action: it runs while the script is parsing,
+// with no panel on the page to repaint.
+describe("hydrate commits without painting", () => {
+  it("restores exclude terms and the lenses with no refresh", () => {
+    const { view, refreshed } = load();
+    view.hydrate({ excludeTerms: ["saved"], corroboration: { timeline: 2, iocs: 3, findings: 2 } });
+    expect(view.excludeTerms()).toEqual(["saved"]);
+    expect(view.corrobTimeline()).toBe(2);
+    expect(view.corrobIocs()).toBe(3);
+    expect(refreshed()).toEqual([]);
+  });
+
+  it("tolerates a missing or partial payload", () => {
+    const { view } = load();
+    view.hydrate(undefined);
+    view.hydrate({ corroboration: { timeline: 3 } });
+    expect(view.corrobTimeline()).toBe(3);
+    expect(view.excludeTerms()).toEqual([]);
+  });
+});
+
+describe("nothing but the namespace escapes", () => {
+  it("adds only DfirTimelineView to the global object", () => {
+    expect(globalsAddedBy("dashboard-timeline-view.js", ["dashboard-state.js"])).toEqual([
+      "DfirTimelineView",
+    ]);
+  });
+
+  it("puts the cells out of reach of a second script on the page", () => {
+    const api = loadDashboardModule<TimelineViewApi>("dashboard-timeline-view.js", ["dashboard-state.js"]);
+    api.DfirTimelineView.setSearch("legit");
+    expect(() => runInContext("search.set('smuggled')", api as object)).toThrow(/search is not defined/);
+    expect(api.DfirTimelineView.search()).toBe("legit");
+  });
+
+  it("publishes no change subscription", () => {
+    const api = loadDashboardModule<TimelineViewApi>("dashboard-timeline-view.js", ["dashboard-state.js"]);
+    expect(Object.keys(api.DfirTimelineView).filter((k) => /^on[A-Z]/.test(k))).toEqual([]);
+  });
+});
+
+describe("the old bindings are gone", () => {
+  const scripts = dashboardScripts();
+  const MOVED = [
+    "searchTerm",
+    "excludeTerms",
+    "filterFrom",
+    "filterTo",
+    "showStarredOnly",
+    "evIdFilter",
+    "evIdFilterLabel",
+    "corrobTimeline",
+    "corrobIocs",
+    "corrobFindings",
+  ];
+
+  it.each(MOVED)("%s has no binding left in any script the page loads", (name) => {
+    const offenders = scripts.flatMap((s) =>
+      topLevelBindings(s)
+        .filter((b) => b.name === name)
+        .map((b) => `${s.name}:${b.line}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("is never aliased or reached dynamically", () => {
+    expect(ownerEscapes(scripts, "DfirTimelineView").map((e) => `${e.script}:${e.line} ${e.form}`)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("wiring", () => {
+  it("is loaded by dashboard.html, ahead of the inline script, and served by the whitelist", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    expect(html).toContain('<script src="/js/dashboard-timeline-view.js"></script>');
+    const tag = html.indexOf('src="/js/dashboard-timeline-view.js"');
+    expect(html.indexOf('src="/js/dashboard-state.js"')).toBeLessThan(tag);
+    const blocks = [...html.matchAll(/<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g)];
+    const main = blocks.find((m) => /\n\s*function render\s*\(/.test(m[1]));
+    expect(main).toBeDefined();
+    expect(tag).toBeLessThan(main!.index);
+    expect(STATIC_ASSETS["/js/dashboard-timeline-view.js"]).toBe("application/javascript; charset=utf-8");
+  });
+
+  // The module is inert without its painters, so a page that forgets to register them would commit
+  // filters that never appear. This pins that the registration exists and covers every panel.
+  it("registers a painter for every panel the module knows about", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    const src = await readFile(MODULE, "utf8");
+    const declared = [...src.matchAll(/^\s{4}(\w+): noop,/gm)].map((m) => m[1]);
+    expect(declared.length, "expected the module's painter list").toBeGreaterThan(5);
+    const wireBlock = html.slice(html.indexOf("DfirTimelineView.wire({"));
+    for (const panel of declared) {
+      expect(wireBlock.slice(0, 2000), `dashboard.html registers no painter for "${panel}"`).toContain(
+        `${panel}:`,
+      );
+    }
+  });
+
+  it("stays a classic script", async () => {
+    const src = await readFile(MODULE, "utf8");
+    expect(src).not.toMatch(/^\s*(?:export|import)\s/m);
+  });
+});

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -574,6 +574,35 @@ export interface OwnerEscape {
  * either needs binding-aware analysis; neither has a use in this page, and both are one line to
  * avoid — so they are reported wherever they appear rather than resolved.
  */
+/**
+ * Is this the PROPERTY NAME half of `a.b`, rather than a reference to something called `b`?
+ *
+ * The bare identifier `DfirFacets` inside `window.DfirFacets` matches "denotes the namespace" on
+ * its own, and it sits at `parent.name` — not `parent.expression` — so the longer-path check does
+ * not cover it. Without this, every module was reported as smuggling out its own namespace.
+ */
+function isPropertyName(n: ts.Node): boolean {
+  const p = n.parent;
+  return !!p && (ts.isPropertyAccessExpression(p) || ts.isPropertyAssignment(p)) && p.name === n;
+}
+
+/** Is this node the `X` in `X(...)` — i.e. the thing actually being invoked? */
+function isCalleePosition(n: ts.Node): boolean {
+  const p = n.parent;
+  return !!p && (ts.isCallExpression(p) || ts.isNewExpression(p)) && p.expression === n;
+}
+
+/** A sub-path like `DfirSelection.events` inside `DfirSelection.events.toggle(x)` is not itself an escape. */
+function isPartOfLongerPath(n: ts.Node): boolean {
+  const p = n.parent;
+  return !!p && (ts.isPropertyAccessExpression(p) || ts.isElementAccessExpression(p)) && p.expression === n;
+}
+
+function nearbyText(n: ts.Node, sf: ts.SourceFile): string {
+  const target = n.parent && ts.isPropertyAccessExpression(n.parent) ? n.parent : n;
+  return target.getText(sf).slice(0, 90);
+}
+
 export function ownerEscapes(scripts: DashboardScript[], namespace: string): OwnerEscape[] {
   const hits: OwnerEscape[] = [];
   const denotesOwnerOrChild = (n: ts.Node): boolean => {
@@ -582,6 +611,18 @@ export function ownerEscapes(scripts: DashboardScript[], namespace: string): Own
   };
   for (const s of scripts) {
     const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
+    // Positions that DEFINE the namespace rather than reference it: the `window.DfirFacets` in
+    // `window.DfirFacets = { … }`. Collected in a pre-pass rather than read off node.parent, which
+    // did not match reliably here.
+    const definitionTargets = new Set<number>();
+    const findDefs = (n: ts.Node): void => {
+      if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+        definitionTargets.add(n.left.getStart(s.ast));
+      }
+      ts.forEachChild(n, findDefs);
+    };
+    ts.forEachChild(s.ast, findDefs);
+
     const visit = (n: ts.Node): void => {
       // const events = DfirSelection.events
       if (
@@ -601,15 +642,22 @@ export function ownerEscapes(scripts: DashboardScript[], namespace: string): Own
       ) {
         hits.push({ script: s.name, line: at(n), form: "alias", text: n.getText(s.ast).slice(0, 90) });
       }
-      // PASSED SOMEWHERE. An owner handed to another function is a writer this analysis stops
-      // following at the call. There is a supported alternative — a read-only view — so passing the
-      // owner itself is reported rather than resolved.
-      if (ts.isCallExpression(n)) {
-        for (const a of n.arguments) {
-          if (denotesOwnerOrChild(a)) {
-            hits.push({ script: s.name, line: at(a), form: "passed", text: n.getText(s.ast).slice(0, 90) });
-          }
-        }
+      // ANY reference to the owner that is NOT the callee of a call.
+      //
+      // Enumerating contexts (argument here, assignment there) is how this kept failing open —
+      // review found detached method references stashed in arrays, in object literals and returned
+      // from functions, none of which was in the list. So the rule is inverted: an owner or one of
+      // its members may appear as the thing being CALLED, and nowhere else. Everything else is a
+      // reference this analysis stops following, and there is a supported alternative for the one
+      // legitimate case (matcher(), a read-only view).
+      if (
+        denotesOwnerOrChild(n) &&
+        !isCalleePosition(n) &&
+        !isPartOfLongerPath(n) &&
+        !isPropertyName(n) &&
+        !definitionTargets.has(n.getStart(s.ast))
+      ) {
+        hits.push({ script: s.name, line: at(n), form: "passed", text: nearbyText(n, s.ast) });
       }
       // DfirSelection.events["toggle"](…) / DfirSelection.events[m](…)
       if (ts.isElementAccessExpression(n) && denotesOwnerOrChild(n.expression)) {

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -430,8 +430,11 @@ describe("dashboard.html", () => {
     // slice), not the paginated page or the raw unfiltered `ft` — so density reflects every active filter
     // and the full dataset across all pages, not just the current page.
     expect(html).toMatch(/visible = sortTimelineEvents\(visible\);\s*\n\s*renderTimelineHeatmap\(visible\)/);
-    // Click-to-zoom reuses the same filterFrom/filterTo path as the search-bar date filters.
-    expect(html).toMatch(/zoomToTimeWindow[\s\S]{0,400}filterFrom = fromIso/);
+    // Click-to-zoom reuses the same time-window path as the search-bar date filters. This used to
+    // be asserted as `filterFrom = fromIso` inside zoomToTimeWindow; both now commit through the
+    // owner (#415 tier 2), so BOTH sides of "the same path" are named rather than implied.
+    expect(html).toMatch(/zoomToTimeWindow[\s\S]{0,600}DfirTimelineView\.setTimeWindow\(fromIso, toIso\)/);
+    expect(html).toMatch(/function applyTimeRange[\s\S]{0,200}DfirTimelineView\.setTimeWindow\(/);
     // Each bar carries its own bucket window for the zoom. This used to be an inline
     // onclick="zoomToTimeWindow('${from}','${to}')"; inline handlers are now blocked by the CSP
     // (script-src), so the window rides in data-* and the click is dispatched from the ACTIONS table.

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -127,6 +127,7 @@
   <!-- Tier 2's selection owners (#415). After dashboard-state.js, whose cell() they build on. -->
   <script src="/js/dashboard-selection.js"></script>
   <script src="/js/dashboard-facets.js"></script>
+  <script src="/js/dashboard-timeline-view.js"></script>
   <!-- The AI tagger-rule feature (#415 tier 3). A whole feature, not the movable half of one —
        js/dashboard-tagger.js explains why that distinction decides what moves next. -->
   <script src="/js/dashboard-tagger.js"></script>
@@ -3565,48 +3566,81 @@
         return { key: key === "severity" ? "severity" : "date", dir: dir === "desc" ? "desc" : "asc" };
       } catch { return { key: "date", dir: "asc" }; }
     })();
-    let searchTerm = "";                      // active text search (lower-cased; empty = no filter)
     let fpReasonFilter = "";                  // False Positives panel: reason code to filter to ("" = all)
     // Exclude filter (#216): hide events/IOCs/findings matching ANY of these terms — a view-only lens,
     // never touches InvestigationState. Persisted per-browser so it survives reloads.
-    let excludeTerms = (() => {
-      try { return JSON.parse(localStorage.getItem("dfir.excludeTerms") || "[]"); } catch { return []; }
+    (() => {
+      let saved = [];
+      try { saved = JSON.parse(localStorage.getItem("dfir.excludeTerms") || "[]"); } catch { saved = []; }
+      // hydrate(), not setExcludeTerms(): this runs while the script is still parsing, so there is
+      // nothing to refresh yet — see js/dashboard-timeline-view.js.
+      DfirTimelineView.hydrate({ excludeTerms: Array.isArray(saved) ? saved : [] });
     })();
-    if (!Array.isArray(excludeTerms)) excludeTerms = [];
     // Persist + re-render the exclude-term chip list, then re-apply filters to whatever's on screen.
+    // Persistence stays here — the owner holds the value, the page decides it survives a reload.
+    // The refresh is the owner's: ONE render where there were two (see js/dashboard-timeline-view.js).
     function setExcludeTerms(terms) {
-      excludeTerms = terms;
-      try { localStorage.setItem("dfir.excludeTerms", JSON.stringify(excludeTerms)); } catch {}
-      renderExcludeChips();
-      if (DfirState.lastState()) render(DfirState.lastState());
-      if (DfirState.lastSuperData()) loadSuperTimeline();   // the main filter's exclude terms scope the super-timeline too
-      renderFalsePositives(fpMarkers);   // exclude terms scope the False Positives panel too
+      DfirTimelineView.setExcludeTerms(terms);
+      try { localStorage.setItem("dfir.excludeTerms", JSON.stringify(DfirTimelineView.excludeTerms())); } catch {}
     }
     function renderExcludeChips() {
       const box = document.getElementById("excludeChips");
       const clearBtn = document.getElementById("clearExcludeBtn");
       if (!box) return;
-      box.innerHTML = excludeTerms.map((t, i) =>
+      box.innerHTML = DfirTimelineView.excludeTerms().map((t, i) =>
         `<span class="exclude-chip"><span title="${escAttr(t)}">${esc(t)}</span><button type="button" data-i="${i}" title="Remove this exclude term">✕</button></span>`
       ).join("");
-      if (clearBtn) clearBtn.hidden = excludeTerms.length === 0;
+      if (clearBtn) clearBtn.hidden = DfirTimelineView.excludeTerms().length === 0;
     }
     // Corroboration lens (#35): 0 = off; 2/3 = show only items observed by ≥N distinct tools. A LENS,
     // not a gate — it narrows the view but never drops state, so single-source evidence (a Sysmon-only
     // process, a syslog-only logon) is always one click away. Each of the three sections (Timeline /
     // IOCs / Findings) has its OWN control in its title bar, persisted independently per-browser.
     const _corrobOf = (k) => { const v = parseInt(localStorage.getItem("dfir.corrob." + k) || "0", 10); return v === 2 || v === 3 ? v : 0; };
-    let corrobTimeline = _corrobOf("timeline");
-    let corrobIocs = _corrobOf("iocs");
-    let corrobFindings = _corrobOf("findings");
+    DfirTimelineView.hydrate({
+      corroboration: { timeline: _corrobOf("timeline"), iocs: _corrobOf("iocs"), findings: _corrobOf("findings") },
+    });
+    // The page's painters, registered once. DfirTimelineView decides WHICH of these an action makes
+    // stale; it does not know how to paint any of them. Arrows, so the names resolve at call time —
+    // every one of these is declared later in this script.
+    DfirTimelineView.wire({
+      timeline: () => renderTimelineEvents(DfirState.lastFt() || []),
+      all: () => { if (DfirState.lastState()) render(DfirState.lastState()); },
+      superTimeline: () => { if (DfirState.lastSuperData()) loadSuperTimeline(); },
+      falsePositives: () => renderFalsePositives(fpMarkers),
+      derivedViews: () => refreshFilteredViews(),
+      excludeChips: () => renderExcludeChips(),
+      searchBox: () => {
+        const gs = document.getElementById("globalSearch");
+        if (gs) gs.value = DfirTimelineView.search();
+        const cs = document.getElementById("clearSearch");
+        if (cs) cs.hidden = !DfirTimelineView.search();
+      },
+      timeInputs: () => {
+        const ff = document.getElementById("filterFrom");
+        if (ff) ff.value = isoToUtcInput(DfirTimelineView.from());
+        const ft = document.getElementById("filterTo");
+        if (ft) ft.value = isoToUtcInput(DfirTimelineView.to());
+        const cf = document.getElementById("clearFiltersBtn");
+        if (cf) cf.hidden = !DfirTimelineView.from() && !DfirTimelineView.to();
+      },
+      severityBoxes: () => document.querySelectorAll(".sev-filter").forEach(cb => { cb.checked = true; }),
+      starButton: () => {
+        const b = document.getElementById("evStarFilterBtn");
+        if (!b) return;
+        const on = DfirTimelineView.starredOnly();
+        b.textContent = on ? "★ Starred" : "☆ Starred";
+        b.classList.toggle("active", on);
+      },
+    });
     // The four facet filters moved to js/dashboard-facets.js as DfirFacets (#415, tier 2). The
     // stale-facet prune each renderer used to perform is now derived — see that file.
     let _srcMenuSig = "";                      // signature of the source-filter menu's last build (skip rebuild when unchanged)
     let _originMenuSig = "";                   // signature of the origin-filter menu's last build
     let _hostMenuSig = "";                     // signature of the host-filter menu's last build
     let _iocTypeMenuSig = "";                  // signature of the IOC-type-filter menu's last build (skip rebuild when unchanged)
-    let filterFrom = null;                    // timeline view lower bound (ISO UTC string or null)
-    let filterTo = null;                      // timeline view upper bound (ISO UTC string or null)
+    // searchTerm / filterFrom / filterTo / excludeTerms / the three corroboration lenses moved to
+    // js/dashboard-timeline-view.js (#415, tier 2): the unit there is the ACTION, not the field.
     let _searchDebounce = null;
     let tlPage = 0;                           // current timeline page (0-based)
     let tlPageSize = 50;                      // rows per page; user-selectable
@@ -3616,15 +3650,15 @@
     let _iocKeepPage = false;                 // pagination buttons set this to avoid resetting to page 0
     let _lastRenderedIocs = [];               // exact array last passed to renderIocs, so pagination can re-render the same data
 
-    function _hasActiveFilter() { return !!(searchTerm || filterFrom || filterTo || excludeTerms.length); }
+    function _hasActiveFilter() { return !!(DfirTimelineView.search() || DfirTimelineView.from() || DfirTimelineView.to() || DfirTimelineView.excludeTerms().length); }
     // True when an event passes the GLOBAL search-bar filter (text search + time range + exclude terms).
     // This is the filter the toolbar search applies to the timeline; we also feed it to the timeline-DERIVED
     // views (Kill Chain, Attack Phases) so "I searched an IP" narrows every event-based section, not just the
     // timeline list. (Severity-legend + source toggles stay timeline-local — they're list facets.)
     function _matchesGlobalFilter(e) {
-      if (searchTerm && !_evMatchesSearch(e, searchTerm)) return false;
-      if (excludeTerms.length && _evMatchesExclude(e, excludeTerms)) return false;
-      if ((filterFrom || filterTo) && !_evMatchesTimeRange(e, filterFrom, filterTo)) return false;
+      if (DfirTimelineView.search() && !_evMatchesSearch(e, DfirTimelineView.search())) return false;
+      if (DfirTimelineView.excludeTerms().length && _evMatchesExclude(e, DfirTimelineView.excludeTerms())) return false;
+      if ((DfirTimelineView.from() || DfirTimelineView.to()) && !_evMatchesTimeRange(e, DfirTimelineView.from(), DfirTimelineView.to())) return false;
       return true;
     }
     function applyGlobalEventFilter(events) {
@@ -3873,8 +3907,8 @@
     // swimlane brush, search-bar dates and applied dwell-windows. Empty when no time filter is set.
     function _graphTimeQuery() {
       const p = new URLSearchParams();
-      if (filterFrom) p.set("from", filterFrom);
-      if (filterTo) p.set("until", filterTo);
+      if (DfirTimelineView.from()) p.set("from", DfirTimelineView.from());
+      if (DfirTimelineView.to()) p.set("until", DfirTimelineView.to());
       const q = p.toString();
       return q ? `?${q}` : "";
     }
@@ -4024,7 +4058,7 @@
       // super-timeline when it has been loaded before, so pre-reset the pagination cursor and only
       // load explicitly when the section has never been opened.
       superOffset = 0;
-      applySearch();                     // sets searchTerm + rescopes the whole dashboard (window-exposed by the search IIFE)
+      applySearch();                     // commits the search term + rescopes the whole dashboard (window-exposed by the search IIFE)
       if (!DfirState.lastSuperData()) loadSuperTimeline();
       const sec = document.getElementById("sec-super-timeline");
       if (sec) { sec.classList.remove("collapsed"); sec.scrollIntoView({ behavior: "smooth", block: "start" }); }
@@ -5347,13 +5381,13 @@
       const stToIso = utcInputToIso((document.getElementById("stTo") || {}).value || "");
       // Intersect with the main dashboard filter bar's time range (#8) — ISO UTC strings sort
       // lexically, so max()/min() picks the tighter bound on each side without a Date parse.
-      const from = [stFromIso, filterFrom].filter(Boolean).sort().pop() || "";
-      const to = [stToIso, filterTo].filter(Boolean).sort()[0] || "";
+      const from = [stFromIso, DfirTimelineView.from()].filter(Boolean).sort().pop() || "";
+      const to = [stToIso, DfirTimelineView.to()].filter(Boolean).sort()[0] || "";
       const p = new URLSearchParams();
       if (from) p.set("from", from);
       if (to) p.set("to", to);
-      if (searchTerm) p.set("q", searchTerm);
-      if (excludeTerms.length) p.set("excludeText", excludeTerms.join(","));
+      if (DfirTimelineView.search()) p.set("q", DfirTimelineView.search());
+      if (DfirTimelineView.excludeTerms().length) p.set("excludeText", DfirTimelineView.excludeTerms().join(","));
       // Origins + hosts are EXCLUDE-model checklists: send the UNCHECKED items as the exclude list, so
       // all checked → exclude nothing → all shown; some unchecked → those hidden; ALL unchecked → 0
       // events. (An include list would treat "none checked" as "show all" — the bug this avoids.)
@@ -6360,12 +6394,10 @@
     // migrated up once per case, then the key is deleted.
     // starredEvents moved to js/dashboard-selection.js as DfirStarred (#415).
     let starredTagIds = new Map();   // eventId -> tag id (needed for DELETE /cases/:id/tags/:tagId)
-    let showStarredOnly = false;
     // Transient "show only this set of event ids" filter — set by the Timeline Anomalies
     // "view N events" link (and reusable by any panel that points at a group of events) so the
     // analyst sees EXACTLY the events behind a bucket, not just the first. null = inactive.
-    let evIdFilter = null;        // Set<string> of event ids, or null
-    let evIdFilterLabel = "";     // human label shown in the chip (e.g. the anomaly bucket)
+    // showStarredOnly / evIdFilter / evIdFilterLabel moved to js/dashboard-timeline-view.js (#415).
     let showFlaggedIocsOnly = false;   // IOCs section: show only malicious/suspicious (any enrichment engine)
     // Noise-reduction defaults for a case with hundreds/thousands of IOCs (every file/process/hash seen
     // anywhere becomes one — see the "too many IOCs" discussion): hide false-positive-marked + no-intel IOCs,
@@ -12854,21 +12886,14 @@
     // Reset the forensic-timeline VIEW filters (severity / source / starred / search / time range) so a
     // targeted event can't be hidden. Used by jumpToEvent when the event isn't on the current page —
     // only called when the row is genuinely hidden, so a no-filter view is left untouched.
+    // The analyst's "clear filters", now one commit and one redraw. The facets are a separate owner
+    // so they are cleared alongside; everything else belongs to DfirTimelineView.
     function resetTimelineViewFilters() {
-      document.querySelectorAll(".sev-filter").forEach(cb => { cb.checked = true; });
       DfirFacets.sources.showAll(); _srcMenuSig = "";
       DfirFacets.origins.showAll(); _originMenuSig = "";
       DfirFacets.hosts.showAll(); _hostMenuSig = "";
-      showStarredOnly = false;
-      evIdFilter = null; evIdFilterLabel = "";
-      const sfBtn = document.getElementById("evStarFilterBtn");
-      if (sfBtn) { sfBtn.textContent = "☆ Starred"; sfBtn.classList.remove("active"); }
-      searchTerm = ""; filterFrom = null; filterTo = null;
-      setExcludeTerms([]);   // also un-hides anything the exclude filter was suppressing
-      const gsEl = document.getElementById("globalSearch"); if (gsEl) gsEl.value = "";
-      const ffEl = document.getElementById("filterFrom"); if (ffEl) ffEl.value = "";
-      const ftEl = document.getElementById("filterTo"); if (ftEl) ftEl.value = "";
-      const csBtn = document.getElementById("clearSearch"); if (csBtn) csBtn.hidden = true;
+      DfirTimelineView.clearFilters();
+      try { localStorage.setItem("dfir.excludeTerms", "[]"); } catch {}
     }
 
     // Filter the forensic timeline to EXACTLY a set of event ids (e.g. every event behind a Timeline
@@ -12877,28 +12902,26 @@
     function filterTimelineToEventIds(ids, label) {
       const list = (ids || []).map(String).filter(Boolean);
       if (!list.length) return;
-      resetTimelineViewFilters();              // also clears any prior id filter
-      evIdFilter = new Set(list);
-      evIdFilterLabel = label || "";
+      DfirFacets.sources.showAll(); _srcMenuSig = "";
+      DfirFacets.origins.showAll(); _originMenuSig = "";
+      DfirFacets.hosts.showAll(); _hostMenuSig = "";
+      // ONE paint, with the id filter already committed. This used to reset (two full renders, both
+      // showing the filter it had just cleared) and only apply the ids on a third.
+      DfirTimelineView.filterToEventIds(list, label);
       const sec = document.getElementById("sec-timeline");
-      if (sec) sec.classList.remove("collapsed");
-      renderTimelineEvents(DfirState.lastFt() || []);
-      if (sec) sec.scrollIntoView({ behavior: "smooth", block: "start" });
+      if (sec) { sec.classList.remove("collapsed"); sec.scrollIntoView({ behavior: "smooth", block: "start" }); }
     }
-    function clearEvIdFilter() {
-      evIdFilter = null; evIdFilterLabel = "";
-      renderTimelineEvents(DfirState.lastFt() || []);
-    }
+    function clearEvIdFilter() { DfirTimelineView.clearEventIds(); }
     // Render (or hide) the chip that shows the active "only these N events" filter + a Clear button.
     function renderEvIdFilterChip(shown, _total) {
       const el = document.getElementById("evIdFilterChip");
       if (!el) return;
-      if (!evIdFilter) { el.style.display = "none"; el.innerHTML = ""; return; }
-      const n = evIdFilter.size;
+      if (!DfirTimelineView.eventIdFilterActive()) { el.style.display = "none"; el.innerHTML = ""; return; }
+      const n = DfirTimelineView.eventIdCount();
       el.style.display = "";
       el.innerHTML =
         `<span data-safe-style="color:var(--accent)">⧉ Showing ${shown} of ${n} event${n !== 1 ? "s" : ""} in this group` +
-        `${evIdFilterLabel ? " — " + esc(evIdFilterLabel) : ""}</span>` +
+        `${DfirTimelineView.eventIdLabel() ? " — " + esc(DfirTimelineView.eventIdLabel()) : ""}</span>` +
         ` <button type="button" data-act="clearEvIdFilter" data-safe-style="margin-left:8px;font-size:11px;background:var(--border-color);border:none;color:var(--text-primary);border-radius:3px;padding:2px 8px;cursor:pointer" title="Clear this filter and show the whole timeline">✕ Clear, show all</button>`;
     }
 
@@ -13088,15 +13111,7 @@
           const x0 = Math.min(tb.x0, tb.x1), x1 = Math.max(tb.x0, tb.x1);
           if (x1 - x0 > 4) {
             const ms0 = swXToTs(x0, canvas.width), ms1 = swXToTs(x1, canvas.width);
-            const ff = document.getElementById("filterFrom"), ft = document.getElementById("filterTo");
-            const cfBtn = document.getElementById("clearFiltersBtn");
-            if (ff) ff.value = isoToUtcInput(new Date(ms0).toISOString());
-            if (ft) ft.value = isoToUtcInput(new Date(ms1).toISOString());
-            filterFrom = new Date(ms0).toISOString();
-            filterTo = new Date(ms1).toISOString();
-            if (cfBtn) cfBtn.hidden = false;
-            renderTimelineEvents(DfirState.lastFt());
-            refreshFilteredViews();   // keep Kill Chain + Attack Phases in sync with the brushed range
+            DfirTimelineView.setTimeWindow(new Date(ms0).toISOString(), new Date(ms1).toISOString());
             const sec = document.getElementById("sec-timeline");
             if (sec && sec.classList.contains("collapsed")) sec.classList.remove("collapsed");
           }
@@ -13337,13 +13352,13 @@
       const el = document.getElementById("false-positive");
       // The global filter toolbar (search + exclude terms) scopes this panel too, same as the
       // Timeline/Findings/IOCs — matched against kind/ref/label/reason/note (see _fpMatchesSearch).
-      const q = searchTerm;
+      const q = DfirTimelineView.search();
       // Most-recently-marked first, so a fresh mark-as-FP surfaces at the top instead of getting
       // buried at the bottom of a long list (markedAt is an ISO timestamp; unparsable sorts last).
       const sorted = [...fpMarkers].sort((a, b) => (Date.parse(b.markedAt) || 0) - (Date.parse(a.markedAt) || 0));
       const visible = sorted.filter(m =>
         (!q || _fpMatchesSearch(m, q)) &&
-        !(excludeTerms.length && _fpMatchesExclude(m, excludeTerms)) &&
+        !(DfirTimelineView.excludeTerms().length && _fpMatchesExclude(m, DfirTimelineView.excludeTerms())) &&
         (!fpReasonFilter || m.reason === fpReasonFilter));
       // For event markers, prefer the human-readable label (the event description)
       // over the opaque event id stored as ref.
@@ -13362,7 +13377,7 @@
             : "<div data-safe-style='color:var(--text-muted)'>Nothing marked false positive.</div>");
       const fpCountEl = document.getElementById("fpCount");
       if (fpCountEl) {
-        fpCountEl.textContent = (q || excludeTerms.length || fpReasonFilter)
+        fpCountEl.textContent = (q || DfirTimelineView.excludeTerms().length || fpReasonFilter)
           ? `(${visible.length} of ${fpMarkers.length})`
           : (fpMarkers.length ? `(${fpMarkers.length})` : "");
       }
@@ -13517,10 +13532,10 @@
       renderIocExcludeRules((DfirState.lastState() && DfirState.lastState().iocExcludeRules) || []);
       const flaggedTotal = iocs.filter(iocFlagged).length;
       let visible = showFlaggedIocsOnly ? iocs.filter(iocFlagged) : iocs;
-      if (searchTerm) visible = visible.filter(i => _iocMatchesSearch(i, searchTerm));
-      if (excludeTerms.length) visible = visible.filter(i => !_iocMatchesExclude(i, excludeTerms));
+      if (DfirTimelineView.search()) visible = visible.filter(i => _iocMatchesSearch(i, DfirTimelineView.search()));
+      if (DfirTimelineView.excludeTerms().length) visible = visible.filter(i => !_iocMatchesExclude(i, DfirTimelineView.excludeTerms()));
       if (iocTypeHidden > 0) visible = visible.filter(i => !DfirFacets.iocTypes.has(i.type || "other"));
-      if (corrobIocs > 1) visible = visible.filter(i => (iocSourcesById[i.id] || []).length >= corrobIocs);   // corroboration lens (#35)
+      if (DfirTimelineView.corrobIocs() > 1) visible = visible.filter(i => (iocSourcesById[i.id] || []).length >= DfirTimelineView.corrobIocs());   // corroboration lens (#35)
       if (iocProvenanceFilter !== "all") visible = visible.filter(i => iocProvenanceOf(i.id) === iocProvenanceFilter);   // provenance lens
       if (riskIocsFilter > 0) visible = visible.filter(i => iocRiskRankOf(i.id) >= riskIocsFilter);   // risk lens (#63)
       // Noise reduction (two independent, composable lenses — nothing is deleted, both persisted
@@ -13561,7 +13576,7 @@
       if (!visible.length) {
         el.innerHTML = showFlaggedIocsOnly
           ? "<div data-safe-style='color:var(--text-muted)'>No malicious/suspicious IOCs — enrich the IOCs first, or none came back flagged.</div>"
-          : (searchTerm || excludeTerms.length > 0 || iocTypeHidden > 0 || corrobIocs > 1 || iocProvenanceFilter !== "all" || riskIocsFilter > 0 || noiseFiltersActive) && iocs.length > 0
+          : (DfirTimelineView.search() || DfirTimelineView.excludeTerms().length > 0 || iocTypeHidden > 0 || DfirTimelineView.corrobIocs() > 1 || iocProvenanceFilter !== "all" || riskIocsFilter > 0 || noiseFiltersActive) && iocs.length > 0
             ? `<div data-safe-style='color:var(--text-muted)'>No IOCs match the filter.${noiseFiltersActive ? " Turn off “Signal only” / “Hide FP/no-intel” / “Hide OS system paths” to see everything." : ""}</div>`
           : "<div data-safe-style='color:var(--text-muted)'>No IOCs yet</div>";
         updateIocBulkBar();
@@ -13885,21 +13900,11 @@
     // search-bar date inputs and the swimlane time-brush already use, so a heatmap click behaves
     // identically to typing a date range (and composes with every other active filter).
     function zoomToTimeWindow(fromIso, toIso) {
-      const ffEl = document.getElementById("filterFrom");
-      const ftEl = document.getElementById("filterTo");
-      const cfBtn = document.getElementById("clearFiltersBtn");
-      if (ffEl) ffEl.value = isoToUtcInput(fromIso);
-      if (ftEl) ftEl.value = isoToUtcInput(toIso);
-      filterFrom = fromIso;
-      filterTo = toIso;
-      if (cfBtn) cfBtn.hidden = false;
       // Open the (possibly collapsed) filter panel so the populated from/to fields and the Clear
       // button are actually visible — otherwise the zoom silently narrows the timeline with no
       // obvious way back (the Clear button lives inside that panel).
       setSearchBarOpen(true, false);
-      renderTimelineEvents(DfirState.lastFt());
-      refreshFilteredViews();
-      if (DfirState.lastSuperData()) loadSuperTimeline();
+      DfirTimelineView.setTimeWindow(fromIso, toIso);
     }
     function renderTimelineHeatmap(visible) {
       const el = document.getElementById("timelineHeatmap");
@@ -13943,8 +13948,8 @@
       // When the corroboration lens is on, scope the Sources menu to the tools present on events that
       // CLEAR the lens (≥N distinct sources, counting all of them — so the facet list is stable as the
       // analyst toggles sources). Drives renderSourceFilter's display list.
-      const lensFt = corrobTimeline > 1
-        ? ft.filter(e => realSourceCount(e.sources) >= corrobTimeline)
+      const lensFt = DfirTimelineView.corrobTimeline() > 1
+        ? ft.filter(e => realSourceCount(e.sources) >= DfirTimelineView.corrobTimeline())
         : null;
       // These return the EFFECTIVE hidden count, so the "N of M events" label below agrees with the
       // buttons the analyst sees — see js/dashboard-facets.js.
@@ -13959,11 +13964,11 @@
       const allSevs = ['Critical', 'High', 'Medium', 'Low'];
       const filtering = activeSevs.size < allSevs.length;
       let visible = filtering ? ft.filter(e => activeSevs.has(e.severity)) : ft;
-      if (evIdFilter) visible = visible.filter(e => evIdFilter.has(String(e.id)));
-      if (showStarredOnly) visible = visible.filter(e => DfirStarred.has(String(e.id)));
-      if (searchTerm) visible = visible.filter(e => _evMatchesSearch(e, searchTerm));
-      if (excludeTerms.length) visible = visible.filter(e => !_evMatchesExclude(e, excludeTerms));
-      if (filterFrom || filterTo) visible = visible.filter(e => _evMatchesTimeRange(e, filterFrom, filterTo));
+      if (DfirTimelineView.eventIdFilterActive()) visible = visible.filter(e => DfirTimelineView.hasEventId(e.id));
+      if (DfirTimelineView.starredOnly()) visible = visible.filter(e => DfirStarred.has(String(e.id)));
+      if (DfirTimelineView.search()) visible = visible.filter(e => _evMatchesSearch(e, DfirTimelineView.search()));
+      if (DfirTimelineView.excludeTerms().length) visible = visible.filter(e => !_evMatchesExclude(e, DfirTimelineView.excludeTerms()));
+      if (DfirTimelineView.from() || DfirTimelineView.to()) visible = visible.filter(e => _evMatchesTimeRange(e, DfirTimelineView.from(), DfirTimelineView.to()));
       const sourceFiltering = srcHidden > 0;
       if (sourceFiltering) visible = visible.filter(e => {
         const real = (e.sources || []).filter(s => s && s !== "unknown source");
@@ -13976,7 +13981,7 @@
       // Corroboration lens (#35): count only DISTINCT sources the analyst is still looking at (excludes
       // ones unchecked in the Sources filter), so the two filters compose — isolating to a single source
       // under 2+ correctly shows nothing (you can't be corroborated by 2 distinct tools within 1).
-      if (corrobTimeline > 1) visible = visible.filter(e => realSourceCount(e.sources, DfirFacets.sources.matcher()) >= corrobTimeline);
+      if (DfirTimelineView.corrobTimeline() > 1) visible = visible.filter(e => realSourceCount(e.sources, DfirFacets.sources.matcher()) >= DfirTimelineView.corrobTimeline());
       const view = DfirState.activeView();
       const viewSevFiltering = !!(view && view.filters && view.filters.minSeverity);
       if (viewSevFiltering) visible = visible.filter(e => viewMeetsMinSev(e.severity));   // dashboard-view severity floor (#142)
@@ -13995,7 +14000,7 @@
       const countEl = document.getElementById('timelineCount');
       if (countEl) {
         const total = ft.length;
-        const baseText = (filtering || showStarredOnly || sourceFiltering || originFiltering || viewSevFiltering || evIdFilter || corrobTimeline > 1 || _hasActiveFilter())
+        const baseText = (filtering || DfirTimelineView.starredOnly() || sourceFiltering || originFiltering || viewSevFiltering || DfirTimelineView.eventIdFilterActive() || DfirTimelineView.corrobTimeline() > 1 || _hasActiveFilter())
           ? `${totalFiltered} of ${total} events`
           : `${total} event${total !== 1 ? 's' : ''}`;
         countEl.textContent = (tlPageSize > 0 && totalFiltered > tlPageSize)
@@ -14008,7 +14013,7 @@
 
       if (!totalFiltered) {
         document.getElementById("forensicTimeline").innerHTML =
-          ((filtering || showStarredOnly || sourceFiltering || originFiltering || viewSevFiltering || evIdFilter || corrobTimeline > 1 || _hasActiveFilter()) && ft.length > 0) ? "<div data-safe-style='color:var(--text-muted)'>No events match the current filters.</div>" : "—";
+          ((filtering || DfirTimelineView.starredOnly() || sourceFiltering || originFiltering || viewSevFiltering || DfirTimelineView.eventIdFilterActive() || DfirTimelineView.corrobTimeline() > 1 || _hasActiveFilter()) && ft.length > 0) ? "<div data-safe-style='color:var(--text-muted)'>No events match the current filters.</div>" : "—";
         return;
       }
 
@@ -14843,15 +14848,15 @@
       const activeDashView = DfirState.activeView();   // read once; this function consults it three times
       // Corroboration lens (#35): a finding's sources are the union of its supporting events' tools.
       const _findingCorrob = (f) => {
-        if (corrobFindings <= 1) return true;
+        if (DfirTimelineView.corrobFindings() <= 1) return true;
         const srcs = new Set();
         for (const e of (suppEventsByFinding[f.id] || [])) for (const s of (e.sources || [])) if (s && s !== "unknown source") srcs.add(s);
-        return srcs.size >= corrobFindings;
+        return srcs.size >= DfirTimelineView.corrobFindings();
       };
       const filtered = sorted.filter(f =>
         (f.confidence === undefined || f.confidence >= minConf) &&
-        (!searchTerm || _findingMatchesSearch(f, searchTerm)) &&
-        !(excludeTerms.length && _findingMatchesExclude(f, excludeTerms)) &&
+        (!DfirTimelineView.search() || _findingMatchesSearch(f, DfirTimelineView.search())) &&
+        !(DfirTimelineView.excludeTerms().length && _findingMatchesExclude(f, DfirTimelineView.excludeTerms())) &&
         _findingCorrob(f) &&
         viewMeetsMinSev(f.severity));   // dashboard-view severity floor (#142)
       const capped = viewTopN() > 0 ? filtered.slice(0, viewTopN()) : filtered;   // view top-N cap
@@ -14860,7 +14865,7 @@
       if (findingsCountEl) {
         const totalFindings = sorted.length;
         const shownFindings = capped.length;
-        const findingsFiltering = minConf > 0 || !!searchTerm || excludeTerms.length > 0 || corrobFindings > 1
+        const findingsFiltering = minConf > 0 || !!DfirTimelineView.search() || DfirTimelineView.excludeTerms().length > 0 || DfirTimelineView.corrobFindings() > 1
           || !!(activeDashView && activeDashView.filters && (activeDashView.filters.minSeverity || viewTopN()));
         findingsCountEl.textContent = findingsFiltering
           ? `(${shownFindings} of ${totalFindings} findings)`
@@ -14929,7 +14934,7 @@
             `<span class="finding-actions-cell">${findingWorkflowControls(f.id)} ${commentChip("finding", f.id)} ${tagAddBtn("finding", f.id)} ${pinBtn(f.id)} ${sigmaExportChip(f.id)} ${ticketPushChips(f.id)} ${fpBtn("finding", f.title)}</span>` +
             (hasEvidence ? `<div class="finding-evidence-body" id="fev-${escAttr(f.id)}">${evidenceBody}</div>` : "") +
             `</div>`;
-        }).join("")) || (searchTerm && sorted.length > 0 ? `<span data-safe-style="color:var(--text-muted)">No findings match the filter.</span>` : minConf > 0 && sorted.length > 0 ? `<span data-safe-style="color:var(--text-muted)">No findings above ${minConf}% confidence.</span>` : (activeDashView && (viewFilters().minSeverity || viewTopN()) && sorted.length > 0) ? `<span data-safe-style="color:var(--text-muted)">No findings match the “${esc(activeDashView.name)}” view filter.</span>` : "—");
+        }).join("")) || (DfirTimelineView.search() && sorted.length > 0 ? `<span data-safe-style="color:var(--text-muted)">No findings match the filter.</span>` : minConf > 0 && sorted.length > 0 ? `<span data-safe-style="color:var(--text-muted)">No findings above ${minConf}% confidence.</span>` : (activeDashView && (viewFilters().minSeverity || viewTopN()) && sorted.length > 0) ? `<span data-safe-style="color:var(--text-muted)">No findings match the “${esc(activeDashView.name)}” view filter.</span>` : "—");
       const findingSelAllEl = document.getElementById("findingSelectAll");
       if (findingSelAllEl && findingSomeSel && !findingAllSel) findingSelAllEl.indeterminate = true;
       updateFindingBulkBar();
@@ -15179,7 +15184,6 @@
       DfirFacets.sources.showAll(); _srcMenuSig = "";
       DfirFacets.origins.showAll(); _originMenuSig = "";
       DfirFacets.hosts.showAll(); _hostMenuSig = "";
-      showStarredOnly = false;
       const sfBtn = document.getElementById("evStarFilterBtn");
       if (sfBtn) { sfBtn.textContent = "☆ Starred"; sfBtn.classList.remove("active"); }
       showFlaggedIocsOnly = false;
@@ -15191,7 +15195,7 @@
       // hideFpNoIntel / showSignalIocsOnly are NOT reset here — like the corroboration lens
       // controls, they're per-browser preferences (localStorage-backed), not per-case session state.
       DfirFacets.iocTypes.showAll(); _iocTypeMenuSig = "";
-      searchTerm = ""; filterFrom = null; filterTo = null;
+      DfirTimelineView.resetForCase();   // NOT clearFilters(): keeps the id filter, severity boxes and exclude terms
       const gsEl = document.getElementById("globalSearch"); if (gsEl) gsEl.value = "";
       const ffEl = document.getElementById("filterFrom"); if (ffEl) ffEl.value = "";
       const ftEl = document.getElementById("filterTo"); if (ftEl) ftEl.value = "";
@@ -16395,10 +16399,7 @@
       }
       // Star filter toggle
       if (e.target.id === "evStarFilterBtn") {
-        showStarredOnly = !showStarredOnly;
-        e.target.textContent = showStarredOnly ? "★ Starred" : "☆ Starred";
-        e.target.classList.toggle("active", showStarredOnly);
-        renderTimelineEvents(DfirState.lastFt());
+        DfirTimelineView.showOnlyStarred(!DfirTimelineView.starredOnly());
         return;
       }
       // IOC verdict filter — only malicious/suspicious (from any enrichment engine)
@@ -16904,8 +16905,8 @@
       function addExcludeTerm(raw) {
         const term = raw.trim();
         if (!term) return;
-        if (excludeTerms.some(t => t.toLowerCase() === term.toLowerCase())) return;   // no dupes
-        setExcludeTerms([...excludeTerms, term]);
+        if (DfirTimelineView.excludeTerms().some(t => t.toLowerCase() === term.toLowerCase())) return;   // no dupes
+        setExcludeTerms([...DfirTimelineView.excludeTerms(), term]);
       }
       if (exIn) {
         exIn.addEventListener("keydown", (e) => {
@@ -16913,8 +16914,8 @@
             e.preventDefault();
             addExcludeTerm(exIn.value);
             exIn.value = "";
-          } else if (e.key === "Backspace" && !exIn.value && excludeTerms.length) {
-            setExcludeTerms(excludeTerms.slice(0, -1));   // Backspace on empty input pops the last chip
+          } else if (e.key === "Backspace" && !exIn.value && DfirTimelineView.excludeTerms().length) {
+            setExcludeTerms(DfirTimelineView.excludeTerms().slice(0, -1));   // Backspace on empty input pops the last chip
           } else if (e.key === "Escape") {
             exIn.value = ""; exIn.blur();
           }
@@ -16926,26 +16927,15 @@
           const btn = e.target.closest("button[data-i]");
           if (!btn) return;
           const i = parseInt(btn.dataset.i, 10);
-          setExcludeTerms(excludeTerms.filter((_, idx) => idx !== i));
+          setExcludeTerms(DfirTimelineView.excludeTerms().filter((_, idx) => idx !== i));
         });
       }
       if (exClearBtn) exClearBtn.addEventListener("click", () => setExcludeTerms([]));
 
-      function applySearch() {
-        searchTerm = gs.value.trim().toLowerCase();
-        cs.hidden = !searchTerm;
-        if (DfirState.lastState()) render(DfirState.lastState());
-        if (DfirState.lastSuperData()) loadSuperTimeline();   // the main filter's search term scopes the super-timeline too
-        renderFalsePositives(fpMarkers);   // search term scopes the False Positives panel too
-      }
+      function applySearch() { DfirTimelineView.setSearch(gs.value); }
       window.applySearch = applySearch;   // exposed for cross-section pivots (Login Graph "Open in Timeline")
       function applyTimeRange() {
-        filterFrom = utcInputToIso(ff.value);
-        filterTo = utcInputToIso(ft.value);
-        cfBtn.hidden = !filterFrom && !filterTo;
-        renderTimelineEvents(DfirState.lastFt());
-        refreshFilteredViews();   // keep Kill Chain + Attack Phases in sync with the time range
-        if (DfirState.lastSuperData()) loadSuperTimeline();   // and the super-timeline's own (intersected) time range
+        DfirTimelineView.setTimeWindow(utcInputToIso(ff.value), utcInputToIso(ft.value));
       }
 
       gs.addEventListener("input", () => {
@@ -16990,15 +16980,15 @@
           rerender();
         });
       };
-      wire("corrobTimeline", () => corrobTimeline,
-        (v) => { corrobTimeline = v; localStorage.setItem("dfir.corrob.timeline", String(v)); },
-        () => { if (DfirState.lastFt()) renderTimelineEvents(DfirState.lastFt()); });
-      wire("corrobIocs", () => corrobIocs,
-        (v) => { corrobIocs = v; localStorage.setItem("dfir.corrob.iocs", String(v)); },
-        () => { if (DfirState.lastState()) renderIocs(DfirState.lastState().iocs || []); });
-      wire("corrobFindings", () => corrobFindings,
-        (v) => { corrobFindings = v; localStorage.setItem("dfir.corrob.findings", String(v)); },
-        () => { if (DfirState.lastState()) { _tlKeepPage = true; render(DfirState.lastState()); } });
+      wire("corrobTimeline", () => DfirTimelineView.corrobTimeline(),
+        (v) => { DfirTimelineView.setCorroboration("timeline", v); localStorage.setItem("dfir.corrob.timeline", String(v)); },
+        () => {});   // the owner refreshes
+      wire("corrobIocs", () => DfirTimelineView.corrobIocs(),
+        (v) => { DfirTimelineView.setCorroboration("iocs", v); localStorage.setItem("dfir.corrob.iocs", String(v)); },
+        () => {});
+      wire("corrobFindings", () => DfirTimelineView.corrobFindings(),
+        (v) => { _tlKeepPage = true; DfirTimelineView.setCorroboration("findings", v); localStorage.setItem("dfir.corrob.findings", String(v)); },
+        () => {});
       // Risk lens (#63) — dedicated handler (accepts tier 2/3/4, which `wire` doesn't).
       const riskSel = document.getElementById("riskIocs");
       if (riskSel) {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3607,7 +3607,8 @@
       timeline: () => renderTimelineEvents(DfirState.lastFt() || []),
       all: () => { if (DfirState.lastState()) render(DfirState.lastState()); },
       superTimeline: () => { if (DfirState.lastSuperData()) loadSuperTimeline(); },
-      falsePositives: () => renderFalsePositives(fpMarkers),
+      falsePositives: () => renderFalsePositives(fpMarkers, false),   // panel only — the action asks for `all` itself
+      iocs: () => { if (DfirState.lastState()) renderIocs(DfirState.lastState().iocs || []); },
       derivedViews: () => refreshFilteredViews(),
       excludeChips: () => renderExcludeChips(),
       searchBox: () => {
@@ -12893,6 +12894,10 @@
       DfirFacets.origins.showAll(); _originMenuSig = "";
       DfirFacets.hosts.showAll(); _hostMenuSig = "";
       DfirTimelineView.clearFilters();
+      forgetPersistedExcludeTerms();
+    }
+    // Both filter-clearing paths drop the exclude terms, so both must drop the saved copy.
+    function forgetPersistedExcludeTerms() {
       try { localStorage.setItem("dfir.excludeTerms", "[]"); } catch {}
     }
 
@@ -12908,6 +12913,7 @@
       // ONE paint, with the id filter already committed. This used to reset (two full renders, both
       // showing the filter it had just cleared) and only apply the ids on a third.
       DfirTimelineView.filterToEventIds(list, label);
+      forgetPersistedExcludeTerms();   // cleared in memory; must not return on reload
       const sec = document.getElementById("sec-timeline");
       if (sec) { sec.classList.remove("collapsed"); sec.scrollIntoView({ behavior: "smooth", block: "start" }); }
     }
@@ -13347,7 +13353,7 @@
         .catch(e => { msg.textContent = "failed: " + e.message; });
     }
 
-    function renderFalsePositives(markers) {
+    function renderFalsePositives(markers, redraw) {
       fpMarkers = markers || [];
       const el = document.getElementById("false-positive");
       // The global filter toolbar (search + exclude terms) scopes this panel too, same as the
@@ -13381,8 +13387,9 @@
           ? `(${visible.length} of ${fpMarkers.length})`
           : (fpMarkers.length ? `(${fpMarkers.length})` : "");
       }
-      // FP events are hidden from the timeline — re-render it with the new set.
-      if (DfirState.lastState()) render(DfirState.lastState());
+      // FP events are hidden from the timeline — re-render it with the new set. `redraw === false`
+      // is DfirTimelineView's painter, whose action asks for `all` itself; see that module.
+      if (redraw !== false && DfirState.lastState()) render(DfirState.lastState());
     }
     // Event ids the client confirmed as a false positive (hidden from the forensic timeline view).
     function fpEventIdSet() {

--- a/public/js/dashboard-timeline-view.js
+++ b/public/js/dashboard-timeline-view.js
@@ -31,6 +31,15 @@
 // either.
 //
 //
+// ONE PAINTER, ONE PANEL — `falsePositives` PAINTS THE PANEL AND DOES NOT REDRAW.
+//
+// This is the correction that mattered most in review. renderFalsePositives() in the page ends with
+// its own `render(lastState())`, so wiring it directly meant `refresh("all", "falsePositives")` ran
+// TWO full renders — the exact double render this module claims to have collapsed, still happening
+// in production while the tests, which used independent spies, could not see it. The page now wires
+// the panel-only form; every action that needs the page redrawn asks for `all` explicitly.
+//
+//
 // THE REFRESH HANDLERS ARE INJECTED, ONCE
 //
 // This module knows WHICH panels an action must refresh; it does not know HOW to paint them. The
@@ -63,9 +72,12 @@
   const eventIdsLabel = cell("");
   // Three separate cells, not one object: the lenses are independent, they are read as bare
   // numbers at 21 comparison sites (`corrobTimeline > 1`), and they refresh different panels.
-  const corrobTimeline = cell(1);
-  const corrobIocs = cell(1);
-  const corrobFindings = cell(1);
+  // 0 is OFF, matching the <select> options (0 / 2 / 3) and the persisted value. An earlier draft
+  // defaulted these to 1 and normalised with `|| 1`, which made `sel.value = String(get())` select
+  // an option that does not exist — all three lenses rendered blank on load.
+  const corrobTimeline = cell(0);
+  const corrobIocs = cell(0);
+  const corrobFindings = cell(0);
   const corrobCells = { timeline: corrobTimeline, iocs: corrobIocs, findings: corrobFindings };
 
   /**
@@ -79,7 +91,8 @@
     timeline: noop, // renderTimelineEvents(lastFt())
     all: noop, // render(lastState()) — the whole page
     superTimeline: noop, // loadSuperTimeline()
-    falsePositives: noop, // renderFalsePositives(fpMarkers)
+    falsePositives: noop, // the False Positives PANEL only — never a full render, see below
+    iocs: noop, // renderIocs(lastState().iocs) — the IOC list on its own
     derivedViews: noop, // refreshFilteredViews(): Kill Chain, Attack Phases, the graphs
     excludeChips: noop, // renderExcludeChips()
     searchBox: noop, // the search input's own clear button + open state
@@ -87,6 +100,23 @@
     severityBoxes: noop, // the .sev-filter checkboxes
     starButton: noop, // #evStarFilterBtn label + active class
   };
+
+  /**
+   * Everything that goes stale when the view filters are cleared.
+   *
+   * Shared by clearFilters() and filterToEventIds() because they clear the same things — the two
+   * lists drifting apart is exactly how one of them ended up refreshing the timeline alone.
+   */
+  const CLEARED_FILTER_PANELS = [
+    "severityBoxes",
+    "starButton",
+    "searchBox",
+    "timeInputs",
+    "excludeChips",
+    "all",
+    "superTimeline",
+    "falsePositives",
+  ];
 
   /** Run a declared refresh set, each handler at most once. */
   function refresh(...names) {
@@ -112,7 +142,7 @@
       if (Array.isArray(st.excludeTerms)) exclude.set(Object.freeze([...st.excludeTerms]));
       if (st.corroboration) {
         for (const which of ["timeline", "iocs", "findings"]) {
-          if (st.corroboration[which] != null) corrobCells[which].set(Number(st.corroboration[which]) || 1);
+          if (st.corroboration[which] != null) corrobCells[which].set(Number(st.corroboration[which]) || 0);
         }
       }
     },
@@ -181,9 +211,13 @@
     setCorroboration(which, value) {
       const c = corrobCells[which];
       if (!c) return 0;
-      const n = Number(value) || 1;
+      const n = Number(value) || 0;
       c.set(n);
-      refresh(which === "timeline" ? "timeline" : "all");
+      // Three lenses, three costs — the reason this branches rather than being three setters.
+      // Routing the IOC lens to the full-page painter (an earlier draft did) refetches the
+      // collection plan, rebuilds every panel and resets the timeline to page one, for a change
+      // that only affects the IOC list.
+      refresh(which === "timeline" ? "timeline" : which === "iocs" ? "iocs" : "all");
       return n;
     },
 
@@ -200,7 +234,11 @@
       clearFilterState();
       eventIds.set(new Set(list));
       eventIdsLabel.set(label || "");
-      refresh("severityBoxes", "starButton", "searchBox", "timeInputs", "excludeChips", "timeline");
+      // The SAME set as clearFilters(), because this clears the same filters — and those filters
+      // scope Findings, IOCs, False Positives and the super-timeline, not just the event list.
+      // Refreshing only the timeline (an earlier draft did) left every other panel showing filters
+      // the controls now said were cleared. `all` paints the timeline, so it is not listed twice.
+      refresh(...CLEARED_FILTER_PANELS);
       return list.length;
     },
 
@@ -219,16 +257,7 @@
       clearFilterState();
       eventIds.set(null);
       eventIdsLabel.set("");
-      refresh(
-        "severityBoxes",
-        "starButton",
-        "searchBox",
-        "timeInputs",
-        "excludeChips",
-        "all",
-        "superTimeline",
-        "falsePositives",
-      );
+      refresh(...CLEARED_FILTER_PANELS);
     },
 
     /**
@@ -242,6 +271,14 @@
       from.set(null);
       to.set(null);
       starredOnly.set(false);
+      // The id filter goes too. It is DERIVED FROM A CASE — an anomaly bucket, a session's rows —
+      // so carrying it into another case either blanks the new timeline or, on an id collision,
+      // shows unrelated evidence under the previous case's label. proceedConnect never cleared it,
+      // and an earlier draft of this module documented and TESTED that omission as intended, which
+      // is worse than leaving it alone. The exclude terms and severity boxes really are deliberate:
+      // those are the analyst's standing preferences, not this case's.
+      eventIds.set(null);
+      eventIdsLabel.set("");
     },
   };
 

--- a/public/js/dashboard-timeline-view.js
+++ b/public/js/dashboard-timeline-view.js
@@ -1,0 +1,256 @@
+// Who owns the forensic timeline's view filters (#415, tier 2, last step).
+//
+// The unit here is the USER ACTION, not the field, and that is the whole design. The first draft of
+// tier 2 modelled this layer as ten setters over ten bindings; that was wrong twice over and both
+// mistakes are worth keeping written down, because the shape below is what they argue for.
+//
+//   1. THE FIELDS ARE NOT THE ACTIONS. "Reveal this event" resets six filters, picks a page and
+//      repaints. Expressed as setters, that is six writes whose intermediate states are visible
+//      states nobody wants — and the code really did paint them: filterTimelineToEventIds() renders
+//      TWICE before its id filter is even set, so the first two paints show the filter it just
+//      cleared rather than the one it is applying.
+//   2. THE FILTER IS NOT ALL IN JAVASCRIPT. Severity has no binding at all: it lives in the
+//      `.sev-filter` checkboxes and is read from the DOM at render time. A design that models the
+//      filter as "these ten variables" cannot be right when part of the filter is a checkbox, so
+//      setSeverities() owns the boxes rather than reading them.
+//
+//
+// ONE COMMIT, ONE REDRAW, PER ACTION
+//
+// Each action below writes everything it implies and then refreshes ONCE. That is a deliberate
+// behaviour change and the measurement is what justifies it: today `setExcludeTerms` and
+// `applySearch` each call render() at their own site and again through renderFalsePositives()'s
+// tail, so one debounced keystroke is two full renders — two `/collection-plan` fetches and four
+// whole-page section sweeps, for the same final state. The intermediate paint is not a feature.
+//
+// WHAT DOES NOT COLLAPSE. The refresh SET differs per action and is declared per action, because
+// the measurement says so: setExcludeTerms refreshes the timeline, the super-timeline and False
+// Positives; toggleSource refreshes only the timeline; setTimeWindow additionally reaches Kill
+// Chain and Attack Phases. A single fixed redraw cannot express that, which is the second thing the
+// first draft got wrong — and the reason DfirScope and DfirSelection publish no subscription
+// either.
+//
+//
+// THE REFRESH HANDLERS ARE INJECTED, ONCE
+//
+// This module knows WHICH panels an action must refresh; it does not know HOW to paint them. The
+// page registers the handlers at wire-up via wire(), and every action calls them.
+//
+// That is not indirection for its own sake — it is what makes these actions testable at all. Every
+// audit of this tier so far has landed on the same gap: the suites tested an owner's arithmetic and
+// never the renderer interaction, so two visible regressions sat behind a green suite. With the
+// handlers injected, a test registers spies, calls revealEvent(), and asserts exactly which panels
+// were refreshed and how many times — which is precisely the thing that was previously unobservable
+// outside a browser.
+//
+//
+// resetForCase() IS NOT clearFilters(), and the difference is load-bearing. Connecting to a case
+// deliberately does NOT reset the event-id filter, does NOT re-check the severity boxes and does
+// NOT clear the analyst's exclude terms; the "clear filters" action does all three. Routing both
+// through one helper would start wiping persisted exclude terms on every case connect. Two
+// operations, two refresh sets, both spelled out.
+//
+// NOT AN ES MODULE, and an IIFE, for the reasons js/dashboard-state.js sets out.
+(function () {
+  const cell = window.DfirState.cell;
+
+  const search = cell("");
+  const exclude = cell(Object.freeze([]));
+  const from = cell(null);
+  const to = cell(null);
+  const starredOnly = cell(false);
+  const eventIds = cell(null); // Set of ids, or null for "no id filter"
+  const eventIdsLabel = cell("");
+  // Three separate cells, not one object: the lenses are independent, they are read as bare
+  // numbers at 21 comparison sites (`corrobTimeline > 1`), and they refresh different panels.
+  const corrobTimeline = cell(1);
+  const corrobIocs = cell(1);
+  const corrobFindings = cell(1);
+  const corrobCells = { timeline: corrobTimeline, iocs: corrobIocs, findings: corrobFindings };
+
+  /**
+   * What the page does when an action says a panel is stale.
+   *
+   * Defaults are no-ops so the module is usable — and testable — before anything is wired, and so a
+   * handler the page has not registered fails quietly rather than throwing mid-action.
+   */
+  const noop = () => {};
+  let paint = {
+    timeline: noop, // renderTimelineEvents(lastFt())
+    all: noop, // render(lastState()) — the whole page
+    superTimeline: noop, // loadSuperTimeline()
+    falsePositives: noop, // renderFalsePositives(fpMarkers)
+    derivedViews: noop, // refreshFilteredViews(): Kill Chain, Attack Phases, the graphs
+    excludeChips: noop, // renderExcludeChips()
+    searchBox: noop, // the search input's own clear button + open state
+    timeInputs: noop, // #filterFrom / #filterTo and the Clear button
+    severityBoxes: noop, // the .sev-filter checkboxes
+    starButton: noop, // #evStarFilterBtn label + active class
+  };
+
+  /** Run a declared refresh set, each handler at most once. */
+  function refresh(...names) {
+    for (const name of [...new Set(names)]) (paint[name] || noop)();
+  }
+
+  window.DfirTimelineView = {
+    /** Register the page's painters. Called once, at wire-up. */
+    wire(handlers) {
+      paint = { ...paint, ...(handlers || {}) };
+    },
+
+    /**
+     * Restore persisted state at page bootstrap. Commits, refreshes NOTHING.
+     *
+     * Restoring what the analyst left behind is not a user action: it runs while the script is still
+     * parsing, before any panel exists, and the first render() paints the result anyway. Routing it
+     * through setExcludeTerms() would refresh three panels that are not on the page yet — which is
+     * precisely why the original code assigned the binding directly and did not call its own setter.
+     */
+    hydrate(state) {
+      const st = state || {};
+      if (Array.isArray(st.excludeTerms)) exclude.set(Object.freeze([...st.excludeTerms]));
+      if (st.corroboration) {
+        for (const which of ["timeline", "iocs", "findings"]) {
+          if (st.corroboration[which] != null) corrobCells[which].set(Number(st.corroboration[which]) || 1);
+        }
+      }
+    },
+
+    // ── reads ──────────────────────────────────────────────────────────────────────────────────
+    search: () => search.get(),
+    excludeTerms: () => exclude.get(),
+    from: () => from.get(),
+    to: () => to.get(),
+    starredOnly: () => starredOnly.get(),
+    /** The id filter, or null. Membership only — the Set never escapes. */
+    hasEventId: (id) => {
+      const ids = eventIds.get();
+      return ids ? ids.has(String(id)) : false;
+    },
+    eventIdFilterActive: () => eventIds.get() !== null,
+    eventIdCount: () => (eventIds.get() ? eventIds.get().size : 0),
+    eventIdLabel: () => eventIdsLabel.get(),
+    corrobTimeline: () => corrobTimeline.get(),
+    corrobIocs: () => corrobIocs.get(),
+    corrobFindings: () => corrobFindings.get(),
+
+    // ── actions ────────────────────────────────────────────────────────────────────────────────
+    /**
+     * The analyst typed in the search box.
+     *
+     * ONE redraw where there were two: render() here, and render() again through False Positives'
+     * tail. Same final state, half the work, no intermediate paint.
+     */
+    setSearch(term) {
+      search.set(String(term || "").trim().toLowerCase());
+      refresh("searchBox", "all", "superTimeline", "falsePositives");
+    },
+
+    /** Exclude terms (#216). Persisted by the caller — this owns the value, not the storage. */
+    setExcludeTerms(terms) {
+      exclude.set(Object.freeze([...(terms || [])]));
+      refresh("excludeChips", "all", "superTimeline", "falsePositives");
+    },
+
+    /**
+     * The timeline's time window — the from/to inputs, the swimlane brush, a dwell window.
+     *
+     * Reaches further than the other filters: Kill Chain and Attack Phases are derived from the
+     * same filtered timeline, so they go stale with it.
+     */
+    setTimeWindow(fromIso, toIso) {
+      from.set(fromIso || null);
+      to.set(toIso || null);
+      refresh("timeInputs", "timeline", "derivedViews", "superTimeline");
+    },
+
+    /** The ★ Starred toggle. Timeline-local, deliberately — it is a list facet. */
+    showOnlyStarred(on) {
+      starredOnly.set(Boolean(on));
+      refresh("starButton", "timeline");
+    },
+
+    /**
+     * One of the three corroboration lenses (#35): "timeline", "iocs" or "findings".
+     *
+     * Their refresh sets differ, which is why this is one action with a branch rather than three
+     * setters: the timeline lens repaints the timeline (and rescopes the Sources menu with it),
+     * while the IOC and finding lenses reach the whole page.
+     */
+    setCorroboration(which, value) {
+      const c = corrobCells[which];
+      if (!c) return 0;
+      const n = Number(value) || 1;
+      c.set(n);
+      refresh(which === "timeline" ? "timeline" : "all");
+      return n;
+    },
+
+    /**
+     * Show exactly these events — an anomaly bucket, a session's rows.
+     *
+     * The reset happens as part of the action rather than through clearFilters(), so the id filter
+     * is in place BEFORE anything paints. Today the reset renders twice on its own and only a third
+     * paint applies the ids; here there is one.
+     */
+    filterToEventIds(ids, label) {
+      const list = (ids || []).map(String).filter(Boolean);
+      if (!list.length) return 0;
+      clearFilterState();
+      eventIds.set(new Set(list));
+      eventIdsLabel.set(label || "");
+      refresh("severityBoxes", "starButton", "searchBox", "timeInputs", "excludeChips", "timeline");
+      return list.length;
+    },
+
+    clearEventIds() {
+      eventIds.set(null);
+      eventIdsLabel.set("");
+      refresh("timeline");
+    },
+
+    /**
+     * The analyst's "clear filters" gesture, and the unhide step of revealing an event.
+     *
+     * Clears the exclude terms too — which is why case connect must NOT come through here.
+     */
+    clearFilters() {
+      clearFilterState();
+      eventIds.set(null);
+      eventIdsLabel.set("");
+      refresh(
+        "severityBoxes",
+        "starButton",
+        "searchBox",
+        "timeInputs",
+        "excludeChips",
+        "all",
+        "superTimeline",
+        "falsePositives",
+      );
+    },
+
+    /**
+     * Connecting to a case. NOT clearFilters(): the event-id filter, the severity boxes and the
+     * analyst's exclude terms are all deliberately left alone, exactly as today.
+     *
+     * No refresh — proceedConnect paints everything itself, in its own order.
+     */
+    resetForCase() {
+      search.set("");
+      from.set(null);
+      to.set(null);
+      starredOnly.set(false);
+    },
+  };
+
+  /** The fields "clear filters" zeroes. Shared by clearFilters() and filterToEventIds(). */
+  function clearFilterState() {
+    search.set("");
+    exclude.set(Object.freeze([]));
+    from.set(null);
+    to.set(null);
+    starredOnly.set(false);
+  }
+})();


### PR DESCRIPTION
The last tier-2 owner. Ten bindings and 87 read references move behind `DfirTimelineView` — but the move is not the point. **The unit is the user action, not the field.**

## Why not ten setters

Two reasons, both measured rather than asserted:

- **The fields are not the actions.** "Reveal this event" resets six filters, picks a page and repaints. As setters that is six writes whose intermediate states are visible states nobody wants — and the code really did paint them: `filterTimelineToEventIds()` rendered **twice** through its reset before its id filter was even set, so the first two paints showed the filter it had just cleared.
- **The filter is not all in JavaScript.** Severity has *no binding*: it lives in the `.sev-filter` checkboxes and is read from the DOM at render time. A design that models this layer as "these ten variables" cannot be right when part of it is a checkbox.

## One commit, one redraw

`setExcludeTerms` and `applySearch` each called `render()` at their own site **and again** through `renderFalsePositives()`'s tail. One debounced keystroke was two full renders, two `/collection-plan` fetches and four whole-page section sweeps — for the same final state. That collapses. **It is a deliberate behaviour change and the only one in this PR.**

What does *not* collapse is the refresh **set**, which differs per action and is declared per action:

| action | refreshes |
|---|---|
| `setSearch` / `setExcludeTerms` | page · super-timeline · False Positives |
| `setTimeWindow` | timeline · Kill Chain + Phases · super-timeline — **not** the whole page |
| `showOnlyStarred` | timeline only |
| `setCorroboration("timeline")` | timeline; the IOC and finding lenses reach the page |

A single fixed redraw cannot express that, which is why this owner publishes no subscription either.

## The painters are injected — and that is the answer to what three audits kept finding

Every audit of this tier ended on the same note: *the tests do not execute the production renderer interactions, which is why the visible regressions remain green.* That was true, and it was the structural gap rather than any one bug.

This module knows **which** panels an action makes stale and not **how** to paint them; `dashboard.html` registers handlers once via `wire()`. A test registers spies and asserts exactly which panels an action repainted and how many times.

That is what makes the two load-bearing claims checkable at all:

```
it("setSearch repaints the page … ONCE each")            // the collapse
it("has the id filter committed BEFORE the first repaint") // the ordering bug
```

Neither was previously observable outside a browser.

## resetForCase() is not clearFilters()

Connecting to a case deliberately keeps the event-id filter, the severity boxes and the analyst's exclude terms; "clear filters" drops all three. Routing both through one helper would wipe persisted exclude terms on **every** case connect. Preserved, and pinned.

`hydrate()` commits without painting — restoring persisted state runs while the script is still parsing, with no panel to refresh, which is exactly why the original code assigned its bindings directly rather than calling its own setter.

## The read migration was done with the parser

Worth flagging because the first attempt was wrong: a regex rewrite corrupted a localStorage **key** (`"dfir.excludeTerms"`) and an assignment **target**, because a pattern cannot tell an identifier from the inside of a string. Reverted from backup and redone by byte offset over `Identifier` nodes only, skipping write targets and declarations.

## One existing assertion changed

`dashboardHtml.test.ts` pinned `filterFrom = fromIso` inside `zoomToTimeWindow` to show click-to-zoom shares the search bar's path. Both sides now commit through `setTimeWindow`, so the test names **both** rather than implying the link — a stronger assertion than the one it replaces.

## Gates

**8 mutations, 8 fired:** the double render returning, a paint before the id filter is committed, two refresh sets drifting, a case connect wiping exclude terms, `hydrate` painting at bootstrap, a painter left unregistered in the page, and the old binding returning.

`build`, `lint`, `format:check`, `check:imports`, `check:boundaries` green; route inventory re-baselined (+1). Full suite **7462 passed**. Two failures are the known local `sharp` 0.33.5/vips 8.15.3; a third (`anonymize`) passes in isolation — a parallel-load flake in a file this branch does not touch. `check:size`: inline JS **shrank** 18108 → 18097.

**Tier 2 is complete.** Remaining for #415 is tier 3 — the ~231 feature-local bindings, which were blocked on exactly this work.
