### PR TITLE
fix(extension): resolve capture-queue writes when the transaction commits

### DIFF
--- a/extension/src/captureQueue.ts
+++ b/extension/src/captureQueue.ts
@@ -44,13 +44,52 @@ export class CaptureQueue {
     });
   }
 
-  private tx<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
-    return this.open().then((db) => new Promise<T>((resolve, reject) => {
-      const store = db.transaction(STORE, mode).objectStore(STORE);
-      const req = fn(store);
-      req.onsuccess = () => resolve(req.result);
+  /** Run `fn` against an open connection and close it afterwards, however it ends. */
+  private async withDb<T>(fn: (db: IDBDatabase) => Promise<T>): Promise<T> {
+    const db = await this.open();
+    try {
+      return await fn(db);
+    } finally {
+      // Left open, every operation leaked a connection — and a still-open connection blocks a
+      // future version upgrade, which would strand the queue rather than migrate it.
+      db.close();
+    }
+  }
+
+  /**
+   * One transaction, resolved when the TRANSACTION completes — not when the individual request
+   * succeeds.
+   *
+   * That distinction is the whole point. A request's onsuccess fires while its transaction is still
+   * open, so `await enqueue(...)` used to return before anything was durable. In a Manifest V3
+   * service worker, which can be suspended the moment it goes idle, "the caller believes the capture
+   * is saved" and "the capture is saved" were two different things, and the gap was where evidence
+   * went missing. Resolving from oncomplete, and rejecting from onabort/onerror, makes the promise
+   * mean what its callers already assumed.
+   */
+  private txOn<T>(
+    db: IDBDatabase,
+    mode: IDBTransactionMode,
+    fn: (store: IDBObjectStore) => IDBRequest<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(STORE, mode);
+      let result: T;
+      const req = fn(tx.objectStore(STORE));
+      req.onsuccess = () => {
+        result = req.result;
+      };
+      // A request error left unhandled aborts the transaction, so onabort is the backstop rather
+      // than the exception: either way the promise rejects and nothing is reported durable.
       req.onerror = () => reject(req.error);
-    }));
+      tx.oncomplete = () => resolve(result);
+      tx.onabort = () => reject(tx.error ?? new Error("capture queue transaction aborted"));
+      tx.onerror = () => reject(tx.error ?? new Error("capture queue transaction failed"));
+    });
+  }
+
+  private tx<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+    return this.withDb((db) => this.txOn<T>(db, mode, fn));
   }
 
   async enqueue(payload: CapturePayload): Promise<void> {
@@ -73,37 +112,48 @@ export class CaptureQueue {
     if (this.draining) return summary;
     this.draining = true;
     try {
-      const db = await this.open();
-      const entries: { key: number; payload: CapturePayload }[] = await new Promise((resolve, reject) => {
-        const out: { key: number; payload: CapturePayload }[] = [];
-        const cursorReq = db.transaction(STORE, "readonly").objectStore(STORE).openCursor();
-        cursorReq.onsuccess = () => {
-          const cursor = cursorReq.result;
-          if (cursor) {
-            out.push({ key: cursor.key as number, payload: (cursor.value as { payload: CapturePayload }).payload });
-            cursor.continue();
-          } else resolve(out);
-        };
-        cursorReq.onerror = () => reject(cursorReq.error);
-      });
+      // ONE connection for the whole drain. Enumeration opened one and every deletion opened
+      // another, so draining fifty captures meant fifty-one connections — pure churn, and fifty-one
+      // chances to leave one open.
+      return await this.withDb(async (db) => {
+        const entries: { key: number; payload: CapturePayload }[] = await new Promise((resolve, reject) => {
+          const out: { key: number; payload: CapturePayload }[] = [];
+          const tx = db.transaction(STORE, "readonly");
+          const cursorReq = tx.objectStore(STORE).openCursor();
+          cursorReq.onsuccess = () => {
+            const cursor = cursorReq.result;
+            if (cursor) {
+              out.push({ key: cursor.key as number, payload: (cursor.value as { payload: CapturePayload }).payload });
+              cursor.continue();
+            }
+          };
+          cursorReq.onerror = () => reject(cursorReq.error);
+          // Resolved from the transaction, like every other operation here — the cursor is finished
+          // only once the transaction that owns it is.
+          tx.oncomplete = () => resolve(out);
+          tx.onabort = () => reject(tx.error ?? new Error("capture queue drain aborted"));
+        });
 
-      for (const entry of entries) {
-        const result = await sender(entry.payload);
-        if (result.outcome === "retry") return summary; // keep this and all later entries
-        if (result.outcome === "drop") {
-          summary.dropped.push({
-            payload: entry.payload,
-            status: result.status ?? 0,
-            ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
-          });
-        } else {
-          summary.sent += 1;
+        for (const entry of entries) {
+          const result = await sender(entry.payload);
+          if (result.outcome === "retry") return summary; // keep this and all later entries
+          if (result.outcome === "drop") {
+            summary.dropped.push({
+              payload: entry.payload,
+              status: result.status ?? 0,
+              ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+            });
+          } else {
+            summary.sent += 1;
+          }
+          // Both "sent" and "drop" remove the entry — a permanently-rejected capture must not stay
+          // at the head of the queue blocking the ones behind it. Awaiting the transaction (not the
+          // request) means a capture is never counted as handled while its removal is still open:
+          // a suspend in that window would have resurrected an already-delivered capture.
+          await this.txOn(db, "readwrite", (s) => s.delete(entry.key));
         }
-        // Both "sent" and "drop" remove the entry — a permanently-rejected capture must not stay
-        // at the head of the queue blocking the ones behind it.
-        await this.tx("readwrite", (s) => s.delete(entry.key));
-      }
-      return summary;
+        return summary;
+      });
     } finally {
       this.draining = false;
     }

--- a/extension/tests/captureQueue.test.ts
+++ b/extension/tests/captureQueue.test.ts
@@ -66,3 +66,116 @@ describe("CaptureQueue", () => {
     expect(await queue.size()).toBe(0);
   });
 });
+
+// A queue promise has to mean "durable", not "the request succeeded". Resolving from a request's
+// onsuccess returned while its transaction was still open, so in a Manifest V3 service worker — which
+// can be suspended the instant it goes idle — the caller believed a capture was saved before it was.
+describe("CaptureQueue durability", () => {
+  // THE CONTRACT, asserted directly on ordering. fake-indexeddb commits promptly, so no
+  // state-observing test can reproduce the service-worker suspend window that made this matter —
+  // but the ordering itself is exactly what changed, and it is observable: the promise must settle
+  // AFTER the transaction's "complete" event, never on the request's success that precedes it.
+  it("resolves an enqueue after the transaction commits, not when the request succeeds", async () => {
+    const q = new CaptureQueue(`dfir-${Math.random().toString(36).slice(2)}`);
+    // Create the store first: the version-change transaction of a first open would otherwise
+    // contribute a "complete" of its own to the measured window.
+    await q.enqueue(payload(1));
+
+    const order: string[] = [];
+    const original = IDBDatabase.prototype.transaction;
+    IDBDatabase.prototype.transaction = function patched(
+      this: IDBDatabase,
+      ...args: Parameters<IDBDatabase["transaction"]>
+    ): IDBTransaction {
+      const tx = original.apply(this, args);
+      // Registered before the queue assigns its own oncomplete, so this listener runs first.
+      tx.addEventListener("complete", () => order.push("commit"));
+      return tx;
+    } as IDBDatabase["transaction"];
+
+    try {
+      await q.enqueue(payload(2));
+      order.push("resolved");
+    } finally {
+      IDBDatabase.prototype.transaction = original;
+    }
+
+    expect(order).toEqual(["commit", "resolved"]);
+  });
+
+  // A fresh CaptureQueue opens its own connection, so it can only see what actually committed. If
+  // enqueue resolved early, the write would still be in an open transaction at this point.
+  it("has committed an enqueue by the time it resolves", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    await new CaptureQueue(name).enqueue(payload(1));
+
+    expect(await new CaptureQueue(name).size()).toBe(1);
+  });
+
+  it("has committed every enqueue of a burst by the time they resolve", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const writer = new CaptureQueue(name);
+    await Promise.all([1, 2, 3, 4, 5].map((n) => writer.enqueue(payload(n))));
+
+    expect(await new CaptureQueue(name).size()).toBe(5);
+  });
+
+  // The same guarantee on the other side: a sent capture's REMOVAL must be committed before the
+  // drain moves on, or a suspend in that window resurrects an already-delivered capture.
+  it("has committed each deletion before the drain reports it sent", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const writer = new CaptureQueue(name);
+    await writer.enqueue(payload(1));
+    await writer.enqueue(payload(2));
+
+    const observed: number[] = [];
+    const summary = await writer.drain(async () => {
+      // Read through an independent connection: it sees committed state only.
+      observed.push(await new CaptureQueue(name).size());
+      return { outcome: "sent" as const };
+    });
+
+    expect(summary.sent).toBe(2);
+    // Before the first send nothing is deleted yet; before the second, the first deletion has
+    // already committed. A drain resolving on request success could still show 2 here.
+    expect(observed).toEqual([2, 1]);
+    expect(await new CaptureQueue(name).size()).toBe(0);
+  });
+
+  it("keeps a retried capture, and its successors, committed in the queue", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const writer = new CaptureQueue(name);
+    await writer.enqueue(payload(1));
+    await writer.enqueue(payload(2));
+
+    const summary = await writer.drain(async () => ({ outcome: "retry" as const, status: 0 }));
+
+    expect(summary.sent).toBe(0);
+    expect(await new CaptureQueue(name).size()).toBe(2);
+  });
+
+  // Connections left open block a future version upgrade, which would strand the queue rather than
+  // migrate it. An upgrade completing is the observable proof that nothing is still holding one.
+  it("closes its connections, so a later version upgrade is not blocked", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const q = new CaptureQueue(name);
+    await q.enqueue(payload(1));
+    await q.size();
+    await q.drain(async () => ({ outcome: "sent" as const }));
+
+    const upgraded = await new Promise<boolean>((resolve, reject) => {
+      const req = indexedDB.open(name, 2);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore("probe");
+      };
+      req.onsuccess = () => {
+        req.result.close();
+        resolve(true);
+      };
+      req.onerror = () => reject(req.error);
+      req.onblocked = () => reject(new Error("upgrade blocked — a connection was left open"));
+    });
+
+    expect(upgraded).toBe(true);
+  });
+});


