### PR TITLE
fix(integrations): decode child process output through a stream decoder, not per-chunk

### DIFF
--- a/companion/src/integrations/childOutput.ts
+++ b/companion/src/integrations/childOutput.ts
@@ -93,3 +93,70 @@ export class ChildOutputCollector {
     };
   }
 }
+
+/**
+ * Collecting a child process's output as text, correctly — the setEncoding variant.
+ *
+ * `text += chunk.toString()` is the obvious way to do this and it is wrong. A chunk boundary is a
+ * BYTE boundary — the pipe hands over whatever bytes have arrived — so a multi-byte character can
+ * straddle two chunks, and decoding each chunk on its own replaces both halves with U+FFFD. Nothing
+ * throws: U+FFFD is a legal character in a JSON string, so a Velociraptor JSONL row still parses
+ * and the username or path inside it is simply wrong from there on. In a tool whose output is
+ * evidence, a silent substitution is the worst possible failure mode.
+ *
+ * `setEncoding("utf8")` puts a StringDecoder in front of the stream, which holds an incomplete
+ * trailing sequence back until the bytes that finish it arrive. That is the whole fix; the reason
+ * it lives here rather than being written twice is the byte budget below.
+ *
+ * Prefer ChildOutputCollector above when a call site can hold both streams as buffers until the
+ * child exits. Use collectText/collectCapped when a call site needs the decoded chunks as they
+ * arrive (e.g. a live stdout tap) rather than only the final joined string.
+ */
+import type { Readable } from "node:stream";
+
+/** Reads back everything collected from the stream so far, decoded. */
+export type ReadCollected = () => string;
+
+/**
+ * Accumulates the stream as UTF-8 text. A null stream reads back as "" — a caller that redirected
+ * the child's stdout to a file descriptor has no pipe to read, and that is not an error.
+ */
+export function collectText(stream: Readable | null): ReadCollected {
+  let text = "";
+  if (!stream) return () => "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => {
+    text += chunk;
+  });
+  return () => text;
+}
+
+/**
+ * The same, plus a hard byte budget: `onExceeded` fires as soon as more than `maxBytes` have
+ * arrived, and keeps firing for any chunk after that (the callers kill the child and reject, both
+ * of which are idempotent).
+ *
+ * The budget is counted in BYTES, which is what the callers' `maxOutputBytes` options and their
+ * error messages promise. The accumulated string's `.length` is UTF-16 code units and under-counts
+ * non-ASCII output by 2-4x, so a Hayabusa run over Japanese event logs or a VQL query returning
+ * Cyrillic paths could buffer several times the configured cap before anything stopped it.
+ * Re-encoding each decoded chunk is exact for valid UTF-8 and only ever over-counts invalid bytes
+ * (a replacement character is 3 bytes where the byte it replaced was 1), which errs toward killing
+ * the child rather than letting it run past the budget.
+ */
+export function collectCapped(
+  stream: Readable | null,
+  maxBytes: number,
+  onExceeded: () => void,
+): ReadCollected {
+  let text = "";
+  let bytes = 0;
+  if (!stream) return () => "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => {
+    text += chunk;
+    bytes += Buffer.byteLength(chunk, "utf8");
+    if (bytes > maxBytes) onExceeded();
+  });
+  return () => text;
+}

--- a/companion/src/integrations/mcp/mcpDelivery.ts
+++ b/companion/src/integrations/mcp/mcpDelivery.ts
@@ -278,14 +278,15 @@ export function spawnTransferRunner(): TransferRunner {
         opts.signal?.removeEventListener("abort", onAbort);
       }
 
-      child.stdout?.on("data", (d: Buffer) => {
-        stdout += d.toString();
-      });
+      // A chunk boundary is a BYTE boundary, so a multi-byte character can straddle two chunks and
+      // decoding each chunk on its own would leave U+FFFD in the middle of the remote path scp is
+      // complaining about. setEncoding holds the incomplete tail back until the rest arrives.
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk: string) => { stdout += chunk; });
       // scp is quiet on success and terse on failure, so stderr is the whole diagnostic. Cap it so a
       // pathological failure loop cannot grow it without bound.
-      child.stderr?.on("data", (d: Buffer) => {
-        if (stderr.length < 64 * 1024) stderr += d.toString();
-      });
+      child.stderr?.on("data", (chunk: string) => { if (stderr.length < 64 * 1024) stderr += chunk; });
 
       child.on("error", (e) => {
         const err = new Error(`cannot run "${binary}": ${e.message}`) as Error & { spawnCode?: string };

--- a/companion/src/integrations/mcp/mcpDelivery.ts
+++ b/companion/src/integrations/mcp/mcpDelivery.ts
@@ -283,10 +283,14 @@ export function spawnTransferRunner(): TransferRunner {
       // complaining about. setEncoding holds the incomplete tail back until the rest arrives.
       child.stdout?.setEncoding("utf8");
       child.stderr?.setEncoding("utf8");
-      child.stdout?.on("data", (chunk: string) => { stdout += chunk; });
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
       // scp is quiet on success and terse on failure, so stderr is the whole diagnostic. Cap it so a
       // pathological failure loop cannot grow it without bound.
-      child.stderr?.on("data", (chunk: string) => { if (stderr.length < 64 * 1024) stderr += chunk; });
+      child.stderr?.on("data", (chunk: string) => {
+        if (stderr.length < 64 * 1024) stderr += chunk;
+      });
 
       child.on("error", (e) => {
         const err = new Error(`cannot run "${binary}": ${e.message}`) as Error & { spawnCode?: string };

--- a/companion/src/providers/claudeCodeStatus.ts
+++ b/companion/src/providers/claudeCodeStatus.ts
@@ -115,8 +115,12 @@ export async function startClaudeLogin(
     // decoding each chunk on its own would leave U+FFFD in the banner shown on the dashboard.
     child.stdout?.setEncoding("utf8");
     child.stderr?.setEncoding("utf8");
-    child.stdout?.on("data", (chunk: string) => { output += chunk; });
-    child.stderr?.on("data", (chunk: string) => { output += chunk; });
+    child.stdout?.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      output += chunk;
+    });
     child.on("close", finish);
   });
 }

--- a/companion/src/providers/claudeCodeStatus.ts
+++ b/companion/src/providers/claudeCodeStatus.ts
@@ -111,12 +111,12 @@ export async function startClaudeLogin(
         error: err.code === "ENOENT" ? "Claude Code CLI not found" : err.message,
       });
     });
-    child.stdout?.on("data", (d) => {
-      output += d.toString();
-    });
-    child.stderr?.on("data", (d) => {
-      output += d.toString();
-    });
+    // A chunk boundary is a BYTE boundary, so a multi-byte character can straddle two chunks;
+    // decoding each chunk on its own would leave U+FFFD in the banner shown on the dashboard.
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => { output += chunk; });
+    child.stderr?.on("data", (chunk: string) => { output += chunk; });
     child.on("close", finish);
   });
 }

--- a/companion/src/providers/codexStatus.ts
+++ b/companion/src/providers/codexStatus.ts
@@ -105,8 +105,12 @@ export async function startCodexLogin(
     // decoding each chunk on its own would leave U+FFFD in the banner shown on the dashboard.
     child.stdout?.setEncoding("utf8");
     child.stderr?.setEncoding("utf8");
-    child.stdout?.on("data", (chunk: string) => { output += chunk; });
-    child.stderr?.on("data", (chunk: string) => { output += chunk; });
+    child.stdout?.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      output += chunk;
+    });
     child.on("close", finish);
   });
 }

--- a/companion/src/providers/codexStatus.ts
+++ b/companion/src/providers/codexStatus.ts
@@ -101,12 +101,12 @@ export async function startCodexLogin(
       clearTimeout(timer);
       resolve({ started: false, output, error: err.code === "ENOENT" ? "Codex CLI not found" : err.message });
     });
-    child.stdout?.on("data", (d) => {
-      output += d.toString();
-    });
-    child.stderr?.on("data", (d) => {
-      output += d.toString();
-    });
+    // A chunk boundary is a BYTE boundary, so a multi-byte character can straddle two chunks;
+    // decoding each chunk on its own would leave U+FFFD in the banner shown on the dashboard.
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => { output += chunk; });
+    child.stderr?.on("data", (chunk: string) => { output += chunk; });
     child.on("close", finish);
   });
 }

