### PR TITLE
fix(providers): decode child stdout through the stream, not per chunk

### DIFF
--- a/companion/src/providers/claudeRunner.ts
+++ b/companion/src/providers/claudeRunner.ts
@@ -46,13 +46,17 @@ export const defaultClaudeRunner: ClaudeRunner = (opts) =>
     const done = (r: ClaudeRunResult) => { if (!settled) { settled = true; cleanup(); resolve(r); } };
 
     child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout, stderr, spawnError: err }));
-    child.stdout.on("data", (d) => {
-      const chunk = d.toString();
+    // Decode through the stream's own StringDecoder, which holds a partial multi-byte sequence back
+    // until the rest arrives. Calling toString() on each Buffer instead turns any character split
+    // across a ~64 KB pipe chunk into two U+FFFDs that concatenation cannot repair — corrupting
+    // non-ASCII evidence and breaking JSON.parse on stream-json lines (#515).
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
       stdout += chunk;
       opts.onStdout?.(chunk);
     });
-    child.stderr.on("data", (d) => {
-      const chunk = d.toString();
+    child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
       opts.onStderr?.(chunk);
     });

--- a/companion/src/providers/codexRunner.ts
+++ b/companion/src/providers/codexRunner.ts
@@ -60,8 +60,13 @@ export const defaultCodexRunner: CodexRunner = (opts) =>
     child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout, stderr, spawnError: err }));
     // Non-null: stdio: ["pipe", "pipe", "pipe"] above guarantees these pipes exist; cross-spawn's
     // return type is the generic ChildProcess (stdout/stderr/stdin typed nullable for other stdio configs).
-    child.stdout!.on("data", (d) => { stdout += d.toString(); });
-    child.stderr!.on("data", (d) => { stderr += d.toString(); });
+    // setEncoding, not per-chunk toString(): the stream's StringDecoder holds a partial multi-byte
+    // sequence until the rest arrives, so a character split across a ~64 KB pipe chunk survives
+    // instead of decoding to two unrecoverable U+FFFDs (#515).
+    child.stdout!.setEncoding("utf8");
+    child.stderr!.setEncoding("utf8");
+    child.stdout!.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr!.on("data", (chunk: string) => { stderr += chunk; });
     child.on("close", (code) => done({ code, stdout, stderr, ...(timedOut ? { timedOut: true } : {}) }));
 
     child.stdin!.on("error", () => { /* ignore EPIPE if the child exits before we finish writing */ });

--- a/companion/tests/providers/claudeRunner.test.ts
+++ b/companion/tests/providers/claudeRunner.test.ts
@@ -18,17 +18,20 @@ describe("defaultClaudeRunner", () => {
   // concatenation cannot repair — mangling non-ASCII evidence (hostnames, filenames) or breaking
   // JSON.parse on a stream-json line, which the MCP runner then silently skips (#515).
   it("reassembles multi-byte UTF-8 split across pipe chunk boundaries", async () => {
-    // A 3-byte character on purpose: the 64 KB boundary is not a multiple of 3, so a split is
-    // guaranteed. A 2-byte character would align with the boundary and never reproduce the bug.
-    const EXPECTED = "€".repeat(70_000); // 210 KB
+    // Split one character across two writes explicitly rather than relying on where a ~64 KB pipe
+    // boundary happens to land — that is platform- and scheduling-dependent, so a size-based test
+    // can pass against the unfixed code on a kernel that happens to align the reads.
     const r = await defaultClaudeRunner({
       bin: process.execPath,
-      args: ["-e", 'process.stdout.write("\\u20ac".repeat(70000))'],
+      args: [
+        "-e",
+        'const b=Buffer.from("\\u20ac","utf8");process.stdout.write(b.subarray(0,1));setTimeout(()=>process.stdout.write(b.subarray(1)),50);',
+      ],
       stdin: "",
       timeoutMs: 30_000,
     });
     expect(r.stdout).not.toContain("�");
-    expect(r.stdout).toBe(EXPECTED);
+    expect(r.stdout).toBe("€");
   });
 
   it("reports a non-zero exit code", async () => {

--- a/companion/tests/providers/claudeRunner.test.ts
+++ b/companion/tests/providers/claudeRunner.test.ts
@@ -13,6 +13,24 @@ describe("defaultClaudeRunner", () => {
     expect(r.stdout).toBe("GOT:hello");
   });
 
+  // A pipe delivers ~64 KB per data event, wherever that lands in the byte stream. Decoding each
+  // Buffer on its own splits any multi-byte character straddling the boundary into two U+FFFDs that
+  // concatenation cannot repair — mangling non-ASCII evidence (hostnames, filenames) or breaking
+  // JSON.parse on a stream-json line, which the MCP runner then silently skips (#515).
+  it("reassembles multi-byte UTF-8 split across pipe chunk boundaries", async () => {
+    // A 3-byte character on purpose: the 64 KB boundary is not a multiple of 3, so a split is
+    // guaranteed. A 2-byte character would align with the boundary and never reproduce the bug.
+    const EXPECTED = "€".repeat(70_000); // 210 KB
+    const r = await defaultClaudeRunner({
+      bin: process.execPath,
+      args: ["-e", 'process.stdout.write("\\u20ac".repeat(70000))'],
+      stdin: "",
+      timeoutMs: 30_000,
+    });
+    expect(r.stdout).not.toContain("�");
+    expect(r.stdout).toBe(EXPECTED);
+  });
+
   it("reports a non-zero exit code", async () => {
     const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", "process.exit(3)"], stdin: "", timeoutMs: 10_000 });
     expect(r.code).toBe(3);

--- a/companion/tests/providers/codexRunner.test.ts
+++ b/companion/tests/providers/codexRunner.test.ts
@@ -12,6 +12,19 @@ describe("defaultCodexRunner", () => {
     expect(r.stdout).toBe("HELLO");
   });
 
+  // Same pipe-chunk hazard as claudeRunner: a 3-byte character cannot align with the ~64 KB
+  // boundary, so decoding each Buffer separately would strand half a character as U+FFFD (#515).
+  it("reassembles multi-byte UTF-8 split across pipe chunk boundaries", async () => {
+    const r = await defaultCodexRunner({
+      bin: process.execPath,
+      args: ["-e", 'process.stdout.write("\\u20ac".repeat(70000))'],
+      stdin: "",
+      timeoutMs: 30_000,
+    });
+    expect(r.stdout).not.toContain("�");
+    expect(r.stdout).toBe("€".repeat(70_000));
+  });
+
   it("captures stderr and a non-zero exit code", async () => {
     const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", "process.stderr.write('boom');process.exit(2)"], stdin: "", timeoutMs: 10_000 });
     expect(r.code).toBe(2);

--- a/companion/tests/providers/codexRunner.test.ts
+++ b/companion/tests/providers/codexRunner.test.ts
@@ -12,17 +12,20 @@ describe("defaultCodexRunner", () => {
     expect(r.stdout).toBe("HELLO");
   });
 
-  // Same pipe-chunk hazard as claudeRunner: a 3-byte character cannot align with the ~64 KB
-  // boundary, so decoding each Buffer separately would strand half a character as U+FFFD (#515).
+  // Same hazard as claudeRunner: the two halves of one character arrive in separate data events,
+  // and decoding each Buffer on its own strands them as two U+FFFDs (#515).
   it("reassembles multi-byte UTF-8 split across pipe chunk boundaries", async () => {
     const r = await defaultCodexRunner({
       bin: process.execPath,
-      args: ["-e", 'process.stdout.write("\\u20ac".repeat(70000))'],
+      args: [
+        "-e",
+        'const b=Buffer.from("\\u20ac","utf8");process.stdout.write(b.subarray(0,1));setTimeout(()=>process.stdout.write(b.subarray(1)),50);',
+      ],
       stdin: "",
       timeoutMs: 30_000,
     });
     expect(r.stdout).not.toContain("�");
-    expect(r.stdout).toBe("€".repeat(70_000));
+    expect(r.stdout).toBe("€");
   });
 
   it("captures stderr and a non-zero exit code", async () => {


### PR DESCRIPTION
Fixes #515.

## Problem
Both CLI runners collected child output by calling `toString()` on each `data` Buffer:

```ts
child.stdout.on("data", (d) => { stdout += d.toString(); });
```

A pipe delivers roughly 64 KB per `data` event, and the boundary falls wherever it falls in the byte stream. Decoding each Buffer independently turns a multi-byte character straddling that boundary into **two U+FFFD replacement characters** — and concatenating the decoded strings cannot put it back together. `setEncoding` avoids this because the stream's internal `StringDecoder` holds the partial sequence until the remaining bytes arrive.

A repo-wide grep found `setEncoding` used only on the SMTP socket, so neither runner had it.

This is reachable in normal use: `mcpAgentRunner` pipes `--output-format stream-json` through `defaultClaudeRunner`, single NDJSON lines routinely exceed 64 KB, and tool results carry non-ASCII evidence (hostnames, filenames, quoted log text). A corrupted character either mangles evidence text or breaks `JSON.parse`, and both `streamProgress` and `terminalResult` **silently skip** lines that fail to parse.

## Fix
`child.stdout.setEncoding("utf8")` and the same on `stderr`, in `claudeRunner.ts` and `codexRunner.ts`; the `data` handlers now take a `string` directly instead of calling `toString()`. No signature or behaviour change beyond correct decoding — the `onStdout`/`onStderr` taps still receive the same chunks.

## A note on the test
The first draft used `"é"` (2 bytes) and **passed against the unfixed code**: 65536 is even, so a 2-byte character aligns exactly with the chunk boundary and never splits. The committed test uses `"€"` (3 bytes) — 3 does not divide 65536, so a split is guaranteed. It fails on the unfixed runner with U+FFFD in the output.

## Test plan
- [x] `tests/providers/claudeRunner.test.ts` and `tests/providers/codexRunner.test.ts` — each spawns a real child writing 70,000 three-byte characters (210 KB) and asserts the collected stdout contains no U+FFFD and equals the input exactly. RED before the fix, GREEN after.
- [x] `npx vitest run tests/providers/ tests/integrations/` — 44 files, 671 tests pass
- [x] `typecheck`, `lint`, `format:check`, `check:size` clean
