### PR TITLE
fix(tools): bound both child streams by real bytes, not string length

### DIFF
--- a/companion/src/integrations/childOutput.ts
+++ b/companion/src/integrations/childOutput.ts
@@ -1,0 +1,95 @@
+// Bounded capture of a spawned child's stdout and stderr, shared by the two runners that shell out
+// to analyst-installed forensic binaries (integrations/tools/toolRunner.ts and
+// integrations/velociraptor/velociraptorApi.ts — the latter is the one the former was modelled on,
+// and both carried the same two defects).
+//
+// WHAT WENT WRONG, twice:
+//
+//   1. Only stdout was capped. stderr was appended to a string with no limit at all until the child
+//      exited or the timeout fired, so a malfunctioning or hostile tool could exhaust the Node heap
+//      by writing to the stream nobody was watching. A forensic tool is an arbitrary local binary
+//      the analyst pointed us at; "it will not do that" is not a property we can assert.
+//
+//   2. The cap counted JavaScript string length while the option was named maxOutputBytes. A UTF-16
+//      code unit is not a byte: multibyte output could exceed the intended limit several times over
+//      before the check fired. Decoding per chunk was independently wrong — a multibyte character
+//      split across a chunk boundary decodes to replacement characters, quietly corrupting output
+//      that an importer then parses.
+//
+// So: count raw Buffer bytes, hold chunks undecoded, and decode ONCE at the end.
+
+/** Default ceiling for the retained stderr tail. Diagnostics, not evidence — the end is the useful part. */
+export const DEFAULT_STDERR_TAIL_BYTES = 64 * 1024;
+
+/**
+ * Accumulates a child process's output under an explicit byte budget.
+ *
+ * stdout is the tool's RESULT, so exceeding its cap is a failure the caller must surface (and kill
+ * the child over) — truncating it would hand an importer a silently incomplete artifact.
+ *
+ * stderr is DIAGNOSTIC, so it is bounded by keeping a rolling tail rather than by failing: a tool
+ * that logs verbosely is normal, the tail is what an error message needs, and dropping the older
+ * bytes costs nothing an analyst was going to read. It therefore can never be the reason a run dies
+ * — but it also can never grow without bound.
+ */
+export class ChildOutputCollector {
+  private readonly stdoutChunks: Buffer[] = [];
+  private stderrChunks: Buffer[] = [];
+  private stdoutBytes = 0;
+  private stderrBytes = 0;
+
+  constructor(
+    private readonly maxStdoutBytes: number,
+    private readonly stderrTailBytes: number = DEFAULT_STDERR_TAIL_BYTES,
+  ) {}
+
+  /** Bytes of stdout captured so far. */
+  get stdoutByteLength(): number {
+    return this.stdoutBytes;
+  }
+
+  /** Bytes of stderr currently retained (never more than the tail budget). */
+  get stderrByteLength(): number {
+    return this.stderrBytes;
+  }
+
+  /**
+   * Add a stdout chunk. Returns true when the byte budget is now exceeded, which the caller must
+   * treat as fatal — kill the child and reject. The chunk is still retained so a caller that wants
+   * to report what it got can.
+   */
+  pushStdout(chunk: Buffer): boolean {
+    this.stdoutChunks.push(chunk);
+    this.stdoutBytes += chunk.byteLength;
+    return this.stdoutBytes > this.maxStdoutBytes;
+  }
+
+  /** Add a stderr chunk, discarding whole older chunks so the retained tail stays within budget. */
+  pushStderr(chunk: Buffer): void {
+    this.stderrChunks.push(chunk);
+    this.stderrBytes += chunk.byteLength;
+    // Drop from the FRONT: the tail is the part that explains a failure.
+    while (this.stderrChunks.length > 1 && this.stderrBytes > this.stderrTailBytes) {
+      const dropped = this.stderrChunks.shift();
+      this.stderrBytes -= dropped ? dropped.byteLength : 0;
+    }
+    // A single chunk larger than the whole budget still has to be cut, or one enormous write
+    // defeats the limit on its own.
+    if (this.stderrChunks.length === 1 && this.stderrBytes > this.stderrTailBytes) {
+      const only = this.stderrChunks[0];
+      this.stderrChunks = [only.subarray(only.byteLength - this.stderrTailBytes)];
+      this.stderrBytes = this.stderrTailBytes;
+    }
+  }
+
+  /**
+   * Decode both streams. Done once, on the concatenated bytes, so a multibyte character split
+   * across chunk boundaries survives intact.
+   */
+  text(): { stdout: string; stderr: string } {
+    return {
+      stdout: Buffer.concat(this.stdoutChunks).toString("utf8"),
+      stderr: Buffer.concat(this.stderrChunks).toString("utf8"),
+    };
+  }
+}

--- a/companion/src/integrations/tools/toolRunner.ts
+++ b/companion/src/integrations/tools/toolRunner.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { openSync, closeSync } from "node:fs";
 import { dirname, isAbsolute } from "node:path";
 import { retryTransientSpawn } from "../velociraptor/velociraptorApi.js";
+import { ChildOutputCollector } from "../childOutput.js";
 
 // Generic runner for the analyst-configured external forensic tools (Hayabusa, Velociraptor CLI,
 // Suricata, Snort, YARA). It shells out to a LOCAL binary the analyst installed — the Companion never
@@ -158,8 +159,10 @@ function spawnToolOnce(
       launchFailed(e);   // Windows throws EPERM synchronously — not via the 'error' event
       return;
     }
-    let out = "";
-    let err = "";
+    // Raw BYTES under one budget, decoded once at the end — see integrations/childOutput.ts for why
+    // counting string length and decoding per chunk were both wrong, and why stderr needs a bound of
+    // its own rather than none at all.
+    const output = new ChildOutputCollector(opts.maxOutputBytes);
     let killed = false;
     const timer = setTimeout(() => {
       killed = true;
@@ -169,8 +172,7 @@ function spawnToolOnce(
     }, opts.timeoutMs);
     // When redirecting to a file, child.stdout is null (goes to the fd) — no in-memory buffer/cap.
     child.stdout?.on("data", (d: Buffer) => {
-      out += d.toString();
-      if (out.length > opts.maxOutputBytes) {
+      if (output.pushStdout(d)) {
         killed = true;
         child.kill();
         clearTimeout(timer);
@@ -178,7 +180,9 @@ function spawnToolOnce(
         reject(new Error(`Tool "${binary}" output exceeded ${opts.maxOutputBytes} bytes — raise the tool's MAX_OUTPUT, or narrow the run`));
       }
     });
-    child.stderr?.on("data", (d: Buffer) => { err += d.toString(); });
+    // Never fatal, never unbounded: a bounded tail keeps the diagnostics a failure message needs
+    // while a tool that spews forever cannot exhaust the heap.
+    child.stderr?.on("data", (d: Buffer) => output.pushStderr(d));
     child.on("error", (e) => {
       if (killed) return;
       clearTimeout(timer);
@@ -188,7 +192,8 @@ function spawnToolOnce(
       if (killed) return;
       clearTimeout(timer);
       closeFd();
-      resolve({ stdout: out, stderr: err, code: code ?? 0 });
+      const { stdout, stderr } = output.text();
+      resolve({ stdout, stderr, code: code ?? 0 });
     });
   });
 }

--- a/companion/src/integrations/velociraptor/velociraptorApi.ts
+++ b/companion/src/integrations/velociraptor/velociraptorApi.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { ChildOutputCollector } from "../childOutput.js";
 
 // Run the hunt-pivot queries the Companion generates against a Velociraptor server through its API.
 // The hunt-pivot is run as a HUNT across ALL enrolled endpoints (not server-side): the pivot VQL is
@@ -183,8 +184,7 @@ function spawnVqlOnce(config: VelociraptorApiConfig, statements: string[], opts:
       launchFailed(e);   // Windows throws EPERM synchronously — not via the 'error' event
       return;
     }
-    let out = "";
-    let err = "";
+    const output = new ChildOutputCollector(opts.maxOutputBytes);   // real bytes, bounded stderr — see integrations/childOutput.ts
     let killed = false;
     const timer = setTimeout(() => {
       killed = true;
@@ -192,15 +192,14 @@ function spawnVqlOnce(config: VelociraptorApiConfig, statements: string[], opts:
       reject(new Error(`Velociraptor query timed out after ${opts.timeoutMs}ms`));
     }, opts.timeoutMs);
     child.stdout.on("data", (d: Buffer) => {
-      out += d.toString();
-      if (out.length > opts.maxOutputBytes) {
+      if (output.pushStdout(d)) {
         killed = true;
         child.kill();
         clearTimeout(timer);
         reject(new Error(`Velociraptor query output exceeded ${opts.maxOutputBytes} bytes — raise DFIR_VELOCIRAPTOR_COLLECT_MAX_OUTPUT (collection) / DFIR_VELOCIRAPTOR_MAX_OUTPUT, or narrow the query`));
       }
     });
-    child.stderr.on("data", (d: Buffer) => { err += d.toString(); });
+    child.stderr.on("data", (d: Buffer) => output.pushStderr(d));   // bounded tail, never fatal
     child.on("error", (e) => {
       if (killed) return;
       clearTimeout(timer);
@@ -209,6 +208,7 @@ function spawnVqlOnce(config: VelociraptorApiConfig, statements: string[], opts:
     child.on("close", (code) => {
       if (killed) return;
       clearTimeout(timer);
+      const { stdout: out, stderr: err } = output.text();
       if (code !== 0) {
         reject(new Error(translateVelociraptorError(err.trim()) || `velociraptor exited with code ${code}`));
         return;

--- a/companion/tests/integrations/childOutput.test.ts
+++ b/companion/tests/integrations/childOutput.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { ChildOutputCollector, DEFAULT_STDERR_TAIL_BYTES } from "../../src/integrations/childOutput.js";
+
+// Two defects this collector exists to prevent, both of which shipped in BOTH child-process runners:
+// an unbounded stderr that a hostile or malfunctioning forensic tool could use to exhaust the heap,
+// and a "maxOutputBytes" cap that actually counted UTF-16 string length.
+
+describe("ChildOutputCollector — stdout budget", () => {
+  it("does not signal while the budget is intact", () => {
+    const out = new ChildOutputCollector(10);
+    expect(out.pushStdout(Buffer.from("12345"))).toBe(false);
+    expect(out.pushStdout(Buffer.from("67890"))).toBe(false);
+    expect(out.stdoutByteLength).toBe(10);
+  });
+
+  it("signals as soon as the budget is exceeded", () => {
+    const out = new ChildOutputCollector(4);
+    expect(out.pushStdout(Buffer.from("abcd"))).toBe(false);
+    expect(out.pushStdout(Buffer.from("e"))).toBe(true);
+  });
+
+  // The bug: "€" is 1 JavaScript string unit but 3 UTF-8 bytes, so a string-length cap let output
+  // run to three times the limit the operator configured.
+  it("counts BYTES, not string length, for multibyte output", () => {
+    const out = new ChildOutputCollector(6);
+    const euro = Buffer.from("€€€", "utf8"); // 9 bytes, 3 string units
+
+    expect(euro.byteLength).toBe(9);
+    expect(euro.toString("utf8").length).toBe(3);
+    expect(out.pushStdout(euro)).toBe(true); // a length-based cap would have said false
+    expect(out.stdoutByteLength).toBe(9);
+  });
+
+  // The other half: decoding each chunk as it arrived turned a character split across a chunk
+  // boundary into replacement characters, silently corrupting what an importer then parsed.
+  it("decodes once, so a character split across chunks survives", () => {
+    const out = new ChildOutputCollector(1024);
+    const euro = Buffer.from("€", "utf8");
+
+    out.pushStdout(euro.subarray(0, 1));
+    out.pushStdout(euro.subarray(1));
+
+    expect(out.text().stdout).toBe("€");
+    expect(out.text().stdout).not.toContain("�");
+  });
+});
+
+describe("ChildOutputCollector — stderr tail", () => {
+  it("keeps stderr whole while it fits the tail budget", () => {
+    const out = new ChildOutputCollector(1024, 32);
+    out.pushStderr(Buffer.from("warning: one\n"));
+    out.pushStderr(Buffer.from("warning: two\n"));
+    expect(out.text().stderr).toBe("warning: one\nwarning: two\n");
+  });
+
+  // A tool that logs forever must not grow the heap. It also must not cost us the END of the log,
+  // which is the part that explains the failure.
+  it("bounds a flood and retains the tail, not the head", () => {
+    const out = new ChildOutputCollector(1024, 64);
+    for (let i = 0; i < 1000; i++) out.pushStderr(Buffer.from(`line ${i}\n`));
+
+    expect(out.stderrByteLength).toBeLessThanOrEqual(64);
+    expect(out.text().stderr).toContain("line 999");
+    expect(out.text().stderr).not.toContain("line 0\n");
+  });
+
+  it("cuts a single write larger than the whole tail budget", () => {
+    const out = new ChildOutputCollector(1024, 16);
+    out.pushStderr(Buffer.from("x".repeat(1000) + "END"));
+
+    expect(out.stderrByteLength).toBe(16);
+    expect(out.text().stderr.endsWith("END")).toBe(true);
+  });
+
+  // stderr is diagnostics: a verbose tool is normal, so the tail must never be the reason a run dies.
+  it("never signals fatal, however much arrives", () => {
+    const out = new ChildOutputCollector(4, 8);
+    for (let i = 0; i < 100; i++) out.pushStderr(Buffer.from("noise noise noise\n"));
+
+    expect(out.pushStdout(Buffer.from("ab"))).toBe(false);
+    expect(out.stdoutByteLength).toBe(2);
+  });
+
+  it("defaults the tail to a bounded size rather than unlimited", () => {
+    const out = new ChildOutputCollector(1024);
+    for (let i = 0; i < 200; i++) out.pushStderr(Buffer.alloc(4096, 0x61));
+
+    expect(DEFAULT_STDERR_TAIL_BYTES).toBeGreaterThan(0);
+    expect(out.stderrByteLength).toBeLessThanOrEqual(DEFAULT_STDERR_TAIL_BYTES);
+  });
+});
+
+describe("ChildOutputCollector — combined", () => {
+  it("keeps the two streams separate", () => {
+    const out = new ChildOutputCollector(1024, 1024);
+    out.pushStdout(Buffer.from("result"));
+    out.pushStderr(Buffer.from("diagnostic"));
+
+    expect(out.text()).toEqual({ stdout: "result", stderr: "diagnostic" });
+  });
+
+  it("reports empty strings when the child wrote nothing", () => {
+    expect(new ChildOutputCollector(16).text()).toEqual({ stdout: "", stderr: "" });
+  });
+});


### PR DESCRIPTION
> **Stacked on #540** (→ #539 → #538 → #537). Merge in order; bases retarget automatically.

## Problem

Two defects, both present in **both** runners that spawn analyst-installed forensic binaries. `toolRunner.ts` states it was "modelled 1:1 on the Velociraptor API runner" — and it inherited these along with everything else. The review named only `toolRunner`; fixing just that would have left the identical hole open next door, so both are fixed here through one shared collector.

**1. Unbounded stderr.** Only stdout was capped. stderr was appended to a string with no limit until the child exited or the timeout fired, so a malfunctioning or hostile tool could exhaust the Node heap by writing to the stream nobody was watching. A forensic tool is an arbitrary local binary the analyst pointed us at — "it won't do that" isn't a property we can assert.

**2. A byte cap that counted string length.** The option is named `maxOutputBytes`, but the check read `String.length`. Multibyte output could run several times past the configured limit before firing — worst for VQL, whose rows routinely carry non-ASCII paths, usernames and command lines. Decoding *per chunk* was independently wrong: a character split across a chunk boundary decoded to replacement characters, silently corrupting output an importer then parsed.

## Fix

New `integrations/childOutput.ts` — `ChildOutputCollector` holds raw `Buffer`s, counts `byteLength`, and decodes **once** on the concatenated bytes.

- **stdout** keeps its hard cap; exceeding it stays fatal and kills the child. Truncating a tool's *result* would hand an importer a silently incomplete artifact.
- **stderr** is diagnostic, so it's bounded by a rolling 64 KB **tail** rather than by failing. A verbose tool is normal and must never be the reason a run dies — but it can no longer grow without bound either. The tail is kept from the end, which is the part that explains a failure.

Error messages and the `ToolRunResult` / `VqlRunResult` shapes are unchanged.

## Test plan

- [x] Byte-vs-length: a 9-byte, 3-string-unit value trips a 6-byte budget (a length cap said "fine")
- [x] A `€` split across two chunks decodes intact, no replacement characters
- [x] Tail bounds a 1000-line flood, retains `line 999`, drops `line 0`
- [x] A single write larger than the whole tail budget is cut to the budget, keeping its end
- [x] stderr never signals fatal regardless of volume; streams stay separate
- [x] All `tests/integrations/` + Velociraptor suites: 668/668 pass
- [x] typecheck, eslint, prettier, file-size / import-cycle / module-boundary ratchets all pass (both runners kept at their ledger caps — net zero lines added)