### PR TITLE
refactor(analysis): break the last import cycle and empty its ledger

### DIFF
--- a/companion/scripts/import-cycles.json
+++ b/companion/scripts/import-cycles.json
@@ -1,3 +1,1 @@
-[
-  "analysis/adversaryEmulation.ts -> analysis/adversaryHints.ts"
-]
+[]

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -133,6 +133,7 @@
     "adversaryEmulation.ts": "analysis/intel",
     "adversaryGroupsData.ts": "analysis/intel",
     "adversaryHints.ts": "analysis/intel",
+    "adversaryTechniques.ts": "analysis/intel",
     "aiControl.ts": "analysis/ai",
     "aiCost.ts": "analysis/ai",
     "analysisRunCompare.ts": "analysis/case",

--- a/companion/src/analysis/adversaryEmulation.ts
+++ b/companion/src/analysis/adversaryEmulation.ts
@@ -28,12 +28,14 @@
 
 import { tacticForTechniques } from "../integrations/iris/mitreTactics.js";
 import { attackTechniqueUrl } from "./attack.js";
+// The shared vocabulary, NOT adversaryHints.js — importing it back from there is what made these
+// two modules a cycle. See adversaryTechniques.ts.
 import {
   baseTechniqueId,
   normalizeTechniqueId,
   type AdversaryGroup,
   type AdversaryHint,
-} from "./adversaryHints.js";
+} from "./adversaryTechniques.js";
 
 // One matched group that supports a given next-technique suggestion.
 export interface NextTechniqueGroup {

--- a/companion/src/analysis/adversaryHints.ts
+++ b/companion/src/analysis/adversaryHints.ts
@@ -24,32 +24,17 @@
 
 import type { InvestigationState } from "./stateTypes.js";
 import { suggestNextTechniques, type NextTechnique, type TechniqueInfoMap } from "./adversaryEmulation.js";
+import {
+  baseTechniqueId,
+  normalizeTechniqueId,
+  type AdversaryGroup,
+  type AdversaryHint,
+} from "./adversaryTechniques.js";
 
-// One adversary group's slimmed record from the bundled dataset. `techniques` carries ATT&CK ids at
-// full granularity — sub-technique (T1059.001) where MITRE maps it, base (T1486) otherwise.
-export interface AdversaryGroup {
-  id: string; // ATT&CK group id, e.g. "G0016"
-  name: string; // e.g. "APT29"
-  aliases: string[]; // other names, e.g. ["Cozy Bear", "The Dukes"]
-  description: string; // short attribution/sector context
-  techniques: string[]; // technique ids (sub-technique where mapped), e.g. ["T1059.001", "T1486"]
-}
-
-// A ranked match: a group whose technique set overlaps the case's by at least `minOverlap` (counted
-// at base-or-better), ordered by a weighted score that rewards exact sub-technique agreement.
-export interface AdversaryHint {
-  id: string;
-  name: string;
-  aliases: string[];
-  description: string;
-  url: string; // attack.mitre.org group page
-  overlapCount: number; // distinct case techniques the group shares at base-or-better (breadth)
-  exactCount: number; // of those, EXACT (same sub-technique / id) matches — the strong signal
-  overlapTechniques: string[]; // all matched case technique ids (full granularity), sorted
-  exactTechniques: string[]; // the subset matched exactly (full-id equality), sorted
-  groupTechniqueCount: number; // distinct techniques attributed to the group (context for the ratio)
-  score: number; // weighted: exactCount + BASE_MATCH_WEIGHT × (overlapCount − exactCount)
-}
+// AdversaryGroup and AdversaryHint moved to adversaryTechniques.ts, which this module and
+// adversaryEmulation.ts now BOTH depend on — see that file for why. Re-exported here so every
+// existing importer keeps working: the shapes did not change, only where they are declared.
+export type { AdversaryGroup, AdversaryHint };
 
 export interface AdversaryHintOptions {
   minOverlap?: number; // minimum overlapping techniques (base-or-better) to surface a group (default 3)
@@ -84,22 +69,9 @@ export const BASE_MATCH_WEIGHT = 0.5;
 export const ADVERSARY_HINTS_CAVEAT =
   "Statistical similarity based on technique overlap — not attribution.";
 
-const TECHNIQUE_RE = /^T(\d{4})(?:\.(\d{3}))?$/; // technique or sub-technique id
-
-// Normalize a technique id to its full, validated form, KEEPING the sub-technique:
-// "t1059.001" → "T1059.001", "T1486" → "T1486". Null when it isn't a valid technique id.
-export function normalizeTechniqueId(raw: string): string | null {
-  const m = TECHNIQUE_RE.exec(raw.trim().toUpperCase());
-  if (!m) return null;
-  return m[2] ? `T${m[1]}.${m[2]}` : `T${m[1]}`;
-}
-
-// The BASE technique of an id ("T1059.001" → "T1059", "T1486" → "T1486"), or null when invalid.
-// Used to award partial credit when the case and a group share a technique but differ on the sub.
-export function baseTechniqueId(raw: string): string | null {
-  const m = TECHNIQUE_RE.exec(raw.trim().toUpperCase());
-  return m ? `T${m[1]}` : null;
-}
+// The id helpers moved to adversaryTechniques.ts alongside the shapes they validate, for the same
+// reason. Re-exported so existing importers are unaffected.
+export { normalizeTechniqueId, baseTechniqueId };
 
 // The ATT&CK group page for a group id (e.g. "G0016" → https://attack.mitre.org/groups/G0016/).
 export function adversaryGroupUrl(id: string): string {

--- a/companion/src/analysis/adversaryTechniques.ts
+++ b/companion/src/analysis/adversaryTechniques.ts
@@ -1,0 +1,63 @@
+// The vocabulary adversary hints and adversary emulation BOTH speak: what a group is, what a ranked
+// hint is, and how a technique id is normalized.
+//
+// It exists to break a cycle rather than to add a layer. adversaryHints.ts called
+// suggestNextTechniques() from adversaryEmulation.ts, and adversaryEmulation.ts imported the id
+// helpers and the two record shapes back from adversaryHints.ts — so each module needed the other
+// loaded first. Node tolerates that until an import is evaluated at module scope rather than call
+// time, at which point one side sees `undefined` and the failure looks like a data bug rather than
+// a load-order bug. The ratchet in scripts/check-imports.mjs recorded it as the one known cycle.
+//
+// The direction is now: hints -> emulation -> here, and hints -> here. Nothing imports back.
+//
+// What belongs here is only what BOTH sides need. suggestNextTechniques stays in emulation and
+// rankAdversaryHints stays in hints — moving either would make this a dumping ground instead of a
+// shared vocabulary, and the next cycle would form inside it.
+
+/** One adversary group's slimmed record from the bundled dataset. `techniques` carries ATT&CK ids at
+ *  full granularity — sub-technique (T1059.001) where MITRE maps it, base (T1486) otherwise. */
+export interface AdversaryGroup {
+  id: string; // ATT&CK group id, e.g. "G0016"
+  name: string; // e.g. "APT29"
+  aliases: string[]; // other names, e.g. ["Cozy Bear", "The Dukes"]
+  description: string; // short attribution/sector context
+  techniques: string[]; // technique ids (sub-technique where mapped), e.g. ["T1059.001", "T1486"]
+}
+
+/** A ranked match: a group whose technique set overlaps the case's by at least `minOverlap`
+ *  (counted at base-or-better), ordered by a weighted score that rewards exact sub-technique
+ *  agreement.
+ *
+ *  CRUCIAL FRAMING, repeated here because this is the shape that travels: this is statistical
+ *  technique-overlap similarity, NOT attribution. `groupTechniqueCount` rides along precisely so a
+ *  reader can weigh "4 of 12" (focused) against "4 of 150" (diffuse). */
+export interface AdversaryHint {
+  id: string;
+  name: string;
+  aliases: string[];
+  description: string;
+  url: string; // attack.mitre.org group page
+  overlapCount: number; // distinct case techniques the group shares at base-or-better (breadth)
+  exactCount: number; // of those, EXACT (same sub-technique / id) matches — the strong signal
+  overlapTechniques: string[]; // all matched case technique ids (full granularity), sorted
+  exactTechniques: string[]; // the subset matched exactly (full-id equality), sorted
+  groupTechniqueCount: number; // distinct techniques attributed to the group (context for the ratio)
+  score: number; // weighted: exactCount + BASE_MATCH_WEIGHT × (overlapCount − exactCount)
+}
+
+const TECHNIQUE_RE = /^T(\d{4})(?:\.(\d{3}))?$/; // technique or sub-technique id
+
+/** Normalize a technique id to its full, validated form, KEEPING the sub-technique:
+ *  "t1059.001" → "T1059.001", "T1486" → "T1486". Null when it isn't a valid technique id. */
+export function normalizeTechniqueId(raw: string): string | null {
+  const m = TECHNIQUE_RE.exec(raw.trim().toUpperCase());
+  if (!m) return null;
+  return m[2] ? `T${m[1]}.${m[2]}` : `T${m[1]}`;
+}
+
+/** The BASE technique of an id ("T1059.001" → "T1059", "T1486" → "T1486"), or null when invalid.
+ *  Used to award partial credit when the case and a group share a technique but differ on the sub. */
+export function baseTechniqueId(raw: string): string | null {
+  const m = TECHNIQUE_RE.exec(raw.trim().toUpperCase());
+  return m ? `T${m[1]}` : null;
+}


### PR DESCRIPTION
Second of the four grandfathered baselines. **1 → 0**, and the exception list is now `[]`.

## The cycle

`adversaryHints.ts` called `suggestNextTechniques()` from `adversaryEmulation.ts`; `adversaryEmulation.ts` imported the technique-id helpers and both record shapes back from `adversaryHints.ts`. Each module needed the other loaded first.

Node tolerates that right up until one of those imports is evaluated at *module scope* rather than at call time — then one side sees `undefined`, and the failure surfaces as a **data** bug (no groups matched, no next techniques) a long way from the load-order cause.

## The fix

`adversaryTechniques.ts` holds exactly what **both** sides need: `AdversaryGroup`, `AdversaryHint`, `normalizeTechniqueId`, `baseTechniqueId`.

```
before:  hints ⇄ emulation
after:   hints → emulation → techniques
         hints ────────────→ techniques
```

Deliberately **not** a dumping ground: `suggestNextTechniques` stays in emulation, `rankAdversaryGroups` stays in hints. Moving either would make the new module the place the next cycle forms.

`adversaryHints.ts` re-exports all four names, so its ten importers — report writer, markdown, AI synthesis, prompt blocks, playbook matching, d3fend mapping, ATT&CK mitigations, false-positive similarity, and two test helpers — compile unchanged. Only the declaration site moved.

## Why this one was worth doing

```
[imports] ok — 0 known cycle(s), none new
```

`scripts/import-cycles.json` is now `[]`. The gate has stopped being a ratchet with one grandfathered entry and become a plain rule: **no cycles**. That's the difference between "don't add a second one" and "don't add one".

Worth noting the boundary gate did its job unprompted — it refused the new file until it declared a domain, with a good reason: *"an unclassified file is an unanswered design question, not a known debt."* It joins its two siblings in `analysis/intel`.

## Test plan

- [x] `check:imports` → **0 cycles**, ledger emptied via `--update` (reductions only)
- [x] Adversary suites: 32/32 pass
- [x] Wider `tests/analysis/` + `tests/reports/`: **4412 pass**
- [x] typecheck, eslint, prettier clean
- [x] Other ratchets unmoved: 13 ledgered files, 47 boundary violations, 0 a11y