### PR TITLE
fix(storage): read through the descriptor that was checked, not the path

### DIFF
--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -19,6 +19,7 @@ import { encryptBuffer, decryptBuffer } from "./caseEncryption.js";
 import { getAppVersion } from "../version.js";
 import { caseSqliteWorker } from "./caseSqliteWorker.js";
 import { INVESTIGATION_DB_FILENAME } from "./stateStore.js";
+import { readFileNoFollow, LinkGuardError } from "../storage/noFollowRead.js";
 
 // Whole-case export/import (#54 follow-up): the entire case directory tree is zipped, then
 // AES-256-GCM encrypted (via caseEncryption.ts) into a single `.dfircase` file that another
@@ -278,18 +279,18 @@ async function archiveGeneration(
       continue;
     }
     const fullPath = join(caseDir, rel);
-    // TOCTOU guard: re-check that the path is not a symlink (or hardlink — see walkDir) before
-    // reading. The file could have been replaced/swapped between the walk and the read.
-    const lst = await lstat(fullPath).catch(rethrowVanished(rel));
-    if (lst.isSymbolicLink())
-      throw new Error(
-        `symlink detected in case directory at "${rel}" — refusing to include in export (security)`,
-      );
-    if (lst.nlink > 1)
-      throw new Error(
-        `hardlink detected in case directory at "${rel}" — refusing to include in export (security)`,
-      );
-    const data = await readFile(fullPath).catch(rethrowVanished(rel));
+    // The link check and the read are ONE operation on ONE descriptor (see storage/noFollowRead.ts).
+    // Re-checking the path and then reading the path left a window in which a process controlling
+    // the case directory could swap the approved file for a symlink and have the read follow it —
+    // sealing an arbitrary host-readable file into the encrypted export.
+    const data = await readFileNoFollow(fullPath).catch((err: unknown) => {
+      if (err instanceof LinkGuardError) {
+        throw new Error(
+          `${err.kind} detected in case directory at "${rel}" — refusing to include in export (security)`,
+        );
+      }
+      return rethrowVanished(rel)(err);
+    });
     entries.push({ path: rel, data });
     manifestFiles.push({
       path: rel,

--- a/companion/src/composition/dropFolder.ts
+++ b/companion/src/composition/dropFolder.ts
@@ -14,29 +14,21 @@
  * with the filesystem. A file awaiting a tool is the one exception: it stays put (so the dashboard's
  * "Run <tool>" can still act on it) and is tracked in memory instead.
  *
- * SYMLINKS AND HARDLINKS ARE REFUSED, twice — once when listing, once immediately before reading
- * (TOCTOU: the path could be swapped in between). A synced cases/ root is exactly where a
- * symlink-to-/etc/shadow is realistic, and a hardlink is indistinguishable from a normal file via
- * stat — but a legitimately dropped file is always nlink === 1, so nlink > 1 means some other
- * directory entry aliases the same inode.
+ * SYMLINKS AND HARDLINKS ARE REFUSED, when listing and again as part of every read. The second
+ * check is not a re-check of the path — that left a TOCTOU window, since the path could be swapped
+ * between checking it and reading it — but a descriptor opened with O_NOFOLLOW and verified by
+ * fstat, which the read then draws from (storage/noFollowRead.ts). A synced cases/ root is exactly
+ * where a symlink-to-/etc/shadow is realistic, and a hardlink is indistinguishable from a normal
+ * file via stat — but a legitimately dropped file is always nlink === 1, so nlink > 1 means some
+ * other directory entry aliases the same inode.
  *
  * ARMED ONLY WHEN options.dropStatusStore IS WIRED (i.e. by startServer), so createApp-only unit
  * tests never spin up a filesystem poller.
  */
 import { basename, dirname, extname, join, relative } from "node:path";
-import {
-  readFile,
-  readdir,
-  stat,
-  lstat,
-  open,
-  copyFile,
-  mkdir,
-  rename,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { readdir, stat, lstat, mkdir, rename, rm, writeFile } from "node:fs/promises";
 import type { CaseStore } from "../storage/caseStore.js";
+import { openNoFollow, readFileNoFollow, readHeadNoFollow, LinkGuardError } from "../storage/noFollowRead.js";
 import type { AppOptions } from "./appOptions.js";
 import type { AiControl } from "../analysis/aiControl.js";
 import type { CaptureMetadata } from "../types.js";
@@ -227,19 +219,27 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
     const dest = await uniqueDest(join(dropDir, ok ? DROP_PROCESSED : DROP_FAILED, relpath));
     await mkdir(dirname(dest), { recursive: true });
     try {
-      // Guard against a symlink swap (TOCTOU): rename follows symlinks on some platforms, and
-      // copyFile always does. Re-check before moving. Also refuse a hardlink (nlink > 1) — see
-      // listDropFiles for why that's just as much a host-file-exfiltration vector as a symlink.
-      const lst = await lstat(src);
-      if (lst.isSymbolicLink())
-        throw new Error("symlink detected in drop folder — refused to move (security)");
-      if (lst.nlink > 1) throw new Error("hardlink detected in drop folder — refused to move (security)");
-      await rename(src, dest);
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException).code === "EXDEV") {
-        await copyFile(src, dest);
+      // rename() operates on the directory entry itself, so it cannot follow a planted symlink to
+      // somewhere else — but it must still refuse to FILE a link away as if it were evidence, and
+      // the EXDEV fallback below reads content and does follow. A path-based lstat here could be
+      // swapped before either call, so the guard is a descriptor: opened with O_NOFOLLOW, fstat'd,
+      // and — on the fallback path — the very descriptor the copy reads from.
+      const guard = await openNoFollow(src);
+      try {
+        await rename(src, dest);
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "EXDEV") throw e;
+        // Cross-filesystem: copy the bytes of the descriptor already verified, never of the path.
+        await writeFile(dest, await guard.readFile());
         await rm(src, { force: true });
-      } else throw e;
+      } finally {
+        await guard.close();
+      }
+    } catch (e) {
+      if (e instanceof LinkGuardError) {
+        throw new Error(`${e.kind} detected in drop folder — refused to move (security)`);
+      }
+      throw e;
     }
   }
 
