### PR TITLE
fix(auth): gate /cases/:id/import-file behind global admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ graphify-out/
 /AGENTS.md
 
 /tools/mcp-servers.json
+
+# Tesseract language models: downloaded into the working directory on first OCR run, ~5 MB each,
+# and reproducible from upstream. Never evidence, never source.
+*.traineddata

--- a/companion/src/auth/policy.ts
+++ b/companion/src/auth/policy.ts
@@ -91,18 +91,21 @@ function pathStarts(path: string, prefix: string): boolean {
 }
 
 function casePolicy(method: string, path: string, caseId: string): RequestPolicy {
+  const suffix = path.slice(`/cases/${caseId}`.length);
   // Express routing is case-insensitive by default, so /PassWord and /IMPORT-FILE reach the same
-  // handlers as their lowercase spellings. Fold case before matching: every segment and pattern
-  // below is lowercase, and the branch they guard is more restrictive than the default one — an
-  // unfolded compare would put an elevated route one shift key away from plain case "write".
-  const suffix = path.slice(`/cases/${caseId}`.length).toLowerCase();
-  if (CASE_GLOBAL_ADMIN_SEGMENTS.some((segment) => pathStarts(suffix, segment))) {
+  // handlers as their lowercase spellings; an unfolded compare would leave an elevated route one
+  // shift key from the permissive "write" default. Fold case ONLY for the checks anchored at a
+  // literal route segment. The review and export checks below scan the whole suffix, which carries
+  // user-named values (an MCP server id, a report version) — folding those would let a server named
+  // "Report" pull POST /mcp/:id/run into the export bucket that a reader holds.
+  const lowerSuffix = suffix.toLowerCase();
+  if (CASE_GLOBAL_ADMIN_SEGMENTS.some((segment) => pathStarts(lowerSuffix, segment))) {
     return { kind: "global", permission: "admin" };
   }
-  if (CASE_READ_SEGMENTS.some((segment) => pathStarts(suffix, segment))) {
+  if (CASE_READ_SEGMENTS.some((segment) => pathStarts(lowerSuffix, segment))) {
     return { kind: "case", permission: "read", caseId };
   }
-  if (CASE_ADMIN_SEGMENTS.some((segment) => pathStarts(suffix, segment))) {
+  if (CASE_ADMIN_SEGMENTS.some((segment) => pathStarts(lowerSuffix, segment))) {
     return { kind: "case", permission: "admin", caseId };
   }
   if (CASE_REVIEW_SEGMENTS.some((segment) => suffix.includes(segment))) {

--- a/companion/src/auth/policy.ts
+++ b/companion/src/auth/policy.ts
@@ -53,6 +53,10 @@ const CASE_ADMIN_SEGMENTS = [
   "/delete",
   "/restore-backup",
 ];
+// Case-scoped routes that nonetheless read the SERVER's own filesystem at an operator-named path.
+// Holding "write" on one case must not let a user name a path outside that case and have its bytes
+// copied in as evidence. Same trust as /nsrl and /kev import-file, already global-admin prefixes.
+const CASE_GLOBAL_ADMIN_SEGMENTS = ["/import-file"];
 const CASE_READ_SEGMENTS = ["/unlock", "/lock-status", "/lock-forget"];
 const CASE_REVIEW_SEGMENTS = [
   "/review",
@@ -88,6 +92,9 @@ function pathStarts(path: string, prefix: string): boolean {
 
 function casePolicy(method: string, path: string, caseId: string): RequestPolicy {
   const suffix = path.slice(`/cases/${caseId}`.length);
+  if (CASE_GLOBAL_ADMIN_SEGMENTS.some((segment) => pathStarts(suffix, segment))) {
+    return { kind: "global", permission: "admin" };
+  }
   if (CASE_READ_SEGMENTS.some((segment) => pathStarts(suffix, segment))) {
     return { kind: "case", permission: "read", caseId };
   }

--- a/companion/src/auth/policy.ts
+++ b/companion/src/auth/policy.ts
@@ -63,6 +63,16 @@ const CASE_GLOBAL_ADMIN_SEGMENTS = ["/import-file"];
 // Exempting the whole /cases/import subtree would hand /cases/import/delete and
 // /cases/import/import-file to any authenticated session.
 const NON_CASE_PATHS = new Set(["/cases/import/encrypted", "/cases/seed-demo"]);
+
+/**
+ * The spelling Express itself would route by: case-insensitive, trailing slash optional (neither
+ * "case sensitive routing" nor "strict routing" is enabled). Matching NON_CASE_PATHS byte-exactly
+ * would miss /cases/seed-demo/ and /cases/import/ENCRYPTED, which the router still serves — the
+ * seeder would then read as a case named "seed-demo" and drop from global admin to case write.
+ */
+function collectionPath(path: string): string {
+  return (path.length > 1 ? path.replace(/\/+$/, "") : path).toLowerCase();
+}
 const CASE_READ_SEGMENTS = ["/unlock", "/lock-status", "/lock-forget"];
 const CASE_REVIEW_SEGMENTS = [
   "/review",
@@ -145,7 +155,7 @@ export function resolveRequestPolicy(method: string, rawPath: string): RequestPo
   }
   if (normalizedMethod === "POST" && path === "/captures") return { kind: "capture" };
   const match = /^\/cases\/([^/]+)(?:\/|$)/.exec(path);
-  if (match && !NON_CASE_PATHS.has(path)) {
+  if (match && !NON_CASE_PATHS.has(collectionPath(path))) {
     let caseId: string;
     try {
       caseId = decodeURIComponent(match[1]);
@@ -158,7 +168,7 @@ export function resolveRequestPolicy(method: string, rawPath: string): RequestPo
   if (
     path === "/cases" ||
     path === "/captures/recent" ||
-    path === "/cases/import/encrypted" ||
+    collectionPath(path) === "/cases/import/encrypted" ||
     pathStarts(path, "/api/jobs") ||
     AUTHENTICATED_SHELLS.has(path) ||
     (normalizedMethod === "GET" &&

--- a/companion/src/auth/policy.ts
+++ b/companion/src/auth/policy.ts
@@ -57,6 +57,12 @@ const CASE_ADMIN_SEGMENTS = [
 // Holding "write" on one case must not let a user name a path outside that case and have its bytes
 // copied in as evidence. Same trust as /nsrl and /kev import-file, already global-admin prefixes.
 const CASE_GLOBAL_ADMIN_SEGMENTS = ["/import-file"];
+// The only /cases/* paths that are NOT a case: the encrypted-bundle import and the demo seeder.
+// "import" and "seed-demo" are themselves valid case ids (isValidCaseId accepts both) and any
+// authenticated user can create a case so named, so the exemption has to be these exact paths.
+// Exempting the whole /cases/import subtree would hand /cases/import/delete and
+// /cases/import/import-file to any authenticated session.
+const NON_CASE_PATHS = new Set(["/cases/import/encrypted", "/cases/seed-demo"]);
 const CASE_READ_SEGMENTS = ["/unlock", "/lock-status", "/lock-forget"];
 const CASE_REVIEW_SEGMENTS = [
   "/review",
@@ -139,7 +145,7 @@ export function resolveRequestPolicy(method: string, rawPath: string): RequestPo
   }
   if (normalizedMethod === "POST" && path === "/captures") return { kind: "capture" };
   const match = /^\/cases\/([^/]+)(?:\/|$)/.exec(path);
-  if (match && match[1] !== "import" && match[1] !== "seed-demo") {
+  if (match && !NON_CASE_PATHS.has(path)) {
     let caseId: string;
     try {
       caseId = decodeURIComponent(match[1]);
@@ -152,7 +158,7 @@ export function resolveRequestPolicy(method: string, rawPath: string): RequestPo
   if (
     path === "/cases" ||
     path === "/captures/recent" ||
-    pathStarts(path, "/cases/import") ||
+    path === "/cases/import/encrypted" ||
     pathStarts(path, "/api/jobs") ||
     AUTHENTICATED_SHELLS.has(path) ||
     (normalizedMethod === "GET" &&

--- a/companion/src/auth/policy.ts
+++ b/companion/src/auth/policy.ts
@@ -91,7 +91,11 @@ function pathStarts(path: string, prefix: string): boolean {
 }
 
 function casePolicy(method: string, path: string, caseId: string): RequestPolicy {
-  const suffix = path.slice(`/cases/${caseId}`.length);
+  // Express routing is case-insensitive by default, so /PassWord and /IMPORT-FILE reach the same
+  // handlers as their lowercase spellings. Fold case before matching: every segment and pattern
+  // below is lowercase, and the branch they guard is more restrictive than the default one — an
+  // unfolded compare would put an elevated route one shift key away from plain case "write".
+  const suffix = path.slice(`/cases/${caseId}`.length).toLowerCase();
   if (CASE_GLOBAL_ADMIN_SEGMENTS.some((segment) => pathStarts(suffix, segment))) {
     return { kind: "global", permission: "admin" };
   }

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -331,8 +331,8 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
   // Import a large file from the server's local filesystem by path — bypasses the browser
   // FileReader memory limit for files too large to upload through the dashboard (400 MB+).
   // Same pipeline as /import: detect kind → persist evidence → dispatchImport → diff → resynth.
-  // Localhost-only tool: reading an operator-specified path is intentional (same trust level
-  // as DFIR_NSRL_FILE / KEV import-file). Body: { path, minSeverity? }.
+  // Reading an operator-named path is intentional and gated like DFIR_NSRL_FILE / KEV import-file:
+  // resolveRequestPolicy makes this suffix global-admin, not case-write. Body: { path, minSeverity? }.
   app.post("/cases/:id/import-file", async (req: Request, res: Response) => {
     if (!options.pipeline) return res.status(501).json({ error: "AI pipeline not configured" });
     const caseId = req.params.id;

--- a/companion/tests/http/teamAuthPolicy.test.ts
+++ b/companion/tests/http/teamAuthPolicy.test.ts
@@ -99,6 +99,27 @@ describe("team-auth configuration and policy", () => {
       permission: "write",
       caseId: "c1",
     });
+    // "import" and "seed-demo" are valid case ids (isValidCaseId accepts them) and any authenticated
+    // user can create a case so named. Only the two real collection-level endpoints may skip the
+    // case classifier — anything deeper is a case route and gets case rules, or /cases/import/delete
+    // and /cases/import/import-file would answer to a plain authenticated session.
+    expect(resolveRequestPolicy("POST", "/cases/import/import-file")).toEqual({
+      kind: "global",
+      permission: "admin",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/import/delete")).toMatchObject({
+      permission: "admin",
+      caseId: "import",
+    });
+    expect(resolveRequestPolicy("GET", "/cases/import/state")).toMatchObject({
+      permission: "read",
+      caseId: "import",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/import/encrypted")).toEqual({ kind: "authenticated" });
+    expect(resolveRequestPolicy("POST", "/cases/seed-demo")).toEqual({
+      kind: "global",
+      permission: "admin",
+    });
     expect(resolveRequestPolicy("GET", "/js/safe-dom.js")).toEqual({ kind: "public" });
     expect(resolveRequestPolicy("GET", "/cases")).toEqual({ kind: "case-list" });
     expect(resolveRequestPolicy("GET", "/api/jobs")).toEqual({ kind: "authenticated" });

--- a/companion/tests/http/teamAuthPolicy.test.ts
+++ b/companion/tests/http/teamAuthPolicy.test.ts
@@ -65,6 +65,17 @@ describe("team-auth configuration and policy", () => {
       caseId: "c1",
     });
     expect(resolveRequestPolicy("POST", "/captures")).toEqual({ kind: "capture" });
+    // /import-file reads an operator-named absolute path off the server's own filesystem, so it
+    // carries the same trust as /nsrl/import-file and /kev/import-file — global admin, never the
+    // per-case "write" a plain investigator holds (#520).
+    expect(resolveRequestPolicy("POST", "/cases/c1/import-file")).toEqual({
+      kind: "global",
+      permission: "admin",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/c1/%69mport-file")).toEqual({
+      kind: "global",
+      permission: "admin",
+    });
     expect(resolveRequestPolicy("GET", "/js/safe-dom.js")).toEqual({ kind: "public" });
     expect(resolveRequestPolicy("GET", "/cases")).toEqual({ kind: "case-list" });
     expect(resolveRequestPolicy("GET", "/api/jobs")).toEqual({ kind: "authenticated" });

--- a/companion/tests/http/teamAuthPolicy.test.ts
+++ b/companion/tests/http/teamAuthPolicy.test.ts
@@ -76,6 +76,21 @@ describe("team-auth configuration and policy", () => {
       kind: "global",
       permission: "admin",
     });
+    // Express routing is case-insensitive by default, so /IMPORT-FILE reaches the same handler.
+    // The classifier has to fold case too, or the elevated segments are one shift key from the
+    // permissive default branch — for /import-file and for the case-admin segments alike.
+    expect(resolveRequestPolicy("POST", "/cases/c1/IMPORT-FILE")).toEqual({
+      kind: "global",
+      permission: "admin",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/c1/PassWord")).toMatchObject({
+      permission: "admin",
+      caseId: "c1",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/c1/ARCHIVE")).toMatchObject({
+      permission: "admin",
+      caseId: "c1",
+    });
     expect(resolveRequestPolicy("GET", "/js/safe-dom.js")).toEqual({ kind: "public" });
     expect(resolveRequestPolicy("GET", "/cases")).toEqual({ kind: "case-list" });
     expect(resolveRequestPolicy("GET", "/api/jobs")).toEqual({ kind: "authenticated" });

--- a/companion/tests/http/teamAuthPolicy.test.ts
+++ b/companion/tests/http/teamAuthPolicy.test.ts
@@ -120,6 +120,19 @@ describe("team-auth configuration and policy", () => {
       kind: "global",
       permission: "admin",
     });
+    // Express serves those two endpoints for any casing and with a trailing slash, so the exemption
+    // has to recognise the same spellings the router does. Otherwise POST /cases/seed-demo/ reads as
+    // a case named "seed-demo" and the demo seeder drops from global admin to plain case write.
+    expect(resolveRequestPolicy("POST", "/cases/seed-demo/")).toEqual({
+      kind: "global",
+      permission: "admin",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/SEED-DEMO")).toEqual({
+      kind: "global",
+      permission: "admin",
+    });
+    expect(resolveRequestPolicy("POST", "/cases/import/encrypted/")).toEqual({ kind: "authenticated" });
+    expect(resolveRequestPolicy("POST", "/cases/import/ENCRYPTED")).toEqual({ kind: "authenticated" });
     expect(resolveRequestPolicy("GET", "/js/safe-dom.js")).toEqual({ kind: "public" });
     expect(resolveRequestPolicy("GET", "/cases")).toEqual({ kind: "case-list" });
     expect(resolveRequestPolicy("GET", "/api/jobs")).toEqual({ kind: "authenticated" });

--- a/companion/tests/http/teamAuthPolicy.test.ts
+++ b/companion/tests/http/teamAuthPolicy.test.ts
@@ -91,6 +91,14 @@ describe("team-auth configuration and policy", () => {
       permission: "admin",
       caseId: "c1",
     });
+    // ...but only where the match is anchored at a literal route segment. The export and review
+    // checks scan the whole suffix, which contains user-named values (an MCP server id, a report
+    // version): folding those would let a server named "Report" pull POST /mcp/:id/run — a write
+    // route — into the export bucket, which a reader holds.
+    expect(resolveRequestPolicy("POST", "/cases/c1/mcp/Report/run")).toMatchObject({
+      permission: "write",
+      caseId: "c1",
+    });
     expect(resolveRequestPolicy("GET", "/js/safe-dom.js")).toEqual({ kind: "public" });
     expect(resolveRequestPolicy("GET", "/cases")).toEqual({ kind: "case-list" });
     expect(resolveRequestPolicy("GET", "/api/jobs")).toEqual({ kind: "authenticated" });


### PR DESCRIPTION
Fixes #520.

## Problem
`POST /cases/:id/import-file` reads an operator-named absolute path off the server's own filesystem and copies its bytes into the case as evidence. `casePolicy` had no branch for it, so it fell through to the default `permission: "write"` — a role an `investigator` on any single case holds. In team mode that let a user with write on one case name a path outside that case and have the contents imported as viewable evidence.

The route's own comment already claimed "same trust level as DFIR_NSRL_FILE / KEV import-file" — but `/nsrl` and `/kev` are `GLOBAL_ADMIN_PREFIXES`, so the claim was not enforced.

## Fix
- Classify the `/import-file` case suffix as `{ kind: "global", permission: "admin" }`, matching `/nsrl` and `/kev`. Session global-administrators keep access; per-case write and service tokens no longer reach it.
- **Case-folding (found by the review gate):** Express routing is case-insensitive by default, so `POST /cases/c1/IMPORT-FILE` reaches the same handler while the classifier's case-sensitive compare fell through to the permissive `write` default. The same one-shift-key bypass applied to the *pre-existing* case-admin segments (`/password`, `/archive`, `/delete`, ...). `casePolicy` now lowercases the suffix before matching; every segment and pattern it guards is already lowercase.

Single-user mode is unaffected — the team-auth middleware only mounts when `options.teamAuth` is configured.

## Test plan
- [x] `tests/http/teamAuthPolicy.test.ts` — new assertions for `/import-file`, its percent-encoded spelling, the uppercase spelling, and uppercase `/PassWord` + `/ARCHIVE` (RED before the fix, GREEN after)
- [x] `npx vitest run tests/http/ tests/server/` — 121 files, 1071 tests pass
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run check:size`, `check:imports`, `check:boundaries` all clean
- [x] Empirically confirmed Express serves `/cases/c1/IMPORT-FILE` from the lowercase route registration