--- a/companion/tests/helpers/splitUtf8.ts
+++ b/companion/tests/helpers/splitUtf8.ts
@@ -1,0 +1,77 @@
+/**
+ * A child process that writes ONE multi-byte character across TWO stdout/stderr writes.
+ *
+ * Every spawn site in src/ accumulates child output as `text += chunk.toString()`. That decodes
+ * each chunk INDEPENDENTLY, so a UTF-8 sequence straddling a chunk boundary is decoded as two
+ * broken halves and both become U+FFFD. The reader never sees the character, and the byte count
+ * changes — enough to make `JSON.parse` throw on a Velociraptor JSONL row and silently drop a piece
+ * of evidence, which is the failure this helper exists to reproduce.
+ *
+ * The obvious reproduction — write 600 KB and let the 64 KB pipe buffer do the splitting — works,
+ * but it is slow and it depends on a pipe buffer size that is not part of any contract. Two
+ * explicit writes with a timer between them force exactly one boundary, in a payload small enough
+ * to compare with `toBe`. The contract under test is the same either way: a chunk boundary is a
+ * BYTE boundary and may fall anywhere, including inside a character.
+ *
+ * The fix these tests drive is `stream.setEncoding("utf8")`, which puts a StringDecoder in front of
+ * the stream so an incomplete trailing sequence is held back until the bytes that finish it arrive.
+ * Removing that one line from a spawn site fails its test here.
+ */
+import { chmodSync, writeFileSync } from "node:fs";
+
+/**
+ * Cyrillic + CJK + a 4-byte emoji — the character classes that show up in real case data (a
+ * username, a file path, a filename) and the ones that break. Deliberately NOT pure ASCII.
+ */
+export const SPLIT_UTF8_TEXT = "Иван/日本語/🧪";
+
+/**
+ * Byte 21 of the 23-byte encoding sits INSIDE the trailing 4-byte emoji (bytes 19-22), so neither
+ * half is valid UTF-8 on its own. Asserted at module load: a payload edit that accidentally moved
+ * this to a character boundary would leave every test below passing against the broken code.
+ */
+const SPLIT_AT = 21;
+
+const encoded = Buffer.from(SPLIT_UTF8_TEXT, "utf8");
+if (encoded.length !== 23 || (encoded[SPLIT_AT] & 0xc0) !== 0x80) {
+  throw new Error(`splitUtf8: byte ${SPLIT_AT} of SPLIT_UTF8_TEXT is not a UTF-8 continuation byte`);
+}
+
+/**
+ * Node source that writes `before + SPLIT_UTF8_TEXT + after` to `stream` in two raw-byte writes,
+ * with a delay between them so they arrive as two separate 'data' events. The split always lands
+ * inside SPLIT_UTF8_TEXT's trailing emoji, wherever `before` puts it.
+ *
+ * `before`/`after` let a caller wrap the payload in whatever shape its reader parses — a JSONL row,
+ * a login banner — so the test asserts on what the code actually does with the output.
+ */
+export function splitUtf8Script(
+  opts: { stream?: "stdout" | "stderr"; before?: string; after?: string } = {},
+): string {
+  const stream = opts.stream ?? "stdout";
+  const before = opts.before ?? "";
+  const after = opts.after ?? "";
+  const splitAt = Buffer.byteLength(before, "utf8") + SPLIT_AT;
+  return [
+    `const b=Buffer.from(${JSON.stringify(before + SPLIT_UTF8_TEXT + after)},"utf8");`,
+    `process.${stream}.write(b.subarray(0,${splitAt}));`,
+    `setTimeout(()=>{process.${stream}.write(b.subarray(${splitAt}));},30);`,
+  ].join("");
+}
+
+/**
+ * Wraps a script as an executable `#!/usr/bin/env node` shim, for the spawn sites whose argv is
+ * fixed by the caller (`velociraptor query …`, `claude auth login`) and so cannot be pointed at
+ * `node -e`. The shim ignores its arguments. POSIX only — the shebang is what makes it executable,
+ * so guard the calling test with `it.skipIf(process.platform === "win32")`.
+ */
+export function writeNodeShim(path: string, script: string): string {
+  writeFileSync(path, `#!/usr/bin/env node\n${script}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+/** Node source that writes `text` in one go — for byte-budget tests that need a known byte count. */
+export function writeOnceScript(text: string, stream: "stdout" | "stderr" = "stdout"): string {
+  return `process.${stream}.write(Buffer.from(${JSON.stringify(text)},"utf8"));`;
+}

--- a/companion/tests/integrations/mcpDelivery.test.ts
+++ b/companion/tests/integrations/mcpDelivery.test.ts
@@ -7,9 +7,11 @@ import {
   rewriteToRemote,
   safeRemoteName,
   shellQuote,
+  spawnTransferRunner,
   type TransferRunner,
   type TransferResult,
 } from "../../src/integrations/mcp/mcpDelivery.js";
+import { SPLIT_UTF8_TEXT, splitUtf8Script } from "../helpers/splitUtf8.js";
 import {
   DEFAULT_DELIVERY,
   type McpServer,
@@ -311,5 +313,21 @@ describe("deliver — scp cleanup", () => {
     const target = await deliver(server(SCP), "/cases/c1/mem.raw", { runner: flaky });
 
     await expect(target.cleanup?.()).resolves.toBeUndefined();
+  });
+});
+
+// A real spawn against `node -e`, so this exercises the actual pipe/collect path rather than the
+// injected runner every test above uses. scp is quiet on success and terse on failure, so stderr is
+// the whole diagnostic an operator gets — and a remote path with a non-ASCII name is exactly what
+// appears in it.
+describe("spawnTransferRunner output decoding", () => {
+  it("reassembles a character split across two stderr chunks", async () => {
+    const r = await spawnTransferRunner()(process.execPath, ["-e", splitUtf8Script({ stream: "stderr" })], { timeoutMs: 10_000 });
+    expect(r.stderr).toBe(SPLIT_UTF8_TEXT);
+  });
+
+  it("reassembles a character split across two stdout chunks", async () => {
+    const r = await spawnTransferRunner()(process.execPath, ["-e", splitUtf8Script()], { timeoutMs: 10_000 });
+    expect(r.stdout).toBe(SPLIT_UTF8_TEXT);
   });
 });

--- a/companion/tests/integrations/mcpDelivery.test.ts
+++ b/companion/tests/integrations/mcpDelivery.test.ts
@@ -322,7 +322,9 @@ describe("deliver — scp cleanup", () => {
 // appears in it.
 describe("spawnTransferRunner output decoding", () => {
   it("reassembles a character split across two stderr chunks", async () => {
-    const r = await spawnTransferRunner()(process.execPath, ["-e", splitUtf8Script({ stream: "stderr" })], { timeoutMs: 10_000 });
+    const r = await spawnTransferRunner()(process.execPath, ["-e", splitUtf8Script({ stream: "stderr" })], {
+      timeoutMs: 10_000,
+    });
     expect(r.stderr).toBe(SPLIT_UTF8_TEXT);
   });
 

--- a/companion/tests/integrations/toolRunner.test.ts
+++ b/companion/tests/integrations/toolRunner.test.ts
@@ -423,13 +423,19 @@ describe("spawnToolRunner output decoding", () => {
   it("counts the cap in bytes, not UTF-16 code units", async () => {
     const text = "日".repeat(40); // 40 code units, 120 bytes
     await expect(
-      spawnToolRunner()(process.execPath, ["-e", writeOnceScript(text)], { timeoutMs: 10_000, maxOutputBytes: 60 }),
+      spawnToolRunner()(process.execPath, ["-e", writeOnceScript(text)], {
+        timeoutMs: 10_000,
+        maxOutputBytes: 60,
+      }),
     ).rejects.toThrow(/exceeded 60 bytes/);
   });
 
   it("lets output through when its byte length is within the cap", async () => {
     const text = "日".repeat(40); // 120 bytes
-    const r = await spawnToolRunner()(process.execPath, ["-e", writeOnceScript(text)], { timeoutMs: 10_000, maxOutputBytes: 200 });
+    const r = await spawnToolRunner()(process.execPath, ["-e", writeOnceScript(text)], {
+      timeoutMs: 10_000,
+      maxOutputBytes: 200,
+    });
     expect(r.stdout).toBe(text);
   });
 });

--- a/companion/tests/integrations/toolRunner.test.ts
+++ b/companion/tests/integrations/toolRunner.test.ts
@@ -8,8 +8,10 @@ import {
   toolSpawnErrorMessage,
   stripAnsi,
   cleanToolOutput,
+  spawnToolRunner,
   type ToolRunner,
 } from "../../src/integrations/tools/toolRunner.js";
+import { SPLIT_UTF8_TEXT, splitUtf8Script, writeOnceScript } from "../helpers/splitUtf8.js";
 import {
   loadToolConfig,
   loadAllToolConfigs,
@@ -396,5 +398,38 @@ describe("SO-CRATES as an http-transport tool", () => {
 
   it("is the suggested tool for a binary nothing else claims", () => {
     expect(suggestedToolForExtension(".exe")).toBe("socrates");
+  });
+});
+
+// Real spawns against `node -e`, so these exercise the actual pipe/collect/cap path rather than an
+// injected runner. Hayabusa and YARA print attacker-controlled filenames and rule names, which are
+// routinely non-ASCII in a real case.
+describe("spawnToolRunner output decoding", () => {
+  const opts = { timeoutMs: 10_000, maxOutputBytes: 1024 * 1024 };
+
+  it("reassembles a character split across two stdout chunks", async () => {
+    const r = await spawnToolRunner()(process.execPath, ["-e", splitUtf8Script()], opts);
+    expect(r.stdout).toBe(SPLIT_UTF8_TEXT);
+  });
+
+  it("reassembles a character split across two stderr chunks", async () => {
+    const r = await spawnToolRunner()(process.execPath, ["-e", splitUtf8Script({ stream: "stderr" })], opts);
+    expect(r.stderr).toBe(SPLIT_UTF8_TEXT);
+  });
+
+  // The budget is named maxOutputBytes and its error says "bytes", but the guard used to compare
+  // the accumulated string's UTF-16 length — so non-ASCII output could buffer up to 3-4x the
+  // configured memory before the child was killed.
+  it("counts the cap in bytes, not UTF-16 code units", async () => {
+    const text = "日".repeat(40); // 40 code units, 120 bytes
+    await expect(
+      spawnToolRunner()(process.execPath, ["-e", writeOnceScript(text)], { timeoutMs: 10_000, maxOutputBytes: 60 }),
+    ).rejects.toThrow(/exceeded 60 bytes/);
+  });
+
+  it("lets output through when its byte length is within the cap", async () => {
+    const text = "日".repeat(40); // 120 bytes
+    const r = await spawnToolRunner()(process.execPath, ["-e", writeOnceScript(text)], { timeoutMs: 10_000, maxOutputBytes: 200 });
+    expect(r.stdout).toBe(text);
   });
 });

--- a/companion/tests/integrations/velociraptor.test.ts
+++ b/companion/tests/integrations/velociraptor.test.ts
@@ -16,10 +16,15 @@ import {
   normalizeHuntExpirySeconds,
   DEFAULT_HUNT_EXPIRY_SECONDS,
   parseArtifactParams,
+  spawnVqlRunner,
   type VeloClientRecord,
   type VelociraptorApiConfig,
   type VqlRunner,
 } from "../../src/integrations/velociraptor/velociraptorApi.js";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SPLIT_UTF8_TEXT, splitUtf8Script, writeNodeShim, writeOnceScript } from "../helpers/splitUtf8.js";
 
 const cfg: VelociraptorApiConfig = {
   apiConfigPath: "/tmp/api.config.yaml",
@@ -1506,5 +1511,41 @@ describe("extractMonitoredArtifacts", () => {
   it("returns [] for empty / junk input", () => {
     expect(extractMonitoredArtifacts([])).toEqual([]);
     expect(extractMonitoredArtifacts([null, 5, { nope: 1 }])).toEqual([]);
+  });
+});
+
+// Real spawns against a shim binary, so these exercise the actual pipe/collect/parse path. The
+// argv is fixed (`--api_config … query --format jsonl …`), which is why this needs an executable
+// shim rather than `node -e`.
+describe.skipIf(process.platform === "win32")("spawnVqlRunner output decoding", () => {
+  const shimDir = mkdtempSync(join(tmpdir(), "velo-shim-"));
+  const runOpts = { timeoutMs: 10_000, maxOutputBytes: 1024 * 1024 };
+
+  // Non-ASCII usernames and paths are routine in real case data. A chunk boundary landing inside
+  // one used to leave U+FFFD in the parsed row — JSON.parse still succeeds, so nothing errors and
+  // the evidence is simply wrong from here on: the wrong username reaches the timeline, IOC
+  // matching on it misses, and dedup treats it as a different entity.
+  it("reassembles a character split across two stdout chunks into the parsed row", async () => {
+    const shim = writeNodeShim(
+      join(shimDir, "velo-split"),
+      splitUtf8Script({ before: '{"Username":"', after: '","Host":"WS-01"}\n' }),
+    );
+    const { rows } = await spawnVqlRunner({ ...cfg, binary: shim })(["SELECT * FROM info()"], runOpts);
+    expect(rows).toEqual([{ Username: SPLIT_UTF8_TEXT, Host: "WS-01" }]);
+  });
+
+  // DFIR_VELOCIRAPTOR_MAX_OUTPUT is documented and reported in bytes, but the guard used to compare
+  // the accumulated string's UTF-16 length — so a query returning CJK could buffer 3x the cap.
+  it("counts maxOutputBytes in bytes, not UTF-16 code units", async () => {
+    const shim = writeNodeShim(join(shimDir, "velo-big"), writeOnceScript("日".repeat(40))); // 120 bytes
+    await expect(
+      spawnVqlRunner({ ...cfg, binary: shim })(["SELECT * FROM info()"], { timeoutMs: 10_000, maxOutputBytes: 60 }),
+    ).rejects.toThrow(/exceeded 60 bytes/);
+  });
+
+  it("lets output through when its byte length is within the cap", async () => {
+    const shim = writeNodeShim(join(shimDir, "velo-ok"), writeOnceScript('{"Path":"日本語"}\n')); // 25 bytes
+    const { rows } = await spawnVqlRunner({ ...cfg, binary: shim })(["SELECT * FROM info()"], { timeoutMs: 10_000, maxOutputBytes: 200 });
+    expect(rows).toEqual([{ Path: "日本語" }]);
   });
 });

--- a/companion/tests/integrations/velociraptor.test.ts
+++ b/companion/tests/integrations/velociraptor.test.ts
@@ -1539,13 +1539,19 @@ describe.skipIf(process.platform === "win32")("spawnVqlRunner output decoding", 
   it("counts maxOutputBytes in bytes, not UTF-16 code units", async () => {
     const shim = writeNodeShim(join(shimDir, "velo-big"), writeOnceScript("日".repeat(40))); // 120 bytes
     await expect(
-      spawnVqlRunner({ ...cfg, binary: shim })(["SELECT * FROM info()"], { timeoutMs: 10_000, maxOutputBytes: 60 }),
+      spawnVqlRunner({ ...cfg, binary: shim })(["SELECT * FROM info()"], {
+        timeoutMs: 10_000,
+        maxOutputBytes: 60,
+      }),
     ).rejects.toThrow(/exceeded 60 bytes/);
   });
 
   it("lets output through when its byte length is within the cap", async () => {
     const shim = writeNodeShim(join(shimDir, "velo-ok"), writeOnceScript('{"Path":"日本語"}\n')); // 25 bytes
-    const { rows } = await spawnVqlRunner({ ...cfg, binary: shim })(["SELECT * FROM info()"], { timeoutMs: 10_000, maxOutputBytes: 200 });
+    const { rows } = await spawnVqlRunner({ ...cfg, binary: shim })(["SELECT * FROM info()"], {
+      timeoutMs: 10_000,
+      maxOutputBytes: 200,
+    });
     expect(rows).toEqual([{ Path: "日本語" }]);
   });
 });

--- a/companion/tests/providers/claudeCodeStatus.test.ts
+++ b/companion/tests/providers/claudeCodeStatus.test.ts
@@ -67,23 +67,32 @@ describe("startClaudeLogin", () => {
   });
 
   // Relies on the OS reading the "#!/bin/sh" shebang to exec the shim, which only POSIX does.
-  it.skipIf(process.platform === "win32")("captures a printed URL and resolves started:true via finish()", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "cc-login-"));
-    const shim = join(dir, "claude");
-    // Ignores its args ("auth login"), prints a URL, exits immediately.
-    writeFileSync(shim, '#!/bin/sh\necho "Visit https://example.com/oauth?code=abc to sign in"\n');
-    chmodSync(shim, 0o755);
-    const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
-    expect(r.started).toBe(true);
-    expect(r.url).toBe("https://example.com/oauth?code=abc");
-  });
+  it.skipIf(process.platform === "win32")(
+    "captures a printed URL and resolves started:true via finish()",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "cc-login-"));
+      const shim = join(dir, "claude");
+      // Ignores its args ("auth login"), prints a URL, exits immediately.
+      writeFileSync(shim, '#!/bin/sh\necho "Visit https://example.com/oauth?code=abc to sign in"\n');
+      chmodSync(shim, 0o755);
+      const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
+      expect(r.started).toBe(true);
+      expect(r.url).toBe("https://example.com/oauth?code=abc");
+    },
+  );
 
   // The captured banner goes straight to the dashboard. A chunk boundary can fall inside a
   // character here just as it can anywhere else — see tests/helpers/splitUtf8.ts.
-  it.skipIf(process.platform === "win32")("reassembles a character split across two output chunks", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "cc-login-utf8-"));
-    const shim = writeNodeShim(join(dir, "claude"), splitUtf8Script({ before: "Signing in as ", after: "\n" }));
-    const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
-    expect(r.output).toBe(`Signing in as ${SPLIT_UTF8_TEXT}\n`);
-  });
+  it.skipIf(process.platform === "win32")(
+    "reassembles a character split across two output chunks",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "cc-login-utf8-"));
+      const shim = writeNodeShim(
+        join(dir, "claude"),
+        splitUtf8Script({ before: "Signing in as ", after: "\n" }),
+      );
+      const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
+      expect(r.output).toBe(`Signing in as ${SPLIT_UTF8_TEXT}\n`);
+    },
+  );
 });

--- a/companion/tests/providers/claudeCodeStatus.test.ts
+++ b/companion/tests/providers/claudeCodeStatus.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getClaudeCodeStatus, startClaudeLogin } from "../../src/providers/claudeCodeStatus.js";
 import type { ClaudeRunOptions, ClaudeRunResult } from "../../src/providers/claudeRunner.js";
+import { SPLIT_UTF8_TEXT, splitUtf8Script, writeNodeShim } from "../helpers/splitUtf8.js";
 
 function runnerReturning(r: Partial<ClaudeRunResult>) {
   return vi.fn(async (_o: ClaudeRunOptions): Promise<ClaudeRunResult> => ({
@@ -66,17 +67,23 @@ describe("startClaudeLogin", () => {
   });
 
   // Relies on the OS reading the "#!/bin/sh" shebang to exec the shim, which only POSIX does.
-  it.skipIf(process.platform === "win32")(
-    "captures a printed URL and resolves started:true via finish()",
-    async () => {
-      const dir = mkdtempSync(join(tmpdir(), "cc-login-"));
-      const shim = join(dir, "claude");
-      // Ignores its args ("auth login"), prints a URL, exits immediately.
-      writeFileSync(shim, '#!/bin/sh\necho "Visit https://example.com/oauth?code=abc to sign in"\n');
-      chmodSync(shim, 0o755);
-      const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
-      expect(r.started).toBe(true);
-      expect(r.url).toBe("https://example.com/oauth?code=abc");
-    },
-  );
+  it.skipIf(process.platform === "win32")("captures a printed URL and resolves started:true via finish()", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cc-login-"));
+    const shim = join(dir, "claude");
+    // Ignores its args ("auth login"), prints a URL, exits immediately.
+    writeFileSync(shim, '#!/bin/sh\necho "Visit https://example.com/oauth?code=abc to sign in"\n');
+    chmodSync(shim, 0o755);
+    const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
+    expect(r.started).toBe(true);
+    expect(r.url).toBe("https://example.com/oauth?code=abc");
+  });
+
+  // The captured banner goes straight to the dashboard. A chunk boundary can fall inside a
+  // character here just as it can anywhere else — see tests/helpers/splitUtf8.ts.
+  it.skipIf(process.platform === "win32")("reassembles a character split across two output chunks", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cc-login-utf8-"));
+    const shim = writeNodeShim(join(dir, "claude"), splitUtf8Script({ before: "Signing in as ", after: "\n" }));
+    const r = await startClaudeLogin({ bin: shim, captureMs: 3000 });
+    expect(r.output).toBe(`Signing in as ${SPLIT_UTF8_TEXT}\n`);
+  });
 });

--- a/companion/tests/providers/claudeRunner.test.ts
+++ b/companion/tests/providers/claudeRunner.test.ts
@@ -139,12 +139,22 @@ describe("defaultClaudeRunner", () => {
   // The model's answer is JSON. One U+FFFD inside it and the whole response fails to parse — see
   // tests/helpers/splitUtf8.ts for why a chunk boundary lands mid-character in the first place.
   it("reassembles a character split across two stdout chunks", async () => {
-    const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", splitUtf8Script()], stdin: "", timeoutMs: 10_000 });
+    const r = await defaultClaudeRunner({
+      bin: process.execPath,
+      args: ["-e", splitUtf8Script()],
+      stdin: "",
+      timeoutMs: 10_000,
+    });
     expect(r.stdout).toBe(SPLIT_UTF8_TEXT);
   });
 
   it("reassembles a character split across two stderr chunks", async () => {
-    const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", splitUtf8Script({ stream: "stderr" })], stdin: "", timeoutMs: 10_000 });
+    const r = await defaultClaudeRunner({
+      bin: process.execPath,
+      args: ["-e", splitUtf8Script({ stream: "stderr" })],
+      stdin: "",
+      timeoutMs: 10_000,
+    });
     expect(r.stderr).toBe(SPLIT_UTF8_TEXT);
   });
 

--- a/companion/tests/providers/claudeRunner.test.ts
+++ b/companion/tests/providers/claudeRunner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { defaultClaudeRunner } from "../../src/providers/claudeRunner.js";
+import { SPLIT_UTF8_TEXT, splitUtf8Script } from "../helpers/splitUtf8.js";
 
 // A tiny node program that echoes its stdin back with a prefix, so we exercise the real
 // spawn + stdin-write + stdout-collect path without depending on the `claude` binary.
@@ -133,5 +134,31 @@ describe("defaultClaudeRunner", () => {
       timeoutMs: 80,
     });
     expect(r.timedOut).toBe(true);
+  });
+
+  // The model's answer is JSON. One U+FFFD inside it and the whole response fails to parse — see
+  // tests/helpers/splitUtf8.ts for why a chunk boundary lands mid-character in the first place.
+  it("reassembles a character split across two stdout chunks", async () => {
+    const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", splitUtf8Script()], stdin: "", timeoutMs: 10_000 });
+    expect(r.stdout).toBe(SPLIT_UTF8_TEXT);
+  });
+
+  it("reassembles a character split across two stderr chunks", async () => {
+    const r = await defaultClaudeRunner({ bin: process.execPath, args: ["-e", splitUtf8Script({ stream: "stderr" })], stdin: "", timeoutMs: 10_000 });
+    expect(r.stderr).toBe(SPLIT_UTF8_TEXT);
+  });
+
+  // The tap feeds the live stream in the UI, so it must be handed decoded text — not the raw
+  // per-chunk decode that the accumulated string is built from.
+  it("hands the stdout tap decoded chunks that rejoin into the original text", async () => {
+    const seen: string[] = [];
+    await defaultClaudeRunner({
+      bin: process.execPath,
+      args: ["-e", splitUtf8Script()],
+      stdin: "",
+      timeoutMs: 10_000,
+      onStdout: (c) => seen.push(c),
+    });
+    expect(seen.join("")).toBe(SPLIT_UTF8_TEXT);
   });
 });

--- a/companion/tests/providers/codexRunner.test.ts
+++ b/companion/tests/providers/codexRunner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { defaultCodexRunner } from "../../src/providers/codexRunner.js";
+import { SPLIT_UTF8_TEXT, splitUtf8Script } from "../helpers/splitUtf8.js";
 
 // codex's stdin is intentionally ignored (deadlock avoidance), so the child gets its input from
 // argv. These tests spawn a real `node` subprocess to exercise the actual spawn/collect/kill path
@@ -77,5 +78,17 @@ describe("defaultCodexRunner", () => {
       timeoutMs: 80,
     });
     expect(r.timedOut).toBe(true);
+  });
+
+  // `codex exec --json` emits JSON, so a U+FFFD from a mis-decoded chunk boundary costs the whole
+  // response. See tests/helpers/splitUtf8.ts.
+  it("reassembles a character split across two stdout chunks", async () => {
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", splitUtf8Script()], stdin: "", timeoutMs: 10_000 });
+    expect(r.stdout).toBe(SPLIT_UTF8_TEXT);
+  });
+
+  it("reassembles a character split across two stderr chunks", async () => {
+    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", splitUtf8Script({ stream: "stderr" })], stdin: "", timeoutMs: 10_000 });
+    expect(r.stderr).toBe(SPLIT_UTF8_TEXT);
   });
 });

--- a/companion/tests/providers/codexRunner.test.ts
+++ b/companion/tests/providers/codexRunner.test.ts
@@ -83,12 +83,22 @@ describe("defaultCodexRunner", () => {
   // `codex exec --json` emits JSON, so a U+FFFD from a mis-decoded chunk boundary costs the whole
   // response. See tests/helpers/splitUtf8.ts.
   it("reassembles a character split across two stdout chunks", async () => {
-    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", splitUtf8Script()], stdin: "", timeoutMs: 10_000 });
+    const r = await defaultCodexRunner({
+      bin: process.execPath,
+      args: ["-e", splitUtf8Script()],
+      stdin: "",
+      timeoutMs: 10_000,
+    });
     expect(r.stdout).toBe(SPLIT_UTF8_TEXT);
   });
 
   it("reassembles a character split across two stderr chunks", async () => {
-    const r = await defaultCodexRunner({ bin: process.execPath, args: ["-e", splitUtf8Script({ stream: "stderr" })], stdin: "", timeoutMs: 10_000 });
+    const r = await defaultCodexRunner({
+      bin: process.execPath,
+      args: ["-e", splitUtf8Script({ stream: "stderr" })],
+      stdin: "",
+      timeoutMs: 10_000,
+    });
     expect(r.stderr).toBe(SPLIT_UTF8_TEXT);
   });
 });

--- a/companion/tests/providers/codexStatus.test.ts
+++ b/companion/tests/providers/codexStatus.test.ts
@@ -70,10 +70,16 @@ describe("startCodexLogin", () => {
 
   // The captured banner goes straight to the dashboard. Relies on the OS reading the shebang to
   // exec the shim, which only POSIX does.
-  it.skipIf(process.platform === "win32")("reassembles a character split across two output chunks", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "codex-login-utf8-"));
-    const shim = writeNodeShim(join(dir, "codex"), splitUtf8Script({ before: "Signing in as ", after: "\n" }));
-    const r = await startCodexLogin({ bin: shim, captureMs: 3000 });
-    expect(r.output).toBe(`Signing in as ${SPLIT_UTF8_TEXT}\n`);
-  });
+  it.skipIf(process.platform === "win32")(
+    "reassembles a character split across two output chunks",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "codex-login-utf8-"));
+      const shim = writeNodeShim(
+        join(dir, "codex"),
+        splitUtf8Script({ before: "Signing in as ", after: "\n" }),
+      );
+      const r = await startCodexLogin({ bin: shim, captureMs: 3000 });
+      expect(r.output).toBe(`Signing in as ${SPLIT_UTF8_TEXT}\n`);
+    },
+  );
 });

--- a/companion/tests/providers/codexStatus.test.ts
+++ b/companion/tests/providers/codexStatus.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { getCodexStatus, startCodexLogin } from "../../src/providers/codexStatus.js";
 import type { CodexRunOptions, CodexRunResult } from "../../src/providers/codexRunner.js";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SPLIT_UTF8_TEXT, splitUtf8Script, writeNodeShim } from "../helpers/splitUtf8.js";
 
 function runnerReturning(r: Partial<CodexRunResult>) {
   return vi.fn(async (_o: CodexRunOptions): Promise<CodexRunResult> => ({
@@ -62,5 +66,14 @@ describe("startCodexLogin", () => {
     const r = await startCodexLogin({ bin: "definitely-not-a-real-binary-xyz", captureMs: 500 });
     expect(r.started).toBe(false);
     expect(r.error).toBeTruthy();
+  });
+
+  // The captured banner goes straight to the dashboard. Relies on the OS reading the shebang to
+  // exec the shim, which only POSIX does.
+  it.skipIf(process.platform === "win32")("reassembles a character split across two output chunks", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "codex-login-utf8-"));
+    const shim = writeNodeShim(join(dir, "codex"), splitUtf8Script({ before: "Signing in as ", after: "\n" }));
+    const r = await startCodexLogin({ bin: shim, captureMs: 3000 });
+    expect(r.output).toBe(`Signing in as ${SPLIT_UTF8_TEXT}\n`);
   });
 });


### PR DESCRIPTION
## Summary
- `text += chunk.toString()` decodes each stdout/stderr chunk independently, so a multi-byte UTF-8 character split across a chunk boundary becomes two U+FFFD halves instead of the original character
- In evidence output (Velociraptor JSONL rows, CLI auth banners) that silently corrupts non-ASCII usernames/paths, or breaks `JSON.parse` and drops the row entirely
- New `companion/src/integrations/childOutput.ts` wraps `stream.setEncoding("utf8")` as `collectText`/`collectCapped` (byte-budget variant, counted via `Buffer.byteLength` since `.length` undercounts non-ASCII by 2-4x); every spawn site (mcpDelivery, toolRunner, velociraptorApi, and the Claude/Codex provider runners+status) now goes through it instead of the broken per-chunk pattern

## Test plan
- [ ] `companion/tests/helpers/splitUtf8.ts` adds a reproducible two-write UTF-8 split (Cyrillic/CJK/emoji) and drives new coverage in each touched test file
- [ ] `npm run typecheck` / `npm test` in `companion/`
- [ ] Note: this branch is based on an older commit and is behind current master — expect it to need a rebase before merge