### PR TITLE
test(server): poll for the presidio activity-log entries instead of racing the write (#489)

### DIFF
--- a/companion/tests/helpers/activityLog.ts
+++ b/companion/tests/helpers/activityLog.ts
@@ -1,0 +1,53 @@
+import request from "supertest";
+import { pollFor } from "./poll.js";
+
+/**
+ * Wait for an activity-log entry to appear after the mutation that writes it has already responded.
+ *
+ * logActivity is DELIBERATELY FIRE-AND-FORGET — `void logActivity(...)` in the routes — so that a
+ * failed log write can never fail the analyst's request. 68 of the 77 call sites are written that
+ * way. The consequence is that the response can be sent before the entry lands, and reading the log
+ * straight after the POST races the write: it wins on a fast dev box and loses on contended CI.
+ *
+ * SO THE WAIT IS THE CORRECT ASSERTION, not a workaround for one. The nine routes that DO await
+ * their append are the ones the dashboard re-reads the moment they respond, and those are pinned
+ * separately by activityLogReadAfterWrite.test.ts against a deliberately slowed store, so dropping
+ * one of those awaits fails every run. A caller reaching for this helper is saying the opposite: no
+ * client reads this log synchronously, so the entry is allowed to arrive a moment later.
+ *
+ * The budget is WALL-CLOCK, via pollFor. A fixed attempt count reports a timeout as a missing entry
+ * — the same symptom the lost write produces — which is how #408 and #489 both got filed as
+ * mysteries rather than as the one-line races they were.
+ */
+export async function awaitActivityEntry(
+  app: Parameters<typeof request>[0],
+  caseId: string,
+  action: string,
+): Promise<{ action: string; detail?: string }> {
+  let seen: string[] = [];
+  return pollFor(
+    () => `an activity-log entry for "${action}" on case ${caseId}, saw only [${seen.join(", ")}]`,
+    async () => {
+      const log = await request(app).get(`/cases/${caseId}/activity-log`);
+      const entries = log.body as { action: string; detail?: string }[];
+      seen = entries.map((e) => e.action);
+      return entries.find((e) => e.action === action);
+    },
+  );
+}
+
+/**
+ * Every activity-log entry for one action, once at least one has arrived.
+ *
+ * The count matters where a test is proving a mutation logs ONCE — a duplicate entry is a real
+ * defect, and asserting on the first match alone would miss it.
+ */
+export async function awaitActivityEntries(
+  app: Parameters<typeof request>[0],
+  caseId: string,
+  action: string,
+): Promise<{ action: string; detail?: string }[]> {
+  await awaitActivityEntry(app, caseId, action);
+  const log = await request(app).get(`/cases/${caseId}/activity-log`);
+  return (log.body as { action: string; detail?: string }[]).filter((e) => e.action === action);
+}

--- a/companion/tests/server/deepPassRoutes.test.ts
+++ b/companion/tests/server/deepPassRoutes.test.ts
@@ -6,10 +6,11 @@ import request from "supertest";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+import { awaitActivityEntry } from "../helpers/activityLog.js";
 import { createApp, buildRuntimePipeline } from "../../src/server.js";
 import { emptyState, type ForensicEvent, type Severity } from "../../src/analysis/stateTypes.js";
 import type { AIProvider, AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
-import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
+import { POLL_TIMEOUT_MS } from "../helpers/poll.js";
 
 class ScriptedProvider implements AIProvider {
   readonly name = "scripted";
@@ -19,12 +20,21 @@ class ScriptedProvider implements AIProvider {
   async analyze(req: AnalyzeRequest): Promise<AnalyzeResult> {
     if (/ONE SLICE/i.test(req.systemPrompt)) {
       if (this.failBatches) throw new Error("Bad control character in string literal in JSON");
-      return { rawText: JSON.stringify({ observations: [{ summary: "s", eventIds: ["c0"], whyItMatters: "w" }] }) };
+      return {
+        rawText: JSON.stringify({ observations: [{ summary: "s", eventIds: ["c0"], whyItMatters: "w" }] }),
+      };
     }
     return {
       rawText: JSON.stringify({
-        findings: [], iocs: [], mitreTechniques: [], attackerPath: "", summary: "s",
-        forensicEvents: [], threadsOpened: [], threadsClosed: [], timelineNote: "",
+        findings: [],
+        iocs: [],
+        mitreTechniques: [],
+        attackerPath: "",
+        summary: "s",
+        forensicEvents: [],
+        threadsOpened: [],
+        threadsClosed: [],
+        timelineNote: "",
       }),
     };
   }
@@ -44,11 +54,16 @@ function events(): ForensicEvent[] {
       timestamp: `2026-05-20T${String(i % 24).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}:00Z`,
       description: `${p} detection ${title(i)}`,
       severity: sev,
-      mitreTechniques: [], relatedFindingIds: [], sourceScreenshots: [],
+      mitreTechniques: [],
+      relatedFindingIds: [],
+      sourceScreenshots: [],
     }));
   return [
-    ...mk(10, "Critical", "c"), ...mk(40, "High", "h"), ...mk(60, "Medium", "m"),
-    ...mk(90, "Low", "l"), ...mk(20, "Info", "i"),
+    ...mk(10, "Critical", "c"),
+    ...mk(40, "High", "h"),
+    ...mk(60, "Medium", "m"),
+    ...mk(90, "Low", "l"),
+    ...mk(20, "Info", "i"),
   ];
 }
 
@@ -68,38 +83,17 @@ async function makeApp(opts: { aiConfigured?: boolean; failBatches?: boolean } =
   // Every AI-status broadcast the route makes, in order — the dashboard's "AI:" pill reads these.
   const aiStatus: { status: string; phase?: string; detail?: string }[] = [];
   const app = createApp(store, {
-    pipeline, stateStore, aiConfigured: opts.aiConfigured !== false,
+    pipeline,
+    stateStore,
+    aiConfigured: opts.aiConfigured !== false,
     activityLogStore: new ActivityLogStore(store),
-    onAiStatus: (_caseId, evt) => { aiStatus.push(evt); },
+    onAiStatus: (_caseId, evt) => {
+      aiStatus.push(evt);
+    },
   });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
   await stateStore.save({ ...emptyState("c1"), forensicTimeline: events() });
   return { app, stateStore, aiStatus };
-}
-
-// logActivity is deliberately FIRE-AND-FORGET (`void store.add(...)` in activityLog.ts) so a log
-// write can never fail the request — which means the response can be sent before the entry lands.
-// Reading the log straight after the POST therefore races the write: it wins on a fast dev box and
-// loses on contended CI (seen live: `Cannot read properties of undefined (reading 'detail')`).
-// Poll for the entry instead of assuming it has arrived; the assertion is unchanged, only the wait.
-// The wait itself is a WALL-CLOCK budget: the 50x20ms loop this replaces returned `undefined` when
-// it expired, so the caller's `expect(entry).toBeTruthy()` reported the timeout as a missing log
-// entry — the same defect the fire-and-forget write would produce (issue #408).
-async function awaitActivityEntry(
-  app: Parameters<typeof request>[0],
-  caseId: string,
-  action: string,
-): Promise<{ action: string; detail?: string }> {
-  let seen: string[] = [];
-  return pollFor(
-    () => `an activity-log entry for "${action}" on case ${caseId}, saw only [${seen.join(", ")}]`,
-    async () => {
-      const log = await request(app).get(`/cases/${caseId}/activity-log`);
-      const entries = log.body as { action: string; detail?: string }[];
-      seen = entries.map((e) => e.action);
-      return entries.find((e) => e.action === action);
-    },
-  );
 }
 
 describe("deep-pass routes", () => {
@@ -114,7 +108,12 @@ describe("deep-pass routes", () => {
     const res = await request(app).get("/cases/c1/deep-pass/preview");
 
     expect(res.status).toBe(200);
-    expect(res.body.floors.map((f: { floor: string }) => f.floor)).toEqual(["Critical", "High", "Medium", "Low"]);
+    expect(res.body.floors.map((f: { floor: string }) => f.floor)).toEqual([
+      "Critical",
+      "High",
+      "Medium",
+      "Low",
+    ]);
     for (const f of res.body.floors) {
       expect(f).toHaveProperty("events");
       expect(f).toHaveProperty("rows");
@@ -129,7 +128,7 @@ describe("deep-pass routes", () => {
     const res = await request(app).get("/cases/c1/deep-pass/preview");
 
     const low = res.body.floors.find((f: { floor: string }) => f.floor === "Low");
-    expect(low.events).toBe(200);   // 10 + 40 + 60 + 90, the 20 Info excluded
+    expect(low.events).toBe(200); // 10 + 40 + 60 + 90, the 20 Info excluded
   });
 
   it("POST .../deep-pass rejects an unparseable minSeverity rather than defaulting", async () => {
@@ -137,7 +136,7 @@ describe("deep-pass routes", () => {
 
     const res = await request(app).post("/cases/c1/deep-pass").send({ minSeverity: "banana" });
 
-    expect(res.status).toBe(400);   // must NOT silently fall back to reading everything
+    expect(res.status).toBe(400); // must NOT silently fall back to reading everything
   });
 
   it("POST .../deep-pass runs the pass and returns its summary", async () => {
@@ -175,9 +174,9 @@ describe("deep-pass routes", () => {
 
     await request(app).post("/cases/c1/deep-pass").send({ minSeverity: "Low" });
 
-    const batchLines = aiStatus.filter(e => /batch \d+ of \d+/i.test(String(e.detail)));
+    const batchLines = aiStatus.filter((e) => /batch \d+ of \d+/i.test(String(e.detail)));
     expect(batchLines.length).toBeGreaterThan(0);
-    expect(batchLines.every(e => e.status === "analyzing" && e.phase === "deep-pass")).toBe(true);
+    expect(batchLines.every((e) => e.status === "analyzing" && e.phase === "deep-pass")).toBe(true);
   });
 
   it("leaves the pill idle — not stuck analyzing — when a run is refused", async () => {
@@ -237,16 +236,20 @@ describe("deep-pass routes", () => {
   // A run whose batches failed read LESS than it appears to. The HTTP body is transient — the
   // activity log is the durable record an analyst re-reads days later, so partial coverage has to
   // survive there too, or an incomplete read is silently filed as a complete one.
-  it("records failed batches in the activity log, not just in the response body", async () => {
-    const { app } = await makeApp({ failBatches: true });
+  it(
+    "records failed batches in the activity log, not just in the response body",
+    async () => {
+      const { app } = await makeApp({ failBatches: true });
 
-    const res = await request(app).post("/cases/c1/deep-pass").send({ minSeverity: "High" });
-    expect(res.status).toBe(200);
-    expect(res.body.batchesFailed).toBeGreaterThan(0);
+      const res = await request(app).post("/cases/c1/deep-pass").send({ minSeverity: "High" });
+      expect(res.status).toBe(200);
+      expect(res.body.batchesFailed).toBeGreaterThan(0);
 
-    const entry = await awaitActivityEntry(app, "c1", "deep-pass");
-    expect(String(entry.detail)).toMatch(/fail/i);
-  }, POLL_TIMEOUT_MS * 2);   // one poll budget, doubled to leave room for setup + assertions
+      const entry = await awaitActivityEntry(app, "c1", "deep-pass");
+      expect(String(entry.detail)).toMatch(/fail/i);
+    },
+    POLL_TIMEOUT_MS * 2,
+  ); // one poll budget, doubled to leave room for setup + assertions
 
   // The dashboard must be able to DISABLE the Run button up front instead of letting the analyst
   // click into a 501. /health.aiEnabled is the VISION gate (hasAiProvider) and answers the wrong
@@ -267,12 +270,16 @@ describe("deep-pass routes", () => {
     expect(res.body.synthesisEnabled).toBe(false);
   });
 
-  it("says nothing about failures when every batch succeeded", async () => {
-    const { app } = await makeApp();
+  it(
+    "says nothing about failures when every batch succeeded",
+    async () => {
+      const { app } = await makeApp();
 
-    await request(app).post("/cases/c1/deep-pass").send({ minSeverity: "High" });
+      await request(app).post("/cases/c1/deep-pass").send({ minSeverity: "High" });
 
-    const entry = await awaitActivityEntry(app, "c1", "deep-pass");
-    expect(String(entry.detail)).not.toMatch(/fail/i);
-  }, POLL_TIMEOUT_MS * 2);
+      const entry = await awaitActivityEntry(app, "c1", "deep-pass");
+      expect(String(entry.detail)).not.toMatch(/fail/i);
+    },
+    POLL_TIMEOUT_MS * 2,
+  );
 });

--- a/companion/tests/server/presidioRoutes.test.ts
+++ b/companion/tests/server/presidioRoutes.test.ts
@@ -14,6 +14,7 @@ import { sendPipelineError } from "../../src/routes/presidioApproval.js";
 import { ActivityLogStore } from "../../src/analysis/activityLog.js";
 import { LoggerImpl, createConsoleLogger } from "../../src/logging/logger.js";
 import { createApp, setServerLogger } from "../../src/server.js";
+import { awaitActivityEntries } from "../helpers/activityLog.js";
 
 let app: ReturnType<typeof createApp>;
 let cases: CaseStore;
@@ -28,19 +29,24 @@ let loggedLines: string[];
 
 beforeEach(async () => {
   loggedLines = [];
-  setServerLogger(new LoggerImpl({
-    level: "info",
-    sessionLogPath: null,
-    consoleFns: {
-      log: (s) => loggedLines.push(s),
-      warn: (s) => loggedLines.push(s),
-      error: (s) => loggedLines.push(s),
-    },
-  }));
+  setServerLogger(
+    new LoggerImpl({
+      level: "info",
+      sessionLogPath: null,
+      consoleFns: {
+        log: (s) => loggedLines.push(s),
+        warn: (s) => loggedLines.push(s),
+        error: (s) => loggedLines.push(s),
+      },
+    }),
+  );
   const root = await mkdtemp(join(tmpdir(), "dfir-presidioroute-"));
   cases = new CaseStore(root);
   await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
-  app = createApp(cases, { stateStore: new StateStore(cases), activityLogStore: new ActivityLogStore(cases) });
+  app = createApp(cases, {
+    stateStore: new StateStore(cases),
+    activityLogStore: new ActivityLogStore(cases),
+  });
   pendingStore = new PresidioPendingStore(cases);
   discoveredStore = new DiscoveredEntitiesStore(cases);
   customStore = new CustomEntitiesStore(cases);
@@ -99,9 +105,7 @@ describe("presidio approval routes", () => {
   });
 
   it("POST .../suppress vetoes a value and clears it from pending", async () => {
-    const res = await request(app)
-      .post("/cases/c1/presidio-pending/suppress")
-      .send({ value: "Jane Doe" });
+    const res = await request(app).post("/cases/c1/presidio-pending/suppress").send({ value: "Jane Doe" });
     expect(res.status).toBe(200);
     expect((await discoveredStore.load("c1")).suppressed).toContain("jane doe");
     expect(await pendingStore.load("c1")).toEqual([]);
@@ -124,12 +128,16 @@ describe("presidio approval routes", () => {
   });
 
   it("POST .../approve rejects an invalid case id", async () => {
-    const res = await request(app).post("/cases/bad%20id/presidio-pending/approve").send({ value: "Jane Doe" });
+    const res = await request(app)
+      .post("/cases/bad%20id/presidio-pending/approve")
+      .send({ value: "Jane Doe" });
     expect(res.status).toBe(400);
   });
 
   it("POST .../suppress rejects an invalid case id", async () => {
-    const res = await request(app).post("/cases/bad%20id/presidio-pending/suppress").send({ value: "Jane Doe" });
+    const res = await request(app)
+      .post("/cases/bad%20id/presidio-pending/suppress")
+      .send({ value: "Jane Doe" });
     expect(res.status).toBe(400);
   });
 
@@ -153,29 +161,29 @@ describe("presidio approval routes", () => {
       .post("/cases/c1/presidio-pending/approve")
       .send({ value: "Jane Doe", category: "PERSON" });
     expect(res.status).toBe(200);
-    const log = await request(app).get("/cases/c1/activity-log");
-    const entries = log.body.filter((e: { action: string }) => e.action === "presidio-approve");
+    // POLLED, not read straight off the response. The approve route logs fire-and-forget (`void
+    // logActivity(...)` in anonymization.ts) so a log failure can never fail the analyst's action,
+    // and nothing in the Presidio panel re-reads the log after approving — so the entry is allowed
+    // to land a moment later, and reading immediately just races it. On CI it lost (#489).
+    const entries = await awaitActivityEntries(app, "c1", "presidio-approve");
     expect(entries).toHaveLength(1);
     expect(entries[0].detail).not.toContain("Jane Doe");
     expect(entries[0].detail).toContain("PERSON");
   });
 
   it("does not write the suppressed value's text to the server log", async () => {
-    const res = await request(app)
-      .post("/cases/c1/presidio-pending/suppress")
-      .send({ value: "Jane Doe" });
+    const res = await request(app).post("/cases/c1/presidio-pending/suppress").send({ value: "Jane Doe" });
     expect(res.status).toBe(200);
     expect(loggedLines.some((l) => l.includes("Jane Doe"))).toBe(false);
     expect(loggedLines.some((l) => /suppressed a finding/.test(l))).toBe(true);
   });
 
   it("does not write the suppressed value's text to the case's activity log", async () => {
-    const res = await request(app)
-      .post("/cases/c1/presidio-pending/suppress")
-      .send({ value: "Jane Doe" });
+    const res = await request(app).post("/cases/c1/presidio-pending/suppress").send({ value: "Jane Doe" });
     expect(res.status).toBe(200);
-    const log = await request(app).get("/cases/c1/activity-log");
-    const entries = log.body.filter((e: { action: string }) => e.action === "presidio-suppress");
+    // Same race as the approve case above, and #489 named only that one — this shape is the class,
+    // not the instance. Slowing the log store made both fail every run.
+    const entries = await awaitActivityEntries(app, "c1", "presidio-suppress");
     expect(entries).toHaveLength(1);
     expect(entries[0].detail).not.toContain("Jane Doe");
   });
@@ -186,8 +194,14 @@ function fakeRes(): Response & { statusCode: number; body: unknown } {
   const res = {
     statusCode: 200,
     body: undefined as unknown,
-    status(code: number) { res.statusCode = code; return res; },
-    json(payload: unknown) { res.body = payload; return res; },
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
   };
   return res as unknown as Response & { statusCode: number; body: unknown };
 }


### PR DESCRIPTION
Closes #489.

## The mechanism, confirmed at source

`companion/src/routes/anonymization.ts:230`:

```ts
void logActivity(options.activityLogStore, options.onActivity, caseId, { ... });
return res.json({ pending: rest });
```

The `void` discards the promise, then the route responds. Reading the activity log straight after the POST races the write — it wins on a fast dev box and loses on contended CI. No need to infer this from the flake profile; it's unambiguous in the code.

## Fire-and-forget is correct here, so the wait is the honest assertion

| | count |
|---|---|
| `void logActivity(...)` in `src/routes/` | **68** |
| `await logActivity(...)` | **9** |

The `void` is deliberate: a failed log write must never fail the analyst's action. The nine awaited routes are the ones the dashboard re-reads the moment they respond, and they stay pinned by `activityLogReadAfterWrite.test.ts` against a deliberately slowed store, so dropping one of those `await`s fails every run.

I checked which side presidio is on: `dashboard-presidio.js:243` posts the approval and **never** re-reads the log. Nothing consumes a read-after-write guarantee on this route, so making it `await` would tax every approval for a promise no client uses. Polling is the correct fix, not a workaround — and the helper's docstring says so, and points at the other suite, so the next reader can tell a legitimate wait from timing superstition.

## Two tests, and no third copy of the helper

- **The issue named one test.** The suppress case at `presidioRoutes.test.ts:177` has the identical shape. Slowing the log store made **both** fail every run.
- **The helper already existed twice.** #408 built `pollFor` plus a local `awaitActivityEntry` inside `deepPassRoutes.test.ts`, with a comment describing this exact race. #220 built the read-after-write suite. Presidio was in neither. `awaitActivityEntry` moves to `tests/helpers/activityLog.ts` and `deepPassRoutes.test.ts` imports it — 25 lines of duplication folded rather than a third copy added.

## Test plan

- [x] **RED under the real condition:** injecting a 50 ms delay into the `ActivityLogStore` made both tests fail every run — the intermittent CI failure reproduced deterministically.
- [x] **GREEN with the delay still injected:** all 17 presidio tests pass, proving the poll actually closes the race rather than getting lucky.
- [x] Delay removed, still green.
- [x] `deepPassRoutes.test.ts` green after folding (15 tests).
- [x] Full suite **9042 passed**, 0 failed. `typecheck`, `lint`, `prettier --check` clean.
- [x] Assertions unchanged — only the wait. The security property (the PII value never reaching the log) is still asserted by the sibling tests against `loggedLines`, which are synchronous and unaffected.

## One correction to the issue

Its argument that a leaked entry *"would make this assert see 2"* does not hold: `beforeEach` builds a fresh `mkdtemp` root and a fresh app per test, so cross-test contamination was never possible. The conclusion — not order contamination — was right; that reasoning was not. Worth knowing so nobody re-derives the wrong isolation model from it.

## Not done

The other 66 `void logActivity` sites are untouched. Only these two had tests racing them; the shared helper is now the obvious tool if another turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDHArgeNeoPwqzgdDdm728