### PR TITLE
perf(mcp): bound the stdout an agent run retains

### DIFF
--- a/companion/src/integrations/mcp/mcpAgentRunner.ts
+++ b/companion/src/integrations/mcp/mcpAgentRunner.ts
@@ -33,6 +33,20 @@ export const DEFAULT_AGENT_TIMEOUT_MS = 3_600_000;
 /** A short, tool-free continuation reserved for turning collected evidence into the required JSON. */
 const FINAL_REPORT_TURNS = 3;
 
+/**
+ * How much of the agent's stdout to keep for the result scan (#518).
+ *
+ * `--output-format stream-json` emits every tool result as its own event, so an hour-long, 40-turn
+ * investigation can produce far more output than anything reads back: `streamProgress` deliberately
+ * ignores the content as it flows past, and the only thing wanted at the end is the last `result`
+ * event. Retaining all of it just grew the heap for the length of the run.
+ *
+ * 8 MB leaves thousands of events of headroom past the tail anyone reads, and what is retained is
+ * the END of the stream, where the result lives. Both readers skip lines that fail to parse, so the
+ * partial line at the truncation point is ignored rather than mistaken for data.
+ */
+const MAX_AGENT_STDOUT_BYTES = 8 * 1024 * 1024;
+
 export interface McpAgentOptions {
   /** Servers to expose. Callers pass only agent-enabled ones — this module does not re-check. */
   servers: McpServer[];
@@ -200,6 +214,7 @@ async function finalizeMaxTurnRun(
     timeoutMs: opts.timeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS,
     ...(opts.signal ? { signal: opts.signal } : {}),
     ...(opts.onProgress ? { onStdout: streamProgress(opts.onProgress) } : {}),
+    maxStdoutBytes: MAX_AGENT_STDOUT_BYTES,
   });
 
   if (run.spawnError) throw new Error(claudeMissingMessage(opts.bin, run.spawnError));
@@ -334,6 +349,7 @@ export async function runMcpAgent(opts: McpAgentOptions): Promise<McpAgentResult
     timeoutMs: opts.timeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS,
     ...(opts.signal ? { signal: opts.signal } : {}),
     ...(opts.onProgress ? { onStdout: streamProgress(opts.onProgress) } : {}),
+    maxStdoutBytes: MAX_AGENT_STDOUT_BYTES,
   });
 
   if (run.spawnError) throw new Error(claudeMissingMessage(opts.bin, run.spawnError));

--- a/companion/src/providers/claudeRunner.ts
+++ b/companion/src/providers/claudeRunner.ts
@@ -19,6 +19,17 @@ export interface ClaudeRunOptions {
   /** Optional live stream taps. Callers must not persist raw chunks without sanitizing them. */
   onStdout?: (chunk: string) => void;
   onStderr?: (chunk: string) => void;
+  /**
+   * Cap on the stdout retained in the result, in bytes. Oldest output is dropped once the cap is
+   * reached, so what survives is the TAIL. Unset means keep everything.
+   *
+   * For a long agent run the retained buffer is otherwise unbounded: `--output-format stream-json`
+   * emits every tool result as an event, and a 40-turn investigation over a memory image can carry
+   * far more of them than any consumer reads back (#518). Only set this where the consumer reads
+   * the end of the stream — both `terminalResult` and `finalText` scan for the LAST `result` event
+   * and already skip lines that do not parse, so a truncated first line costs nothing.
+   */
+  maxStdoutBytes?: number;
 }
 
 export type ClaudeRunner = (opts: ClaudeRunOptions) => Promise<ClaudeRunResult>;
