### PR TITLE
fix(test): close three blind spots in domAccessOutsideFunctions, and scope it lexically (#480)

### DIFF
--- a/companion/tests/dashboard/dashboardAstContract.test.ts
+++ b/companion/tests/dashboard/dashboardAstContract.test.ts
@@ -12,7 +12,7 @@
 // is as useless as one that flags nothing.
 
 import { describe, expect, it } from "vitest";
-import { duplicateBindings } from "./featureManifest.js";
+import { duplicateBindings, read } from "./featureManifest.js";
 import {
   buildCallGraph,
   callsByName,
@@ -356,6 +356,53 @@ describe("the module-scope DOM check follows an alias and a helper that runs at 
       `const wire = () => { document.getElementById("x").onclick = function () {}; };\nwire();`,
     ],
     ["a destructure off the document", `const { body } = document;\nvoid body;`],
+    // AN INLINE CALLBACK IS THE COMMON SPELLING, and only the named one was covered. The check
+    // entered `ids.forEach(wire)` by looking the name up in scope, so the function expression
+    // written in place — which every one of these modules prefers — walked straight past it.
+    [
+      "an inline function expression handed to a synchronous iteration",
+      `["a", "b"].forEach(function (id) { document.getElementById(id).onclick = function () {}; });`,
+    ],
+    [
+      "an inline arrow handed to a synchronous iteration",
+      `["a", "b"].forEach((id) => { document.getElementById(id).onclick = function () {}; });`,
+    ],
+    [
+      "an expression-bodied arrow, whose body is the access itself",
+      `const ids = ["a"].map((id) => document.getElementById(id));\nvoid ids;`,
+    ],
+    // THE DOCUMENT CAN ARRIVE AS AN ARGUMENT. Every alias the check knew was bound by a `const`;
+    // passing the same value across a call boundary renamed it somewhere the walk never looked.
+    [
+      "a parameter the module passed the document to",
+      `function wire(d) { d.getElementById("x").onclick = function () {}; }\nwire(document);`,
+    ],
+    [
+      "a parameter passed an alias of the document",
+      `const doc = document;\nfunction wire(d) { d.getElementById("x").onclick = function () {}; }\nwire(doc);`,
+    ],
+    [
+      "a parameter defaulted to the document",
+      `function wire(d = document) { d.getElementById("x").onclick = function () {}; }\nwire();`,
+    ],
+    // A MICROTASK IS LOAD-TIME WORK IN A <head> SCRIPT. The checkpoint drains when this script's
+    // job ends and BEFORE the parser resumes, so the body still does not exist — the docstring
+    // used to file these under "correctly silent" alongside setTimeout, which is a real defer.
+    [
+      "a queueMicrotask callback",
+      `queueMicrotask(function () { document.getElementById("x").onclick = function () {}; });`,
+    ],
+    [
+      "a callback on an already-resolved promise",
+      `Promise.resolve().then(function () { document.getElementById("x").onclick = function () {}; });`,
+    ],
+    // A SHADOWED NAME MUST NOT FOLLOW THE CALLER DOWNHILL. Unbinding `document` for the callee
+    // that rebound it leaked into every helper THAT callee went on to call, and those helpers see
+    // the real global — so the access below is load-time work the gate had stopped reporting.
+    [
+      "a sibling helper's own access, when the caller shadowed the name",
+      `function touch() { document.body.textContent = ""; }\nfunction call(document) { touch(); }\ncall(fakeDoc);`,
+    ],
   ])("reports %s", (_label, body) => {
     expect(hits(body), "a DOM touch that really happens at load went unreported").not.toEqual([]);
   });
@@ -397,11 +444,105 @@ describe("the module-scope DOM check follows an alias and a helper that runs at 
       "an element captured and used inside the same deferred function",
       `function init() { const doc = document; doc.getElementById("x").onclick = function () {}; }\nwindow.init = init;`,
     ],
