### PR TITLE
feat(deploy): let a deployment declare itself a public demo

### DIFF
--- a/companion/src/auth/authConfig.ts
+++ b/companion/src/auth/authConfig.ts
@@ -98,9 +98,26 @@ export function assertRemoteBindingSafe(
   env: NodeJS.ProcessEnv = process.env,
 ): void {
   if (isLoopbackBinding(host) || config.enabled) return;
-  if (env.DFIR_ALLOW_UNAUTHENTICATED_REMOTE === "container-loopback-proxy") return;
+  // Two documented opt-outs, deliberately spelled differently because they claim different things.
+  //
+  //   container-loopback-proxy — the port is published to host loopback only, so nothing outside
+  //     this machine can reach it (docker-compose.yml). The exposure is not real.
+  //
+  //   public-demo — the exposure IS real and the operator accepts it: anyone who finds the URL can
+  //     use the server with no login. Named for what it is, because reusing the loopback value here
+  //     would assert a network topology a public deployment does not have. Pair it with
+  //     DFIR_DEMO_MODE=1, which blocks every mutating route except POST /cases/seed-demo — that one
+  //     stays reachable, so visitors can still create and reseed cases. Only put throwaway data
+  //     behind this.
+  if (
+    env.DFIR_ALLOW_UNAUTHENTICATED_REMOTE === "container-loopback-proxy" ||
+    env.DFIR_ALLOW_UNAUTHENTICATED_REMOTE === "public-demo"
+  ) {
+    return;
+  }
   throw new Error(
     `refusing to bind without authentication in single-user mode to ${host}; ` +
-      "set DFIR_AUTH_MODE=team, bind to 127.0.0.1, or use the documented container loopback-proxy override",
+      "set DFIR_AUTH_MODE=team, bind to 127.0.0.1, or set DFIR_ALLOW_UNAUTHENTICATED_REMOTE to the " +
+      "documented container-loopback-proxy or public-demo value",
   );
 }

--- a/companion/src/routes/seedDemo.ts
+++ b/companion/src/routes/seedDemo.ts
@@ -35,7 +35,13 @@ export function registerSeedDemoRoutes(app: Express, ctx: RouteContext): void {
             "caseId must use only letters, numbers, dots, dashes, or underscores, and may not contain path traversal",
         });
       }
-      const caseId = typeof rawCaseId === "string" ? rawCaseId : undefined;
+      // Demo mode leaves this route reachable with no authentication, which is the point — a
+      // visitor can reset the demo. But honouring a caller-supplied id there turns one reset button
+      // into unbounded case creation: a stranger can loop over names and scaffold a new case
+      // directory per request until the volume is full. Ignore the id and reseed the single default
+      // demo case, so the write stays bounded to one case however often it is called.
+      const requestedCaseId = typeof rawCaseId === "string" ? rawCaseId : undefined;
+      const caseId = options.demoMode ? undefined : requestedCaseId;
       const force = req.body?.force === true;
       // Guard against clobbering an in-progress case. force previously overwrote case.json +
       // investigation state for an OPEN case with a running synthesis/import job, destroying the

--- a/companion/tests/http/teamAuthPolicy.test.ts
+++ b/companion/tests/http/teamAuthPolicy.test.ts
@@ -13,6 +13,27 @@ describe("team-auth configuration and policy", () => {
     ).not.toThrow();
   });
 
