### PR TITLE
test(dashboard): the missing-module gate excluded shorthand, and its census read text (#478, #480)

### DIFF
--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -16,6 +16,7 @@ import {
   buildCallGraph,
   callsByName,
   domAccessOutsideFunctions,
+  functionsOf,
   ownerEscapes,
   calleesInsideLoops,
   commitsInsideLoops,
@@ -219,6 +220,13 @@ describe("the guard analyser reads the branch, not just the condition", () => {
     ["the ELSE of a === function test", `if (typeof Foo === "function") { a(); } else { Foo(); }`],
     ["a call inside a template literal", "const s = `${Foo()}`;"],
     ["a spread of the bare name", `go(...Foo);`],
+    // SHORTHAND IS A READ, not a property name. `{ Foo }` desugars to `{ Foo: Foo }` and evaluates
+    // the binding, so it throws exactly like a bare reference — but the analyser grouped
+    // ShorthandPropertyAssignment with PropertyAssignment, where excluding the name IS right, and
+    // fell straight through the hole. isValueRef() at the top of the helper had it correct all
+    // along and said so in a comment; two implementations of one rule, and the wrong one was wired.
+    ["a shorthand property that evaluates the binding", `const wiring = { Foo };`],
+    ["a shorthand inside a load-time IIFE", `(() => { register({ Foo }); })();`],
   ])("reports %s", (_label, src) => {
     expect(refs(src), "a missing module throws here and aborts the rest of the script").toContain("Foo");
   });
@@ -248,12 +256,55 @@ describe("the guard analyser reads the branch, not just the condition", () => {
     ["a call from inside an object method", `const o = { go() { Foo(); } };`],
     ["a property that shares the name", `const o = { Foo: 1 }; go(o.Foo);`],
     ["a parameter that shares the name", `function go(Foo) { return Foo; }`],
+    // Both of these were REPORTED before the analyser deferred to isValueRef(). A gate that flags
+    // correct code gets switched off, so a false positive costs the same as a false negative here.
+    ["a renamed destructuring key", `const { Foo: local } = q;`],
+    ["a loop label that shares the name", `Foo: for (;;) { break Foo; }`],
   ])("ignores %s", (_label, src) => {
     expect(
       refs(src),
       "contained to one interaction, or not a reference to the global at all — reporting it would " +
         "bury the six that can abort the page",
     ).not.toContain("Foo");
+  });
+});
+
+// The feature-module suite asks "did this module leave a duplicate of one of its functions behind
+// in the page?" It harvests the module's declared names, then looks for those names in the inline
+// script. The inline half always used the parser; the module half was a regex over the source, and
+// a regex reads text. Every row below is a declaration the regex missed or misread — and a name
+// missing from the census is a duplicate the gate cannot look for.
+describe("the declaration census reads the parser, not the text", () => {
+  const declared = (src: string): string[] =>
+    functionsOf(scriptFromSource("m.js", src))
+      .filter((f) => f.declaration)
+      .map((f) => f.name);
+
+  it.each([
+    ["a plain declaration", `function wire() {}`],
+    ["an async declaration", `async function wire() {}`],
+    // The mutation that motivated this: legal, invisible to /^\s*(?:async )?function (\w+)\s*\(/.
+    ["a comment between the keyword and the name", `function /* moved out */ wire() {}`],
+    ["a comment between the name and its parens", `function wire /* (#415) */ () {}`],
+    ["a newline between the keyword and the name", `function\nwire() {}`],
+    ["a generator declaration", `function* wire() {}`],
+    ["a declaration nested inside another function", `function outer() { function wire() {} }`],
+    ["a declaration inside a block", `{ function wire() {} }`],
+  ])("sees %s", (_label, src) => {
+    expect(declared(src), "a name missing from the census is a duplicate the gate cannot hunt").toContain(
+      "wire",
+    );
+  });
+
+  it.each([
+    // These are not declarations, and counting them would make the census hunt for names the module
+    // never owned — every false name is a chance to fail a PR for nothing.
+    ["a function expression assigned to a const", `const wire = function () {};`],
+    ["an arrow assigned to a const", `const wire = () => {};`],
+    ["a method shorthand in an object literal", `const o = { wire() {} };`],
+    ["the word function inside a string", `const s = "function wire() {}";`],
+  ])("does not count %s", (_label, src) => {
+    expect(declared(src)).not.toContain("wire");
   });
 });
 

