### PR TITLE
test(dashboard): close the tier-2 gate gaps withdrawn from #470 (#415)

### DIFF
--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -6,7 +6,7 @@
   "analysis/velociraptorImport.ts": 1503,
   "integrations/velociraptor/velociraptorApi.ts": 1086,
   "public/css/dashboard.css": 3261,
-  "public/dashboard.html#inline-js": 18104,
+  "public/dashboard.html#inline-js": 18102,
   "reports/markdown.ts": 1461,
   "routes/caseLifecycle.ts": 1204,
   "routes/import.ts": 1766,

--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -14,10 +14,11 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCallGraph,
+  ownerEscapes,
   calleesInsideLoops,
   commitsInsideLoops,
   ownerCalls,
-  reachableWithin,
+  reachableFrom,
   scriptFromSource,
   topLevelBindings,
 } from "../helpers/dashboardAst.js";
@@ -25,7 +26,7 @@ import {
 const COMMITS = ["toggle", "addAll", "removeAll", "clear", "showAll", "hideAll"];
 
 describe("the loop rule follows a wrapper, but not a deferred callback", () => {
-  it("catches a commit two hops from a loop callee", () => {
+  it("catches a commit several hops from a loop callee", () => {
     const s = scriptFromSource(
       "p.js",
       `
@@ -37,7 +38,7 @@ describe("the loop rule follows a wrapper, but not a deferred callback", () => {
     const graph = buildCallGraph([s]);
     let caught = false;
     for (const callee of calleesInsideLoops([s])) {
-      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      const reach = new Set([callee, ...reachableFrom(graph, [callee])]);
       for (const c of committers) if (reach.has(c)) caught = true;
     }
     expect(caught, "two-hop wrapper still invisible").toBe(true);
@@ -54,7 +55,7 @@ describe("the loop rule follows a wrapper, but not a deferred callback", () => {
     const graph = buildCallGraph([s]);
     const hits: string[] = [];
     for (const callee of calleesInsideLoops([s])) {
-      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      const reach = new Set([callee, ...reachableFrom(graph, [callee])]);
       for (const c of committers) if (reach.has(c)) hits.push(`${callee}->${c}`);
     }
     expect(hits, "a keystroke handler is not a per-element commit").toEqual([]);
@@ -93,6 +94,81 @@ describe("the loop rule follows a wrapper, but not a deferred callback", () => {
       const src = await readFile(new URL(`../../../public/js/${f}`, import.meta.url), "utf8");
       expect(commitsInsideLoops(scriptFromSource(f, src), ["commit", "set"])).toEqual([]);
     }
+  });
+
+  // Every form review found walking past the gates, each kept as the regression test it should
+  // always have been.
+  it("catches a commit inside an iteration callback within a bulk operation", () => {
+    const s = scriptFromSource(
+      "m.js",
+      `
+      function idSet() {
+        const cell = window.DfirState.cell(new Set());
+        return { addAll(ids) { ids.forEach((id) => cell.set(new Set([id]))); } };
+      }`,
+    );
+    expect(commitsInsideLoops(s, ["commit", "set"]).map((c) => c.fn)).toContain("addAll");
+  });
+
+  it.each([
+    [
+      "a synchronous IIFE",
+      `for (const id of ids) (function () { DfirSelection.events.toggle(id, true); })();`,
+    ],
+    ["a parenthesised callback", `ids.forEach((id) => { DfirSelection.events.toggle(id, true); });`],
+    [
+      "one queued commit per item",
+      `for (const id of ids) queueMicrotask(() => DfirSelection.events.toggle(id, true));`,
+    ],
+  ])("still counts %s as per-element", (_label, src) => {
+    expect(ownerCalls([scriptFromSource("p.js", src)], "DfirSelection", COMMITS).some((c) => c.inLoop)).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    [
+      "an inline listener",
+      `for (const id of ids) el(id).addEventListener("click", () => DfirSelection.events.clear());`,
+    ],
+    [
+      "a named handler",
+      `function h() { DfirSelection.events.clear(); }\nfor (const id of ids) el(id).addEventListener("click", h);`,
+    ],
+    ["an on* assignment", `for (const id of ids) { el(id).onclick = () => DfirSelection.events.clear(); }`],
+  ])("does not count %s, which runs on an event and not per element", (_label, src) => {
+    const s = scriptFromSource("p.js", src);
+    expect(ownerCalls([s], "DfirSelection", COMMITS).some((c) => c.inLoop)).toBe(false);
+    const committers = new Set(
+      ownerCalls([s], "DfirSelection", COMMITS)
+        .map((c) => c.fn)
+        .filter((f) => !f.startsWith("<")),
+    );
+    const graph = buildCallGraph([s]);
+    const viaCallee = [...calleesInsideLoops([s])].some((c) => {
+      const reach = new Set([c, ...reachableFrom(graph, [c])]);
+      return [...committers].some((x) => reach.has(x));
+    });
+    expect(viaCallee).toBe(false);
+  });
+
+  it.each([
+    ["a var in a for-of head", `for (var selectedEvents of sets) {}`],
+    ["a logical-assignment global", `window.hiddenSources ??= new Set();`],
+    ["a template-literal key", 'globalThis[`searchTerm`] = "";'],
+  ])("counts %s as a binding", (_label, src) => {
+    const name = ["selectedEvents", "hiddenSources", "searchTerm"].find((n) => src.includes(n))!;
+    expect(topLevelBindings(scriptFromSource("p.js", src)).map((b) => b.name)).toContain(name);
+  });
+
+  it.each([
+    ["a reflective invoke", `DfirSelection.events.toggle.call(null, "x");`],
+    ["a method overwrite", `DfirSelection.events.toggle = function () {};`],
+  ])("does not let %s past both gates", (_label, src) => {
+    const s = scriptFromSource("p.js", src);
+    const seen =
+      ownerCalls([s], "DfirSelection", COMMITS).length > 0 || ownerEscapes([s], "DfirSelection").length > 0;
+    expect(seen, "reaches a writable member and is reported by neither gate").toBe(true);
   });
 
   it("counts a computed global assignment as a binding", () => {

--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -1,0 +1,110 @@
+// The CONTRACT of tests/helpers/dashboardAst.ts, tested directly.
+//
+// WHY THIS FILE EXISTS. Six holes have been found in these gates across #415, and every one was
+// found by a person reading the helper rather than by a test: the `async function` shape, the
+// single-file scan, the direct-call-only reachability, the window-rooted namespace, the callback
+// loop, and the detached method reference. The gates themselves stayed green throughout, because
+// the page happened not to contain the shape being missed.
+//
+// So the helpers are now exercised on snippets that DO contain those shapes. Each case below is a
+// bypass that review found in a real audit, kept as the regression test it should always have been —
+// and each has a partner asserting what must NOT be reported, because a check that flags everything
+// is as useless as one that flags nothing.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildCallGraph,
+  calleesInsideLoops,
+  commitsInsideLoops,
+  ownerCalls,
+  reachableWithin,
+  scriptFromSource,
+  topLevelBindings,
+} from "../helpers/dashboardAst.js";
+
+const COMMITS = ["toggle", "addAll", "removeAll", "clear", "showAll", "hideAll"];
+
+describe("the loop rule follows a wrapper, but not a deferred callback", () => {
+  it("catches a commit two hops from a loop callee", () => {
+    const s = scriptFromSource(
+      "p.js",
+      `
+      function inner(x) { DfirSelection.events.toggle(x, true); }
+      function outer(x) { inner(x); }
+      function drive(xs) { for (const x of xs) outer(x); }`,
+    );
+    const committers = new Set(ownerCalls([s], "DfirSelection", COMMITS).map((c) => c.fn));
+    const graph = buildCallGraph([s]);
+    let caught = false;
+    for (const callee of calleesInsideLoops([s])) {
+      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      for (const c of committers) if (reach.has(c)) caught = true;
+    }
+    expect(caught, "two-hop wrapper still invisible").toBe(true);
+  });
+
+  it("does not count a keystroke handler registered inside a loop", () => {
+    const s = scriptFromSource(
+      "p.js",
+      `
+      function commitIt() { DfirSelection.events.clear(); }
+      ["a","b"].forEach((id) => document.getElementById(id).addEventListener("click", () => commitIt()));`,
+    );
+    const committers = new Set(ownerCalls([s], "DfirSelection", COMMITS).map((c) => c.fn));
+    const graph = buildCallGraph([s]);
+    const hits: string[] = [];
+    for (const callee of calleesInsideLoops([s])) {
+      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      for (const c of committers) if (reach.has(c)) hits.push(`${callee}->${c}`);
+    }
+    expect(hits, "a keystroke handler is not a per-element commit").toEqual([]);
+  });
+
+  it("catches cell.set() inside a bulk operation", () => {
+    const s = scriptFromSource(
+      "m.js",
+      `
+      function idSet() {
+        const cell = window.DfirState.cell(new Set());
+        return { addAll(ids) { for (const id of ids) cell.set(new Set([id])); } };
+      }`,
+    );
+    expect(commitsInsideLoops(s, ["commit", "set"]).map((c) => c.fn)).toContain("addAll");
+  });
+
+  it("catches a helper that commits, called from a bulk loop", () => {
+    const s = scriptFromSource(
+      "m.js",
+      `
+      function idSet() {
+        const cell = window.DfirState.cell(new Set());
+        const commit = (n) => cell.set(n);
+        function put(x) { commit(new Set([x])); }
+        return { hideAll(ids) { for (const id of ids) put(id); } };
+      }`,
+    );
+    const found = commitsInsideLoops(s, ["commit", "set"]);
+    expect(found.map((c) => `${c.fn} via ${c.via}`)).toContain("hideAll via put");
+  });
+
+  it("reports nothing against the real owner modules", async () => {
+    const { readFile } = await import("node:fs/promises");
+    for (const f of ["dashboard-selection.js", "dashboard-facets.js"]) {
+      const src = await readFile(new URL(`../../../public/js/${f}`, import.meta.url), "utf8");
+      expect(commitsInsideLoops(scriptFromSource(f, src), ["commit", "set"])).toEqual([]);
+    }
+  });
+
+  it("counts a computed global assignment as a binding", () => {
+    for (const [src, name] of [
+      [`globalThis["hiddenSources"] = new Set();`, "hiddenSources"],
+      [`window["selectedEvents"] = new Set();`, "selectedEvents"],
+      [`self["searchTerm"] = "";`, "searchTerm"],
+    ] as const) {
+      expect(
+        topLevelBindings(scriptFromSource("p.js", src)).map((b) => b.name),
+        src,
+      ).toContain(name);
+    }
+  });
+});

--- a/companion/tests/dashboard/dashboardFacets.test.ts
+++ b/companion/tests/dashboard/dashboardFacets.test.ts
@@ -12,7 +12,6 @@ import {
   ownerCalls,
   ownerEscapes,
   reachableFrom,
-  reachableWithin,
   scriptFromSource,
   topLevelBindings,
 } from "../helpers/dashboardAst.js";
@@ -260,7 +259,7 @@ describe("no renderer writes a facet", () => {
 
   // Two hops, matching the selection owner's rule — a direct-callee check misses
   // `for (…) outer(x)` where outer() calls inner() which commits.
-  it("has no function reachable from a loop within two hops that commits", () => {
+  it("has no function reachable from a loop through any number of hops that commits", () => {
     const committers = new Set(
       ownerCalls(scripts, "DfirFacets", COMMITS)
         .map((c) => c.fn)
@@ -269,7 +268,7 @@ describe("no renderer writes a facet", () => {
     const graph = buildCallGraph(scripts);
     const offenders: string[] = [];
     for (const callee of calleesInsideLoops(scripts)) {
-      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      const reach = new Set([callee, ...reachableFrom(graph, [callee])]);
       for (const c of committers) if (reach.has(c)) offenders.push(`${callee}() reaches ${c}()`);
     }
     expect([...new Set(offenders)]).toEqual([]);

--- a/companion/tests/dashboard/dashboardFacets.test.ts
+++ b/companion/tests/dashboard/dashboardFacets.test.ts
@@ -6,13 +6,13 @@ import type { FacetsApi, FiltersApi } from "./dashboardApi.js";
 import {
   buildCallGraph,
   calleesInsideLoops,
+  commitsInsideLoops,
   dashboardScripts,
   functionsOf,
-  insideLoop,
-  ownerCallPositions,
   ownerCalls,
   ownerEscapes,
   reachableFrom,
+  reachableWithin,
   scriptFromSource,
   topLevelBindings,
 } from "../helpers/dashboardAst.js";
@@ -258,14 +258,21 @@ describe("no renderer writes a facet", () => {
     expect(offenders, '"hide none" used to add one facet at a time; hideAll() commits once.').toEqual([]);
   });
 
-  it("has no function called from inside a loop that commits", () => {
+  // Two hops, matching the selection owner's rule — a direct-callee check misses
+  // `for (…) outer(x)` where outer() calls inner() which commits.
+  it("has no function reachable from a loop within two hops that commits", () => {
     const committers = new Set(
       ownerCalls(scripts, "DfirFacets", COMMITS)
         .map((c) => c.fn)
         .filter((f) => !f.startsWith("<")),
     );
-    const offenders = [...calleesInsideLoops(scripts)].filter((c) => committers.has(c));
-    expect(offenders).toEqual([]);
+    const graph = buildCallGraph(scripts);
+    const offenders: string[] = [];
+    for (const callee of calleesInsideLoops(scripts)) {
+      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      for (const c of committers) if (reach.has(c)) offenders.push(`${callee}() reaches ${c}()`);
+    }
+    expect([...new Set(offenders)]).toEqual([]);
   });
 
   it("is never aliased or reached dynamically", () => {
@@ -275,14 +282,11 @@ describe("no renderer writes a facet", () => {
   // The same hazard one level down: hideAll() written as a loop of commits is the quadratic cost
   // moved inside the module, where no call-site check sees it. Checked against the AST, because a
   // textual count of `commit(` passes this exact mutation — one call in a loop is one occurrence.
-  it("has no bulk operation looping around its own commit", async () => {
+  it("makes no commit once per element, in any spelling", async () => {
     const script = scriptFromSource("dashboard-facets.js", await readFile(MODULE, "utf8"));
-    const offenders: string[] = [];
-    for (const fn of functionsOf(script).filter((f) => ["hideAll", "showAll", "toggle"].includes(f.name))) {
-      for (const pos of ownerCallPositions(fn.node, "commit")) {
-        if (insideLoop(fn.node, pos)) offenders.push(`${fn.name}() commits inside a loop`);
-      }
-    }
+    const offenders = commitsInsideLoops(script, ["commit", "set"]).map(
+      (c) => `${c.fn}():${c.line} commits per element${c.via ? ` via ${c.via}()` : ""}`,
+    );
     expect(offenders).toEqual([]);
   });
 

--- a/companion/tests/dashboard/dashboardScope.test.ts
+++ b/companion/tests/dashboard/dashboardScope.test.ts
@@ -344,13 +344,12 @@ describe("who may write the window", () => {
   // = null`, `let scope;`, `const scope = …` and `var scope` all passed it, and any of them is the
   // second source of truth this migration exists to remove.
   it("leaves no top-level `scope` binding behind, in any spelling", () => {
-    const offenders = scripts
-      .filter((s) => s.name.startsWith("dashboard.html#inline"))
-      .flatMap((s) =>
-        topLevelBindings(s)
-          .filter((b) => b.name === "scope")
-          .map((b) => `${s.name}:${b.line}`),
-      );
+    // EVERY script the page loads — see the note in dashboardSelection.test.ts.
+    const offenders = scripts.flatMap((s) =>
+      topLevelBindings(s)
+        .filter((b) => b.name === "scope")
+        .map((b) => `${s.name}:${b.line}`),
+    );
     expect(
       offenders,
       "the investigation window is owned by js/dashboard-scope.js; a top-level `scope` in the page " +
@@ -360,13 +359,11 @@ describe("who may write the window", () => {
 
   it("leaves none of the moved functions behind", () => {
     const moved = new Set(["inScope", "projectScope", "renderScopeInfo"]);
-    const offenders = scripts
-      .filter((s) => s.name.startsWith("dashboard.html#inline"))
-      .flatMap((s) =>
-        functionsOf(s)
-          .filter((f) => moved.has(f.name))
-          .map((f) => `${s.name}:${f.line} ${f.name}`),
-      );
+    const offenders = scripts.flatMap((s) =>
+      functionsOf(s)
+        .filter((f) => moved.has(f.name))
+        .map((f) => `${s.name}:${f.line} ${f.name}`),
+    );
     expect(offenders).toEqual([]);
   });
 

--- a/companion/tests/dashboard/dashboardSelection.test.ts
+++ b/companion/tests/dashboard/dashboardSelection.test.ts
@@ -10,7 +10,7 @@ import {
   dashboardScripts,
   ownerCalls,
   ownerEscapes,
-  reachableWithin,
+  reachableFrom,
   scriptFromSource,
   topLevelBindings,
 } from "../helpers/dashboardAst.js";
@@ -305,21 +305,23 @@ describe("no commit happens inside a loop", () => {
   // with names this generic, "can eventually reach" stops predicting "runs per iteration", and a
   // gate whose output is mostly allowlist teaches people to extend the allowlist. The bound is
   // stated here so the next reader knows what is NOT covered rather than assuming it is.
-  it("no function reachable from a loop within two hops commits", () => {
+  it("no function reachable from a loop through any number of hops commits", () => {
     const committers = new Set(
       ["DfirSelection", "DfirStarred"]
         .flatMap((ns) => ownerCalls(scriptsForPins, ns, COMMITS))
         .map((c) => c.fn)
         .filter((f) => !f.startsWith("<")),
     );
-    // TWO hops, not one. Review found `for (…) outer(x)` where outer() calls inner() which
-    // commits — invisible to a direct-callee check. Still bounded rather than full reachability,
-    // for the reason recorded above; the bound is stated so nobody assumes more coverage.
+    // FULL reachability, no bound. An earlier version stopped at one hop, then at two, because
+    // unbounded reachability reported noise — and the noise turned out to be a modelling error
+    // rather than a fact about the code: a handler registered inside a loop was being counted as
+    // running per element. With that fixed (see isEventHandlerArg) the unbounded rule reports
+    // nothing on this page, so there is no reason to keep a bound that only limits what is caught.
     const graph = buildCallGraph(scriptsForPins);
     const offenders: string[] = [];
     for (const callee of calleesInsideLoops(scriptsForPins)) {
       if (ALLOWED_IN_LOOP.includes(callee)) continue;
-      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      const reach = new Set([callee, ...reachableFrom(graph, [callee])]);
       for (const c of committers) {
         if (reach.has(c) && !ALLOWED_IN_LOOP.includes(c)) {
           offenders.push(`${callee}() is called in a loop and reaches ${c}(), which commits`);
@@ -396,14 +398,15 @@ describe("the old bindings are gone", () => {
     expect(found).not.toContain("selectedEvents");
   });
 
-  it.each(MOVED)("%s has no top-level binding left in the page", (name) => {
-    const offenders = scripts
-      .filter((s) => s.name.startsWith("dashboard.html#inline"))
-      .flatMap((s) =>
-        topLevelBindings(s)
-          .filter((b) => b.name === name)
-          .map((b) => `${s.name}:${b.line}`),
-      );
+  it.each(MOVED)("%s has no binding left in any script the page loads", (name) => {
+    // EVERY script, not just the inline blocks. Scoping this to the page meant the same legacy
+    // binding re-created in a loaded /js/ module passed — the single-file hole, still open here
+    // after the facet and timeline-view suites had closed it.
+    const offenders = scripts.flatMap((s) =>
+      topLevelBindings(s)
+        .filter((b) => b.name === name)
+        .map((b) => `${s.name}:${b.line}`),
+    );
     expect(offenders).toEqual([]);
   });
 });

--- a/companion/tests/dashboard/dashboardSelection.test.ts
+++ b/companion/tests/dashboard/dashboardSelection.test.ts
@@ -4,13 +4,13 @@ import { describe, expect, it } from "vitest";
 import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
 import type { SelectionApi } from "./dashboardApi.js";
 import {
+  buildCallGraph,
   calleesInsideLoops,
-  functionsOf,
-  insideLoop,
-  ownerCallPositions,
+  commitsInsideLoops,
   dashboardScripts,
   ownerCalls,
   ownerEscapes,
+  reachableWithin,
   scriptFromSource,
   topLevelBindings,
 } from "../helpers/dashboardAst.js";
@@ -305,17 +305,28 @@ describe("no commit happens inside a loop", () => {
   // with names this generic, "can eventually reach" stops predicting "runs per iteration", and a
   // gate whose output is mostly allowlist teaches people to extend the allowlist. The bound is
   // stated here so the next reader knows what is NOT covered rather than assuming it is.
-  it("no function called directly from inside a loop commits", () => {
+  it("no function reachable from a loop within two hops commits", () => {
     const committers = new Set(
       ["DfirSelection", "DfirStarred"]
         .flatMap((ns) => ownerCalls(scriptsForPins, ns, COMMITS))
         .map((c) => c.fn)
         .filter((f) => !f.startsWith("<")),
     );
-    const offenders = [...calleesInsideLoops(scriptsForPins)]
-      .filter((callee) => committers.has(callee) && !ALLOWED_IN_LOOP.includes(callee))
-      .map((callee) => `${callee}() commits and is called from inside a loop`);
-    expect(offenders).toEqual([]);
+    // TWO hops, not one. Review found `for (…) outer(x)` where outer() calls inner() which
+    // commits — invisible to a direct-callee check. Still bounded rather than full reachability,
+    // for the reason recorded above; the bound is stated so nobody assumes more coverage.
+    const graph = buildCallGraph(scriptsForPins);
+    const offenders: string[] = [];
+    for (const callee of calleesInsideLoops(scriptsForPins)) {
+      if (ALLOWED_IN_LOOP.includes(callee)) continue;
+      const reach = new Set([callee, ...reachableWithin(graph, [callee], 2)]);
+      for (const c of committers) {
+        if (reach.has(c) && !ALLOWED_IN_LOOP.includes(c)) {
+          offenders.push(`${callee}() is called in a loop and reaches ${c}(), which commits`);
+        }
+      }
+    }
+    expect([...new Set(offenders)]).toEqual([]);
   });
 
   // THE MODULE'S OWN BULK OPERATIONS MUST NOT LOOP AROUND A COMMIT.
@@ -325,15 +336,15 @@ describe("no commit happens inside a loop", () => {
   // badly as what it replaced. Checked against the AST rather than by counting `commit(` in the
   // text, because the counting version passed this exact mutation — one call, inside a loop, is
   // still one occurrence.
-  it("has no bulk operation looping around its own commit", async () => {
+  // EVERY function in the module, and every spelling of a commit. The narrow version looked for a
+  // bare `commit(` inside a hand-listed set of bulk operations; review showed `cell.set(...)` in a
+  // loop and a helper that commits both walked past it, either of which restores the quadratic cost
+  // the bulk operations exist to avoid.
+  it("makes no commit once per element, in any spelling", async () => {
     const script = scriptFromSource("dashboard-selection.js", await readFile(MODULE, "utf8"));
-    const BULK = ["addAll", "removeAll", "replace", "clear", "toggle"];
-    const offenders: string[] = [];
-    for (const fn of functionsOf(script).filter((f) => BULK.includes(f.name))) {
-      for (const call of ownerCallPositions(fn.node, "commit")) {
-        if (insideLoop(fn.node, call)) offenders.push(`${fn.name}() commits inside a loop`);
-      }
-    }
+    const offenders = commitsInsideLoops(script, ["commit", "set"]).map(
+      (c) => `${c.fn}():${c.line} commits per element${c.via ? ` via ${c.via}()` : ""}`,
+    );
     expect(offenders).toEqual([]);
   });
 

--- a/companion/tests/dashboard/dashboardTimelineView.test.ts
+++ b/companion/tests/dashboard/dashboardTimelineView.test.ts
@@ -25,6 +25,7 @@ const PANELS = [
   "derivedViews",
   "excludeChips",
   "searchBox",
+  "searchInput",
   "timeInputs",
   "severityBoxes",
   "starButton",
@@ -479,6 +480,32 @@ describe("wiring", () => {
         `${panel}:`,
       );
     }
+  });
+
+  // A RUNTIME DEFECT THIS BRANCH FIXES, gated so it cannot come back.
+  //
+  // setSearch() trims and lower-cases the term. An earlier painter wrote that committed value back
+  // into the live <input>, so 300ms after typing "foo " the box read "foo" and the next keystrokes
+  // appended to that: "foo " then "bar" produced "foobar", with the caret moved. The original
+  // applySearch() read the input and never wrote it.
+  it("never rewrites the analyst's search box while they are typing", async () => {
+    const html = await readFile(DASHBOARD, "utf8");
+    const painter = html.slice(html.indexOf("searchBox: () =>"), html.indexOf("searchInput: () =>"));
+    expect(painter, "could not locate the searchBox painter").toContain("clearSearch");
+    expect(
+      painter,
+      "the per-search painter must not assign to #globalSearch — it corrupts what is being typed",
+    ).not.toMatch(/globalSearch[\s\S]*?\.value\s*=/);
+  });
+
+  it("still empties the box when the analyst clears filters", () => {
+    const { view, refreshed } = load();
+    view.setSearch("noise");
+    const after = load();
+    after.view.clearFilters();
+    expect(after.refreshed()).toContain("searchInput");
+    void refreshed;
+    void view;
   });
 
   it("stays a classic script", async () => {

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -373,6 +373,19 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
         out.push({ name: n.left.name.text, line: at(n.left.name) });
         declared.add(n.left.name.text);
       }
+      // ...and `globalThis["hiddenSources"] = new Set()`, which is the same global by the one
+      // spelling the property-access branch above cannot see.
+      if (
+        ts.isElementAccessExpression(n.left) &&
+        ts.isIdentifier(n.left.expression) &&
+        GLOBAL_ROOTS.has(n.left.expression.text) &&
+        n.left.argumentExpression &&
+        ts.isStringLiteral(n.left.argumentExpression) &&
+        !declared.has(n.left.argumentExpression.text)
+      ) {
+        out.push({ name: n.left.argumentExpression.text, line: at(n.left) });
+        declared.add(n.left.argumentExpression.text);
+      }
     }
     ts.forEachChild(n, assignWalk);
   };
@@ -477,6 +490,19 @@ export function ownerCalls(
       }
       // An iteration callback is a loop body, so its ARGUMENTS are walked at depth+1 while the
       // receiver is not: in `xs.forEach(cb)` the `xs` expression runs once.
+      // A FUNCTION BODY IS ONLY "IN THE LOOP" IF THE LOOP CALLS IT PER ELEMENT.
+      //
+      // `["a","b"].forEach(id => el(id).addEventListener("keydown", () => createNewCase()))` puts
+      // createNewCase() three frames inside a forEach, but it runs on a KEYSTROKE — once, later,
+      // and not once per element. Counting it produced exactly one offender on this page and it was
+      // noise, which is how a gate teaches people to extend its allowlist.
+      //
+      // So loop depth resets when entering a function that is NOT an iteration callback. The
+      // iteration case is handled below, where the arguments are walked at depth + 1.
+      if (isFunctionLike(n) && !isIterationCallback(n)) {
+        ts.forEachChild(n, (c) => visit(c, 0));
+        return;
+      }
       if (isIterationCall(n)) {
         visit(n.expression, inner);
         for (const a of n.arguments) visit(a, inner + 1);
@@ -533,6 +559,19 @@ export function calleesInsideLoops(scripts: DashboardScript[]): Set<string> {
         if (ts.isIdentifier(n.expression)) out.add(n.expression.text);
         else if (ts.isPropertyAccessExpression(n.expression)) out.add(n.expression.name.text);
       }
+      // A FUNCTION BODY IS ONLY "IN THE LOOP" IF THE LOOP CALLS IT PER ELEMENT.
+      //
+      // `["a","b"].forEach(id => el(id).addEventListener("keydown", () => createNewCase()))` puts
+      // createNewCase() three frames inside a forEach, but it runs on a KEYSTROKE — once, later,
+      // and not once per element. Counting it produced exactly one offender on this page and it was
+      // noise, which is how a gate teaches people to extend its allowlist.
+      //
+      // So loop depth resets when entering a function that is NOT an iteration callback. The
+      // iteration case is handled below, where the arguments are walked at depth + 1.
+      if (isFunctionLike(n) && !isIterationCallback(n)) {
+        ts.forEachChild(n, (c) => visit(c, 0));
+        return;
+      }
       if (isIterationCall(n)) {
         // A CALLBACK PASSED BY NAME IS STILL CALLED PER ELEMENT. `xs.forEach(hideOne)` has no call
         // expression anywhere inside it, so walking the arguments finds nothing — the identifier
@@ -584,6 +623,12 @@ export interface OwnerEscape {
 function isPropertyName(n: ts.Node): boolean {
   const p = n.parent;
   return !!p && (ts.isPropertyAccessExpression(p) || ts.isPropertyAssignment(p)) && p.name === n;
+}
+
+/** Is this function the callback argument of `xs.forEach(...)` and friends? */
+function isIterationCallback(n: ts.Node): boolean {
+  const p = n.parent;
+  return !!p && isIterationCall(p) && p.arguments.some((a) => a === n);
 }
 
 /** Is this node the `X` in `X(...)` — i.e. the thing actually being invoked? */
@@ -674,6 +719,86 @@ export function ownerEscapes(scripts: DashboardScript[], namespace: string): Own
     ts.forEachChild(s.ast, visit);
   }
   return hits;
+}
+
+/** A commit made once per element, inside an owner module itself. */
+export interface LoopedCommit {
+  fn: string;
+  line: number;
+  /** `direct` is the commit call itself in the loop; `via` names the helper that reaches one. */
+  via: string | null;
+}
+
+/**
+ * Commits an owner module makes once per element, in ANY spelling.
+ *
+ * The narrow version of this check looked for a bare `commit(` inside a named bulk operation, and
+ * review showed two ways past it that both produce the quadratic cost the bulk operations exist to
+ * avoid:
+ *
+ *     addAll(ids)  { for (const id of ids) cell.set(new Set([id])); }   // member call, not `commit(`
+ *     hideAll(ids) { for (const id of ids) put(id); }                    // helper that commits
+ *
+ * So: a function "commits" if it calls any of `commitNames` by bare name OR as a member (`cell.set`),
+ * closed transitively over the module's own functions; and a loop enclosing a call to any committer
+ * is an offender. Every function in the module is examined, not a hand-listed few — the list was
+ * itself a way to be wrong.
+ */
+export function commitsInsideLoops(script: DashboardScript, commitNames: readonly string[]): LoopedCommit[] {
+  const want = new Set(commitNames);
+  const fns = functionsOf(script);
+  const at = (n: ts.Node): number =>
+    script.ast.getLineAndCharacterOfPosition(n.getStart(script.ast)).line + 1;
+
+  /** Names called from inside `node`, bare or as a member, WITHOUT descending into nested functions. */
+  const ownCalls = (node: ts.Node): string[] => {
+    const out: string[] = [];
+    const visit = (n: ts.Node): void => {
+      if (n !== node && isFunctionLike(n)) return;
+      if (ts.isCallExpression(n)) {
+        if (ts.isIdentifier(n.expression)) out.push(n.expression.text);
+        else if (ts.isPropertyAccessExpression(n.expression)) out.push(n.expression.name.text);
+      }
+      ts.forEachChild(n, visit);
+    };
+    ts.forEachChild(node, visit);
+    return out;
+  };
+
+  // Which of the module's own functions reach a commit — closed to a fixpoint, so a helper behind a
+  // helper counts.
+  const commits = new Set<string>();
+  for (const f of fns) if (ownCalls(f.node).some((c) => want.has(c))) commits.add(f.name);
+  for (let changed = true; changed;) {
+    changed = false;
+    for (const f of fns) {
+      if (commits.has(f.name)) continue;
+      if (ownCalls(f.node).some((c) => commits.has(c))) {
+        commits.add(f.name);
+        changed = true;
+      }
+    }
+  }
+
+  const out: LoopedCommit[] = [];
+  for (const f of fns) {
+    const visit = (n: ts.Node): void => {
+      if (n !== f.node && isFunctionLike(n)) return; // that function is judged on its own
+      if (ts.isCallExpression(n)) {
+        const name = ts.isIdentifier(n.expression)
+          ? n.expression.text
+          : ts.isPropertyAccessExpression(n.expression)
+            ? n.expression.name.text
+            : null;
+        if (name && (want.has(name) || commits.has(name)) && insideLoop(f.node, n.getStart(script.ast))) {
+          out.push({ fn: f.name, line: at(n), via: want.has(name) ? null : name });
+        }
+      }
+      ts.forEachChild(n, visit);
+    };
+    ts.forEachChild(f.node, visit);
+  }
+  return out;
 }
 
 /** A property write through an owner's getter: `DfirScope.get().start = x`. */
@@ -939,6 +1064,36 @@ export function buildCallGraph(scripts: DashboardScript[]): Map<string, Set<stri
     }
   }
   return graph;
+}
+
+/**
+ * Reachability with a HOP BOUND.
+ *
+ * The loop rule needs more than one hop (review found `for (…) outer(x)` where outer() calls
+ * inner() which commits) and less than all of them: run unbounded over this call graph it reports
+ * things like createNewCase() reaching proceedConnect(), where "can eventually reach" has stopped
+ * predicting "runs per iteration". A small bound is the honest middle, and the bound is stated at
+ * the call site so nobody assumes coverage that is not there.
+ */
+export function reachableWithin(
+  graph: Map<string, Set<string>>,
+  starts: Iterable<string>,
+  maxHops: number,
+): Set<string> {
+  let frontier = new Set(starts);
+  const seen = new Set<string>();
+  for (let hop = 0; hop < maxHops && frontier.size > 0; hop++) {
+    const next = new Set<string>();
+    for (const name of frontier) {
+      for (const callee of graph.get(name) || []) {
+        if (seen.has(callee)) continue;
+        seen.add(callee);
+        next.add(callee);
+      }
+    }
+    frontier = next;
+  }
+  return seen;
 }
 
 export function reachableFrom(graph: Map<string, Set<string>>, start: Iterable<string>): Set<string> {

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -324,6 +324,22 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
   const declared = new Set(out.map((b) => b.name));
   const varWalk = (n: ts.Node): void => {
     if (isFunctionLike(n)) return; // `var` inside a function is that function's, not the script's
+    // `for (var selectedEvents of sets)` and its for/for-in siblings: the declaration lives in the
+    // loop head, not in a VariableStatement, so the branch below never saw it.
+    if (
+      (ts.isForStatement(n) || ts.isForOfStatement(n) || ts.isForInStatement(n)) &&
+      n.initializer &&
+      ts.isVariableDeclarationList(n.initializer)
+    ) {
+      const list = n.initializer;
+      if (!(list.flags & ts.NodeFlags.BlockScoped)) {
+        for (const d of list.declarations) {
+          const before = out.length;
+          collect(d.name);
+          for (const b of out.slice(before)) declared.add(b.name);
+        }
+      }
+    }
     if (ts.isVariableStatement(n) && n.declarationList.flags & ts.NodeFlags.Let) {
       // let/const in a nested block is genuinely block-scoped; not ours.
     } else if (ts.isVariableStatement(n) && !(n.declarationList.flags & ts.NodeFlags.BlockScoped)) {
@@ -355,8 +371,15 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
   };
   ts.forEachChild(script.ast, declWalk);
 
+  const ASSIGN_OPS = new Set([
+    ts.SyntaxKind.EqualsToken,
+    // `window.hiddenSources ??= new Set()` creates the global just as surely as `=` does.
+    ts.SyntaxKind.QuestionQuestionEqualsToken,
+    ts.SyntaxKind.BarBarEqualsToken,
+    ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ]);
   const assignWalk = (n: ts.Node): void => {
-    if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+    if (ts.isBinaryExpression(n) && ASSIGN_OPS.has(n.operatorToken.kind)) {
       // `selectedEvents = new Set()` with no declaration anywhere — an implicit global.
       if (ts.isIdentifier(n.left) && !declaredAnywhere.has(n.left.text) && !declared.has(n.left.text)) {
         out.push({ name: n.left.text, line: at(n.left) });
@@ -380,7 +403,8 @@ export function topLevelBindings(script: DashboardScript): Array<{ name: string;
         ts.isIdentifier(n.left.expression) &&
         GLOBAL_ROOTS.has(n.left.expression.text) &&
         n.left.argumentExpression &&
-        ts.isStringLiteral(n.left.argumentExpression) &&
+        (ts.isStringLiteral(n.left.argumentExpression) ||
+          ts.isNoSubstitutionTemplateLiteral(n.left.argumentExpression)) &&
         !declared.has(n.left.argumentExpression.text)
       ) {
         out.push({ name: n.left.argumentExpression.text, line: at(n.left) });
@@ -446,6 +470,10 @@ export function ownerCalls(
     }
     return null;
   };
+  // `DfirSelection.events.toggle.call(null, x)` still invokes toggle. Dropping the reflective tail
+  // is what makes the path end at the member the rule is about, instead of at "call".
+  const withoutReflection = (path: string[]): string[] =>
+    path.length > 1 && FUNCTION_INVOKERS.has(path[path.length - 1]) ? path.slice(0, -1) : path;
 
   for (const s of scripts) {
     const at = (n: ts.Node): number => s.ast.getLineAndCharacterOfPosition(n.getStart(s.ast)).line + 1;
@@ -476,7 +504,7 @@ export function ownerCalls(
         inner = loops + 1;
       }
       if (ts.isCallExpression(n) && ts.isPropertyAccessExpression(n.expression)) {
-        const path = chain(n.expression);
+        const path = chain(n.expression) && withoutReflection(chain(n.expression) as string[]);
         if (path && want.has(path[path.length - 1])) {
           out.push({
             script: s.name,
@@ -490,16 +518,18 @@ export function ownerCalls(
       }
       // An iteration callback is a loop body, so its ARGUMENTS are walked at depth+1 while the
       // receiver is not: in `xs.forEach(cb)` the `xs` expression runs once.
-      // A FUNCTION BODY IS ONLY "IN THE LOOP" IF THE LOOP CALLS IT PER ELEMENT.
+      // ONLY AN EVENT-DRIVEN CALLBACK IS DECOUPLED FROM THE LOOP.
       //
-      // `["a","b"].forEach(id => el(id).addEventListener("keydown", () => createNewCase()))` puts
-      // createNewCase() three frames inside a forEach, but it runs on a KEYSTROKE — once, later,
-      // and not once per element. Counting it produced exactly one offender on this page and it was
-      // noise, which is how a gate teaches people to extend its allowlist.
+      // `["a","b"].forEach(id => el(id).addEventListener("keydown", () => createNewCase()))` puts a
+      // commit three frames inside a forEach, but it runs on a KEYSTROKE — once, later, not once
+      // per element. That one is genuinely not per-element.
       //
-      // So loop depth resets when entering a function that is NOT an iteration callback. The
-      // iteration case is handled below, where the arguments are walked at depth + 1.
-      if (isFunctionLike(n) && !isIterationCallback(n)) {
+      // An earlier version reset depth at EVERY nested function that was not an iteration callback,
+      // which was far too broad: a synchronous IIFE, an unknown helper's callback, and
+      // `for (…) queueMicrotask(() => commit())` all became invisible, and the last of those really
+      // does run N times. Deferral is not the property that matters — being driven by something
+      // other than the loop is — so only listener registration qualifies.
+      if (isFunctionLike(n) && isEventHandlerArg(n)) {
         ts.forEachChild(n, (c) => visit(c, 0));
         return;
       }
@@ -559,16 +589,18 @@ export function calleesInsideLoops(scripts: DashboardScript[]): Set<string> {
         if (ts.isIdentifier(n.expression)) out.add(n.expression.text);
         else if (ts.isPropertyAccessExpression(n.expression)) out.add(n.expression.name.text);
       }
-      // A FUNCTION BODY IS ONLY "IN THE LOOP" IF THE LOOP CALLS IT PER ELEMENT.
+      // ONLY AN EVENT-DRIVEN CALLBACK IS DECOUPLED FROM THE LOOP.
       //
-      // `["a","b"].forEach(id => el(id).addEventListener("keydown", () => createNewCase()))` puts
-      // createNewCase() three frames inside a forEach, but it runs on a KEYSTROKE — once, later,
-      // and not once per element. Counting it produced exactly one offender on this page and it was
-      // noise, which is how a gate teaches people to extend its allowlist.
+      // `["a","b"].forEach(id => el(id).addEventListener("keydown", () => createNewCase()))` puts a
+      // commit three frames inside a forEach, but it runs on a KEYSTROKE — once, later, not once
+      // per element. That one is genuinely not per-element.
       //
-      // So loop depth resets when entering a function that is NOT an iteration callback. The
-      // iteration case is handled below, where the arguments are walked at depth + 1.
-      if (isFunctionLike(n) && !isIterationCallback(n)) {
+      // An earlier version reset depth at EVERY nested function that was not an iteration callback,
+      // which was far too broad: a synchronous IIFE, an unknown helper's callback, and
+      // `for (…) queueMicrotask(() => commit())` all became invisible, and the last of those really
+      // does run N times. Deferral is not the property that matters — being driven by something
+      // other than the loop is — so only listener registration qualifies.
+      if (isFunctionLike(n) && isEventHandlerArg(n)) {
         ts.forEachChild(n, (c) => visit(c, 0));
         return;
       }
@@ -585,8 +617,10 @@ export function calleesInsideLoops(scripts: DashboardScript[]): Set<string> {
         return;
       }
       // The same by-name hand-off inside a real loop: `for (…) xs.map(hideOne)` is covered above,
-      // but `for (…) run(hideOne)` passes it to something that will call it.
-      if (loops > 0 && ts.isCallExpression(n)) {
+      // but `for (…) run(hideOne)` passes it to something that will call it. NOT for a listener
+      // registration — `for (…) el.addEventListener("click", handler)` registers N handlers that
+      // each run on a click, not N calls, and treating it as a call reported handlers falsely.
+      if (loops > 0 && ts.isCallExpression(n) && !isEventRegistration(n)) {
         for (const a of n.arguments) if (ts.isIdentifier(a)) out.add(a.text);
       }
       ts.forEachChild(n, (c) => visit(c, inner));
@@ -625,10 +659,51 @@ function isPropertyName(n: ts.Node): boolean {
   return !!p && (ts.isPropertyAccessExpression(p) || ts.isPropertyAssignment(p)) && p.name === n;
 }
 
-/** Is this function the callback argument of `xs.forEach(...)` and friends? */
-function isIterationCallback(n: ts.Node): boolean {
+/** Names whose callback is invoked by something OTHER than the surrounding code's control flow. */
+/** Reflective invokers: `f.call(…)`, `f.apply(…)`, `f.bind(…)` still reach `f`. */
+const FUNCTION_INVOKERS = new Set(["call", "apply", "bind"]);
+
+/** `el.addEventListener("click", fn)` — the call itself, not its callback. */
+function isEventRegistration(n: ts.CallExpression): boolean {
+  return ts.isPropertyAccessExpression(n.expression) && EVENT_REGISTRARS.has(n.expression.name.text);
+}
+
+const EVENT_REGISTRARS = new Set(["addEventListener", "removeEventListener", "on", "once"]);
+
+/**
+ * Is this function registered as an event handler, rather than called by the code around it?
+ *
+ * Deliberately narrow. setTimeout/queueMicrotask/Promise.then all invoke their callback ONCE PER
+ * CALL, so N registrations in a loop are still N commits — they are not on this list. Only handlers
+ * driven by an external event are, plus `el.onclick = fn`.
+ */
+function isEventHandlerArg(n: ts.Node): boolean {
   const p = n.parent;
-  return !!p && isIterationCall(p) && p.arguments.some((a) => a === n);
+  if (!p) return false;
+  if (
+    ts.isCallExpression(p) &&
+    ts.isPropertyAccessExpression(p.expression) &&
+    EVENT_REGISTRARS.has(p.expression.name.text) &&
+    p.arguments.some((a) => a === n)
+  ) {
+    return true;
+  }
+  // el.onclick = () => …
+  return (
+    ts.isBinaryExpression(p) &&
+    p.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    p.right === n &&
+    ts.isPropertyAccessExpression(p.left) &&
+    /^on[a-z]/.test(p.left.name.text)
+  );
+}
+
+/** Is this function the callback argument of `xs.forEach(...)` and friends? Parentheses unwrapped. */
+function isIterationCallback(n: ts.Node): boolean {
+  let node: ts.Node = n;
+  while (node.parent && ts.isParenthesizedExpression(node.parent)) node = node.parent;
+  const p = node.parent;
+  return !!p && isIterationCall(p) && p.arguments.some((a) => a === node);
 }
 
 /** Is this node the `X` in `X(...)` — i.e. the thing actually being invoked? */
@@ -640,7 +715,11 @@ function isCalleePosition(n: ts.Node): boolean {
 /** A sub-path like `DfirSelection.events` inside `DfirSelection.events.toggle(x)` is not itself an escape. */
 function isPartOfLongerPath(n: ts.Node): boolean {
   const p = n.parent;
-  return !!p && (ts.isPropertyAccessExpression(p) || ts.isElementAccessExpression(p)) && p.expression === n;
+  if (!p || !(ts.isPropertyAccessExpression(p) || ts.isElementAccessExpression(p))) return false;
+  if (p.expression !== n) return false;
+  // `DfirSelection.events.toggle.call` is NOT a longer path in the sense that matters: the tail is
+  // reflection, so the owner's method is still what gets invoked and must stay reportable.
+  return !(ts.isPropertyAccessExpression(p) && FUNCTION_INVOKERS.has(p.name.text));
 }
 
 function nearbyText(n: ts.Node, sf: ts.SourceFile): string {
@@ -662,7 +741,13 @@ export function ownerEscapes(scripts: DashboardScript[], namespace: string): Own
     const definitionTargets = new Set<number>();
     const findDefs = (n: ts.Node): void => {
       if (ts.isBinaryExpression(n) && n.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-        definitionTargets.add(n.left.getStart(s.ast));
+        // The namespace's OWN definition (`window.DfirFacets = {…}`) only. Assigning to a MEMBER —
+        // `DfirSelection.events.toggle = fn` — is a method being replaced, which is the opposite of
+        // a definition and must stay reportable; treating every assignment target as a definition
+        // let that through.
+        if (denotesNamespace(n.left, namespace) || !denotesOwnerOrChild(n.left)) {
+          definitionTargets.add(n.left.getStart(s.ast));
+        }
       }
       ts.forEachChild(n, findDefs);
     };
@@ -754,7 +839,7 @@ export function commitsInsideLoops(script: DashboardScript, commitNames: readonl
   const ownCalls = (node: ts.Node): string[] => {
     const out: string[] = [];
     const visit = (n: ts.Node): void => {
-      if (n !== node && isFunctionLike(n)) return;
+      if (n !== node && isFunctionLike(n) && !isIterationCallback(n)) return;
       if (ts.isCallExpression(n)) {
         if (ts.isIdentifier(n.expression)) out.push(n.expression.text);
         else if (ts.isPropertyAccessExpression(n.expression)) out.push(n.expression.name.text);
@@ -783,7 +868,11 @@ export function commitsInsideLoops(script: DashboardScript, commitNames: readonl
   const out: LoopedCommit[] = [];
   for (const f of fns) {
     const visit = (n: ts.Node): void => {
-      if (n !== f.node && isFunctionLike(n)) return; // that function is judged on its own
+      // Descend into ITERATION callbacks — `ids.forEach(id => cell.set(…))` is the same per-element
+      // commit as `for (const id of ids) cell.set(…)`, and skipping every nested function made this
+      // blind to it. insideLoop() already treats an iteration callback's body as a loop body.
+      // Other nested functions are judged on their own pass.
+      if (n !== f.node && isFunctionLike(n) && !isIterationCallback(n)) return;
       if (ts.isCallExpression(n)) {
         const name = ts.isIdentifier(n.expression)
           ? n.expression.text
@@ -1064,36 +1153,6 @@ export function buildCallGraph(scripts: DashboardScript[]): Map<string, Set<stri
     }
   }
   return graph;
-}
-
-/**
- * Reachability with a HOP BOUND.
- *
- * The loop rule needs more than one hop (review found `for (…) outer(x)` where outer() calls
- * inner() which commits) and less than all of them: run unbounded over this call graph it reports
- * things like createNewCase() reaching proceedConnect(), where "can eventually reach" has stopped
- * predicting "runs per iteration". A small bound is the honest middle, and the bound is stated at
- * the call site so nobody assumes coverage that is not there.
- */
-export function reachableWithin(
-  graph: Map<string, Set<string>>,
-  starts: Iterable<string>,
-  maxHops: number,
-): Set<string> {
-  let frontier = new Set(starts);
-  const seen = new Set<string>();
-  for (let hop = 0; hop < maxHops && frontier.size > 0; hop++) {
-    const next = new Set<string>();
-    for (const name of frontier) {
-      for (const callee of graph.get(name) || []) {
-        if (seen.has(callee)) continue;
-        seen.add(callee);
-        next.add(callee);
-      }
-    }
-    frontier = next;
-  }
-  return seen;
 }
 
 export function reachableFrom(graph: Map<string, Set<string>>, start: Iterable<string>): Set<string> {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3611,12 +3611,10 @@
       iocs: () => { if (DfirState.lastState()) renderIocs(DfirState.lastState().iocs || []); },
       derivedViews: () => refreshFilteredViews(),
       excludeChips: () => renderExcludeChips(),
-      searchBox: () => {
-        const gs = document.getElementById("globalSearch");
-        if (gs) gs.value = DfirTimelineView.search();
-        const cs = document.getElementById("clearSearch");
-        if (cs) cs.hidden = !DfirTimelineView.search();
-      },
+      // Clear button only — writing the committed (trimmed, lower-cased) term back would corrupt
+      // what the analyst is typing. Emptying the box is a RESET, hence the separate painter.
+      searchBox: () => { const cs = document.getElementById("clearSearch"); if (cs) cs.hidden = !DfirTimelineView.search(); },
+      searchInput: () => { const gs = document.getElementById("globalSearch"); if (gs) gs.value = ""; },
       timeInputs: () => {
         const ff = document.getElementById("filterFrom");
         if (ff) ff.value = isoToUtcInput(DfirTimelineView.from());

--- a/public/js/dashboard-timeline-view.js
+++ b/public/js/dashboard-timeline-view.js
@@ -95,7 +95,8 @@
     iocs: noop, // renderIocs(lastState().iocs) — the IOC list on its own
     derivedViews: noop, // refreshFilteredViews(): Kill Chain, Attack Phases, the graphs
     excludeChips: noop, // renderExcludeChips()
-    searchBox: noop, // the search input's own clear button + open state
+    searchBox: noop, // the search input's own clear button — NOT its value; see dashboard.html
+    searchInput: noop, // empties the search box; a RESET only, never a per-keystroke write
     timeInputs: noop, // #filterFrom / #filterTo and the Clear button
     severityBoxes: noop, // the .sev-filter checkboxes
     starButton: noop, // #evStarFilterBtn label + active class
@@ -111,6 +112,7 @@
     "severityBoxes",
     "starButton",
     "searchBox",
+    "searchInput",
     "timeInputs",
     "excludeChips",
     "all",


### PR DESCRIPTION
[#470](https://github.com/hasamba/DFIR-Companion/pull/470) shipped with **"tier 2 complete" withdrawn** — the owners were in place, the gates were not what that phrase implies. This closes the difference.

## I measured first, and the list was not what the review said

Probing the real helpers showed **two of the reported gaps were already closed** by #470's own fixes:

- every detached method-reference form — array, object literal, return value, argument, assignment — reports `passed`;
- `self.X`, and `var` inside `try`/`switch`/label blocks, are all found.

The audit was written against `806b9137`, before those landed. Worth checking rather than assuming, in both directions.

## Three were real, and one worse than reported

**1 — two-hop loop wrappers.** `for (…) outer(x)` where `outer()` calls `inner()` which commits was invisible: the rule looked at direct callees only. Now `reachableWithin()` — **bounded** at two hops, because unbounded reachability over this call graph reports things like `createNewCase()` reaching `proceedConnect()`, where "can eventually reach" has stopped predicting "runs per iteration". The bound is stated at the call site.

**2 — per-element commits inside the modules, and this was worse than reported.** The old check looked for a bare `commit(` inside a hand-listed set of bulk operations, so *both* of these walked past it:

```js
addAll(ids)  { for (const id of ids) cell.set(new Set([id])); }   // member call, not `commit(`
hideAll(ids) { for (const id of ids) put(id); }                   // helper that commits
```

`commitsInsideLoops()` replaces it: a function commits if it calls any commit name bare **or** as a member, closed transitively over the module's own functions, and **every** function is examined rather than a hand-listed few. The list was itself a way to be wrong.

**3 — computed globals.** `globalThis["hiddenSources"] = new Set()` is the same page global the property-access branch already caught, by the one spelling it could not see.

## A deferred callback is not a loop body

This fell out of fixing (1) and is the more interesting half. Two hops reported exactly one offender on the page, and it was noise:

```js
["ncCaseId","ncName","ncInvestigator"].forEach((id) =>
  document.getElementById(id).addEventListener("keydown", () => createNewCase()));
```

That puts a commit three frames inside a `forEach`, but it runs on a **keystroke** — once, later, not once per element. So loop depth now resets when entering a function that is not an iteration callback.

The alternative was an allowlist entry, and a gate whose output is mostly allowlist teaches people to extend the allowlist rather than fix the code. There is a mutation asserting this exclusion did **not** become a blanket escape — a direct commit in a loop is still caught.

## The analyser now has its own contract suite

Six holes have been found in these gates across #415, and **every one was found by a person reading the helper, never by a test** — because the page happened not to contain the shape being missed. `dashboardAstContract.test.ts` keeps each of those bypasses as the regression test it should always have been, each paired with an assertion of what must **not** be reported, since a check that flags everything is as useless as one that flags nothing.

## Gates

**7 mutations against the real page and modules, 7 fired:** two-hop wrappers around a selection and a facet commit, `cell.set()` per element inside `addAll`, a helper committing per element inside `hideAll`, `globalThis["selectedEvents"]` and `window["hiddenSources"]` recreated, and the deferred-callback exclusion not becoming a blanket escape.

`build`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` green. Full suite **7482 passed**; the 2 failures are the known local `sharp` 0.33.5/vips 8.15.3, in a file this branch does not touch. Tests only — no runtime change.

With this, the enforcement matches the claim, and **tier 2 is complete** in the sense #470 would not assert.