@@ -252,7 +252,7 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
     name: string,
     mtimeMs: number,
   ): Promise<void> {
-    const raw = await readFile(fullPath);
+    const raw = await readFileNoFollow(fullPath);
     let webp: Buffer;
     try {
       const sharp = (await import("sharp")).default;
@@ -291,15 +291,14 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
     const full = join(dropDir, file.relpath);
     const name = basename(file.relpath);
     try {
-      // TOCTOU guard: re-check that the path is not a symlink before reading. A file could have
-      // been replaced with a symlink between listDropFiles and this read. Also refuse a hardlink
-      // (nlink > 1) — indistinguishable from a normal file via stat, but a legitimately-dropped
-      // file is always nlink === 1 (see listDropFiles).
-      const lst = await lstat(full);
-      if (lst.isSymbolicLink())
-        return { ok: false, reason: "symlink detected in drop folder — refused to read (security)" };
-      if (lst.nlink > 1)
-        return { ok: false, reason: "hardlink detected in drop folder — refused to read (security)" };
+      // The link guard travels WITH each read rather than preceding it: every read below goes
+      // through storage/noFollowRead.ts, which opens with O_NOFOLLOW and reads from the descriptor
+      // it just verified. Checking the path here and reading the path later left a window in which
+      // a process sharing this folder could swap the approved file for a symlink and have an
+      // arbitrary host file imported into the case as evidence. A hardlink is refused too — it is
+      // invisible to a symlink check, and a legitimately-dropped file is always nlink === 1.
+      // A LinkGuardError from any of them becomes a refusal in the catch below.
+      //
       // A raw file an external tool handles (built-in EVTX/PCAP, or any extension a CUSTOM tool claims)
       // — can't be read as text. Run the configured tool against the on-disk file (size-independent, so
       // checked BEFORE the oversize cap), or surface it as pending so the dashboard offers "Run/Configure
@@ -309,15 +308,11 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
       // raw rather than read as text. Only the first 8 KB — the file may be gigabytes.
       let head: Buffer | undefined;
       try {
-        const fh = await open(full, "r");
-        try {
-          const buf = Buffer.alloc(Math.min(8192, Math.max(0, file.size)));
-          if (buf.length) await fh.read(buf, 0, buf.length, 0);
-          head = buf;
-        } finally {
-          await fh.close();
-        }
-      } catch {
+        head = await readHeadNoFollow(full, Math.min(8192, Math.max(0, file.size)));
+      } catch (err) {
+        // A planted link must REFUSE the file, not quietly degrade to extension-only guessing —
+        // that would hand the path to a tool or the text reader anyway.
+        if (err instanceof LinkGuardError) throw err;
         /* unreadable head → fall back to extension-only classification */
       }
 
@@ -361,7 +356,7 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
         await ingestDroppedImage(caseId, full, name, file.mtimeMs);
         return { ok: true };
       }
-      const text = await readFile(full, "utf8");
+      const text = (await readFileNoFollow(full)).toString("utf8");
       if (!text.trim()) return { ok: false, reason: "empty file" };
       const kind = resolveImportKind(name, text);
       if (kind === "unknown")
@@ -374,6 +369,9 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
         };
       return { ok: true };
     } catch (err) {
+      if (err instanceof LinkGuardError) {
+        return { ok: false, reason: `${err.kind} detected in drop folder — refused to read (security)` };
+      }
       recordImportFailure(caseId, "drop", name, err);
       return { ok: false, reason: (err as Error)?.message ?? String(err) };
     }

