### PR TITLE
fix(dashboard): stub #415's last four modules in the facade (#415)

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4625,7 +4625,7 @@
       const reader = new FileReader();
       reader.onload = () => {
         const uri = String(reader.result || "");
-        if (!setReportLogo(uri)) { st.textContent = "logo too large (max ~750 KB) — use a smaller image"; return; }
+        if (setReportLogo(uri) === false) { st.textContent = "logo too large (max ~750 KB) — use a smaller image"; return; }
         st.textContent = "logo loaded — click Save case details"; setTimeout(() => st.textContent = "", 3000);
       };
       reader.onerror = () => { st.textContent = "could not read that image file"; };

--- a/public/js/dashboard-facade.js
+++ b/public/js/dashboard-facade.js
@@ -560,6 +560,28 @@
     "veloClientsList",
     "veloMonAutoBrowsed",
     "setVeloMonAutoBrowsed",
+    // #415's last four extractions. Every one of these was declared in the page before the move, so
+    // it could not fail to resolve; making them modules turned fifteen certainties into cross-module
+    // dependencies, and the render path is among them. commentChip and eachCommentList are called
+    // bare by dashboard-render.js on EVERY render, so without a stub a 404 on the comments module
+    // empties findings and timelines instead of only disabling comments — strictly worse than the
+    // page-declared Map they replaced. initActivityLog and initConfidenceControl are the sentinels
+    // and are guarded at their call sites, so they are deliberately absent.
+    "commentChip",
+    "eachCommentList",
+    "loadComments",
+    "openCommentModal",
+    "closeCommentModal",
+    "renderCommentModal",
+    "postComment",
+    "deleteComment",
+    "loadConfidenceControl",
+    "saveConfidenceControl",
+    "fillReportMeta",
+    "loadReportMeta",
+    "saveReportMeta",
+    "setReportLogo",
+    "loadActivityLog",
   ];
   // Not `window[n] = window[n] || noop`: a name that exists but is not callable is a different bug,
   // and quietly replacing it would hide that one too.


### PR DESCRIPTION
Follow-up to #501. **Confirmed P1 from Codex review of that branch.**

## The regression

`dashboard-facade.js` exists so a feature survives a sibling 404. #501 added four modules and never added their published names to `STUBBED`. All **15** of those names were declared in the inline script before the move, so they could not fail to resolve — turning them into modules turned fifteen certainties into cross-module dependencies with no cover. The extraction made the page *less* resilient than it was.

## Why the comments case is destructive, not degraded

`dashboard-render.js` calls `commentChip()` on every question, thread and finding row, and `eachCommentList()` once per render. Both are bare calls on the **core render path**, so a 404 on `dashboard-comments.js` throws before findings or timelines are written — an empty dashboard, not a dashboard without comments. The `commentsByTarget` Map it replaced was page-declared and always present.

## What's covered, and what deliberately isn't

- **13 names stubbed**, following the `tagChip` precedent — the same shape (a value-returning chip renderer on the render path) already uses the plain no-op stub.
- **`initActivityLog` and `initConfidenceControl` stay out.** They're the sentinels and are `typeof`-guarded at their single call sites, which is the other correct answer the facade documents.
- **`setReportLogo` needed its call site hardened**, not just a stub. It returns a boolean and the page tested `if (!setReportLogo(uri))`, so a stub returning `undefined` would report *"logo too large"* for a module that simply wasn't there. It tests `=== false` now.

## The gate hole — not fixed here

The gate that should have caught this (`dashboardFeatureLifecycle.test.ts`, *"every module name the page calls bare is stubbed by the facade"*) only covers names inside a **load-time refresh fan-out** — a statement making three or more `…Reload()` calls. The render path is not a reload chain, so it stayed green legitimately.

The general form is *"every published name called bare by another script is stubbed or guarded"*. I measured it and it needs care before it can be trusted: a naive version reports 79 uncovered names, but most are an artifact of modelling only `typeof X === "function"` when the page's dominant guard spelling is `typeof X !== "undefined"`. Both need modelling. Worth its own issue rather than a rushed gate.

## Test plan

- [x] Full suite **9082 passed**, 0 failed.
- [x] `lint`, `check:size`, `prettier --check` clean.
- [x] All 15 names verified against **any** `typeof` guard spelling before stubbing — zero were covered.

## How it was found

Codex review scoped to the branch (`--scope branch --base b2fc466f^`). The same reviewer at default working-tree scope had reported the tree clean minutes earlier, because the merged work was no longer in the diff. The scope argument was the difference between a false all-clear and a P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDHArgeNeoPwqzgdDdm728