### PR TITLE
fix(auth): bound and rate-limit OIDC flow creation

### DIFF
--- a/companion/src/auth/authRoutes.ts
+++ b/companion/src/auth/authRoutes.ts
@@ -1,5 +1,5 @@
 import type { Express, Request, Response } from "express";
-import { getLoginLimiter, getLoginIpLimiter } from "../http/rateLimiter.js";
+import { getLoginLimiter, getLoginIpLimiter, getOidcStartLimiter } from "../http/rateLimiter.js";
 import { withNonce } from "../http/securityHeaders.js";
 import { readPublicAsset } from "../serverAssets.js";
 import type { TeamAuth } from "./teamAuth.js";
@@ -120,6 +120,15 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
 
   app.get("/auth/oidc/start", async (req: Request, res: Response) => {
     if (!auth.oidcClient) return res.status(404).json({ error: "OIDC is not configured" });
+    // The only PUBLIC route that allocates server state: each call stores a state, nonce, verifier,
+    // return path and expiry for ten minutes. Unlimited, an unauthenticated caller could allocate
+    // memory as fast as it could issue requests. Gated before begin(), so a throttled request costs
+    // nothing — no discovery fetch, no flow stored. The client's own hard flow ceiling is the
+    // backstop for many clients at once; this bounds any single one.
+    if (!getOidcStartLimiter().tryAcquire(req.ip ?? "unknown")) {
+      res.setHeader("Retry-After", "60");
+      return res.status(429).json({ error: "too many sign-in attempts, try again later" });
+    }
     try {
       const started = await auth.oidcClient.begin(
         typeof req.query.returnTo === "string" ? req.query.returnTo : undefined,

--- a/companion/src/auth/oidcClient.ts
+++ b/companion/src/auth/oidcClient.ts
@@ -12,6 +12,11 @@ import type { OidcConfig } from "./authConfig.js";
 const FLOW_TTL_MS = 10 * 60_000;
 const CLOCK_SKEW_SECONDS = 60;
 
+// Hard ceiling on in-flight OIDC logins. A flow is a handful of short strings, so this is a few
+// hundred KB at worst — far more concurrent logins than any deployment of this tool will see, and
+// small enough that an unauthenticated caller cannot make it matter. See sweepFlows.
+const MAX_OUTSTANDING_FLOWS = 1000;
+
 interface OidcDiscovery {
   issuer: string;
   authorizationEndpoint: string;
@@ -187,9 +192,27 @@ export class OidcClient {
     };
   }
 
+  /**
+   * Drop expired flows, then enforce a hard ceiling on how many can be outstanding at once.
+   *
+   * The sweep alone never bounded anything: it only ran when another flow started, and every flow
+   * lives for ten minutes, so a caller issuing starts faster than they expire grew the map without
+   * limit — no credentials required, since /auth/oidc/start is public. The route is rate-limited per
+   * IP now, but a limiter is a rate, not a ceiling: enough distinct clients still add up. The cap is
+   * what actually bounds the memory.
+   *
+   * Eviction is oldest-first (Map preserves insertion order), which is the least-harmful choice
+   * available: the oldest outstanding flow is the one closest to expiring anyway, and losing it
+   * costs its owner a restarted login rather than anything durable.
+   */
   private sweepFlows(now = Date.now()): void {
     for (const [state, flow] of this.flows) {
       if (flow.expiresAt <= now) this.flows.delete(state);
+    }
+    while (this.flows.size >= MAX_OUTSTANDING_FLOWS) {
+      const oldest = this.flows.keys().next();
+      if (oldest.done) break;
+      this.flows.delete(oldest.value);
     }
   }
 

--- a/companion/src/http/rateLimiter.ts
+++ b/companion/src/http/rateLimiter.ts
@@ -152,6 +152,8 @@ let _loginLimiter: AttemptLimiter | null = null;
 let _loginIpLimiter: SlidingWindowLimiter | null = null;
 let _loginSweepTimer: NodeJS.Timeout | null = null;
 let _loginIpSweepTimer: NodeJS.Timeout | null = null;
+let _oidcStartLimiter: SlidingWindowLimiter | null = null;
+let _oidcStartSweepTimer: NodeJS.Timeout | null = null;
 
 export function getUnlockLimiter(): AttemptLimiter {
   if (!_unlockLimiter) {
@@ -237,6 +239,22 @@ export function getLoginIpLimiter(): SlidingWindowLimiter {
   return _loginIpLimiter;
 }
 
+/** Per-IP budget for GET /auth/oidc/start, the one PUBLIC route that allocates server state.
+ *  Every call stores a state, nonce, verifier, return path and expiry for ten minutes, so without
+ *  a limiter an unauthenticated caller could allocate memory as fast as it could issue requests —
+ *  no credentials, no provider round-trip needed. 20 a minute is far past a human clicking
+ *  "Sign in with SSO" (each click is one flow, and a retry after a provider error is another),
+ *  and it caps one client's outstanding flows well below the client's own hard flow ceiling. */
+export function getOidcStartLimiter(): SlidingWindowLimiter {
+  if (!_oidcStartLimiter) {
+    const limiter = new SlidingWindowLimiter(20, 60_000);
+    _oidcStartLimiter = limiter;
+    _oidcStartSweepTimer = setInterval(() => limiter.sweep(), SWEEP_INTERVAL_MS);
+    _oidcStartSweepTimer.unref?.();
+  }
+  return _oidcStartLimiter;
+}
+
 /** Reset singletons (tests). Also clears each singleton's sweep timer so repeated
  *  reset+get cycles in a test suite don't stack up abandoned intervals. */
 export function resetLimiters(): void {
@@ -246,6 +264,7 @@ export function resetLimiters(): void {
   if (_importIpSweepTimer) clearInterval(_importIpSweepTimer);
   if (_loginSweepTimer) clearInterval(_loginSweepTimer);
   if (_loginIpSweepTimer) clearInterval(_loginIpSweepTimer);
+  if (_oidcStartSweepTimer) clearInterval(_oidcStartSweepTimer);
   _unlockSweepTimer = null;
   _aiSweepTimer = null;
   _importSweepTimer = null;
@@ -258,4 +277,6 @@ export function resetLimiters(): void {
   _loginIpSweepTimer = null;
   _loginLimiter = null;
   _loginIpLimiter = null;
+  _oidcStartSweepTimer = null;
+  _oidcStartLimiter = null;
 }

--- a/companion/tests/http/oidcClient.test.ts
+++ b/companion/tests/http/oidcClient.test.ts
@@ -121,3 +121,68 @@ describe("OIDC authorization-code client", () => {
     ).rejects.toThrow(/state/i);
   });
 });
+
+// /auth/oidc/start is public and stores a state, nonce, verifier, return path and expiry per call,
+// each living ten minutes. Expiry was swept only when ANOTHER flow started, so a caller issuing
+// starts faster than they expire grew the map without limit — no credentials needed.
+describe("OIDC flow storage is bounded", () => {
+  const discoveryOnly: typeof fetch = async (input) => {
+    if (String(input).endsWith("/.well-known/openid-configuration")) {
+      return Response.json({
+        issuer: ISSUER,
+        authorization_endpoint: `${ISSUER}/authorize`,
+        token_endpoint: `${ISSUER}/token`,
+        jwks_uri: `${ISSUER}/jwks`,
+        code_challenge_methods_supported: ["S256"],
+      });
+    }
+    throw new Error(`unexpected fetch: ${String(input)}`);
+  };
+
+  function makeClient(): OidcClient {
+    return new OidcClient(
+      { issuer: ISSUER, clientId: CLIENT_ID, redirectUri: REDIRECT_URI, scopes: ["openid"] },
+      discoveryOnly,
+    );
+  }
+
+  it("keeps outstanding flows under a hard ceiling however many are started", async () => {
+    const c = makeClient();
+    const flows = () => (c as unknown as { flows: Map<string, unknown> }).flows;
+
+    for (let i = 0; i < 1200; i++) await c.begin("/dashboard");
+
+    // Unbounded, this would be 1200 live entries with nothing to remove them for ten minutes.
+    expect(flows().size).toBeLessThanOrEqual(1000);
+  });
+
+  it("evicts the oldest flow, so the most recent logins still complete", async () => {
+    const c = makeClient();
+    const flows = () => (c as unknown as { flows: Map<string, unknown> }).flows;
+
+    const first = await c.begin("/dashboard");
+    for (let i = 0; i < 1100; i++) await c.begin("/dashboard");
+    const last = await c.begin("/dashboard");
+
+    // The oldest is gone (its owner restarts a login); the newest — the one a real user is
+    // mid-way through — is still there.
+    expect(flows().has(first.state)).toBe(false);
+    expect(flows().has(last.state)).toBe(true);
+  });
+
+  // The pre-existing behaviour that must survive the cap: an expired flow is still dropped, and
+  // a live one is still usable.
+  it("still drops expired flows and keeps live ones", async () => {
+    const c = makeClient();
+    const flows = () => (c as unknown as { flows: Map<string, { expiresAt: number }> }).flows;
+
+    const stale = await c.begin("/dashboard");
+    const entry = flows().get(stale.state);
+    if (entry) entry.expiresAt = Date.now() - 1;
+
+    const fresh = await c.begin("/dashboard");
+
+    expect(flows().has(stale.state)).toBe(false);
+    expect(flows().has(fresh.state)).toBe(true);
+  });
+});

--- a/companion/tests/http/oidcStartRateLimit.test.ts
+++ b/companion/tests/http/oidcStartRateLimit.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStore } from "../../src/auth/authStore.js";
+import { TeamAuth } from "../../src/auth/teamAuth.js";
+import { OidcClient } from "../../src/auth/oidcClient.js";
+import { createApp } from "../../src/server.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { resetLimiters } from "../../src/http/rateLimiter.js";
+
+/**
+ * GET /auth/oidc/start, resource bounds.
+ *
+ * This is the one PUBLIC route that allocates server state: every call stored a state, nonce,
+ * verifier, return path and expiry in an unbounded in-memory map, each entry living ten minutes,
+ * and expiry was swept only when another flow started. A caller reachable beyond localhost could
+ * therefore consume memory as fast as it could issue requests, without ever authenticating.
+ */
+const ISSUER = "https://identity.example.test";
+const BOOTSTRAP_TOKEN = "test-bootstrap-token-with-enough-entropy";
+
+let app: ReturnType<typeof createApp>;
+let started = 0;
+
+const discoveryFetch = (async (input: RequestInfo | URL) => {
+  if (String(input).endsWith("/.well-known/openid-configuration")) {
+    started += 1;
+    return Response.json({
+      issuer: ISSUER,
+      authorization_endpoint: `${ISSUER}/authorize`,
+      token_endpoint: `${ISSUER}/token`,
+      jwks_uri: `${ISSUER}/jwks`,
+      code_challenge_methods_supported: ["S256"],
+    });
+  }
+  throw new Error(`unexpected fetch: ${String(input)}`);
+}) as typeof fetch;
+
+beforeEach(async () => {
+  resetLimiters();
+  started = 0;
+  const root = await mkdtemp(join(tmpdir(), "dfir-oidc-limit-"));
+  const cases = new CaseStore(join(root, "cases"));
+  const auth = new TeamAuth({
+    store: new AuthStore(join(root, "auth.sqlite")),
+    bootstrapToken: BOOTSTRAP_TOKEN,
+    cookieSecure: false,
+    sessionTtlMs: 60 * 60_000,
+    oidcClient: new OidcClient(
+      {
+        issuer: ISSUER,
+        clientId: "dfir-companion",
+        redirectUri: "https://dfir.example.test/auth/oidc/callback",
+        scopes: ["openid"],
+      },
+      discoveryFetch,
+    ),
+  });
+  app = createApp(cases, { teamAuth: auth });
+});
+
+afterEach(() => {
+  resetLimiters();
+});
+
+describe("GET /auth/oidc/start is rate-limited", () => {
+  it("stops an unauthenticated caller from allocating flows without limit", async () => {
+    let sawLimit = false;
+    let redirects = 0;
+
+    // Unlimited, every one of these stored a ten-minute flow and none ever answered 429.
+    for (let i = 0; i < 40 && !sawLimit; i++) {
+      const res = await request(app).get("/auth/oidc/start");
+      if (res.status === 429) sawLimit = true;
+      else if (res.status === 302) redirects += 1;
+    }
+
+    expect(sawLimit).toBe(true);
+    // The budget is generous enough that ordinary use is unaffected — a human clicking "Sign in
+    // with SSO", including retries, is nowhere near this.
+    expect(redirects).toBeGreaterThanOrEqual(20);
+  });
+
+  it("answers a throttled request with Retry-After and allocates nothing for it", async () => {
+    let res = await request(app).get("/auth/oidc/start");
+    while (res.status !== 429) res = await request(app).get("/auth/oidc/start");
+
+    expect(res.headers["retry-after"]).toBe("60");
+    const afterThrottle = started;
+
+    // A throttled request must cost nothing: gated BEFORE begin(), so no discovery fetch and no
+    // flow stored. Otherwise the limiter would bound the response but not the work.
+    await request(app).get("/auth/oidc/start");
+    expect(started).toBe(afterThrottle);
+  });
+
+  it("still serves the first sign-in normally", async () => {
+    const res = await request(app).get("/auth/oidc/start");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain(`${ISSUER}/authorize`);
+    expect(res.headers["set-cookie"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
> **Stacked on #543** (→ #542 → #541 → #540 → #539 → #538 → #537). Merge in order; bases retarget automatically.

## Problem

`GET /auth/oidc/start` is the one **public** route that allocates server state. Every call stored a state, nonce, verifier, return path and expiry in an in-memory map with no ceiling — each entry living ten minutes, with expiry swept only when *another* flow started.

A caller reachable beyond localhost could consume memory as fast as it could issue requests, without ever authenticating: no credentials, no provider round-trip needed.

## Fix

Two bounds, because one isn't enough.

**1. A per-IP budget on the route** — 20/minute, using the same `SlidingWindowLimiter` + sweep-timer pattern the login routes already use. (`getLoginIpLimiter` was already imported into this very file and simply never applied here.) Checked **before** `begin()`, so a throttled request costs nothing: no discovery fetch, no flow stored — otherwise the limiter would bound the response but not the work. 20/min is far past a human clicking "Sign in with SSO", retries included.

**2. A hard ceiling of 1000 outstanding flows** in the client. A limiter is a *rate*, not a *ceiling*: enough distinct clients still add up, and the cap is what actually bounds memory. Eviction is oldest-first — the least-harmful option, since the oldest outstanding flow is closest to expiring anyway and losing it costs its owner a restarted login rather than anything durable. The existing expiry sweep runs first, so live flows are only evicted when nothing has expired.

## Test plan

- [x] **RED confirmed** — all four new tests fail against the previous implementation:
  - the flow map exceeds any ceiling (1200 starts → 1200 live entries)
  - no oldest-first eviction
  - the route never reaches a 429
  - a throttled request still does the work
- [x] Ceiling holds at ≤1000 across 1200 starts; oldest evicted, newest (a real user mid-login) retained
- [x] Throttled response carries `Retry-After: 60` and triggers **no** discovery fetch
- [x] Existing behaviour preserved: expired flows still dropped, live ones still usable, first sign-in still redirects to the provider with its state cookie
- [x] All `tests/http/`: 120/120 pass
- [x] typecheck, eslint, prettier, file-size / import-cycle / module-boundary ratchets all pass