--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -16,7 +16,7 @@ import {
   buildCallGraph,
   callsByName,
   domAccessOutsideFunctions,
-  functionsOf,
+  functionBindingsOf,
   ownerEscapes,
   calleesInsideLoops,
   commitsInsideLoops,
@@ -227,6 +227,7 @@ describe("the guard analyser reads the branch, not just the condition", () => {
     // along and said so in a comment; two implementations of one rule, and the wrong one was wired.
     ["a shorthand property that evaluates the binding", `const wiring = { Foo };`],
     ["a shorthand inside a load-time IIFE", `(() => { register({ Foo }); })();`],
+    ["a shorthand nested in a longhand value", `const wiring = { outer: { Foo } };`],
   ])("reports %s", (_label, src) => {
     expect(refs(src), "a missing module throws here and aborts the rest of the script").toContain("Foo");
   });
@@ -260,6 +261,14 @@ describe("the guard analyser reads the branch, not just the condition", () => {
     // correct code gets switched off, so a false positive costs the same as a false negative here.
     ["a renamed destructuring key", `const { Foo: local } = q;`],
     ["a loop label that shares the name", `Foo: for (;;) { break Foo; }`],
+    // SHORTHAND IN A PATTERN IS A WRITE. TypeScript spells `{ Foo }` the same in `const w = { Foo }`
+    // (a read, reported above) and `({ Foo } = src)` (an assignment, silent here) — and only the
+    // read can throw when the module is missing. Paired with the reports rows on purpose: one rule
+    // covering both directions is the only way this stays right.
+    ["a destructuring assignment target", `let Foo; ({ Foo } = src);`],
+    ["a destructuring assignment target with a default", `let Foo; ({ Foo = 1 } = src);`],
+    ["a nested destructuring assignment target", `let Foo; ({ outer: { Foo } } = src);`],
+    ["a destructuring target in a for-of", `let Foo; for ({ Foo } of xs) {}`],
   ])("ignores %s", (_label, src) => {
     expect(
       refs(src),
@@ -274,37 +283,45 @@ describe("the guard analyser reads the branch, not just the condition", () => {
 // script. The inline half always used the parser; the module half was a regex over the source, and
 // a regex reads text. Every row below is a declaration the regex missed or misread — and a name
 // missing from the census is a duplicate the gate cannot look for.
-describe("the declaration census reads the parser, not the text", () => {
-  const declared = (src: string): string[] =>
-    functionsOf(scriptFromSource("m.js", src))
-      .filter((f) => f.declaration)
-      .map((f) => f.name);
+describe("the function census counts every binding, and only bindings", () => {
+  const bound = (src: string): string[] =>
+    functionBindingsOf(scriptFromSource("m.js", src)).map((b) => b.name);
 
   it.each([
     ["a plain declaration", `function wire() {}`],
     ["an async declaration", `async function wire() {}`],
-    // The mutation that motivated this: legal, invisible to /^\s*(?:async )?function (\w+)\s*\(/.
+    // Legal, and invisible to the /^\s*(?:async )?function (\w+)\s*\(/ this replaced.
     ["a comment between the keyword and the name", `function /* moved out */ wire() {}`],
     ["a comment between the name and its parens", `function wire /* (#415) */ () {}`],
     ["a newline between the keyword and the name", `function\nwire() {}`],
     ["a generator declaration", `function* wire() {}`],
     ["a declaration nested inside another function", `function outer() { function wire() {} }`],
     ["a declaration inside a block", `{ function wire() {} }`],
+    // THE ONE THAT SHADOWS. A declaration-only census called these "names the module never owned";
+    // they are top-level lexical bindings, and one restored in the inline script wins over the
+    // module's published function at every call site in it.
+    ["a function expression bound to a const", `const wire = function () {};`],
+    ["an arrow bound to a const", `const wire = () => {};`],
+    ["an async arrow bound to a let", `let wire = async () => {};`],
+    ["a function expression bound to a var", `var wire = function () {};`],
+    ["a named function expression bound to a const", `const wire = function inner() {};`],
   ])("sees %s", (_label, src) => {
-    expect(declared(src), "a name missing from the census is a duplicate the gate cannot hunt").toContain(
+    expect(bound(src), "a name missing from the census is a duplicate the gate cannot hunt").toContain(
       "wire",
     );
   });
 
   it.each([
-    // These are not declarations, and counting them would make the census hunt for names the module
-    // never owned — every false name is a chance to fail a PR for nothing.
-    ["a function expression assigned to a const", `const wire = function () {};`],
-    ["an arrow assigned to a const", `const wire = () => {};`],
+    // A property is not a binding — nothing can shadow through one, and the ACTIONS dispatch table
+    // is made of these. Counting them would make the census hunt names the module never owned.
+    ["an arrow in an object property", `const ACTIONS = { wire: (el) => wire(el) };`],
     ["a method shorthand in an object literal", `const o = { wire() {} };`],
+    ["a class method", `class C { wire() {} }`],
+    ["an assignment onto window", `window.wire = function () {};`],
+    ["a const bound to a non-function", `const wire = 42;`],
     ["the word function inside a string", `const s = "function wire() {}";`],
   ])("does not count %s", (_label, src) => {
-    expect(declared(src)).not.toContain("wire");
+    expect(bound(src)).not.toContain("wire");
   });
 });
 

--- a/companion/tests/dashboard/dashboardFeatureModules.test.ts
+++ b/companion/tests/dashboard/dashboardFeatureModules.test.ts
@@ -2,11 +2,13 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { STATIC_ASSETS } from "../../src/http/staticAssets.js";
 import { runInContext } from "node:vm";
+import type { DashboardScript } from "../helpers/dashboardAst.js";
 import {
   callsAfter,
   callsByName,
   dashboardScripts,
   domAccessOutsideFunctions,
+  functionBindingsOf,
   functionsOf,
   moduleGlobals,
   scriptFromSource,
@@ -228,6 +230,27 @@ describe("the global-name enumeration these checks rest on", () => {
 const read = (f: string) => readFile(new URL(`../../../public/js/${f}`, import.meta.url), "utf8");
 const scripts = dashboardScripts();
 
+/**
+ * THE CENSUS SEAM: names the module binds that the inline script binds too.
+ *
+ * A named function rather than two lines inlined into the assertion, because the two lines are the
+ * thing that has now been wrong twice and neither wrongness was reachable from a test. Its own
+ * contract lives in the `describe` at the bottom of this file — synthetic module and inline sources
+ * carrying the exact mutations that got through, so the seam is exercised and not just its helper.
+ */
+const duplicateBindings = (
+  moduleName: string,
+  moduleSrc: string,
+  inlineScripts: DashboardScript[],
+): string[] => {
+  const declared = functionBindingsOf(scriptFromSource(moduleName, moduleSrc)).map((b) => b.name);
+  return inlineScripts.flatMap((s) =>
+    functionBindingsOf(s)
+      .filter((b) => declared.includes(b.name))
+      .map((b) => `${s.name}:${b.line} ${b.name}`),
+  );
+};
+
 describe.each(FEATURES)("$file", (feat) => {
   // THESE RUN THE MODULE. The first version asserted on the file's TEXT — that it contained
   // `(function () {` and one `window.x = x` line per published name — and review showed what that
@@ -263,27 +286,22 @@ describe.each(FEATURES)("$file", (feat) => {
   // referring to it. A name left behind in the page resolves to undefined at call time.
   it("leaves nothing behind in the inline script", async () => {
     const src = await read(feat.file);
-    // ANY DEPTH, AND ASKED OF THE AST: dashboard-tickets.js declares fourteen of its functions
-    // inside initTicketIntegrations(), and an IIFE-level pattern saw none of them — so a duplicate
-    // left behind in the page went unnoticed. This was a regex, and a regex reads text: a comment
-    // between the keyword and the name, `function /* moved */ initTicketIntegrations()`, dropped
-    // the name from the census and the duplicate went unnoticed again, one layer further in. The
-    // parser is already imported eight lines below for the inline half of this very check.
-    const declared = functionsOf(scriptFromSource(feat.file, src))
-      .filter((f) => f.declaration)
-      .map((f) => f.name);
-    expect(declared.length, "no functions found — the extraction produced an empty module").toBeGreaterThan(
-      0,
-    );
+    // ONE CENSUS, ASKED OF BOTH SIDES. This was two questions: a regex over the module's text and
+    // an AST walk over the inline script. They disagreed twice over. A regex reads text, so a
+    // comment between the keyword and the name — `function /* moved */ initTicketIntegrations()` —
+    // dropped the name and the duplicate went unnoticed; and both sides counted DECLARATIONS only,
+    // so `const loadAnomalies = () => {}` restored in the page shadowed the module's published
+    // function for every inline call site while the whole suite stayed green.
+    //
+    // functionBindingsOf() answers it once, for declarations AND function-valued bindings, and
+    // still leaves the ACTIONS dispatch table alone — see its own note on why a property is not a
+    // binding.
+    expect(
+      functionBindingsOf(scriptFromSource(feat.file, src)).length,
+      "no functions found — the extraction produced an empty module",
+    ).toBeGreaterThan(0);
     const inline = scripts.filter((s) => s.name.startsWith("dashboard.html#inline"));
-    // DECLARATIONS only. The ACTIONS dispatch table holds
-    // `setComplianceDiscovered: (el) => setComplianceDiscovered(el)` entries whose arrow takes the
-    // property's name — those must stay, since they are how a click reaches the module.
-    const leftBehind = inline.flatMap((s) =>
-      functionsOf(s)
-        .filter((f) => f.declaration && declared.includes(f.name))
-        .map((f) => `${s.name}:${f.line} ${f.name}`),
-    );
+    const leftBehind = duplicateBindings(feat.file, src, inline);
     expect(leftBehind, "the feature must move as a unit or not at all").toEqual([]);
   });
 
@@ -738,5 +756,78 @@ describe("what stayed behind, on purpose", () => {
     );
     const html = await readFile(DASHBOARD, "utf8");
     expect(html).toContain("initCustodyButtons();");
+  });
+});
+
+// ── THE CENSUS SEAM ITSELF ───────────────────────────────────────────────────────────────────────
+//
+// The suite above asks duplicateBindings() about the REAL modules, and the real modules are clean —
+// so it returns [] whether the seam works or not. That is how this check was wrong twice without a
+// single red test: a green suite proves the page is tidy, never that the gate can see.
+//
+// These rows drive the same function with synthetic module + inline sources carrying exactly the
+// mutations that got through. Each one FAILS if the seam regresses to what it was.
+describe("the census seam catches a duplicate the page kept", () => {
+  const inline = (src: string): DashboardScript[] => [scriptFromSource("dashboard.html#inline-1", src)];
+
+  it.each([
+    [
+      "a plain declaration on both sides",
+      `function loadAnomalies() { return 1; }`,
+      `function loadAnomalies() { return 2; }`,
+    ],
+    [
+      // Defeated the regex census: legal, and the name vanished from the module's half.
+      "a module declaration hidden behind a comment",
+      `function /* moved out */ loadAnomalies() { return 1; }`,
+      `function loadAnomalies() { return 2; }`,
+    ],
+    [
+      // Defeated the declaration-only census on the INLINE side. This is the one that shadows.
+      "an arrow left behind in the page",
+      `function loadAnomalies() { return 1; }`,
+      `const loadAnomalies = () => 2;`,
+    ],
+    [
+      // ...and on the MODULE side, so neither half may be declaration-only.
+      "a module that binds its function to a const",
+      `const loadAnomalies = function () { return 1; };`,
+      `function loadAnomalies() { return 2; }`,
+    ],
+    ["an arrow on both sides", `const loadAnomalies = () => 1;`, `const loadAnomalies = () => 2;`],
+  ])("reports %s", (_label, moduleSrc, inlineSrc) => {
+    expect(
+      duplicateBindings("m.js", moduleSrc, inline(inlineSrc)),
+      "a duplicate the gate cannot see is a stale copy the page keeps calling",
+    ).not.toEqual([]);
+  });
+
+  it.each([
+    [
+      // The ACTIONS dispatch table. These MUST stay behind — they are how a click reaches the module.
+      "a dispatch entry that forwards to the module",
+      `function loadAnomalies() { return 1; }`,
+      `const ACTIONS = { loadAnomalies: (el) => loadAnomalies(el) };`,
+    ],
+    [
+      "a call site, not a binding",
+      `function loadAnomalies() { return 1; }`,
+      `document.getElementById("x").onclick = () => loadAnomalies();`,
+    ],
+    [
+      "the module's own publication onto window",
+      `function loadAnomalies() { return 1; }`,
+      `window.loadAnomalies = window.loadAnomalies;`,
+    ],
+    [
+      "a name the module does not own",
+      `function loadAnomalies() { return 1; }`,
+      `function renderSomethingElse() {}`,
+    ],
+  ])("stays silent on %s", (_label, moduleSrc, inlineSrc) => {
+    expect(
+      duplicateBindings("m.js", moduleSrc, inline(inlineSrc)),
+      "flagging correct code is how a gate gets switched off",
+    ).toEqual([]);
   });
 });

--- a/companion/tests/dashboard/dashboardFeatureModules.test.ts
+++ b/companion/tests/dashboard/dashboardFeatureModules.test.ts
@@ -263,10 +263,15 @@ describe.each(FEATURES)("$file", (feat) => {
   // referring to it. A name left behind in the page resolves to undefined at call time.
   it("leaves nothing behind in the inline script", async () => {
     const src = await read(feat.file);
-    // ANY indentation: dashboard-tickets.js declares fourteen of its functions inside
-    // initTicketIntegrations(), and an IIFE-level pattern saw none of them — so a duplicate left
-    // behind in the page went unnoticed.
-    const declared = [...src.matchAll(/^\s*(?:async )?function (\w+)\s*\(/gm)].map((m) => m[1]);
+    // ANY DEPTH, AND ASKED OF THE AST: dashboard-tickets.js declares fourteen of its functions
+    // inside initTicketIntegrations(), and an IIFE-level pattern saw none of them — so a duplicate
+    // left behind in the page went unnoticed. This was a regex, and a regex reads text: a comment
+    // between the keyword and the name, `function /* moved */ initTicketIntegrations()`, dropped
+    // the name from the census and the duplicate went unnoticed again, one layer further in. The
+    // parser is already imported eight lines below for the inline half of this very check.
+    const declared = functionsOf(scriptFromSource(feat.file, src))
+      .filter((f) => f.declaration)
+      .map((f) => f.name);
     expect(declared.length, "no functions found — the extraction produced an empty module").toBeGreaterThan(
       0,
     );

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -1911,22 +1911,18 @@ export function unguardedTopLevelRefs(
     script.ast.getLineAndCharacterOfPosition(n.getStart(script.ast)).line + 1;
   walkLoadTime(script, (n) => {
     if (!ts.isIdentifier(n) || !names.has(n.text)) return;
-    const parent = n.parent;
-    if (!parent) return;
-    // `typeof N` is the guard itself, and the one place the name may appear undeclared.
-    if (ts.isTypeOfExpression(parent)) return;
-    // Not a reference to the global: a property called `search`, a key called `from`, a binding
-    // that happens to share the name. Every one of these appears in the page.
-    if (ts.isPropertyAccessExpression(parent) && parent.name === n) return;
-    if ((ts.isPropertyAssignment(parent) || ts.isShorthandPropertyAssignment(parent)) && parent.name === n) {
-      return;
-    }
-    if (ts.isVariableDeclaration(parent) && parent.name === n) return;
-    if (ts.isFunctionDeclaration(parent) && parent.name === n) return;
-    if (ts.isClassDeclaration(parent) && parent.name === n) return;
-    if (ts.isParameter(parent) && parent.name === n) return;
-    if (ts.isBindingElement(parent) && parent.name === n) return;
-    // ONE guard predicate, not two. This function and topLevelUnguardedRefs were written
+    if (!n.parent) return;
+    // ONE REFERENCE PREDICATE, NOT TWO — the same argument the guard comment below makes, and it
+    // took a second rot to apply it here. A bespoke exclusion list lived at this line and drifted
+    // from isValueRef() in three places: it grouped ShorthandPropertyAssignment with
+    // PropertyAssignment, so `{ initTicketIntegrations }` — which desugars to `{ N: N }` and
+    // EVALUATES the binding — was excluded as if it were a property name, and a missing module
+    // threw there with the gate reporting zero; and it missed a renamed destructuring key
+    // (`const { N: local } = q`) and a loop label, reporting both as hazards. isValueRef() answered
+    // all three correctly and says so in its own comment: "`{ kevClear }` shorthand is deliberately
+    // absent: it reads the value." The wrong copy was the one wired in.
+    if (!isValueRef(n)) return;
+    // ONE GUARD PREDICATE, NOT TWO. This function and topLevelUnguardedRefs were written
     // independently against the same question and kept two answers to it, which differed on
     // `try { N(); } catch {}` — this one demanded a typeof guard the other correctly did not,
     // because a catch already stops the ReferenceError aborting the script. Two implementations of

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -155,6 +155,49 @@ export function functionsOf(script: DashboardScript): FunctionInfo[] {
   return out;
 }
 
+/**
+ * EVERY NAME THIS SCRIPT BINDS TO A FUNCTION — the census behind "did the feature move as a unit?"
+ *
+ * Both halves of that check must ask the same question of the same shapes, or a duplicate slips
+ * through the difference. It used to be asked twice, differently: a regex over the module's text
+ * and `functionsOf().filter(f => f.declaration)` over the inline script.
+ *
+ * A DECLARATION IS NOT THE ONLY WAY TO BIND A FUNCTION, and the declaration-only rule missed the
+ * one that actually hurts. `const loadAnomalies = () => {}` left behind in the inline script is a
+ * top-level lexical binding, so it SHADOWS the module's published `window.loadAnomalies` for every
+ * call site in that script — the feature looks moved, its tests pass, and the page runs the stale
+ * copy. Restoring exactly that mutation passed the whole suite.
+ *
+ * WHAT IS DELIBERATELY NOT COUNTED, and why the naive "any function-valued node" rule is wrong: the
+ * ACTIONS dispatch table is full of `setComplianceDiscovered: (el) => setComplianceDiscovered(el)`
+ * entries, and those must STAY behind when the function they call moves out — they are how a click
+ * reaches the module. A property is not a binding; nothing can shadow through one. Same for class
+ * and object methods.
+ */
+export function functionBindingsOf(script: DashboardScript): Array<{ name: string; line: number }> {
+  const out: Array<{ name: string; line: number }> = [];
+  const at = (n: ts.Node): number =>
+    script.ast.getLineAndCharacterOfPosition(n.getStart(script.ast)).line + 1;
+  const visit = (n: ts.Node): void => {
+    if (ts.isFunctionDeclaration(n) && n.name && ts.isIdentifier(n.name)) {
+      out.push({ name: n.name.text, line: at(n) });
+    }
+    // `const f = () => {}` / `let f = function () {}` / `var f = async () => {}`. The binding is the
+    // variable, so a destructured or array-pattern name is not one of these by construction.
+    if (
+      ts.isVariableDeclaration(n) &&
+      ts.isIdentifier(n.name) &&
+      n.initializer &&
+      (ts.isArrowFunction(n.initializer) || ts.isFunctionExpression(n.initializer))
+    ) {
+      out.push({ name: n.name.text, line: at(n) });
+    }
+    ts.forEachChild(n, visit);
+  };
+  ts.forEachChild(script.ast, visit);
+  return out;
+}
+
 /** Names called from inside `node`, including from functions nested within it. */
 export function callsWithin(node: ts.Node): Set<string> {
   const out = new Set<string>();
@@ -1023,6 +1066,46 @@ export function guarantees(cond: ts.Node, name: string, branch: boolean): boolea
  * is `DfirTimelineView`, which sits at `parent.expression` and so is not excluded by the
  * property-name rule that hides `hydrate`.
  */
+/**
+ * Is this node inside the TARGET of a destructuring assignment rather than a value being read?
+ *
+ * `({ Foo } = src)` and `[Foo] = xs` and `for ({ Foo } of xs)` all WRITE Foo. A write to a name a
+ * missing module would have declared does not throw — it is the read that throws — so reporting one
+ * is a false positive, and a gate that flags correct code gets switched off.
+ *
+ * Walks out through the pattern's own shapes only (object/array literals, the value half of a
+ * property, parens, spread) so that `({ a: Foo } = x)` and `({ Foo } = x)` both resolve, while a
+ * genuine read nested in an initializer — `const o = { Foo }` — stops at the variable declaration.
+ */
+function isAssignmentTarget(node: ts.Node): boolean {
+  let cur: ts.Node = node;
+  let parent = cur.parent;
+  while (parent) {
+    if (ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      return parent.left === cur;
+    }
+    // `for ({ Foo } of xs)` / `for ([Foo] in o)` — the initializer is a target, the expression is not.
+    if ((ts.isForOfStatement(parent) || ts.isForInStatement(parent)) && parent.initializer === cur) {
+      return true;
+    }
+    if (
+      ts.isObjectLiteralExpression(parent) ||
+      ts.isArrayLiteralExpression(parent) ||
+      ts.isParenthesizedExpression(parent) ||
+      ts.isSpreadAssignment(parent) ||
+      ts.isSpreadElement(parent) ||
+      ts.isShorthandPropertyAssignment(parent) ||
+      (ts.isPropertyAssignment(parent) && parent.initializer === cur)
+    ) {
+      cur = parent;
+      parent = cur.parent;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
 function isValueRef(n: ts.Identifier): boolean {
   const p = n.parent;
   if (!p) return true;
@@ -1050,6 +1133,11 @@ function isValueRef(n: ts.Identifier): boolean {
   // Labels are their own namespace.
   if (ts.isLabeledStatement(p) && p.label === n) return false;
   if ((ts.isBreakStatement(p) || ts.isContinueStatement(p)) && p.label === n) return false;
+  // SHORTHAND IS A READ IN A LITERAL AND A WRITE IN A PATTERN, and TypeScript spells both
+  // `ShorthandPropertyAssignment`: `const w = { kevClear }` evaluates the binding, while
+  // `({ kevClear } = src)` assigns to it. Only the first can throw when the module is missing —
+  // the second is a destructuring assignment, which is how the node reaches an `=` from its left.
+  if (ts.isShorthandPropertyAssignment(p) && isAssignmentTarget(p)) return false;
   // A name being DECLARED. `{ kevClear }` shorthand is deliberately absent: it reads the value.
   const declares =
     ts.isVariableDeclaration(p) ||


### PR DESCRIPTION
Rank 1 of the ordering that came out of measuring what remains in #415. Closes #478 and the census half of #480. Test-helper changes only — no production file is touched.

## 1. Shorthand is a read, and the analyser called it a property name (#478)

`{ initTicketIntegrations }` desugars to `{ N: N }` and **evaluates the binding**, so a missing module throws there exactly as it does at a bare reference. `unguardedTopLevelRefs()` grouped `ShorthandPropertyAssignment` with `PropertyAssignment` — where excluding the name *is* correct — and returned early.

The right answer was already in the file. `isValueRef()` handles every one of these and says so in its own comment: *"`{ kevClear }` shorthand is deliberately absent: it reads the value."* A bespoke exclusion list had been written beside it and drifted. The list is gone; the analyser defers to `isValueRef`. That is the same argument the guard comment nine lines below already makes about `isGuarded` — **one predicate, not two.** Twelve lines become one.

The deferral also retires two **false positives**, which cost the same as a false negative because a gate that flags correct code gets switched off: a renamed destructuring key (`const { N: local } = q`) and a loop label sharing the name were both reported as hazards.

## 2. The declaration census read text (#480, census half)

The check asks *"did this module leave a duplicate of one of its functions behind in the page?"* The inline half always used the parser; the module half was a regex.

Measured on the **real module**, not a fixture — injecting a comment between the keyword and the name of `dashboard-tickets.js`'s `initTicketIntegrations`:

| | declarations found | sees `initTicketIntegrations` |
|---|---|---|
| unmutated, regex | 15 | yes |
| unmutated, AST | 15 | yes |
| **mutated, regex** | **14** | **no** |
| mutated, AST | 15 | yes |

A name missing from the census is a duplicate the gate cannot look for. It now asks `functionsOf()`, which this test already imported and used eight lines below for the inline half of the same check.

## Evidence

**16 new contract rows, every one written before the fix and confirmed failing against the old code** — 4 on the analyser (2 shorthand shapes now reported, 2 false positives retired) and 12 on the census (8 declaration shapes seen, including the comment form, a newline between keyword and name, a generator, and declarations nested in a function or a block; 4 non-declarations still not counted, so the census cannot start hunting names the module never owned).

Full suite green: **7,735 tests, 564 files**. `check:size`, `format:check` and `typecheck` clean.

## What this does not do

**Zero shorthand references to module-owned globals exist in the inline script today**, so this closes a hole nobody has fallen into yet rather than fixing a live defect. The gate still reports zero unguarded load-time references while the real figure is in the hundreds — that is #476, whose predicate this shares a call path with, and which is why this landed first: fixing #476 over a broken reference test would multiply one false negative across every newly visited reference.