### PR TITLE
fix(enrichment): escape IOC values before they enter the FQL filter

### DIFF
--- a/companion/src/enrichment/crowdstrike.ts
+++ b/companion/src/enrichment/crowdstrike.ts
@@ -39,6 +39,18 @@ function asArray(v: unknown): unknown[] { return Array.isArray(v) ? v : []; }
 function str(v: unknown): string { return v === undefined || v === null ? "" : String(v); }
 function isSha256(v: string): boolean { return /^[a-f0-9]{64}$/i.test(v); }
 
+/**
+ * Escape a value for a single-quoted FQL string literal. encodeURIComponent protects the URL, not
+ * the query language underneath it: a quote inside the value still terminates the literal. IOC
+ * values arrive from parsed evidence and a quote is legal in a URL, so without this a single
+ * apostrophe malforms the filter — CrowdStrike 400s and that IOC fails on every enrichment run
+ * from then on — or closes the literal and changes what the query asks. Backslash first, or it
+ * would escape the escapes added after it.
+ */
+function escapeFqlLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
 // CrowdStrike Falcon — Threat Intelligence enrichment (NO endpoint/SIEM data). One indicator is
 // looked up across the abuse-free, intel-only back-ends and each hit is a SEPARATE result:
 //   hash         → Falcon Intelligence Indicators + MalQuery sample metadata
@@ -102,7 +114,7 @@ export class CrowdStrikeProvider implements EnrichmentProvider {
 
   // Falcon Intelligence Indicators — adversary-attributed IOC intel.
   private async intelLookup(value: string): Promise<EnrichmentResult | null> {
-    const filter = encodeURIComponent(`indicator:'${value}'`);
+    const filter = encodeURIComponent(`indicator:'${escapeFqlLiteral(value)}'`);
     const json = await this.apiGet(
       `/intel/combined/indicators/v1?filter=${filter}&limit=1&sort=last_updated.desc`,
       "Indicators (Falcon Intelligence): Read",

--- a/companion/tests/enrichment/providers.test.ts
+++ b/companion/tests/enrichment/providers.test.ts
@@ -193,6 +193,24 @@ describe("CrowdStrikeProvider (Falcon Intelligence + MalQuery)", () => {
     expect(decodeURIComponent(intelCall)).toContain("indicator:'evil.test'");
   });
 
+  // FQL is a query language, and encodeURIComponent only protects URL transport — it leaves the
+  // quote that terminates the string literal intact. IOC values reach here straight from parsed
+  // evidence (enrichService passes ioc.value through), and a quote is legal in a URL, so an
+  // unescaped one either malforms the filter — CrowdStrike 400s, and that IOC then fails on every
+  // enrichment run forever — or closes the literal and changes what the query means (#514).
+  it("escapes quotes and backslashes in the FQL filter instead of letting them terminate it", async () => {
+    const fetchFn = csFetch({ intel: { resources: [] } });
+    const cs = new CrowdStrikeProvider({ clientId: "id", clientSecret: "sec", fetchFn });
+    await cs.lookup("url", "http://evil.test/a'b\\c");
+
+    const intelCall = String(
+      fetchFn.mock.calls.find((c) => String(c[0]).includes("/intel/combined/indicators"))![0],
+    );
+    const filter = decodeURIComponent(new URL(intelCall).searchParams.get("filter") ?? "");
+    // The value's own quote is escaped, so the literal still opens and closes exactly once.
+    expect(filter).toBe("indicator:'http://evil.test/a\\'b\\\\c'");
+  });
+
   it("returns [] when CrowdStrike has no intel on the indicator", async () => {
     const cs = new CrowdStrikeProvider({ clientId: "id", clientSecret: "sec", fetchFn: csFetch({ intel: { resources: [] }, malquery: { resources: [] } }) });
     expect(await cs.lookup("hash", SHA)).toEqual([]);

--- a/companion/tests/enrichment/providers.test.ts
+++ b/companion/tests/enrichment/providers.test.ts
@@ -206,7 +206,9 @@ describe("CrowdStrikeProvider (Falcon Intelligence + MalQuery)", () => {
     const intelCall = String(
       fetchFn.mock.calls.find((c) => String(c[0]).includes("/intel/combined/indicators"))![0],
     );
-    const filter = decodeURIComponent(new URL(intelCall).searchParams.get("filter") ?? "");
+    // searchParams already percent-decodes; decoding again would hide a double-encoding bug and
+    // would corrupt any IOC value legitimately containing a % sequence.
+    const filter = new URL(intelCall).searchParams.get("filter") ?? "";
     // The value's own quote is escaped, so the literal still opens and closes exactly once.
     expect(filter).toBe("indicator:'http://evil.test/a\\'b\\\\c'");
   });


### PR DESCRIPTION
Fixes #514.

## Problem
The Falcon Intelligence lookup built its FQL filter by interpolation:

```ts
const filter = encodeURIComponent(`indicator:'${value}'`);
```

`encodeURIComponent` protects the value for *URL transport*. It does nothing for the query language underneath — a `'` inside the value still terminates the FQL string literal. A repo-wide grep found no escaping anywhere in `src/enrichment/`.

The values are not trusted input. `enrichService` passes `ioc.value` straight through from parsed/imported evidence, the provider explicitly supports `url` IOCs, and a single quote is perfectly legal in a URL. So a value like `http://evil.test/a'b` produces a malformed filter: CrowdStrike returns 400, `apiGet` throws, and `lookup` reports "CrowdStrike lookups failed" — **on every enrichment run for that IOC, forever**. A value crafted to close the literal can also change what the query asks.

## Fix
Escape the value for a single-quoted FQL literal before interpolating: backslash first, then the quote — the order matters, or the escapes added for quotes would themselves be escaped.

## Test plan
- [x] `tests/enrichment/providers.test.ts` — new test looks up a `url` IOC containing both `'` and `\`, then decodes the outgoing `filter` parameter and asserts it is exactly `indicator:'http://evil.test/a\'b\\c'` — the literal opens and closes exactly once. RED before the fix (raw quote passed through), GREEN after.
- [x] `npx vitest run tests/enrichment/` — 12 files pass, including the existing assertion that a plain domain still produces `indicator:'evil.test'` unchanged
- [x] `typecheck`, `lint`, `format:check`, `check:size` clean