### PR DESCRIPTION
> **Stacked on #541** (→ #540 → #539 → #538 → #537). Merge in order; bases retarget automatically.

## Problem

Queue operations resolved from the individual IndexedDB **request**'s `onsuccess`, which fires while the enclosing **transaction** is still open. So `await enqueue(...)` returned before anything was durable.

In a Manifest V3 service worker — suspendable the moment it goes idle — "the caller believes the capture is saved" and "the capture is saved" were two different things, and the gap between them is where evidence goes missing. The same applied to each deletion during a drain: a suspend after a capture was counted sent but before its removal committed would resurrect an already-delivered capture on the next drain.

Connections were also **never closed**. A drain opened one for enumeration plus another for every single deletion — fifty captures meant fifty-one connections, each a chance to leave a handle behind. An open handle blocks a future version upgrade, which would strand the queue rather than migrate it.

## Fix

- Writes resolve from `transaction.oncomplete`, reject from `onabort`/`onerror`. (A request error left unhandled aborts the transaction, so `onabort` is the backstop rather than the exception.)
- The cursor enumeration resolves from its transaction too — a cursor is finished only when the transaction that owns it is.
- Every operation closes its connection in a `finally`; a drain uses **one** connection for the whole batch.

Public API (`enqueue` / `size` / `clear` / `drain`, `QueueSendResult`, `DrainSummary`) is unchanged — the promises just now mean what their callers already assumed.

## Test plan

- [x] **Ordering contract asserted directly**: the promise settles *after* the transaction's `complete` event, never on the request success that precedes it
- [x] Commit visibility through independent connections: single enqueue, a 5-write burst, per-deletion drain progress (`[2, 1]`), and the retry path
- [x] Connection leak: a subsequent version upgrade completes rather than firing `blocked`
- [x] **RED confirmed**: the ordering test and the upgrade test both fail against the previous implementation
- [x] Honest limitation: the state-observing tests *cannot* go red — `fake-indexeddb` commits promptly and does not reproduce a worker suspend. They are regression cover for the contract, not proof of the original failure
- [x] Full extension suite: 218/218 pass; `tsc --noEmit` clean