### PR TITLE
fix(settings): serialize .env saves so a concurrent one is not lost

### DIFF
--- a/companion/src/settings/envManager.ts
+++ b/companion/src/settings/envManager.ts
@@ -207,6 +207,23 @@ export async function getEnvForSettings(): Promise<Record<string, string>> {
  * Update specific keys in the .env file, preserving comments and structure.
  * Keys not already in the file are appended. Empty-string values are skipped.
  */
+// One writer at a time. updateEnv is a read-modify-write over a single file, so two overlapping
+// saves — the setup wizard and the Settings modal, or two browser tabs — both read the same
+// baseline and the second atomicWrite replaces the first caller's keys wholesale. atomicWrite makes
+// each individual write atomic; it cannot make the read and the write one step. The 200 has already
+// gone out by then, so the loss is silent (#510).
+let envWriteQueue: Promise<unknown> = Promise.resolve();
+
+function withEnvWriteLock<T>(run: () => Promise<T>): Promise<T> {
+  // Run whether or not the previous save succeeded: one failed write must not wedge every later one.
+  const result = envWriteQueue.then(run, run);
+  envWriteQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
 export async function updateEnv(updates: Record<string, string>): Promise<void> {
   // Fail closed on the record syntax even though the route validates first (#422). This function
   // is exported, and the cost of a caller forgetting is an attacker-authored line in the file the
@@ -217,28 +234,31 @@ export async function updateEnv(updates: Record<string, string>): Promise<void> 
       throw new Error(`refusing to write malformed .env record for key "${safeKeyLabel(key)}"`);
     }
   }
-  const raw = await readRaw();
-  const lines = raw.split("\n");
-  const updatedKeys = new Set<string>();
+  // Read and write as one step, or a concurrent save that read the same baseline overwrites us.
+  return withEnvWriteLock(async () => {
+    const raw = await readRaw();
+    const lines = raw.split("\n");
+    const updatedKeys = new Set<string>();
 
-  const newLines = lines.map(line => {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) return line;
-    const eq = trimmed.indexOf("=");
-    if (eq < 0) return line;
-    const key = trimmed.slice(0, eq).trim();
-    if (key in updates) {
-      updatedKeys.add(key);
-      return `${key}=${updates[key]}`;
+    const newLines = lines.map(line => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) return line;
+      const eq = trimmed.indexOf("=");
+      if (eq < 0) return line;
+      const key = trimmed.slice(0, eq).trim();
+      if (key in updates) {
+        updatedKeys.add(key);
+        return `${key}=${updates[key]}`;
+      }
+      return line;
+    });
+
+    for (const [key, val] of Object.entries(updates)) {
+      if (!updatedKeys.has(key) && val !== "") {
+        newLines.push(`${key}=${val}`);
+      }
     }
-    return line;
+
+    await atomicWrite(resolveEnvFilePath(), newLines.join("\n"));
   });
-
-  for (const [key, val] of Object.entries(updates)) {
-    if (!updatedKeys.has(key) && val !== "") {
-      newLines.push(`${key}=${val}`);
-    }
-  }
-
-  await atomicWrite(resolveEnvFilePath(), newLines.join("\n"));
 }

