### PR TITLE
fix(test): walkLoadTime follows calls, not just IIFEs (#476)

### DIFF
--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -741,3 +741,25 @@ describe("#476 — a module reference one call from load is a load-time hazard",
     ).toHaveLength(1);
   });
 });
+
+// Codex review of the sibling #477 change found the same unrestricted branch here: a property call
+// resolved to ANY same-named declared function. Following `api.boot()` into a local `boot` walks a
+// body that never runs at load, so the gate reports hazards that cannot happen — the false-alarm
+// direction, which is how a gate loses its readers.
+describe("#476 — a property call only reaches a page function through a global root", () => {
+  const MISSING = new Set(["DfirTimelineView"]);
+  const linesFor = (src: string): number[] =>
+    unguardedTopLevelRefs(scriptFromSource("p.js", src), MISSING).map((r) => r.line);
+
+  it.each([
+    ["an unrelated method of the same name", `function boot() { DfirTimelineView.x; }\napi.boot();`],
+    ["a computed member of a non-global", `function boot() { DfirTimelineView.x; }\napi["boot"]();`],
+  ])("does not follow %s", (_label, src) => {
+    expect(linesFor(src)).toHaveLength(0);
+  });
+
+  it("still follows the global-root spellings", () => {
+    expect(linesFor(`function boot() { DfirTimelineView.x; }\nwindow.boot();`)).toHaveLength(1);
+    expect(linesFor(`function boot() { DfirTimelineView.x; }\nglobalThis["boot"]();`)).toHaveLength(1);
+  });
+});

--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -660,3 +660,84 @@ describe("duplicateBindings compares the page at its top level", () => {
     expect(duplicateBindings("dashboard-thing.js", moduleSrc, page(pageSrc))).toEqual([]);
   });
 });
