### PR TITLE
fix(routes): block pushes into a closed or archived case

### DIFF
--- a/companion/src/routes/pushNotify.ts
+++ b/companion/src/routes/pushNotify.ts
@@ -47,6 +47,14 @@ export function registerPushNotifyRoutes(app: Express, ctx: RouteContext): void 
     }
 
     if (!(await store.caseExists(caseId))) return res.status(404).json({ error: "case not found" });
+    // Same write guard as the other evidence routes: a closed or archived case is immutable and
+    // takes no new evidence. The caller here is an unattended webhook or poller that has no idea
+    // the case was closed, so it needs the 423 as much as the dashboard does.
+    const caseMeta = await store.getCaseMeta(caseId).catch(() => null);
+    if (caseMeta?.status === "closed" || caseMeta?.status === "archived") {
+      const action = caseMeta.status === "archived" ? "restore it" : "reopen it";
+      return res.status(423).json({ error: `Case "${caseId}" is ${caseMeta.status} — ${action} before pushing evidence` });
+    }
 
     const { text, source, filename } = extractPushPayload(req.body);
     if (!text.trim()) return res.status(400).json({ error: "empty push payload" });

--- a/companion/tests/server/pushRoute.test.ts
+++ b/companion/tests/server/pushRoute.test.ts
@@ -33,7 +33,7 @@ async function makeApp(opts: { pushToken?: string; withTokenStore?: boolean } = 
     pushTokenStore: opts.withTokenStore === false ? undefined : new PushTokenStore(store),
   });
   await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
-  return { app, stateStore };
+  return { app, stateStore, store };
 }
 
 describe("POST /cases/:id/push — generic push ingest", () => {
@@ -65,6 +65,27 @@ describe("POST /cases/:id/push — generic push ingest", () => {
     expect(res.body.source).toBe("siem-webhook");
     expect(await waitForEvents(stateStore, "c1")).toBeGreaterThan(0);
   }, POLL_TIMEOUT_MS * 2);   // one waitForEvents budget, doubled to leave room for setup + assertions
+
+  // /push runs the same import → diff → re-synthesize pipeline as the Import button, so it owes the
+  // same write guard: a closed or archived case is immutable and takes no new evidence (#511). The
+  // token holder here is a SIEM webhook or poller that has no idea the case was closed.
+  it("423s a push into a closed case and imports nothing", async () => {
+    const { app, store, stateStore } = await makeApp({ pushToken: "secret" });
+    await store.updateCaseMeta("c1", { status: "closed" });
+    const res = await request(app).post("/cases/c1/push").set("X-DFIR-Key", "secret").send({ source: "siem", events: [THOR_EVENT] });
+    expect(res.status).toBe(423);
+    expect(res.body.error).toMatch(/closed/i);
+    const after = await stateStore.load("c1").catch(() => null);
+    expect(after?.forensicTimeline ?? []).toEqual([]);
+  });
+
+  it("423s a push into an archived case", async () => {
+    const { app, store } = await makeApp({ pushToken: "secret" });
+    await store.updateCaseMeta("c1", { status: "archived" });
+    const res = await request(app).post("/cases/c1/push").set("X-DFIR-Key", "secret").send({ events: [THOR_EVENT] });
+    expect(res.status).toBe(423);
+    expect(res.body.error).toMatch(/archived/i);
+  });
 
   it("accepts a Bearer token too", async () => {
     const { app } = await makeApp({ pushToken: "secret" });


### PR DESCRIPTION
Fixes #511.

## Problem
`POST /cases/:id/push` runs the same import → diff → re-synthesize pipeline as the Import button, but never read `caseMeta.status`. A closed or archived case is supposed to be immutable; the push route happily appended new evidence to one.

The invariant is enforced as a hand-copied 423 check in nine sibling handlers (`import.ts` ×2, `aiSynthesis.ts`, `mcp.ts` ×3, `custody.ts`, `captures.ts`, `deepPass.ts`) — `/push` was simply omitted. No upstream middleware covers it either: `caseLockGate` explicitly *exempts* `/push`, and `importCaseGuard` is only a 404 existence check.

The caller here is an unattended SIEM webhook or Velociraptor poller that has no way to know the case was closed, so it needs the 423 more than the dashboard does.

## Fix
Add the same guard the sibling evidence routes use, right after the existing `caseExists` 404 and before any payload work, so nothing is ingested.

## Follow-up
This is now the *tenth* copy of the same four-line check. Consolidating them into one mounted gate is worth doing separately — filed as a follow-up rather than bundled here, so this stays a small, reviewable behavior fix.

## Test plan
- [x] `tests/server/pushRoute.test.ts` — new: 423 on a closed case with the forensic timeline asserted still empty, and 423 on an archived case (both RED before the fix: they returned 202 and ingested)
- [x] `npx vitest run tests/server/` — 112 files, 960 tests pass
- [x] `npm run typecheck`, `lint`, `format:check`, `check:size` clean