--- a/companion/src/settings/envManager.ts
+++ b/companion/src/settings/envManager.ts
@@ -212,6 +212,11 @@ export async function getEnvForSettings(): Promise<Record<string, string>> {
 // baseline and the second atomicWrite replaces the first caller's keys wholesale. atomicWrite makes
 // each individual write atomic; it cannot make the read and the write one step. The 200 has already
 // gone out by then, so the loss is silent (#510).
+//
+// Scope is this process, which is the whole exposure: the companion is the only writer of its own
+// .env, and every save arrives through one server. Two companions pointed at one file would still
+// race, and closing that would take an on-disk lock — not worth the failure modes (a stale lock
+// blocks every save) for a configuration nothing else is supposed to be writing.
 let envWriteQueue: Promise<unknown> = Promise.resolve();
 
 function withEnvWriteLock<T>(run: () => Promise<T>): Promise<T> {

--- a/companion/tests/settings/envWriteLock.test.ts
+++ b/companion/tests/settings/envWriteLock.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { updateEnv } from "../../src/settings/envManager.js";
 
 /**
@@ -44,7 +44,31 @@ describe("updateEnv — concurrent saves", () => {
     const written = await readFile(envFile, "utf8");
     // One winner, not two lines for one key: the loser's write was read and replaced, not skipped.
     expect(written.match(/^DFIR_RACED=/gm)).toHaveLength(1);
-    expect(written).toMatch(/DFIR_RACED=(first|second)/);
+    // And a specific winner: the queue is FIFO and these were enqueued left to right, so the save
+    // that arrived second is the one left standing. Accepting either value would pass even if the
+    // ordering were reversed, which is the property worth pinning.
+    expect(written).toContain("DFIR_RACED=second");
+  });
+
+  // The anti-wedge property: a save whose write throws must reject its own caller and must not stop
+  // the ones queued behind it. Without that, one EACCES would strand every later save in the process.
+  it("rejects the failed save without wedging the queue behind it", async () => {
+    // Fail the write by nesting the target under a regular FILE, which yields ENOTDIR. Removing
+    // directory permissions would not do it: CI often runs as root, where the mode bits are ignored
+    // and the "failing" write would quietly succeed, leaving this test green and meaningless.
+    const blocker = join(dirname(envFile), "not-a-directory");
+    await writeFile(blocker, "", "utf8");
+    process.env.DFIR_ENV_FILE = join(blocker, ".env");
+
+    await expect(updateEnv({ DFIR_WILL_FAIL: "x" })).rejects.toThrow();
+
+    process.env.DFIR_ENV_FILE = envFile;
+    // The queue still runs: a save enqueued after the failure completes normally.
+    await updateEnv({ DFIR_AFTER_FAILURE: "ok" });
+
+    const written = await readFile(envFile, "utf8");
+    expect(written).toContain("DFIR_AFTER_FAILURE=ok");
+    expect(written).not.toContain("DFIR_WILL_FAIL");
   });
 
   it("survives a burst without dropping anyone", async () => {

--- a/companion/tests/settings/envWriteLock.test.ts
+++ b/companion/tests/settings/envWriteLock.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { updateEnv } from "../../src/settings/envManager.js";
+
+/**
+ * updateEnv is a read-modify-write over one file (#510).
+ *
+ * Two saves in flight at once — the setup wizard and the Settings modal, or two browser tabs —
+ * both read the same baseline before either writes, so the second atomicWrite replaced the first
+ * caller's keys wholesale. The request had already returned 200, so the loss was silent.
+ *
+ * These use the real filesystem (no fs mock) via the DFIR_ENV_FILE override, because the bug is
+ * entirely about the ordering of real reads and writes.
+ */
+describe("updateEnv — concurrent saves", () => {
+  const originalEnv = { ...process.env };
+  let envFile: string;
+
+  beforeEach(async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dfir-envlock-"));
+    envFile = join(dir, ".env");
+    await writeFile(envFile, "# managed by dfir-companion\nDFIR_EXISTING=keep-me\n", "utf8");
+    process.env.DFIR_ENV_FILE = envFile;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("keeps both callers' keys when two saves overlap", async () => {
+    await Promise.all([updateEnv({ DFIR_FIRST: "one" }), updateEnv({ DFIR_SECOND: "two" })]);
+
+    const written = await readFile(envFile, "utf8");
+    expect(written).toContain("DFIR_FIRST=one");
+    expect(written).toContain("DFIR_SECOND=two");
+    expect(written).toContain("DFIR_EXISTING=keep-me");
+  });
+
+  it("applies the later value when two saves race on the SAME key", async () => {
+    await Promise.all([updateEnv({ DFIR_RACED: "first" }), updateEnv({ DFIR_RACED: "second" })]);
+
+    const written = await readFile(envFile, "utf8");
+    // One winner, not two lines for one key: the loser's write was read and replaced, not skipped.
+    expect(written.match(/^DFIR_RACED=/gm)).toHaveLength(1);
+    expect(written).toMatch(/DFIR_RACED=(first|second)/);
+  });
+
+  it("survives a burst without dropping anyone", async () => {
+    const keys = Array.from({ length: 8 }, (_, i) => `DFIR_BURST_${i}`);
+    await Promise.all(keys.map((key) => updateEnv({ [key]: "set" })));
+
+    const written = await readFile(envFile, "utf8");
+    for (const key of keys) expect(written).toContain(`${key}=set`);
+  });
+});


### PR DESCRIPTION
Fixes #510.

## Problem
`updateEnv` reads the whole `.env`, merges the caller's keys in memory, and writes the file back:

```ts
const raw = await readRaw();          // both callers read the same baseline
… merge …
await atomicWrite(resolveEnvFilePath(), newLines.join("\n"));   // last writer wins
```

Nothing serialized that sequence. Two saves in flight — the setup wizard and the Settings modal, two browser tabs, or a save racing an integration test — both read the same baseline, so the second `atomicWrite` replaced the first caller's keys wholesale. `atomicWrite` makes each individual write atomic; it cannot make the read and the write one step.

Both requests had already returned **200**, so the caller had no way to know its keys were gone.

## Fix
Queue the read-modify-write behind a module-level promise chain, so a save always reads a baseline that includes every save before it. A failed write does not wedge the ones queued behind it.

## Test plan
New `tests/settings/envWriteLock.test.ts` — real filesystem via the `DFIR_ENV_FILE` override, since the bug is entirely about real read/write ordering:
- [x] two overlapping saves of **different** keys: both survive, and the pre-existing key is untouched (RED before the fix — the first caller's key was missing entirely)
- [x] two saves racing on the **same** key: exactly one line for that key, carrying one of the two values — the loser was read and replaced, not duplicated
- [x] a burst of 8 concurrent saves: none dropped (RED before)
- [x] `npx vitest run tests/settings/ tests/server/` — 117 files pass
- [x] `typecheck`, `lint`, `format:check`, `check:size` clean