### PR TITLE
fix(reports): publish a report generation as a unit, not file by file

### DIFF
--- a/companion/src/reports/reportGeneration.ts
+++ b/companion/src/reports/reportGeneration.ts
@@ -1,0 +1,77 @@
+import { writeFile, rename, unlink } from "node:fs/promises";
+import { atomicTempPath } from "../storage/atomicWrite.js";
+
+// A report is not one file, it is eight — markdown, HTML, four CSVs, the state export, and the
+// analysis-run provenance record. They were written one after another, straight over the previous
+// report's files. Any interruption between them (a crash, a full disk, a permission error, or a
+// failed provenance write) left some artifacts from the NEW report sitting beside artifacts from
+// the OLD one.
+//
+// Every individual file stays readable, which is what makes this dangerous rather than merely
+// annoying: nothing looks broken. A report directory can present a findings CSV from one
+// generation, a narrative from another, and provenance for a run that never finished — and for a
+// forensic deliverable, internally inconsistent claims with stale provenance are worse than a
+// missing report, because someone will rely on them.
+//
+// So: render everything, stage everything, and only then publish. Nothing in the reports directory
+// changes until every artifact AND the provenance record have succeeded.
+
+interface Staged {
+  tmp: string;
+  target: string;
+}
+
+/**
+ * A report generation held in staging, publishable as a unit.
+ *
+ * Staged files use atomicWrite's temp-path form, so the export walker and anything else that
+ * inspects a case already treats them as a write in progress rather than case content.
+ */
+export class ReportGeneration {
+  private readonly staged: Staged[] = [];
+  private published = false;
+
+  /** Write one artifact into staging. Nothing is visible at its real path until publish(). */
+  async stage(target: string, contents: string): Promise<void> {
+    const tmp = atomicTempPath(target);
+    await writeFile(tmp, contents, "utf8");
+    this.staged.push({ tmp, target });
+  }
+
+  /**
+   * Move every staged artifact into place.
+   *
+   * Renames within one directory are the most reliable operation available here — no bytes move and
+   * each replacement is atomic — so the window in which a mixed generation could be observed shrinks
+   * from the whole render (seconds: rendering, disk writes, a provenance round-trip) to the few
+   * microseconds between renames. It is NOT a single atomic swap of the whole directory, and this
+   * comment is the place that says so rather than leaving a reader to assume otherwise; a directory
+   * swap would break the other files that legitimately live in reports/ (custody manifests, exports).
+   *
+   * A failure part-way through leaves the remaining staged files in place rather than deleting them,
+   * so the bytes are still on disk for an operator to inspect.
+   */
+  async publish(): Promise<void> {
+    for (const { tmp, target } of this.staged) {
+      await rename(tmp, target);
+    }
+    this.published = true;
+    this.staged.length = 0;
+  }
+
+  /**
+   * Throw away everything staged. Called when rendering or provenance failed, so a half-built
+   * generation never reaches the reports directory — and never accumulates as debris either.
+   */
+  async discard(): Promise<void> {
+    if (this.published) return;
+    await Promise.all(
+      this.staged.map(({ tmp }) =>
+        unlink(tmp).catch(() => {
+          /* already gone, or never created — nothing to undo */
+        }),
+      ),
+    );
+    this.staged.length = 0;
+  }
+}

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -1,5 +1,5 @@
-import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { ReportGeneration } from "./reportGeneration.js";
 import type { CaseStore } from "../storage/caseStore.js";
 import type { StateStore } from "../analysis/stateStore.js";
 import { NO_SCOPE, type ScopeStore } from "../analysis/scope.js";
@@ -558,79 +558,92 @@ export class ReportWriter {
     const complianceControl = this.complianceControl ? await this.complianceControl.load(caseId) : {};
     const custody = this.custodyStore ? await this.custodyStore.load(caseId) : undefined;
     const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths, modelPerf, complianceControl, custody);
-    await writeFile(paths.markdown, c.markdown, "utf8");
-    await writeFile(paths.html, c.html, "utf8");
-    await writeFile(paths.findingsCsv, c.findingsCsv, "utf8");
-    await writeFile(paths.iocsCsv, c.iocsCsv, "utf8");
-    await writeFile(paths.timelineCsv, c.timelineCsv, "utf8");
-    await writeFile(paths.forensicTimelineCsv, c.forensicTimelineCsv, "utf8");
-    await writeFile(paths.stateJson, c.stateJson, "utf8");
+    // Staged, not published: nothing in reports/ changes until every artifact AND the provenance
+    // record below have succeeded. Writing them straight over the previous report left a mixed
+    // generation behind whenever anything in between failed — see reports/reportGeneration.ts.
+    const generation = new ReportGeneration();
     const sourceRuns = this.analysisRuns ? await this.analysisRuns.list(caseId) : [];
     let reportRunId: string | undefined;
-    if (this.analysisRuns) {
-      const reportRun = await this.analysisRuns.record(caseId, {
-        kind: "report",
-        parentRunId: opts.parentRunId,
-        startedAt,
-        finishedAt: new Date().toISOString(),
-        versions: { schema: "report/v1" },
-        input: {
-          artifacts: [],
-          eventIds: state.forensicTimeline.map((event) => event.id),
-          entityIds: [
-            ...state.findings.map((finding) => finding.id),
-            ...state.iocs.map((ioc) => ioc.id),
-          ],
-          selectionHash: hashManifestValue({
-            sourceRunIds: sourceRuns.map((run) => run.id),
+    // discard() is a no-op once published, so the finally covers every failure path — a render
+    // error, a full disk, a permission error, or a provenance write that never completed — without
+    // needing to know which one happened.
+    try {
+      await generation.stage(paths.markdown, c.markdown);
+      await generation.stage(paths.html, c.html);
+      await generation.stage(paths.findingsCsv, c.findingsCsv);
+      await generation.stage(paths.iocsCsv, c.iocsCsv);
+      await generation.stage(paths.timelineCsv, c.timelineCsv);
+      await generation.stage(paths.forensicTimelineCsv, c.forensicTimelineCsv);
+      await generation.stage(paths.stateJson, c.stateJson);
+      if (this.analysisRuns) {
+        const reportRun = await this.analysisRuns.record(caseId, {
+          kind: "report",
+          parentRunId: opts.parentRunId,
+          startedAt,
+          finishedAt: new Date().toISOString(),
+          versions: { schema: "report/v1" },
+          input: {
+            artifacts: [],
             eventIds: state.forensicTimeline.map((event) => event.id),
-          }),
-        },
-        configuration: {
-          templateHash: hashManifestValue(template),
-          parameters: {
-            templateId: template.id,
-            pinnedRunIds: sourceRuns.map((run) => run.id),
+            entityIds: [
+              ...state.findings.map((finding) => finding.id),
+              ...state.iocs.map((ioc) => ioc.id),
+            ],
+            selectionHash: hashManifestValue({
+              sourceRunIds: sourceRuns.map((run) => run.id),
+              eventIds: state.forensicTimeline.map((event) => event.id),
+            }),
           },
-          filteringPolicy: {
-            reportScopeApplied: true,
-            falsePositivesExcluded: true,
+          configuration: {
+            templateHash: hashManifestValue(template),
+            parameters: {
+              templateId: template.id,
+              pinnedRunIds: sourceRuns.map((run) => run.id),
+            },
+            filteringPolicy: {
+              reportScopeApplied: true,
+              falsePositivesExcluded: true,
+            },
           },
-        },
-        output: {
-          entityIds: [
-            "report.md",
-            "report.html",
-            "findings.csv",
-            "iocs.csv",
-            "timeline.csv",
-            "forensic-timeline.csv",
-            "state-export.json",
-          ],
-          hashes: [
-            ["report.md", c.markdown],
-            ["report.html", c.html],
-            ["findings.csv", c.findingsCsv],
-            ["iocs.csv", c.iocsCsv],
-            ["timeline.csv", c.timelineCsv],
-            ["forensic-timeline.csv", c.forensicTimelineCsv],
-            ["state-export.json", c.stateJson],
-          ].map(([id, contents]) => ({
-            id,
-            sha256: createHash("sha256").update(contents).digest("hex"),
-          })),
-          claims: state.findings.map((finding) => claimSnapshot(finding.id, {
-            title: finding.title,
-            severity: finding.severity,
-            description: finding.description,
-            evidenceEventIds: finding.relatedEventIds,
-          })),
-        },
-      });
-      reportRunId = reportRun.id;
-      await writeFile(paths.analysisRuns, JSON.stringify(await this.analysisRuns.list(caseId), null, 2), "utf8");
-    } else {
-      await writeFile(paths.analysisRuns, "[]\n", "utf8");
+          output: {
+            entityIds: [
+              "report.md",
+              "report.html",
+              "findings.csv",
+              "iocs.csv",
+              "timeline.csv",
+              "forensic-timeline.csv",
+              "state-export.json",
+            ],
+            hashes: [
+              ["report.md", c.markdown],
+              ["report.html", c.html],
+              ["findings.csv", c.findingsCsv],
+              ["iocs.csv", c.iocsCsv],
+              ["timeline.csv", c.timelineCsv],
+              ["forensic-timeline.csv", c.forensicTimelineCsv],
+              ["state-export.json", c.stateJson],
+            ].map(([id, contents]) => ({
+              id,
+              sha256: createHash("sha256").update(contents).digest("hex"),
+            })),
+            claims: state.findings.map((finding) => claimSnapshot(finding.id, {
+              title: finding.title,
+              severity: finding.severity,
+              description: finding.description,
+              evidenceEventIds: finding.relatedEventIds,
+            })),
+          },
+        });
+        reportRunId = reportRun.id;
+        await generation.stage(paths.analysisRuns, JSON.stringify(await this.analysisRuns.list(caseId), null, 2));
+      } else {
+        await generation.stage(paths.analysisRuns, "[]\n");
+      }
+      // Every artifact and the provenance record are on disk — publish them as one generation.
+      await generation.publish();
+    } finally {
+      await generation.discard();
     }
     // #77 report versioning: snapshot markdown + meta + the diff-relevant slice of state so the
     // dashboard can diff two generations and roll back to a prior version's editable meta.

--- a/companion/src/storage/atomicWrite.ts
+++ b/companion/src/storage/atomicWrite.ts
@@ -38,6 +38,18 @@ function tempPathFor(target: string): string {
   return `${target}.${randomUUID()}.tmp`;
 }
 
+/**
+ * A temp path for `target` in the same form atomicWrite uses.
+ *
+ * Exported so a multi-file publication (reports/reportGeneration.ts) can stage its artifacts under
+ * names the rest of the system ALREADY understands as a write in progress — caseTransientPaths.ts
+ * skips exactly this shape, so a staged generation can never be mistaken for case content or end up
+ * in an archive.
+ */
+export function atomicTempPath(target: string): string {
+  return tempPathFor(target);
+}
+
 /** True when `path` is a temp file atomicWrite created — a write in progress, not case content. */
 export function isAtomicWriteTempPath(path: string): boolean {
   return TEMP_SUFFIX_PATTERN.test(path);

--- a/companion/tests/reports/reportGeneration.test.ts
+++ b/companion/tests/reports/reportGeneration.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ReportWriter } from "../../src/reports/reportWriter.js";
+import { ReportGeneration } from "../../src/reports/reportGeneration.js";
+import { isAtomicWriteTempPath } from "../../src/storage/atomicWrite.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+
+// A report is eight files written over the previous report's eight. Any interruption between them
+// left NEW artifacts beside OLD ones — each individually readable, which is what makes it dangerous:
+// a report directory presenting a findings CSV from one generation and a narrative from another,
+// with provenance for a run that never finished.
+
+let caseStore: CaseStore;
+let stateStore: StateStore;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-reportgen-"));
+  caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  stateStore = new StateStore(caseStore);
+  const state = emptyState("c1");
+  state.lastSummary = "first generation";
+  await stateStore.save(state);
+});
+
+describe("ReportGeneration", () => {
+  it("makes nothing visible until publish", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const target = join(dir, "report.md");
+    const generation = new ReportGeneration();
+
+    await generation.stage(target, "staged content");
+    expect((await readdir(dir)).includes("report.md")).toBe(false);
+
+    await generation.publish();
+    expect(await readFile(target, "utf8")).toBe("staged content");
+  });
+
+  it("stages under names the rest of the system reads as a write in progress", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const generation = new ReportGeneration();
+    await generation.stage(join(dir, "report.md"), "x");
+
+    // Every staged file must match atomicWrite's temp shape, which caseTransientPaths.ts skips —
+    // otherwise a concurrent export would seal a half-built report into an archive.
+    const staged = await readdir(dir);
+    expect(staged.length).toBeGreaterThan(0);
+    expect(staged.every((name) => isAtomicWriteTempPath(name))).toBe(true);
+
+    await generation.discard();
+  });
+
+  it("leaves no debris behind when discarded", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const generation = new ReportGeneration();
+    await generation.stage(join(dir, "report.md"), "a");
+    await generation.stage(join(dir, "findings.csv"), "b");
+
+    await generation.discard();
+    expect(await readdir(dir)).toEqual([]);
+  });
+
+  it("treats discard after publish as a no-op, so the published files survive", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const generation = new ReportGeneration();
+    await generation.stage(join(dir, "report.md"), "published");
+
+    await generation.publish();
+    await generation.discard();
+
+    expect(await readFile(join(dir, "report.md"), "utf8")).toBe("published");
+  });
+});
+
+describe("ReportWriter — generation is all-or-nothing", () => {
+  // The exact interruption the fix exists for: the artifacts render fine, then the provenance
+  // record fails. That used to leave a NEW report.md, HTML and CSVs beside the OLD
+  // analysis-runs.json — a directory whose narrative and provenance disagreed, with nothing to
+  // indicate it.
+  it("keeps the previous report intact when provenance fails mid-generation", async () => {
+    const paths = await new ReportWriter(caseStore, stateStore).writeAll("c1");
+    const before = {
+      markdown: await readFile(paths.markdown, "utf8"),
+      findings: await readFile(paths.findingsCsv, "utf8"),
+      runs: await readFile(paths.analysisRuns, "utf8"),
+    };
+    expect(before.markdown).toContain("first generation");
+
+    const state = await stateStore.load("c1");
+    state.lastSummary = "second generation";
+    await stateStore.save(state);
+
+    const failing = new ReportWriter(caseStore, stateStore, {
+      analysisRuns: {
+        list: async () => [],
+        record: async () => {
+          throw new Error("disk full");
+        },
+      } as unknown as NonNullable<ConstructorParameters<typeof ReportWriter>[2]>["analysisRuns"],
+    });
+
+    await expect(failing.writeAll("c1")).rejects.toThrow(/disk full/);
+
+    // Not one artifact of the failed generation reached the directory, and no staging survived.
+    expect(await readFile(paths.markdown, "utf8")).toBe(before.markdown);
+    expect(await readFile(paths.markdown, "utf8")).not.toContain("second generation");
+    expect(await readFile(paths.findingsCsv, "utf8")).toBe(before.findings);
+    expect(await readFile(paths.analysisRuns, "utf8")).toBe(before.runs);
+    expect((await readdir(caseStore.reportsDir("c1"))).some(isAtomicWriteTempPath)).toBe(false);
+  });
+
+  it("replaces every artifact together on a successful regeneration", async () => {
+    const writer = new ReportWriter(caseStore, stateStore);
+    await writer.writeAll("c1");
+
+    const state = await stateStore.load("c1");
+    state.lastSummary = "second generation";
+    await stateStore.save(state);
+    const paths = await writer.writeAll("c1");
+
+    expect(await readFile(paths.markdown, "utf8")).toContain("second generation");
+    expect(await readFile(paths.markdown, "utf8")).not.toContain("first generation");
+    // No staging left over on the happy path either.
+    expect((await readdir(caseStore.reportsDir("c1"))).some(isAtomicWriteTempPath)).toBe(false);
+  });
+
+  it("does not disturb unrelated files that legitimately live in reports/", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const sidecar = join(dir, "chain-of-custody.json");
+    await writeFile(sidecar, '{"kept":true}', "utf8");
+
+    await new ReportWriter(caseStore, stateStore).writeAll("c1");
+
+    expect(await readFile(sidecar, "utf8")).toBe('{"kept":true}');
+  });
+});


### PR DESCRIPTION
> **Stacked on #542** (→ #541 → #540 → #539 → #538 → #537). Merge in order; bases retarget automatically.

## Problem

A report is **eight** files — markdown, HTML, four CSVs, the state export, and the analysis-run provenance record — written one after another straight over the previous report's eight. Any interruption between them (crash, full disk, permission error, failed provenance write) left artifacts from the *new* report sitting beside artifacts from the *old* one.

Every individual file stays readable, which is what makes this dangerous rather than merely annoying: **nothing looks broken**. A report directory could present a findings CSV from one generation, a narrative from another, and provenance for a run that never finished. For a forensic deliverable, internally inconsistent claims with stale provenance are worse than a missing report — because someone will rely on them.

## Fix

Render everything → stage everything → publish only once every artifact **and** the provenance record have succeeded.

- `discard()` is a no-op after publish, so one `finally` covers every failure path without needing to know which one happened — and no staging debris accumulates.
- Staged files use atomicWrite's existing `<target>.<uuid>.tmp` form (`atomicTempPath`, newly exported for this), so the rest of the system already treats them as a write in progress. `caseTransientPaths.ts` skips exactly that shape — which is what stops a concurrent export sealing a half-built report into an archive.

### Why renames, not a directory swap

Publication is a sequence of renames within one directory. No bytes move and each replacement is atomic, so the window in which a mixed generation could be observed shrinks from the whole render (seconds: rendering, disk writes, a provenance round-trip) to the few microseconds between renames.

It is **not** a single atomic swap, and `publish()` says so in a comment rather than leaving a reader to assume otherwise. A directory swap isn't available here: `reports/` legitimately holds other files (custody manifests, exports) that a regeneration must not disturb — covered by a test.

## Test plan

- [x] **RED confirmed**: the mid-generation provenance-failure test fails against the previous implementation, leaving a new `report.md` beside the old `analysis-runs.json`
- [x] Provenance failure → previous `report.md`, `findings.csv` and `analysis-runs.json` all byte-identical to before, no `second generation` content anywhere, no staging left
- [x] Nothing visible at its real path until `publish()`; staged names all match the temp shape the export walker skips
- [x] `discard()` removes all debris; `discard()` after `publish()` is a no-op and published files survive
- [x] Successful regeneration replaces every artifact together, no staging left over
- [x] An unrelated `chain-of-custody.json` in `reports/` is untouched by a regeneration
- [x] All `tests/reports/`: 419/419 pass
- [x] typecheck, eslint, prettier, file-size / import-cycle / module-boundary ratchets all pass