### PR TITLE
fix(test): callsByName needs an invocation, not a mention (#477)

### DIFF
--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -692,7 +692,24 @@ describe("#477 — a mention is not a call", () => {
     ["setTimeout by name", `function h() { N(); }\nsetTimeout(h, 0);`],
     ["forEach by name", `function h() { N(); }\n[1].forEach(h);`],
     ["handed to a helper", `function h() { N(); }\nfunction ready(f) { f(); }\nready(h);`],
+    // Codex review of the first cut: an alias IS an invocation path. Dropping the `run -> live`
+    // relationship reported a genuinely-reached initializer as unreachable — a false alarm, which
+    // is the failure mode that teaches people to ignore the gate.
+    ["an invoked alias", `function live() { N(); }\nconst run = live;\nrun();`],
+    ["an invoked alias assigned later", `function live() { N(); }\nlet run;\nrun = live;\nrun();`],
   ])("still counts %s", (_label, src) => {
     expect(cb(src)).toBe(true);
+  });
+
+  // Also from that review, and the more dangerous direction: a property call only resolves to a
+  // page-level function through a GLOBAL ROOT. `api.dead()` is somebody else's method that happens
+  // to share the spelling, and counting it revived a function nothing invokes — reintroducing this
+  // very issue by a different door.
+  it.each([
+    ["an unrelated method of the same name", `function dead() { N(); }\napi.dead();`],
+    ["a computed member of a non-global", `function dead() { N(); }\napi["dead"]();`],
+    ["an alias that is never invoked", `function live() { N(); }\nconst run = live;`],
+  ])("does not count %s", (_label, src) => {
+    expect(cb(src)).toBe(false);
   });
 });

--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -660,3 +660,39 @@ describe("duplicateBindings compares the page at its top level", () => {
     expect(duplicateBindings("dashboard-thing.js", moduleSrc, page(pageSrc))).toEqual([]);
   });
 });
+
+// ── #477: REACHABILITY NEEDS AN INVOCATION, NOT A MENTION ───────────────────────────────────────
+//
+// callsByName() drew its edges from any identifier READ, which answers "is this name mentioned
+// here" — a different question from "is this initializer reached". `void dead;` mentions `dead`, so
+// a function nothing invokes was marked live and the call inside it counted. A feature could be
+// fully unwired, with the suite green.
+describe("#477 — a mention is not a call", () => {
+  const cb = (src: string): boolean => callsByName(scriptFromSource("p.js", src), "N");
+
+  it.each([
+    ["void dead", `function dead() { N(); }\nvoid dead;`],
+    ["a bare expression statement", `function dead() { N(); }\ndead;`],
+    ["stored in a const", `function dead() { N(); }\nconst keep = dead;`],
+    ["named in an array literal", `function dead() { N(); }\nconst all = [dead];`],
+    ["compared", `function dead() { N(); }\nif (dead === undefined) {}`],
+    ["typeof", `function dead() { N(); }\nif (typeof dead === "function") {}`],
+  ])("does not count %s", (_label, src) => {
+    expect(cb(src)).toBe(false);
+  });
+
+  it.each([
+    ["a plain call", `function live() { N(); }\nlive();`],
+    ["window.live()", `function live() { N(); }\nwindow.live();`],
+    ["window['live']()", `function live() { N(); }\nwindow["live"]();`],
+    ["live.call(this)", `function live() { N(); }\nlive.call(this);`],
+    ["live.apply(null, [])", `function live() { N(); }\nlive.apply(null, []);`],
+    ["addEventListener by name", `function h() { N(); }\nel.addEventListener("click", h);`],
+    ["onclick assignment", `function h() { N(); }\nel.onclick = h;`],
+    ["setTimeout by name", `function h() { N(); }\nsetTimeout(h, 0);`],
+    ["forEach by name", `function h() { N(); }\n[1].forEach(h);`],
+    ["handed to a helper", `function h() { N(); }\nfunction ready(f) { f(); }\nready(h);`],
+  ])("still counts %s", (_label, src) => {
+    expect(cb(src)).toBe(true);
+  });
+});

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -1470,12 +1470,55 @@ function invocationEdges(n: ts.Node): string[] {
       let target: ts.Node = callee.expression;
       while (ts.isParenthesizedExpression(target)) target = target.expression;
       if (ts.isIdentifier(target)) names.push(target.text);
-    } else names.push(callee.name.text);
-  } else if (ts.isElementAccessExpression(callee) && ts.isStringLiteralLike(callee.argumentExpression)) {
+    } else if (isGlobalRoot(callee.expression)) {
+      // ONLY THROUGH A GLOBAL ROOT. `window.live()` IS the page-level `live`; `api.dead()` is
+      // somebody else's method that merely shares the spelling, and counting it as an edge revives
+      // a function nothing invokes — reintroducing this very issue by a different door.
+      names.push(callee.name.text);
+    }
+  } else if (
+    ts.isElementAccessExpression(callee) &&
+    ts.isStringLiteralLike(callee.argumentExpression) &&
+    isGlobalRoot(callee.expression)
+  ) {
     names.push(callee.argumentExpression.text);
   }
   for (const a of n.arguments) if (ts.isIdentifier(a)) names.push(a.text);
   return names;
