### PR TITLE
test(jobDurability): wait for the resume handler, not for the status flip (#506)

### DIFF
--- a/companion/tests/analysis/jobDurability.test.ts
+++ b/companion/tests/analysis/jobDurability.test.ts
@@ -250,11 +250,15 @@ describe("durable job ledger", () => {
       ok: true,
       job: { id: registered.jobId, cancellable: true },
     });
-    await pollFor("resumed EVTX job starting", async () => {
-      return restarted.get(registered.jobId)?.status === "running" ? true : undefined;
-    });
+    // Wait for handler entry, not for the status flip. `scheduleQueued` marks the job "running"
+    // and only resolves its admission after an intervening ledger write, so a poll on the status
+    // can return a full disk round-trip before `runResumedJob` invokes the handler — which is what
+    // sets `receivedSignal` (issue #506). Handler entry implies "running": `runResumedJob` bails
+    // unless the job is running, so this poll subsumes the status check rather than dropping it.
+    await pollFor("the resumed EVTX job's handler to receive its abort signal", async () => receivedSignal);
 
     expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(restarted.get(registered.jobId)?.status).toBe("running");
     expect(await restarted.cancel(registered.jobId)).toMatchObject({ ok: true });
     expect(receivedSignal?.aborted).toBe(true);
   });


### PR DESCRIPTION
Fixes #506.

## The gap is wider than the issue estimates

#506 reads the race as a single `await` boundary. It is a full ledger write. `jobManager.scheduleQueued`:

| line | what happens |
|---|---|
| `:550` | `startJob()` → status becomes `"running"` | ← **the test polled here** |
| `:552` | `await persistUpdate(started)` → a disk round-trip |
| `:554` | `admissions.resolve()` → only now does `runResumedJob` unblock, invoke the handler, and set `receivedSignal` | ← **the test asserted on this** |

So the assertion could fire an entire filesystem write before the handler existed. That write is precisely what a contended runner makes slow — which is why CI failed once and the re-run of the same commit passed.

## Measured, not inferred

A throwaway harness ran the old shape 60×:

| condition | result |
|---|---|
| old shape, idle hardware | **0/60** failures — matches the reported 5/5 local passes |
| old shape, `ledger.update` wrapped with a 100 ms delay (slow CI disk, in exactly that window) | **20/20 failures** |
| **this fix**, identical injection still in place | **0/20** |

The harness was deleted; it is not part of this diff.

## The change

```ts
await pollFor("the resumed EVTX job's handler to receive its abort signal", async () => receivedSignal);

expect(receivedSignal).toBeInstanceOf(AbortSignal);
expect(restarted.get(registered.jobId)?.status).toBe("running");
```

The status check is kept, but demoted from gate to assertion. `runResumedJob:622` returns early unless the job is running, so handler entry **implies** `running`. The poll now waits on the strictly later event and the status claim comes for free — nothing is dropped, the dependency is just inverted the right way round.

## The shape does not repeat

#506 asks whether other assertions in the file follow a status poll with a claim about handler-side state. They do not. All five other status polls in the suite are safe, for two distinct reasons worth separating:

- `jobDurability:210` polls `"succeeded"` then asserts handler-side `resumedFrom` — same surface shape, but safe because `runResumedJob` calls `finish()` **after** `await handler(...)`, making `"succeeded"` a genuine happens-after rather than a proxy.
- `jobDurability:168`, `server/jobs.test.ts:121`, `server.test.ts:1924`, `huntOutcomes.test.ts:216` — each either polls the assertion itself, or asserts on the object it polled.

## One note on the flake family

#506 counts this as the third of a kind, after #489 and #492. It differs in a way that matters for prevention: those were a lost write and a wall-clock threshold, but this wait condition was **structurally wrong from the moment it was written**. It passed for months only because idle hardware closes the window — no amount of re-running would have surfaced it locally.

## Test plan

- [x] Full suite green — **9085/9085**, 574 files
- [x] `tests/analysis/jobDurability.test.ts` — 9/9, five consecutive runs
- [x] Deterministic repro fails 20/20 before, passes 0/20 after, under identical injected delay
- [x] `npx tsc -p tsconfig.test.json` clean
- [x] `npx eslint` clean
- [x] Prettier clean
