### PR TITLE
fix(test): govern the extracted modules by load order, not by imports they do not use (#482)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -235,19 +235,38 @@ belongs in a boundary ledger pretending to be a small fix:
    inline JS and CSS as separate shrink-only budgets. The markup itself is deliberately not measured
    — ~3,000 lines of HTML is fine; a 16,000-line program inside a markup file is not.
 
-   **`check:imports` does not, in practice, cover the extracted modules.** It includes `public/js/**`
-   so that "the first cycle between extracted feature modules fails a PR", but all 26 modules #415
-   has produced are classic scripts publishing onto `window` — none uses `import`/`export`, so the
-   regex-based graph sees 26 nodes and 0 edges. The real graph is ~35 edges carried by globals. That
-   pattern is deliberate (a feature must survive a sibling 404; see `public/js/dashboard-facade.js`),
-   but it routes every inter-module dependency around the gate. Tracked in #482.
+   **`check:imports` does not cover the extracted modules, and no longer claims to.** It includes
+   `public/js/**` so that "the first cycle between extracted feature modules fails a PR", but all
+   138 modules #415 has produced are classic scripts publishing onto `window` — none uses
+   `import`/`export`, so the regex-based graph sees 138 nodes and 0 edges. That pattern is
+   deliberate (a feature must survive a sibling 404; see `public/js/dashboard-facade.js`), and it
+   routes every inter-module dependency around that gate. The root stays for the pre-#415 ES modules
+   under `public/js`, which do import.
+
+   The ~463-edge global graph is governed instead by
+   `companion/tests/dashboard/dashboardLoadOrder.test.ts`. **It does not look for cycles**, because
+   that question is borrowed from ES-module semantics and does not transfer: here every cross-module
+   name resolves through `window` at call time, so two features whose handlers call each other are
+   fine, and 32 such cycles exist today, harmlessly. It asks about ORDER instead — whether a module
+   calls a sibling's published name *during load*, before that sibling's `<script>` tag has run.
+   Unguarded that throws inside the load-time IIFE and takes the rest of the module with it; guarded
+   with `typeof` it is skipped in silence and the feature is simply never there. That is the blank
+   page `check:imports` was reaching for.
+
+   Standing it up found one: `dashboard-ioc-provenance.js` probed `window.DfirFacade` at its own
+   load, ten module tags before the facade publishes it, so the guard was always false and its
+   "feature unavailable" notice could never appear. That probe now sits with its siblings in the
+   inline script, which runs after every module. With it fixed the count is zero, so the gate is
+   hard and unbaselined. Closed by #482.
 
    It is **not** in the domain map above, and that is the remaining gap: the layer/tier rules cover
    `companion/src` only. Two extraction patterns now exist and they are not interchangeable:
-   `public/js/hunt-workbench.js` and five siblings are ES modules with direct vitest coverage, while
-   the 26 `dashboard-*.js` feature modules are classic scripts whose contract is enforced by the
-   manifest gate in `companion/tests/dashboard/dashboardFeatureModules.test.ts`. Nine of those ten
-   tier-3 features have no behavioural test of their own — the gap #479 tracks.
+   `public/js/hunt-workbench.js` and five siblings are ES modules with direct vitest coverage —
+   those six predate #415 and are **not** what the extraction produces — while the 138
+   `dashboard-*.js` feature modules are classic scripts whose contract is enforced by the manifest
+   gate in `companion/tests/dashboard/dashboardFeatureModules.test.ts` and whose load order is
+   enforced by `dashboardLoadOrder.test.ts`. Most have no behavioural test of their own; the
+   swimlane's execution fixture (`dashboardSwimlaneWiring.test.ts`, #479) is the pattern for one.
 
 ## Migration
 

--- a/companion/scripts/check-imports.mjs
+++ b/companion/scripts/check-imports.mjs
@@ -31,10 +31,20 @@ import { fileURLToPath } from "node:url";
 
 const COMPANION = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SRC = join(COMPANION, "src");
-// The dashboard's extracted feature modules. They import NOTHING from each other today, so this
-// root contributes zero cycles — which is exactly why it is wired in now. As #384 pulls features
-// out of dashboard.html's 19k lines of inline script, these modules start importing one another,
-// and the first cycle should fail a PR rather than be discovered later from a blank page.
+// The dashboard's extracted feature modules. This root was wired in on the expectation that as
+// features came out of dashboard.html they would start importing one another, so the first cycle
+// would fail a PR. THAT IS NOT THE PATTERN #415 SETTLED ON: all of them are classic scripts
+// publishing onto `window` so a feature survives a sibling 404 (see public/js/dashboard-facade.js),
+// and 138 modules later not one uses import/export. A graph resolved by regex over import
+// statements therefore sees 138 nodes and 0 edges, and this root cannot fail for them. It stays
+// because the pre-#415 ES modules under public/js DO import, and a cycle among those is still
+// worth catching — but it governs those, not the extracted features.
+//
+// The extracted features' real graph — ~463 edges carried by globals — is governed instead by
+// tests/dashboard/dashboardLoadOrder.test.ts, which asks the question that actually bites here:
+// not "is there a cycle" (harmless when every name resolves through `window` at call time) but
+// "does a module call a sibling's name during load, before that sibling's <script> has run". That
+// is the blank page this comment used to warn about. See #482.
 const PUBLIC_JS = resolve(COMPANION, "..", "public", "js");
 const BASELINE = join(COMPANION, "scripts", "import-cycles.json");
 

--- a/companion/tests/dashboard/dashboardLoadOrder.test.ts
+++ b/companion/tests/dashboard/dashboardLoadOrder.test.ts
@@ -1,0 +1,208 @@
+// LOAD ORDER BETWEEN THE EXTRACTED MODULES (#482).
+//
+// `check:imports` includes `public/js/**` so that "the first cycle between extracted feature
+// modules fails a PR". It cannot: all 138 of them are CLASSIC SCRIPTS publishing onto `window`, so
+// the regex-over-import-statements graph sees 138 nodes and 0 edges. The real graph is ~463 edges
+// carried by globals, and every one of them routes around that gate.
+//
+// CYCLES ARE THE WRONG QUESTION HERE, which is why this file does not ask it. The reasoning behind
+// the import gate is ES-module semantics, where a cycle means a half-initialised binding. These are
+// classic scripts: every cross-module name resolves through `window` at CALL time, so two features
+// whose click handlers call each other are fine, and 32 such cycles exist today, harmlessly.
+//
+// The failure that actually happens — the one the import gate's own comment describes as
+// "discovered later from a blank page", and that PR #475 hit twice — is about ORDER, not cycles: a
+// module reaching for a sibling's published name DURING LOAD, before that sibling's <script> tag
+// has run. The name is not there yet. Unguarded that is a ReferenceError inside a load-time IIFE,
+// which kills the rest of that module; guarded with `typeof`, it is worse, because the guard is
+// simply false and the feature is silently, permanently absent with nothing in the console.
+//
+// That number is 0 today, so this is a hard gate with no baseline, and the first PR to introduce
+// the bug fails rather than shipping a blank panel.
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  loadOrderViolations,
+  moduleGlobals,
+  scriptFromSource,
+  type DashboardScript,
+} from "../helpers/dashboardAst.js";
+
+const JS_DIR = join(process.cwd(), "..", "public", "js");
+const DASHBOARD = join(process.cwd(), "..", "public", "dashboard.html");
+
+describe("the load-order analysis, on modules built for the purpose", () => {
+  // Asking the real files proves nothing about the analysis: they are clean, so it returns []
+  // whether the check works or not. These sources contain the shape being looked for.
+  const mods = (sources: Record<string, string>): Array<{ file: string; script: DashboardScript }> =>
+    Object.entries(sources).map(([file, src]) => ({ file, script: scriptFromSource(file, src) }));
+  const run = (sources: Record<string, string>, published: Record<string, string[]>) =>
+    loadOrderViolations(
+      mods(sources),
+      new Map(Object.entries(published)),
+      new Map(Object.keys(sources).map((f, i) => [f, i])),
+    );
+
+  const LATE = { lateThing: ["b.js"] };
+
+  it("reports a load-time call into a module that loads later", () => {
+    const v = run({ "a.js": `(function () { lateThing(); })();`, "b.js": `` }, LATE);
+    expect(v.map((x) => `${x.from} -> ${x.to}:${x.name}`)).toEqual(["a.js -> b.js:lateThing"]);
+  });
+
+  it("reports the typeof-guarded form too, which fails silently rather than loudly", () => {
+    // The guard converts a ReferenceError into a no-op. The feature is still absent, and now there
+    // is nothing in the console either — strictly the worse of the two outcomes.
+    const v = run(
+      { "a.js": `(function () { if (typeof lateThing === "function") lateThing(); })();`, "b.js": `` },
+      LATE,
+    );
+    expect(v.map((x) => x.name)).toEqual(["lateThing"]);
+  });
+
+  it("reports a call reached through a helper that itself runs at load", () => {
+    const v = run({ "a.js": `(function () { function go() { lateThing(); } go(); })();`, "b.js": `` }, LATE);
+    expect(v.map((x) => x.name)).toEqual(["lateThing"]);
+  });
+
+  it.each([
+    ["the callee loads FIRST", { "b.js": ``, "a.js": `(function () { lateThing(); })();` }],
+    [
+      "the call is deferred to a handler",
+      { "a.js": `(function () { btn.onclick = function () { lateThing(); }; })();`, "b.js": `` },
+    ],
+    [
+      "the call is deferred to an event",
+      {
+        "a.js": `(function () { addEventListener("DOMContentLoaded", function () { lateThing(); }); })();`,
+        "b.js": ``,
+      },
+    ],
+    [
+      "the name is only published, never called",
+      { "a.js": `(function () { window.lateThing = lateThing; })();`, "b.js": `` },
+    ],
+    [
+      "the module declares the name itself",
+      { "a.js": `(function () { function lateThing() {} lateThing(); })();`, "b.js": `` },
+    ],
+  ])("says nothing when %s", (_label, sources) => {
+    expect(run(sources, LATE), "flagged a call that cannot hit a missing name").toEqual([]);
+  });
+
+  it("says nothing about a module the page never loads", () => {
+    // Order is derived from the page's <script> tags, so a file on disk that no tag references
+    // cannot be out of order with anything. Reporting it would be noise nobody can act on.
+    const v = loadOrderViolations(
+      mods({ "a.js": `(function () { lateThing(); })();`, "orphan.js": `` }),
+      new Map([["lateThing", ["orphan.js"]]]),
+      new Map([["a.js", 0]]),
+    );
+    expect(v).toEqual([]);
+  });
+
+  it("names the line, so the failure points at the call and not at the file", () => {
+    const v = run({ "a.js": `(function () {\n\n  lateThing();\n})();`, "b.js": `` }, LATE);
+    expect(v[0]?.line).toBe(3);
+  });
+
+  // A NAMESPACE IS THE DOMINANT SPELLING, and the first cut of this gate could not see it. 16
+  // modules reach a sibling as `DfirState.cell(…)` rather than as a bare function — including
+  // dashboard-facets.js, which calls `window.DfirState.cell(new Set())` at load. That is safe today
+  // only because dashboard-state.js happens to sit at tag 1 and facets at 12; swap them and the
+  // page throws during load with this gate green. Caught by Codex review.
+  const NS = { DfirState: ["b.js"] };
+
+  it.each([
+    ["a bare namespace call", `(function () { DfirState.cell(1); })();`],
+    ["the window-qualified spelling", `(function () { window.DfirState.cell(1); })();`],
+    ["the computed spelling", `(function () { window["DfirState"].cell(1); })();`],
+  ])("reports %s into a later module", (_label, src) => {
+    expect(run({ "a.js": src, "b.js": `` }, NS).map((x) => x.name)).toEqual(["DfirState"]);
+  });
+
+  it.each([
+    ["the namespace loads first", { "b.js": ``, "a.js": `(function () { DfirState.cell(1); })();` }],
+    [
+      "the namespace is the module's own local",
+      { "a.js": `(function () { const DfirState = mk(); DfirState.cell(1); })();`, "b.js": `` },
+    ],
+    [
+      "the namespace call is deferred",
+      { "a.js": `(function () { btn.onclick = function () { DfirState.cell(1); }; })();`, "b.js": `` },
+    ],
+    [
+      "the namespace is read but never called",
+      { "a.js": `(function () { const c = DfirState.cell; void c; })();`, "b.js": `` },
+    ],
+  ])("says nothing when %s", (_label, sources) => {
+    expect(run(sources, NS)).toEqual([]);
+  });
+
+  // A NAMED HANDLER IS NOT LOAD-TIME WORK. The deferred cases above all passed an INLINE function,
+  // and the named form — the commoner style here — took a different path: invokedNames() followed
+  // every identifier ARGUMENT of every call, so `addEventListener("click", h)` was walked as though
+  // the page had clicked it. Also Codex.
+  it.each([
+    ["a click handler", `(function () { function h() { lateThing(); } addEventListener("click", h); })();`],
+    ["a timer", `(function () { function h() { lateThing(); } setTimeout(h, 0); })();`],
+    ["a promise callback", `(function () { function h() { lateThing(); } fetch("/x").then(h); })();`],
+  ])("says nothing about %s that merely mentions the name", (_label, src) => {
+    expect(run({ "a.js": src, "b.js": `` }, LATE)).toEqual([]);
+  });
+
+  it("still follows a handler into a synchronous iteration, which does run at load", () => {
+    // The other side of the same fix: forEach invokes now, so its callback IS load-time work.
+    const src = `(function () { function h() { lateThing(); } ["a"].forEach(h); })();`;
+    expect(run({ "a.js": src, "b.js": `` }, LATE).map((x) => x.name)).toEqual(["lateThing"]);
+  });
+
+  it("says nothing about a local that merely shares a sibling's spelling", () => {
+    // The gate used to join two file-wide analyses: "is this name free ANYWHERE in the file" and
+    // "is it called at load ANYWHERE in the file". Neither knows the other's call site, so a local
+    // called at load was reported on the strength of an unrelated deferred reference. Codex again.
+    const src = `(function () {
+  function a() { function lateThing() {} lateThing(); }
+  a();
+  function b() { lateThing(); }
+  window.b = b;
+})();`;
+    expect(run({ "a.js": src, "b.js": `` }, LATE)).toEqual([]);
+  });
+});
+
+describe("no extracted module reaches for a sibling before it is loaded", () => {
+  const html = readFileSync(DASHBOARD, "utf8");
+  const order = new Map<string, number>();
+  [...html.matchAll(/<script[^>]*src="\/js\/([^"]+)"/g)].forEach((m, i) => {
+    if (!order.has(m[1])) order.set(m[1], i);
+  });
+  const modules = readdirSync(JS_DIR)
+    .filter((f) => f.endsWith(".js"))
+    .sort()
+    .map((file) => ({ file, script: scriptFromSource(file, readFileSync(join(JS_DIR, file), "utf8")) }));
+  const published = new Map(
+    [...moduleGlobals()].map(([name, owners]) => [name, owners.map((o) => o.replace(/^js\//, ""))] as const),
+  );
+
+  it("has a world to check, so a green result means something", () => {
+    // A closed-world check whose world is empty passes for the wrong reason — the same failure this
+    // whole file exists to prevent, one level up.
+    expect(order.size, "no /js/ script tags found in the page").toBeGreaterThan(60);
+    expect(modules.length, "no module files found on disk").toBeGreaterThan(60);
+    expect(published.size, "no module publications found").toBeGreaterThan(100);
+  });
+
+  it("calls no sibling's published name during load", () => {
+    const violations = loadOrderViolations(modules, published, order).map(
+      (v) => `${v.from}:${v.line} calls ${v.name}(), published by ${v.to}, which loads later`,
+    );
+    expect(
+      violations.sort(),
+      "this runs before the sibling's <script> tag, so the name is not there yet: unguarded it " +
+        "throws inside the load-time IIFE and kills the rest of the module, and guarded with " +
+        "typeof it is simply skipped and the feature is silently absent for good",
+    ).toEqual([]);
+  });
+});

--- a/companion/tests/helpers/dashboardAst.ts
+++ b/companion/tests/helpers/dashboardAst.ts
@@ -2189,6 +2189,20 @@ function declaredFunctionsOf(script: DashboardScript): Map<string, ts.Node> {
  * writing the call. Over-collecting is safe: a name that is not a declared function is dropped by
  * the caller, so an extra spelling costs one map lookup that misses.
  */
+/** Array methods that invoke their callback SYNCHRONOUSLY, so a callback handed to one runs now. */
+const SYNC_CALLBACK_INVOKERS = new Set([
+  "forEach",
+  "map",
+  "filter",
+  "some",
+  "every",
+  "find",
+  "findIndex",
+  "flatMap",
+  "reduce",
+  "sort",
+]);
+
 function invokedNames(n: ts.CallExpression): string[] {
   const names: string[] = [];
   let callee: ts.Node = n.expression;
@@ -2214,6 +2228,11 @@ function invokedNames(n: ts.CallExpression): string[] {
   ) {
     names.push(callee.argumentExpression.text);
   }
+  // DELIBERATELY UNRESTRICTED. Handing a name to `addEventListener` or `setTimeout` counts here,
+  // because the questions this feeds — #477's "does the page really call it" and #476's "is this
+  // reference one hop from load" — are both satisfied by the wiring existing at all. The stricter
+  // "does it run BEFORE the parser finishes" question needs the opposite answer, so it does not
+  // use this: see loadTimeDependencies(), which carries its own walk for exactly that reason.
   for (const a of n.arguments) if (ts.isIdentifier(a)) names.push(a.text);
   return names;
 }
@@ -2541,6 +2560,238 @@ export function moduleGlobals(scripts: DashboardScript[] = dashboardScripts()): 
     });
     for (const name of names) out.set(name, [...(out.get(name) ?? []), s.name]);
   }
+  return out;
+}
+
+/** A module reaching for a sibling's published name before that sibling has loaded. */
+export interface LoadOrderViolation {
+  /** The module making the call. */
+  from: string;
+  /** The name it calls. */
+  name: string;
+  /** The module that publishes that name, whose <script> tag comes later. */
+  to: string;
+  line: number;
+}
+
+/**
+ * Cross-module calls that run DURING LOAD against a module the page loads afterwards.
+ *
+ * `check:imports` was supposed to govern this graph and cannot: these are classic scripts
+ * publishing onto `window`, so its regex over import statements sees every module as an island
+ * (#482). The dependencies are real regardless — they just travel through the global object.
+ *
+ * CYCLES ARE NOT THE HAZARD, so this does not look for them. That question is borrowed from ES
+ * modules, where a cycle means a half-initialised binding; here every cross-module name is resolved
+ * through `window` at CALL time, so two features whose handlers call each other are fine and dozens
+ * of such cycles exist harmlessly. ORDER is the hazard: a call that runs while the page is still
+ * parsing reaches a name whose defining <script> has not executed. Unguarded it throws inside the
+ * load-time IIFE and takes the rest of that module with it; guarded with `typeof` it is skipped in
+ * silence and the feature is simply never there — the blank page the import gate's own comment
+ * warned about.
+ *
+ * A NAMESPACE IS A DEPENDENCY. Most of these modules reach a sibling as `DfirState.cell(…)` or
+ * `window.DfirState.cell(…)` rather than as a bare function — 16 of them, including
+ * dashboard-facets.js, which does exactly that at load. An analysis that only matched a call whose
+ * CALLEE is the published name saw none of it, so the dominant shape was invisible; the root of the
+ * callee chain is the name that has to exist, and that is what is checked.
+ *
+ * IT ASKS AT THE CALL SITE, not across the file. The first version joined two file-wide answers —
+ * "is this name free anywhere" and "is it called at load anywhere" — and neither knows the other's
+ * position, so a local called at load was reported on the strength of an unrelated deferred
+ * reference elsewhere in the file. Binding is now resolved where the call actually is.
+ *
+ * WHAT IT WILL NOT SAY. Only calls are considered, not mere references: `const c = Sibling.cell`
+ * and `window.x = sibling` copy a value that may still be undefined, but flagging those would
+ * report most of the facade, and the throw they cause is a separate question from ordering.
+ * Deferred work is out of scope by construction. A module the page never loads has no position, so
+ * it cannot be out of order with anything and is skipped.
+ */
+export function loadOrderViolations(
+  modules: ReadonlyArray<{ file: string; script: DashboardScript }>,
+  publishedBy: ReadonlyMap<string, readonly string[]>,
+  order: ReadonlyMap<string, number>,
+): LoadOrderViolation[] {
+  const out: LoadOrderViolation[] = [];
+  for (const { file, script } of modules) {
+    const mine = order.get(file);
+    if (mine === undefined) continue;
+    for (const dep of loadTimeDependencies(script)) {
+      for (const to of publishedBy.get(dep.name) ?? []) {
+        const at = order.get(to);
+        if (to === file || at === undefined || at <= mine) continue;
+        out.push({ from: file, name: dep.name, to, line: dep.line });
+      }
+    }
+  }
+  return out;
+}
+
+/** The names of every binding a pattern introduces: `{ a, b: [c] }` gives a and c. */
+function bindingNamesOf(n: ts.Node, out: Set<string>): void {
+  if (ts.isIdentifier(n)) out.add(n.text);
+  else if (ts.isObjectBindingPattern(n) || ts.isArrayBindingPattern(n)) {
+    for (const e of n.elements) if (ts.isBindingElement(e)) bindingNamesOf(e.name, out);
+  }
+}
+
+const scopeDeclCache = new Map<ts.Node, Set<string>>();
+
+/** Every name this scope introduces: parameters, catch bindings, and its own declarations. */
+function declaredInScope(scope: ts.Node): Set<string> {
+  const cached = scopeDeclCache.get(scope);
+  if (cached) return cached;
+  const out = new Set<string>();
+  if (isFunctionLike(scope)) {
+    const fn = scope as ts.FunctionLikeDeclaration;
+    for (const p of fn.parameters) bindingNamesOf(p.name, out);
+    if (ts.isFunctionDeclaration(scope) && scope.name) out.add(scope.name.text);
+  }
+  if (ts.isCatchClause(scope) && scope.variableDeclaration) {
+    bindingNamesOf(scope.variableDeclaration.name, out);
+  }
+  // `var` and function declarations hoist out of nested blocks, so the walk descends through them
+  // and stops only at a nested function, which is a scope of its own.
+  const collect = (n: ts.Node): void => {
+    if (ts.isFunctionDeclaration(n)) {
+      if (n.name) out.add(n.name.text);
+      return;
+    }
+    if (isFunctionLike(n)) return;
+    if (ts.isVariableDeclaration(n)) bindingNamesOf(n.name, out);
+    if (ts.isClassDeclaration(n) && n.name) out.add(n.name.text);
+    ts.forEachChild(n, collect);
+  };
+  const body = isFunctionLike(scope) ? (scope as ts.FunctionLikeDeclaration).body : scope;
+  if (body) ts.forEachChild(body, collect);
+  scopeDeclCache.set(scope, out);
+  return out;
+}
+
+/** Is this name declared by any scope enclosing this node, rather than coming from the page? */
+function boundAt(node: ts.Node, name: string): boolean {
+  for (let p: ts.Node | undefined = node.parent; p; p = p.parent) {
+    const isScope =
+      isFunctionLike(p) ||
+      ts.isSourceFile(p) ||
+      ts.isBlock(p) ||
+      ts.isCatchClause(p) ||
+      ts.isForStatement(p) ||
+      ts.isForOfStatement(p) ||
+      ts.isForInStatement(p);
+    if (isScope && declaredInScope(p).has(name)) return true;
+  }
+  return false;
+}
+
+/**
+ * The name a call needs to already exist: the root of its callee chain.
+ *
+ * `lateThing()` needs `lateThing`; `DfirState.cell()` needs `DfirState`; and a chain rooted at a
+ * global object needs the segment AFTER it, because `window.DfirState.cell()` depends on
+ * `DfirState` and not on `window`.
+ */
+function calleeRoot(call: ts.CallExpression): { name: string; node: ts.Node } | null {
+  const strip = (n: ts.Node): ts.Node => {
+    let cur = n;
+    while (ts.isParenthesizedExpression(cur)) cur = cur.expression;
+    return cur;
+  };
+  let cur = strip(call.expression);
+  // `f.call(…)` / `f.apply(…)` — the invoked function is the object, not the property.
+  if (ts.isPropertyAccessExpression(cur) && (cur.name.text === "call" || cur.name.text === "apply")) {
+    cur = strip(cur.expression);
+  }
+  const chain: ts.Node[] = [];
+  while (ts.isPropertyAccessExpression(cur) || ts.isElementAccessExpression(cur)) {
+    chain.unshift(cur);
+    cur = strip(cur.expression);
+  }
+  if (!ts.isIdentifier(cur)) return null;
+  if (!GLOBAL_ROOTS.has(cur.text)) return { name: cur.text, node: cur };
+  const first = chain[0];
+  if (first && ts.isPropertyAccessExpression(first)) return { name: first.name.text, node: first.name };
+  if (first && ts.isElementAccessExpression(first) && ts.isStringLiteralLike(first.argumentExpression)) {
+    return { name: first.argumentExpression.text, node: first.argumentExpression };
+  }
+  return null;
+}
+
+/**
+ * Every name a script CALLS while it loads, that it does not bind itself at that call site.
+ *
+ * IT CANNOT USE walkLoadTime(). That walk follows every identifier ARGUMENT of every call, so
+ * `addEventListener("click", h)` and `setTimeout(h, 0)` are walked as though the handler had
+ * already run. That is deliberate and correct there — #477 asks "does the page really call this"
+ * and #476 asks "is this reference one hop from load", and both are answered by the wiring
+ * existing at all. This asks the narrower question of what runs BEFORE THE PARSER REACHES THE
+ * NEXT <script>, where a registered handler is precisely the thing that has NOT run yet, and
+ * reporting it would reject the safest way to depend on a sibling. So the traversal here follows
+ * only what genuinely runs now: the top level, an IIFE, a local function something calls, and a
+ * callback handed to an Array method that invokes synchronously.
+ */
+export function loadTimeDependencies(script: DashboardScript): Array<{ name: string; line: number }> {
+  const out: Array<{ name: string; line: number }> = [];
+  const sf = script.ast;
+  const declared = declaredFunctionsOf(script);
+  const entered = new Set<ts.Node>();
+
+  const strip = (n: ts.Node): ts.Node => {
+    let cur = n;
+    while (ts.isParenthesizedExpression(cur)) cur = cur.expression;
+    return cur;
+  };
+  const iifeBodyOf = (n: ts.CallExpression): ts.Node | null => {
+    let callee = strip(n.expression);
+    if (
+      ts.isPropertyAccessExpression(callee) &&
+      (callee.name.text === "call" || callee.name.text === "apply")
+    ) {
+      callee = strip(callee.expression);
+    }
+    return ts.isFunctionExpression(callee) || ts.isArrowFunction(callee) ? callee.body : null;
+  };
+
+  const enter = (fn: ts.Node | undefined): void => {
+    if (!fn || entered.has(fn)) return; // and it stops recursion, direct or mutual
+    entered.add(fn);
+    // The DECLARATION's children, not the body alone, so a default parameter value is in scope.
+    ts.forEachChild(fn, visit);
+  };
+
+  const visit = (n: ts.Node): void => {
+    if (ts.isCallExpression(n)) {
+      const root = calleeRoot(n);
+      if (root && !boundAt(root.node, root.name)) {
+        out.push({
+          name: root.name,
+          line: sf.getLineAndCharacterOfPosition(root.node.getStart(sf)).line + 1,
+        });
+      }
+      const body = iifeBodyOf(n);
+      if (body) {
+        ts.forEachChild(body, visit);
+        // An IIFE's ARGUMENTS are evaluated at load too — `(fn => …)(DfirTimelineView)`.
+        for (const arg of n.arguments) visit(arg);
+        return;
+      }
+      const callee = strip(n.expression);
+      if (ts.isIdentifier(callee)) enter(declared.get(callee.text));
+      if (ts.isPropertyAccessExpression(callee) && SYNC_CALLBACK_INVOKERS.has(callee.name.text)) {
+        for (const arg of n.arguments) {
+          const a = strip(arg);
+          if (ts.isIdentifier(a)) enter(declared.get(a.text));
+          else if (ts.isFunctionExpression(a) || ts.isArrowFunction(a)) enter(a);
+        }
+      }
+      ts.forEachChild(n, visit);
+      return;
+    }
+    if (isFunctionLike(n)) return; // judged on its own pass, only if something calls it at load
+    ts.forEachChild(n, visit);
+  };
+
+  ts.forEachChild(sf, visit);
   return out;
 }
 

--- a/public/js/dashboard-ioc-provenance.js
+++ b/public/js/dashboard-ioc-provenance.js
@@ -375,11 +375,6 @@
   // keeps the refresh fan-out alive — and a no-op panel looks exactly like a panel with nothing
   // to show. DfirFacade.stubbed records which names the facade had to fill in, so asking it is
   // how a module with no entry point of its own still gets to say it is gone.
-  if (window.DfirFacade && window.DfirFacade.filled.includes("loadBeacons")) {
-    dfirFeatureUnavailable(
-      "Beacons, evidence gaps, playbook match and mitigations",
-    );
-  }
 
   // Timeline Gaps (#83) moved to js/dashboard-timeline-gaps.js (#415 tier 3). No initializer.
   // Memory Next Steps (#101) moved to js/dashboard-memory-next-steps.js (#415 tier 3).
@@ -404,13 +399,22 @@
     return iocProvenanceChains[iocId];
   }
 
-  // The persisted risk-filter choice. Also the module's only load-time work, so it is the whole
-  // initializer.
+  // The persisted risk-filter choice, and the facade probe below.
   function initIocProvenance() {
     try {
       riskIocsFilter =
         parseInt(localStorage.getItem("dfir.risk.iocs") || "0", 10) || 0;
     } catch {}
+    // THE PROBE HAS TO RUN HERE, not at module load, which is where it used to sit. The facade is
+    // ten module tags further down the page, so `window.DfirFacade` was always undefined then, the
+    // guard was always false, and the notice could never appear -- a feature reporting its own
+    // absence, silently absent itself. The page calls this initializer after every module, which is
+    // the first moment the answer exists. Found by the load-order gate, #482.
+    if (window.DfirFacade && window.DfirFacade.filled.includes("loadBeacons")) {
+      dfirFeatureUnavailable(
+        "Beacons, evidence gaps, playbook match and mitigations",
+      );
+    }
   }
 
   // ---- what the controls set ----


### PR DESCRIPTION
Closes #482.

## The gate that cannot fire

`check:imports` includes `public/js/**` so that *"the first cycle between extracted feature modules fails a PR"*. It cannot. All **138** modules #415 has produced are classic scripts publishing onto `window` — deliberately, so a feature survives a sibling 404 — and **not one** uses `import`/`export`. A graph resolved by regex over import statements sees 138 nodes and 0 edges, while the real graph is **~463 edges** carried by globals.

## Cycles are the wrong question here

The issue proposed a cycle gate. Measuring first showed why that is not the right fix:

- There are already **32 cycles**, not the 0 the issue reports. A hard cycle gate would fail on day one and need a 32-entry baseline.
- They are harmless. Cycle-detection reasoning comes from ES modules, where a cycle means a half-initialised binding. In classic scripts every cross-module name resolves through `window` at *call* time, so two features whose click handlers call each other are fine.

**Order** is what actually bites, and it is what the import gate's own comment described — *"discovered later from a blank page"*, which PR #475 hit twice. A module calling a sibling's published name **during load** runs before that sibling's tag. Unguarded it throws inside the load-time IIFE and takes the rest of the module with it; guarded with `typeof` it is skipped in silence and the feature is simply never there.

## It found a real bug on its first honest run

`dashboard-ioc-provenance.js` probed `window.DfirFacade` at its own load — ten module tags before `dashboard-facade.js` publishes it. The guard was always false, so the "Beacons, evidence gaps, playbook match and mitigations unavailable" notice **could never appear**: the exact failure mode, in the code that existed to report it. `loadBeacons` was not in the page's probe list either, so deleting the dead block would have lost the coverage. The probe moves to the inline script beside its siblings, which runs after every module.