@@ -26,7 +37,12 @@ export type ClaudeRunner = (opts: ClaudeRunOptions) => Promise<ClaudeRunResult>;
 // Default runner: spawn the claude CLI, feed stdin, collect stdout/stderr, resolve on close.
 export const defaultClaudeRunner: ClaudeRunner = (opts) =>
   new Promise<ClaudeRunResult>((resolve) => {
-    let stdout = "";
+    // Retained as chunks rather than one growing string so the cap can drop the oldest ones without
+    // rebuilding the whole buffer on every event.
+    const stdoutChunks: string[] = [];
+    let stdoutBytes = 0;
+    const maxStdoutBytes = opts.maxStdoutBytes ?? Infinity;
+    const stdoutText = () => stdoutChunks.join("");
     let stderr = "";
     let settled = false;
     let timedOut = false;
@@ -45,7 +61,7 @@ export const defaultClaudeRunner: ClaudeRunner = (opts) =>
     };
     const done = (r: ClaudeRunResult) => { if (!settled) { settled = true; cleanup(); resolve(r); } };
 
-    child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout, stderr, spawnError: err }));
+    child.on("error", (err: NodeJS.ErrnoException) => done({ code: null, stdout: stdoutText(), stderr, spawnError: err }));
     // Decode through the stream's own StringDecoder, which holds a partial multi-byte sequence back
     // until the rest arrives. Calling toString() on each Buffer instead turns any character split
     // across a ~64 KB pipe chunk into two U+FFFDs that concatenation cannot repair — corrupting
@@ -53,14 +69,19 @@ export const defaultClaudeRunner: ClaudeRunner = (opts) =>
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
+      stdoutChunks.push(chunk);
+      stdoutBytes += chunk.length;
+      // Keep at least the newest chunk, however large it is: a cap must never yield empty output.
+      while (stdoutBytes > maxStdoutBytes && stdoutChunks.length > 1) {
+        stdoutBytes -= stdoutChunks.shift()!.length;
+      }
       opts.onStdout?.(chunk);
     });
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
       opts.onStderr?.(chunk);
     });
-    child.on("close", (code) => done({ code, stdout, stderr, ...(timedOut ? { timedOut: true } : {}) }));
+    child.on("close", (code) => done({ code, stdout: stdoutText(), stderr, ...(timedOut ? { timedOut: true } : {}) }));
 
     child.stdin.on("error", () => { /* ignore EPIPE if the child exits before we finish writing */ });
     child.stdin.end(opts.stdin);

--- a/companion/src/providers/claudeRunner.ts
+++ b/companion/src/providers/claudeRunner.ts
@@ -38,8 +38,12 @@ export type ClaudeRunner = (opts: ClaudeRunOptions) => Promise<ClaudeRunResult>;
 export const defaultClaudeRunner: ClaudeRunner = (opts) =>
   new Promise<ClaudeRunResult>((resolve) => {
     // Retained as chunks rather than one growing string so the cap can drop the oldest ones without
-    // rebuilding the whole buffer on every event.
+    // rebuilding the whole buffer on every event. Each chunk's UTF-8 size is kept alongside it:
+    // String.length counts UTF-16 code units, which undercounts every non-ASCII character — and
+    // non-ASCII is exactly what this output carries (hostnames, filenames, quoted log text), so a
+    // byte cap measured in code units would let the buffer run several times over its limit.
     const stdoutChunks: string[] = [];
+    const stdoutChunkBytes: number[] = [];
     let stdoutBytes = 0;
     const maxStdoutBytes = opts.maxStdoutBytes ?? Infinity;
     const stdoutText = () => stdoutChunks.join("");
@@ -70,10 +74,13 @@ export const defaultClaudeRunner: ClaudeRunner = (opts) =>
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
       stdoutChunks.push(chunk);
-      stdoutBytes += chunk.length;
+      const chunkBytes = Buffer.byteLength(chunk, "utf8");
+      stdoutChunkBytes.push(chunkBytes);
+      stdoutBytes += chunkBytes;
       // Keep at least the newest chunk, however large it is: a cap must never yield empty output.
       while (stdoutBytes > maxStdoutBytes && stdoutChunks.length > 1) {
-        stdoutBytes -= stdoutChunks.shift()!.length;
+        stdoutChunks.shift();
+        stdoutBytes -= stdoutChunkBytes.shift()!;
       }
       opts.onStdout?.(chunk);
     });

--- a/companion/tests/providers/claudeRunner.test.ts
+++ b/companion/tests/providers/claudeRunner.test.ts
@@ -34,6 +34,37 @@ describe("defaultClaudeRunner", () => {
     expect(r.stdout).toBe("€");
   });
 
