### PR TITLE
fix(jobs): release the admission when a start's ledger write fails

### DIFF
--- a/companion/src/analysis/jobManager.ts
+++ b/companion/src/analysis/jobManager.ts
@@ -556,9 +556,12 @@ export class JobManager {
             // propagate: the job would stay "running" to every reader, its admission would never
             // settle (runResumedJob's await hangs for good), and nextAdmissible would keep counting
             // it against perCaseConcurrency — the case would never admit another job until a
-            // restart. Fail it in memory instead, hand the error to whoever waits on the admission,
-            // and stop the pass; the failure is retryable and the next scheduleQueued picks the
-            // queue up again.
+            // restart. Fail it in memory instead and hand the error to whoever waits on the
+            // admission. Then keep going rather than stopping the pass: the failed job is terminal
+            // so nextAdmissible cannot pick it again (no spin), and every other queued job still
+            // gets its chance — breaking here would strand them until some later registration or
+            // terminal transition happened to schedule another pass. The failure is retryable, so
+            // if the ledger is genuinely down each job fails visibly and can be resumed.
             const normalized =
               error instanceof Error ? error : new Error(String(error));
             this.table = failJob(
@@ -579,7 +582,7 @@ export class JobManager {
             this.controllers.delete(next.id);
             this.emit(next.caseId);
             this.reportError(normalized);
-            break;
+            continue;
           }
           this.armRuntimeBudget(started);
           this.admissions.get(next.id)?.resolve();

--- a/companion/src/analysis/jobManager.ts
+++ b/companion/src/analysis/jobManager.ts
@@ -549,7 +549,38 @@ export class JobManager {
           if (!next) break;
           this.table = startJob(this.table, next.id, this.now());
           const started = getJob(this.table, next.id)!;
-          await this.persistUpdate(started);
+          try {
+            await this.persistUpdate(started);
+          } catch (error) {
+            // The start is already applied in memory, so a failed ledger write cannot simply
+            // propagate: the job would stay "running" to every reader, its admission would never
+            // settle (runResumedJob's await hangs for good), and nextAdmissible would keep counting
+            // it against perCaseConcurrency — the case would never admit another job until a
+            // restart. Fail it in memory instead, hand the error to whoever waits on the admission,
+            // and stop the pass; the failure is retryable and the next scheduleQueued picks the
+            // queue up again.
+            const normalized =
+              error instanceof Error ? error : new Error(String(error));
+            this.table = failJob(
+              this.table,
+              next.id,
+              {
+                code: "ledger_write_failed",
+                message: normalized.message,
+                retryable: true,
+                at: this.now(),
+              },
+              this.now(),
+            );
+            this.clearBudgetTimer(next.id);
+            this.admissions.get(next.id)?.reject(normalized);
+            this.admissions.delete(next.id);
+            this.durabilities.delete(next.id);
+            this.controllers.delete(next.id);
+            this.emit(next.caseId);
+            this.reportError(normalized);
+            break;
+          }
           this.armRuntimeBudget(started);
           this.admissions.get(next.id)?.resolve();
           this.emit(started.caseId);

--- a/companion/tests/analysis/jobDurability.test.ts
+++ b/companion/tests/analysis/jobDurability.test.ts
@@ -17,6 +17,7 @@ async function harness(
     globalConcurrency?: number;
     perCaseConcurrency?: number;
     max?: number;
+    onError?: (error: Error) => void;
   } = {},
 ) {
   const root = await mkdtemp(join(tmpdir(), "dfir-job-ledger-"));
@@ -304,5 +305,39 @@ describe("durable job ledger", () => {
 
     expect(manager.list("case-a").map((job) => job.id)).toEqual([first.jobId]);
     expect(manager.list("case-b").map((job) => job.id)).toEqual([second.jobId]);
+  });
+
+  // scheduleQueued marks a job "running" in memory BEFORE it can persist that transition. If the
+  // ledger write fails there is no way back on its own: the job is running to every reader, its
+  // admission promise never settles, and because nextAdmissible counts running jobs against
+  // perCaseConcurrency (1 with a ledger) the case never admits another job again — a permanent
+  // wedge that only a restart clears (#512).
+  it("releases the admission and the case slot when the ledger write for a start fails", async () => {
+    const errors: Error[] = [];
+    const { ledger, manager } = await harness({ onError: (error) => errors.push(error) });
+    const realUpdate = ledger.update.bind(ledger);
+    let failNext = true;
+    ledger.update = async (job) => {
+      if (failNext && job.status === "running") {
+        failNext = false;
+        throw new Error("ledger offline");
+      }
+      return realUpdate(job);
+    };
+
+    const wedged = manager.register({ caseId: "case-a", kind: "import" });
+    await expect(wedged.ready).rejects.toThrow(/ledger offline/);
+    await manager.drain();
+
+    // The failed admission must not leave a phantom "running" job holding the case's only slot.
+    expect(manager.get(wedged.jobId)?.status).not.toBe("running");
+    expect(errors.map((error) => error.message)).toContain("ledger offline");
+
+    // The case still accepts work: the next job is admitted and runs to completion.
+    const next = manager.register({ caseId: "case-a", kind: "import" });
+    await next.ready;
+    expect(manager.get(next.jobId)?.status).toBe("running");
+    await manager.finish(next.jobId);
+    expect(manager.get(next.jobId)?.status).toBe("succeeded");
   });
 });

--- a/companion/tests/analysis/jobDurability.test.ts
+++ b/companion/tests/analysis/jobDurability.test.ts
@@ -340,4 +340,48 @@ describe("durable job ledger", () => {
     await manager.finish(next.jobId);
     expect(manager.get(next.jobId)?.status).toBe("succeeded");
   });
+
+  // Failing the one job must not abandon the rest of the pass. Nothing guarantees another
+  // scheduleQueued run — it takes a fresh registration or a terminal transition — so a job already
+  // sitting in the queue would wait indefinitely for an admission that never settles.
+  it("still admits the jobs queued behind one whose ledger write failed", async () => {
+    const { ledger, manager } = await harness({
+      globalConcurrency: 2,
+      perCaseConcurrency: 2,
+      onError: () => {},
+    });
+    // Saturate the two slots, then queue two more. Their own registration passes admit nothing, so
+    // the only pass that can ever start them is the one triggered by a slot being freed below —
+    // which is exactly the pass the failure interrupts.
+    const running = [
+      manager.register({ caseId: "case-a", kind: "import" }),
+      manager.register({ caseId: "case-a", kind: "import" }),
+    ];
+    await Promise.all(running.map((job) => job.ready));
+    const doomed = manager.register({ caseId: "case-a", kind: "enrichment" });
+    const behind = manager.register({ caseId: "case-a", kind: "synthesis" });
+    // Let both registrations commit AND their own scheduling passes drain, so the pass triggered by
+    // the finish below is genuinely the only one left that can start either of them.
+    await Promise.all([doomed.durable, behind.durable]);
+    await manager.drain();
+    expect(manager.get(doomed.jobId)?.status).toBe("queued");
+    expect(manager.get(behind.jobId)?.status).toBe("queued");
+
+    const realUpdate = ledger.update.bind(ledger);
+    let failNext = true;
+    ledger.update = async (job) => {
+      if (failNext && job.status === "running") {
+        failNext = false;
+        throw new Error("ledger offline");
+      }
+      return realUpdate(job);
+    };
+
+    // One freed slot, one pass: it must get past the doomed job to the one behind it.
+    await manager.finish(running[0].jobId);
+
+    await expect(doomed.ready).rejects.toThrow(/ledger offline/);
+    await behind.ready;
+    expect(manager.get(behind.jobId)?.status).toBe("running");
+  });
 });


### PR DESCRIPTION
Fixes #512.

## Problem
`scheduleQueued` applied the `running` transition to the in-memory table and *only then* awaited `persistUpdate`:

```ts
this.table = startJob(this.table, next.id, this.now());
const started = getJob(this.table, next.id)!;
await this.persistUpdate(started);        // throws
this.admissions.get(next.id)?.resolve();  // never reached
```

A failed ledger write (EIO, disk full, a locked SQLite file) therefore left the job:

- **running to every reader**, with no rollback,
- holding an **admission promise that never settles** — `runResumedJob` awaits it and hangs for good, never reaching `finish`/`fail`,
- **counted by `nextAdmissible`** against `perCaseConcurrency`, which defaults to **1** whenever a ledger is configured.

So one transient ledger error wedged that case's job queue permanently. Nothing repaired it: the chain's own `.catch` only fires on the *next* `scheduleQueued` call and merely calls `reportError`; `resume()` discards the rejection with `void`. Only a process restart (`restore()` re-marking it interrupted) recovered.

## Fix
Catch the persist failure inside the loop and unwind the optimistic start:

- `failJob(...)` in memory with `{ code: "ledger_write_failed", retryable: true }` — the slot is freed because `nextAdmissible` only counts `running`,
- **reject** the admission so waiters receive the error instead of hanging (`runResumedJob`'s `catch` then sees a terminal job and does not double-fail),
- clear the budget timer, controller and durability entries,
- `emit` + `reportError`, then `break` the pass rather than spinning on the same job.

The failure is retryable and the next `scheduleQueued` (after any terminal transition) picks the queue back up, so a transient outage costs one job instead of the whole case. As a side effect `drain()` no longer inherits a poisoned scheduling chain.

## Test plan
- [x] `tests/analysis/jobDurability.test.ts` — new test stubs `ledger.update` to throw once on the `running` write, then asserts the admission rejects, the job is not left `running`, the error reaches `onError`, and **the case still admits and completes the next job**. RED before the fix (it threw out of `drain()`), GREEN after.
- [x] `npx vitest run tests/analysis/ tests/server/jobs.test.ts tests/http/` — 310 files, 4109 tests pass
- [x] `typecheck`, `lint`, `format:check`, `check:size` clean