+    // THE THREE FIXES BELOW MUST NOT COST THESE. Each shape the check newly learned has a
+    // neighbour that looks like it and is not, and reporting one of those blocks a correct module
+    // — the failure this gate is least able to survive, because the only way out is to weaken it.
+    [
+      "an inline callback on a deferred promise",
+      `fetch("/api").then(function () { document.getElementById("x").textContent = ""; });`,
+    ],
+    [
+      "an inline callback on a promise from a call that merely returns one",
+      `loadCase().then(function () { document.getElementById("x").textContent = ""; });`,
+    ],
+    [
+      "a parameter that received an ELEMENT rather than the document",
+      `function wire(el) { el.querySelector("a").textContent = ""; }\nwire(cachedPanel);`,
+    ],
+    [
+      "a parameter shadowing the document that received something else",
+      `function wire(document) { document.getElementById("x").textContent = ""; }\nwire(fakeDoc);`,
+    ],
+    // WHICH HANDLER ACTUALLY RUNS. A settled chain fulfils, so the rejection side is dead code,
+    // and reporting it would block the ordinary way these modules guard a load-time step.
+    [
+      "a catch handler on a chain that fulfils",
+      `Promise.resolve().catch(function () { document.getElementById("x").textContent = ""; });`,
+    ],
+    [
+      "the rejection handler of a chain that fulfils",
+      `Promise.resolve().then(ok, function () { document.getElementById("x").textContent = ""; });`,
+    ],
+    // AND WHETHER THE CHAIN IS SETTLED AT ALL. `Promise.resolve(p)` adopts p, so the callback waits
+    // on p; and past the first link, whether the drain continues depends on what each handler
+    // returned, which is not knowable here.
+    [
+      "a callback on a promise that merely wraps a pending one",
+      `Promise.resolve(fetch("/api")).then(function () { document.getElementById("x").textContent = ""; });`,
+    ],
+    [
+      "a callback further down a resolved chain, where a handler may have returned a promise",
+      `Promise.resolve(1).then(step).then(() => { document.getElementById("x").textContent = ""; });`,
+    ],
+    // AN INVOKER SUPPLIES ITS OWN ARGUMENTS, so a default never fires: forEach hands the callback
+    // an element, and `d` is that element rather than the document its signature falls back to.
+    [
+      "a default the iteration's own argument replaces",
+      `["x"].forEach((d = document) => { d.body.textContent = ""; });`,
+    ],
+    [
+      "a local queueMicrotask that never calls back",
+      `function queueMicrotask(cb) { void cb; }\nqueueMicrotask(() => { document.getElementById("x").textContent = ""; });`,
+    ],
   ])("says nothing about %s", (_label, body) => {
     expect(
       hits(body),
       "flagged work that does not run at load — the gate would block a correct module",
     ).toEqual([]);
+  });
+});
+
+// AND THE SAME SHAPES IN A REAL FILE. Everything above is a snippet, and a snippet cannot show
+// that the production assertion in dashboardFeatureLifecycle.test.ts would have caught the
+// regression — a helper can be right about `wrap(body)` and still be reached differently once it
+// is walking a 400-line IIFE with its own helpers and captures. So each shape is injected at the
+// load scope of a module the suite really guards, with the clean file as the control.
+describe("the module-scope DOM check catches these in a module the suite really guards", () => {
+  const MODULE = "dashboard-tickets.js";
+  /** Splice a line in just inside the module's IIFE, which is where load-time work would sit. */
+  const inject = (src: string, line: string): string => {
+    const brace = src.indexOf("{", src.indexOf("(function"));
+    return `${src.slice(0, brace + 1)}\n${line}\n${src.slice(brace + 1)}`;
+  };
+  const offenders = (src: string) => domAccessOutsideFunctions(scriptFromSource(MODULE, src));
+
+  it.each([
+    [
+      "an inline arrow in a synchronous iteration",
+      `["a"].forEach((id) => { document.getElementById(id).onclick = null; });`,
+    ],
+    ["an expression-bodied arrow", `const _p = ["a"].map((id) => document.getElementById(id)); void _p;`],
+    [
+      "the document handed across a call",
+      `function _w(d) { d.getElementById("x").onclick = null; }\n_w(document);`,
+    ],
+    ["a microtask", `queueMicrotask(function () { document.getElementById("x").onclick = null; });`],
+    [
+      "a settled promise callback",
+      `Promise.resolve().then(function () { document.getElementById("x").onclick = null; });`,
+    ],
+  ])("catches %s", async (_label, line) => {
+    const src = await read(MODULE);
+    expect(offenders(src), `${MODULE} is not clean, so this mutation proves nothing`).toEqual([]);
+    expect(offenders(inject(src, line)), "the mutation ran at load and the gate stayed green").not.toEqual(
+      [],
+    );
+  });
+
+  it("and still says nothing when that same work is deferred to a fetch", async () => {
+    const src = await read(MODULE);
+    const line = `fetch("/api/x").then(function () { document.getElementById("x").onclick = null; });`;
+    expect(offenders(inject(src, line))).toEqual([]);
   });
 });
 

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -1569,15 +1569,28 @@ export function callsByName(script: DashboardScript, name: string): boolean {
  * The same walk carries the locals bound to the document, because `const doc = document` renames
  * the root and the chain no longer bottoms out at the identifier this was looking for.
  *
+ * THE DOCUMENT ALSO TRAVELS AS AN ARGUMENT. `wire(document)` renames it across a call boundary
+ * exactly as `const doc = document` renames it within one, so entering a callee binds its
+ * parameters to what the caller passed. The same pass UNBINDS the others, because a parameter
+ * shadows whatever the caller called that name — `document` included, and taking the parameter in
+ * `function wire(document)` for the global was a false positive that would block a correct module.
+ *
+ * A MICROTASK IS LOAD-TIME WORK HERE. This note used to file `queueMicrotask` and promise
+ * callbacks alongside `setTimeout` under "correctly silent", and for a <head> script that is
+ * wrong: the microtask checkpoint drains when this script's job ends and BEFORE the parser
+ * resumes, so the body still does not exist. Only an ALREADY-RESOLVED promise counts —
+ * `fetch(…).then(…)` settles when the network does, which is not load.
+ *
  * WHAT IT DELIBERATELY DOES NOT CLAIM. "Called during load" is decided structurally, from a call
- * whose callee is a bare name declared in a scope already known to run at load — plus a function
- * handed to one of the Array methods that invoke synchronously. Everything indirect is out of
- * reach without a type system and is NOT reported: `table[key]()`, `(cond ? a : b)()`,
- * `fn.call(...)` through a variable, `eval`/`new Function`, a helper reached only as a property of
- * an object, and a document obtained from a function's return value. Deferred registration —
- * `addEventListener`, `setTimeout`, `queueMicrotask`, a promise callback — is not load-time work
- * and is correctly silent. A check that claimed those too would be guessing, and a gate that
- * guesses is how this issue got here.
+ * whose callee is a bare name declared in a scope already known to run at load, a function written
+ * in place or named at one of the Array methods that invoke synchronously, and a microtask
+ * callback. Everything indirect is out of reach without a type system and is NOT reported:
+ * `table[key]()`, `(cond ? a : b)()`, `fn.call(...)` through a variable, `eval`/`new Function`, a
+ * helper reached only as a property of an object, a DESTRUCTURED parameter, and a document
+ * obtained from a function's return value. `addEventListener` and `setTimeout` really do defer and
+ * stay silent. It errs the other way on one shape: a method NAMED like a synchronous Array one is
+ * taken at its word rather than by resolving its receiver, so a hand-rolled `forEach` that never
+ * calls back would be reported. Guessing at the rest is how this issue got here.
  */
 export function domAccessOutsideFunctions(script: DashboardScript): string[] {
   const sf = script.ast;
@@ -1606,11 +1619,18 @@ export function domAccessOutsideFunctions(script: DashboardScript): string[] {
     return false;
   };
 
-  /** Does this member chain bottom out at the document — directly, via a global, or via an alias? */
+  /**
+   * Does this member chain bottom out at the document — directly, via a global, or via an alias?
+   *
+   * `document` is not special-cased here; it is seeded into the root scope's alias set instead, so
+   * that the ONE set decides what the name means. That is what lets a parameter shadow it: a bare
+   * `document` was hardcoded as the global no matter what the enclosing signature had rebound it
+   * to, and no amount of unbinding at the call boundary could reach a literal in this comparison.
+   */
   const rootsAtDocument = (n: ts.Node, aliases: ReadonlySet<string>): boolean => {
     let cur: ts.Node = n;
     for (;;) {
-      if (ts.isIdentifier(cur)) return cur.text === "document" || aliases.has(cur.text);
+      if (ts.isIdentifier(cur)) return aliases.has(cur.text);
       if (isGlobalDocument(cur)) return true;
       if (ts.isPropertyAccessExpression(cur) || ts.isElementAccessExpression(cur)) cur = cur.expression;
       else if (ts.isNonNullExpression(cur) || ts.isParenthesizedExpression(cur)) cur = cur.expression;
@@ -1638,8 +1658,9 @@ export function domAccessOutsideFunctions(script: DashboardScript): string[] {
   };
 
   // Array methods that invoke their callback SYNCHRONOUSLY, so `ids.forEach(wire)` at load scope
-  // runs wire at load. setTimeout/queueMicrotask/then are deliberately absent: those run after the
-  // parser is done, which is the whole point of deferring to them.
+  // runs wire at load. setTimeout stays deliberately absent: it runs after the parser is done,
+  // which is the whole point of deferring to it. queueMicrotask and a settled `then` do NOT get
+  // that far — see the microtask paragraph above — so they are handled just below.
   const SYNC_INVOKERS = new Set([
     "forEach",
     "map",
@@ -1652,6 +1673,59 @@ export function domAccessOutsideFunctions(script: DashboardScript): string[] {
     "reduce",
     "sort",
   ]);
+
+  const unwrap = (n: ts.Node): ts.Node => {
+    let cur = n;
+    while (ts.isParenthesizedExpression(cur)) cur = cur.expression;
+    return cur;
+  };
+
+  /**
+   * `Promise.resolve()` over a value that is provably not itself a promise.
+   *
+   * BOTH HALVES OF THAT MATTER. `Promise.resolve(p)` ADOPTS p, so the callback waits on whatever p
+   * waits on — `Promise.resolve(fetch(…)).then(wire)` runs wire when the network answers, not
+   * during the load drain. And only the FIRST link of the chain is knowable: past it, whether the
+   * drain continues depends on what each handler returned, and a handler returning a pending
+   * promise suspends the rest. Guessing there is what the note above refuses to do, so a deeper
+   * link is out of reach and stays silent.
+   */
+  const isSettledRoot = (n: ts.Node): boolean => {
+    const cur = unwrap(n);
+    if (!ts.isCallExpression(cur)) return false;
+    const callee = unwrap(cur.expression);
+    return (
+      ts.isPropertyAccessExpression(callee) &&
+      callee.name.text === "resolve" &&
+      ts.isIdentifier(callee.expression) &&
+      callee.expression.text === "Promise" &&
+      cur.arguments.every((a) => ts.isStringLiteralLike(a) || ts.isNumericLiteral(a))
+    );
+  };
+
+  /**
+   * The arguments this call runs as functions before the parser reaches the body.
+   *
+   * Empty for everything else, including a settled chain's DEAD handlers: a chain that fulfils
+   * never enters `.catch`, nor the second argument of `.then`, and reporting either would block a
+   * module for guarding a load-time step the ordinary way.
+   */
+  const loadTimeCallbacks = (n: ts.CallExpression, scope: LoadScope): readonly ts.Expression[] => {
+    const callee = unwrap(n.expression);
+    const first = n.arguments.length ? [n.arguments[0]] : [];
+    // A module that declares its own `queueMicrotask` gets that one, not the platform's — and the
+    // local is entered by the ordinary named-call path just below, on its own merits.
+    if (ts.isIdentifier(callee))
+      return callee.text === "queueMicrotask" && !scope.fns.has("queueMicrotask") ? n.arguments : [];
+    if (!ts.isPropertyAccessExpression(callee)) return [];
+    if (SYNC_INVOKERS.has(callee.name.text)) return n.arguments;
+    if (callee.name.text === "queueMicrotask")
+      return ts.isIdentifier(callee.expression) && GLOBAL_ROOTS.has(callee.expression.text)
+        ? n.arguments
+        : [];
+    if (!isSettledRoot(callee.expression)) return [];
+    return callee.name.text === "then" || callee.name.text === "finally" ? first : [];
+  };
 
   /** What a scope knows: its callable local functions, and its locals bound to the document. */
   interface LoadScope {
@@ -1689,16 +1763,73 @@ export function domAccessOutsideFunctions(script: DashboardScript): string[] {
     return { fns, docs };
   };
 
-  const visited = new Set<ts.Node>();
+  // Keyed by the callee AND the documents its parameters were bound to, because the same helper
+  // called twice is two different questions: `wire(x); wire(document);` must not be skipped the
+  // second time on the strength of the first. The set of bindings is finite, so this terminates.
+  const visited = new Set<string>();
+  // WHERE EACH FUNCTION WAS DECLARED, because a callee sees the names ITS OWN declaration site
+  // sees. Handing it the caller's scope instead made the walk dynamically scoped, and the bug that
+  // buys is silence: `function call(document) { touch(); }` correctly unbinds the name for its own
+  // body, and that unbinding then followed the walk into `touch`, whose free `document` is the
+  // real global. A missed load-time access is the exact failure this whole check exists to catch.
+  const declScope = new Map<ts.Node, LoadScope>();
 
   const scan = (body: ts.Node, outer: LoadScope): void => {
     const scope = collect(body, outer);
-    const enter = (fn: ts.Node): void => {
-      if (visited.has(fn)) return; // and it stops mutual recursion walking forever
-      visited.add(fn);
-      const inner = (fn as ts.FunctionLikeDeclaration).body;
-      if (inner) scan(inner, scope);
+    // Functions declared in THIS body take this scope; ones inherited from an enclosing scope keep
+    // the association they were given there, since collect() never descends into a function body.
+    for (const fn of scope.fns.values()) if (!declScope.has(fn)) declScope.set(fn, scope);
+
+    /**
+     * Enter a callee in its own lexical scope, adjusted for what its parameters shadow and receive.
+     *
+     * `args` is the caller's argument list, or null when an INVOKER supplies the arguments — a
+     * forEach callback is handed an element and a microtask callback a resolved value, neither of
+     * which this can name. Null still shadows, because the parameters exist either way; it just
+     * declines to bind them, and in particular declines to apply a default the invoker overwrote.
+     */
+    const enter = (fn: ts.Node, args: ts.NodeArray<ts.Expression> | null): void => {
+      const decl = fn as ts.FunctionLikeDeclaration;
+      const inner = decl.body;
+      if (!inner) return;
+      // A function written in place is declared right here; a named one carries its own site.
+      const lexical = declScope.get(fn) ?? scope;
+      const fns = new Map(lexical.fns);
+      const docs = new Set(lexical.docs);
+      decl.parameters.forEach((p, i) => {
+        if (!ts.isIdentifier(p.name)) return; // a destructured parameter is out of reach
+        // SHADOWING FIRST, and unconditionally: inside the body this name is the parameter,
+        // whatever it meant outside. Without this, `function wire(document)` read as the global.
+        fns.delete(p.name.text);
+        docs.delete(p.name.text);
+        if (!args) return;
+        // Then ONLY the document itself propagates, on the same terms as a `const` alias, and
+        // resolved in the CALLER's scope because that is where the argument was written:
+        // `wire(document.getElementById(…))` hands over an element, and treating that as a
+        // document would report every legitimate capture the callee makes from it.
+        const passed = args[i] ?? p.initializer;
+        if (
+          passed &&
+          (ts.isIdentifier(passed) || isGlobalDocument(passed)) &&
+          rootsAtDocument(passed, scope.docs)
+        ) {
+          docs.add(p.name.text);
+        }
+      });
+      const key = `${decl.pos}:${decl.end}:${[...docs].sort().join(",")}`;
+      if (visited.has(key)) return; // and it stops mutual recursion walking forever
+      visited.add(key);
+      scan(inner, { fns, docs });
     };
+
+    /** The function a call would invoke: written in place, or a local named at the call site. */
+    const callbackArg = (arg: ts.Expression): ts.Node | null => {
+      const e = unwrap(arg);
+      if (ts.isFunctionExpression(e) || ts.isArrowFunction(e)) return e;
+      if (ts.isIdentifier(e)) return scope.fns.get(e.text) ?? null;
+      return null;
+    };
+
     const visit = (n: ts.Node): void => {
       const immediate = iifeBody(n);
       if (immediate) {
@@ -1708,11 +1839,10 @@ export function domAccessOutsideFunctions(script: DashboardScript): string[] {
       if (ts.isCallExpression(n)) {
         const callee = n.expression;
         if (ts.isIdentifier(callee) && scope.fns.has(callee.text))
-          enter(scope.fns.get(callee.text) as ts.Node);
-        if (ts.isPropertyAccessExpression(callee) && SYNC_INVOKERS.has(callee.name.text)) {
-          for (const arg of n.arguments) {
-            if (ts.isIdentifier(arg) && scope.fns.has(arg.text)) enter(scope.fns.get(arg.text) as ts.Node);
-          }
+          enter(scope.fns.get(callee.text) as ts.Node, n.arguments);
+        for (const arg of loadTimeCallbacks(n, scope)) {
+          const fn = callbackArg(arg);
+          if (fn) enter(fn, null); // null: the invoker chooses the arguments, and this cannot name them
         }
         ts.forEachChild(n, visit);
         return;
@@ -1733,10 +1863,14 @@ export function domAccessOutsideFunctions(script: DashboardScript): string[] {
       }
       ts.forEachChild(n, visit);
     };
-    ts.forEachChild(body, visit);
+    // AN EXPRESSION-BODIED ARROW HAS NO STATEMENTS, so descending into the body's children skips
+    // the body itself: `() => document.body` would have offered up only the two identifiers, and
+    // the access they spell was never examined. Judge such a body as the expression it is.
+    if (ts.isSourceFile(body) || ts.isBlock(body)) ts.forEachChild(body, visit);
+    else visit(body);
   };
 
-  scan(sf, { fns: new Map(), docs: new Set() });
+  scan(sf, { fns: new Map(), docs: new Set(["document"]) });
   return out;
 }
 


### PR DESCRIPTION
Closes the remaining half of #480. The declaration-census half landed in #484, and the "runs against one feature of ten" half was already fixed by the `FEATURES` parameterisation — the issue body is stale on both.

## The three blind spots

`domAccessOutsideFunctions()` guards a real hazard: these are `<head>` scripts, so anything reaching the DOM during load finds no markup — captures are null, listeners attach to nothing, and nothing errors. Three shapes walked past it.

- **An inline callback.** The `SYNC_INVOKERS` branch entered an argument only when it was an identifier resolvable in scope, so `ids.forEach(wire)` was covered and `ids.forEach((id) => …)` — the spelling these modules actually prefer — was not.
- **An expression-bodied arrow.** `scan()` ended in `ts.forEachChild(body, visit)`, which for `() => document.body` handed over the two identifiers and never the access they spell.
- **The document arriving as an argument.** Every alias the walk knew was bound by a `const`; passing the same value across a call boundary renamed it somewhere nothing looked.

## Two more the work turned up

`rootsAtDocument()` compared against the literal string `"document"`, so no amount of unbinding at a call boundary could reach it and `function wire(document)` read as the global — a **false positive** that would block a correct module. The name is now seeded into the root scope so one set decides what it means. Separately, `visited` was keyed by node, making `wire(x); wire(document);` one question instead of two.

## The microtask correction

The docstring filed `queueMicrotask` and promise callbacks under "correctly silent" alongside `setTimeout`. For a `<head>` script that is wrong — the microtask checkpoint drains when this script's job ends and *before* the parser resumes. Only an already-resolved promise counts, only its first link, and only the handler that can actually run: a chain that fulfils never enters `.catch`, nor `.then`'s second argument.

## What review caught

The first cut of this had a **false negative** — the exact failure the gate exists to prevent. Entering a callee with the *caller's* scope is dynamic scoping, so correctly unbinding a shadowed name for that callee followed the walk into every helper it went on to call, and those helpers see the real global. Callees now enter in the scope where they were **declared**, while arguments still resolve in the caller's. Four smaller scheduling defects were fixed alongside it.

## Test plan

- [x] Nine mutations proving each shape fires, plus a block injecting all five into the load scope of a real module (`dashboard-tickets.js`) with the clean file as control — a helper can be right about a snippet and reached differently inside a 400-line IIFE.
- [x] Partners asserting what must stay silent: a deferred `fetch`, a dead rejection handler, a default an invoker overwrites, a module-local `queueMicrotask`, a parameter holding an element.
- [x] Every test written and watched failing before the code that makes it pass.
- [x] Full suite: 9013 passed, 0 failed.
- [x] `npm run typecheck`, `npm run lint`, `prettier --check` all clean.
- [x] No change to any production module — none of the 115 features trips the strengthened gate.

## Known limitation, documented in the helper

A method *named* like a synchronous Array one is taken at its word rather than by resolving its receiver, so a hand-rolled `forEach` that never calls back would be reported. Resolving that needs a type system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDHArgeNeoPwqzgdDdm728