### PR TITLE
refactor(ingest): route the platform importers through the shared commit tail

### DIFF
--- a/companion/src/analysis/ingest/importState.ts
+++ b/companion/src/analysis/ingest/importState.ts
@@ -34,6 +34,13 @@ export async function commitDelta(
     importedAt: string;
     onProgress?: (done: number, total: number) => void | Promise<void>;
     signal?: AbortSignal;
+    /**
+     * Wait for the progress callback before returning. Only the EVTX importer does, because its
+     * callback checkpoints the job and the import is not really finished until that lands. Everyone
+     * else fires and forgets, and must keep doing so: awaiting would let a rejected checkpoint mark
+     * an import failed AFTER its state was already saved, so the retry would re-import it.
+     */
+    awaitProgress?: boolean;
   },
 ): Promise<InvestigationState> {
   return ctx.withStateLock(caseId, async () => {
@@ -50,7 +57,8 @@ export async function commitDelta(
     });
     await ctx.opts.stateStore.save(state);
     ctx.opts.onState?.(state);
-    await opts.onProgress?.(1, 1);
+    const progress = opts.onProgress?.(1, 1);
+    if (opts.awaitProgress) await progress;
     return state;
   });
 }

--- a/companion/src/analysis/ingest/importState.ts
+++ b/companion/src/analysis/ingest/importState.ts
@@ -14,14 +14,34 @@ import type { ImportContext } from "./importContext.js";
  * code lives where the callers do.
  */
 
-/** The load → merge → save → announce tail all deterministic imports share. */
-async function commitDelta(
+/**
+ * The load → merge → save → announce tail all deterministic imports share.
+ *
+ * Exported because it was not actually being shared: every wrapper in platformImports.ts had this
+ * same block pasted into it, so the one sequence that must stay consistent across importers — take
+ * the lock, merge under the import's timestamp, save, announce — existed in a dozen copies free to
+ * drift apart (#517).
+ *
+ * `signal` is checked inside the lock: an import cancelled while queued behind another write to the
+ * same case must not merge its delta after the analyst gave up on it.
+ */
+export async function commitDelta(
   ctx: ImportContext,
   caseId: string,
   delta: ReturnType<typeof deltaSchema.parse>,
-  opts: { label: string; importedAt: string; onProgress?: (done: number, total: number) => void },
+  opts: {
+    label: string;
+    importedAt: string;
+    onProgress?: (done: number, total: number) => void | Promise<void>;
+    signal?: AbortSignal;
+  },
 ): Promise<InvestigationState> {
   return ctx.withStateLock(caseId, async () => {
+    if (opts.signal?.aborted) {
+      throw Object.assign(new Error("import processing cancelled; stored evidence retained"), {
+        name: "AbortError",
+      });
+    }
     let state = await ctx.opts.stateStore.load(caseId);
     state = await ctx.mergeWithAliases(state, delta, {
       windowSequence: -1,
@@ -30,7 +50,7 @@ async function commitDelta(
     });
     await ctx.opts.stateStore.save(state);
     ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
+    await opts.onProgress?.(1, 1);
     return state;
   });
 }

--- a/companion/src/analysis/ingest/platformImports.ts
+++ b/companion/src/analysis/ingest/platformImports.ts
@@ -540,5 +540,7 @@ export async function importEvtxXml(
   };
   const delta = deltaSchema.parse(raw);
 
-  return commitDelta(ctx, caseId, delta, opts);
+  // awaitProgress: this importer's callback checkpoints the job, and the import is not finished
+  // until that lands — it is the one wrapper whose tail awaited it before the tails were shared.
+  return commitDelta(ctx, caseId, delta, { ...opts, awaitProgress: true });
 }

--- a/companion/src/analysis/ingest/platformImports.ts
+++ b/companion/src/analysis/ingest/platformImports.ts
@@ -19,7 +19,7 @@ import { parseTheHive, type TheHiveImportOptions } from "../theHiveImport.js";
 import { detectTool } from "../toolDetect.js";
 import { parseWazuhAlerts, type WazuhImportOptions } from "../wazuhImport.js";
 import { YARA_SOURCE, parseYaraOutput, type YaraImportOptions } from "../yaraImport.js";
-import { noteEmptyImport } from "./importState.js";
+import { commitDelta, noteEmptyImport } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
 
 /**
@@ -80,18 +80,7 @@ export async function importSiem(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Run a USER-authored declarative importer (the external plugin path). Mirrors the built-in
@@ -139,18 +128,7 @@ export async function importDeclarative(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import a malware-sandbox detonation report (CAPEv2 or CrowdStrike Falcon Sandbox).
@@ -193,18 +171,7 @@ export async function importSandbox(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import memory-forensics tool output (Volatility 3 or Rekall). Deterministic (no AI call): each
@@ -253,18 +220,7 @@ export async function importMemory(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import an email artifact (.eml RFC 2822, or best-effort .msg). Deterministic (no AI call):
@@ -308,18 +264,7 @@ export async function importEmail(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import a TheHive 5 case, alert, or observable export. Deterministic (no AI call):
@@ -362,18 +307,7 @@ export async function importTheHive(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import an existing DFIR-IRIS case (issue #88) — the reverse of the IRIS push. Takes the raw
@@ -417,18 +351,7 @@ export async function importIris(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import Wazuh SIEM/EDR alert exports (alerts.json / NDJSON / API export). Deterministic
@@ -471,18 +394,7 @@ export async function importWazuh(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import YARA CLI scan output (`yara -s -m <rules> <target>`). Deterministic (no AI): each rule
@@ -526,18 +438,7 @@ export async function importYara(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import SO-CRATES (dougburks/so-crates) verdicts — Suricata IDS alerts, YARA file matches, and
@@ -579,18 +480,7 @@ export async function importSocrates(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }
 
 // Import Windows Event XML through the shared deterministic SIEM/EVTX mapping.
@@ -650,20 +540,5 @@ export async function importEvtxXml(
   };
   const delta = deltaSchema.parse(raw);
 
-  return ctx.withStateLock(caseId, async () => {
-    if (opts.signal?.aborted)
-      throw Object.assign(new Error("import processing cancelled; stored evidence retained"), {
-        name: "AbortError",
-      });
-    let state = await ctx.opts.stateStore.load(caseId);
-    state = await ctx.mergeWithAliases(state, delta, {
-      windowSequence: -1,
-      timestamp: opts.importedAt,
-      sourceScreenshots: [opts.label],
-    });
-    await ctx.opts.stateStore.save(state);
-    ctx.opts.onState?.(state);
-    await opts.onProgress?.(1, 1);
-    return state;
-  });
+  return commitDelta(ctx, caseId, delta, opts);
 }


### PR DESCRIPTION
Fixes #517.

## What was actually duplicated
`importState.ts` **already had** `commitDelta` — the load → merge → save → announce tail every deterministic import ends in — but it was private, used only by `noteEmptyImport` and `persistPlasoParsed`. Meanwhile all **eleven** wrappers in `platformImports.ts` had pasted their own copy of the same block.

So the one sequence that must stay consistent across importers (take the state lock, merge under the import's timestamp, save, announce) existed in a dozen independent versions. That is the drift risk the issue describes, and it needed no new abstraction to fix — just using the one that was already there.

## Change
- Export `commitDelta`, with an optional `AbortSignal` (checked **inside** the lock, so an import cancelled while queued behind another write to the same case cannot merge afterwards) and an awaitable `onProgress`.
- All eleven wrappers now call it. `platformImports.ts` goes from **669 to 544 lines**.

Ten of the tails were byte-identical; the EVTX one differed only by the abort check and awaiting its progress callback — both now supported by the shared helper, so no behaviour is lost.

## What deliberately did not change
The parse *heads* stay per-importer. They genuinely differ — different parsers, id schemes, source labels, empty-guard conditions and timeline-note wording — so collapsing them into one factory would be a rewrite of eleven importers, not a de-duplication, and would risk exactly the behaviour changes this cleanup should not introduce.

## Test plan
- [x] `npx vitest run tests/analysis/` — 300 files pass
- [x] `npx vitest run tests/server/ tests/ingest/ tests/composition/` — 116 files pass
- [x] `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` clean