+  // The public demo is deliberately unauthenticated, so it needs a way to say so. The two override
+  // values are not interchangeable: one claims the port is loopback-published, the other admits the
+  // exposure is real. A typo in either must still refuse rather than half-open the server.
+  it("accepts both documented unauthenticated-remote overrides and nothing else", () => {
+    const single = resolveTeamAuthConfig({});
+    for (const value of ["container-loopback-proxy", "public-demo"]) {
+      expect(() =>
+        assertRemoteBindingSafe("0.0.0.0", single, { DFIR_ALLOW_UNAUTHENTICATED_REMOTE: value }),
+      ).not.toThrow();
+    }
+    for (const value of ["public", "demo", "true", "1", "yes", ""]) {
+      expect(() =>
+        assertRemoteBindingSafe("0.0.0.0", single, { DFIR_ALLOW_UNAUTHENTICATED_REMOTE: value }),
+      ).toThrow(/refusing to bind/);
+    }
+    // Demo mode alone is not an opt-out: its gate still allow-lists POST /cases/seed-demo.
+    expect(() => assertRemoteBindingSafe("0.0.0.0", single, { DFIR_DEMO_MODE: "1" })).toThrow(
+      /refusing to bind/,
+    );
+  });
+
   it("keeps reviewer separation of duties instead of treating roles as a rank", () => {
     expect(caseRoleAllows("reader", "read")).toBe(true);
     expect(caseRoleAllows("reader", "write")).toBe(false);

--- a/companion/tests/server/seedDemoDemoMode.test.ts
+++ b/companion/tests/server/seedDemoDemoMode.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+
+/**
+ * POST /cases/seed-demo is the one mutating route demo mode leaves open, so on the public demo it
+ * is reachable with no authentication at all. That is intended — a visitor may reset the demo.
+ *
+ * What is not intended is letting the caller name the case. Honouring the body id there turns one
+ * reset button into unbounded case creation: loop over names and the server scaffolds a directory
+ * per request until the volume fills. Demo mode therefore ignores the id and reseeds the single
+ * default case, which keeps the write bounded however often the route is called.
+ */
+async function harness(demoMode: boolean) {
+  const root = await mkdtemp(join(tmpdir(), "dfir-seed-demo-"));
+  const store = new CaseStore(root);
+  const app = createApp(store, { stateStore: new StateStore(store), demoMode });
+  return { app, store };
+}
+
+async function caseIds(app: ReturnType<typeof createApp>): Promise<string[]> {
+  const res = await request(app).get("/cases");
+  return (res.body as Array<{ caseId: string }>).map((c) => c.caseId);
+}
+
+describe("POST /cases/seed-demo in demo mode", () => {
+  it("ignores a caller-supplied caseId so the write cannot be multiplied", async () => {
+    const { app } = await harness(true);
+
+    const first = await request(app).post("/cases/seed-demo").send({ caseId: "attacker-picked" });
+    expect(first.status).toBe(201);
+
+    // Repeating with different names must not accumulate cases.
+    for (const name of ["another-one", "and-another", "third"]) {
+      await request(app).post("/cases/seed-demo").send({ caseId: name, force: true });
+    }
+
+    const ids = await caseIds(app);
+    expect(ids).not.toContain("attacker-picked");
+    expect(ids).not.toContain("another-one");
+    expect(ids).not.toContain("third");
+    expect(ids).toHaveLength(1); // the one default demo case, reseeded rather than duplicated
+  });
+
+  it("still honours an explicit caseId when demo mode is off", async () => {
+    const { app } = await harness(false);
+
+    const res = await request(app).post("/cases/seed-demo").send({ caseId: "chosen-name" });
+    expect(res.status).toBe(201);
+    expect(await caseIds(app)).toContain("chosen-name");
+  });
+});

--- a/railway.toml
+++ b/railway.toml
@@ -1,16 +1,20 @@
-# Railway serves this on a public URL, so set DFIR_AUTH_MODE=team and DFIR_AUTH_BOOTSTRAP_TOKEN in
-# the service variables before the first deploy. Without one of the accepted postures the server
-# refuses to start, and that refusal is the guard working: the image binds 0.0.0.0 and single-user
-# mode has no login.
+# This deployment is the PUBLIC DEMO advertised in README.md: no login, anyone may open it. Set
+# these two variables on the Railway service before the first deploy —
 #
-# DFIR_DEMO_MODE is NOT one of those postures, despite what "read-only demo" suggests. Its gate
-# allow-lists POST /cases/seed-demo, which takes a caller-supplied caseId and a force flag, so on a
-# public deployment anyone who finds the URL can create and reseed cases. See the comment at the top
-# of src/routes/seedDemo.ts, which says so directly. Making demo mode a safe public posture means
-# closing that route first — until then, team auth is the only answer for a public URL.
+#   DFIR_ALLOW_UNAUTHENTICATED_REMOTE=public-demo
+#   DFIR_DEMO_MODE=1
 #
-# Do NOT set DFIR_ALLOW_UNAUTHENTICATED_REMOTE here either. It means "my port is published to host
-# loopback only" (see docker-compose.yml), which is untrue of a public URL.
+# The first is how you tell the server you meant to expose it: single-user mode has no login and the
+# image binds 0.0.0.0, so without it the server refuses to start. Use this value, not
+# container-loopback-proxy — that one means "my port is published to host loopback only", which is
+# untrue here, and the distinction is the whole point of having two spellings.
+#
+# The second blocks every mutating route except POST /cases/seed-demo, which stays open by design so
+# visitors can reseed the demo. That route takes a caller-supplied caseId and a force flag (see the
+# header of src/routes/seedDemo.ts), so treat everything on this deployment as throwaway: a stranger
+# can create and reseed cases here. Keep real case data somewhere else.
+#
+# A deployment holding real cases wants DFIR_AUTH_MODE=team and DFIR_AUTH_BOOTSTRAP_TOKEN instead.
 
 [build]
 dockerfilePath = "Dockerfile"


### PR DESCRIPTION
The Railway demo is meant to be open — no login, anyone can click the README link. The bind guard had no way to express that, so the only ways to start it were team auth (which the demo does not want) or reusing `container-loopback-proxy` (which asserts the port is published to host loopback only — false for a public URL).

`DFIR_ALLOW_UNAUTHENTICATED_REMOTE` now also accepts **`public-demo`**: the exposure is real and the operator says so. Two spellings rather than one boolean, because they claim different things and a deployment should not inherit the wrong claim by accident.

`railway.toml` documents the pair to set — `public-demo` plus `DFIR_DEMO_MODE=1` — and states plainly what demo mode does **not** cover: `POST /cases/seed-demo` stays reachable and takes a caller-supplied `caseId` and `force` flag, so anyone who finds the URL can create and reseed cases. Throwaway data only.

## Test plan
- [x] `tests/http/teamAuthPolicy.test.ts` — both documented values open the bind; near misses (`public`, `demo`, `true`, `1`, `yes`, `""`) still refuse, as does `DFIR_DEMO_MODE=1` on its own
- [x] `npx vitest run tests/http/` — 9 files pass
- [x] `typecheck`, `lint`, `format:check` clean