--- a/companion/src/storage/noFollowRead.ts
+++ b/companion/src/storage/noFollowRead.ts
@@ -1,0 +1,109 @@
+import { open, lstat, type FileHandle } from "node:fs/promises";
+import { constants } from "node:fs";
+
+// Reading a file that a symlink check has just approved is two syscalls, and the gap between them
+// belongs to whoever controls the directory. Every path-based guard in this codebase had the same
+// shape — lstat the path, decide it is a plain file, then open/readFile/copyFile that path AGAIN —
+// so a process able to write into a case directory or a shared drop folder could replace the
+// checked file with a symlink in between and have the second call follow it. The payoff is not
+// hypothetical: an arbitrary host-readable file gets imported into a case as evidence, sent to an
+// AI provider for analysis, or sealed into an encrypted export.
+//
+// The fix is to stop naming the file twice. Open it ONCE with O_NOFOLLOW, verify the descriptor
+// itself with fstat, and read from that same descriptor — the checked object and the read object
+// are then the same object by construction, with no window to swap.
+
+/**
+ * Whether the platform can refuse to follow a symlink at open() time. POSIX has O_NOFOLLOW; Windows
+ * does not, so there the guard degrades to a metadata comparison around the open (below), which
+ * narrows the window rather than closing it.
+ */
+export const NOFOLLOW_SUPPORTED = typeof constants.O_NOFOLLOW === "number";
+
+export type LinkGuardKind = "symlink" | "hardlink";
+
+/**
+ * The path was, or became, something other than the plain unshared file it was taken for. Carries
+ * WHICH so each caller can phrase it in its own terms (an export refuses to include, the drop
+ * folder refuses to read) without matching on message text.
+ */
+export class LinkGuardError extends Error {
+  constructor(
+    readonly kind: LinkGuardKind,
+    readonly path: string,
+  ) {
+    super(`${kind} detected at "${path}"`);
+    this.name = "LinkGuardError";
+  }
+}
+
+/**
+ * Open `path` for reading, guaranteeing the descriptor refers to a plain file that no symlink was
+ * followed to reach and that no other directory entry aliases.
+ *
+ * Throws LinkGuardError("symlink") if the path is a link, LinkGuardError("hardlink") if the opened
+ * file has more than one link. A hardlink is invisible to a symlink check and to readdir alike —
+ * only the link count reveals that some other path, anywhere on the same filesystem, names this
+ * exact inode. Every file this application writes into a case is nlink === 1.
+ *
+ * The caller owns the returned handle and must close it.
+ */
+export async function openNoFollow(path: string): Promise<FileHandle> {
+  // Without O_NOFOLLOW the pre-check is the only thing that can reject a link that is ALREADY in
+  // place; the identity comparison after the open is what catches a swap during it.
+  const before = NOFOLLOW_SUPPORTED ? null : await lstat(path);
+  if (before?.isSymbolicLink()) throw new LinkGuardError("symlink", path);
+
+  let handle: FileHandle;
+  try {
+    handle = await open(path, constants.O_RDONLY | (NOFOLLOW_SUPPORTED ? constants.O_NOFOLLOW : 0));
+  } catch (err) {
+    // ELOOP is precisely "you asked me not to follow a symlink, and it is one".
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") throw new LinkGuardError("symlink", path);
+    throw err;
+  }
+
+  try {
+    const opened = await handle.stat();
+    if (opened.nlink > 1) throw new LinkGuardError("hardlink", path);
+    // Windows fallback: the file the descriptor points at must be the file that was checked. Inode
+    // and device are the identity a rename or relink cannot preserve.
+    if (before && (before.ino !== opened.ino || before.dev !== opened.dev)) {
+      throw new LinkGuardError("symlink", path);
+    }
+    return handle;
+  } catch (err) {
+    await handle.close().catch(() => {
+      /* the throw below is what the caller needs to see */
+    });
+    throw err;
+  }
+}
+
+/** Read a whole file through openNoFollow's guarantees, closing the descriptor either way. */
+export async function readFileNoFollow(path: string): Promise<Buffer> {
+  const handle = await openNoFollow(path);
+  try {
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Read at most `length` bytes from the start of a file through openNoFollow's guarantees.
+ *
+ * Used to sniff a file's head without reading a multi-gigabyte evidence file into memory. Returns
+ * the bytes actually read, which may be shorter than requested.
+ */
+export async function readHeadNoFollow(path: string, length: number): Promise<Buffer> {
+  const handle = await openNoFollow(path);
+  try {
+    const buffer = Buffer.alloc(Math.max(0, length));
+    if (!buffer.length) return buffer;
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}

--- a/companion/tests/server/dropFolderSymlink.test.ts
+++ b/companion/tests/server/dropFolderSymlink.test.ts
@@ -26,11 +26,12 @@ import { createApp } from "../../src/server.js";
 // accidentally safe even before this fix too — Dirent.isFile() already returns false for a symlink
 // dirent, so it was filtered before ever reaching stat() — but the REAL pre-fix symlink bug was a
 // narrower TOCTOU race (a file that reads as a normal file when first listed, then gets swapped to
-// a symlink before the read/move that follows once it's marked "ready"). That race isn't exercised
-// here — it would need to land squarely inside the drop poller's sub-second settle window — so the
-// symlink test below documents the now-deliberate (not incidental) guarantee at the listing stage,
-// while the processDropFile/moveDropFile lstat re-checks that close the TOCTOU window itself remain
-// unverified by an automated test.
+// a symlink before the read/move that follows once it's marked "ready"). That race is not exercised
+// HERE — it would need to land squarely inside the drop poller's sub-second settle window — so the
+// symlink test below documents the now-deliberate (not incidental) guarantee at the listing stage.
+// The race itself no longer depends on timing at all: processDropFile and moveDropFile no longer
+// re-check a path and then read it, they read through the descriptor they verified
+// (storage/noFollowRead.ts), and tests/storage/noFollowRead.test.ts exercises the swap directly.
 
 function findingPipeline(stateStore: StateStore): AnalysisPipeline {
   return new AnalysisPipeline({

--- a/companion/tests/storage/noFollowRead.test.ts
+++ b/companion/tests/storage/noFollowRead.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, symlink, link, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openNoFollow,
+  readFileNoFollow,
+  readHeadNoFollow,
+  LinkGuardError,
+} from "../../src/storage/noFollowRead.js";
+
+// The guarantee these tests exist for: a link check and the read it authorizes are ONE operation on
+// ONE descriptor. Every path-based guard in this codebase used to lstat a path and then read that
+// path again, and the gap between the two belonged to whoever controlled the directory.
+
+let dir: string;
+let secretPath: string;
+const SECRET = "host-only-secret\n";
+const CONTENT = "legitimate evidence\n";
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "dfir-nofollow-"));
+  secretPath = join(dir, "secret.txt");
+  await writeFile(secretPath, SECRET, "utf8");
+});
+
+describe("readFileNoFollow", () => {
+  it("reads an ordinary file unchanged", async () => {
+    const path = join(dir, "evidence.json");
+    await writeFile(path, CONTENT, "utf8");
+    expect((await readFileNoFollow(path)).toString("utf8")).toBe(CONTENT);
+  });
+
+  it("refuses a symlink instead of following it to the host file", async () => {
+    const path = join(dir, "planted");
+    await symlink(secretPath, path);
+
+    const err = await readFileNoFollow(path).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LinkGuardError);
+    expect((err as LinkGuardError).kind).toBe("symlink");
+  });
+
+  it("refuses a hardlink, which no symlink check and no readdir can see", async () => {
+    const path = join(dir, "aliased");
+    await link(secretPath, path);
+
+    const err = await readFileNoFollow(path).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LinkGuardError);
+    expect((err as LinkGuardError).kind).toBe("hardlink");
+  });
+
+  it("refuses a symlink pointing at a directory or a dangling target too", async () => {
+    await mkdir(join(dir, "elsewhere"));
+    await symlink(join(dir, "elsewhere"), join(dir, "to-dir"));
+    await symlink(join(dir, "does-not-exist"), join(dir, "dangling"));
+
+    await expect(readFileNoFollow(join(dir, "to-dir"))).rejects.toBeInstanceOf(LinkGuardError);
+    await expect(readFileNoFollow(join(dir, "dangling"))).rejects.toBeInstanceOf(LinkGuardError);
+  });
+
+  // THE RACE ITSELF. The path is swapped between a plain file and a symlink to the secret while
+  // reads run against it. A check-then-read implementation loses this: it lstats the plain file,
+  // the swap lands, and the read follows the link. Reading through the checked descriptor cannot —
+  // there is no interval in which the two disagree. Every read must either return the legitimate
+  // content or refuse; the secret must never come back.
+  it("never returns the swap target's content, however the swap is timed", async () => {
+    const path = join(dir, "raced");
+    let leaked = false;
+    let reads = 0;
+
+    for (let i = 0; i < 200; i++) {
+      await rm(path, { force: true });
+      if (i % 2 === 0) await writeFile(path, CONTENT, "utf8");
+      else await symlink(secretPath, path);
+
+      // Started before the swap below, resolved after it — the window a path-based guard exposes.
+      const reading = readFileNoFollow(path).then(
+        (buf) => buf.toString("utf8"),
+        (err: unknown) => {
+          if (!(err instanceof LinkGuardError) && (err as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw err;
+          }
+          return null;
+        },
+      );
+      await rm(path, { force: true }).catch(() => {});
+      await symlink(secretPath, path).catch(() => {});
+
+      const got = await reading;
+      if (got !== null) {
+        reads++;
+        if (got.includes("host-only-secret")) leaked = true;
+      }
+    }
+
+    expect(leaked).toBe(false);
+    // Guard against a vacuous pass: some reads must actually have succeeded.
+    expect(reads).toBeGreaterThan(0);
+  });
+});
+
+describe("readHeadNoFollow", () => {
+  it("reads only the requested prefix", async () => {
+    const path = join(dir, "big.bin");
+    await writeFile(path, "0123456789", "utf8");
+    expect((await readHeadNoFollow(path, 4)).toString("utf8")).toBe("0123");
+  });
+
+  it("returns what exists when the file is shorter than the request", async () => {
+    const path = join(dir, "short.bin");
+    await writeFile(path, "ab", "utf8");
+    expect((await readHeadNoFollow(path, 8)).toString("utf8")).toBe("ab");
+  });
+
+  it("returns an empty buffer for a zero-length request without opening a hole", async () => {
+    const path = join(dir, "empty-req");
+    await writeFile(path, "abc", "utf8");
+    expect((await readHeadNoFollow(path, 0)).length).toBe(0);
+  });
+
+  it("applies the same link guard as a whole-file read", async () => {
+    const path = join(dir, "planted-head");
+    await symlink(secretPath, path);
+    await expect(readHeadNoFollow(path, 8)).rejects.toBeInstanceOf(LinkGuardError);
+  });
+});
+
+describe("openNoFollow", () => {
+  it("hands back a descriptor the caller closes", async () => {
+    const path = join(dir, "handle.txt");
+    await writeFile(path, CONTENT, "utf8");
+
+    const handle = await openNoFollow(path);
+    try {
+      expect((await handle.readFile()).toString("utf8")).toBe(CONTENT);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  // A rejected open must not leak the descriptor it had already obtained.
+  it("closes the descriptor when the fstat check rejects it", async () => {
+    const path = join(dir, "aliased-2");
+    await link(secretPath, path);
+    await expect(openNoFollow(path)).rejects.toBeInstanceOf(LinkGuardError);
+  });
+});


### PR DESCRIPTION
> **Stacked on #539** (→ #538 → #537). Merge in order; bases retarget automatically.

## Problem

Every symlink guard in the export and drop-folder paths had the same shape: `lstat` a path, decide it's a plain file, then `open`/`readFile`/`copyFile` **that path again**. The gap between the two calls belongs to whoever controls the directory — and a synced `cases/` root or a shared drop folder is exactly where another process plausibly does.

Swapping the approved file for a symlink in that window makes the second call follow it. Payoff: an arbitrary host-readable file gets imported into a case as evidence, sent to an AI provider for analysis, or sealed into an encrypted export.

The existing drop-folder test admitted this: it noted the race "isn't exercised here — it would need to land squarely inside the drop poller's sub-second settle window", leaving the `processDropFile`/`moveDropFile` re-checks "unverified by an automated test".

## Fix

New `storage/noFollowRead.ts` closes the window by removing it:

- `openNoFollow()` opens **once** with `O_NOFOLLOW`, verifies the descriptor with `fstat` — symlink via `ELOOP`, hardlink via `nlink > 1` — and hands back the handle.
- `readFileNoFollow` / `readHeadNoFollow` read from **that same descriptor**. The checked object and the read object are the same object by construction.
- Where `O_NOFOLLOW` doesn't exist (Windows), it falls back to `lstat` before the open plus an inode/device comparison after it — narrows the window rather than closing it, and is documented as such rather than claimed as equivalent.

Converted call sites:

| Site | Was | Now |
|---|---|---|
| `caseExportArchive` per-file read | `lstat` → `readFile(path)` | `readFileNoFollow` |
| drop folder head sniff | `lstat` → `open(path)` | `readHeadNoFollow` |
| drop folder text read | `readFile(path)` | `readFileNoFollow` |
| drop folder image ingest | `readFile(path)` | `readFileNoFollow` |
| `moveDropFile` EXDEV fallback | `lstat` → `copyFile(path)` | copies bytes of the verified descriptor |

The head sniff no longer degrades to extension-only guessing when the guard fires — a planted link must **refuse** the file, not fall through to the tool path. Error wording at both call sites is unchanged, so existing expectations hold.

## Test plan

- [x] New helper suite (11 tests): plain read, symlink, hardlink, symlink-to-directory, dangling symlink, prefix reads, zero-length request, descriptor cleanup on rejection
- [x] **The race itself**: path swapped between a plain file and a symlink across 200 iterations; asserts the target's content never comes back, and that real reads still succeeded (guards against a vacuous pass)
- [x] Stale comment in `dropFolderSymlink.test.ts` corrected — the race is no longer timing-dependent or unverified
- [x] Drop-folder, storage and export suites: 129/129 pass
- [x] typecheck, eslint, prettier, file-size / import-cycle / module-boundary ratchets all pass