### PR TITLE
fix(providers): send the Gemini key as a header, not a query parameter

### DIFF
--- a/companion/src/providers/gemini.ts
+++ b/companion/src/providers/gemini.ts
@@ -30,13 +30,16 @@ export class GeminiProvider implements AIProvider {
     for (const img of req.images) {
       parts.push({ inline_data: { mime_type: img.mimeType, data: img.base64 } });
     }
-    const url = `${this.baseUrl}/models/${this.opts.model}:generateContent?key=${this.opts.apiKey}`;
+    // The key goes in a header, never the query string: a URL is written into the request line, so
+    // ?key=... lands in the access log of every proxy or gateway on the path — and baseUrl is
+    // operator-configurable, so that path is not always one they control. Google supports both.
+    const url = `${this.baseUrl}/models/${this.opts.model}:generateContent`;
     const timeoutMs = this.opts.timeoutMs ?? 60_000;
     let res: Response;
     try {
       res = await this.fetchFn(url, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", "x-goog-api-key": this.opts.apiKey },
         body: JSON.stringify({
           contents: [{ role: "user", parts }],
           generationConfig: {

--- a/companion/tests/providers/gemini.test.ts
+++ b/companion/tests/providers/gemini.test.ts
@@ -20,6 +20,35 @@ describe("GeminiProvider — base URL validation (#246)", () => {
   });
 });
 
+describe("GeminiProvider — API key placement (#516)", () => {
+  // A key in the query string is written into the request line, so it lands in the access log of
+  // any proxy or gateway on the path — and baseUrl is user-configurable, so that path can be one
+  // the operator does not control. Google accepts the key as a header; nothing needs it in the URL.
+  it("sends the key in the x-goog-api-key header and keeps it out of the URL", async () => {
+    let seenUrl = "";
+    let seenHeaders: Record<string, string> = {};
+    const provider = new GeminiProvider({
+      apiKey: "super-secret-key",
+      model: "gemini-2.5-pro",
+      fetchFn: async (input: RequestInfo | URL, init?: RequestInit) => {
+        seenUrl = String(input);
+        seenHeaders = (init?.headers ?? {}) as Record<string, string>;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }] }),
+          text: async () => "",
+        } as unknown as Response;
+      },
+    });
+    await provider.analyze({ systemPrompt: "s", userPrompt: "x", images: [] });
+
+    expect(seenUrl).not.toContain("super-secret-key");
+    expect(seenUrl).not.toContain("key=");
+    expect(seenHeaders["x-goog-api-key"]).toBe("super-secret-key");
+  });
+});
+
 describe("GeminiProvider — usageMetadata parsing (#3)", () => {
   it("reports input/output/cacheRead tokens from usageMetadata so the AI cost card is not always 0/0", async () => {
     const fakeResponse = {


### PR DESCRIPTION
Fixes #516.

## Problem
`GeminiProvider.analyze` put the API key in the request URL:

```ts
const url = `${this.baseUrl}/models/${model}:generateContent?key=${this.opts.apiKey}`;
```

A URL is written into the HTTP request line, so `?key=…` is recorded verbatim in the access log of every proxy, gateway or TLS-inspecting middlebox on the path. `baseUrl` is operator-configurable, so that path is not always one the operator controls — pointing the provider at a company gateway silently logs the key on every vision and synthesis call. The only header sent was `content-type`.

## Fix
Send the key as `x-goog-api-key`, which the Generative Language API supports, and drop it from the URL entirely.

Note `shodan.ts` also uses `?key=` — that is Shodan's only documented auth scheme, not an oversight, so it is left alone.

## Test plan
- [x] `tests/providers/gemini.test.ts` — new test captures the outgoing URL and headers and asserts the URL contains neither the key nor `key=`, and that `x-goog-api-key` carries it. RED before the fix, GREEN after.
- [x] `npx vitest run tests/providers/` — 16 files pass, including the existing base-URL validation and usage-metadata tests
- [x] `typecheck`, `lint`, `format:check`, `check:size` clean
