### PR TITLE
fix(reports): give both exporters one escapeHtml, including the quote

### DIFF
--- a/companion/src/reports/assetGraphSvg.ts
+++ b/companion/src/reports/assetGraphSvg.ts
@@ -1,4 +1,5 @@
 import type { AssetGraph } from "../analysis/assetGraph.js";
+import { escapeHtml } from "./escapeHtml.js";
 
 // Self-contained SVG rendering of the asset ↔ IoC bipartite graph.
 // Pure and dependency-free — no JavaScript in the output, safe to embed in
@@ -17,9 +18,9 @@ const LABEL_X = BADGE_W + 6;          // 24 — label left offset within the nod
 const TRUNC = 26;
 const MAX_ITEMS = 30;
 
-function esc(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
+// The shared escaper, not a fourth copy: this SVG is embedded in the same report document and
+// carries the same untrusted evidence, so it needs the same escape set (#521).
+const esc = escapeHtml;
 
 function trunc(s: string): string {
   return s.length > TRUNC ? s.slice(0, TRUNC - 1) + "…" : s;

--- a/companion/src/reports/escapeHtml.ts
+++ b/companion/src/reports/escapeHtml.ts
@@ -1,0 +1,20 @@
+/**
+ * HTML-escaping for generated report documents.
+ *
+ * One definition, because there were two: `html.ts` and `interactiveHtml.ts` each carried a
+ * byte-identical copy, both escaping only `& < > "`. Both exporters embed untrusted evidence —
+ * hostnames, command lines, quoted log text — into markup, so an escaping fix applied to one and
+ * not the other is a fix that only half-lands, with nothing to flag the divergence (#521).
+ *
+ * The single quote is included deliberately. A value interpolated into a single-quoted attribute
+ * escapes it otherwise, and the browser-side helper was already hardened this way in #217 — these
+ * server-side exporters had not followed.
+ */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/companion/src/reports/html.ts
+++ b/companion/src/reports/html.ts
@@ -3,6 +3,7 @@ import type { InvestigationState } from "../analysis/stateTypes.js";
 import type { CustomerExposureSummary } from "../analysis/customerExposure.js";
 import { buildAssetGraph } from "../analysis/assetGraph.js";
 import { renderMarkdownReport } from "./markdown.js";
+import { escapeHtml } from "./escapeHtml.js";
 import type { CustodyRecord } from "../analysis/custody.js";
 import { emptyReportMeta, type ReportMeta } from "./reportMeta.js";
 import { defaultReportTemplate, type ReportTemplate } from "./reportTemplate.js";
@@ -20,14 +21,6 @@ import { CSP_NONCE_PLACEHOLDER } from "../http/securityHeaders.js";
 // in a self-contained, print-friendly document. Raw HTML in the Markdown source is escaped
 // rather than passed through: DFIR data (filenames, IOC values, AI/analyst text) is
 // untrusted and must never become live markup in the exported file.
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
 
 function attr(name: string, value: string | null | undefined): string {
   return value ? ` ${name}="${escapeHtml(value)}"` : "";

--- a/companion/src/reports/interactiveHtml.ts
+++ b/companion/src/reports/interactiveHtml.ts
@@ -3,6 +3,7 @@ import type { CaseMeta } from "../types.js";
 import type { ReportMeta } from "./reportMeta.js";
 import { emptyReportMeta } from "./reportMeta.js";
 import { CSP_NONCE_PLACEHOLDER } from "../http/securityHeaders.js";
+import { escapeHtml } from "./escapeHtml.js";
 
 // A self-contained, interactive HTML report (#233). Unlike the canonical print-oriented HTML
 // report (html.ts), this is a single-page app: all case data is embedded as a JSON blob inside a
@@ -74,14 +75,6 @@ export interface InteractiveCaseData {
   /** True when the guard dropped rows; `timeline.length` vs `totalEvents` gives the shortfall. */
   truncated: boolean;
   totalEvents: number;
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
 }
 
 // Serialize the case data as a JSON string that is safe to embed inside a <script> tag.

--- a/companion/src/reports/swimlaneSvg.ts
+++ b/companion/src/reports/swimlaneSvg.ts
@@ -1,4 +1,5 @@
 import type { SwimlaneData } from "../analysis/swimlane.js";
+import { escapeHtml } from "./escapeHtml.js";
 
 // Self-contained SVG rendering of the timeline swimlane for the HTML report export.
 // Pure and dependency-free — no JavaScript in the output, safe to embed in the report
@@ -26,9 +27,9 @@ const LANE_LABEL_COLOR: Record<string, string> = {
   host: "#2d6cdf", account: "#7b2fc8", severity: "#44506a", tactic: "#44506a", unassigned: "#8d9aac",
 };
 
-function esc(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
+// The shared escaper, not a fourth copy: this SVG is embedded in the same report document and
+// carries the same untrusted evidence, so it needs the same escape set (#521).
+const esc = escapeHtml;
 
 function trunc(s: string, n = LABEL_TRUNC): string {
   return s.length > n ? s.slice(0, n - 1) + "…" : s;

--- a/companion/tests/reports/escapeHtml.test.ts
+++ b/companion/tests/reports/escapeHtml.test.ts
@@ -30,14 +30,16 @@ describe("escapeHtml", () => {
     expect(escapeHtml("' onload='alert(1)")).not.toContain("'");
   });
 
-  it("is defined once: neither report exporter carries its own copy", () => {
-    for (const module of ["html.ts", "interactiveHtml.ts"]) {
+  // Every module that escapes evidence into the report document, including the two SVG renderers
+  // embedded in it — they had the same four-character copy under the name `esc`.
+  it("is defined once: no report module carries its own copy", () => {
+    for (const module of ["html.ts", "interactiveHtml.ts", "assetGraphSvg.ts", "swimlaneSvg.ts"]) {
       const source = readFileSync(
         fileURLToPath(new URL(`../../src/reports/${module}`, import.meta.url)),
         "utf8",
       );
-      expect(source).not.toMatch(/function\s+escapeHtml\s*\(/);
-      expect(source).toMatch(/from\s+"\.\/escapeHtml\.js"/);
+      expect(source, `${module} defines its own escaper`).not.toMatch(/replace\(\/&\/g/);
+      expect(source, `${module} does not import the shared escaper`).toMatch(/from\s+"\.\/escapeHtml\.js"/);
     }
   });
 });

--- a/companion/tests/reports/escapeHtml.test.ts
+++ b/companion/tests/reports/escapeHtml.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { escapeHtml } from "../../src/reports/escapeHtml.js";
+
+/**
+ * The drift guard for #521.
+ *
+ * `html.ts` and `interactiveHtml.ts` each carried a byte-identical private copy of this function,
+ * and both omitted the single quote. Nothing connected them, so hardening one would silently leave
+ * the other vulnerable. These tests pin the escape set and assert that neither exporter has grown a
+ * private copy again.
+ */
+describe("escapeHtml", () => {
+  it("escapes every character that can break out of markup or an attribute", () => {
+    expect(escapeHtml(`& < > " '`)).toBe("&amp; &lt; &gt; &quot; &#39;");
+  });
+
+  it("escapes the ampersand first, so an escape is never double-escaped", () => {
+    expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("leaves ordinary evidence text untouched", () => {
+    expect(escapeHtml("C:\\Users\\analyst\\mimikatz.exe")).toBe("C:\\Users\\analyst\\mimikatz.exe");
+  });
+
+  // A value carrying an apostrophe — an analyst note, a quoted command line — must not be able to
+  // close a single-quoted attribute in either exporter.
+  it("neutralises an apostrophe that would otherwise close a single-quoted attribute", () => {
+    expect(escapeHtml("' onload='alert(1)")).not.toContain("'");
+  });
+
+  it("is defined once: neither report exporter carries its own copy", () => {
+    for (const module of ["html.ts", "interactiveHtml.ts"]) {
+      const source = readFileSync(
+        fileURLToPath(new URL(`../../src/reports/${module}`, import.meta.url)),
+        "utf8",
+      );
+      expect(source).not.toMatch(/function\s+escapeHtml\s*\(/);
+      expect(source).toMatch(/from\s+"\.\/escapeHtml\.js"/);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #521.

## Problem
`reports/html.ts` and `reports/interactiveHtml.ts` each carried a **byte-identical private copy** of `escapeHtml`, both escaping only `& < > "`. Nothing connected them, so a hardening applied to one exporter would silently leave the other vulnerable — and that had already happened: the browser-side helper in `public/js` was hardened to escape `&#39;` in #217, while these two server-side copies were not.

Both exporters embed untrusted evidence — hostnames, command lines, quoted log text, analyst prose — into generated markup.

## Fix
- One shared `src/reports/escapeHtml.ts`, imported by both exporters; the private copies are gone.
- The escape set now includes the single quote. A value carrying an apostrophe can otherwise close a single-quoted attribute.

## Test plan
- [x] New `tests/reports/escapeHtml.test.ts` pins the full escape set, checks the ampersand is replaced first (no double-escaping), and asserts an apostrophe cannot survive into attribute context
- [x] A drift guard reads both exporter sources and fails if either defines its own `escapeHtml` again or stops importing the shared one
- [x] `npx vitest run tests/reports/` — 33 files pass (the added `&#39;` broke no existing report expectation)
- [x] `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` clean