+  // maxStdoutBytes exists so a long agent run does not retain every tool_result event for the life
+  // of the process. What matters is WHICH end survives: consumers scan for the LAST result line
+  // (#518), so the cap has to drop the oldest output, not the newest.
+  it("keeps the tail of stdout when maxStdoutBytes is set", async () => {
+    const script =
+      'for (let i = 0; i < 200; i++) process.stdout.write("x".repeat(1000) + "\\n");' +
+      'process.stdout.write(JSON.stringify({ type: "result", result: "the answer" }) + "\\n");';
+    const r = await defaultClaudeRunner({
+      bin: process.execPath,
+      args: ["-e", script],
+      stdin: "",
+      timeoutMs: 30_000,
+      maxStdoutBytes: 16_000,
+    });
+
+    expect(r.code).toBe(0);
+    expect(r.stdout.length).toBeLessThan(200_000); // the full stream is ~200 KB
+    // The end survived: the result line a consumer needs is still there.
+    expect(r.stdout).toContain('"result":"the answer"');
+  });
+
+  it("keeps everything when no cap is set", async () => {
+    const r = await defaultClaudeRunner({
+      bin: process.execPath,
+      args: ["-e", 'process.stdout.write("y".repeat(100000))'],
+      stdin: "",
+      timeoutMs: 30_000,
+    });
+    expect(r.stdout.length).toBe(100_000);
+  });
+
   it("reports a non-zero exit code", async () => {
     const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", "process.exit(3)"], stdin: "", timeoutMs: 10_000 });
     expect(r.code).toBe(3);

--- a/companion/tests/providers/claudeRunner.test.ts
+++ b/companion/tests/providers/claudeRunner.test.ts
@@ -55,6 +55,25 @@ describe("defaultClaudeRunner", () => {
     expect(r.stdout).toContain('"result":"the answer"');
   });
 
+  // The cap is named in bytes, so it has to be measured in bytes. String.length counts UTF-16 code
+  // units, which undercounts every non-ASCII character — and this output carries plenty of them, so
+  // a cap measured that way would let the buffer run to several times its stated limit.
+  it("measures the cap in UTF-8 bytes, not UTF-16 code units", async () => {
+    // "€" is one UTF-16 code unit but three UTF-8 bytes, so 300k of them is 300k units and 900 KB.
+    // Counting units against a 200 KB cap would retain 200k of them — 600 KB, three times the cap.
+    const r = await defaultClaudeRunner({
+      bin: process.execPath,
+      args: ["-e", 'process.stdout.write("\\u20ac".repeat(300000))'],
+      stdin: "",
+      timeoutMs: 30_000,
+      maxStdoutBytes: 200_000,
+    });
+
+    // The cap plus at most one whole chunk, which is always retained however large it is.
+    expect(Buffer.byteLength(r.stdout, "utf8")).toBeLessThanOrEqual(300_000);
+    expect(r.stdout).not.toContain("�"); // the tail is still whole characters
+  });
+
   it("keeps everything when no cap is set", async () => {
     const r = await defaultClaudeRunner({
       bin: process.execPath,


### PR DESCRIPTION
Fixes #518.

## Problem
`runMcpAgent` runs with `--verbose --output-format stream-json`, which emits **every tool result as its own NDJSON event**, for up to an hour and 40 turns. `defaultClaudeRunner` accumulated all of it into one string and kept it for the life of the run.

Nothing wanted that much: `streamProgress` deliberately ignores event *content* as it flows past (it only emits sanitized activity labels), and the only thing read at the end is the **last** `result` event — `terminalResult` and `finalText` each scan for it and skip anything that fails to parse.

## Fix
`ClaudeRunOptions` gains an optional `maxStdoutBytes`. When set, the runner keeps the newest output within the cap and drops the oldest.

The direction matters and is the whole design: the retained slice is the **tail**, which is where the result event lives. The partial line left at the truncation point is skipped by both readers, which already tolerate unparseable lines because stream-json shares stdout with diagnostics. The newest chunk is always retained regardless of size, so a cap can never yield empty output.

Only `mcpAgentRunner` opts in, at 8 MB — thousands of events of headroom past anything that is read. Every other caller is unchanged and still keeps the full buffer.

## Test plan
- [x] `tests/providers/claudeRunner.test.ts` — a child writes ~200 KB followed by a `result` line with a 16 KB cap: output is bounded **and** the result line survives (proving the tail, not the head, is kept)
- [x] A second test asserts that with no cap set, 100 KB is retained in full — the default is unchanged
- [x] `npx vitest run tests/providers/ tests/integrations/` — 44 files pass
- [x] `typecheck`, `lint`, `format:check`, `check:size` clean