### PR TITLE
docs(architecture): say which inline-JS measure the target counts (#415)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -227,7 +227,11 @@ belongs in a boundary ledger pretending to be a small fix:
    `analysis ↔ integrations` edge has to be ledgered whichever layer the directory is assigned.
 2. **`public/dashboard.html` is decomposed, and all three of its targets are met.** Its inline
    JavaScript is 1,964 lines against the 2,000-line target, down from 19,203 when #384 wired the
-   gates in. The CSS half finished first: 3,234 lines of `<style>` became `public/css/dashboard-*.css`
+   gates in. **That is all five `<script>` blocks without a `src`, which is what `check:size`
+   ratchets** — 1,776 in the main block plus 82, 45, 43 and 18 in the four small ones. The main
+   block alone is the flattering number and has never been the measure; #490 caught it circulating
+   as if it were, at a point when choosing it would have closed #415 with 170 extractable lines
+   still inline. The CSS half finished first: 3,234 lines of `<style>` became `public/css/dashboard-*.css`
    — since split by concern into seven files, the largest 488 lines — leaving 4 lines that are a DOM
    node the runtime writes into rather than a stylesheet. #415 is closed.
 


### PR DESCRIPTION
Supersedes #490, carrying forward the one part of it that outlived the work.

## The problem #490 found is real

Two numbers were in circulation for the same target, and `ARCHITECTURE.md` named neither:

| measure | today | reads as |
|---|---|---|
| all five src-less `<script>` blocks — what `check:size` ratchets | **1,964** | met |
| main block alone | **1,776** | met, with 224 lines of apparent headroom |

Only the first has ever been the measure. The gap is 188 lines across four small blocks (82 + 45 + 43 + 18).

## Why this matters *more* now the target is met, not less

"1,964 against 2,000" invites the next reader to re-measure. Measuring the main block gives 1,776 and 224 lines of headroom under a budget that is **shrink-only and has none**. One sentence closes that off.

## Why #490 itself is superseded

It was written when the target was unreachable, and proposed two things to reach it:

- **Exclude the 18-line pre-paint theme bootstrap** from the measure. Not needed — 1,964 is under 2,000 with it counted, and introducing an exclusion to a target that is already met only weakens it.
- **Extract the team-mode fetch wrapper, and the two status cards** (82 + 45 + 43) to reach 1,985. Superseded — #501 took 193 lines out of the main block instead and landed at 1,964 on the strict measure.

Its worry that *"picking the flattering number would have closed #415 on 170 lines of extractable code"* is precisely what this sentence now prevents. Credit where due: that's the finding being preserved.

## Test plan

- [x] `tests/architecture/` — 60 passed. Docs only; no code, no gate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDHArgeNeoPwqzgdDdm728