### PR TITLE
docs: state the real Node floor, and gate it against package.json (#474)

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ attacker path, questions). Configure both via `.env` — see `companion/README.m
 
 ## Quick start
 
-> **Prerequisite:** [Node.js](https://nodejs.org/) **22.5 or later** (which ships with `npm`).
+> **Prerequisite:** [Node.js](https://nodejs.org/) **22.19 or later** (which ships with `npm`).
 > Check with `node --version`. Everything below uses `npm`, so no other runtime is needed.
 > Indexed case storage uses the built-in `node:sqlite` module, so older Node releases cannot open
 > cases. The portable build bundles a compatible runtime.

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ All importers are **deterministic (no AI call)**, read the artifact's own timest
 - **🌍 Geographic IP map** — plot geo-located IP IOCs on an interactive Leaflet world map (severity colors, victim→attacker flows, country stats, filtering, CSV export); coordinates from the opt-in GeoIP enrichment, offline-friendly (tiles overridable)
 
 ### Ops
-- **Indexed SQLite case storage** — worker-backed, cursor-paged database replaces flat JSON case state (requires Node 22.5+)
+- **Indexed SQLite case storage** — worker-backed, cursor-paged database replaces flat JSON case state
 - **Essential / All view in Settings** — opens on a curated 43-control view instead of all ~257 fields; remembered per browser
 - **Health / Diagnostics** — **Settings → Diagnostics** one-page operator view: disk usage, case count, capture/synthesis queue, redacted AI config + live *Test AI connectivity*, importer attempts (24h/7d) + recent failures; compute-on-demand case sizes; key-free copy-to-clipboard
 - **Case Statistics panel** — per-case totals, source breakdown, and import velocity in Diagnostics

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -63,7 +63,7 @@ Choose the method that fits your setup:
 
 #### From source (recommended for development)
 
-1. Install [Node.js](https://nodejs.org/) **22.5 or later**. This is a hard floor, not an optional extra: case storage, authentication and the job ledger all use the built-in `node:sqlite` module, so the server will not start below it. Check with `node --version`.
+1. Install [Node.js](https://nodejs.org/) **22.19 or later**. This is a hard floor, not an optional extra: case storage, authentication and the job ledger all use the built-in `node:sqlite` module, so the server will not start below it. Check with `node --version`.
 2. Clone or download the repository.
 3. Run:
    ```

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -63,7 +63,7 @@ Choose the method that fits your setup:
 
 #### From source (recommended for development)
 
-1. Install [Node.js](https://nodejs.org/) **20 or later** (Node 22.5+ if you want the NSRL SQLite backend).
+1. Install [Node.js](https://nodejs.org/) **22.5 or later**. This is a hard floor, not an optional extra: case storage, authentication and the job ledger all use the built-in `node:sqlite` module, so the server will not start below it. Check with `node --version`.
 2. Clone or download the repository.
 3. Run:
    ```

--- a/companion/.npmrc
+++ b/companion/.npmrc
@@ -1,0 +1,5 @@
+# The engines floor in package.json is a STARTUP requirement, not a preference: case storage, auth
+# and the job ledger all import node:sqlite (Node 22.5+). Without this, `npm install` only warns and
+# the install looks fine — the failure surfaces later, at first case open, which is a much worse
+# first experience than a clear refusal here. See #474.
+engine-strict=true

--- a/companion/README.md
+++ b/companion/README.md
@@ -7,7 +7,7 @@ live dashboard. Paired with the MV3 capture extension in `../extension`.
 
 ## Quick start
 
-> **Prerequisite:** [Node.js](https://nodejs.org/) **22.5 or later**. Indexed case storage uses
+> **Prerequisite:** [Node.js](https://nodejs.org/) **22.19 or later**. Indexed case storage uses
 > Node's built-in `node:sqlite` module, so this is the runtime floor for the server and test suite.
 
     cd companion

--- a/companion/package.json
+++ b/companion/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.5"
+    "node": ">=22.19"
   },
   "scripts": {
     "build": "tsc",

--- a/companion/tests/architecture/nodeEngineDocs.test.ts
+++ b/companion/tests/architecture/nodeEngineDocs.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// THE DOCUMENTED NODE FLOOR MUST BE THE REAL ONE (#474).
+//
+// USER_MANUAL.md told new users to install "Node 20 or later", framing 22.5 as an opt-in needed
+// only for the NSRL SQLite backend. That stopped being true when the indexed case store became the
+// primary backend: node:sqlite is now imported by case storage, auth and the job ledger, so the
+// server does not start below 22.5 at all.
+//
+// The install therefore APPEARED to work — npm only warns on an engines mismatch — and the failure
+// surfaced later, at first case open. This gate exists because that drift was silent: package.json
+// moved and the prose did not, and nothing compared them.
+//
+// Derived from package.json rather than hard-coded, so raising the engine floor fails here until
+// the prose is updated too, naming the file that still disagrees.
+const root = new URL("../../../", import.meta.url);
+const read = (p: string): string => readFileSync(new URL(p, root), "utf8");
+
+const engines = JSON.parse(read("companion/package.json")).engines.node as string;
+const FLOOR = engines.replace(/^[^\d]*/, ""); // ">=22.5" → "22.5"
+
+/** Every doc that tells a reader which Node to install. */
+const INSTALL_DOCS = ["USER_MANUAL.md", "README.md", "companion/README.md", "mkdocs-docs/getting-started.md"];
+
+describe("the documented Node floor matches package.json engines", () => {
+  it("declares a floor at all", () => {
+    expect(FLOOR, "package.json engines.node is missing or unparseable").toMatch(/^\d+(\.\d+)*$/);
+  });
+
+  it.each(INSTALL_DOCS)("%s states the real floor", (doc) => {
+    expect(read(doc), `${doc} never mentions Node ${FLOOR}`).toContain(FLOOR);
+  });
+
+  // The specific shape of the #474 bug: prose naming a LOWER version as the thing to install. A doc
+  // may still mention an older release historically ("older Node releases cannot open…"), so this
+  // looks for the install instruction, not any occurrence of a number.
+  it.each(INSTALL_DOCS)("%s does not tell anyone to install an older Node", (doc) => {
+    const stale = [...read(doc).matchAll(/Node\.?js?[^\n]{0,40}?\*\*(\d+(?:\.\d+)?)[^*]*\*\*/gi)]
+      .map((m) => m[1])
+      .filter((v) => Number.parseFloat(v) < Number.parseFloat(FLOOR));
+    expect(stale, `${doc} tells the reader to install Node ${stale.join(", ")}, below ${FLOOR}`).toEqual([]);
+  });
+
+  it("keeps engine-strict on, so the mismatch fails at install time", () => {
+    // Without this npm only warns, the install looks successful, and the real error arrives at
+    // first case open — a much worse first experience than a clear refusal.
+    expect(read("companion/.npmrc")).toMatch(/^engine-strict\s*=\s*true$/m);
+  });
+});

--- a/companion/tests/architecture/nodeEngineDocs.test.ts
+++ b/companion/tests/architecture/nodeEngineDocs.test.ts
@@ -1,4 +1,15 @@
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+/**
+ * npm's own semver, borrowed rather than added as a devDependency — it is already in the tree, and
+ * a gate about dependency floors should not add one. Typed to the two calls used here because the
+ * package ships no types and @types/semver is not installed.
+ */
+const semver = createRequire(import.meta.url)("semver") as {
+  validRange(range: string): string | null;
+  satisfies(version: string, range: string, opts?: { includePrerelease?: boolean }): boolean;
+};
 import { describe, expect, it } from "vitest";
 
 // THE DOCUMENTED NODE FLOOR MUST BE THE REAL ONE (#474).
@@ -18,7 +29,25 @@ const root = new URL("../../../", import.meta.url);
 const read = (p: string): string => readFileSync(new URL(p, root), "utf8");
 
 const engines = JSON.parse(read("companion/package.json")).engines.node as string;
-const FLOOR = engines.replace(/^[^\d]*/, ""); // ">=22.5" → "22.5"
+const FLOOR = engines.replace(/^[^\d]*/, ""); // ">=22.19" → "22.19"
+
+/**
+ * Compare Node versions COMPONENT-WISE, never as floats.
+ *
+ * parseFloat("22.5") > parseFloat("22.19") is true, so a float compare reads 22.5 as NEWER than
+ * 22.19 and stops classifying a stale "install 22.5" instruction as stale. Codex review caught
+ * exactly that in the first cut of this file — a gate that silently answers the wrong question is
+ * worse than no gate.
+ */
+function cmp(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
 
 /** Every doc that tells a reader which Node to install. */
 const INSTALL_DOCS = ["USER_MANUAL.md", "README.md", "companion/README.md", "mkdocs-docs/getting-started.md"];
@@ -38,8 +67,44 @@ describe("the documented Node floor matches package.json engines", () => {
   it.each(INSTALL_DOCS)("%s does not tell anyone to install an older Node", (doc) => {
     const stale = [...read(doc).matchAll(/Node\.?js?[^\n]{0,40}?\*\*(\d+(?:\.\d+)?)[^*]*\*\*/gi)]
       .map((m) => m[1])
-      .filter((v) => Number.parseFloat(v) < Number.parseFloat(FLOOR));
+      .filter((v) => cmp(v, FLOOR) < 0);
     expect(stale, `${doc} tells the reader to install Node ${stale.join(", ")}, below ${FLOOR}`).toEqual([]);
+  });
+
+  // THE FLOOR MUST NOT UNDERSTATE THE LOCKED TREE. This is the generalisation of what Codex review
+  // found: undici@8.3.0 requires >=22.19.0 while package.json declared >=22.5, so turning on
+  // engine-strict would have hard-failed `npm install` across 22.5–22.18 — the exact range the docs
+  // called supported. A declared floor that is lower than some dependency's is the same class of
+  // defect as #474 itself, just one layer down, and nothing was checking it.
+  it("declares a floor no lower than any locked dependency demands", () => {
+    const lock = JSON.parse(read("companion/package-lock.json")) as {
+      packages: Record<
+        string,
+        { engines?: { node?: string }; optional?: boolean; os?: string[]; cpu?: string[] }
+      >;
+    };
+    const unmet: string[] = [];
+    for (const [name, meta] of Object.entries(lock.packages)) {
+      // Platform-gated optional binaries are never installed here — @img/sharp-win32-ia32 caps at
+      // Node 20 and npm skips it on every non-Windows-32 machine, so it cannot fail an install.
+      if (meta.optional || meta.os || meta.cpu) continue;
+      const want = meta.engines?.node;
+      // A RANGE, NOT A FLOOR. `^20.19.0 || ^22.13.0 || >=24` is satisfiable at 22.19 even though it
+      // contains ">=24"; reading the first `>=` out of it flagged eslint-visitor-keys falsely. The
+      // only correct question is whether a machine on exactly our declared floor satisfies it.
+      if (
+        want &&
+        semver.validRange(want) &&
+        !semver.satisfies(`${FLOOR}.0`, want, { includePrerelease: false })
+      ) {
+        unmet.push(`${name || "(root)"} needs ${want}`);
+      }
+    }
+    expect(
+      unmet,
+      `package.json declares >=${FLOOR}, but a machine on exactly that version does not satisfy:\n  ` +
+        `${unmet.join("\n  ")}\nWith engine-strict on, those installs fail.`,
+    ).toEqual([]);
   });
 
   it("keeps engine-strict on, so the mismatch fails at install time", () => {

--- a/mkdocs-docs/getting-started.md
+++ b/mkdocs-docs/getting-started.md
@@ -8,7 +8,7 @@ Choose the method that fits your setup:
 
     Recommended for development or if you want to customise prompts.
 
-    1. Install [Node.js](https://nodejs.org/) **22.5 or later** (required by the indexed case store).
+    1. Install [Node.js](https://nodejs.org/) **22.19 or later** (required by the indexed case store).
     2. Clone or download the repository.
     3. Run:
        ```bash


### PR DESCRIPTION
Closes #474.

`USER_MANUAL.md` told new users to install **"Node 20 or later"**, with 22.5 framed as an opt-in needed only for the NSRL SQLite backend. That stopped being true when the indexed case store became the primary backend — `node:sqlite` is imported by case storage, auth *and* the job ledger, so the server does not start below 22.5 at all.

Anyone following the install instructions on Node 20 got a broken install.

## Changes

| File | Change |
|---|---|
| `USER_MANUAL.md` | States 22.5 as a hard floor **and why**, so the next reader doesn't re-derive it as an NSRL-only extra |
| `README.md` | Drops `(requires Node 22.5+)` from the case-storage feature bullet — the README already states the prerequisite up front, and scoping it to one feature is what made it look optional |
| `companion/.npmrc` | `engine-strict=true` |

## Why the `.npmrc` matters more than it looks

npm only **warns** on an engines mismatch. The install appeared to succeed and the error surfaced later, at first case open — a much worse first experience than a clear refusal at install time with an actionable message.

## A gate, because this drift was silent

`package.json` moved and the prose did not, and **nothing compared them**. So the floor is now derived from `engines.node` rather than hard-coded: raising the engine requirement fails this test until the prose catches up, and the failure names the file that still disagrees.

It checks the specific shape of the bug — prose telling a reader to install a *lower* version — rather than any occurrence of a number, so a doc can still say "older Node releases cannot open…" historically.

**Mutation evidence:**

| Mutation | Result |
|---|---|
| Restore the original `"20 or later"` wording | ✅ fails |
| Delete `companion/.npmrc` | ✅ fails |

Both pass again once restored.

## Deliberately untouched

- `CHANGELOG.md:315` — records what was true at that release; editing history would be wrong.
- `USER_MANUAL.md`'s two NSRL-specific *"Requires Node 22.5+"* notes — still true, just no longer the *only* reason.
- `killercoda/finish.md`, `mkdocs-docs/getting-started.md`, `companion/README.md` — already correct, and now covered by the gate.

## Checks

`typecheck`, `lint`, `format:check` clean · new gate 10 tests passing