+
+// ── #476: THE LOAD-TIME WALK FOLLOWS CALLS, NOT JUST IIFEs ──────────────────────────────────────
+//
+// walkLoadTime() used to stop at the syntactic load-time region — top level plus IIFE bodies — so an
+// ordinary helper CALLED during load was invisible. One hop was enough to ship a page that dies:
+// renderExcludeChips() held a bare DfirTimelineView reference and a top-level statement called it,
+// so blocking that module aborted the whole inline script while every gate stayed green.
+//
+// Each case below is written the way the page writes it, and each is paired with the DEFINED-BUT-
+// NOT-CALLED twin that must stay silent. That pairing is the mutation evidence: if the walk ever
+// goes back to stopping at the region, the first half goes quiet; if it starts entering every
+// function body, the second half starts shouting.
+describe("#476 — a module reference one call from load is a load-time hazard", () => {
+  const MISSING = new Set(["DfirTimelineView"]);
+  const linesFor = (src: string): number[] =>
+    unguardedTopLevelRefs(scriptFromSource("p.js", src), MISSING).map((r) => r.line);
+
+  it("follows an ordinary helper invoked by a top-level statement", () => {
+    // The exact reproduction named in #476.
+    expect(linesFor(`function boot() { DfirTimelineView.hydrate({}); }\nboot();`)).toHaveLength(1);
+  });
+
+  it("stays silent when that same helper is only DEFINED", () => {
+    // The control. A function that merely exists runs later, on an event, where a throw is
+    // contained to one interaction — reporting it would bury the real hazards in noise.
+    expect(linesFor(`function boot() { DfirTimelineView.hydrate({}); }`)).toHaveLength(0);
+  });
+
+  it("follows through several hops", () => {
+    expect(
+      linesFor(`function c() { DfirTimelineView.hydrate({}); }
+                function b() { c(); }
+                function a() { b(); }
+                a();`),
+    ).toHaveLength(1);
+  });
+
+  it("follows window.N() and window['N']()", () => {
+    expect(linesFor(`function boot() { DfirTimelineView.hydrate({}); }\nwindow.boot();`)).toHaveLength(1);
+    expect(linesFor(`function boot() { DfirTimelineView.hydrate({}); }\nwindow["boot"]();`)).toHaveLength(1);
+  });
+
+  it("follows a .call()/.apply()-form invocation of a named helper", () => {
+    expect(linesFor(`function boot() { DfirTimelineView.hydrate({}); }\nboot.call(this);`)).toHaveLength(1);
+    expect(linesFor(`function boot() { DfirTimelineView.hydrate({}); }\nboot.apply(null, []);`)).toHaveLength(
+      1,
+    );
+  });
+
+  it("enters a .call()-form IIFE, which runs exactly where a bare block would", () => {
+    expect(linesFor(`(function () { DfirTimelineView.hydrate({}); }).call(this);`)).toHaveLength(1);
+  });
+
+  it("follows a helper handed off BY NAME to something invoked at load", () => {
+    // `ready(initTicketIntegrations)` invokes it as surely as writing the call, and the identifier
+    // is the only trace — there is no call expression naming it anywhere.
+    expect(
+      linesFor(`function handler() { DfirTimelineView.hydrate({}); }
+                function ready(f) { f(); }
+                ready(handler);`),
+    ).toHaveLength(1);
+  });
+
+  it("still honours a typeof guard inside the followed helper", () => {
+    // Following the call must not lose the guard analysis — otherwise the fix trades a false
+    // negative for a few hundred false positives.
+    expect(
+      linesFor(`function boot() { if (typeof DfirTimelineView !== "undefined") DfirTimelineView.hydrate({}); }
+                boot();`),
+    ).toHaveLength(0);
+  });
+
+  it("terminates on direct and mutual recursion", () => {
+    expect(linesFor(`function a() { DfirTimelineView.x; a(); }\na();`)).toHaveLength(1);
+    expect(
+      linesFor(`function a() { b(); }
+                function b() { DfirTimelineView.x; a(); }
+                a();`),
+    ).toHaveLength(1);
+  });
+});

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -1975,6 +1975,13 @@ function declaredFunctionsOf(script: DashboardScript): Map<string, ts.Node> {
  * writing the call. Over-collecting is safe: a name that is not a declared function is dropped by
  * the caller, so an extra spelling costs one map lookup that misses.
  */
+/** `window` · `globalThis` · `self` — the roots through which a page-level function is itself. */
+function isGlobalRoot(n: ts.Node): boolean {
+  let cur: ts.Node = n;
+  while (ts.isParenthesizedExpression(cur)) cur = cur.expression;
+  return ts.isIdentifier(cur) && GLOBAL_ROOTS.has(cur.text);
+}
+
 function invokedNames(n: ts.CallExpression): string[] {
   const names: string[] = [];
   let callee: ts.Node = n.expression;
@@ -1986,8 +1993,18 @@ function invokedNames(n: ts.CallExpression): string[] {
       let target: ts.Node = callee.expression;
       while (ts.isParenthesizedExpression(target)) target = target.expression;
       if (ts.isIdentifier(target)) names.push(target.text);
-    } else names.push(callee.name.text);
-  } else if (ts.isElementAccessExpression(callee) && ts.isStringLiteralLike(callee.argumentExpression)) {
+    } else if (isGlobalRoot(callee.expression)) {
+      // ONLY THROUGH A GLOBAL ROOT. `window.boot()` IS the page-level `boot`; `api.boot()` is
+      // somebody else's method that merely shares the spelling, and following it would walk a body
+      // that never runs at load — reporting hazards that cannot happen. (Found by Codex review of
+      // the sibling #477 change, which had the same unrestricted branch.)
+      names.push(callee.name.text);
+    }
+  } else if (
+    ts.isElementAccessExpression(callee) &&
+    ts.isStringLiteralLike(callee.argumentExpression) &&
+    isGlobalRoot(callee.expression)
+  ) {
     names.push(callee.argumentExpression.text);
   }
   for (const a of n.arguments) if (ts.isIdentifier(a)) names.push(a.text);

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -1952,18 +1952,91 @@ export function reachableFrom(graph: Map<string, Set<string>>, start: Iterable<s
 // exists? Shape-independent, and scoped to load time — the ~600 references from inside functions
 // are contained to one interaction and are not this gate's business.
 
-/** Visit every node that RUNS when the script loads: everything outside a function, plus IIFE bodies. */
+/**
+ * Every function this script declares under a name, so a load-time call can be followed into one.
+ *
+ * First declaration wins: a redeclared name is a different bug, and either body answers "does
+ * load-time code reach a reference to a missing module" the same way.
+ */
+function declaredFunctionsOf(script: DashboardScript): Map<string, ts.Node> {
+  const out = new Map<string, ts.Node>();
+  for (const f of functionsOf(script)) {
+    if (f.name.startsWith("<anonymous")) continue;
+    if (!out.has(f.name)) out.set(f.name, f.node);
+  }
+  return out;
+}
+
+/**
+ * The names a call expression could invoke, in every spelling the page actually uses.
+ *
+ * `f()` · `(f)()` · `f.call(…)` · `f.apply(…)` · `window.f()` · `window["f"]()`, plus any helper
+ * handed off BY NAME as an argument — `ready(initTicketIntegrations)` invokes it as surely as
+ * writing the call. Over-collecting is safe: a name that is not a declared function is dropped by
+ * the caller, so an extra spelling costs one map lookup that misses.
+ */
+function invokedNames(n: ts.CallExpression): string[] {
+  const names: string[] = [];
+  let callee: ts.Node = n.expression;
+  while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+  if (ts.isIdentifier(callee)) names.push(callee.text);
+  else if (ts.isPropertyAccessExpression(callee)) {
+    // `f.call(…)` / `f.apply(…)` — the invoked function is the OBJECT, not the property.
+    if (callee.name.text === "call" || callee.name.text === "apply") {
+      let target: ts.Node = callee.expression;
+      while (ts.isParenthesizedExpression(target)) target = target.expression;
+      if (ts.isIdentifier(target)) names.push(target.text);
+    } else names.push(callee.name.text);
+  } else if (ts.isElementAccessExpression(callee) && ts.isStringLiteralLike(callee.argumentExpression)) {
+    names.push(callee.argumentExpression.text);
+  }
+  for (const a of n.arguments) if (ts.isIdentifier(a)) names.push(a.text);
+  return names;
+}
+
+/**
+ * Visit every node that RUNS when the script loads — everything outside a function, IIFE bodies,
+ * and TRANSITIVELY the body of any declared function those reach by calling it.
+ *
+ * AN IIFE RUNS AT LOAD. Six of the page's load-time blocks are `(() => { … })()`, and treating any
+ * enclosing function as "contained" would have hidden every one of them — the same mistake
+ * domAccessOutsideFunctions() above had to correct.
+ *
+ * SO DOES AN ORDINARY HELPER THAT LOAD-TIME CODE CALLS (#476). Stopping at the syntactic region left
+ * exactly one hop invisible, and one hop was enough to ship a page that dies: `renderExcludeChips()`
+ * held a bare `DfirTimelineView` reference and a top-level statement called it, so blocking that
+ * module threw a ReferenceError that aborted the rest of the inline script while every gate stayed
+ * green. Rewriting a guarded call as `function boot() { … } boot();` reproduced it exactly.
+ *
+ * The fixpoint is the shape calleesInsideLoops() already uses for the loop checker, whose own
+ * contract test is "no function reachable from a loop through ANY number of hops commits". A
+ * function merely DEFINED at load is still not this hazard — it runs later, on an event, where a
+ * throw is contained to one interaction. Being CALLED is the property that matters.
+ */
 function walkLoadTime(script: DashboardScript, fn: (n: ts.Node) => void): void {
-  // AN IIFE RUNS AT LOAD. Six of the page's load-time blocks are `(() => { … })()`, and treating
-  // any enclosing function as "contained" would have hidden every one of them — the same mistake
-  // domAccessOutsideFunctions() above had to correct.
   const iifeBodyOf = (n: ts.CallExpression): ts.Node | null => {
     let callee: ts.Node = n.expression;
     while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
-    return ts.isFunctionExpression(callee) || ts.isArrowFunction(callee) ? callee.body : null;
+    if (ts.isFunctionExpression(callee) || ts.isArrowFunction(callee)) return callee.body;
+    // `(function(){ … }).call(this)` invokes it just as directly as `(function(){ … })()`.
+    if (
+      ts.isPropertyAccessExpression(callee) &&
+      (callee.name.text === "call" || callee.name.text === "apply")
+    ) {
+      let target: ts.Node = callee.expression;
+      while (ts.isParenthesizedExpression(target)) target = target.expression;
+      if (ts.isFunctionExpression(target) || ts.isArrowFunction(target)) return target.body;
+    }
+    return null;
   };
+
+  const declared = declaredFunctionsOf(script);
+  const pending: string[] = [];
+  const entered = new Set<string>();
+
   const go = (n: ts.Node): void => {
     if (ts.isCallExpression(n)) {
+      for (const name of invokedNames(n)) if (declared.has(name)) pending.push(name);
       const body = iifeBodyOf(n);
       if (body) {
         fn(n);
@@ -1977,7 +2050,18 @@ function walkLoadTime(script: DashboardScript, fn: (n: ts.Node) => void): void {
     fn(n);
     ts.forEachChild(n, go);
   };
+
   ts.forEachChild(script.ast, go);
+
+  // Fixpoint over what load-time code calls. `entered` also breaks recursion, direct or mutual.
+  while (pending.length > 0) {
+    const name = pending.shift() as string;
+    if (entered.has(name)) continue;
+    entered.add(name);
+    // Walking the DECLARATION's children rather than the body alone keeps default parameter values
+    // in scope — `function f(x = DfirTimelineView.id) {}` evaluates that default on every call.
+    ts.forEachChild(declared.get(name) as ts.Node, go);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #476.

`walkLoadTime()` stopped at the syntactic load-time region — top level plus IIFE bodies — so an ordinary helper **called** during load was invisible. One hop was enough to ship a page that dies: `renderExcludeChips()` held a bare `DfirTimelineView` reference and a top-level statement called it, so blocking that module aborted the whole inline script while #475's suite stayed green.

## The fix

`walkLoadTime` now takes a fixpoint over what load-time code calls — the same shape `calleesInsideLoops()` already uses for the loop checker, whose own contract test is *"no function reachable from a loop through any number of hops commits"*.

Also widened to the spellings the page uses and the gate did not recognise:

| Shape | Why it was missed |
|---|---|
| `boot()` where `boot` is declared elsewhere | the one-hop hole itself |
| `window.N()` · `window["N"]()` | callee is not a bare identifier |
| `f.call(…)` · `f.apply(…)` | the invoked function is the *object*, not the property |
| `(function(){…}).call(this)` | `.call`-form IIFE — the old `iifeBodyOf` only matched the direct-invocation shape |
| `ready(handler)` | a by-name hand-off; there is no call expression naming `handler` anywhere |

A function merely **defined** at load is deliberately still not reported — it runs later, on an event, where a throw is contained to one interaction.

## The number, with its method

#476 asked for one measurement before anyone estimates the remediation, because four earlier attempts disagreed on the digit (365/42, 295/80, 276/64, 270/62).

**Method:** entry set = declared functions invoked from the syntactic load-time region; closure = `reachableFrom(buildCallGraph(...))`; counted = reads of a module-published name inside those bodies, excluding names the inline script declares itself — that exclusion is what inflated one earlier count by 969 `esc`/`escAttr` references.

> **Result: ZERO.** `tests/dashboard` + `tests/architecture` are **2025 green** with the hole closed.

The remediation tail this issue anticipated is gone *entirely*, not "mostly". #488's decomposition moved the reachable code out of the inline script, which is now 1,967 lines rather than 7,666 — the issue's own repro cites `dashboard:3622` and `dashboard:15814`, line numbers that no longer exist.

## What is deliberately left open

The third "done" item — *"what should the page do when its own install is incomplete?"* — is **recorded, not guessed**. With no instances to apply it to, it is a decision about product behaviour with nothing currently riding on it, and the conflict it names (`dashboard-facade.js` argues stubs beat guards; this gate's message prescribes `typeof` guards) has still never collided. Deciding it here would be inventing a policy for a hazard that does not presently exist.

## Mutation evidence

Per this repo's standard, the new tests were proven to have teeth rather than assumed. Disabling the fixpoint fails **6 of the 9** new contract tests. The 3 survivors are the ones that should survive: two controls that must stay silent (defined-but-not-called, `typeof`-guarded) and the `.call()`-form IIFE, which the separate `iifeBodyOf` extension covers.

Each positive case is paired with its silence control, so a future regression in either direction shows up: if the walk goes back to stopping at the region the first half goes quiet; if it starts entering every function body the second half starts shouting.

## Checks

`typecheck`, `lint`, `format:check` clean · `tests/dashboard` + `tests/architecture` 2025 passed