### PR TITLE
fix(export): build a case archive from one generation, not a live walk

### DIFF
--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -32,6 +32,11 @@ export const MIN_PASSWORD_LENGTH = 8;
 const IMPORT_STAGING_DIRNAME = ".import-staging";
 const IMPORT_STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
+// Where an export stages the database snapshot it archives instead of the live file. Dotted and a
+// level above the cases for the same reason import staging is: nothing that enumerates the cases
+// root, and nothing that walks a case, may mistake it for case content.
+const EXPORT_STAGING_DIRNAME = ".export-staging";
+
 export class CaseImportConflictError extends Error {
   constructor(public readonly caseId: string) {
     super(`case ${caseId} already exists — import under a different case id`);
@@ -165,9 +170,22 @@ async function walkDir(dir: string, baseRel = ""): Promise<string[]> {
   return out;
 }
 
+export interface CaseExportOptions {
+  /**
+   * The app's per-case state mutex (createApp's runStateExclusive). Passing it makes the export a
+   * critical section: every load→save the app performs through the same lock either completes
+   * before the snapshot is taken or waits until the archive is built, so the export cannot capture
+   * a case midway through one. Omitted in tests and by callers with no lock wired, which run
+   * unserialized exactly as before.
+   */
+  runExclusive?: <T>(caseId: string, fn: () => Promise<T>) => Promise<T>;
+}
+
 /**
  * Build a `.dfircase` file: the whole case directory zipped, then AES-256-GCM encrypted with a
  * password-derived key. Throws if the case doesn't exist (no files under its directory).
+ *
+ * The archive is ONE generation of the case, not a walk of a moving target — see buildCaseArchive.
  */
 export async function exportEncryptedCase(
   store: CaseStore,
@@ -177,16 +195,88 @@ export async function exportEncryptedCase(
   // chain-of-custody manifest (#231). Passed in rather than written into the case first, so
   // exporting never mutates the case it is exporting.
   extraEntries: ZipEntry[] = [],
+  opts: CaseExportOptions = {},
 ): Promise<Buffer> {
   if (!isValidCaseId(caseId)) throw new Error(`invalid case id "${caseId}"`);
+  const run = opts.runExclusive ?? (<T>(_id: string, fn: () => Promise<T>) => fn());
+  return run(caseId, () => buildCaseArchive(store, caseId, password, extraEntries));
+}
+
+/**
+ * The archive itself, built from a single case generation.
+ *
+ * The database is taken through SQLite's own snapshot path (the worker's backupDatabase, which is
+ * VACUUM INTO plus an integrity_check) rather than copied as ordinary bytes. Copying the file while
+ * a transaction is open could yield an archive whose database does not open at all — the one defect
+ * an evidence archive cannot have — and reading the live file gave a database from one instant with
+ * a manifest counted at another. Entity counts now come from that same snapshot, so what the
+ * manifest claims and what the archive contains are the same generation by construction.
+ *
+ * Journal mode is DELETE (see caseTransientPaths.ts), so the database file alone is the complete
+ * database: there is no -wal/-shm sidecar that could disagree with the snapshot.
+ */
+async function buildCaseArchive(
+  store: CaseStore,
+  caseId: string,
+  password: string,
+  extraEntries: ZipEntry[],
+): Promise<Buffer> {
   const caseDir = store.caseDir(caseId);
   const relPaths = (await walkDir(caseDir)).map((p) => p.replace(/\\/g, "/"));
   if (relPaths.length === 0) throw new Error(`case ${caseId} does not exist`);
+
+  const stagingRoot = join(store.casesRoot, EXPORT_STAGING_DIRNAME);
+  await mkdir(stagingRoot, { recursive: true });
+  const staging = await mkdtemp(join(stagingRoot, `${caseId}-`));
+  try {
+    return await archiveGeneration(caseDir, caseId, password, relPaths, extraEntries, staging);
+  } finally {
+    // The snapshot is a full copy of the case database, so it never outlives the request that
+    // needed it — including when the export throws.
+    await rm(staging, { recursive: true, force: true }).catch(() => {
+      /* nothing left to clean */
+    });
+  }
+}
+
+async function archiveGeneration(
+  caseDir: string,
+  caseId: string,
+  password: string,
+  relPaths: string[],
+  extraEntries: ZipEntry[],
+  staging: string,
+): Promise<Buffer> {
+  // The live database, and the consistent snapshot standing in for it in the archive. `false` means
+  // the case has no database yet (a case created but never written to), in which case there is
+  // nothing to substitute and nothing to count.
+  const liveDbPath = join(caseDir, "state", INVESTIGATION_DB_FILENAME);
+  const snapshotPath = join(staging, INVESTIGATION_DB_FILENAME);
+  const dbRel = `state/${INVESTIGATION_DB_FILENAME}`;
+  const snapshotted = await caseSqliteWorker.request<boolean>({
+    op: "backupDatabase",
+    dbPath: liveDbPath,
+    targetPath: snapshotPath,
+  });
 
   const entries: ZipEntry[] = [];
   const manifestFiles: Array<{ path: string; sha256: string; bytes: number }> = [];
   let totalBytes = 0;
   for (const rel of relPaths) {
+    // The database enters the archive as its SNAPSHOT, never as the live file: the live bytes can
+    // be mid-transaction, and they would also disagree with the counts below. The snapshot is one
+    // this process just wrote into its own staging directory, so it needs no link re-check.
+    if (snapshotted && rel === dbRel) {
+      const data = await readFile(snapshotPath);
+      entries.push({ path: rel, data });
+      manifestFiles.push({
+        path: rel,
+        sha256: createHash("sha256").update(data).digest("hex"),
+        bytes: data.length,
+      });
+      totalBytes += data.length;
+      continue;
+    }
     const fullPath = join(caseDir, rel);
     // TOCTOU guard: re-check that the path is not a symlink (or hardlink — see walkDir) before
     // reading. The file could have been replaced/swapped between the walk and the read.
@@ -220,9 +310,13 @@ export async function exportEncryptedCase(
     totalBytes += entry.data.length;
   }
   const counts = countsFromEntries(entries);
+  // Counted from the SNAPSHOT — the database that is actually in the archive. Counting the live one
+  // described a case that had moved on since the bytes were captured, so a recipient verifying the
+  // manifest against the archive could find fewer events than it claimed and reasonably conclude
+  // evidence had been dropped.
   const databaseCounts = await caseSqliteWorker.request<Record<string, number> | null>({
     op: "entityCounts",
-    dbPath: join(caseDir, "state", INVESTIGATION_DB_FILENAME),
+    dbPath: snapshotted ? snapshotPath : liveDbPath,
     kinds: ["forensicTimeline", "findings", "iocs"],
   });
   if (databaseCounts) {

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -452,7 +452,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
             data: Buffer.from(JSON.stringify(await buildCustodyManifest(store, options.custodyStore, id, instanceSecret), null, 2), "utf8"),
           }]
         : [];
-      const archive = await exportEncryptedCase(store, id, password, custodyManifest);
+      const archive = await exportEncryptedCase(store, id, password, custodyManifest, { runExclusive: ctx.runStateExclusive });
       const filename = dfircaseFilename(id, meta?.name);
       // Same as the ZIP path: the evidence is leaving, so the chain records it (#231).
       await options.custodyStore?.recordExport(id, { exportedBy: meta?.investigator || "analyst", destination: `encrypted archive: ${filename}` });

--- a/companion/tests/analysis/caseExportArchive.test.ts
+++ b/companion/tests/analysis/caseExportArchive.test.ts
@@ -14,6 +14,10 @@ import {
 import { createZip, readZip } from "../../src/analysis/zipArchive.js";
 import { encryptBuffer, decryptBuffer, DecryptionError } from "../../src/analysis/caseEncryption.js";
 import { atomicWrite } from "../../src/storage/atomicWrite.js";
+import { createHash } from "node:crypto";
+import { StateStore, INVESTIGATION_DB_FILENAME } from "../../src/analysis/stateStore.js";
+import { StateLock } from "../../src/analysis/stateLock.js";
+import { caseSqliteWorker } from "../../src/analysis/caseSqliteWorker.js";
 
 const PASSWORD = "correct horse battery staple";
 
@@ -75,6 +79,112 @@ describe("exportEncryptedCase", () => {
   it("rejects an invalid case id instead of reading outside the cases root", async () => {
     const store = await harness();
     await expect(exportEncryptedCase(store, "../../etc", PASSWORD)).rejects.toThrow(/invalid case id/);
+  });
+});
+
+// The archive must be ONE generation of the case. It used to be a walk of a live directory: the
+// database was copied as ordinary bytes (so a concurrent transaction could make the copy unusable)
+// and the manifest's entity counts were queried from the LIVE database after those bytes had
+// already been captured — describing a case that had since moved on.
+describe("exportEncryptedCase — single-generation snapshot (#3)", () => {
+  function entriesOf(archive: Buffer): Map<string, Buffer> {
+    return new Map(readZip(decryptBuffer(archive, PASSWORD)).map((e) => [e.path, e.data]));
+  }
+
+  async function seedDatabase(store: CaseStore, caseId: string): Promise<void> {
+    await store.createCase({ caseId, name: "n", investigator: "i", aiProvider: null });
+    const stateStore = new StateStore(store);
+    const state = await stateStore.load(caseId);
+    const event = (id: string) => ({
+      id,
+      timestamp: "2026-01-01T00:00:00Z",
+      description: `event ${id}`,
+      severity: "High",
+      mitreTechniques: [],
+      relatedFindingIds: [],
+      sourceScreenshots: [],
+    });
+    state.findings = [{ id: "f1" }, { id: "f2" }] as typeof state.findings;
+    state.iocs = [{ id: "i1" }] as typeof state.iocs;
+    state.forensicTimeline = [event("e1"), event("e2"), event("e3")] as typeof state.forensicTimeline;
+    await stateStore.save(state);
+  }
+
+  it("archives a consistent database snapshot that opens on its own", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-1");
+
+    const files = entriesOf(await exportEncryptedCase(store, "SNAP-1", PASSWORD));
+    const archived = files.get(`state/${INVESTIGATION_DB_FILENAME}`);
+    expect(archived).toBeDefined();
+
+    // A snapshot is a standalone database: written out on its own it must open and read back the
+    // same entities. Copied live bytes are what could fail this.
+    const loose = join(await mkdtemp(join(tmpdir(), "dfir-snapcheck-")), INVESTIGATION_DB_FILENAME);
+    await writeFile(loose, archived as Buffer);
+    const counts = await caseSqliteWorker.request<Record<string, number> | null>({
+      op: "entityCounts",
+      dbPath: loose,
+      kinds: ["forensicTimeline", "findings", "iocs"],
+    });
+    expect(counts).toMatchObject({ forensicTimeline: 3, findings: 2, iocs: 1 });
+  });
+
+  it("counts the manifest from the database it archived, not the live one", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-2");
+
+    const files = entriesOf(await exportEncryptedCase(store, "SNAP-2", PASSWORD));
+    const manifest = JSON.parse((files.get("archive-manifest.json") as Buffer).toString("utf8"));
+
+    expect(manifest.counts).toMatchObject({ forensicEvents: 3, findings: 2, iocs: 1 });
+
+    // The manifest's checksum for the database must be the checksum of the bytes in the archive —
+    // the property a recipient actually verifies.
+    const archived = files.get(`state/${INVESTIGATION_DB_FILENAME}`) as Buffer;
+    const listed = manifest.files.find(
+      (f: { path: string }) => f.path === `state/${INVESTIGATION_DB_FILENAME}`,
+    );
+    expect(listed.sha256).toBe(createHash("sha256").update(archived).digest("hex"));
+    expect(listed.bytes).toBe(archived.length);
+  });
+
+  it("runs inside the caller's per-case lock, so app state writes cannot interleave", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-3");
+    const order: string[] = [];
+    const lock = new StateLock();
+
+    const exported = exportEncryptedCase(store, "SNAP-3", PASSWORD, [], {
+      runExclusive: (caseId, fn) =>
+        lock.runExclusive(caseId, async () => {
+          order.push("export:start");
+          const out = await fn();
+          order.push("export:end");
+          return out;
+        }),
+    });
+    const write = lock.runExclusive("SNAP-3", async () => {
+      order.push("write");
+    });
+    await Promise.all([exported, write]);
+
+    // The write waited for the whole export rather than landing in the middle of it.
+    expect(order).toEqual(["export:start", "export:end", "write"]);
+  });
+
+  it("leaves no staging directory behind, on success or on failure", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-4");
+    const stagingRoot = join(store.casesRoot, ".export-staging");
+
+    await exportEncryptedCase(store, "SNAP-4", PASSWORD);
+    expect(existsSync(stagingRoot) ? await readdir(stagingRoot) : []).toEqual([]);
+
+    // A symlink planted in the case makes the export throw mid-build; the snapshot must still go.
+    await symlink("/etc/hostname", join(store.screenshotsDir("SNAP-4"), "loot"));
+    await expect(exportEncryptedCase(store, "SNAP-4", PASSWORD)).rejects.toThrow(/symlink/);
+    expect(existsSync(stagingRoot) ? await readdir(stagingRoot) : []).toEqual([]);
   });
 });
 


### PR DESCRIPTION
> **Stacked on #538** (which is stacked on #537). Merge in order; bases retarget automatically.

## Problem

Encrypted whole-case export walked a **live** case directory and read its files sequentially while the app kept writing. Three consequences, worst first:

1. **The SQLite database was copied as ordinary bytes.** A read concurrent with an open transaction can produce a database that doesn't open at all — the one defect an evidence archive must never have.
2. **Manifest counts came from the live database, queried *after* the bytes were captured.** So the manifest described a case that had already moved on. A recipient verifying the archive against its own manifest could find fewer events than claimed and reasonably conclude evidence was dropped in transit.
3. **Nothing serialized the export against the app's writes** — and the route permits open cases.

## Fix

- **Database via SQLite's own snapshot path.** Reuses the worker's existing `backupDatabase` op (`VACUUM INTO` + `integrity_check`, already used by the backup manager), staged outside the case and substituted for the live file in the archive. Journal mode is `DELETE`, so the database file alone is complete — no `-wal`/`-shm` can disagree with the snapshot.
- **Counts read from that same snapshot**, so what the manifest claims and what the archive contains are the same generation *by construction*.
- **Runs inside the app's per-case state mutex** (`createApp`'s `runStateExclusive`, passed as an option): a load→save either completes before the snapshot or waits until the archive is built. Callers with no lock wired (tests) behave exactly as before.
- **Staging removed in a `finally`**, so a full copy of a case database never outlives the request — including when the export throws.

### Scope note

This makes the *database* a true snapshot and the manifest consistent with the archived bytes. Full snapshot isolation for every sidecar would additionally require every writer in the app to take the same per-case lock; the export now participates in that lock, which is the hook for it, but converting the remaining write paths is deliberately not in this PR.

## Test plan

- [x] Archived database written out standalone opens and reports the expected entity counts (3 events / 2 findings / 1 IOC)
- [x] Manifest counts, and the manifest's sha256 + byte length for the database, describe the **archived** bytes
- [x] A concurrent state write on the same lock cannot interleave with the export (asserted on ordering)
- [x] No `.export-staging` content survives either the success path or a mid-build failure (planted symlink)
- [x] `caseExportArchive` suite: 44/44 pass, including all existing import/zip-slip/Windows-alias cases
- [x] typecheck, eslint, prettier, file-size / import-cycle / module-boundary ratchets all pass