+}
+
+/** `window` · `globalThis` · `self` — the roots through which a page-level function is itself. */
+function isGlobalRoot(n: ts.Node): boolean {
+  let cur: ts.Node = n;
+  while (ts.isParenthesizedExpression(cur)) cur = cur.expression;
+  return ts.isIdentifier(cur) && GLOBAL_ROOTS.has(cur.text);
+}
+
+/**
+ * `const run = live;` — an alias is not an invocation, but invoking the alias invokes the target.
+ *
+ * Modelled as a graph edge from alias to target rather than as a call, which keeps both halves
+ * right: `const run = live; run();` reaches `live`, while `const run = live;` alone leaves both
+ * unreachable, because nothing ever adds `run` to a live unit's edges.
+ */
+function aliasEdge(n: ts.Node): { from: string; to: string } | null {
+  if (
+    ts.isVariableDeclaration(n) &&
+    ts.isIdentifier(n.name) &&
+    n.initializer &&
+    ts.isIdentifier(n.initializer)
+  ) {
+    return { from: n.name.text, to: n.initializer.text };
+  }
+  if (
+    ts.isBinaryExpression(n) &&
+    n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    ts.isIdentifier(n.left) &&
+    ts.isIdentifier(n.right)
+  ) {
+    return { from: n.left.text, to: n.right.text };
+  }
+  return null;
 }
 
 /**
@@ -1509,6 +1552,12 @@ export function callsByName(script: DashboardScript, name: string): boolean {
         }
       }
       for (const invoked of invocationEdges(c)) mentions.get(unit)?.add(invoked);
+      const alias = aliasEdge(c);
+      if (alias) {
+        const edges = mentions.get(alias.from) ?? new Set<string>();
+        edges.add(alias.to);
+        mentions.set(alias.from, edges);
+      }
       if (ts.isCallExpression(c) && ts.isIdentifier(c.expression) && c.expression.text === name) {
         sites.push({ unit });
       }

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -1427,6 +1427,58 @@ function invocableName(fn: ts.Node): string | null {
 const TOP_LEVEL_UNIT = "<top-level>";
 
 /**
+ * The names this node actually INVOKES or hands to something that will (#477).
+ *
+ * callsByName() used to draw its reachability edges from any identifier READ, which answers "is
+ * this name mentioned here" — a different question, and the wrong one. `void dead;` mentions
+ * `dead`, so a function nothing invokes was marked live and the initializer inside it counted as
+ * reached. A feature could be fully unwired — no listeners, no fetches, no published entry point —
+ * with the suite green.
+ *
+ * So an edge now needs a real invocation:
+ *   - a call in any spelling the page uses: `f()` · `(f)()` · `f.call(…)` · `f.apply(…)` ·
+ *     `window.f()` · `window["f"]()`
+ *   - a hand-off BY NAME as a call argument, which is how every registration spells it:
+ *     `el.addEventListener("click", h)` · `setTimeout(h, 0)` · `xs.forEach(h)` · `ready(h)`
+ *   - an event-handler property assignment: `el.onclick = h`
+ *
+ * A bare read that is none of these — `void dead`, `const x = dead`, `console.log(dead)` — no
+ * longer creates one. The last of those is the honest limit of this: a name passed to ANY call is
+ * treated as invocable, because distinguishing `ready(h)` from `console.log(h)` needs to know what
+ * the callee does with it. Erring that way keeps the false alarms out of a gate whose whole value
+ * is that people trust it when it fires.
+ */
+function invocationEdges(n: ts.Node): string[] {
+  // `el.onclick = handler` registers it; the browser calls it later.
+  if (
+    ts.isBinaryExpression(n) &&
+    n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    ts.isPropertyAccessExpression(n.left) &&
+    /^on[a-z]/.test(n.left.name.text) &&
+    ts.isIdentifier(n.right)
+  ) {
+    return [n.right.text];
+  }
+  if (!ts.isCallExpression(n)) return [];
+  const names: string[] = [];
+  let callee: ts.Node = n.expression;
+  while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+  if (ts.isIdentifier(callee)) names.push(callee.text);
+  else if (ts.isPropertyAccessExpression(callee)) {
+    // `f.call(…)` / `f.apply(…)` — the invoked function is the OBJECT, not the property.
+    if (callee.name.text === "call" || callee.name.text === "apply") {
+      let target: ts.Node = callee.expression;
+      while (ts.isParenthesizedExpression(target)) target = target.expression;
+      if (ts.isIdentifier(target)) names.push(target.text);
+    } else names.push(callee.name.text);
+  } else if (ts.isElementAccessExpression(callee) && ts.isStringLiteralLike(callee.argumentExpression)) {
+    names.push(callee.argumentExpression.text);
+  }
+  for (const a of n.arguments) if (ts.isIdentifier(a)) names.push(a.text);
+  return names;
+}
+
+/**
  * Does this script make a REACHABLE call to `name`?
  *
  * A comment mentioning it never counted. Neither, now, do the two shapes review used to walk past
@@ -1456,7 +1508,7 @@ export function callsByName(script: DashboardScript, name: string): boolean {
           if (!mentions.has(next)) mentions.set(next, new Set<string>());
         }
       }
-      if (ts.isIdentifier(c) && isValueRef(c)) mentions.get(unit)?.add(c.text);
+      for (const invoked of invocationEdges(c)) mentions.get(unit)?.add(invoked);
       if (ts.isCallExpression(c) && ts.isIdentifier(c.expression) && c.expression.text === name) {
         sites.push({ unit });
       }


### PR DESCRIPTION
Closes #477.

`callsByName()` drew its reachability edges from any identifier **read**, which answers *"is this name mentioned here"* — a different question from *"is this initializer reached"*.

```js
function dead() {
  initTicketIntegrations();
}
void dead;          // ← a mention. `dead` was marked live; the call inside it counted.
```

A feature could be fully unwired — no listeners, no fetches, no published entry point — with the suite green. This is the check standing between the repo and an initializer that silently stops running.

## What an edge needs now

| Accepted | Why |
|---|---|
| `f()` · `(f)()` · `f.call(…)` · `f.apply(…)` | a call, in the spellings the page uses |
| `window.f()` · `window["f"]()` | same call, through the global object |
| `el.addEventListener("click", h)` · `setTimeout(h, 0)` · `xs.forEach(h)` · `ready(h)` | a hand-off **by name** — how every registration spells it |
| `el.onclick = h` | event-handler property assignment |

| Rejected | |
|---|---|
| `void dead` · `dead;` · `const keep = dead` · `[dead]` · `dead === undefined` · `typeof dead` | a bare read invokes nothing |

## It also fixed two false negatives nobody had filed

`window.live()` and `window["live"]()` never created an edge under the old rule either — the callee is not a bare identifier, so a page whose entry point is invoked through the global object read as **unreachable**. Both are now covered, and both are pinned by tests.

## The honest limit

A name passed to **any** call counts as invocable, because telling `ready(h)` from `console.log(h)` requires knowing what the callee does with it. That is written into the helper rather than left for someone to rediscover. Erring that way keeps false alarms out of a gate whose entire value is that people trust it when it fires.

## Mutation evidence

Restoring the mention-based edge fails **7 of the 16** new contract tests — five that must stay silent, plus the two window-spelling cases that must fire. Both directions are pinned, so a future regression either way shows up.

## Relationship to #476

#477 suggested reusing #476's reachability if that landed first. It has not (#493 is open), so this is independent and based on `master`. The two touch the same file but different functions — `callsByName` here, `walkLoadTime` there — and whichever merges second will need a trivial rebase. The call-spelling logic is deliberately named `invocationEdges` here to avoid colliding with #493's `invokedNames`; folding them into one helper is a good follow-up once both are in.

## Checks

`typecheck`, `lint`, `format:check` clean · `tests/dashboard` + `tests/architecture` **2032 passed**