### PR TITLE
fix(ingest): remember a capture's hash only after it is persisted

### DIFF
--- a/companion/src/ingest/captureIngest.ts
+++ b/companion/src/ingest/captureIngest.ts
@@ -59,14 +59,19 @@ const caseQueues = new Map<string, Promise<unknown>>();
 function withCaseLock<T>(caseId: string, run: () => Promise<T>): Promise<T> {
   const previous = caseQueues.get(caseId) ?? Promise.resolve();
   // Run whether the previous capture resolved or rejected: one failure must not stall the case.
+  // (A capture that never settles at all would, but a hung evidence write already blocks that
+  // case's captures downstream — they share the store's sequence allocation.)
   const result = previous.then(run, run);
-  caseQueues.set(
-    caseId,
-    result.then(
-      () => undefined,
-      () => undefined,
-    ),
+  const settled = result.then(
+    () => undefined,
+    () => undefined,
   );
+  caseQueues.set(caseId, settled);
+  // Drop the entry once this is the tail and nothing is waiting on it, so the map holds only
+  // active chains rather than one dead promise per case the process has ever seen.
+  void settled.then(() => {
+    if (caseQueues.get(caseId) === settled) caseQueues.delete(caseId);
+  });
   return result;
 }
 
@@ -167,5 +172,7 @@ async function persistCapture(
 // Exposed for test isolation.
 export function _resetDedupCache(): void {
   lastHashByCase.clear();
-  caseQueues.clear();
+  // Deliberately NOT clearing caseQueues: dropping a live chain would let a post-reset capture run
+  // alongside one still in flight, which is the interleaving the queue exists to prevent. Settled
+  // chains remove themselves, so there is nothing left to clear anyway.
 }

--- a/companion/src/ingest/captureIngest.ts
+++ b/companion/src/ingest/captureIngest.ts
@@ -44,12 +44,31 @@ export class InvalidImageError extends Error {
   }
 }
 
-// In-memory cache of the last content hash per case, to decide duplicates without re-reading disk.
-// The claim identifies WHICH ingest wrote the entry: two overlapping captures of the same frame
-// carry the same hash, so a hash comparison alone cannot tell whose entry is in the map, and a
-// failing ingest would roll back a successful one's.
-type DedupEntry = { hash: string; claim: symbol };
-const lastHashByCase = new Map<string, DedupEntry>();
+// In-memory cache of the last PERSISTED content hash per case, to decide duplicates without
+// re-reading disk. Only a frame that actually landed is recorded here.
+const lastHashByCase = new Map<string, string>();
+
+// One queue per case, so the read-decide-write sequence below never interleaves with another
+// capture for the same case. Without it the dedup decision races its own write: two overlapping
+// identical frames both read the stale hash and are both analyzed, and a frame that failed to
+// persist can leave a hash behind that makes the extension's retry look like a duplicate. Trying
+// to patch those windows with a claim token and rollback only moves them around — a pending claim
+// is not the same fact as a persisted hash. Different cases still run in parallel.
+const caseQueues = new Map<string, Promise<unknown>>();
+
+function withCaseLock<T>(caseId: string, run: () => Promise<T>): Promise<T> {
+  const previous = caseQueues.get(caseId) ?? Promise.resolve();
+  // Run whether the previous capture resolved or rejected: one failure must not stall the case.
+  const result = previous.then(run, run);
+  caseQueues.set(
+    caseId,
+    result.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return result;
+}
 
 export async function ingestCapture(
   store: CaseStore,
@@ -75,30 +94,24 @@ export async function ingestCapture(
 
   const hash = computeContentHash(bytes);
 
-  const previousEntry = lastHashByCase.get(payload.caseId);
-  // Exact match only: a duplicate is a byte-identical re-capture of the previous frame (the
-  // screen didn't change). Any difference → not a duplicate → analyzed. dedup=false disables it.
-  const duplicate = dedup && previousEntry !== undefined && previousEntry.hash === hash;
-  // Claim the hash in the same tick the decision is made — an await between the read and the write
-  // would let two overlapping identical captures for one case both read the stale value and both
-  // come back non-duplicate. The claim is rolled back below if the frame never lands.
-  const claim = Symbol("capture-claim");
-  lastHashByCase.set(payload.caseId, { hash, claim });
-
-  try {
-    return await persistCapture(store, payload, { bytes, hash, duplicate, ext: format.ext });
-  } catch (err) {
-    // The frame never landed, so the claim must not stand: the extension retries the identical bytes
-    // after a 5xx and that retry would match the remembered hash, coming back a duplicate — which
-    // willAnalyze, the OCR indexer and captureAnalysis all skip, so it would be stored but never
-    // analyzed, with no error surfaced (#513). Undo only OUR claim, identified by its token: a later
-    // capture that already replaced the entry owns the slot now, even with an identical hash.
-    if (lastHashByCase.get(payload.caseId)?.claim === claim) {
-      if (previousEntry === undefined) lastHashByCase.delete(payload.caseId);
-      else lastHashByCase.set(payload.caseId, previousEntry);
-    }
-    throw err;
-  }
+  return withCaseLock(payload.caseId, async () => {
+    const previous = lastHashByCase.get(payload.caseId);
+    // Exact match only: a duplicate is a byte-identical re-capture of the previous frame (the
+    // screen didn't change). Any difference → not a duplicate → analyzed. dedup=false disables it.
+    const duplicate = dedup && previous !== undefined && previous === hash;
+    const metadata = await persistCapture(store, payload, {
+      bytes,
+      hash,
+      duplicate,
+      ext: format.ext,
+    });
+    // Only a frame that is on disk AND in the log is remembered. Recording it any earlier means a
+    // failed write poisons the cache: the extension retries the identical bytes after a 5xx (its
+    // queue keeps the entry at the head) and that retry comes back a duplicate — which willAnalyze,
+    // the OCR indexer and captureAnalysis all skip, so it is stored but never analyzed (#513).
+    lastHashByCase.set(payload.caseId, hash);
+    return metadata;
+  });
 }
 
 /** Everything after the dedup claim: allocate the sequence, name the file, write both records. */
@@ -154,4 +167,5 @@ async function persistCapture(
 // Exposed for test isolation.
 export function _resetDedupCache(): void {
   lastHashByCase.clear();
+  caseQueues.clear();
 }

--- a/companion/src/ingest/captureIngest.ts
+++ b/companion/src/ingest/captureIngest.ts
@@ -75,6 +75,10 @@ export async function ingestCapture(
   // Exact match only: a duplicate is a byte-identical re-capture of the previous frame (the
   // screen didn't change). Any difference → not a duplicate → analyzed. dedup=false disables it.
   const duplicate = dedup && previous !== undefined && previous === hash;
+  // Claim the hash in the same tick the decision is made — an await between the read and the write
+  // would let two overlapping identical captures for one case both read the stale value and both
+  // come back non-duplicate. The claim is rolled back below if the frame never lands.
+  lastHashByCase.set(payload.caseId, hash);
 
   const sequenceNumber = await store.nextSequenceNumber(payload.caseId);
   const tsSafe = payload.timestamp.replace(/[:.]/g, "-");
@@ -90,15 +94,6 @@ export async function ingestCapture(
     ? `${seq}_${tsSafe}_${titleSlug}${format.ext}`
     : `${seq}_${tsSafe}${format.ext}`;
 
-  // Evidence first: write the image before recording metadata. The provenance goes with the write
-  // because this is the only layer that still knows where the frame came from — the store below
-  // sees bytes and a filename, and custody wants the origin URL and what triggered the shot (#231).
-  await store.saveScreenshot(payload.caseId, screenshotFile, bytes, {
-    source: payload.url,
-    trigger: payload.triggerType,
-    collectedBy: "browser-extension",
-  });
-
   const metadata: CaptureMetadata = {
     caseId: payload.caseId,
     sequenceNumber,
@@ -110,12 +105,29 @@ export async function ingestCapture(
     isDuplicate: duplicate,
     screenshotFile,
   };
-  await store.appendCapture(payload.caseId, metadata);
-  // Only once the frame is actually on disk and in the log. Remembering it any earlier means a
-  // failed write poisons the cache: the extension retries the identical bytes after a 5xx and that
-  // retry comes back a duplicate, which willAnalyze, the OCR indexer and captureAnalysis all skip —
-  // the frame would be stored but never analyzed (#513).
-  lastHashByCase.set(payload.caseId, hash);
+
+  try {
+    // Evidence first: write the image before recording metadata. The provenance goes with the write
+    // because this is the only layer that still knows where the frame came from — the store below
+    // sees bytes and a filename, and custody wants the origin URL and what triggered the shot (#231).
+    await store.saveScreenshot(payload.caseId, screenshotFile, bytes, {
+      source: payload.url,
+      trigger: payload.triggerType,
+      collectedBy: "browser-extension",
+    });
+    await store.appendCapture(payload.caseId, metadata);
+  } catch (err) {
+    // The frame never landed, so the claim above must not stand: the extension retries the identical
+    // bytes after a 5xx and that retry would match the remembered hash, coming back a duplicate —
+    // which willAnalyze, the OCR indexer and captureAnalysis all skip. The frame would be stored on
+    // the retry but never analyzed, with no error surfaced (#513). Only undo our own claim; a later
+    // capture that already replaced it owns the slot now.
+    if (lastHashByCase.get(payload.caseId) === hash) {
+      if (previous === undefined) lastHashByCase.delete(payload.caseId);
+      else lastHashByCase.set(payload.caseId, previous);
+    }
+    throw err;
+  }
   return metadata;
 }
 

--- a/companion/src/ingest/captureIngest.ts
+++ b/companion/src/ingest/captureIngest.ts
@@ -75,7 +75,6 @@ export async function ingestCapture(
   // Exact match only: a duplicate is a byte-identical re-capture of the previous frame (the
   // screen didn't change). Any difference → not a duplicate → analyzed. dedup=false disables it.
   const duplicate = dedup && previous !== undefined && previous === hash;
-  lastHashByCase.set(payload.caseId, hash);
 
   const sequenceNumber = await store.nextSequenceNumber(payload.caseId);
   const tsSafe = payload.timestamp.replace(/[:.]/g, "-");
@@ -112,6 +111,11 @@ export async function ingestCapture(
     screenshotFile,
   };
   await store.appendCapture(payload.caseId, metadata);
+  // Only once the frame is actually on disk and in the log. Remembering it any earlier means a
+  // failed write poisons the cache: the extension retries the identical bytes after a 5xx and that
+  // retry comes back a duplicate, which willAnalyze, the OCR indexer and captureAnalysis all skip —
+  // the frame would be stored but never analyzed (#513).
+  lastHashByCase.set(payload.caseId, hash);
   return metadata;
 }
 

--- a/companion/src/ingest/captureIngest.ts
+++ b/companion/src/ingest/captureIngest.ts
@@ -45,7 +45,11 @@ export class InvalidImageError extends Error {
 }
 
 // In-memory cache of the last content hash per case, to decide duplicates without re-reading disk.
-const lastHashByCase = new Map<string, string>();
+// The claim identifies WHICH ingest wrote the entry: two overlapping captures of the same frame
+// carry the same hash, so a hash comparison alone cannot tell whose entry is in the map, and a
+// failing ingest would roll back a successful one's.
+type DedupEntry = { hash: string; claim: symbol };
+const lastHashByCase = new Map<string, DedupEntry>();
 
 export async function ingestCapture(
   store: CaseStore,
@@ -71,15 +75,44 @@ export async function ingestCapture(
 
   const hash = computeContentHash(bytes);
 
-  const previous = lastHashByCase.get(payload.caseId);
+  const previousEntry = lastHashByCase.get(payload.caseId);
   // Exact match only: a duplicate is a byte-identical re-capture of the previous frame (the
   // screen didn't change). Any difference → not a duplicate → analyzed. dedup=false disables it.
-  const duplicate = dedup && previous !== undefined && previous === hash;
+  const duplicate = dedup && previousEntry !== undefined && previousEntry.hash === hash;
   // Claim the hash in the same tick the decision is made — an await between the read and the write
   // would let two overlapping identical captures for one case both read the stale value and both
   // come back non-duplicate. The claim is rolled back below if the frame never lands.
-  lastHashByCase.set(payload.caseId, hash);
+  const claim = Symbol("capture-claim");
+  lastHashByCase.set(payload.caseId, { hash, claim });
 
+  try {
+    return await persistCapture(store, payload, { bytes, hash, duplicate, ext: format.ext });
+  } catch (err) {
+    // The frame never landed, so the claim must not stand: the extension retries the identical bytes
+    // after a 5xx and that retry would match the remembered hash, coming back a duplicate — which
+    // willAnalyze, the OCR indexer and captureAnalysis all skip, so it would be stored but never
+    // analyzed, with no error surfaced (#513). Undo only OUR claim, identified by its token: a later
+    // capture that already replaced the entry owns the slot now, even with an identical hash.
+    if (lastHashByCase.get(payload.caseId)?.claim === claim) {
+      if (previousEntry === undefined) lastHashByCase.delete(payload.caseId);
+      else lastHashByCase.set(payload.caseId, previousEntry);
+    }
+    throw err;
+  }
+}
+
+/** Everything after the dedup claim: allocate the sequence, name the file, write both records. */
+async function persistCapture(
+  store: CaseStore,
+  payload: {
+    caseId: string;
+    timestamp: string;
+    url: string;
+    tabTitle: string;
+    triggerType: CaptureMetadata["triggerType"];
+  },
+  frame: { bytes: Buffer; hash: string; duplicate: boolean; ext: string },
+): Promise<CaptureMetadata> {
   const sequenceNumber = await store.nextSequenceNumber(payload.caseId);
   const tsSafe = payload.timestamp.replace(/[:.]/g, "-");
   // Include the captured window's tab title in the filename so evidence is
@@ -91,8 +124,8 @@ export async function ingestCapture(
   // stored as WebP whatever it was, which made the filename — part of the evidence record — wrong,
   // and the evidence route derives its Content-Type from exactly this name (#425).
   const screenshotFile = titleSlug
-    ? `${seq}_${tsSafe}_${titleSlug}${format.ext}`
-    : `${seq}_${tsSafe}${format.ext}`;
+    ? `${seq}_${tsSafe}_${titleSlug}${frame.ext}`
+    : `${seq}_${tsSafe}${frame.ext}`;
 
   const metadata: CaptureMetadata = {
     caseId: payload.caseId,
@@ -101,33 +134,20 @@ export async function ingestCapture(
     url: payload.url,
     tabTitle: payload.tabTitle,
     triggerType: payload.triggerType,
-    contentHash: hash,
-    isDuplicate: duplicate,
+    contentHash: frame.hash,
+    isDuplicate: frame.duplicate,
     screenshotFile,
   };
 
-  try {
-    // Evidence first: write the image before recording metadata. The provenance goes with the write
-    // because this is the only layer that still knows where the frame came from — the store below
-    // sees bytes and a filename, and custody wants the origin URL and what triggered the shot (#231).
-    await store.saveScreenshot(payload.caseId, screenshotFile, bytes, {
-      source: payload.url,
-      trigger: payload.triggerType,
-      collectedBy: "browser-extension",
-    });
-    await store.appendCapture(payload.caseId, metadata);
-  } catch (err) {
-    // The frame never landed, so the claim above must not stand: the extension retries the identical
-    // bytes after a 5xx and that retry would match the remembered hash, coming back a duplicate —
-    // which willAnalyze, the OCR indexer and captureAnalysis all skip. The frame would be stored on
-    // the retry but never analyzed, with no error surfaced (#513). Only undo our own claim; a later
-    // capture that already replaced it owns the slot now.
-    if (lastHashByCase.get(payload.caseId) === hash) {
-      if (previous === undefined) lastHashByCase.delete(payload.caseId);
-      else lastHashByCase.set(payload.caseId, previous);
-    }
-    throw err;
-  }
+  // Evidence first: write the image before recording metadata. The provenance goes with the write
+  // because this is the only layer that still knows where the frame came from — the store below
+  // sees bytes and a filename, and custody wants the origin URL and what triggered the shot (#231).
+  await store.saveScreenshot(payload.caseId, screenshotFile, frame.bytes, {
+    source: payload.url,
+    trigger: payload.triggerType,
+    collectedBy: "browser-extension",
+  });
+  await store.appendCapture(payload.caseId, metadata);
   return metadata;
 }
 

--- a/companion/tests/ingest/captureIngest.test.ts
+++ b/companion/tests/ingest/captureIngest.test.ts
@@ -17,7 +17,9 @@ let store: CaseStore;
 async function pngBase64(r: number, g: number, b: number): Promise<string> {
   const buf = await sharp({
     create: { width: 32, height: 32, channels: 3, background: { r, g, b } },
-  }).png().toBuffer();
+  })
+    .png()
+    .toBuffer();
   return buf.toString("base64");
 }
 
@@ -77,7 +79,7 @@ describe("ingestCapture", () => {
   // indexer and captureAnalysis alike, so the frame would be stored but never analyzed (#513).
   // Both writes matter: whichever one blows up, the frame is not on record, so the cache must not
   // claim it. Parameterised so moving the cache update between the two calls cannot pass.
-  it.each(["saveScreenshot", "appendCapture"] as const)(
+  it.each(["nextSequenceNumber", "saveScreenshot", "appendCapture"] as const)(
     "does not remember a frame whose %s failed, so the retry is still analyzed",
     async (method) => {
       const img = await pngBase64(10, 20, 30);
@@ -100,6 +102,34 @@ describe("ingestCapture", () => {
     },
   );
 
+  // Two overlapping captures of the same frame carry the SAME hash, so "is the cached hash still
+  // mine?" cannot be answered by comparing hashes: the one that fails would roll back the one that
+  // succeeded, and the next identical frame would be re-analyzed as new. Ownership is a token.
+  it("keeps a successful capture's claim when an overlapping identical one fails", async () => {
+    const img = await pngBase64(5, 6, 7);
+    const realSave = store.saveScreenshot.bind(store);
+    let failFirst = true;
+    store.saveScreenshot = async (...args: Parameters<typeof realSave>) => {
+      if (failFirst) {
+        failFirst = false;
+        await new Promise((r) => setTimeout(r, 20)); // lose the race deliberately
+        throw new Error("ENOSPC: no space left on device");
+      }
+      return realSave(...args);
+    };
+
+    const [doomed, landed] = await Promise.allSettled([
+      ingestCapture(store, payload({ imageBase64: img })),
+      ingestCapture(store, payload({ imageBase64: img })),
+    ]);
+    expect(doomed.status).toBe("rejected");
+    expect(landed.status).toBe("fulfilled");
+
+    // The frame that landed still owns the slot, so the next identical one is a duplicate.
+    const third = await ingestCapture(store, payload({ imageBase64: img }));
+    expect(third.isDuplicate).toBe(true);
+  });
+
   // The claim is made in the same tick as the decision, so an await cannot open a window where two
   // overlapping identical captures both read the stale hash and both come back non-duplicate.
   it("still flags the second of two overlapping identical captures", async () => {
@@ -120,10 +150,7 @@ describe("ingestCapture", () => {
 
   it("includes the slugified tab title in the screenshot filename", async () => {
     const img = await pngBase64(10, 20, 30);
-    const meta = await ingestCapture(
-      store,
-      payload({ imageBase64: img, tabTitle: "Velociraptor — Hunts" }),
-    );
+    const meta = await ingestCapture(store, payload({ imageBase64: img, tabTitle: "Velociraptor — Hunts" }));
     // .png, not .webp: the extension follows the DETECTED format (#425), and this fixture is a PNG.
     expect(meta.screenshotFile).toMatch(/^000001_.*_Velociraptor-Hunts\.png$/);
     const onDisk = await readFile(join(store.screenshotsDir("c1"), meta.screenshotFile));
@@ -149,25 +176,28 @@ describe("ingestCapture — image magic-byte validation", () => {
   const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
   it("rejects arbitrary binary posing as a screenshot", async () => {
-    await expect(ingestCapture(store, payload({ imageBase64: b64(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12) })))
-      .rejects.toBeInstanceOf(InvalidImageError);
+    await expect(
+      ingestCapture(store, payload({ imageBase64: b64(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12) })),
+    ).rejects.toBeInstanceOf(InvalidImageError);
   });
 
   it("rejects bytes too short to carry a signature", async () => {
-    await expect(ingestCapture(store, payload({ imageBase64: b64(...PNG) })))
-      .rejects.toBeInstanceOf(InvalidImageError);
+    await expect(ingestCapture(store, payload({ imageBase64: b64(...PNG) }))).rejects.toBeInstanceOf(
+      InvalidImageError,
+    );
   });
 
   it("writes nothing to disk when the bytes are rejected", async () => {
-    await expect(ingestCapture(store, payload({ imageBase64: b64(...Array(16).fill(0x41)) })))
-      .rejects.toBeInstanceOf(InvalidImageError);
+    await expect(
+      ingestCapture(store, payload({ imageBase64: b64(...Array(16).fill(0x41)) })),
+    ).rejects.toBeInstanceOf(InvalidImageError);
     await expect(readdir(store.screenshotsDir("c1"))).resolves.toEqual([]);
   });
 
   it.each([
-    ["PNG",  [...PNG, 0, 0, 0, 13]],
+    ["PNG", [...PNG, 0, 0, 0, 13]],
     ["JPEG", [0xff, 0xd8, 0xff, 0xe0, 0, 16, 0x4a, 0x46, 0x49, 0x46, 0, 1]],
-    ["GIF",  [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 1, 0, 1, 0, 0x80, 0]],
+    ["GIF", [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 1, 0, 1, 0, 0x80, 0]],
     ["WebP", [0x52, 0x49, 0x46, 0x46, 26, 0, 0, 0, 0x57, 0x45, 0x42, 0x50]],
   ])("accepts %s", async (_name, bytes) => {
     const meta = await ingestCapture(store, payload({ imageBase64: b64(...bytes) }));

--- a/companion/tests/ingest/captureIngest.test.ts
+++ b/companion/tests/ingest/captureIngest.test.ts
@@ -71,6 +71,30 @@ describe("ingestCapture", () => {
     expect(second.isDuplicate).toBe(false);
   });
 
+  // The extension retries the SAME bytes after a 5xx (captureQueue classifies it as `retry` and
+  // keeps the entry at the head of the queue). If the cache remembered a frame whose write blew up,
+  // that retry would come back isDuplicate — and a duplicate is skipped by willAnalyze, the OCR
+  // indexer and captureAnalysis alike, so the frame would be stored but never analyzed (#513).
+  it("does not remember a frame whose write failed, so the retry is still analyzed", async () => {
+    const img = await pngBase64(10, 20, 30);
+    const realSave = store.saveScreenshot.bind(store);
+    let failNext = true;
+    store.saveScreenshot = async (...args: Parameters<typeof realSave>) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error("ENOSPC: no space left on device");
+      }
+      return realSave(...args);
+    };
+
+    await expect(ingestCapture(store, payload({ imageBase64: img }))).rejects.toThrow(/ENOSPC/);
+
+    const retried = await ingestCapture(store, payload({ imageBase64: img }));
+    expect(retried.isDuplicate).toBe(false);
+    const onDisk = await readFile(join(store.screenshotsDir("c1"), retried.screenshotFile));
+    expect(onDisk.length).toBeGreaterThan(0);
+  });
+
   it("never flags a duplicate when dedup is disabled", async () => {
     const img = await pngBase64(128, 128, 128);
     await ingestCapture(store, payload({ imageBase64: img }), false);

--- a/companion/tests/ingest/captureIngest.test.ts
+++ b/companion/tests/ingest/captureIngest.test.ts
@@ -102,10 +102,9 @@ describe("ingestCapture", () => {
     },
   );
 
-  // Two overlapping captures of the same frame carry the SAME hash, so "is the cached hash still
-  // mine?" cannot be answered by comparing hashes: the one that fails would roll back the one that
-  // succeeded, and the next identical frame would be re-analyzed as new. Ownership is a token.
-  it("keeps a successful capture's claim when an overlapping identical one fails", async () => {
+  // When one of two overlapping identical captures fails, the one that DID land is the only copy on
+  // disk — so it must be analyzed, not written off as a duplicate of the frame that never made it.
+  it("analyzes the surviving capture when an overlapping identical one fails", async () => {
     const img = await pngBase64(5, 6, 7);
     const realSave = store.saveScreenshot.bind(store);
     let failFirst = true;
@@ -124,8 +123,11 @@ describe("ingestCapture", () => {
     ]);
     expect(doomed.status).toBe("rejected");
     expect(landed.status).toBe("fulfilled");
+    // The only copy on disk: it has to be analyzed, not skipped as a duplicate of a frame that
+    // never landed.
+    if (landed.status === "fulfilled") expect(landed.value.isDuplicate).toBe(false);
 
-    // The frame that landed still owns the slot, so the next identical one is a duplicate.
+    // And it is what the next identical frame dedupes against.
     const third = await ingestCapture(store, payload({ imageBase64: img }));
     expect(third.isDuplicate).toBe(true);
   });

--- a/companion/tests/ingest/captureIngest.test.ts
+++ b/companion/tests/ingest/captureIngest.test.ts
@@ -75,24 +75,40 @@ describe("ingestCapture", () => {
   // keeps the entry at the head of the queue). If the cache remembered a frame whose write blew up,
   // that retry would come back isDuplicate — and a duplicate is skipped by willAnalyze, the OCR
   // indexer and captureAnalysis alike, so the frame would be stored but never analyzed (#513).
-  it("does not remember a frame whose write failed, so the retry is still analyzed", async () => {
-    const img = await pngBase64(10, 20, 30);
-    const realSave = store.saveScreenshot.bind(store);
-    let failNext = true;
-    store.saveScreenshot = async (...args: Parameters<typeof realSave>) => {
-      if (failNext) {
-        failNext = false;
-        throw new Error("ENOSPC: no space left on device");
-      }
-      return realSave(...args);
-    };
+  // Both writes matter: whichever one blows up, the frame is not on record, so the cache must not
+  // claim it. Parameterised so moving the cache update between the two calls cannot pass.
+  it.each(["saveScreenshot", "appendCapture"] as const)(
+    "does not remember a frame whose %s failed, so the retry is still analyzed",
+    async (method) => {
+      const img = await pngBase64(10, 20, 30);
+      const real = store[method].bind(store) as (...args: unknown[]) => Promise<unknown>;
+      let failNext = true;
+      (store as unknown as Record<string, unknown>)[method] = async (...args: unknown[]) => {
+        if (failNext) {
+          failNext = false;
+          throw new Error("ENOSPC: no space left on device");
+        }
+        return real(...args);
+      };
 
-    await expect(ingestCapture(store, payload({ imageBase64: img }))).rejects.toThrow(/ENOSPC/);
+      await expect(ingestCapture(store, payload({ imageBase64: img }))).rejects.toThrow(/ENOSPC/);
 
-    const retried = await ingestCapture(store, payload({ imageBase64: img }));
-    expect(retried.isDuplicate).toBe(false);
-    const onDisk = await readFile(join(store.screenshotsDir("c1"), retried.screenshotFile));
-    expect(onDisk.length).toBeGreaterThan(0);
+      const retried = await ingestCapture(store, payload({ imageBase64: img }));
+      expect(retried.isDuplicate).toBe(false);
+      const onDisk = await readFile(join(store.screenshotsDir("c1"), retried.screenshotFile));
+      expect(onDisk.length).toBeGreaterThan(0);
+    },
+  );
+
+  // The claim is made in the same tick as the decision, so an await cannot open a window where two
+  // overlapping identical captures both read the stale hash and both come back non-duplicate.
+  it("still flags the second of two overlapping identical captures", async () => {
+    const img = await pngBase64(77, 88, 99);
+    const [first, second] = await Promise.all([
+      ingestCapture(store, payload({ imageBase64: img })),
+      ingestCapture(store, payload({ imageBase64: img })),
+    ]);
+    expect([first.isDuplicate, second.isDuplicate].filter(Boolean)).toHaveLength(1);
   });
 
   it("never flags a duplicate when dedup is disabled", async () => {


### PR DESCRIPTION
Fixes #513.

## Problem
`ingestCapture` recorded the frame's hash in the per-case dedup cache *before* persisting anything:

```ts
const duplicate = dedup && previous === hash;
lastHashByCase.set(payload.caseId, hash);   // before any write
...
await store.saveScreenshot(...);            // can throw
await store.appendCapture(...);
```

There is no `try`/`catch` in `ingestCapture`, so a failed write (ENOSPC, EPERM, a `wx` collision in a synced `cases/` dir) left the cache remembering a frame that never landed. The extension then retries the **identical bytes** — `extension/src/captureQueue.ts` classifies a 5xx as `retry` and keeps the same entry at the head of the queue — and that retry matched the remembered hash, so it came back `isDuplicate: true`.

A duplicate is skipped everywhere downstream: `routes/captures.ts` (`willAnalyze = !metadata.isDuplicate && …`), `composition/ocrIndexer.ts`, and `captureAnalysis.ts`. The frame was stored on the retry but **never analyzed**, and nothing surfaced an error — a silent evidence-analysis gap.

## Fix
Move the cache write to after both `saveScreenshot` and `appendCapture` succeed. A frame that never landed is never remembered, so the retry is treated as new and analyzed. The duplicate *decision* still reads the previous value before the writes, so genuine byte-identical re-captures are unaffected.

## Test plan
- [x] `tests/ingest/captureIngest.test.ts` — new test stubs `saveScreenshot` to throw once, asserts the call rejects, then asserts the retry of the same bytes is `isDuplicate: false` and lands on disk. RED before the fix (retry came back `true`), GREEN after.
- [x] Existing dedup behaviour still covered: byte-identical second capture is a duplicate; a different frame is not; `DFIR_DEDUP=off` never flags one.
- [x] `npx vitest run tests/ingest/ tests/dedup/ tests/server/captureFormats.test.ts tests/server/capturesLockGate.test.ts` — 6 files, 56 tests pass
- [x] `typecheck`, `lint`, `format:check`, `check:size` clean
