### PR TITLE
fix(cases): claim a case id atomically instead of check-then-create

### DIFF
--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -1,7 +1,7 @@
 import type { Express, Request, Response } from "express";
 import { readFile } from "node:fs/promises";
 import { ZodError } from "zod";
-import { isValidCaseId } from "../storage/caseStore.js";
+import { isValidCaseId, CaseAlreadyExistsError } from "../storage/caseStore.js";
 import { withNonce } from "../http/securityHeaders.js";
 import { sanitizeCaseMeta } from "../analysis/casePassword.js";
 import { buildInitialQuestions, buildInitialNextSteps } from "../analysis/templateStore.js";
@@ -100,11 +100,10 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
   });
 
   // Create a case. This is the one place a case is born (the dashboard's New case form and
-  // `npm run`-style tooling call it); the extension no longer creates cases. Rejects a
-  // duplicate id so the form can't silently clobber an existing case's metadata/evidence.
-  // Optional `templateId`: pre-populates key questions from the named template.
-  // Optional `incidentTypeId` (#236): additionally applies an incident type's auto-playbook —
-  // type-specific key questions, next steps, and expected-finding confirm/deny seeds.
+  // `npm run`-style tooling call it); the extension no longer creates cases. The caseExists check
+  // is only the friendly duplicate answer — two simultaneous requests both pass it, so createCase's
+  // exclusive claim is the guarantee, and a loser 409s from the catch without reaching grantCreator.
+  // Optional `templateId` seeds key questions; `incidentTypeId` (#236) also applies its auto-playbook.
   app.post("/cases", async (req: Request, res: Response) => {
     try {
       const { caseId, name, investigator, aiProvider, templateId, incidentTypeId } = req.body ?? {};
@@ -146,6 +145,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       await ensureDropFolders(caseId).catch(() => { /* the watcher re-ensures on its next poll */ });
       return res.status(201).json(sanitizeCaseMeta(meta));
     } catch (err) {
+      if (err instanceof CaseAlreadyExistsError) return res.status(409).json({ error: err.message });
       return res.status(500).json({ error: (err as Error).message });
     }
   });

--- a/companion/src/storage/caseStore.ts
+++ b/companion/src/storage/caseStore.ts
@@ -21,6 +21,21 @@ export function isValidCaseId(caseId: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(caseId) && !caseId.includes("..");
 }
 
