### PR TITLE
fix(synthesis): run one re-synthesis per import, not one per file

### DIFF
--- a/companion/src/composition/captureAnalysis.ts
+++ b/companion/src/composition/captureAnalysis.ts
@@ -49,7 +49,11 @@ export interface CaptureAnalysis {
   backfill(caseId: string): Promise<void>;
   /** Debounced auto-synthesis after captures/imports land. No-op unless autoSynthesize is on. */
   scheduleSynthesis(caseId: string): void;
-  /** Immediate background re-synthesis after an import or a false-positive change. */
+  /**
+   * Immediate background re-synthesis after an import or a false-positive change. Self-coalescing:
+   * a newer kick supersedes an older one for the same case, so N rapid changes (a multi-file
+   * import, a batch false-positive) cost one synthesis, not N.
+   */
   resynthesizeInBackground(caseId: string): void;
 }
 
@@ -273,20 +277,31 @@ export function createCaptureAnalysis(deps: CaptureAnalysisDeps): CaptureAnalysi
         return;
       }
       // #225: track synthesis as a cancellable job so the dashboard can list it + abort a long/stuck run.
+      // exclusive, like the two sibling synthesis registrations: EVERY caller of this function is a
+      // "the case changed, re-derive it" kick, and synthesize() reads the case fresh, so the newest
+      // kick subsumes every older one — running them in series would spend N LLM calls to reach the
+      // answer the last one produces on its own. That matters most for a multi-file import, where
+      // the dashboard POSTs each file separately and each completed import kicks again: without
+      // exclusive, a six-file import stacked six full re-syntheses behind the case's single
+      // concurrency slot instead of running one after the last file landed.
       const job = options.jobManager?.register({
         caseId,
         kind: "synthesis",
         label: "re-synthesis",
         cancellable: true,
-      });
-      if (job) await job.ready;
-      options.onAiStatus?.(caseId, {
-        status: "analyzing",
-        phase: "synthesizing",
-        at: new Date().toISOString(),
-        detail: "re-synthesizing without legitimate items",
+        exclusive: true,
       });
       try {
+        // Inside the try: superseding a still-QUEUED run rejects its admission (never resolving it),
+        // and this function is fired-and-forgotten, so a rejection escaping here is an unhandled
+        // one rather than a cancellation the catch below can report.
+        if (job) await job.ready;
+        options.onAiStatus?.(caseId, {
+          status: "analyzing",
+          phase: "synthesizing",
+          at: new Date().toISOString(),
+          detail: "re-synthesizing without legitimate items",
+        });
         await pipeline.synthesize(caseId, job?.signal ? { signal: job.signal } : {});
         if (job) await options.jobManager?.finish(job.jobId);
         options.onAiStatus?.(caseId, { status: "idle", at: new Date().toISOString() });
@@ -294,12 +309,16 @@ export function createCaptureAnalysis(deps: CaptureAnalysisDeps): CaptureAnalysi
       } catch (err) {
         const aborted = job?.signal?.aborted === true;
         if (job) await options.jobManager?.fail(job.jobId, err); // no-op if the job was already cancelled
-        options.onAiStatus?.(
-          caseId,
-          aborted
-            ? { status: "idle", at: new Date().toISOString(), detail: "synthesis cancelled" }
-            : { status: "error", at: new Date().toISOString(), detail: (err as Error).message },
-        );
+        // A newer exclusive registration may have superseded this run — if a synthesis job for this
+        // case is still active, that newer run owns the status; don't stomp it to idle.
+        if (!(aborted && options.jobManager?.hasActive(caseId, "synthesis"))) {
+          options.onAiStatus?.(
+            caseId,
+            aborted
+              ? { status: "idle", at: new Date().toISOString(), detail: "synthesis cancelled" }
+              : { status: "error", at: new Date().toISOString(), detail: (err as Error).message },
+          );
+        }
       }
     })();
   }