With it fixed the count is zero, so the gate is **hard and unbaselined**.

## Review found the first cut unsound both ways

All three reproduced against the live helper before any change:

| Finding | Fix |
|---|---|
| Could not see `DfirState.cell(…)` — the spelling **16 modules** use | `calleeRoot()` takes the root of the callee chain, seeing through `window` and `window["…"]` |
| Rejected safe deferred wiring (`addEventListener("click", h)`) | Fixed **locally**. Restricting `invokedNames()` centrally broke four #476/#477 tests, and they are right — those ask whether the page wires a name *at all* |
| Reported a local that merely shared a sibling's spelling | `boundAt()` resolves binding at the call site instead of joining two file-wide analyses |

## Test plan

- [x] 24 tests: 16 seam tests on purpose-built sources, plus the real gate over 138 modules / 143 tags. Asking the real files alone proves nothing — they return `[]` whether the analysis works or not.
- [x] Every shape has a partner asserting what must stay silent: earlier-loading callee, deferred handler, inline and named callbacks, timers, promise callbacks, module-local namespace, read-but-not-called, untagged file.
- [x] Proved against a real module: injecting a guarded load-time call into `dashboard-state.js` reaching `dashboard-swimlane.js` fails the gate.
- [x] Full suite **9042 passed**, 0 failed. `typecheck`, `lint`, `check:imports`, `prettier --check` clean.

## Docs

`ARCHITECTURE.md` and the `PUBLIC_JS` comment stop claiming a gate that cannot fire and point at the new one, with the reasoning recorded so the cycle question is not re-litigated. The stale line calling the six pre-#415 ES modules "the extraction pattern" is corrected — they predate #415 and are not what it produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDHArgeNeoPwqzgdDdm728