### PR TITLE
fix(tests): stop negative tests printing their own refusals onto every run

### DIFF
--- a/companion/tests/architecture/childStderr.test.ts
+++ b/companion/tests/architecture/childStderr.test.ts
@@ -24,6 +24,39 @@ import { runScriptExpectingFailure } from "../helpers/runScript.js";
 
 const TESTS = new URL("../", import.meta.url);
 
+/**
+ * Line numbers of spawns in `source` that would echo the child's stderr onto this process's.
+ *
+ * The rule is the invariant itself — every spawn passes an explicit `stdio` that pipes stderr —
+ * rather than "call the helper", which is only one way of satisfying it. Enforcing the proxy would
+ * fail a spawn that is already correct, and a guard that fires on correct code gets relaxed by
+ * whoever hits it next, usually by deleting it.
+ *
+ * Reads the argument list by matching parens rather than by line, because the four call sites that
+ * caused this all wrapped their options object onto its own lines. A paren inside a string literal
+ * would confuse the balance; none of these calls has one, and the failure mode is a false positive
+ * naming a real line, which is the safe direction.
+ */
+export function unpipedSpawns(source: string): number[] {
+  const found: number[] = [];
+  const call = /\b(?:execFileSync|execSync|spawnSync)\s*\(/g;
+  for (let m = call.exec(source); m; m = call.exec(source)) {
+    const open = m.index + m[0].length - 1;
+    let depth = 0;
+    let i = open;
+    for (; i < source.length; i++) {
+      if (source[i] === "(") depth++;
+      else if (source[i] === ")" && --depth === 0) break;
+    }
+    const args = source.slice(open + 1, i);
+    // `stdio: "inherit"` is the loud way to do exactly what the default does quietly.
+    if (!/\bstdio\s*:/.test(args) || /["']inherit["']/.test(args)) {
+      found.push(source.slice(0, m.index).split("\n").length);
+    }
+  }
+  return found;
+}
+
 /** Every .ts file under tests/, as a path relative to tests/. */
 async function testSources(dir: URL, prefix = ""): Promise<string[]> {
   const out: string[] = [];
@@ -55,11 +88,10 @@ describe("tests do not leak a child process's stderr into the run", () => {
 
   afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
-  it("spawns scripts only through the stderr-capturing helper", async () => {
+  it("gives every spawn in the suite an explicit stdio that pipes stderr", async () => {
     // Structural, not behavioural, and deliberately so. The leak is invisible from inside the
     // process that leaks — the parent's stderr belongs to the test runner — so the cheap thing a
-    // test can check is that no call site sets the leak up. One helper owns the `stdio` option;
-    // any other spawn is a copy of the options object waiting to drop it again.
+    // test can check is that no call site sets the leak up.
     const files = await testSources(TESTS);
     expect(files.length, "found no test sources — the walk is looking in the wrong place").toBeGreaterThan(
       10,
@@ -67,21 +99,37 @@ describe("tests do not leak a child process's stderr into the run", () => {
 
     const offenders: string[] = [];
     for (const file of files) {
-      if (file === "helpers/runScript.ts") continue;
+      // This file is the one place the offending shape appears as DATA — the fixture in the test
+      // below is a string of deliberately bad spawns, and scanning it reports itself. Its own two
+      // spawns go through the helper, so nothing here is exempted from the rule in practice.
+      if (file === "architecture/childStderr.test.ts") continue;
       const source = await readFile(new URL(file, TESTS), "utf8");
-      for (const [i, line] of source.split("\n").entries()) {
-        // The call form, not the bare name: the helper is named in prose in more than one comment,
-        // and a mention is not a spawn.
-        if (/\b(?:execFileSync|spawnSync)\s*\(/.test(line)) offenders.push(`${file}:${i + 1}`);
-      }
+      offenders.push(...unpipedSpawns(source).map((line) => `${file}:${line}`));
     }
 
     expect(
       offenders,
-      "spawn scripts via tests/helpers/runScript.ts — a bare execFileSync echoes the child's " +
-        "stderr onto the run's own, which is how four refusal messages came to print on every " +
-        "green run",
+      "these spawns would echo the child's stderr onto the run's own, which is how four refusal " +
+        "messages came to print on every green run. Use tests/helpers/runScript.ts, or pass " +
+        '`stdio: ["ignore", "pipe", "pipe"]` yourself',
     ).toEqual([]);
+  });
+
+  it("flags a spawn that omits stdio, and only that one", () => {
+    // The detector, watched working. Scanning real files reports "[]" both when every spawn is
+    // correct AND when the scan has quietly stopped recognising spawns at all — two cases a
+    // file-walking assertion cannot tell apart on its own.
+    const source = [
+      'const a = execFileSync(node, [s], { encoding: "utf8" });', // 1: no stdio
+      "const b = execFileSync(node, [s], {",
+      '  encoding: "utf8",', // options wrapped across lines, as all four leaks were
+      "});", // reported at line 2, where the call starts
+      'const c = execFileSync(node, [s], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });',
+      'const d = spawnSync(node, [s], { stdio: "inherit" });', // 6: loudly does the default
+      "const e = runScript(SCRIPT, [s]);", // not a spawn at all
+    ].join("\n");
+
+    expect(unpipedSpawns(source)).toEqual([1, 2, 6]);
   });
 
   it("still hands the refusal text to the test that asked for it", () => {

--- a/companion/tests/architecture/childStderr.test.ts
+++ b/companion/tests/architecture/childStderr.test.ts
@@ -19,42 +19,85 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import ts from "typescript";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { runScriptExpectingFailure } from "../helpers/runScript.js";
 
 const TESTS = new URL("../", import.meta.url);
 
 /**
- * Line numbers of spawns in `source` that would echo the child's stderr onto this process's.
+ * Which stdio slot a spawn gives its child's STDERR, or null when that cannot be determined.
  *
- * The rule is the invariant itself — every spawn passes an explicit `stdio` that pipes stderr —
- * rather than "call the helper", which is only one way of satisfying it. Enforcing the proxy would
- * fail a spawn that is already correct, and a guard that fires on correct code gets relaxed by
- * whoever hits it next, usually by deleting it.
+ * Verified against Node rather than assumed, because half of these are not obvious:
  *
- * Reads the argument list by matching parens rather than by line, because the four call sites that
- * caused this all wrapped their options object onto its own lines. A paren inside a string literal
- * would confuse the balance; none of these calls has one, and the failure mode is a false positive
- * naming a real line, which is the safe direction.
+ *   stdio: "pipe"                          captured   (no stdio option)                    LEAKS
+ *   stdio: ["ignore", "pipe", "pipe"]      captured   stdio: "inherit"                     LEAKS
+ *   stdio: ["ignore", "pipe", "ignore"]    captured   stdio: ["ignore", "pipe", "inherit"] LEAKS
+ *   stdio: ["ignore", "pipe"]              captured   stdio: ["ignore", "pipe", 2]         LEAKS
+ *
+ * The raw descriptor is why a keyword search cannot do this job: `2` IS the parent's stderr and
+ * says nothing about itself. The short array is why counting elements cannot either — Node fills
+ * the missing slots with "pipe".
+ *
+ * Anything that hides the answer — a spread in the options or in the array, a value that is not a
+ * literal — returns null and is reported. Over-reporting costs someone one explicit stdio;
+ * under-reporting cost this repo months of FAIL scrolling past on green runs.
+ */
+function stderrSlot(call: ts.CallExpression): string | null {
+  const last = call.arguments.at(-1);
+  if (!last || !ts.isObjectLiteralExpression(last)) return null; // no options object: the default
+  let value: ts.Expression | undefined;
+  for (const p of last.properties) {
+    if (ts.isSpreadAssignment(p)) return null; // {...base} may carry an stdio we cannot see
+    if (ts.isShorthandPropertyAssignment(p) && p.name.text === "stdio") return null;
+    if (ts.isPropertyAssignment(p) && p.name.getText() === "stdio") value = p.initializer;
+  }
+  if (!value) return null;
+  const literal = (n: ts.Node): string | null =>
+    ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n) ? n.text : null;
+  const whole = literal(value);
+  if (whole) return whole; // a bare string applies to all three streams
+  if (!ts.isArrayLiteralExpression(value)) return null;
+  const slots = value.elements;
+  if (slots.some((e) => ts.isSpreadElement(e))) return null; // the positions become unknowable
+  if (slots.length < 3) return "pipe"; // Node fills the rest
+  return literal(slots[2]);
+}
+
+const SPAWNS = new Set(["execFileSync", "execSync", "spawnSync"]);
+
+/**
+ * Line numbers of spawns in `source` whose child stderr would reach this process.
+ *
+ * PARSED, NOT SCANNED. Five review rounds found five defects in a hand-rolled text scanner, and
+ * every one was lexical rather than about stdio: a call named in a comment read as real, a call
+ * quoted as data read as real, a comment in front of a spread hid the spread, and filtering
+ * strings out then hid a real call inside a template interpolation. Each fix was right and the
+ * next edge case was already waiting. TypeScript is already a dependency here — scripts/
+ * dashboard-inventory.mjs parses with it for the same reason — so the whole class goes away.
  */
 export function unpipedSpawns(source: string): number[] {
+  const sf = ts.createSourceFile("scan.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
   const found: number[] = [];
-  const call = /\b(?:execFileSync|execSync|spawnSync)\s*\(/g;
-  for (let m = call.exec(source); m; m = call.exec(source)) {
-    const open = m.index + m[0].length - 1;
-    let depth = 0;
-    let i = open;
-    for (; i < source.length; i++) {
-      if (source[i] === "(") depth++;
-      else if (source[i] === ")" && --depth === 0) break;
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const name = ts.isPropertyAccessExpression(callee)
+        ? callee.name.text
+        : ts.isIdentifier(callee)
+          ? callee.text
+          : "";
+      if (SPAWNS.has(name)) {
+        const slot = stderrSlot(node);
+        if (slot !== "pipe" && slot !== "ignore") {
+          found.push(sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1);
+        }
+      }
     }
-    const args = source.slice(open + 1, i);
-    // `stdio: "inherit"` is the loud way to do exactly what the default does quietly.
-    if (!/\bstdio\s*:/.test(args) || /["']inherit["']/.test(args)) {
-      found.push(source.slice(0, m.index).split("\n").length);
-    }
-  }
-  return found;
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found.sort((a, b) => a - b);
 }
 
 /** Every .ts file under tests/, as a path relative to tests/. */
@@ -99,10 +142,10 @@ describe("tests do not leak a child process's stderr into the run", () => {
 
     const offenders: string[] = [];
     for (const file of files) {
-      // This file is the one place the offending shape appears as DATA — the fixture in the test
-      // below is a string of deliberately bad spawns, and scanning it reports itself. Its own two
-      // spawns go through the helper, so nothing here is exempted from the rule in practice.
-      if (file === "architecture/childStderr.test.ts") continue;
+      // No file is exempt, including this one. It used to be skipped because its fixture — a list
+      // of deliberately bad spawns written as strings — was reported as real code. Skipping was
+      // the wrong fix: an exemption is a hole the size of whatever else is in the file. The
+      // scanner now knows a quoted call from a call.
       const source = await readFile(new URL(file, TESTS), "utf8");
       offenders.push(...unpipedSpawns(source).map((line) => `${file}:${line}`));
     }
@@ -115,21 +158,97 @@ describe("tests do not leak a child process's stderr into the run", () => {
     ).toEqual([]);
   });
 
-  it("flags a spawn that omits stdio, and only that one", () => {
-    // The detector, watched working. Scanning real files reports "[]" both when every spawn is
-    // correct AND when the scan has quietly stopped recognising spawns at all — two cases a
-    // file-walking assertion cannot tell apart on its own.
+  it("flags every spawn whose stderr reaches this process, and no others", () => {
+    // The detector, watched working, against each form measured above. Scanning real files reports
+    // "[]" both when every spawn is correct AND when the scan has quietly stopped recognising
+    // spawns at all — two cases a file-walking assertion cannot tell apart on its own.
+    //
+    // The `2` case is why this reads the value instead of searching for "inherit": a raw file
+    // descriptor leaks and contains no keyword to find. An earlier version of this guard passed it.
     const source = [
-      'const a = execFileSync(node, [s], { encoding: "utf8" });', // 1: no stdio
+      'const a = execFileSync(node, [s], { encoding: "utf8" });', // 1: no stdio at all
       "const b = execFileSync(node, [s], {",
-      '  encoding: "utf8",', // options wrapped across lines, as all four leaks were
+      '  encoding: "utf8",', // options wrapped across lines, as all four real leaks were
       "});", // reported at line 2, where the call starts
       'const c = execFileSync(node, [s], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });',
       'const d = spawnSync(node, [s], { stdio: "inherit" });', // 6: loudly does the default
-      "const e = runScript(SCRIPT, [s]);", // not a spawn at all
+      'const e = execFileSync(node, [s], { stdio: ["ignore", "pipe", "inherit"] });', // 7
+      'const f = execFileSync(node, [s], { stdio: ["ignore", "pipe", 2] });', // 8: fd 2 IS our stderr
+      'const g = execFileSync(node, [s], { stdio: ["ignore", "pipe"] });', // short: Node fills "pipe"
+      "const h = execFileSync(node, [s], { stdio: whateverOptsSays });", // 10: not statically readable
+      'const i = execFileSync(node, [s], { stdio: "pipe" });',
+      'const j = execFileSync(node, [s], { stdio: ["ignore", "pipe", "ignore"] });',
+      "const k = runScript(SCRIPT, [s]);", // not a spawn at all
+      "const l = execFileSync(node, [s], { stdio: [...STDIO] });", // 14: spread hides the slots
+      'const m = execFileSync(node, [s], { stdio: ["ignore", ...rest] });', // 15: same, partially
+      "const n = execFileSync(node, [s], { stdio: [/* keep */ ...STDIO] });", // 16: comment first
+      "const o = execFileSync(node, [s], {", // 17: and the same across lines
+      "  stdio: [",
+      "    // the usual triple",
+      "    ...STDIO,",
+      "  ],",
+      "});",
+      "// execFileSync(node, [s], {}) — a call in prose is not a call", // 23: must NOT be flagged
+      'const p = describe("execFileSync(node, [s], {})", () => {});', // 24: nor is one quoted as data
+      // 25: but a template INTERPOLATION is code, however much it looks like string innards.
+      'const q = `${execFileSync(node, [s], { encoding: "utf8" })}`;',
     ].join("\n");
 
-    expect(unpipedSpawns(source)).toEqual([1, 2, 6]);
+    expect(unpipedSpawns(source)).toEqual([1, 2, 6, 7, 8, 10, 14, 15, 16, 17, 25]);
+  });
+
+  it("agrees with what each stdio form actually does to a real child's stderr", () => {
+    // The detector's table, checked against Node instead of against my reading of the docs.
+    //
+    // Every entry here was wrong in some earlier version of this guard: the first accepted any
+    // `stdio` key at all, the second searched for the word "inherit" and so waved through the raw
+    // descriptor. Both looked right. So each form is now RUN — a child that spawns a grandchild
+    // which writes to stderr, with us capturing the child's stderr — and the observed leak is
+    // asserted to match what unpipedSpawns() says about the same text.
+    //
+    // It also pins Node's behaviour rather than trusting it: if a short stdio array ever stopped
+    // defaulting the missing slot to "pipe", this fails instead of the guard quietly going wrong.
+    //
+    // Only statically-readable forms belong here. A spread like `[...STDIO]` is flagged whatever it
+    // expands to, so running it would compare a deliberate false positive against a clean result
+    // and fail. That asymmetry is the design — over-reporting costs someone one explicit stdio,
+    // under-reporting costs another few months of FAIL scrolling past — and it is pinned in the
+    // fixture above instead.
+    const forms = [
+      "", // no stdio option at all
+      ', stdio: "pipe"',
+      ', stdio: "inherit"',
+      ', stdio: ["ignore", "pipe", "pipe"]',
+      ', stdio: ["ignore", "pipe", "inherit"]',
+      ', stdio: ["ignore", "pipe", 2]',
+      ', stdio: ["ignore", "pipe"]',
+      ', stdio: ["ignore", "pipe", "ignore"]',
+    ];
+
+    for (const form of forms) {
+      const options = `{ encoding: "utf8"${form} }`;
+      const child = join(dir, "spawner.mjs");
+      // Exits non-zero so runScriptExpectingFailure hands back the stderr it collected. Whether the
+      // grandchild's "LEAKED" appears there is exactly the question — it can only have arrived by
+      // escaping the inner spawn's stdio.
+      writeFileSync(
+        child,
+        'import { execFileSync } from "node:child_process";\n' +
+          "try {\n" +
+          `  execFileSync(process.execPath, ["-e", 'console.error("LEAKED")'], ${options});\n` +
+          "} catch {}\n" +
+          "process.exit(7);\n",
+      );
+
+      const { status, stderr } = runScriptExpectingFailure(child, []);
+      expect(status, "the probe child did not run").toBe(7);
+
+      const leaks = stderr.includes("LEAKED");
+      const flagged = unpipedSpawns(`execFileSync(node, [s], ${options});`).length > 0;
+      expect(flagged, `stdio \`${form || "(absent)"}\`: leaks=${leaks}, detector says ${flagged}`).toBe(
+        leaks,
+      );
+    }
   });
 
   it("still hands the refusal text to the test that asked for it", () => {

--- a/companion/tests/architecture/childStderr.test.ts
+++ b/companion/tests/architecture/childStderr.test.ts
@@ -1,0 +1,103 @@
+// A test that provokes a script into refusing must not print that refusal onto the run's stderr.
+//
+// This is the guard for a defect that survived months of green runs. execFileSync's default `stdio`
+// echoes the child's stderr to the parent as well as capturing it, so four negative tests — each
+// asserting that a script correctly REFUSES a deliberately broken fixture — printed their refusals
+// into every test run:
+//
+//   [inventory] FAIL: sections cover 2 lines but the inline script is 4. …
+//   [split] REFUSING: … (×3)
+//
+// The inventory line was read, reasonably, as the real dashboard failing its coverage check. It was
+// not: it describes a four-line fixture built inside the test, and the check passes against
+// public/dashboard.html (1,774 lines, all covered). Nothing was broken except the output — which is
+// its own defect, because a run that prints FAIL while everything passes teaches people to read
+// past the word, and the guards exist precisely for the day it is real.
+//
+// Nothing guarded the property, so nothing noticed when four call sites acquired it. This does.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runScriptExpectingFailure } from "../helpers/runScript.js";
+
+const TESTS = new URL("../", import.meta.url);
+
+/** Every .ts file under tests/, as a path relative to tests/. */
+async function testSources(dir: URL, prefix = ""): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      out.push(...(await testSources(new URL(`${entry.name}/`, dir), `${prefix}${entry.name}/`)));
+    } else if (entry.name.endsWith(".ts")) {
+      out.push(`${prefix}${entry.name}`);
+    }
+  }
+  return out;
+}
+
+describe("tests do not leak a child process's stderr into the run", () => {
+  // Two throwaway scripts standing in for the real ones: one that refuses the way check scripts do,
+  // one that succeeds. Real files rather than `node -e`, because runScript's whole contract is
+  // "given a script path, run it" and testing it through a flag would test a different call shape.
+  let dir: string;
+  let refuses: string;
+  let succeeds: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "dfir-stderr-"));
+    refuses = join(dir, "refuses.mjs");
+    succeeds = join(dir, "succeeds.mjs");
+    writeFileSync(refuses, 'console.error("REFUSING: synthetic");\nprocess.exit(3);\n');
+    writeFileSync(succeeds, "process.exit(0);\n");
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("spawns scripts only through the stderr-capturing helper", async () => {
+    // Structural, not behavioural, and deliberately so. The leak is invisible from inside the
+    // process that leaks — the parent's stderr belongs to the test runner — so the cheap thing a
+    // test can check is that no call site sets the leak up. One helper owns the `stdio` option;
+    // any other spawn is a copy of the options object waiting to drop it again.
+    const files = await testSources(TESTS);
+    expect(files.length, "found no test sources — the walk is looking in the wrong place").toBeGreaterThan(
+      10,
+    );
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      if (file === "helpers/runScript.ts") continue;
+      const source = await readFile(new URL(file, TESTS), "utf8");
+      for (const [i, line] of source.split("\n").entries()) {
+        // The call form, not the bare name: the helper is named in prose in more than one comment,
+        // and a mention is not a spawn.
+        if (/\b(?:execFileSync|spawnSync)\s*\(/.test(line)) offenders.push(`${file}:${i + 1}`);
+      }
+    }
+
+    expect(
+      offenders,
+      "spawn scripts via tests/helpers/runScript.ts — a bare execFileSync echoes the child's " +
+        "stderr onto the run's own, which is how four refusal messages came to print on every " +
+        "green run",
+    ).toEqual([]);
+  });
+
+  it("still hands the refusal text to the test that asked for it", () => {
+    // The complement, and the reason this pair is worth having: suppressing the echo is only
+    // correct if the message is still there to assert on. A helper that swallowed stderr outright
+    // would satisfy the test above and silently gut every refusal assertion in the suite.
+    const { status, stderr } = runScriptExpectingFailure(refuses, []);
+    expect(status).toBe(3);
+    expect(stderr).toContain("REFUSING: synthetic");
+  });
+
+  it("fails loudly when a script it expected to refuse actually succeeds", () => {
+    // A guard that has stopped guarding must not read as a pass. Under the old try/catch shape the
+    // assertions lived in the catch block, so a script that stopped refusing ran no assertions at
+    // all — an `expect.unreachable` call was the only thing between that and a green test, and it
+    // had to be remembered at every call site.
+    expect(() => runScriptExpectingFailure(succeeds, [])).toThrow(/exit non-zero, but it succeeded/);
+  });
+});

--- a/companion/tests/architecture/dashboardInventory.test.ts
+++ b/companion/tests/architecture/dashboardInventory.test.ts
@@ -12,10 +12,10 @@
 // fail CI on each one and be regenerated without being read, which is how a ledger stops meaning
 // anything. The JSON is a planning snapshot; the invariant is what is enforced.
 import { describe, expect, it } from "vitest";
-import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runScript, runScriptExpectingFailure } from "../helpers/runScript.js";
 
 const SCRIPT = new URL("../../scripts/dashboard-inventory.mjs", import.meta.url).pathname;
 
@@ -45,7 +45,7 @@ const run = (): {
     foreignStanzas: string[];
     functions: number;
   }[];
-} => JSON.parse(execFileSync(process.execPath, [SCRIPT, "--json"], { encoding: "utf8" }));
+} => JSON.parse(runScript(SCRIPT, ["--json"]));
 
 describe("dashboard extraction inventory", () => {
   const report = run();
@@ -225,11 +225,7 @@ describe("dashboard extraction inventory", () => {
     );
     writeFileSync(join(dir, "js", "sibling.js"), "calledOnlyBySibling();\n");
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       const only = r.sections.find((s: { label: string }) => s.label === "Lonely feature");
       expect(only.publish).toContain("calledOnlyBySibling");
       // The complement: a function nothing calls must NOT be published, or "publish" degenerates
@@ -259,11 +255,7 @@ describe("dashboard extraction inventory", () => {
     );
     writeFileSync(join(dir, "js", "sibling.js"), "// mentionedInProse() is documented here.\n");
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       const only = r.sections.find((s: { label: string }) => s.label === "Lonely feature");
       expect(only.publish).toEqual([]);
     } finally {
@@ -293,11 +285,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       const feature = r.sections.find((s: { label: string }) => s.label === "The feature");
       expect(feature.moduleScopeDom).toBe(0);
       expect(feature.boundElsewhere).toEqual(["closeThing"]);
@@ -327,11 +315,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       const feature = r.sections.find((s: { label: string }) => s.label === "The feature");
       expect(feature.boundElsewhere).toEqual([]);
       expect(feature.needsInitializer).toBe(false);
@@ -363,11 +347,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       const only = r.sections[0];
       expect(only.clusters).toEqual([2, 2]);
       expect(only.looksLikeTwoFeatures).toBe(true);
@@ -400,11 +380,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       // aOne+aTwo is a cluster of two; stowaway is a cluster of one that counts; SMALL_TABLE is a
       // singleton that does not.
       expect(r.sections[0].clusters).toEqual([2, 1]);
@@ -433,11 +409,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       expect(r.sections[0].clusters).toEqual([4]);
       expect(r.sections[0].looksLikeTwoFeatures).toBe(false);
     } finally {
@@ -470,11 +442,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       expect(r.sections[0].foreignStanzas).toEqual(["5 initGone"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -504,11 +472,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       expect(r.sections[0].foreignStanzas).toEqual(["5 initGone"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -534,11 +498,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       expect(r.sections[0].foreignStanzas).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -579,11 +539,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       const sec = r.sections.find((s: { label: string }) => s.label === "Owner");
       expect(sec.vocabulary.join(" "), "30 call sites is vocabulary").toContain("shout");
       // The complement: a name called once must NOT be flagged, or every declaration reads as
@@ -618,11 +574,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       const sec = r.sections.find((s: { label: string }) => s.label === "Helpers and state");
       // Both function forms are publishable, neither is a state escape.
       expect(sec.publish).toContain("quote");
@@ -682,11 +634,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const r = JSON.parse(
-        execFileSync(process.execPath, [SCRIPT, "--html", join(dir, "dashboard.html"), "--json"], {
-          encoding: "utf8",
-        }),
-      );
+      const r = JSON.parse(runScript(SCRIPT, ["--html", join(dir, "dashboard.html"), "--json"]));
       // renderThingRow must NOT match on a prefix — the list is exact names, not shapes.
       expect(r.sections[0].coreMachinery).toEqual([]);
       expect(r.sections[0].isCoreMachinery).toBe(false);
@@ -715,12 +663,13 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      execFileSync(process.execPath, [SCRIPT, "--html", broken, "--json"], { encoding: "utf8" });
-      expect.unreachable("inventory accepted a dashboard with code outside every section");
-    } catch (e) {
-      const err = e as { status?: number; stderr?: string };
-      expect(err.status, "expected a non-zero exit").toBeGreaterThan(0);
-      expect(err.stderr ?? "").toContain("invisible to this inventory");
+      // Through the helper, so the refusal this test is PROVOKING lands in `stderr` here instead of
+      // on the run's own stderr. It used to print `[inventory] FAIL: sections cover 2 lines but the
+      // inline script is 4` on every green run — this fixture's four lines, read by anyone
+      // scanning the output as the real dashboard failing its coverage check.
+      const { status, stderr } = runScriptExpectingFailure(SCRIPT, ["--html", broken, "--json"]);
+      expect(status, "expected a non-zero exit").toBeGreaterThan(0);
+      expect(stderr).toContain("invisible to this inventory");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -746,10 +695,7 @@ describe("dashboard extraction inventory", () => {
       ].join("\n"),
     );
     try {
-      const out = execFileSync(process.execPath, [SCRIPT, "--html", fixed, "--json"], {
-        encoding: "utf8",
-      });
-      const r = JSON.parse(out);
+      const r = JSON.parse(runScript(SCRIPT, ["--html", fixed, "--json"]));
       expect(r.covered).toBe(r.inlineScript.lines);
       expect(r.sections.map((s: { label: string }) => s.label)).toEqual([
         "Stray, now owned",

--- a/companion/tests/architecture/dashboardSectionSplit.test.ts
+++ b/companion/tests/architecture/dashboardSectionSplit.test.ts
@@ -7,10 +7,10 @@
 // would have left three buttons permanently dead — in a <head> script the query runs before the
 // markup exists, binds nothing, and reports nothing. The first case below is exactly that shape.
 import { describe, expect, it } from "vitest";
-import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runScript, runScriptExpectingFailure } from "../helpers/runScript.js";
 
 const SCRIPT = new URL("../../scripts/dashboard-section-split.mjs", import.meta.url).pathname;
 
@@ -22,12 +22,23 @@ const dashboardWith = (body: string[]): { dir: string; path: string } => {
   return { dir, path };
 };
 
-const split = (path: string, from: number, to: number) =>
-  JSON.parse(
-    execFileSync(process.execPath, [SCRIPT, String(from), String(to), "--json", "--html", path], {
-      encoding: "utf8",
-    }),
-  );
+const args = (path: string, from: number, to: number): string[] => [
+  String(from),
+  String(to),
+  "--json",
+  "--html",
+  path,
+];
+
+const split = (path: string, from: number, to: number) => JSON.parse(runScript(SCRIPT, args(path, from, to)));
+
+/**
+ * The refusal cases. These go through the helper so the `[split] REFUSING: …` line each one is
+ * PROVOKING is captured rather than printed onto the run's own stderr — three of them were, on
+ * every green run, describing throwaway fixtures rather than anything wrong with the dashboard.
+ */
+const splitExpectingFailure = (path: string, from: number, to: number) =>
+  runScriptExpectingFailure(SCRIPT, args(path, from, to));
 
 describe("dashboard section split", () => {
   it("puts a bare block that wires a button into the initializer, not the body", () => {
@@ -109,14 +120,9 @@ describe("dashboard section split", () => {
       "  }", // 5
     ]);
     try {
-      execFileSync(process.execPath, [SCRIPT, "3", "4", "--json", "--html", path], {
-        encoding: "utf8",
-      });
-      expect.unreachable("accepted a range ending inside a function body");
-    } catch (e) {
-      const err = e as { status?: number; stderr?: string };
-      expect(err.status).toBe(1);
-      expect(err.stderr ?? "").toContain("REFUSING");
+      const { status, stderr } = splitExpectingFailure(path, 3, 4);
+      expect(status).toBe(1);
+      expect(stderr).toContain("REFUSING");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -145,12 +151,9 @@ describe("dashboard section split", () => {
       '  if (typeof initSomethingElse !== "undefined") initSomethingElse();',
     ]);
     try {
-      execFileSync(process.execPath, [SCRIPT, "3", "4", "--json", "--html", path], { encoding: "utf8" });
-      expect.unreachable("accepted a range containing another feature's initializer");
-    } catch (e) {
-      const err = e as { status?: number; stderr?: string };
-      expect(err.status).toBe(1);
-      expect(err.stderr ?? "").toContain("initSomethingElse");
+      const { status, stderr } = splitExpectingFailure(path, 3, 4);
+      expect(status).toBe(1);
+      expect(stderr).toContain("initSomethingElse");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -166,12 +169,9 @@ describe("dashboard section split", () => {
       '  if (typeof initOther === "function") initOther();',
     ]);
     try {
-      execFileSync(process.execPath, [SCRIPT, "3", "4", "--json", "--html", path], { encoding: "utf8" });
-      expect.unreachable('accepted a range containing an === "function" guard');
-    } catch (e) {
-      const err = e as { status?: number; stderr?: string };
-      expect(err.status).toBe(1);
-      expect(err.stderr ?? "").toContain("initOther");
+      const { status, stderr } = splitExpectingFailure(path, 3, 4);
+      expect(status).toBe(1);
+      expect(stderr).toContain("initOther");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -196,12 +196,7 @@ describe("dashboard section split", () => {
     // that gets acted on without being questioned.
     const { dir, path } = dashboardWith(["  function f() {}"]);
     try {
-      execFileSync(process.execPath, [SCRIPT, "40", "10", "--json", "--html", path], {
-        encoding: "utf8",
-      });
-      expect.unreachable("accepted a range that ends before it starts");
-    } catch (e) {
-      expect((e as { status?: number }).status).toBe(2);
+      expect(splitExpectingFailure(path, 40, 10).status).toBe(2);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/companion/tests/helpers/runScript.ts
+++ b/companion/tests/helpers/runScript.ts
@@ -23,14 +23,19 @@
 // directly is not forced through here.
 import { execFileSync } from "node:child_process";
 
-/** stderr into the result, never onto the parent's. stdin closed: none of these scripts read it. */
-const STDIO = ["ignore", "pipe", "pipe"] as const;
-
-/** Run `node <script> <args>` and return its stdout. Throws if the script exits non-zero. */
+/**
+ * Run `node <script> <args>` and return its stdout. Throws if the script exits non-zero.
+ *
+ * The stdio triple is written out literally rather than hoisted to a shared constant: stderr into
+ * the result, never onto the parent's, and stdin closed because none of these scripts read it.
+ * childStderr.test.ts reads this value to decide whether the call is safe, and it cannot follow an
+ * identifier — a spread of a constant would be reported as unreadable, which is the correct
+ * behaviour for a guard that has to be conservative and a silly thing to make it do here.
+ */
 export function runScript(script: string, args: string[]): string {
   return execFileSync(process.execPath, [script, ...args], {
     encoding: "utf8",
-    stdio: [...STDIO],
+    stdio: ["ignore", "pipe", "pipe"],
   });
 }
 

--- a/companion/tests/helpers/runScript.ts
+++ b/companion/tests/helpers/runScript.ts
@@ -18,7 +18,9 @@
 // Setting `stdio` explicitly is the whole fix — `error.stderr` is populated either way, so
 // assertions on the refusal text are unaffected. These helpers exist so that stays true: the four
 // call sites that leaked were four copies of one options object, and a fifth copy is how it comes
-// back. childStderr.test.ts pins that no test spawns a script any other way.
+// back. childStderr.test.ts enforces the invariant rather than this file — a spawn that sets its
+// own piping `stdio` is equally correct — so a test with a good reason to call execFileSync
+// directly is not forced through here.
 import { execFileSync } from "node:child_process";
 
 /** stderr into the result, never onto the parent's. stdin closed: none of these scripts read it. */

--- a/companion/tests/helpers/runScript.ts
+++ b/companion/tests/helpers/runScript.ts
@@ -1,0 +1,57 @@
+// Running one of scripts/*.mjs from a test, with the child's stderr CAPTURED rather than echoed.
+//
+// execFileSync's default `stdio` writes the child's stderr to the PARENT's stderr as well as into
+// the thrown error. Every negative test — the ones whose whole point is that a script refuses —
+// therefore printed that refusal into the test run's own output. Four did, on every run, for
+// months:
+//
+//   [inventory] FAIL: sections cover 2 lines but the inline script is 4. …
+//   [split] REFUSING: 1 statement(s) start inside 3-4 and end past it (3-5). …
+//   [split] REFUSING: 1 guard stanza(s) inside 3-4 initialise OTHER features (4 initSomethingElse). …
+//   [split] REFUSING: 1 guard stanza(s) inside 3-4 initialise OTHER features (4 initOther). …
+//
+// All four came from throwaway fixtures built inside the tests, and every test passed. That
+// combination is the defect: a green run that prints FAIL teaches people to read past the word
+// FAIL, so the day one of these guards fires against the real dashboard it scrolls by as more of
+// the usual noise. A check nobody will believe has stopped being a check.
+//
+// Setting `stdio` explicitly is the whole fix — `error.stderr` is populated either way, so
+// assertions on the refusal text are unaffected. These helpers exist so that stays true: the four
+// call sites that leaked were four copies of one options object, and a fifth copy is how it comes
+// back. childStderr.test.ts pins that no test spawns a script any other way.
+import { execFileSync } from "node:child_process";
+
+/** stderr into the result, never onto the parent's. stdin closed: none of these scripts read it. */
+const STDIO = ["ignore", "pipe", "pipe"] as const;
+
+/** Run `node <script> <args>` and return its stdout. Throws if the script exits non-zero. */
+export function runScript(script: string, args: string[]): string {
+  return execFileSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+    stdio: [...STDIO],
+  });
+}
+
+/** Run it and parse stdout as JSON — the `--json` shape all of these scripts speak. */
+export function runScriptJson<T>(script: string, args: string[]): T {
+  return JSON.parse(runScript(script, args)) as T;
+}
+
+/**
+ * Run it expecting a REFUSAL, returning the exit status and the stderr it refused with.
+ *
+ * Throws when the script SUCCEEDS, so a guard that has quietly stopped guarding fails the test
+ * rather than skipping its assertions inside a catch block that never runs.
+ */
+export function runScriptExpectingFailure(
+  script: string,
+  args: string[],
+): { status: number; stderr: string } {
+  try {
+    runScript(script, args);
+  } catch (e) {
+    const err = e as { status?: number; stderr?: string };
+    return { status: err.status ?? 0, stderr: err.stderr ?? "" };
+  }
+  throw new Error(`expected \`${script} ${args.join(" ")}\` to exit non-zero, but it succeeded`);
+}


### PR DESCRIPTION
## The report

Every companion test run prints this, and has for months:

```
[inventory] FAIL: sections cover 2 lines but the inline script is 4. A block sits outside every banner comment and is invisible to this inventory.
```

The suspicion to check first was that `scripts/dashboard-inventory.mjs` had gone stale — #415 moved the inline JavaScript out into `public/js/*.js`, and "4 lines of inline script" is implausible for a 20k-line dashboard, so the tool was probably never repointed.

## What it actually is

**The tool is fine.** Run against the real file it passes:

```
$ node scripts/dashboard-inventory.mjs
[inventory] inline script: 1774 lines in 14 sections (1774 covered)
$ echo $?
0
```

`HTML_PATH` resolves to `public/dashboard.html` (474 KB, present), the locator finds the block, and coverage is exact. Nothing needed repointing and no banner was missing.

The "4 lines" is a **fixture built inside the test**. `dashboardInventory.test.ts` has a negative test that hands the script a deliberately broken 4-line dashboard and asserts it refuses — a guard, working. Three more like it live in `dashboardSectionSplit.test.ts`, which is where the `[split] REFUSING:` lines come from. All 27 inventory tests passed while printing FAIL.

**The defect is the output.** `execFileSync`'s default `stdio` writes the child's stderr to the *parent's* stderr as well as capturing it into the thrown error. Provoking a refusal therefore prints it. Verified directly:

```
parent-saw: LEAK-DEFAULT          # {encoding:"utf8"}
                                  # {stdio:["ignore","pipe","pipe"]} — nothing
```

`error.stderr` is populated in both cases, so nothing depended on the echo.

That is worth fixing rather than shrugging at: a green run that prints `FAIL` teaches people to read past the word, so the day the coverage check fires against the real dashboard it scrolls by as more of the usual noise. A check nobody will believe has stopped being a check.

## The change

- **`tests/helpers/runScript.ts`** (new) owns the spawn, with `stdio` set so the child's stderr lands only in the result. `runScript` / `runScriptJson` / `runScriptExpectingFailure`.
- **`dashboardInventory.test.ts`**, **`dashboardSectionSplit.test.ts`**: all 21 spawn sites go through it. The four refusal cases lose their try/catch — `runScriptExpectingFailure` throws when the script *succeeds*, so a guard that has stopped guarding fails the test instead of silently skipping the assertions that lived in a catch block.
- **`childStderr.test.ts`** (new) pins what nothing was watching:
  - no test spawns a script except through the helper (the leak was four copies of one options object; a fifth is how it comes back);
  - the refusal text is *still* available to assert on — a helper that swallowed stderr outright would satisfy the check above and quietly gut every refusal assertion in the suite;
  - a script that stops refusing fails loudly.

Both sibling `[split]` leaks are fixed here too: same root cause, same options object, same fix.

## End state

`npx vitest run tests/architecture/` — 63 passed, and grepping its output for `[inventory]` / `[split]` / `REFUSING` / `FAIL:` returns nothing. The coverage check now passes silently and would genuinely fail loudly.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx vitest run` — **582 files, 9165 tests, all passing**
- [x] `node scripts/dashboard-inventory.mjs` — exits 0, 1774/1774 covered
- [x] Full architecture run greps clean for leaked child stderr