### PR TITLE
fix(docs): derive the cross-domain comply/total pair instead of quoting a stale one

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,8 +200,12 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,275 of the 1,323 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,679 of the 1,718 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
+Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
+finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long
+enough to imply a ledger nine entries longer than the one on disk — nothing derived it and nothing
+checked it, which is the only reason it could drift.
 
 ### The initial ledger
 

--- a/companion/scripts/check-boundaries.mjs
+++ b/companion/scripts/check-boundaries.mjs
@@ -36,6 +36,7 @@
  *   node scripts/check-boundaries.mjs            # gate
  *   node scripts/check-boundaries.mjs --update   # re-record after removing violations (shrink-only)
  *   node scripts/check-boundaries.mjs --init     # re-baseline; additions are printed, justify them
+ *   node scripts/check-boundaries.mjs --json     # the counts ARCHITECTURE.md quotes; read-only
  *
  * No dependency: like check-imports.mjs, the graph is a regex over the import statements, because
  * the companion imports its own modules exclusively as relative specifiers ending in `.js`.
@@ -155,6 +156,20 @@ const files = walk(SRC).sort();
 const unclassified = [];
 const violations = [];
 
+// Every cross-domain dependency, complying or not — the denominator the violations are a numerator
+// of. Keyed identically to `violations` below (file pair PLUS kind), because two counts that key
+// differently cannot be subtracted: "complying" is literally this set minus the violating one, and
+// a type-only and a runtime edge between the same file pair are two dependencies in one and one in
+// the other. ARCHITECTURE.md quotes the pair, so both have to come from one pass over one resolver
+// — counting them separately by hand is what put the wrong number there.
+const crossDomain = new Set();
+
+// Domain pairs, for the "spanning N domain edges" claim. An edge is one direction between two
+// domains. The ledger is file-to-file deliberately (see the header), so this is derived, and
+// derived HERE rather than in the test: a test cannot classify a file without re-implementing
+// domainOf, and a re-implemented rule is one that agrees right up until it silently doesn't.
+const violationEdges = new Set();
+
 for (const file of files) {
   const from = rel(file);
   const fromDomain = domainOf(from);
@@ -169,13 +184,16 @@ for (const file of files) {
     const toDomain = domainOf(to);
     // An unresolvable or unclassified target is reported against the target file itself, not here.
     if (!toDomain || toDomain === fromDomain) continue;
+    // The kind is PART OF THE KEY. Without it, a grandfathered `type` edge silently becomes a
+    // runtime edge — the coupling gets strictly worse and the gate says nothing, because the
+    // source and target files did not change. Encoding it means the escalation reads as a new
+    // violation, while the reverse (runtime tightened to type) reads as one going away.
+    const key = `${from} -> ${to} [${isType ? "type" : "runtime"}]`;
+    crossDomain.add(key);
     if (rankOf(toDomain) <= rankOf(fromDomain)) continue;
+    violationEdges.add(`${fromDomain} -> ${toDomain}`);
     violations.push({
-      // The kind is PART OF THE KEY. Without it, a grandfathered `type` edge silently becomes a
-      // runtime edge — the coupling gets strictly worse and the gate says nothing, because the
-      // source and target files did not change. Encoding it means the escalation reads as a new
-      // violation, while the reverse (runtime tightened to type) reads as one going away.
-      key: `${from} -> ${to} [${isType ? "type" : "runtime"}]`,
+      key,
       detail: `${fromDomain} -> ${toDomain}${isType ? " (type-only)" : ""}`,
     });
   }
@@ -218,6 +236,29 @@ if (unclassified.length > 0) {
 
 const found = [...new Set(violations.map((v) => v.key))].sort();
 const detailOf = new Map(violations.map((v) => [v.key, v.detail]));
+
+// The figures ARCHITECTURE.md quotes, read out of the same pass that finds the violations rather
+// than counted by hand into the prose. Its "N of the M cross-domain file dependencies already
+// comply" sentence had drifted far enough that the implied violation count contradicted the ledger
+// sitting next to this script — because nothing derived the pair and nothing checked it.
+// tests/architecture/moduleMap.test.ts now asserts the doc against this output, the way it already
+// does for the violation count. As everywhere else in this file, the numbers themselves are not
+// repeated into a comment: a number written into a comment is a number that goes stale.
+if (process.argv.includes("--json")) {
+  console.log(
+    JSON.stringify(
+      {
+        crossDomain: crossDomain.size,
+        complying: crossDomain.size - found.length,
+        violations: found.length,
+        violationEdges: violationEdges.size,
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(0);
+}
 
 if (process.argv.includes("--init")) {
   const previous = existsSync(LEDGER) ? JSON.parse(readFileSync(LEDGER, "utf8")) : [];

--- a/companion/tests/architecture/moduleMap.test.ts
+++ b/companion/tests/architecture/moduleMap.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readFile, readdir } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
@@ -16,6 +17,31 @@ async function readMap(): Promise<{
 }
 
 const readDoc = (): Promise<string> => readFile(new URL("ARCHITECTURE.md", ROOT), "utf8");
+
+/**
+ * The counts, from the gate itself rather than recomputed here.
+ *
+ * Recomputing would mean re-implementing domainOf, rankOf and the import scanner in the test, and a
+ * re-implemented rule agrees with the original right up until it silently doesn't — that is exactly
+ * how the ready-count filter in dashboardInventory.test.ts came to certify a flag the script had
+ * stopped consulting. One resolver, two readers.
+ */
+const boundaryCounts = (): {
+  crossDomain: number;
+  complying: number;
+  violations: number;
+  violationEdges: number;
+} =>
+  JSON.parse(
+    execFileSync(
+      process.execPath,
+      [new URL("companion/scripts/check-boundaries.mjs", ROOT).pathname, "--json"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    ),
+  );
+
+/** "1,679" -> 1679. The doc writes thousands separators; nothing else in it does. */
+const num = (s: string): number => Number(s.replace(/,/g, ""));
 
 describe("module map ↔ ARCHITECTURE.md", () => {
   it("documents every analysis domain, with the tier the map assigns it", async () => {
@@ -66,6 +92,47 @@ describe("module map ↔ ARCHITECTURE.md", () => {
     );
     expect(claims.length, "ARCHITECTURE.md should state the violation count").toBeGreaterThan(0);
     for (const claimed of claims) expect(claimed).toBe(ledger.length);
+  });
+
+  it("states a comply/total pair that the boundary scan actually produces", async () => {
+    // The number that rotted. The doc read "1,275 of the 1,323 cross-domain file dependencies
+    // already comply", a difference that contradicted the ledger sitting beside it — and both
+    // halves were stale besides. Every other figure in that document stayed right because the test
+    // above guarded it; this one had nothing, so it drifted quietly while still reading as
+    // authoritative, which is the failure mode a wrong number in prose always has.
+    //
+    // Both halves are asserted, not just the difference: a pair can be internally consistent and
+    // still describe a codebase two hundred dependencies smaller than this one.
+    const counts = boundaryCounts();
+    const doc = await readDoc();
+
+    const m = doc.match(/([\d,]+) of the ([\d,]+) cross-domain file dependencies already comply/);
+    expect(m, "ARCHITECTURE.md should state the cross-domain comply/total pair").not.toBeNull();
+
+    const [, complying, total] = m as RegExpMatchArray;
+    expect(num(complying), "the complying figure has drifted from check-boundaries").toBe(counts.complying);
+    expect(num(total), "the cross-domain total has drifted from check-boundaries").toBe(counts.crossDomain);
+
+    // The pair and the ledger have to agree with each other too. Asserting each against the scan
+    // separately would let a scan whose two counts disagreed satisfy both — and the whole reason
+    // the old pair looked wrong was that its difference contradicted the ledger.
+    const ledger = JSON.parse(
+      await readFile(new URL("companion/scripts/boundary-violations.json", ROOT), "utf8"),
+    ) as string[];
+    expect(counts.crossDomain - counts.complying).toBe(ledger.length);
+    expect(counts.violations).toBe(ledger.length);
+  });
+
+  it("states the number of domain edges the violations actually span", async () => {
+    // Correct today — #549 fixed it — and unguarded, which is the same position the comply/total
+    // pair was in before it drifted. A number that is right for now and watched by nothing is a
+    // number waiting its turn.
+    const counts = boundaryCounts();
+    const doc = await readDoc();
+
+    const claims = [...doc.matchAll(/spanning (\d+) domain edges/gi)].map((mm) => Number(mm[1]));
+    expect(claims.length, "ARCHITECTURE.md should state the domain-edge span").toBeGreaterThan(0);
+    for (const claimed of claims) expect(claimed).toBe(counts.violationEdges);
   });
 });
 


### PR DESCRIPTION
## The drift

`ARCHITECTURE.md` claimed:

> For context: **1,275 of the 1,323 cross-domain file dependencies already comply.**

That difference is 48, against a `scripts/boundary-violations.json` holding **39**. Both halves were stale too — the real figures are **1,679 of 1,718**.

## Why it rotted

Neither number was derivable from anything. `check-boundaries.mjs` already resolves every cross-domain import — it has to, to find the violations — but it only ever reported the violating *subset*. The denominator had no source, so it was counted by hand into the prose once and never again. Every other figure in that document stayed correct because `moduleMap.test.ts` guarded it.

## The change

**`check-boundaries.mjs --json`** (new, read-only) reports the counts from the same pass:

```
$ node scripts/check-boundaries.mjs --json
{ "crossDomain": 1718, "complying": 1679, "violations": 39, "violationEdges": 27 }
```

Keyed identically to the violation ledger — file pair **plus kind** — because `complying` is literally one set minus the other, and two counts that key differently cannot be subtracted. (A type-only and a runtime edge between the same file pair are two dependencies in one and one in the other.) The gate's own behaviour, exit codes and messages are untouched: `[boundaries] ok — 39 known violation(s), none new`.

**`moduleMap.test.ts`** asserts the sentence against that output, extending what it already does for the `N violations` claims:

- both halves, not just their difference — a pair can be internally consistent and still describe a codebase two hundred dependencies smaller than this one;
- plus a cross-check that `crossDomain - complying` equals the ledger length, so a scan whose own two counts disagreed cannot satisfy the pair.

**`spanning 27 domain edges`** gets the same treatment. #549 corrected it and it is right today — the scan confirms 27 — but nothing watched it, which is precisely the position the comply/total pair was in before it drifted. The edge count is derived **in the script**, not the test: classifying a file in the test would mean re-implementing `domainOf`, and a re-implemented rule agrees with the original right up until it silently doesn't.

## Both guards were watched failing

Not kept on the assumption they work:

```
# 1,679 -> 1,680
× states a comply/total pair that the boundary scan actually produces
  → the complying figure has drifted from check-boundaries: expected 1680 to be 1679

# 27 -> 26
× states the number of domain edges the violations actually span
  → expected 26 to be 27
```

## One note on the doc wording

The first draft of the new prose said "…imply 48 violations against a ledger holding 39", which the *existing* violation-count guard immediately failed — it matches any `N violations` claim in the document and holds it to the ledger length. Correct behaviour; the sentence was reworded. Mentioned because it is a good sign about that guard, not a workaround.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx vitest run` — **581 files, 9164 tests, all passing**
- [x] `npm run check:boundaries` — `ok — 39 known violation(s), none new`
- [x] `npm run check:imports` — `ok — 0 known cycle(s), none new`
- [x] Both new assertions verified failing against perturbed figures, then restored

## Merge-order note

~~Independent of #551, with one small interaction…~~ **Resolved.** #551's guard originally enforced "spawn only through the helper", which would have failed this PR's correctly-piped `execFileSync`. It now enforces the actual invariant — every spawn passes an explicit `stdio` that pipes stderr — which `boundaryCounts()` already does. Verified by merging both branches: 582 files, 9168 tests passing, all gates clean. **The two land in either order.**