+/**
+ * The case id is already owned by someone else. Thrown by createCase when its exclusive claim on
+ * case.json loses — which is the ONLY way a caller can learn it lost, since a check-then-create
+ * pair cannot: both racers pass the check.
+ *
+ * A distinct type rather than a message match so the route can answer 409 (someone else has it)
+ * instead of 500 (we broke), and so a future caller cannot mistake it for a disk failure.
+ */
+export class CaseAlreadyExistsError extends Error {
+  constructor(readonly caseId: string) {
+    super(`case ${caseId} already exists`);
+    this.name = "CaseAlreadyExistsError";
+  }
+}
+
 /** What the caller knows about where an artifact came from; only the capture path has all of it. */
 export interface ArtifactProvenance {
   source?: string;
@@ -168,10 +183,18 @@ export class CaseStore {
     await rm(dir, { recursive: true });
   }
 
-  // NOTE: does not itself guard against an id collision with an archived case (caseDir()
-  // resolves to the archived location and this would silently overwrite its case.json).
-  // Callers are responsible for that check — see POST /cases in server.ts, which calls
-  // caseExists() (archive-aware) and 409s before ever reaching here.
+  // Creating a case CLAIMS its id, so the write of case.json is exclusive (`wx` — O_CREAT|O_EXCL,
+  // atomic on POSIX and Windows alike) and is the FIRST thing that touches the case. A caller's
+  // caseExists() check cannot make this safe on its own: two requests for the same id both pass the
+  // check, both used to create, and the later metadata write simply became the final case.json —
+  // which under team auth handed BOTH requesters administrator on the same case. The exclusive
+  // create is the single point where exactly one of them can win.
+  //
+  // This also subsumes the archived-collision hazard the callers used to be responsible for:
+  // caseDir() resolves an archived id to its archived folder, so the claim collides there too and
+  // an archived case's metadata can no longer be silently overwritten.
+  //
+  // The subdirectories are created only AFTER the claim succeeds, so a loser leaves nothing behind.
   async createCase(input: CreateCaseInput): Promise<CaseMeta> {
     const meta: CaseMeta = {
       caseId: input.caseId,
@@ -180,16 +203,30 @@ export class CaseStore {
       investigator: input.investigator,
       aiProvider: input.aiProvider,
     };
-    for (const dir of [
+    // Resolved once: caseDir() is existsSync-based, so re-resolving it after the mkdir below would
+    // answer a different question than the one the claim is made against.
+    const dir = this.caseDir(input.caseId);
+    await mkdir(dir, { recursive: true });
+    try {
+      await writeFile(join(dir, "case.json"), JSON.stringify(meta, null, 2), {
+        encoding: "utf8",
+        flag: "wx",
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+        throw new CaseAlreadyExistsError(input.caseId);
+      }
+      throw err;
+    }
+    for (const sub of [
       this.screenshotsDir(input.caseId),
       this.metadataDir(input.caseId),
       this.stateDir(input.caseId),
       this.reportsDir(input.caseId),
       this.importsDir(input.caseId),
     ]) {
-      await mkdir(dir, { recursive: true });
+      await mkdir(sub, { recursive: true });
     }
-    await writeFile(this.caseMetaPath(input.caseId), JSON.stringify(meta, null, 2), "utf8");
     return meta;
   }
 

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -88,6 +88,24 @@ describe("HTTP server", () => {
     expect(res.status).toBe(409);
   });
 
+  // The duplicate check above is a check-then-create pair, which two SIMULTANEOUS requests both
+  // pass. Exactly one must still end up creating the case: the 201 is also what gates
+  // teamAuth.grantCreator, so two 201s would mean two administrators on one case.
+  it("POST /cases lets only one of two simultaneous requests create the same caseId", async () => {
+    const send = (name: string) =>
+      request(app).post("/cases").send({ caseId: "race", name, investigator: "y", aiProvider: null });
+
+    const [a, b] = await Promise.all([send("first"), send("second")]);
+    // Never a 500: losing a claim is a legitimate answer, not a server fault.
+    expect([a.status, b.status].sort()).toEqual([201, 409]);
+
+    const winner = a.status === 201 ? a : b;
+    const listed = await request(app).get("/cases");
+    const created = listed.body.filter((c: { caseId: string }) => c.caseId === "race");
+    expect(created).toHaveLength(1);
+    expect(created[0].name).toBe(winner.body.name);
+  });
+
   it("POST /cases rejects path-like case IDs before touching storage paths", async () => {
     const res = await request(app).post("/cases").send({ caseId: "..\\outside", name: "A", investigator: "y", aiProvider: null });
     expect(res.status).toBe(400);

--- a/companion/tests/storage/caseStore.test.ts
+++ b/companion/tests/storage/caseStore.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, readFile, stat, mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, mkdir, rename, writeFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CaseStore } from "../../src/storage/caseStore.js";
-import type { CaptureMetadata } from "../../src/types.js";
+import { CaseStore, CaseAlreadyExistsError } from "../../src/storage/caseStore.js";
+import type { CaptureMetadata, CaseMeta } from "../../src/types.js";
 
 let root: string;
 beforeEach(async () => {
@@ -39,6 +40,73 @@ describe("CaseStore.createCase", () => {
     const store = new CaseStore(root);
     expect(store.screenshotsDir("case-001")).toBe(join(root, "case-001", "screenshots"));
     expect(store.capturesLogPath("case-001")).toBe(join(root, "case-001", "metadata", "captures.jsonl"));
+  });
+
+  // Creation is the point a case id gets an OWNER. Two callers racing for the same id both used to
+  // succeed — the second metadata write simply became the final case.json — and under team auth
+  // both of them were then granted administrator on it.
+  it("lets only one of two concurrent creations claim the same id", async () => {
+    const store = new CaseStore(root);
+    const claim = (name: string) =>
+      store.createCase({ caseId: "race-1", name, investigator: name, aiProvider: null });
+
+    const results = await Promise.allSettled([claim("first"), claim("second")]);
+    const won = results.filter((r) => r.status === "fulfilled");
+    const lost = results.filter((r) => r.status === "rejected");
+
+    expect(won).toHaveLength(1);
+    expect(lost).toHaveLength(1);
+    expect(lost[0].reason).toBeInstanceOf(CaseAlreadyExistsError);
+
+    // The case.json on disk must be the WINNER's, not whichever write happened to land last.
+    const written = JSON.parse(await readFile(join(root, "race-1", "case.json"), "utf8"));
+    const winner: CaseMeta = won[0].value;
+    expect(written.name).toBe(winner.name);
+    expect(written.investigator).toBe(winner.investigator);
+  });
+
+  it("refuses to recreate an id that already exists, rather than overwriting its metadata", async () => {
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "taken", name: "original", investigator: "i", aiProvider: null });
+
+    await expect(
+      store.createCase({ caseId: "taken", name: "usurper", investigator: "j", aiProvider: null }),
+    ).rejects.toBeInstanceOf(CaseAlreadyExistsError);
+
+    const written = JSON.parse(await readFile(join(root, "taken", "case.json"), "utf8"));
+    expect(written.name).toBe("original");
+  });
+
+  // caseDir() is archive-aware, so an id colliding with an ARCHIVED case used to resolve to the
+  // archived folder and silently overwrite its case.json. The exclusive create refuses that too,
+  // instead of relying on every caller remembering to check first.
+  it("refuses an id that collides with an archived case", async () => {
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "arch-claim", name: "original", investigator: "i", aiProvider: null });
+    await store.archiveCaseFolder("arch-claim");
+
+    await expect(
+      store.createCase({ caseId: "arch-claim", name: "usurper", investigator: "j", aiProvider: null }),
+    ).rejects.toBeInstanceOf(CaseAlreadyExistsError);
+
+    const written = JSON.parse(
+      await readFile(join(root, "_archived", "arch-claim", "case.json"), "utf8"),
+    );
+    expect(written.name).toBe("original");
+  });
+
+  // A loser must not leave a half-built case behind: the subdirectories are created only after the
+  // claim succeeds, so the winner's layout is the only one on disk.
+  it("does not leave partial folders behind when a claim is lost", async () => {
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "solo", name: "n", investigator: "i", aiProvider: null });
+    await rm(join(root, "solo", "reports"), { recursive: true });
+
+    await expect(
+      store.createCase({ caseId: "solo", name: "n2", investigator: "i", aiProvider: null }),
+    ).rejects.toBeInstanceOf(CaseAlreadyExistsError);
+
+    expect(existsSync(join(root, "solo", "reports"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
> **Stacked on #537** — base is `fix/mcp-process-substitution`. Merge #537 first; this PR's base will retarget to `master` automatically.

## Problem

`POST /cases` checked `caseExists()` and then created the case in a **separate** step (recursive `mkdir` + an ordinary `case.json` write). Two simultaneous requests for the same id both pass the check, both create, and the later metadata write simply becomes the final `case.json`. Reproduced at the storage layer: both calls fulfilled, second one won the file.

The consequence isn't just a clobbered name. `POST /cases` grants the requester **administrator** on the new case via `teamAuth.grantCreator` — and it did so for *both* racers. In a team-auth deployment two unrelated people end up with admin on one case.

## Fix

`case.json` is now written with `flag: "wx"` (`O_CREAT|O_EXCL` — atomic on POSIX and Windows) as the **first** thing that touches the case:

- Exactly one caller can claim an id; the loser gets a typed `CaseAlreadyExistsError`.
- The route answers that with **409, never 500** — losing a claim is a legitimate outcome, not a fault — and the loser never reaches `grantCreator`.
- Subdirectories are created only *after* the claim succeeds, so a loser leaves nothing behind.

It also subsumes a hazard callers were previously told to handle themselves: `caseDir()` is archive-aware, so an id colliding with an **archived** case used to resolve to the archived folder and silently overwrite its `case.json`. The exclusive claim refuses that too.

The `caseExists()` pre-check stays — it's the friendly duplicate answer, just no longer mistaken for the guarantee.

## Test plan

- [x] Storage: concurrent claim (exactly one fulfils, winner's metadata survives), sequential recreation, archived-id collision, no partial folders after a lost claim
- [x] All four confirmed **RED** against a non-exclusive write, GREEN with `wx`
- [x] Route: two simultaneous `POST /cases` → exactly one 201 + one 409, one case listed, winner's name persisted
- [x] `tests/server.test.ts` + `tests/storage/` + team-auth suites: 182/182 pass
- [x] typecheck, eslint, prettier, file-size / import-cycle / module-boundary ratchets all pass (`caseLifecycle.ts` kept at its ledger cap — net zero lines added)