### PR TITLE
fix: land code-review findings 2-8 (recovery from mis-merged stack)

### DIFF
--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -19,6 +19,7 @@ import { encryptBuffer, decryptBuffer } from "./caseEncryption.js";
 import { getAppVersion } from "../version.js";
 import { caseSqliteWorker } from "./caseSqliteWorker.js";
 import { INVESTIGATION_DB_FILENAME } from "./stateStore.js";
+import { readFileNoFollow, LinkGuardError } from "../storage/noFollowRead.js";
 
 // Whole-case export/import (#54 follow-up): the entire case directory tree is zipped, then
 // AES-256-GCM encrypted (via caseEncryption.ts) into a single `.dfircase` file that another
@@ -278,18 +279,18 @@ async function archiveGeneration(
       continue;
     }
     const fullPath = join(caseDir, rel);
-    // TOCTOU guard: re-check that the path is not a symlink (or hardlink — see walkDir) before
-    // reading. The file could have been replaced/swapped between the walk and the read.
-    const lst = await lstat(fullPath).catch(rethrowVanished(rel));
-    if (lst.isSymbolicLink())
-      throw new Error(
-        `symlink detected in case directory at "${rel}" — refusing to include in export (security)`,
-      );
-    if (lst.nlink > 1)
-      throw new Error(
-        `hardlink detected in case directory at "${rel}" — refusing to include in export (security)`,
-      );
-    const data = await readFile(fullPath).catch(rethrowVanished(rel));
+    // The link check and the read are ONE operation on ONE descriptor (see storage/noFollowRead.ts).
+    // Re-checking the path and then reading the path left a window in which a process controlling
+    // the case directory could swap the approved file for a symlink and have the read follow it —
+    // sealing an arbitrary host-readable file into the encrypted export.
+    const data = await readFileNoFollow(fullPath).catch((err: unknown) => {
+      if (err instanceof LinkGuardError) {
+        throw new Error(
+          `${err.kind} detected in case directory at "${rel}" — refusing to include in export (security)`,
+        );
+      }
+      return rethrowVanished(rel)(err);
+    });
     entries.push({ path: rel, data });
     manifestFiles.push({
       path: rel,

--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -32,6 +32,11 @@ export const MIN_PASSWORD_LENGTH = 8;
 const IMPORT_STAGING_DIRNAME = ".import-staging";
 const IMPORT_STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
+// Where an export stages the database snapshot it archives instead of the live file. Dotted and a
+// level above the cases for the same reason import staging is: nothing that enumerates the cases
+// root, and nothing that walks a case, may mistake it for case content.
+const EXPORT_STAGING_DIRNAME = ".export-staging";
+
 export class CaseImportConflictError extends Error {
   constructor(public readonly caseId: string) {
     super(`case ${caseId} already exists — import under a different case id`);
@@ -165,9 +170,22 @@ async function walkDir(dir: string, baseRel = ""): Promise<string[]> {
   return out;
 }
 
+export interface CaseExportOptions {
+  /**
+   * The app's per-case state mutex (createApp's runStateExclusive). Passing it makes the export a
+   * critical section: every load→save the app performs through the same lock either completes
+   * before the snapshot is taken or waits until the archive is built, so the export cannot capture
+   * a case midway through one. Omitted in tests and by callers with no lock wired, which run
+   * unserialized exactly as before.
+   */
+  runExclusive?: <T>(caseId: string, fn: () => Promise<T>) => Promise<T>;
+}
+
 /**
  * Build a `.dfircase` file: the whole case directory zipped, then AES-256-GCM encrypted with a
  * password-derived key. Throws if the case doesn't exist (no files under its directory).
+ *
+ * The archive is ONE generation of the case, not a walk of a moving target — see buildCaseArchive.
  */
 export async function exportEncryptedCase(
   store: CaseStore,
@@ -177,16 +195,88 @@ export async function exportEncryptedCase(
   // chain-of-custody manifest (#231). Passed in rather than written into the case first, so
   // exporting never mutates the case it is exporting.
   extraEntries: ZipEntry[] = [],
+  opts: CaseExportOptions = {},
 ): Promise<Buffer> {
   if (!isValidCaseId(caseId)) throw new Error(`invalid case id "${caseId}"`);
+  const run = opts.runExclusive ?? (<T>(_id: string, fn: () => Promise<T>) => fn());
+  return run(caseId, () => buildCaseArchive(store, caseId, password, extraEntries));
+}
+
+/**
+ * The archive itself, built from a single case generation.
+ *
+ * The database is taken through SQLite's own snapshot path (the worker's backupDatabase, which is
+ * VACUUM INTO plus an integrity_check) rather than copied as ordinary bytes. Copying the file while
+ * a transaction is open could yield an archive whose database does not open at all — the one defect
+ * an evidence archive cannot have — and reading the live file gave a database from one instant with
+ * a manifest counted at another. Entity counts now come from that same snapshot, so what the
+ * manifest claims and what the archive contains are the same generation by construction.
+ *
+ * Journal mode is DELETE (see caseTransientPaths.ts), so the database file alone is the complete
+ * database: there is no -wal/-shm sidecar that could disagree with the snapshot.
+ */
+async function buildCaseArchive(
+  store: CaseStore,
+  caseId: string,
+  password: string,
+  extraEntries: ZipEntry[],
+): Promise<Buffer> {
   const caseDir = store.caseDir(caseId);
   const relPaths = (await walkDir(caseDir)).map((p) => p.replace(/\\/g, "/"));
   if (relPaths.length === 0) throw new Error(`case ${caseId} does not exist`);
+
+  const stagingRoot = join(store.casesRoot, EXPORT_STAGING_DIRNAME);
+  await mkdir(stagingRoot, { recursive: true });
+  const staging = await mkdtemp(join(stagingRoot, `${caseId}-`));
+  try {
+    return await archiveGeneration(caseDir, caseId, password, relPaths, extraEntries, staging);
+  } finally {
+    // The snapshot is a full copy of the case database, so it never outlives the request that
+    // needed it — including when the export throws.
+    await rm(staging, { recursive: true, force: true }).catch(() => {
+      /* nothing left to clean */
+    });
+  }
+}
+
+async function archiveGeneration(
+  caseDir: string,
+  caseId: string,
+  password: string,
+  relPaths: string[],
+  extraEntries: ZipEntry[],
+  staging: string,
+): Promise<Buffer> {
+  // The live database, and the consistent snapshot standing in for it in the archive. `false` means
+  // the case has no database yet (a case created but never written to), in which case there is
+  // nothing to substitute and nothing to count.
+  const liveDbPath = join(caseDir, "state", INVESTIGATION_DB_FILENAME);
+  const snapshotPath = join(staging, INVESTIGATION_DB_FILENAME);
+  const dbRel = `state/${INVESTIGATION_DB_FILENAME}`;
+  const snapshotted = await caseSqliteWorker.request<boolean>({
+    op: "backupDatabase",
+    dbPath: liveDbPath,
+    targetPath: snapshotPath,
+  });
 
   const entries: ZipEntry[] = [];
   const manifestFiles: Array<{ path: string; sha256: string; bytes: number }> = [];
   let totalBytes = 0;
   for (const rel of relPaths) {
+    // The database enters the archive as its SNAPSHOT, never as the live file: the live bytes can
+    // be mid-transaction, and they would also disagree with the counts below. The snapshot is one
+    // this process just wrote into its own staging directory, so it needs no link re-check.
+    if (snapshotted && rel === dbRel) {
+      const data = await readFile(snapshotPath);
+      entries.push({ path: rel, data });
+      manifestFiles.push({
+        path: rel,
+        sha256: createHash("sha256").update(data).digest("hex"),
+        bytes: data.length,
+      });
+      totalBytes += data.length;
+      continue;
+    }
     const fullPath = join(caseDir, rel);
     // TOCTOU guard: re-check that the path is not a symlink (or hardlink — see walkDir) before
     // reading. The file could have been replaced/swapped between the walk and the read.
@@ -220,9 +310,13 @@ export async function exportEncryptedCase(
     totalBytes += entry.data.length;
   }
   const counts = countsFromEntries(entries);
+  // Counted from the SNAPSHOT — the database that is actually in the archive. Counting the live one
+  // described a case that had moved on since the bytes were captured, so a recipient verifying the
+  // manifest against the archive could find fewer events than it claimed and reasonably conclude
+  // evidence had been dropped.
   const databaseCounts = await caseSqliteWorker.request<Record<string, number> | null>({
     op: "entityCounts",
-    dbPath: join(caseDir, "state", INVESTIGATION_DB_FILENAME),
+    dbPath: snapshotted ? snapshotPath : liveDbPath,
     kinds: ["forensicTimeline", "findings", "iocs"],
   });
   if (databaseCounts) {

--- a/companion/src/auth/authRoutes.ts
+++ b/companion/src/auth/authRoutes.ts
@@ -1,5 +1,5 @@
 import type { Express, Request, Response } from "express";
-import { getLoginLimiter, getLoginIpLimiter } from "../http/rateLimiter.js";
+import { getLoginLimiter, getLoginIpLimiter, getOidcStartLimiter } from "../http/rateLimiter.js";
 import { withNonce } from "../http/securityHeaders.js";
 import { readPublicAsset } from "../serverAssets.js";
 import type { TeamAuth } from "./teamAuth.js";
@@ -120,6 +120,15 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
 
   app.get("/auth/oidc/start", async (req: Request, res: Response) => {
     if (!auth.oidcClient) return res.status(404).json({ error: "OIDC is not configured" });
+    // The only PUBLIC route that allocates server state: each call stores a state, nonce, verifier,
+    // return path and expiry for ten minutes. Unlimited, an unauthenticated caller could allocate
+    // memory as fast as it could issue requests. Gated before begin(), so a throttled request costs
+    // nothing — no discovery fetch, no flow stored. The client's own hard flow ceiling is the
+    // backstop for many clients at once; this bounds any single one.
+    if (!getOidcStartLimiter().tryAcquire(req.ip ?? "unknown")) {
+      res.setHeader("Retry-After", "60");
+      return res.status(429).json({ error: "too many sign-in attempts, try again later" });
+    }
     try {
       const started = await auth.oidcClient.begin(
         typeof req.query.returnTo === "string" ? req.query.returnTo : undefined,

--- a/companion/src/auth/oidcClient.ts
+++ b/companion/src/auth/oidcClient.ts
@@ -12,6 +12,11 @@ import type { OidcConfig } from "./authConfig.js";
 const FLOW_TTL_MS = 10 * 60_000;
 const CLOCK_SKEW_SECONDS = 60;
 
+// Hard ceiling on in-flight OIDC logins. A flow is a handful of short strings, so this is a few
+// hundred KB at worst — far more concurrent logins than any deployment of this tool will see, and
+// small enough that an unauthenticated caller cannot make it matter. See sweepFlows.
+const MAX_OUTSTANDING_FLOWS = 1000;
+
 interface OidcDiscovery {
   issuer: string;
   authorizationEndpoint: string;
@@ -187,9 +192,27 @@ export class OidcClient {
     };
   }
 
+  /**
+   * Drop expired flows, then enforce a hard ceiling on how many can be outstanding at once.
+   *
+   * The sweep alone never bounded anything: it only ran when another flow started, and every flow
+   * lives for ten minutes, so a caller issuing starts faster than they expire grew the map without
+   * limit — no credentials required, since /auth/oidc/start is public. The route is rate-limited per
+   * IP now, but a limiter is a rate, not a ceiling: enough distinct clients still add up. The cap is
+   * what actually bounds the memory.
+   *
+   * Eviction is oldest-first (Map preserves insertion order), which is the least-harmful choice
+   * available: the oldest outstanding flow is the one closest to expiring anyway, and losing it
+   * costs its owner a restarted login rather than anything durable.
+   */
   private sweepFlows(now = Date.now()): void {
     for (const [state, flow] of this.flows) {
       if (flow.expiresAt <= now) this.flows.delete(state);
+    }
+    while (this.flows.size >= MAX_OUTSTANDING_FLOWS) {
+      const oldest = this.flows.keys().next();
+      if (oldest.done) break;
+      this.flows.delete(oldest.value);
     }
   }
 

--- a/companion/src/composition/dropFolder.ts
+++ b/companion/src/composition/dropFolder.ts
@@ -14,29 +14,21 @@
  * with the filesystem. A file awaiting a tool is the one exception: it stays put (so the dashboard's
  * "Run <tool>" can still act on it) and is tracked in memory instead.
  *
- * SYMLINKS AND HARDLINKS ARE REFUSED, twice — once when listing, once immediately before reading
- * (TOCTOU: the path could be swapped in between). A synced cases/ root is exactly where a
- * symlink-to-/etc/shadow is realistic, and a hardlink is indistinguishable from a normal file via
- * stat — but a legitimately dropped file is always nlink === 1, so nlink > 1 means some other
- * directory entry aliases the same inode.
+ * SYMLINKS AND HARDLINKS ARE REFUSED, when listing and again as part of every read. The second
+ * check is not a re-check of the path — that left a TOCTOU window, since the path could be swapped
+ * between checking it and reading it — but a descriptor opened with O_NOFOLLOW and verified by
+ * fstat, which the read then draws from (storage/noFollowRead.ts). A synced cases/ root is exactly
+ * where a symlink-to-/etc/shadow is realistic, and a hardlink is indistinguishable from a normal
+ * file via stat — but a legitimately dropped file is always nlink === 1, so nlink > 1 means some
+ * other directory entry aliases the same inode.
  *
  * ARMED ONLY WHEN options.dropStatusStore IS WIRED (i.e. by startServer), so createApp-only unit
  * tests never spin up a filesystem poller.
  */
 import { basename, dirname, extname, join, relative } from "node:path";
-import {
-  readFile,
-  readdir,
-  stat,
-  lstat,
-  open,
-  copyFile,
-  mkdir,
-  rename,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { readdir, stat, lstat, mkdir, rename, rm, writeFile } from "node:fs/promises";
 import type { CaseStore } from "../storage/caseStore.js";
+import { openNoFollow, readFileNoFollow, readHeadNoFollow, LinkGuardError } from "../storage/noFollowRead.js";
 import type { AppOptions } from "./appOptions.js";
 import type { AiControl } from "../analysis/aiControl.js";
 import type { CaptureMetadata } from "../types.js";
@@ -227,19 +219,27 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
     const dest = await uniqueDest(join(dropDir, ok ? DROP_PROCESSED : DROP_FAILED, relpath));
     await mkdir(dirname(dest), { recursive: true });
     try {
-      // Guard against a symlink swap (TOCTOU): rename follows symlinks on some platforms, and
-      // copyFile always does. Re-check before moving. Also refuse a hardlink (nlink > 1) — see
-      // listDropFiles for why that's just as much a host-file-exfiltration vector as a symlink.
-      const lst = await lstat(src);
-      if (lst.isSymbolicLink())
-        throw new Error("symlink detected in drop folder — refused to move (security)");
-      if (lst.nlink > 1) throw new Error("hardlink detected in drop folder — refused to move (security)");
-      await rename(src, dest);
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException).code === "EXDEV") {
-        await copyFile(src, dest);
+      // rename() operates on the directory entry itself, so it cannot follow a planted symlink to
+      // somewhere else — but it must still refuse to FILE a link away as if it were evidence, and
+      // the EXDEV fallback below reads content and does follow. A path-based lstat here could be
+      // swapped before either call, so the guard is a descriptor: opened with O_NOFOLLOW, fstat'd,
+      // and — on the fallback path — the very descriptor the copy reads from.
+      const guard = await openNoFollow(src);
+      try {
+        await rename(src, dest);
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "EXDEV") throw e;
+        // Cross-filesystem: copy the bytes of the descriptor already verified, never of the path.
+        await writeFile(dest, await guard.readFile());
         await rm(src, { force: true });
-      } else throw e;
+      } finally {
+        await guard.close();
+      }
+    } catch (e) {
+      if (e instanceof LinkGuardError) {
+        throw new Error(`${e.kind} detected in drop folder — refused to move (security)`);
+      }
+      throw e;
     }
   }
 
@@ -252,7 +252,7 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
     name: string,
     mtimeMs: number,
   ): Promise<void> {
-    const raw = await readFile(fullPath);
+    const raw = await readFileNoFollow(fullPath);
     let webp: Buffer;
     try {
       const sharp = (await import("sharp")).default;
@@ -291,15 +291,14 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
     const full = join(dropDir, file.relpath);
     const name = basename(file.relpath);
     try {
-      // TOCTOU guard: re-check that the path is not a symlink before reading. A file could have
-      // been replaced with a symlink between listDropFiles and this read. Also refuse a hardlink
-      // (nlink > 1) — indistinguishable from a normal file via stat, but a legitimately-dropped
-      // file is always nlink === 1 (see listDropFiles).
-      const lst = await lstat(full);
-      if (lst.isSymbolicLink())
-        return { ok: false, reason: "symlink detected in drop folder — refused to read (security)" };
-      if (lst.nlink > 1)
-        return { ok: false, reason: "hardlink detected in drop folder — refused to read (security)" };
+      // The link guard travels WITH each read rather than preceding it: every read below goes
+      // through storage/noFollowRead.ts, which opens with O_NOFOLLOW and reads from the descriptor
+      // it just verified. Checking the path here and reading the path later left a window in which
+      // a process sharing this folder could swap the approved file for a symlink and have an
+      // arbitrary host file imported into the case as evidence. A hardlink is refused too — it is
+      // invisible to a symlink check, and a legitimately-dropped file is always nlink === 1.
+      // A LinkGuardError from any of them becomes a refusal in the catch below.
+      //
       // A raw file an external tool handles (built-in EVTX/PCAP, or any extension a CUSTOM tool claims)
       // — can't be read as text. Run the configured tool against the on-disk file (size-independent, so
       // checked BEFORE the oversize cap), or surface it as pending so the dashboard offers "Run/Configure
@@ -309,15 +308,11 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
       // raw rather than read as text. Only the first 8 KB — the file may be gigabytes.
       let head: Buffer | undefined;
       try {
-        const fh = await open(full, "r");
-        try {
-          const buf = Buffer.alloc(Math.min(8192, Math.max(0, file.size)));
-          if (buf.length) await fh.read(buf, 0, buf.length, 0);
-          head = buf;
-        } finally {
-          await fh.close();
-        }
-      } catch {
+        head = await readHeadNoFollow(full, Math.min(8192, Math.max(0, file.size)));
+      } catch (err) {
+        // A planted link must REFUSE the file, not quietly degrade to extension-only guessing —
+        // that would hand the path to a tool or the text reader anyway.
+        if (err instanceof LinkGuardError) throw err;
         /* unreadable head → fall back to extension-only classification */
       }
 
@@ -361,7 +356,7 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
         await ingestDroppedImage(caseId, full, name, file.mtimeMs);
         return { ok: true };
       }
-      const text = await readFile(full, "utf8");
+      const text = (await readFileNoFollow(full)).toString("utf8");
       if (!text.trim()) return { ok: false, reason: "empty file" };
       const kind = resolveImportKind(name, text);
       if (kind === "unknown")
@@ -374,6 +369,9 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
         };
       return { ok: true };
     } catch (err) {
+      if (err instanceof LinkGuardError) {
+        return { ok: false, reason: `${err.kind} detected in drop folder — refused to read (security)` };
+      }
       recordImportFailure(caseId, "drop", name, err);
       return { ok: false, reason: (err as Error)?.message ?? String(err) };
     }

--- a/companion/src/http/rateLimiter.ts
+++ b/companion/src/http/rateLimiter.ts
@@ -152,6 +152,8 @@ let _loginLimiter: AttemptLimiter | null = null;
 let _loginIpLimiter: SlidingWindowLimiter | null = null;
 let _loginSweepTimer: NodeJS.Timeout | null = null;
 let _loginIpSweepTimer: NodeJS.Timeout | null = null;
+let _oidcStartLimiter: SlidingWindowLimiter | null = null;
+let _oidcStartSweepTimer: NodeJS.Timeout | null = null;
 
 export function getUnlockLimiter(): AttemptLimiter {
   if (!_unlockLimiter) {
@@ -237,6 +239,22 @@ export function getLoginIpLimiter(): SlidingWindowLimiter {
   return _loginIpLimiter;
 }
 
+/** Per-IP budget for GET /auth/oidc/start, the one PUBLIC route that allocates server state.
+ *  Every call stores a state, nonce, verifier, return path and expiry for ten minutes, so without
+ *  a limiter an unauthenticated caller could allocate memory as fast as it could issue requests —
+ *  no credentials, no provider round-trip needed. 20 a minute is far past a human clicking
+ *  "Sign in with SSO" (each click is one flow, and a retry after a provider error is another),
+ *  and it caps one client's outstanding flows well below the client's own hard flow ceiling. */
+export function getOidcStartLimiter(): SlidingWindowLimiter {
+  if (!_oidcStartLimiter) {
+    const limiter = new SlidingWindowLimiter(20, 60_000);
+    _oidcStartLimiter = limiter;
+    _oidcStartSweepTimer = setInterval(() => limiter.sweep(), SWEEP_INTERVAL_MS);
+    _oidcStartSweepTimer.unref?.();
+  }
+  return _oidcStartLimiter;
+}
+
 /** Reset singletons (tests). Also clears each singleton's sweep timer so repeated
  *  reset+get cycles in a test suite don't stack up abandoned intervals. */
 export function resetLimiters(): void {
@@ -246,6 +264,7 @@ export function resetLimiters(): void {
   if (_importIpSweepTimer) clearInterval(_importIpSweepTimer);
   if (_loginSweepTimer) clearInterval(_loginSweepTimer);
   if (_loginIpSweepTimer) clearInterval(_loginIpSweepTimer);
+  if (_oidcStartSweepTimer) clearInterval(_oidcStartSweepTimer);
   _unlockSweepTimer = null;
   _aiSweepTimer = null;
   _importSweepTimer = null;
@@ -258,4 +277,6 @@ export function resetLimiters(): void {
   _loginIpSweepTimer = null;
   _loginLimiter = null;
   _loginIpLimiter = null;
+  _oidcStartSweepTimer = null;
+  _oidcStartLimiter = null;
 }

--- a/companion/src/integrations/childOutput.ts
+++ b/companion/src/integrations/childOutput.ts
@@ -1,0 +1,95 @@
+// Bounded capture of a spawned child's stdout and stderr, shared by the two runners that shell out
+// to analyst-installed forensic binaries (integrations/tools/toolRunner.ts and
+// integrations/velociraptor/velociraptorApi.ts — the latter is the one the former was modelled on,
+// and both carried the same two defects).
+//
+// WHAT WENT WRONG, twice:
+//
+//   1. Only stdout was capped. stderr was appended to a string with no limit at all until the child
+//      exited or the timeout fired, so a malfunctioning or hostile tool could exhaust the Node heap
+//      by writing to the stream nobody was watching. A forensic tool is an arbitrary local binary
+//      the analyst pointed us at; "it will not do that" is not a property we can assert.
+//
+//   2. The cap counted JavaScript string length while the option was named maxOutputBytes. A UTF-16
+//      code unit is not a byte: multibyte output could exceed the intended limit several times over
+//      before the check fired. Decoding per chunk was independently wrong — a multibyte character
+//      split across a chunk boundary decodes to replacement characters, quietly corrupting output
+//      that an importer then parses.
+//
+// So: count raw Buffer bytes, hold chunks undecoded, and decode ONCE at the end.
+
+/** Default ceiling for the retained stderr tail. Diagnostics, not evidence — the end is the useful part. */
+export const DEFAULT_STDERR_TAIL_BYTES = 64 * 1024;
+
+/**
+ * Accumulates a child process's output under an explicit byte budget.
+ *
+ * stdout is the tool's RESULT, so exceeding its cap is a failure the caller must surface (and kill
+ * the child over) — truncating it would hand an importer a silently incomplete artifact.
+ *
+ * stderr is DIAGNOSTIC, so it is bounded by keeping a rolling tail rather than by failing: a tool
+ * that logs verbosely is normal, the tail is what an error message needs, and dropping the older
+ * bytes costs nothing an analyst was going to read. It therefore can never be the reason a run dies
+ * — but it also can never grow without bound.
+ */
+export class ChildOutputCollector {
+  private readonly stdoutChunks: Buffer[] = [];
+  private stderrChunks: Buffer[] = [];
+  private stdoutBytes = 0;
+  private stderrBytes = 0;
+
+  constructor(
+    private readonly maxStdoutBytes: number,
+    private readonly stderrTailBytes: number = DEFAULT_STDERR_TAIL_BYTES,
+  ) {}
+
+  /** Bytes of stdout captured so far. */
+  get stdoutByteLength(): number {
+    return this.stdoutBytes;
+  }
+
+  /** Bytes of stderr currently retained (never more than the tail budget). */
+  get stderrByteLength(): number {
+    return this.stderrBytes;
+  }
+
+  /**
+   * Add a stdout chunk. Returns true when the byte budget is now exceeded, which the caller must
+   * treat as fatal — kill the child and reject. The chunk is still retained so a caller that wants
+   * to report what it got can.
+   */
+  pushStdout(chunk: Buffer): boolean {
+    this.stdoutChunks.push(chunk);
+    this.stdoutBytes += chunk.byteLength;
+    return this.stdoutBytes > this.maxStdoutBytes;
+  }
+
+  /** Add a stderr chunk, discarding whole older chunks so the retained tail stays within budget. */
+  pushStderr(chunk: Buffer): void {
+    this.stderrChunks.push(chunk);
+    this.stderrBytes += chunk.byteLength;
+    // Drop from the FRONT: the tail is the part that explains a failure.
+    while (this.stderrChunks.length > 1 && this.stderrBytes > this.stderrTailBytes) {
+      const dropped = this.stderrChunks.shift();
+      this.stderrBytes -= dropped ? dropped.byteLength : 0;
+    }
+    // A single chunk larger than the whole budget still has to be cut, or one enormous write
+    // defeats the limit on its own.
+    if (this.stderrChunks.length === 1 && this.stderrBytes > this.stderrTailBytes) {
+      const only = this.stderrChunks[0];
+      this.stderrChunks = [only.subarray(only.byteLength - this.stderrTailBytes)];
+      this.stderrBytes = this.stderrTailBytes;
+    }
+  }
+
+  /**
+   * Decode both streams. Done once, on the concatenated bytes, so a multibyte character split
+   * across chunk boundaries survives intact.
+   */
+  text(): { stdout: string; stderr: string } {
+    return {
+      stdout: Buffer.concat(this.stdoutChunks).toString("utf8"),
+      stderr: Buffer.concat(this.stderrChunks).toString("utf8"),
+    };
+  }
+}

--- a/companion/src/integrations/tools/toolRunner.ts
+++ b/companion/src/integrations/tools/toolRunner.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { openSync, closeSync } from "node:fs";
 import { dirname, isAbsolute } from "node:path";
 import { retryTransientSpawn } from "../velociraptor/velociraptorApi.js";
+import { ChildOutputCollector } from "../childOutput.js";
 
 // Generic runner for the analyst-configured external forensic tools (Hayabusa, Velociraptor CLI,
 // Suricata, Snort, YARA). It shells out to a LOCAL binary the analyst installed — the Companion never
@@ -158,8 +159,10 @@ function spawnToolOnce(
       launchFailed(e);   // Windows throws EPERM synchronously — not via the 'error' event
       return;
     }
-    let out = "";
-    let err = "";
+    // Raw BYTES under one budget, decoded once at the end — see integrations/childOutput.ts for why
+    // counting string length and decoding per chunk were both wrong, and why stderr needs a bound of
+    // its own rather than none at all.
+    const output = new ChildOutputCollector(opts.maxOutputBytes);
     let killed = false;
     const timer = setTimeout(() => {
       killed = true;
@@ -169,8 +172,7 @@ function spawnToolOnce(
     }, opts.timeoutMs);
     // When redirecting to a file, child.stdout is null (goes to the fd) — no in-memory buffer/cap.
     child.stdout?.on("data", (d: Buffer) => {
-      out += d.toString();
-      if (out.length > opts.maxOutputBytes) {
+      if (output.pushStdout(d)) {
         killed = true;
         child.kill();
         clearTimeout(timer);
@@ -178,7 +180,9 @@ function spawnToolOnce(
         reject(new Error(`Tool "${binary}" output exceeded ${opts.maxOutputBytes} bytes — raise the tool's MAX_OUTPUT, or narrow the run`));
       }
     });
-    child.stderr?.on("data", (d: Buffer) => { err += d.toString(); });
+    // Never fatal, never unbounded: a bounded tail keeps the diagnostics a failure message needs
+    // while a tool that spews forever cannot exhaust the heap.
+    child.stderr?.on("data", (d: Buffer) => output.pushStderr(d));
     child.on("error", (e) => {
       if (killed) return;
       clearTimeout(timer);
@@ -188,7 +192,8 @@ function spawnToolOnce(
       if (killed) return;
       clearTimeout(timer);
       closeFd();
-      resolve({ stdout: out, stderr: err, code: code ?? 0 });
+      const { stdout, stderr } = output.text();
+      resolve({ stdout, stderr, code: code ?? 0 });
     });
   });
 }

--- a/companion/src/integrations/velociraptor/velociraptorApi.ts
+++ b/companion/src/integrations/velociraptor/velociraptorApi.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { ChildOutputCollector } from "../childOutput.js";
 
 // Run the hunt-pivot queries the Companion generates against a Velociraptor server through its API.
 // The hunt-pivot is run as a HUNT across ALL enrolled endpoints (not server-side): the pivot VQL is
@@ -183,8 +184,7 @@ function spawnVqlOnce(config: VelociraptorApiConfig, statements: string[], opts:
       launchFailed(e);   // Windows throws EPERM synchronously — not via the 'error' event
       return;
     }
-    let out = "";
-    let err = "";
+    const output = new ChildOutputCollector(opts.maxOutputBytes);   // real bytes, bounded stderr — see integrations/childOutput.ts
     let killed = false;
     const timer = setTimeout(() => {
       killed = true;
@@ -192,15 +192,14 @@ function spawnVqlOnce(config: VelociraptorApiConfig, statements: string[], opts:
       reject(new Error(`Velociraptor query timed out after ${opts.timeoutMs}ms`));
     }, opts.timeoutMs);
     child.stdout.on("data", (d: Buffer) => {
-      out += d.toString();
-      if (out.length > opts.maxOutputBytes) {
+      if (output.pushStdout(d)) {
         killed = true;
         child.kill();
         clearTimeout(timer);
         reject(new Error(`Velociraptor query output exceeded ${opts.maxOutputBytes} bytes — raise DFIR_VELOCIRAPTOR_COLLECT_MAX_OUTPUT (collection) / DFIR_VELOCIRAPTOR_MAX_OUTPUT, or narrow the query`));
       }
     });
-    child.stderr.on("data", (d: Buffer) => { err += d.toString(); });
+    child.stderr.on("data", (d: Buffer) => output.pushStderr(d));   // bounded tail, never fatal
     child.on("error", (e) => {
       if (killed) return;
       clearTimeout(timer);
@@ -209,6 +208,7 @@ function spawnVqlOnce(config: VelociraptorApiConfig, statements: string[], opts:
     child.on("close", (code) => {
       if (killed) return;
       clearTimeout(timer);
+      const { stdout: out, stderr: err } = output.text();
       if (code !== 0) {
         reject(new Error(translateVelociraptorError(err.trim()) || `velociraptor exited with code ${code}`));
         return;

--- a/companion/src/reports/reportGeneration.ts
+++ b/companion/src/reports/reportGeneration.ts
@@ -1,0 +1,77 @@
+import { writeFile, rename, unlink } from "node:fs/promises";
+import { atomicTempPath } from "../storage/atomicWrite.js";
+
+// A report is not one file, it is eight — markdown, HTML, four CSVs, the state export, and the
+// analysis-run provenance record. They were written one after another, straight over the previous
+// report's files. Any interruption between them (a crash, a full disk, a permission error, or a
+// failed provenance write) left some artifacts from the NEW report sitting beside artifacts from
+// the OLD one.
+//
+// Every individual file stays readable, which is what makes this dangerous rather than merely
+// annoying: nothing looks broken. A report directory can present a findings CSV from one
+// generation, a narrative from another, and provenance for a run that never finished — and for a
+// forensic deliverable, internally inconsistent claims with stale provenance are worse than a
+// missing report, because someone will rely on them.
+//
+// So: render everything, stage everything, and only then publish. Nothing in the reports directory
+// changes until every artifact AND the provenance record have succeeded.
+
+interface Staged {
+  tmp: string;
+  target: string;
+}
+
+/**
+ * A report generation held in staging, publishable as a unit.
+ *
+ * Staged files use atomicWrite's temp-path form, so the export walker and anything else that
+ * inspects a case already treats them as a write in progress rather than case content.
+ */
+export class ReportGeneration {
+  private readonly staged: Staged[] = [];
+  private published = false;
+
+  /** Write one artifact into staging. Nothing is visible at its real path until publish(). */
+  async stage(target: string, contents: string): Promise<void> {
+    const tmp = atomicTempPath(target);
+    await writeFile(tmp, contents, "utf8");
+    this.staged.push({ tmp, target });
+  }
+
+  /**
+   * Move every staged artifact into place.
+   *
+   * Renames within one directory are the most reliable operation available here — no bytes move and
+   * each replacement is atomic — so the window in which a mixed generation could be observed shrinks
+   * from the whole render (seconds: rendering, disk writes, a provenance round-trip) to the few
+   * microseconds between renames. It is NOT a single atomic swap of the whole directory, and this
+   * comment is the place that says so rather than leaving a reader to assume otherwise; a directory
+   * swap would break the other files that legitimately live in reports/ (custody manifests, exports).
+   *
+   * A failure part-way through leaves the remaining staged files in place rather than deleting them,
+   * so the bytes are still on disk for an operator to inspect.
+   */
+  async publish(): Promise<void> {
+    for (const { tmp, target } of this.staged) {
+      await rename(tmp, target);
+    }
+    this.published = true;
+    this.staged.length = 0;
+  }
+
+  /**
+   * Throw away everything staged. Called when rendering or provenance failed, so a half-built
+   * generation never reaches the reports directory — and never accumulates as debris either.
+   */
+  async discard(): Promise<void> {
+    if (this.published) return;
+    await Promise.all(
+      this.staged.map(({ tmp }) =>
+        unlink(tmp).catch(() => {
+          /* already gone, or never created — nothing to undo */
+        }),
+      ),
+    );
+    this.staged.length = 0;
+  }
+}

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -1,5 +1,5 @@
-import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { ReportGeneration } from "./reportGeneration.js";
 import type { CaseStore } from "../storage/caseStore.js";
 import type { StateStore } from "../analysis/stateStore.js";
 import { NO_SCOPE, type ScopeStore } from "../analysis/scope.js";
@@ -558,79 +558,92 @@ export class ReportWriter {
     const complianceControl = this.complianceControl ? await this.complianceControl.load(caseId) : {};
     const custody = this.custodyStore ? await this.custodyStore.load(caseId) : undefined;
     const c = this.renderContents(state, meta, exposure, graph, notebookEntries, playbookTasks, template, kevCatalog, hypotheses, secondLookLeads, coverage, lateralPaths, modelPerf, complianceControl, custody);
-    await writeFile(paths.markdown, c.markdown, "utf8");
-    await writeFile(paths.html, c.html, "utf8");
-    await writeFile(paths.findingsCsv, c.findingsCsv, "utf8");
-    await writeFile(paths.iocsCsv, c.iocsCsv, "utf8");
-    await writeFile(paths.timelineCsv, c.timelineCsv, "utf8");
-    await writeFile(paths.forensicTimelineCsv, c.forensicTimelineCsv, "utf8");
-    await writeFile(paths.stateJson, c.stateJson, "utf8");
+    // Staged, not published: nothing in reports/ changes until every artifact AND the provenance
+    // record below have succeeded. Writing them straight over the previous report left a mixed
+    // generation behind whenever anything in between failed — see reports/reportGeneration.ts.
+    const generation = new ReportGeneration();
     const sourceRuns = this.analysisRuns ? await this.analysisRuns.list(caseId) : [];
     let reportRunId: string | undefined;
-    if (this.analysisRuns) {
-      const reportRun = await this.analysisRuns.record(caseId, {
-        kind: "report",
-        parentRunId: opts.parentRunId,
-        startedAt,
-        finishedAt: new Date().toISOString(),
-        versions: { schema: "report/v1" },
-        input: {
-          artifacts: [],
-          eventIds: state.forensicTimeline.map((event) => event.id),
-          entityIds: [
-            ...state.findings.map((finding) => finding.id),
-            ...state.iocs.map((ioc) => ioc.id),
-          ],
-          selectionHash: hashManifestValue({
-            sourceRunIds: sourceRuns.map((run) => run.id),
+    // discard() is a no-op once published, so the finally covers every failure path — a render
+    // error, a full disk, a permission error, or a provenance write that never completed — without
+    // needing to know which one happened.
+    try {
+      await generation.stage(paths.markdown, c.markdown);
+      await generation.stage(paths.html, c.html);
+      await generation.stage(paths.findingsCsv, c.findingsCsv);
+      await generation.stage(paths.iocsCsv, c.iocsCsv);
+      await generation.stage(paths.timelineCsv, c.timelineCsv);
+      await generation.stage(paths.forensicTimelineCsv, c.forensicTimelineCsv);
+      await generation.stage(paths.stateJson, c.stateJson);
+      if (this.analysisRuns) {
+        const reportRun = await this.analysisRuns.record(caseId, {
+          kind: "report",
+          parentRunId: opts.parentRunId,
+          startedAt,
+          finishedAt: new Date().toISOString(),
+          versions: { schema: "report/v1" },
+          input: {
+            artifacts: [],
             eventIds: state.forensicTimeline.map((event) => event.id),
-          }),
-        },
-        configuration: {
-          templateHash: hashManifestValue(template),
-          parameters: {
-            templateId: template.id,
-            pinnedRunIds: sourceRuns.map((run) => run.id),
+            entityIds: [
+              ...state.findings.map((finding) => finding.id),
+              ...state.iocs.map((ioc) => ioc.id),
+            ],
+            selectionHash: hashManifestValue({
+              sourceRunIds: sourceRuns.map((run) => run.id),
+              eventIds: state.forensicTimeline.map((event) => event.id),
+            }),
           },
-          filteringPolicy: {
-            reportScopeApplied: true,
-            falsePositivesExcluded: true,
+          configuration: {
+            templateHash: hashManifestValue(template),
+            parameters: {
+              templateId: template.id,
+              pinnedRunIds: sourceRuns.map((run) => run.id),
+            },
+            filteringPolicy: {
+              reportScopeApplied: true,
+              falsePositivesExcluded: true,
+            },
           },
-        },
-        output: {
-          entityIds: [
-            "report.md",
-            "report.html",
-            "findings.csv",
-            "iocs.csv",
-            "timeline.csv",
-            "forensic-timeline.csv",
-            "state-export.json",
-          ],
-          hashes: [
-            ["report.md", c.markdown],
-            ["report.html", c.html],
-            ["findings.csv", c.findingsCsv],
-            ["iocs.csv", c.iocsCsv],
-            ["timeline.csv", c.timelineCsv],
-            ["forensic-timeline.csv", c.forensicTimelineCsv],
-            ["state-export.json", c.stateJson],
-          ].map(([id, contents]) => ({
-            id,
-            sha256: createHash("sha256").update(contents).digest("hex"),
-          })),
-          claims: state.findings.map((finding) => claimSnapshot(finding.id, {
-            title: finding.title,
-            severity: finding.severity,
-            description: finding.description,
-            evidenceEventIds: finding.relatedEventIds,
-          })),
-        },
-      });
-      reportRunId = reportRun.id;
-      await writeFile(paths.analysisRuns, JSON.stringify(await this.analysisRuns.list(caseId), null, 2), "utf8");
-    } else {
-      await writeFile(paths.analysisRuns, "[]\n", "utf8");
+          output: {
+            entityIds: [
+              "report.md",
+              "report.html",
+              "findings.csv",
+              "iocs.csv",
+              "timeline.csv",
+              "forensic-timeline.csv",
+              "state-export.json",
+            ],
+            hashes: [
+              ["report.md", c.markdown],
+              ["report.html", c.html],
+              ["findings.csv", c.findingsCsv],
+              ["iocs.csv", c.iocsCsv],
+              ["timeline.csv", c.timelineCsv],
+              ["forensic-timeline.csv", c.forensicTimelineCsv],
+              ["state-export.json", c.stateJson],
+            ].map(([id, contents]) => ({
+              id,
+              sha256: createHash("sha256").update(contents).digest("hex"),
+            })),
+            claims: state.findings.map((finding) => claimSnapshot(finding.id, {
+              title: finding.title,
+              severity: finding.severity,
+              description: finding.description,
+              evidenceEventIds: finding.relatedEventIds,
+            })),
+          },
+        });
+        reportRunId = reportRun.id;
+        await generation.stage(paths.analysisRuns, JSON.stringify(await this.analysisRuns.list(caseId), null, 2));
+      } else {
+        await generation.stage(paths.analysisRuns, "[]\n");
+      }
+      // Every artifact and the provenance record are on disk — publish them as one generation.
+      await generation.publish();
+    } finally {
+      await generation.discard();
     }
     // #77 report versioning: snapshot markdown + meta + the diff-relevant slice of state so the
     // dashboard can diff two generations and roll back to a prior version's editable meta.

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -452,7 +452,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
             data: Buffer.from(JSON.stringify(await buildCustodyManifest(store, options.custodyStore, id, instanceSecret), null, 2), "utf8"),
           }]
         : [];
-      const archive = await exportEncryptedCase(store, id, password, custodyManifest);
+      const archive = await exportEncryptedCase(store, id, password, custodyManifest, { runExclusive: ctx.runStateExclusive });
       const filename = dfircaseFilename(id, meta?.name);
       // Same as the ZIP path: the evidence is leaving, so the chain records it (#231).
       await options.custodyStore?.recordExport(id, { exportedBy: meta?.investigator || "analyst", destination: `encrypted archive: ${filename}` });

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -1,7 +1,7 @@
 import type { Express, Request, Response } from "express";
 import { readFile } from "node:fs/promises";
 import { ZodError } from "zod";
-import { isValidCaseId } from "../storage/caseStore.js";
+import { isValidCaseId, CaseAlreadyExistsError } from "../storage/caseStore.js";
 import { withNonce } from "../http/securityHeaders.js";
 import { sanitizeCaseMeta } from "../analysis/casePassword.js";
 import { buildInitialQuestions, buildInitialNextSteps } from "../analysis/templateStore.js";
@@ -100,11 +100,10 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
   });
 
   // Create a case. This is the one place a case is born (the dashboard's New case form and
-  // `npm run`-style tooling call it); the extension no longer creates cases. Rejects a
-  // duplicate id so the form can't silently clobber an existing case's metadata/evidence.
-  // Optional `templateId`: pre-populates key questions from the named template.
-  // Optional `incidentTypeId` (#236): additionally applies an incident type's auto-playbook —
-  // type-specific key questions, next steps, and expected-finding confirm/deny seeds.
+  // `npm run`-style tooling call it); the extension no longer creates cases. The caseExists check
+  // is only the friendly duplicate answer — two simultaneous requests both pass it, so createCase's
+  // exclusive claim is the guarantee, and a loser 409s from the catch without reaching grantCreator.
+  // Optional `templateId` seeds key questions; `incidentTypeId` (#236) also applies its auto-playbook.
   app.post("/cases", async (req: Request, res: Response) => {
     try {
       const { caseId, name, investigator, aiProvider, templateId, incidentTypeId } = req.body ?? {};
@@ -146,6 +145,7 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       await ensureDropFolders(caseId).catch(() => { /* the watcher re-ensures on its next poll */ });
       return res.status(201).json(sanitizeCaseMeta(meta));
     } catch (err) {
+      if (err instanceof CaseAlreadyExistsError) return res.status(409).json({ error: err.message });
       return res.status(500).json({ error: (err as Error).message });
     }
   });

--- a/companion/src/storage/atomicWrite.ts
+++ b/companion/src/storage/atomicWrite.ts
@@ -38,6 +38,18 @@ function tempPathFor(target: string): string {
   return `${target}.${randomUUID()}.tmp`;
 }
 
+/**
+ * A temp path for `target` in the same form atomicWrite uses.
+ *
+ * Exported so a multi-file publication (reports/reportGeneration.ts) can stage its artifacts under
+ * names the rest of the system ALREADY understands as a write in progress — caseTransientPaths.ts
+ * skips exactly this shape, so a staged generation can never be mistaken for case content or end up
+ * in an archive.
+ */
+export function atomicTempPath(target: string): string {
+  return tempPathFor(target);
+}
+
 /** True when `path` is a temp file atomicWrite created — a write in progress, not case content. */
 export function isAtomicWriteTempPath(path: string): boolean {
   return TEMP_SUFFIX_PATTERN.test(path);

--- a/companion/src/storage/caseStore.ts
+++ b/companion/src/storage/caseStore.ts
@@ -21,6 +21,21 @@ export function isValidCaseId(caseId: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(caseId) && !caseId.includes("..");
 }
 
+/**
+ * The case id is already owned by someone else. Thrown by createCase when its exclusive claim on
+ * case.json loses — which is the ONLY way a caller can learn it lost, since a check-then-create
+ * pair cannot: both racers pass the check.
+ *
+ * A distinct type rather than a message match so the route can answer 409 (someone else has it)
+ * instead of 500 (we broke), and so a future caller cannot mistake it for a disk failure.
+ */
+export class CaseAlreadyExistsError extends Error {
+  constructor(readonly caseId: string) {
+    super(`case ${caseId} already exists`);
+    this.name = "CaseAlreadyExistsError";
+  }
+}
+
 /** What the caller knows about where an artifact came from; only the capture path has all of it. */
 export interface ArtifactProvenance {
   source?: string;
@@ -168,10 +183,18 @@ export class CaseStore {
     await rm(dir, { recursive: true });
   }
 
-  // NOTE: does not itself guard against an id collision with an archived case (caseDir()
-  // resolves to the archived location and this would silently overwrite its case.json).
-  // Callers are responsible for that check — see POST /cases in server.ts, which calls
-  // caseExists() (archive-aware) and 409s before ever reaching here.
+  // Creating a case CLAIMS its id, so the write of case.json is exclusive (`wx` — O_CREAT|O_EXCL,
+  // atomic on POSIX and Windows alike) and is the FIRST thing that touches the case. A caller's
+  // caseExists() check cannot make this safe on its own: two requests for the same id both pass the
+  // check, both used to create, and the later metadata write simply became the final case.json —
+  // which under team auth handed BOTH requesters administrator on the same case. The exclusive
+  // create is the single point where exactly one of them can win.
+  //
+  // This also subsumes the archived-collision hazard the callers used to be responsible for:
+  // caseDir() resolves an archived id to its archived folder, so the claim collides there too and
+  // an archived case's metadata can no longer be silently overwritten.
+  //
+  // The subdirectories are created only AFTER the claim succeeds, so a loser leaves nothing behind.
   async createCase(input: CreateCaseInput): Promise<CaseMeta> {
     const meta: CaseMeta = {
       caseId: input.caseId,
@@ -180,16 +203,30 @@ export class CaseStore {
       investigator: input.investigator,
       aiProvider: input.aiProvider,
     };
-    for (const dir of [
+    // Resolved once: caseDir() is existsSync-based, so re-resolving it after the mkdir below would
+    // answer a different question than the one the claim is made against.
+    const dir = this.caseDir(input.caseId);
+    await mkdir(dir, { recursive: true });
+    try {
+      await writeFile(join(dir, "case.json"), JSON.stringify(meta, null, 2), {
+        encoding: "utf8",
+        flag: "wx",
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+        throw new CaseAlreadyExistsError(input.caseId);
+      }
+      throw err;
+    }
+    for (const sub of [
       this.screenshotsDir(input.caseId),
       this.metadataDir(input.caseId),
       this.stateDir(input.caseId),
       this.reportsDir(input.caseId),
       this.importsDir(input.caseId),
     ]) {
-      await mkdir(dir, { recursive: true });
+      await mkdir(sub, { recursive: true });
     }
-    await writeFile(this.caseMetaPath(input.caseId), JSON.stringify(meta, null, 2), "utf8");
     return meta;
   }
 

--- a/companion/src/storage/noFollowRead.ts
+++ b/companion/src/storage/noFollowRead.ts
@@ -1,0 +1,109 @@
+import { open, lstat, type FileHandle } from "node:fs/promises";
+import { constants } from "node:fs";
+
+// Reading a file that a symlink check has just approved is two syscalls, and the gap between them
+// belongs to whoever controls the directory. Every path-based guard in this codebase had the same
+// shape — lstat the path, decide it is a plain file, then open/readFile/copyFile that path AGAIN —
+// so a process able to write into a case directory or a shared drop folder could replace the
+// checked file with a symlink in between and have the second call follow it. The payoff is not
+// hypothetical: an arbitrary host-readable file gets imported into a case as evidence, sent to an
+// AI provider for analysis, or sealed into an encrypted export.
+//
+// The fix is to stop naming the file twice. Open it ONCE with O_NOFOLLOW, verify the descriptor
+// itself with fstat, and read from that same descriptor — the checked object and the read object
+// are then the same object by construction, with no window to swap.
+
+/**
+ * Whether the platform can refuse to follow a symlink at open() time. POSIX has O_NOFOLLOW; Windows
+ * does not, so there the guard degrades to a metadata comparison around the open (below), which
+ * narrows the window rather than closing it.
+ */
+export const NOFOLLOW_SUPPORTED = typeof constants.O_NOFOLLOW === "number";
+
+export type LinkGuardKind = "symlink" | "hardlink";
+
+/**
+ * The path was, or became, something other than the plain unshared file it was taken for. Carries
+ * WHICH so each caller can phrase it in its own terms (an export refuses to include, the drop
+ * folder refuses to read) without matching on message text.
+ */
+export class LinkGuardError extends Error {
+  constructor(
+    readonly kind: LinkGuardKind,
+    readonly path: string,
+  ) {
+    super(`${kind} detected at "${path}"`);
+    this.name = "LinkGuardError";
+  }
+}
+
+/**
+ * Open `path` for reading, guaranteeing the descriptor refers to a plain file that no symlink was
+ * followed to reach and that no other directory entry aliases.
+ *
+ * Throws LinkGuardError("symlink") if the path is a link, LinkGuardError("hardlink") if the opened
+ * file has more than one link. A hardlink is invisible to a symlink check and to readdir alike —
+ * only the link count reveals that some other path, anywhere on the same filesystem, names this
+ * exact inode. Every file this application writes into a case is nlink === 1.
+ *
+ * The caller owns the returned handle and must close it.
+ */
+export async function openNoFollow(path: string): Promise<FileHandle> {
+  // Without O_NOFOLLOW the pre-check is the only thing that can reject a link that is ALREADY in
+  // place; the identity comparison after the open is what catches a swap during it.
+  const before = NOFOLLOW_SUPPORTED ? null : await lstat(path);
+  if (before?.isSymbolicLink()) throw new LinkGuardError("symlink", path);
+
+  let handle: FileHandle;
+  try {
+    handle = await open(path, constants.O_RDONLY | (NOFOLLOW_SUPPORTED ? constants.O_NOFOLLOW : 0));
+  } catch (err) {
+    // ELOOP is precisely "you asked me not to follow a symlink, and it is one".
+    if ((err as NodeJS.ErrnoException).code === "ELOOP") throw new LinkGuardError("symlink", path);
+    throw err;
+  }
+
+  try {
+    const opened = await handle.stat();
+    if (opened.nlink > 1) throw new LinkGuardError("hardlink", path);
+    // Windows fallback: the file the descriptor points at must be the file that was checked. Inode
+    // and device are the identity a rename or relink cannot preserve.
+    if (before && (before.ino !== opened.ino || before.dev !== opened.dev)) {
+      throw new LinkGuardError("symlink", path);
+    }
+    return handle;
+  } catch (err) {
+    await handle.close().catch(() => {
+      /* the throw below is what the caller needs to see */
+    });
+    throw err;
+  }
+}
+
+/** Read a whole file through openNoFollow's guarantees, closing the descriptor either way. */
+export async function readFileNoFollow(path: string): Promise<Buffer> {
+  const handle = await openNoFollow(path);
+  try {
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Read at most `length` bytes from the start of a file through openNoFollow's guarantees.
+ *
+ * Used to sniff a file's head without reading a multi-gigabyte evidence file into memory. Returns
+ * the bytes actually read, which may be shorter than requested.
+ */
+export async function readHeadNoFollow(path: string, length: number): Promise<Buffer> {
+  const handle = await openNoFollow(path);
+  try {
+    const buffer = Buffer.alloc(Math.max(0, length));
+    if (!buffer.length) return buffer;
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}

--- a/companion/tests/analysis/caseExportArchive.test.ts
+++ b/companion/tests/analysis/caseExportArchive.test.ts
@@ -14,6 +14,10 @@ import {
 import { createZip, readZip } from "../../src/analysis/zipArchive.js";
 import { encryptBuffer, decryptBuffer, DecryptionError } from "../../src/analysis/caseEncryption.js";
 import { atomicWrite } from "../../src/storage/atomicWrite.js";
+import { createHash } from "node:crypto";
+import { StateStore, INVESTIGATION_DB_FILENAME } from "../../src/analysis/stateStore.js";
+import { StateLock } from "../../src/analysis/stateLock.js";
+import { caseSqliteWorker } from "../../src/analysis/caseSqliteWorker.js";
 
 const PASSWORD = "correct horse battery staple";
 
@@ -75,6 +79,112 @@ describe("exportEncryptedCase", () => {
   it("rejects an invalid case id instead of reading outside the cases root", async () => {
     const store = await harness();
     await expect(exportEncryptedCase(store, "../../etc", PASSWORD)).rejects.toThrow(/invalid case id/);
+  });
+});
+
+// The archive must be ONE generation of the case. It used to be a walk of a live directory: the
+// database was copied as ordinary bytes (so a concurrent transaction could make the copy unusable)
+// and the manifest's entity counts were queried from the LIVE database after those bytes had
+// already been captured — describing a case that had since moved on.
+describe("exportEncryptedCase — single-generation snapshot (#3)", () => {
+  function entriesOf(archive: Buffer): Map<string, Buffer> {
+    return new Map(readZip(decryptBuffer(archive, PASSWORD)).map((e) => [e.path, e.data]));
+  }
+
+  async function seedDatabase(store: CaseStore, caseId: string): Promise<void> {
+    await store.createCase({ caseId, name: "n", investigator: "i", aiProvider: null });
+    const stateStore = new StateStore(store);
+    const state = await stateStore.load(caseId);
+    const event = (id: string) => ({
+      id,
+      timestamp: "2026-01-01T00:00:00Z",
+      description: `event ${id}`,
+      severity: "High",
+      mitreTechniques: [],
+      relatedFindingIds: [],
+      sourceScreenshots: [],
+    });
+    state.findings = [{ id: "f1" }, { id: "f2" }] as typeof state.findings;
+    state.iocs = [{ id: "i1" }] as typeof state.iocs;
+    state.forensicTimeline = [event("e1"), event("e2"), event("e3")] as typeof state.forensicTimeline;
+    await stateStore.save(state);
+  }
+
+  it("archives a consistent database snapshot that opens on its own", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-1");
+
+    const files = entriesOf(await exportEncryptedCase(store, "SNAP-1", PASSWORD));
+    const archived = files.get(`state/${INVESTIGATION_DB_FILENAME}`);
+    expect(archived).toBeDefined();
+
+    // A snapshot is a standalone database: written out on its own it must open and read back the
+    // same entities. Copied live bytes are what could fail this.
+    const loose = join(await mkdtemp(join(tmpdir(), "dfir-snapcheck-")), INVESTIGATION_DB_FILENAME);
+    await writeFile(loose, archived as Buffer);
+    const counts = await caseSqliteWorker.request<Record<string, number> | null>({
+      op: "entityCounts",
+      dbPath: loose,
+      kinds: ["forensicTimeline", "findings", "iocs"],
+    });
+    expect(counts).toMatchObject({ forensicTimeline: 3, findings: 2, iocs: 1 });
+  });
+
+  it("counts the manifest from the database it archived, not the live one", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-2");
+
+    const files = entriesOf(await exportEncryptedCase(store, "SNAP-2", PASSWORD));
+    const manifest = JSON.parse((files.get("archive-manifest.json") as Buffer).toString("utf8"));
+
+    expect(manifest.counts).toMatchObject({ forensicEvents: 3, findings: 2, iocs: 1 });
+
+    // The manifest's checksum for the database must be the checksum of the bytes in the archive —
+    // the property a recipient actually verifies.
+    const archived = files.get(`state/${INVESTIGATION_DB_FILENAME}`) as Buffer;
+    const listed = manifest.files.find(
+      (f: { path: string }) => f.path === `state/${INVESTIGATION_DB_FILENAME}`,
+    );
+    expect(listed.sha256).toBe(createHash("sha256").update(archived).digest("hex"));
+    expect(listed.bytes).toBe(archived.length);
+  });
+
+  it("runs inside the caller's per-case lock, so app state writes cannot interleave", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-3");
+    const order: string[] = [];
+    const lock = new StateLock();
+
+    const exported = exportEncryptedCase(store, "SNAP-3", PASSWORD, [], {
+      runExclusive: (caseId, fn) =>
+        lock.runExclusive(caseId, async () => {
+          order.push("export:start");
+          const out = await fn();
+          order.push("export:end");
+          return out;
+        }),
+    });
+    const write = lock.runExclusive("SNAP-3", async () => {
+      order.push("write");
+    });
+    await Promise.all([exported, write]);
+
+    // The write waited for the whole export rather than landing in the middle of it.
+    expect(order).toEqual(["export:start", "export:end", "write"]);
+  });
+
+  it("leaves no staging directory behind, on success or on failure", async () => {
+    const store = await harness();
+    await seedDatabase(store, "SNAP-4");
+    const stagingRoot = join(store.casesRoot, ".export-staging");
+
+    await exportEncryptedCase(store, "SNAP-4", PASSWORD);
+    expect(existsSync(stagingRoot) ? await readdir(stagingRoot) : []).toEqual([]);
+
+    // A symlink planted in the case makes the export throw mid-build; the snapshot must still go.
+    await symlink("/etc/hostname", join(store.screenshotsDir("SNAP-4"), "loot"));
+    await expect(exportEncryptedCase(store, "SNAP-4", PASSWORD)).rejects.toThrow(/symlink/);
+    expect(existsSync(stagingRoot) ? await readdir(stagingRoot) : []).toEqual([]);
   });
 });
 

--- a/companion/tests/http/oidcClient.test.ts
+++ b/companion/tests/http/oidcClient.test.ts
@@ -121,3 +121,68 @@ describe("OIDC authorization-code client", () => {
     ).rejects.toThrow(/state/i);
   });
 });
+
+// /auth/oidc/start is public and stores a state, nonce, verifier, return path and expiry per call,
+// each living ten minutes. Expiry was swept only when ANOTHER flow started, so a caller issuing
+// starts faster than they expire grew the map without limit — no credentials needed.
+describe("OIDC flow storage is bounded", () => {
+  const discoveryOnly: typeof fetch = async (input) => {
+    if (String(input).endsWith("/.well-known/openid-configuration")) {
+      return Response.json({
+        issuer: ISSUER,
+        authorization_endpoint: `${ISSUER}/authorize`,
+        token_endpoint: `${ISSUER}/token`,
+        jwks_uri: `${ISSUER}/jwks`,
+        code_challenge_methods_supported: ["S256"],
+      });
+    }
+    throw new Error(`unexpected fetch: ${String(input)}`);
+  };
+
+  function makeClient(): OidcClient {
+    return new OidcClient(
+      { issuer: ISSUER, clientId: CLIENT_ID, redirectUri: REDIRECT_URI, scopes: ["openid"] },
+      discoveryOnly,
+    );
+  }
+
+  it("keeps outstanding flows under a hard ceiling however many are started", async () => {
+    const c = makeClient();
+    const flows = () => (c as unknown as { flows: Map<string, unknown> }).flows;
+
+    for (let i = 0; i < 1200; i++) await c.begin("/dashboard");
+
+    // Unbounded, this would be 1200 live entries with nothing to remove them for ten minutes.
+    expect(flows().size).toBeLessThanOrEqual(1000);
+  });
+
+  it("evicts the oldest flow, so the most recent logins still complete", async () => {
+    const c = makeClient();
+    const flows = () => (c as unknown as { flows: Map<string, unknown> }).flows;
+
+    const first = await c.begin("/dashboard");
+    for (let i = 0; i < 1100; i++) await c.begin("/dashboard");
+    const last = await c.begin("/dashboard");
+
+    // The oldest is gone (its owner restarts a login); the newest — the one a real user is
+    // mid-way through — is still there.
+    expect(flows().has(first.state)).toBe(false);
+    expect(flows().has(last.state)).toBe(true);
+  });
+
+  // The pre-existing behaviour that must survive the cap: an expired flow is still dropped, and
+  // a live one is still usable.
+  it("still drops expired flows and keeps live ones", async () => {
+    const c = makeClient();
+    const flows = () => (c as unknown as { flows: Map<string, { expiresAt: number }> }).flows;
+
+    const stale = await c.begin("/dashboard");
+    const entry = flows().get(stale.state);
+    if (entry) entry.expiresAt = Date.now() - 1;
+
+    const fresh = await c.begin("/dashboard");
+
+    expect(flows().has(stale.state)).toBe(false);
+    expect(flows().has(fresh.state)).toBe(true);
+  });
+});

--- a/companion/tests/http/oidcStartRateLimit.test.ts
+++ b/companion/tests/http/oidcStartRateLimit.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStore } from "../../src/auth/authStore.js";
+import { TeamAuth } from "../../src/auth/teamAuth.js";
+import { OidcClient } from "../../src/auth/oidcClient.js";
+import { createApp } from "../../src/server.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { resetLimiters } from "../../src/http/rateLimiter.js";
+
+/**
+ * GET /auth/oidc/start, resource bounds.
+ *
+ * This is the one PUBLIC route that allocates server state: every call stored a state, nonce,
+ * verifier, return path and expiry in an unbounded in-memory map, each entry living ten minutes,
+ * and expiry was swept only when another flow started. A caller reachable beyond localhost could
+ * therefore consume memory as fast as it could issue requests, without ever authenticating.
+ */
+const ISSUER = "https://identity.example.test";
+const BOOTSTRAP_TOKEN = "test-bootstrap-token-with-enough-entropy";
+
+let app: ReturnType<typeof createApp>;
+let started = 0;
+
+const discoveryFetch = (async (input: RequestInfo | URL) => {
+  if (String(input).endsWith("/.well-known/openid-configuration")) {
+    started += 1;
+    return Response.json({
+      issuer: ISSUER,
+      authorization_endpoint: `${ISSUER}/authorize`,
+      token_endpoint: `${ISSUER}/token`,
+      jwks_uri: `${ISSUER}/jwks`,
+      code_challenge_methods_supported: ["S256"],
+    });
+  }
+  throw new Error(`unexpected fetch: ${String(input)}`);
+}) as typeof fetch;
+
+beforeEach(async () => {
+  resetLimiters();
+  started = 0;
+  const root = await mkdtemp(join(tmpdir(), "dfir-oidc-limit-"));
+  const cases = new CaseStore(join(root, "cases"));
+  const auth = new TeamAuth({
+    store: new AuthStore(join(root, "auth.sqlite")),
+    bootstrapToken: BOOTSTRAP_TOKEN,
+    cookieSecure: false,
+    sessionTtlMs: 60 * 60_000,
+    oidcClient: new OidcClient(
+      {
+        issuer: ISSUER,
+        clientId: "dfir-companion",
+        redirectUri: "https://dfir.example.test/auth/oidc/callback",
+        scopes: ["openid"],
+      },
+      discoveryFetch,
+    ),
+  });
+  app = createApp(cases, { teamAuth: auth });
+});
+
+afterEach(() => {
+  resetLimiters();
+});
+
+describe("GET /auth/oidc/start is rate-limited", () => {
+  it("stops an unauthenticated caller from allocating flows without limit", async () => {
+    let sawLimit = false;
+    let redirects = 0;
+
+    // Unlimited, every one of these stored a ten-minute flow and none ever answered 429.
+    for (let i = 0; i < 40 && !sawLimit; i++) {
+      const res = await request(app).get("/auth/oidc/start");
+      if (res.status === 429) sawLimit = true;
+      else if (res.status === 302) redirects += 1;
+    }
+
+    expect(sawLimit).toBe(true);
+    // The budget is generous enough that ordinary use is unaffected — a human clicking "Sign in
+    // with SSO", including retries, is nowhere near this.
+    expect(redirects).toBeGreaterThanOrEqual(20);
+  });
+
+  it("answers a throttled request with Retry-After and allocates nothing for it", async () => {
+    let res = await request(app).get("/auth/oidc/start");
+    while (res.status !== 429) res = await request(app).get("/auth/oidc/start");
+
+    expect(res.headers["retry-after"]).toBe("60");
+    const afterThrottle = started;
+
+    // A throttled request must cost nothing: gated BEFORE begin(), so no discovery fetch and no
+    // flow stored. Otherwise the limiter would bound the response but not the work.
+    await request(app).get("/auth/oidc/start");
+    expect(started).toBe(afterThrottle);
+  });
+
+  it("still serves the first sign-in normally", async () => {
+    const res = await request(app).get("/auth/oidc/start");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain(`${ISSUER}/authorize`);
+    expect(res.headers["set-cookie"]).toBeDefined();
+  });
+});

--- a/companion/tests/integrations/childOutput.test.ts
+++ b/companion/tests/integrations/childOutput.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { ChildOutputCollector, DEFAULT_STDERR_TAIL_BYTES } from "../../src/integrations/childOutput.js";
+
+// Two defects this collector exists to prevent, both of which shipped in BOTH child-process runners:
+// an unbounded stderr that a hostile or malfunctioning forensic tool could use to exhaust the heap,
+// and a "maxOutputBytes" cap that actually counted UTF-16 string length.
+
+describe("ChildOutputCollector — stdout budget", () => {
+  it("does not signal while the budget is intact", () => {
+    const out = new ChildOutputCollector(10);
+    expect(out.pushStdout(Buffer.from("12345"))).toBe(false);
+    expect(out.pushStdout(Buffer.from("67890"))).toBe(false);
+    expect(out.stdoutByteLength).toBe(10);
+  });
+
+  it("signals as soon as the budget is exceeded", () => {
+    const out = new ChildOutputCollector(4);
+    expect(out.pushStdout(Buffer.from("abcd"))).toBe(false);
+    expect(out.pushStdout(Buffer.from("e"))).toBe(true);
+  });
+
+  // The bug: "€" is 1 JavaScript string unit but 3 UTF-8 bytes, so a string-length cap let output
+  // run to three times the limit the operator configured.
+  it("counts BYTES, not string length, for multibyte output", () => {
+    const out = new ChildOutputCollector(6);
+    const euro = Buffer.from("€€€", "utf8"); // 9 bytes, 3 string units
+
+    expect(euro.byteLength).toBe(9);
+    expect(euro.toString("utf8").length).toBe(3);
+    expect(out.pushStdout(euro)).toBe(true); // a length-based cap would have said false
+    expect(out.stdoutByteLength).toBe(9);
+  });
+
+  // The other half: decoding each chunk as it arrived turned a character split across a chunk
+  // boundary into replacement characters, silently corrupting what an importer then parsed.
+  it("decodes once, so a character split across chunks survives", () => {
+    const out = new ChildOutputCollector(1024);
+    const euro = Buffer.from("€", "utf8");
+
+    out.pushStdout(euro.subarray(0, 1));
+    out.pushStdout(euro.subarray(1));
+
+    expect(out.text().stdout).toBe("€");
+    expect(out.text().stdout).not.toContain("�");
+  });
+});
+
+describe("ChildOutputCollector — stderr tail", () => {
+  it("keeps stderr whole while it fits the tail budget", () => {
+    const out = new ChildOutputCollector(1024, 32);
+    out.pushStderr(Buffer.from("warning: one\n"));
+    out.pushStderr(Buffer.from("warning: two\n"));
+    expect(out.text().stderr).toBe("warning: one\nwarning: two\n");
+  });
+
+  // A tool that logs forever must not grow the heap. It also must not cost us the END of the log,
+  // which is the part that explains the failure.
+  it("bounds a flood and retains the tail, not the head", () => {
+    const out = new ChildOutputCollector(1024, 64);
+    for (let i = 0; i < 1000; i++) out.pushStderr(Buffer.from(`line ${i}\n`));
+
+    expect(out.stderrByteLength).toBeLessThanOrEqual(64);
+    expect(out.text().stderr).toContain("line 999");
+    expect(out.text().stderr).not.toContain("line 0\n");
+  });
+
+  it("cuts a single write larger than the whole tail budget", () => {
+    const out = new ChildOutputCollector(1024, 16);
+    out.pushStderr(Buffer.from("x".repeat(1000) + "END"));
+
+    expect(out.stderrByteLength).toBe(16);
+    expect(out.text().stderr.endsWith("END")).toBe(true);
+  });
+
+  // stderr is diagnostics: a verbose tool is normal, so the tail must never be the reason a run dies.
+  it("never signals fatal, however much arrives", () => {
+    const out = new ChildOutputCollector(4, 8);
+    for (let i = 0; i < 100; i++) out.pushStderr(Buffer.from("noise noise noise\n"));
+
+    expect(out.pushStdout(Buffer.from("ab"))).toBe(false);
+    expect(out.stdoutByteLength).toBe(2);
+  });
+
+  it("defaults the tail to a bounded size rather than unlimited", () => {
+    const out = new ChildOutputCollector(1024);
+    for (let i = 0; i < 200; i++) out.pushStderr(Buffer.alloc(4096, 0x61));
+
+    expect(DEFAULT_STDERR_TAIL_BYTES).toBeGreaterThan(0);
+    expect(out.stderrByteLength).toBeLessThanOrEqual(DEFAULT_STDERR_TAIL_BYTES);
+  });
+});
+
+describe("ChildOutputCollector — combined", () => {
+  it("keeps the two streams separate", () => {
+    const out = new ChildOutputCollector(1024, 1024);
+    out.pushStdout(Buffer.from("result"));
+    out.pushStderr(Buffer.from("diagnostic"));
+
+    expect(out.text()).toEqual({ stdout: "result", stderr: "diagnostic" });
+  });
+
+  it("reports empty strings when the child wrote nothing", () => {
+    expect(new ChildOutputCollector(16).text()).toEqual({ stdout: "", stderr: "" });
+  });
+});

--- a/companion/tests/reports/reportGeneration.test.ts
+++ b/companion/tests/reports/reportGeneration.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ReportWriter } from "../../src/reports/reportWriter.js";
+import { ReportGeneration } from "../../src/reports/reportGeneration.js";
+import { isAtomicWriteTempPath } from "../../src/storage/atomicWrite.js";
+import { emptyState } from "../../src/analysis/stateTypes.js";
+
+// A report is eight files written over the previous report's eight. Any interruption between them
+// left NEW artifacts beside OLD ones — each individually readable, which is what makes it dangerous:
+// a report directory presenting a findings CSV from one generation and a narrative from another,
+// with provenance for a run that never finished.
+
+let caseStore: CaseStore;
+let stateStore: StateStore;
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-reportgen-"));
+  caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  stateStore = new StateStore(caseStore);
+  const state = emptyState("c1");
+  state.lastSummary = "first generation";
+  await stateStore.save(state);
+});
+
+describe("ReportGeneration", () => {
+  it("makes nothing visible until publish", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const target = join(dir, "report.md");
+    const generation = new ReportGeneration();
+
+    await generation.stage(target, "staged content");
+    expect((await readdir(dir)).includes("report.md")).toBe(false);
+
+    await generation.publish();
+    expect(await readFile(target, "utf8")).toBe("staged content");
+  });
+
+  it("stages under names the rest of the system reads as a write in progress", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const generation = new ReportGeneration();
+    await generation.stage(join(dir, "report.md"), "x");
+
+    // Every staged file must match atomicWrite's temp shape, which caseTransientPaths.ts skips —
+    // otherwise a concurrent export would seal a half-built report into an archive.
+    const staged = await readdir(dir);
+    expect(staged.length).toBeGreaterThan(0);
+    expect(staged.every((name) => isAtomicWriteTempPath(name))).toBe(true);
+
+    await generation.discard();
+  });
+
+  it("leaves no debris behind when discarded", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const generation = new ReportGeneration();
+    await generation.stage(join(dir, "report.md"), "a");
+    await generation.stage(join(dir, "findings.csv"), "b");
+
+    await generation.discard();
+    expect(await readdir(dir)).toEqual([]);
+  });
+
+  it("treats discard after publish as a no-op, so the published files survive", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const generation = new ReportGeneration();
+    await generation.stage(join(dir, "report.md"), "published");
+
+    await generation.publish();
+    await generation.discard();
+
+    expect(await readFile(join(dir, "report.md"), "utf8")).toBe("published");
+  });
+});
+
+describe("ReportWriter — generation is all-or-nothing", () => {
+  // The exact interruption the fix exists for: the artifacts render fine, then the provenance
+  // record fails. That used to leave a NEW report.md, HTML and CSVs beside the OLD
+  // analysis-runs.json — a directory whose narrative and provenance disagreed, with nothing to
+  // indicate it.
+  it("keeps the previous report intact when provenance fails mid-generation", async () => {
+    const paths = await new ReportWriter(caseStore, stateStore).writeAll("c1");
+    const before = {
+      markdown: await readFile(paths.markdown, "utf8"),
+      findings: await readFile(paths.findingsCsv, "utf8"),
+      runs: await readFile(paths.analysisRuns, "utf8"),
+    };
+    expect(before.markdown).toContain("first generation");
+
+    const state = await stateStore.load("c1");
+    state.lastSummary = "second generation";
+    await stateStore.save(state);
+
+    const failing = new ReportWriter(caseStore, stateStore, {
+      analysisRuns: {
+        list: async () => [],
+        record: async () => {
+          throw new Error("disk full");
+        },
+      } as unknown as NonNullable<ConstructorParameters<typeof ReportWriter>[2]>["analysisRuns"],
+    });
+
+    await expect(failing.writeAll("c1")).rejects.toThrow(/disk full/);
+
+    // Not one artifact of the failed generation reached the directory, and no staging survived.
+    expect(await readFile(paths.markdown, "utf8")).toBe(before.markdown);
+    expect(await readFile(paths.markdown, "utf8")).not.toContain("second generation");
+    expect(await readFile(paths.findingsCsv, "utf8")).toBe(before.findings);
+    expect(await readFile(paths.analysisRuns, "utf8")).toBe(before.runs);
+    expect((await readdir(caseStore.reportsDir("c1"))).some(isAtomicWriteTempPath)).toBe(false);
+  });
+
+  it("replaces every artifact together on a successful regeneration", async () => {
+    const writer = new ReportWriter(caseStore, stateStore);
+    await writer.writeAll("c1");
+
+    const state = await stateStore.load("c1");
+    state.lastSummary = "second generation";
+    await stateStore.save(state);
+    const paths = await writer.writeAll("c1");
+
+    expect(await readFile(paths.markdown, "utf8")).toContain("second generation");
+    expect(await readFile(paths.markdown, "utf8")).not.toContain("first generation");
+    // No staging left over on the happy path either.
+    expect((await readdir(caseStore.reportsDir("c1"))).some(isAtomicWriteTempPath)).toBe(false);
+  });
+
+  it("does not disturb unrelated files that legitimately live in reports/", async () => {
+    const dir = caseStore.reportsDir("c1");
+    const sidecar = join(dir, "chain-of-custody.json");
+    await writeFile(sidecar, '{"kept":true}', "utf8");
+
+    await new ReportWriter(caseStore, stateStore).writeAll("c1");
+
+    expect(await readFile(sidecar, "utf8")).toBe('{"kept":true}');
+  });
+});

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -88,6 +88,24 @@ describe("HTTP server", () => {
     expect(res.status).toBe(409);
   });
 
+  // The duplicate check above is a check-then-create pair, which two SIMULTANEOUS requests both
+  // pass. Exactly one must still end up creating the case: the 201 is also what gates
+  // teamAuth.grantCreator, so two 201s would mean two administrators on one case.
+  it("POST /cases lets only one of two simultaneous requests create the same caseId", async () => {
+    const send = (name: string) =>
+      request(app).post("/cases").send({ caseId: "race", name, investigator: "y", aiProvider: null });
+
+    const [a, b] = await Promise.all([send("first"), send("second")]);
+    // Never a 500: losing a claim is a legitimate answer, not a server fault.
+    expect([a.status, b.status].sort()).toEqual([201, 409]);
+
+    const winner = a.status === 201 ? a : b;
+    const listed = await request(app).get("/cases");
+    const created = listed.body.filter((c: { caseId: string }) => c.caseId === "race");
+    expect(created).toHaveLength(1);
+    expect(created[0].name).toBe(winner.body.name);
+  });
+
   it("POST /cases rejects path-like case IDs before touching storage paths", async () => {
     const res = await request(app).post("/cases").send({ caseId: "..\\outside", name: "A", investigator: "y", aiProvider: null });
     expect(res.status).toBe(400);

--- a/companion/tests/server/dropFolderSymlink.test.ts
+++ b/companion/tests/server/dropFolderSymlink.test.ts
@@ -26,11 +26,12 @@ import { createApp } from "../../src/server.js";
 // accidentally safe even before this fix too — Dirent.isFile() already returns false for a symlink
 // dirent, so it was filtered before ever reaching stat() — but the REAL pre-fix symlink bug was a
 // narrower TOCTOU race (a file that reads as a normal file when first listed, then gets swapped to
-// a symlink before the read/move that follows once it's marked "ready"). That race isn't exercised
-// here — it would need to land squarely inside the drop poller's sub-second settle window — so the
-// symlink test below documents the now-deliberate (not incidental) guarantee at the listing stage,
-// while the processDropFile/moveDropFile lstat re-checks that close the TOCTOU window itself remain
-// unverified by an automated test.
+// a symlink before the read/move that follows once it's marked "ready"). That race is not exercised
+// HERE — it would need to land squarely inside the drop poller's sub-second settle window — so the
+// symlink test below documents the now-deliberate (not incidental) guarantee at the listing stage.
+// The race itself no longer depends on timing at all: processDropFile and moveDropFile no longer
+// re-check a path and then read it, they read through the descriptor they verified
+// (storage/noFollowRead.ts), and tests/storage/noFollowRead.test.ts exercises the swap directly.
 
 function findingPipeline(stateStore: StateStore): AnalysisPipeline {
   return new AnalysisPipeline({

--- a/companion/tests/storage/caseStore.test.ts
+++ b/companion/tests/storage/caseStore.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, readFile, stat, mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, mkdir, rename, writeFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CaseStore } from "../../src/storage/caseStore.js";
-import type { CaptureMetadata } from "../../src/types.js";
+import { CaseStore, CaseAlreadyExistsError } from "../../src/storage/caseStore.js";
+import type { CaptureMetadata, CaseMeta } from "../../src/types.js";
 
 let root: string;
 beforeEach(async () => {
@@ -39,6 +40,73 @@ describe("CaseStore.createCase", () => {
     const store = new CaseStore(root);
     expect(store.screenshotsDir("case-001")).toBe(join(root, "case-001", "screenshots"));
     expect(store.capturesLogPath("case-001")).toBe(join(root, "case-001", "metadata", "captures.jsonl"));
+  });
+
+  // Creation is the point a case id gets an OWNER. Two callers racing for the same id both used to
+  // succeed — the second metadata write simply became the final case.json — and under team auth
+  // both of them were then granted administrator on it.
+  it("lets only one of two concurrent creations claim the same id", async () => {
+    const store = new CaseStore(root);
+    const claim = (name: string) =>
+      store.createCase({ caseId: "race-1", name, investigator: name, aiProvider: null });
+
+    const results = await Promise.allSettled([claim("first"), claim("second")]);
+    const won = results.filter((r) => r.status === "fulfilled");
+    const lost = results.filter((r) => r.status === "rejected");
+
+    expect(won).toHaveLength(1);
+    expect(lost).toHaveLength(1);
+    expect(lost[0].reason).toBeInstanceOf(CaseAlreadyExistsError);
+
+    // The case.json on disk must be the WINNER's, not whichever write happened to land last.
+    const written = JSON.parse(await readFile(join(root, "race-1", "case.json"), "utf8"));
+    const winner: CaseMeta = won[0].value;
+    expect(written.name).toBe(winner.name);
+    expect(written.investigator).toBe(winner.investigator);
+  });
+
+  it("refuses to recreate an id that already exists, rather than overwriting its metadata", async () => {
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "taken", name: "original", investigator: "i", aiProvider: null });
+
+    await expect(
+      store.createCase({ caseId: "taken", name: "usurper", investigator: "j", aiProvider: null }),
+    ).rejects.toBeInstanceOf(CaseAlreadyExistsError);
+
+    const written = JSON.parse(await readFile(join(root, "taken", "case.json"), "utf8"));
+    expect(written.name).toBe("original");
+  });
+
+  // caseDir() is archive-aware, so an id colliding with an ARCHIVED case used to resolve to the
+  // archived folder and silently overwrite its case.json. The exclusive create refuses that too,
+  // instead of relying on every caller remembering to check first.
+  it("refuses an id that collides with an archived case", async () => {
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "arch-claim", name: "original", investigator: "i", aiProvider: null });
+    await store.archiveCaseFolder("arch-claim");
+
+    await expect(
+      store.createCase({ caseId: "arch-claim", name: "usurper", investigator: "j", aiProvider: null }),
+    ).rejects.toBeInstanceOf(CaseAlreadyExistsError);
+
+    const written = JSON.parse(
+      await readFile(join(root, "_archived", "arch-claim", "case.json"), "utf8"),
+    );
+    expect(written.name).toBe("original");
+  });
+
+  // A loser must not leave a half-built case behind: the subdirectories are created only after the
+  // claim succeeds, so the winner's layout is the only one on disk.
+  it("does not leave partial folders behind when a claim is lost", async () => {
+    const store = new CaseStore(root);
+    await store.createCase({ caseId: "solo", name: "n", investigator: "i", aiProvider: null });
+    await rm(join(root, "solo", "reports"), { recursive: true });
+
+    await expect(
+      store.createCase({ caseId: "solo", name: "n2", investigator: "i", aiProvider: null }),
+    ).rejects.toBeInstanceOf(CaseAlreadyExistsError);
+
+    expect(existsSync(join(root, "solo", "reports"))).toBe(false);
   });
 });
 

--- a/companion/tests/storage/noFollowRead.test.ts
+++ b/companion/tests/storage/noFollowRead.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, symlink, link, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  openNoFollow,
+  readFileNoFollow,
+  readHeadNoFollow,
+  LinkGuardError,
+} from "../../src/storage/noFollowRead.js";
+
+// The guarantee these tests exist for: a link check and the read it authorizes are ONE operation on
+// ONE descriptor. Every path-based guard in this codebase used to lstat a path and then read that
+// path again, and the gap between the two belonged to whoever controlled the directory.
+
+let dir: string;
+let secretPath: string;
+const SECRET = "host-only-secret\n";
+const CONTENT = "legitimate evidence\n";
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "dfir-nofollow-"));
+  secretPath = join(dir, "secret.txt");
+  await writeFile(secretPath, SECRET, "utf8");
+});
+
+describe("readFileNoFollow", () => {
+  it("reads an ordinary file unchanged", async () => {
+    const path = join(dir, "evidence.json");
+    await writeFile(path, CONTENT, "utf8");
+    expect((await readFileNoFollow(path)).toString("utf8")).toBe(CONTENT);
+  });
+
+  it("refuses a symlink instead of following it to the host file", async () => {
+    const path = join(dir, "planted");
+    await symlink(secretPath, path);
+
+    const err = await readFileNoFollow(path).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LinkGuardError);
+    expect((err as LinkGuardError).kind).toBe("symlink");
+  });
+
+  it("refuses a hardlink, which no symlink check and no readdir can see", async () => {
+    const path = join(dir, "aliased");
+    await link(secretPath, path);
+
+    const err = await readFileNoFollow(path).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LinkGuardError);
+    expect((err as LinkGuardError).kind).toBe("hardlink");
+  });
+
+  it("refuses a symlink pointing at a directory or a dangling target too", async () => {
+    await mkdir(join(dir, "elsewhere"));
+    await symlink(join(dir, "elsewhere"), join(dir, "to-dir"));
+    await symlink(join(dir, "does-not-exist"), join(dir, "dangling"));
+
+    await expect(readFileNoFollow(join(dir, "to-dir"))).rejects.toBeInstanceOf(LinkGuardError);
+    await expect(readFileNoFollow(join(dir, "dangling"))).rejects.toBeInstanceOf(LinkGuardError);
+  });
+
+  // THE RACE ITSELF. The path is swapped between a plain file and a symlink to the secret while
+  // reads run against it. A check-then-read implementation loses this: it lstats the plain file,
+  // the swap lands, and the read follows the link. Reading through the checked descriptor cannot —
+  // there is no interval in which the two disagree. Every read must either return the legitimate
+  // content or refuse; the secret must never come back.
+  it("never returns the swap target's content, however the swap is timed", async () => {
+    const path = join(dir, "raced");
+    let leaked = false;
+    let reads = 0;
+
+    for (let i = 0; i < 200; i++) {
+      await rm(path, { force: true });
+      if (i % 2 === 0) await writeFile(path, CONTENT, "utf8");
+      else await symlink(secretPath, path);
+
+      // Started before the swap below, resolved after it — the window a path-based guard exposes.
+      const reading = readFileNoFollow(path).then(
+        (buf) => buf.toString("utf8"),
+        (err: unknown) => {
+          if (!(err instanceof LinkGuardError) && (err as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw err;
+          }
+          return null;
+        },
+      );
+      await rm(path, { force: true }).catch(() => {});
+      await symlink(secretPath, path).catch(() => {});
+
+      const got = await reading;
+      if (got !== null) {
+        reads++;
+        if (got.includes("host-only-secret")) leaked = true;
+      }
+    }
+
+    expect(leaked).toBe(false);
+    // Guard against a vacuous pass: some reads must actually have succeeded.
+    expect(reads).toBeGreaterThan(0);
+  });
+});
+
+describe("readHeadNoFollow", () => {
+  it("reads only the requested prefix", async () => {
+    const path = join(dir, "big.bin");
+    await writeFile(path, "0123456789", "utf8");
+    expect((await readHeadNoFollow(path, 4)).toString("utf8")).toBe("0123");
+  });
+
+  it("returns what exists when the file is shorter than the request", async () => {
+    const path = join(dir, "short.bin");
+    await writeFile(path, "ab", "utf8");
+    expect((await readHeadNoFollow(path, 8)).toString("utf8")).toBe("ab");
+  });
+
+  it("returns an empty buffer for a zero-length request without opening a hole", async () => {
+    const path = join(dir, "empty-req");
+    await writeFile(path, "abc", "utf8");
+    expect((await readHeadNoFollow(path, 0)).length).toBe(0);
+  });
+
+  it("applies the same link guard as a whole-file read", async () => {
+    const path = join(dir, "planted-head");
+    await symlink(secretPath, path);
+    await expect(readHeadNoFollow(path, 8)).rejects.toBeInstanceOf(LinkGuardError);
+  });
+});
+
+describe("openNoFollow", () => {
+  it("hands back a descriptor the caller closes", async () => {
+    const path = join(dir, "handle.txt");
+    await writeFile(path, CONTENT, "utf8");
+
+    const handle = await openNoFollow(path);
+    try {
+      expect((await handle.readFile()).toString("utf8")).toBe(CONTENT);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  // A rejected open must not leak the descriptor it had already obtained.
+  it("closes the descriptor when the fstat check rejects it", async () => {
+    const path = join(dir, "aliased-2");
+    await link(secretPath, path);
+    await expect(openNoFollow(path)).rejects.toBeInstanceOf(LinkGuardError);
+  });
+});

--- a/extension/src/captureQueue.ts
+++ b/extension/src/captureQueue.ts
@@ -44,13 +44,52 @@ export class CaptureQueue {
     });
   }
 
-  private tx<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
-    return this.open().then((db) => new Promise<T>((resolve, reject) => {
-      const store = db.transaction(STORE, mode).objectStore(STORE);
-      const req = fn(store);
-      req.onsuccess = () => resolve(req.result);
+  /** Run `fn` against an open connection and close it afterwards, however it ends. */
+  private async withDb<T>(fn: (db: IDBDatabase) => Promise<T>): Promise<T> {
+    const db = await this.open();
+    try {
+      return await fn(db);
+    } finally {
+      // Left open, every operation leaked a connection — and a still-open connection blocks a
+      // future version upgrade, which would strand the queue rather than migrate it.
+      db.close();
+    }
+  }
+
+  /**
+   * One transaction, resolved when the TRANSACTION completes — not when the individual request
+   * succeeds.
+   *
+   * That distinction is the whole point. A request's onsuccess fires while its transaction is still
+   * open, so `await enqueue(...)` used to return before anything was durable. In a Manifest V3
+   * service worker, which can be suspended the moment it goes idle, "the caller believes the capture
+   * is saved" and "the capture is saved" were two different things, and the gap was where evidence
+   * went missing. Resolving from oncomplete, and rejecting from onabort/onerror, makes the promise
+   * mean what its callers already assumed.
+   */
+  private txOn<T>(
+    db: IDBDatabase,
+    mode: IDBTransactionMode,
+    fn: (store: IDBObjectStore) => IDBRequest<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(STORE, mode);
+      let result: T;
+      const req = fn(tx.objectStore(STORE));
+      req.onsuccess = () => {
+        result = req.result;
+      };
+      // A request error left unhandled aborts the transaction, so onabort is the backstop rather
+      // than the exception: either way the promise rejects and nothing is reported durable.
       req.onerror = () => reject(req.error);
-    }));
+      tx.oncomplete = () => resolve(result);
+      tx.onabort = () => reject(tx.error ?? new Error("capture queue transaction aborted"));
+      tx.onerror = () => reject(tx.error ?? new Error("capture queue transaction failed"));
+    });
+  }
+
+  private tx<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+    return this.withDb((db) => this.txOn<T>(db, mode, fn));
   }
 
   async enqueue(payload: CapturePayload): Promise<void> {
@@ -73,37 +112,48 @@ export class CaptureQueue {
     if (this.draining) return summary;
     this.draining = true;
     try {
-      const db = await this.open();
-      const entries: { key: number; payload: CapturePayload }[] = await new Promise((resolve, reject) => {
-        const out: { key: number; payload: CapturePayload }[] = [];
-        const cursorReq = db.transaction(STORE, "readonly").objectStore(STORE).openCursor();
-        cursorReq.onsuccess = () => {
-          const cursor = cursorReq.result;
-          if (cursor) {
-            out.push({ key: cursor.key as number, payload: (cursor.value as { payload: CapturePayload }).payload });
-            cursor.continue();
-          } else resolve(out);
-        };
-        cursorReq.onerror = () => reject(cursorReq.error);
-      });
+      // ONE connection for the whole drain. Enumeration opened one and every deletion opened
+      // another, so draining fifty captures meant fifty-one connections — pure churn, and fifty-one
+      // chances to leave one open.
+      return await this.withDb(async (db) => {
+        const entries: { key: number; payload: CapturePayload }[] = await new Promise((resolve, reject) => {
+          const out: { key: number; payload: CapturePayload }[] = [];
+          const tx = db.transaction(STORE, "readonly");
+          const cursorReq = tx.objectStore(STORE).openCursor();
+          cursorReq.onsuccess = () => {
+            const cursor = cursorReq.result;
+            if (cursor) {
+              out.push({ key: cursor.key as number, payload: (cursor.value as { payload: CapturePayload }).payload });
+              cursor.continue();
+            }
+          };
+          cursorReq.onerror = () => reject(cursorReq.error);
+          // Resolved from the transaction, like every other operation here — the cursor is finished
+          // only once the transaction that owns it is.
+          tx.oncomplete = () => resolve(out);
+          tx.onabort = () => reject(tx.error ?? new Error("capture queue drain aborted"));
+        });
 
-      for (const entry of entries) {
-        const result = await sender(entry.payload);
-        if (result.outcome === "retry") return summary; // keep this and all later entries
-        if (result.outcome === "drop") {
-          summary.dropped.push({
-            payload: entry.payload,
-            status: result.status ?? 0,
-            ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
-          });
-        } else {
-          summary.sent += 1;
+        for (const entry of entries) {
+          const result = await sender(entry.payload);
+          if (result.outcome === "retry") return summary; // keep this and all later entries
+          if (result.outcome === "drop") {
+            summary.dropped.push({
+              payload: entry.payload,
+              status: result.status ?? 0,
+              ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+            });
+          } else {
+            summary.sent += 1;
+          }
+          // Both "sent" and "drop" remove the entry — a permanently-rejected capture must not stay
+          // at the head of the queue blocking the ones behind it. Awaiting the transaction (not the
+          // request) means a capture is never counted as handled while its removal is still open:
+          // a suspend in that window would have resurrected an already-delivered capture.
+          await this.txOn(db, "readwrite", (s) => s.delete(entry.key));
         }
-        // Both "sent" and "drop" remove the entry — a permanently-rejected capture must not stay
-        // at the head of the queue blocking the ones behind it.
-        await this.tx("readwrite", (s) => s.delete(entry.key));
-      }
-      return summary;
+        return summary;
+      });
     } finally {
       this.draining = false;
     }

--- a/extension/tests/captureQueue.test.ts
+++ b/extension/tests/captureQueue.test.ts
@@ -66,3 +66,116 @@ describe("CaptureQueue", () => {
     expect(await queue.size()).toBe(0);
   });
 });
+
+// A queue promise has to mean "durable", not "the request succeeded". Resolving from a request's
+// onsuccess returned while its transaction was still open, so in a Manifest V3 service worker — which
+// can be suspended the instant it goes idle — the caller believed a capture was saved before it was.
+describe("CaptureQueue durability", () => {
+  // THE CONTRACT, asserted directly on ordering. fake-indexeddb commits promptly, so no
+  // state-observing test can reproduce the service-worker suspend window that made this matter —
+  // but the ordering itself is exactly what changed, and it is observable: the promise must settle
+  // AFTER the transaction's "complete" event, never on the request's success that precedes it.
+  it("resolves an enqueue after the transaction commits, not when the request succeeds", async () => {
+    const q = new CaptureQueue(`dfir-${Math.random().toString(36).slice(2)}`);
+    // Create the store first: the version-change transaction of a first open would otherwise
+    // contribute a "complete" of its own to the measured window.
+    await q.enqueue(payload(1));
+
+    const order: string[] = [];
+    const original = IDBDatabase.prototype.transaction;
+    IDBDatabase.prototype.transaction = function patched(
+      this: IDBDatabase,
+      ...args: Parameters<IDBDatabase["transaction"]>
+    ): IDBTransaction {
+      const tx = original.apply(this, args);
+      // Registered before the queue assigns its own oncomplete, so this listener runs first.
+      tx.addEventListener("complete", () => order.push("commit"));
+      return tx;
+    } as IDBDatabase["transaction"];
+
+    try {
+      await q.enqueue(payload(2));
+      order.push("resolved");
+    } finally {
+      IDBDatabase.prototype.transaction = original;
+    }
+
+    expect(order).toEqual(["commit", "resolved"]);
+  });
+
+  // A fresh CaptureQueue opens its own connection, so it can only see what actually committed. If
+  // enqueue resolved early, the write would still be in an open transaction at this point.
+  it("has committed an enqueue by the time it resolves", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    await new CaptureQueue(name).enqueue(payload(1));
+
+    expect(await new CaptureQueue(name).size()).toBe(1);
+  });
+
+  it("has committed every enqueue of a burst by the time they resolve", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const writer = new CaptureQueue(name);
+    await Promise.all([1, 2, 3, 4, 5].map((n) => writer.enqueue(payload(n))));
+
+    expect(await new CaptureQueue(name).size()).toBe(5);
+  });
+
+  // The same guarantee on the other side: a sent capture's REMOVAL must be committed before the
+  // drain moves on, or a suspend in that window resurrects an already-delivered capture.
+  it("has committed each deletion before the drain reports it sent", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const writer = new CaptureQueue(name);
+    await writer.enqueue(payload(1));
+    await writer.enqueue(payload(2));
+
+    const observed: number[] = [];
+    const summary = await writer.drain(async () => {
+      // Read through an independent connection: it sees committed state only.
+      observed.push(await new CaptureQueue(name).size());
+      return { outcome: "sent" as const };
+    });
+
+    expect(summary.sent).toBe(2);
+    // Before the first send nothing is deleted yet; before the second, the first deletion has
+    // already committed. A drain resolving on request success could still show 2 here.
+    expect(observed).toEqual([2, 1]);
+    expect(await new CaptureQueue(name).size()).toBe(0);
+  });
+
+  it("keeps a retried capture, and its successors, committed in the queue", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const writer = new CaptureQueue(name);
+    await writer.enqueue(payload(1));
+    await writer.enqueue(payload(2));
+
+    const summary = await writer.drain(async () => ({ outcome: "retry" as const, status: 0 }));
+
+    expect(summary.sent).toBe(0);
+    expect(await new CaptureQueue(name).size()).toBe(2);
+  });
+
+  // Connections left open block a future version upgrade, which would strand the queue rather than
+  // migrate it. An upgrade completing is the observable proof that nothing is still holding one.
+  it("closes its connections, so a later version upgrade is not blocked", async () => {
+    const name = `dfir-${Math.random().toString(36).slice(2)}`;
+    const q = new CaptureQueue(name);
+    await q.enqueue(payload(1));
+    await q.size();
+    await q.drain(async () => ({ outcome: "sent" as const }));
+
+    const upgraded = await new Promise<boolean>((resolve, reject) => {
+      const req = indexedDB.open(name, 2);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore("probe");
+      };
+      req.onsuccess = () => {
+        req.result.close();
+        resolve(true);
+      };
+      req.onerror = () => reject(req.error);
+      req.onblocked = () => reject(new Error("upgrade blocked — a connection was left open"));
+    });
+
+    expect(upgraded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why this PR exists

PRs #538–#544 all report `MERGED`, but **none of their content reached `master`**. They were stacked, so each had its predecessor as its base — and merging them top-down collapsed the content sideways through the branch chain instead of down into `master`.

Every merge commit checks out as `in-master=NO`. `origin/master` is at `8e9dae65`, which is fix #1 (#537) and nothing else.

That's a setup mistake on my part: stacking made each PR reviewable in isolation, but it also meant seven merges landed somewhere other than the trunk. Nothing was lost — all commits were intact on `origin/fix/bounded-oidc-flows` — but the fixes were not actually shipped.

## What this is

The seven unshipped commits, cherry-picked cleanly onto current `master`, unchanged. Fix #1 is excluded since #537 already landed as a squash.

| # | Commit | Original PR |
|---|---|---|
| 2 | `fix(cases): claim a case id atomically instead of check-then-create` | #538 |
| 3 | `fix(export): build a case archive from one generation, not a live walk` | #539 |
| 4 | `fix(storage): read through the descriptor that was checked, not the path` | #540 |
| 5 | `fix(tools): bound both child streams by real bytes, not string length` | #541 |
| 6 | `fix(extension): resolve capture-queue writes when the transaction commits` | #542 |
| 7 | `fix(reports): publish a report generation as a unit, not file by file` | #543 |
| 8 | `fix(auth): bound and rate-limit OIDC flow creation` | #544 |

Each commit message and the per-fix rationale are unchanged — the original PR descriptions (#538–#544) remain the detailed review record for each one.

## Merging this

Merge **this PR into `master`**. It has no stacked base, so there's nothing to sequence. The seven old branches can then be deleted; their PRs are already closed.

## Test plan

- [x] All seven cherry-picks applied with no conflicts
- [x] Companion: 1321 tests across storage, export, integrations, reports, http and server suites — all pass
- [x] Extension: 218/218 pass, `tsc --noEmit` clean
- [x] typecheck, eslint, prettier all clean
- [x] Ratchets unchanged and passing: 13 ledgered files (none grew), 1 known import cycle (none new), 47 known boundary violations (none new), 49 known a11y violations (none new)