--- a/companion/tests/composition/resynthesisCoalescing.test.ts
+++ b/companion/tests/composition/resynthesisCoalescing.test.ts
@@ -1,0 +1,120 @@
+// A multi-file import must produce ONE synthesis run, not one per file.
+//
+// The dashboard's import picker takes multiple files and POSTs them one at a time
+// (public/js/dashboard-unified-import.js), and every completed import fires
+// resynthesizeInBackground(). With perCaseConcurrency = 1 those kicks cannot run concurrently, so
+// without supersede semantics they stack up in the queue — the reported bug was six "synthesis is
+// queued / re-synthesis" cards in the cockpit for one six-file import, each of which would have run
+// a full LLM synthesis of the same case.
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { JobManager } from "../../src/analysis/jobManager.js";
+import { createCaptureAnalysis } from "../../src/composition/captureAnalysis.js";
+import type { AppOptions } from "../../src/composition/appOptions.js";
+import type { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import type { AiControl } from "../../src/analysis/aiControl.js";
+
+const CASE_ID = "case-multi-import";
+
+async function harness() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-resynth-"));
+  const store = new CaseStore(root);
+  // perCaseConcurrency: 1 without a ledger — the production default when the durable ledger is
+  // wired (jobManager.ts), and what makes the kicks queue instead of running side by side.
+  const jobManager = new JobManager({ perCaseConcurrency: 1 });
+
+  const synthesized: string[] = [];
+  let releaseSynthesis: () => void = () => {};
+  const pipeline = {
+    hasSynthesisProvider: () => true,
+    synthesize: (caseId: string) => {
+      synthesized.push(caseId);
+      return new Promise((resolve) => {
+        releaseSynthesis = () => resolve({});
+      });
+    },
+  } as unknown as AnalysisPipeline;
+
+  const statuses: { status: string; detail?: string }[] = [];
+  const options = {
+    pipeline,
+    jobManager,
+    onAiStatus: (_caseId: string, s: { status: string; detail?: string }) => statuses.push(s),
+  } as unknown as AppOptions;
+
+  const analysis = createCaptureAnalysis({
+    store,
+    options,
+    hasAiProvider: () => true,
+    getControl: async () => ({ enabled: true }) as AiControl,
+    setControl: async () => ({ enabled: true }) as AiControl,
+    recordAiError: () => {},
+    autoEnrichIfEnabled: () => {},
+  });
+
+  return {
+    analysis,
+    jobManager,
+    synthesized,
+    statuses,
+    releaseSynthesis: () => releaseSynthesis(),
+  };
+}
+
+/** Let every queued `void (async () => …)()` kick reach its job registration. */
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
+};
+
+const liveSynthesisJobs = (jm: JobManager) =>
+  jm.list(CASE_ID).filter((j) => j.kind === "synthesis" && j.status !== "cancelled");
+
+describe("re-synthesis after a multi-file import", () => {
+  it("collapses one kick per imported file into a single surviving synthesis job", async () => {
+    const { analysis, jobManager, synthesized, releaseSynthesis } = await harness();
+
+    // Occupy the case's single concurrency slot the way an in-flight import does, so the kicks
+    // queue behind it exactly as they did in the bug report.
+    const importJob = jobManager.register({ caseId: CASE_ID, kind: "import", label: "evtx" });
+    await importJob.ready;
+
+    // Six files in one import → six kicks.
+    for (let i = 0; i < 6; i++) analysis.resynthesizeInBackground(CASE_ID);
+    await settle();
+
+    const live = liveSynthesisJobs(jobManager);
+    expect(live).toHaveLength(1);
+    expect(live[0].status).toBe("queued");
+    expect(synthesized).toEqual([]); // nothing runs while the import still holds the slot
+
+    // Import finishes → the one surviving kick is admitted and runs once.
+    await jobManager.finish(importJob.jobId);
+    await settle();
+    expect(synthesized).toEqual([CASE_ID]);
+
+    releaseSynthesis();
+    await settle();
+  });
+
+  it("does not report 'synthesis cancelled' while a newer kick still owns the case", async () => {
+    const { analysis, jobManager, statuses, releaseSynthesis } = await harness();
+
+    const importJob = jobManager.register({ caseId: CASE_ID, kind: "import", label: "evtx" });
+    await importJob.ready;
+    for (let i = 0; i < 6; i++) analysis.resynthesizeInBackground(CASE_ID);
+    await settle();
+
+    // A superseded kick must stay silent: the newer run owns the AI status banner, and stomping it
+    // to idle leaves the dashboard claiming the case is idle while synthesis is still pending.
+    expect(statuses.map((s) => s.detail)).not.toContain("synthesis cancelled");
+    expect(statuses.filter((s) => s.status === "idle")).toEqual([]);
+
+    await jobManager.finish(importJob.jobId);
+    await settle();
+    releaseSynthesis();
+    await settle();
+  });
+});


### PR DESCRIPTION
## The bug

Selecting several files in the import picker queued one full AI re-synthesis **per file**. A six-file import produced six stacked `synthesis is queued / re-synthesis` cards in the cockpit, each waiting to run a complete synthesis over the same case.

## Root cause

The picker POSTs each selected file separately (`public/js/dashboard-unified-import.js`), and every completed import fires `resynthesizeInBackground()`.

That function was **the only one of the three synthesis registrations that omitted `exclusive: true`** — `scheduleSynthesis()` and the manual re-synthesize in `routes/aiSynthesis.ts` both set it. Without the flag the kicks did not supersede one another, and since a case runs one job at a time (`perCaseConcurrency` defaults to 1 when the durable ledger is wired) they simply stacked in the queue.

## The fix

Register exclusively, so the newest kick subsumes the older ones. `synthesize()` reads the case fresh, so the surviving run — kicked by the last file to land — reaches the same answer the six would have converged on, for one LLM call instead of six. Superseded jobs become `cancelled`, which the cockpit's activity section does not list, so the duplicate cards go with them.

Two consequences of the flag are handled in the same change:

- **`await job.ready` moves inside the `try`.** Superseding a still-*queued* run rejects its admission rather than resolving it. This function is fire-and-forget, so that rejection escaped as an unhandled rejection instead of the cancellation the `catch` reports.
- **The abort branch gains the `hasActive(caseId, "synthesis")` guard** its two siblings already carry. Without it, a superseded run stomps the AI status to idle `"synthesis cancelled"` while the newer run is still synthesizing.

## Scope beyond the reported symptom

The same pile-up affected every path that kicks repeatedly for one logical change — batch false-positive marking, threat-intel imports, and Velociraptor multi-artifact ingest. All are fixed by the same flag.

## Verification

- New test `companion/tests/composition/resynthesisCoalescing.test.ts` reproduces the reported scenario (six kicks behind an in-flight import, `perCaseConcurrency: 1`). It fails on the parent commit with `expected 1, got 6` and passes here. A second case pins the status-banner guard.
- Full suite: **9340 passed**. One unrelated failure, `tests/http/loginRateLimit.test.ts`, timed out under full-suite CPU contention; it passes in isolation in ~4s against a 15s budget.
- `npm run typecheck`, `eslint`, and `prettier --check` clean on the changed files.

