### PR TITLE
feat(notifications): let a Telegram channel borrow the war-room bot's token and chat

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,7 +200,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,726 of the 1,765 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,727 of the 1,766 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,7 @@ to a channel and paste its URL (the Companion sends a MessageCard). **SMTP email
 optional username+password, and from/to; opportunistic STARTTLS + AUTH LOGIN are used when offered. For a quick
 local test, point it at [Mailpit](https://github.com/axllent/mailpit) (`docker run -p 1025:1025 -p 8025:8025 axllent/mailpit`).
 
-**Telegram** — uses a Bot API token + a chat/channel/group ID (no env vars needed):
+**Telegram** — uses a Bot API token + a chat/channel/group ID:
 
 1. Open a chat with [@BotFather](https://t.me/BotFather), run `/newbot`, and copy the token (`123456789:AAF…`).
 2. Get your chat ID:
@@ -1130,7 +1130,13 @@ local test, point it at [Mailpit](https://github.com/axllent/mailpit) (`docker r
    - *Private channel* — add the bot as an **administrator**; forward a post to `@getidsbot` to get the numeric ID (usually `-100…`).
 3. In the Companion: **Settings → Notifications → Add a channel → Telegram bot**, paste the token and chat ID, then click **Test**.
 
-The token is stored in `notifications/config.json` (beside `cases/`) and is **never echoed back to the browser**.
+**Already running the [war-room bot](#war-room-slash-command-bot-optional)?** Leave the token blank and fill in only
+the chat ID — the channel reuses `DFIR_TELEGRAM_BOT_TOKEN` from `.env`, and the field shows *(already set)*. The token
+stays in `.env` alone, so rotating it there rotates this channel too. Type a token here only to send through a
+*different* bot; it then overrides the env one for this channel.
+
+A token typed here is stored in `notifications/config.json` (beside `cases/`) and is **never echoed back to the
+browser** — the dashboard only learns whether one is set, and whether it came from `.env`.
 
 | Variable | Default | Meaning |
 |---|---|---|

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -695,6 +695,11 @@ DFIR_SYNTH_ADVERSARY_HINTS=off
 # second poller for the same bot. Clear an old webhook with .../deleteWebhook before polling.
 # DFIR_TELEGRAM_ACTION_USERS=      # comma-separated numeric Telegram user ids
 # DFIR_TELEGRAM_API_BASE=          # override the Bot API base (default https://api.telegram.org)
+#
+# DFIR_TELEGRAM_BOT_TOKEN also carries OUTBOUND alerts: a notification channel (Settings →
+# Notifications → Telegram bot) saved with a blank bot token borrows this one at send time, so the
+# same bot pushes findings out and takes commands back in. Fill in only the chat ID there. The token
+# is never copied into notifications/config.json — rotate it here and the channel follows.
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/companion/src/analysis/notifications.ts
+++ b/companion/src/analysis/notifications.ts
@@ -88,9 +88,30 @@ export interface NotificationEvent {
 }
 
 // Telegram bot config. botToken is stored but never echoed back to the browser (the route redacts it).
+// It may be EMPTY: an operator who already set the war-room bot's DFIR_TELEGRAM_BOT_TOKEN in .env
+// does not type it again here, and the sender resolves it at send time (resolveTelegramBotToken).
 export interface TelegramChannelConfig {
-  botToken: string; // secret — never echoed to the browser
+  botToken: string; // secret — never echoed to the browser. Empty = use the env token.
   chatId: string; // chat/channel/group ID (e.g., "@channelname" or "-1001234567890")
+}
+
+// The war-room bot's token, passed in by whichever caller sits at the env boundary (the route, the
+// notifier). This module reads NO env of its own — that is what keeps it pure and its tests
+// order-independent.
+export interface TelegramEnvOpts {
+  envTelegramBotToken?: string;
+}
+
+/**
+ * Which bot token actually sends for this channel: the channel's own if it has one, else the
+ * war-room bot's env token. Resolved at SEND time rather than copied into the store at save time,
+ * so .env stays the single source of truth and rotating it rotates the channel too.
+ */
+export function resolveTelegramBotToken(
+  channel: Pick<NotificationChannel, "telegram">,
+  envBotToken?: string,
+): string {
+  return (channel.telegram?.botToken ?? "").trim() || (envBotToken ?? "").trim();
 }
 
 // SMTP transport config for an email channel. Secrets (password) are stored but never echoed back
@@ -337,8 +358,14 @@ const defaultEvents = (): Record<NotificationEventKind, boolean> => ({
 // a (http/https) URL; email requires host/port/from/to. On an UPDATE the UI never re-sends the
 // redacted secret (webhook URL / SMTP password), so pass the `existing` channel: a blank webhook
 // URL then falls back to the saved one for validation (the same redacted-round-trip the env
-// password fields use). Returns a structured error instead of throwing so the route can answer 400.
-export function parseChannelInput(raw: unknown, existing?: NotificationChannel): ParsedChannelInput {
+// password fields use). `opts.envTelegramBotToken` lets a telegram channel leave its token blank
+// when the war-room bot already has one in .env. Returns a structured error instead of throwing so
+// the route can answer 400.
+export function parseChannelInput(
+  raw: unknown,
+  existing?: NotificationChannel,
+  opts?: TelegramEnvOpts,
+): ParsedChannelInput {
   const parsed = channelInputSchema.safeParse(raw);
   if (!parsed.success) {
     return {
@@ -369,7 +396,19 @@ export function parseChannelInput(raw: unknown, existing?: NotificationChannel):
     // Blank token on update → keep the saved one (same redacted-round-trip pattern as webhookUrl).
     const sameTypeExisting = existing?.type === "telegram" ? existing.telegram : undefined;
     const token = (v.telegram?.botToken ?? "").trim() || (sameTypeExisting?.botToken ?? "");
-    if (!token) return { ok: false, error: "telegram channel requires a bot token" };
+    // Nothing typed and nothing saved is still fine when the war-room bot has a token in .env. The
+    // draft keeps an EMPTY token in that case — deliberately NOT a copy of the env value, so .env
+    // remains the only place it lives and a rotation there takes effect without re-saving here.
+    //
+    // The token is required to CREATE the channel, never to keep editing one. An env-backed channel
+    // stores an empty token, so if DFIR_TELEGRAM_BOT_TOKEN later goes away, demanding one here would
+    // 400 every subsequent edit — including the dashboard's enable/disable toggle, which PUTs a
+    // blank token and ignores a non-2xx. The channel would read "off" in the browser while staying
+    // ON in the store, and would resume sending the moment the token came back. A tokenless channel
+    // simply cannot send (the dispatcher says so, and the list shows it in red), which is the honest
+    // state to leave it in — being unable to turn it off is not.
+    if (!token && !(opts?.envTelegramBotToken ?? "").trim() && !sameTypeExisting)
+      return { ok: false, error: "telegram channel requires a bot token" };
     const chatId = (v.telegram?.chatId ?? "").trim();
     if (!chatId) return { ok: false, error: "telegram channel requires a chat ID" };
     draft.telegram = { botToken: token, chatId };
@@ -449,10 +488,13 @@ export function applyChannelPatch(
 export interface RedactedChannel extends Omit<NotificationChannel, "webhookUrl" | "smtp" | "telegram"> {
   hasWebhookUrl: boolean;
   smtp?: Omit<SmtpChannelConfig, "password"> & { hasPassword: boolean };
-  telegram?: { chatId: string; hasBotToken: boolean };
+  // hasBotToken answers "will this channel be able to send" — true whether the token is the
+  // channel's own or the war-room bot's. usesEnvBotToken says WHICH, so the UI can name the source
+  // instead of implying the analyst typed one here.
+  telegram?: { chatId: string; hasBotToken: boolean; usesEnvBotToken: boolean };
 }
 
-export function redactChannel(channel: NotificationChannel): RedactedChannel {
+export function redactChannel(channel: NotificationChannel, opts?: TelegramEnvOpts): RedactedChannel {
   const { webhookUrl, smtp, telegram, ...rest } = channel;
   const out: RedactedChannel = { ...rest, hasWebhookUrl: Boolean(webhookUrl) };
   if (smtp) {
@@ -460,7 +502,13 @@ export function redactChannel(channel: NotificationChannel): RedactedChannel {
     out.smtp = { ...smtpRest, hasPassword: Boolean(password) };
   }
   if (telegram) {
-    out.telegram = { chatId: telegram.chatId, hasBotToken: Boolean(telegram.botToken) };
+    const own = Boolean(telegram.botToken?.trim());
+    const fromEnv = !own && Boolean((opts?.envTelegramBotToken ?? "").trim());
+    out.telegram = {
+      chatId: telegram.chatId,
+      hasBotToken: own || fromEnv,
+      usesEnvBotToken: fromEnv,
+    };
   }
   return out;
 }

--- a/companion/src/analysis/slashCommandStore.ts
+++ b/companion/src/analysis/slashCommandStore.ts
@@ -72,3 +72,24 @@ export type ChatPlatform = "slack" | "teams" | "telegram";
 export function bindingKey(platform: ChatPlatform, channelId: string): string {
   return `${platform}:${channelId}`;
 }
+
+/**
+ * The Telegram chats the bot has been bound to, for the notification channel form to OFFER as
+ * destinations (#58 follow-up). The operator already told the bot about these with `/dfir bind`,
+ * so the Chat ID box can pre-fill instead of sending them to read a JSON file.
+ *
+ * Offer, never auto-send: a notification carries case content, so the chosen chat is pre-filled
+ * into a visible field and still has to be saved — this returns candidates, not a default target.
+ * Keys are `<platform>:<channelId>`, and a channel id may itself contain ":" (`@name` handles do
+ * not, but nothing guarantees that), so the prefix is sliced off rather than split on.
+ */
+export function telegramChatsFromBindings(
+  map: ChannelBindingMap,
+): Array<{ chatId: string; caseId: string; boundAt: string }> {
+  const prefix = "telegram:";
+  return Object.entries(map)
+    .filter(([key]) => key.startsWith(prefix))
+    .map(([key, b]) => ({ chatId: key.slice(prefix.length), caseId: b.caseId, boundAt: b.boundAt }))
+    .filter((c) => c.chatId !== "")
+    .sort((a, b) => a.chatId.localeCompare(b.chatId));
+}

--- a/companion/src/composition/runtimeStores.ts
+++ b/companion/src/composition/runtimeStores.ts
@@ -237,6 +237,11 @@ export function createRuntimeStores({ casesRoot, host, port, logDir }: RuntimeSt
     store: notificationStore,
     fetchFn: tlsFetchFor("NOTIFY") ?? fetch,
     smtpConnect: nodeSmtpConnect,
+    // Telegram channels with no token of their own borrow the war-room bot's, and every telegram
+    // channel reaches Telegram the way the war-room bot does. Thunks, so both are read per send
+    // rather than frozen here at startup.
+    telegramBotToken: () => process.env.DFIR_TELEGRAM_BOT_TOKEN,
+    telegramApiBase: () => process.env.DFIR_TELEGRAM_API_BASE,
     log: (m) => logLine(m),
   });
   // Deep-link notifications back to the dashboard. Override the host/port guess with DFIR_PUBLIC_URL.

--- a/companion/src/integrations/notify/notifyDispatch.ts
+++ b/companion/src/integrations/notify/notifyDispatch.ts
@@ -1,5 +1,6 @@
 import type { FetchFn } from "../../enrichment/provider.js";
 import {
+  resolveTelegramBotToken,
   shouldNotify,
   testEvent,
   type NotificationChannel,
@@ -34,6 +35,14 @@ const WEBHOOK_FORMATTERS: Partial<Record<NotificationChannelType, (e: Notificati
 export interface NotifyTransport {
   fetchFn: FetchFn;
   smtpConnect?: SmtpConnect; // absent → email channels are skipped with a clear reason
+  // The war-room bot's DFIR_TELEGRAM_BOT_TOKEN, injected rather than read here so this module stays
+  // env-free. Used by telegram channels that carry no token of their own.
+  telegramBotToken?: string;
+  // DFIR_TELEGRAM_API_BASE — a self-hosted Bot API or an egress proxy. Applies to EVERY telegram
+  // channel, not just token-borrowing ones: it says how to reach Telegram from this box, which is a
+  // property of the network rather than of the bot. Posting to api.telegram.org anyway would fail
+  // on a closed network, or slip past the proxy the operator put there on purpose.
+  telegramApiBase?: string;
   timeoutMs?: number;
   now?: () => string;
 }
@@ -77,8 +86,15 @@ async function sendToChannel(
       return { ...base, ok: r.ok, ...(r.error ? { error: r.error } : {}) };
     }
     if (channel.type === "telegram") {
-      if (!channel.telegram?.botToken) return { ...base, ok: false, error: "no bot token configured" };
-      const url = `https://api.telegram.org/bot${channel.telegram.botToken}/sendMessage`;
+      const botToken = resolveTelegramBotToken(channel, transport.telegramBotToken);
+      if (!botToken) return { ...base, ok: false, error: "no bot token configured" };
+      // The token can now come from the env, so the channel's own transport block is no longer
+      // implicitly proven to exist by having one — check the chat ID on its own.
+      if (!channel.telegram?.chatId) return { ...base, ok: false, error: "no chat ID configured" };
+      // Same default + trailing-slash trim as the war-room poller and slash-command result sender,
+      // so one bot is addressed one way everywhere.
+      const apiBase = (transport.telegramApiBase ?? "").trim() || "https://api.telegram.org";
+      const url = `${apiBase.replace(/\/+$/, "")}/bot${botToken}/sendMessage`;
       const payload = { chat_id: channel.telegram.chatId, ...formatTelegram(event) };
       const r = await postWebhook(transport.fetchFn, url, payload, transport.timeoutMs);
       return { ...base, ok: r.ok, ...(r.error ? { error: r.error } : {}) };
@@ -109,6 +125,12 @@ export interface NotifierDeps {
   store?: NotificationConfigStore; // absent → notifier is a no-op (notifications not configured)
   fetchFn: FetchFn;
   smtpConnect?: SmtpConnect;
+  // THUNKS, not values: the notifier is built once at startup, so capturing these would pin them to
+  // boot-time values. The token is on the /settings/reload allowlist and therefore rotates without a
+  // restart; the API base is not, and still needs one — a thunk simply costs nothing and keeps the
+  // two read the same way.
+  telegramBotToken?: () => string | undefined;
+  telegramApiBase?: () => string | undefined;
   timeoutMs?: number;
   log?: (message: string) => void;
 }
@@ -122,11 +144,14 @@ export interface Notifier {
 }
 
 export function createNotifier(deps: NotifierDeps): Notifier {
-  const transport: NotifyTransport = {
+  // Rebuilt per send so the telegram thunks are re-read rather than captured at startup.
+  const transportNow = (): NotifyTransport => ({
     fetchFn: deps.fetchFn,
     smtpConnect: deps.smtpConnect,
+    telegramBotToken: deps.telegramBotToken?.(),
+    telegramApiBase: deps.telegramApiBase?.(),
     timeoutMs: deps.timeoutMs,
-  };
+  });
 
   async function dispatch(event: NotificationEvent): Promise<ChannelResult[]> {
     if (!deps.store) return [];
@@ -138,7 +163,7 @@ export function createNotifier(deps: NotifierDeps): Notifier {
       return [];
     }
     if (!channels.length) return [];
-    const results = await dispatchEvent(channels, event, transport);
+    const results = await dispatchEvent(channels, event, transportNow());
     if (results.length) {
       const sent = results.filter((r) => r.ok).length;
       const failed = results.filter((r) => !r.ok);
@@ -157,6 +182,7 @@ export function createNotifier(deps: NotifierDeps): Notifier {
     const event = testEvent(at);
     // A test bypasses enable/threshold/kind filters so the analyst can verify a disabled or
     // high-threshold channel directly.
+    const transport = transportNow();
     const results = await Promise.all(channels.map((c) => sendToChannel(c, event, transport)));
     deps.log?.(`[notify] test → ${results.filter((r) => r.ok).length}/${results.length} channel(s) ok`);
     return results;

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -31,6 +31,7 @@ import {
   updateEnv as updateEnvFile,
   reloadEnvPrefix,
   validateEnvUpdates,
+  RELOADABLE_ENV_PREFIXES,
 } from "../settings/envManager.js";
 import { readPublicAsset } from "../serverAssets.js";
 import { isTerminal, type Job } from "../analysis/jobRegistry.js";
@@ -65,7 +66,8 @@ import type { RouteContext } from "./context.js";
  *     standard JSON 500 instead of Express's default HTML page — the only observable delta.)
  *
  * Module-private helpers moved verbatim (used only by routes here): removeCaseFromActiveListBestEffort,
- * deleteCaseFolderBestEffort (case archive/delete plumbing) and the RELOADABLE_PREFIXES allowlist.
+ * deleteCaseFolderBestEffort (case archive/delete plumbing). The /settings/reload allowlist now
+ * lives in settings/envManager.ts as RELOADABLE_ENV_PREFIXES, beside its writable twin.
  * logLine/errLine mirror createApp's (serverLogger.info/error) so the moved call sites stay verbatim.
  *
  * Shared surface — reuses stable ctx fields (store, options, serverLogger, hasAiProvider), stable helpers
@@ -796,37 +798,13 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
   // "✓ Saved & configured" (that check reads process.env) while the running server ignored the change.
   // `rebuilt` names the components actually swapped; it is empty for a prefix with nothing to rebuild
   // (DFIR_TOOL_ and friends — see rebuildForPrefix in server.ts for why each is excluded).
-  const RELOADABLE_PREFIXES = new Set([
-    "DFIR_VISION_",
-    "DFIR_AI_",
-    "DFIR_IRIS_",
-    "DFIR_VELOCIRAPTOR_",
-    "DFIR_TIMESKETCH_",
-    "DFIR_NOTION_",
-    "DFIR_CLICKUP_",
-    "DFIR_VT_",
-    "DFIR_ABUSEIPDB_",
-    "DFIR_HUNTINGCH_",
-    "DFIR_MB_",
-    "DFIR_CROWDSTRIKE_",
-    "DFIR_SHODAN_",
-    "DFIR_MISP_",
-    "DFIR_YETI_",
-    "DFIR_OPENCTI_",
-    "DFIR_ROCKYRACCOON_",
-    "DFIR_GEOIP_",
-    "DFIR_LEAKCHECK_",
-    "DFIR_HIBP_",
-    "DFIR_DEHASHED_",
-    "DFIR_PUSH_TOKEN",
-    "DFIR_NSRL_",
-    "DFIR_TOOL_",
-  ]);
+  // The allowlist itself lives in settings/envManager.ts, beside the WRITABLE one it has always been
+  // described as mirroring.
   app.post("/settings/reload", async (req: Request, res: Response) => {
     try {
       const prefix = typeof req.body?.prefix === "string" ? req.body.prefix.trim() : "";
       if (!prefix) return res.status(400).json({ error: "prefix is required" });
-      if (!RELOADABLE_PREFIXES.has(prefix)) {
+      if (!RELOADABLE_ENV_PREFIXES.has(prefix)) {
         return res.status(400).json({ error: `prefix not in the reloadable allowlist: ${prefix}` });
       }
       const applied = await reloadEnvPrefix(prefix);

--- a/companion/src/routes/pushNotify.ts
+++ b/companion/src/routes/pushNotify.ts
@@ -4,6 +4,7 @@ import { generatePushToken } from "../analysis/pushTokenStore.js";
 import { resolvePushAuth } from "../analysis/pushAuth.js";
 import { extractPushPayload } from "../analysis/pushPayload.js";
 import { parseChannelInput, redactChannel } from "../analysis/notifications.js";
+import { telegramChatsFromBindings } from "../analysis/slashCommandStore.js";
 import type { RouteContext } from "./context.js";
 import { requestAuthentication } from "../auth/types.js";
 
@@ -142,16 +143,42 @@ export function registerPushNotifyRoutes(app: Express, ctx: RouteContext): void 
   // and per-event-kind toggles. Opt-in (the store starts empty). Secrets (webhook URLs, SMTP
   // passwords) are REDACTED in every response — the browser only learns whether each is set.
 
-  app.get("/notifications/status", (_req: Request, res: Response) => {
-    res
-      .status(200)
-      .json({ configured: !!options.notificationStore, emailEnabled: !!options.notifyEmailEnabled });
+  // The env boundary for telegram: a channel may leave its bot token blank and borrow the war-room
+  // bot's DFIR_TELEGRAM_BOT_TOKEN. Read LIVE per request (never captured at wiring time) so a token
+  // added to .env and applied via /settings/reload takes effect without a restart.
+  const telegramEnvOpts = () => ({ envTelegramBotToken: process.env.DFIR_TELEGRAM_BOT_TOKEN });
+
+  app.get("/notifications/status", async (_req: Request, res: Response) => {
+    // The chats the war-room bot is already bound to, offered as candidate destinations for a new
+    // Telegram channel. Best-effort: an unreadable bindings file must not break the Settings pane,
+    // which needs the two flags above far more than it needs the suggestions.
+    let telegramChats: Array<{ chatId: string; caseId: string }> = [];
+    if (options.slashCommandChannelStore) {
+      try {
+        telegramChats = telegramChatsFromBindings(await options.slashCommandChannelStore.loadAll()).map(
+          ({ chatId, caseId }) => ({ chatId, caseId }),
+        );
+      } catch {
+        /* leave the suggestions empty — the analyst can still type a chat ID */
+      }
+    }
+    res.status(200).json({
+      configured: !!options.notificationStore,
+      emailEnabled: !!options.notifyEmailEnabled,
+      // Lets the Settings form say "already set" on the bot token field BEFORE any channel exists.
+      // A boolean only — the token itself never reaches the browser.
+      telegramEnvToken: Boolean((process.env.DFIR_TELEGRAM_BOT_TOKEN ?? "").trim()),
+      telegramChats,
+    });
   });
 
   app.get("/notifications", async (_req: Request, res: Response) => {
     if (!options.notificationStore) return res.status(200).json([]);
     try {
-      return res.status(200).json((await options.notificationStore.load()).map(redactChannel));
+      const opts = telegramEnvOpts();
+      return res
+        .status(200)
+        .json((await options.notificationStore.load()).map((c) => redactChannel(c, opts)));
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -159,13 +186,13 @@ export function registerPushNotifyRoutes(app: Express, ctx: RouteContext): void 
 
   app.post("/notifications", async (req: Request, res: Response) => {
     if (!options.notificationStore) return res.status(501).json({ error: "notifications not configured" });
-    const parsed = parseChannelInput(req.body);
+    const parsed = parseChannelInput(req.body, undefined, telegramEnvOpts());
     if (!parsed.ok || !parsed.draft)
       return res.status(400).json({ error: parsed.error ?? "invalid channel" });
     try {
       const channel = await options.notificationStore.add(parsed.draft);
       logLine(`[notify] channel added: ${channel.type} "${channel.name}" (${channel.id})`);
-      return res.status(201).json(redactChannel(channel));
+      return res.status(201).json(redactChannel(channel, telegramEnvOpts()));
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
@@ -177,12 +204,12 @@ export function registerPushNotifyRoutes(app: Express, ctx: RouteContext): void 
       const existing = await options.notificationStore.get(req.params.id);
       if (!existing) return res.status(404).json({ error: "notification channel not found" });
       // Pass `existing` so a blank (redacted) webhook URL keeps the saved one.
-      const parsed = parseChannelInput(req.body, existing);
+      const parsed = parseChannelInput(req.body, existing, telegramEnvOpts());
       if (!parsed.ok || !parsed.draft)
         return res.status(400).json({ error: parsed.error ?? "invalid channel" });
       const channel = await options.notificationStore.update(req.params.id, parsed.draft);
       if (!channel) return res.status(404).json({ error: "notification channel not found" });
-      return res.status(200).json(redactChannel(channel));
+      return res.status(200).json(redactChannel(channel, telegramEnvOpts()));
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }

--- a/companion/src/settings/envManager.ts
+++ b/companion/src/settings/envManager.ts
@@ -35,8 +35,51 @@ const DENIED_ENV_KEYS = new Set([
   "DFIR_ALLOW_UNAUTHENTICATED_REMOTE",
 ]);
 
-// Only keys starting with one of these prefixes may be written via POST /settings/env.
-// Mirrors RELOADABLE_PREFIXES in caseLifecycle.ts (the /settings/reload allowlist) — the
+/**
+ * Which prefixes POST /settings/reload may re-read from the .env FILE into the live process.
+ * Read by routes/caseLifecycle.ts, and kept HERE rather than there because it is the twin of
+ * WRITABLE_ENV_PREFIXES below and the two are only comprehensible side by side: writable is what
+ * the dashboard may change, reloadable is what re-reading is allowed to pick up. They are NOT the
+ * same list, and the difference is the interesting part — DFIR_TELEGRAM_BOT_TOKEN is reloadable
+ * (an operator editing .env by hand can rotate it without a restart) but NOT writable (the
+ * dashboard has no business rewriting the war-room bot's credential).
+ *
+ * Membership is exact-match on the string the route sends, so an entry without a trailing
+ * underscore names one key rather than a family.
+ */
+export const RELOADABLE_ENV_PREFIXES = new Set([
+  "DFIR_VISION_",
+  "DFIR_AI_",
+  "DFIR_IRIS_",
+  "DFIR_VELOCIRAPTOR_",
+  "DFIR_TIMESKETCH_",
+  "DFIR_NOTION_",
+  "DFIR_CLICKUP_",
+  "DFIR_VT_",
+  "DFIR_ABUSEIPDB_",
+  "DFIR_HUNTINGCH_",
+  "DFIR_MB_",
+  "DFIR_CROWDSTRIKE_",
+  "DFIR_SHODAN_",
+  "DFIR_MISP_",
+  "DFIR_YETI_",
+  "DFIR_OPENCTI_",
+  "DFIR_ROCKYRACCOON_",
+  "DFIR_GEOIP_",
+  "DFIR_LEAKCHECK_",
+  "DFIR_HIBP_",
+  "DFIR_DEHASHED_",
+  "DFIR_PUSH_TOKEN",
+  "DFIR_NSRL_",
+  "DFIR_TOOL_",
+  // The exact key, not the DFIR_TELEGRAM_ family: a Telegram notification channel may borrow this
+  // token, and both the channel route and the notifier read it live, so a rotation in .env has to be
+  // reachable without a restart. Its siblings stay off deliberately — ACTION_USERS and SECRET_TOKEN
+  // authorize the INBOUND bot, and nothing in the outbound path re-reads them.
+  "DFIR_TELEGRAM_BOT_TOKEN",
+]);
+
+// Only keys starting with one of these prefixes may be written via POST /settings/env. The
 // dashboard can configure AI, integrations, enrichment, push, NSRL, and tools, but cannot
 // rewrite core server config, security toggles, or filesystem paths.
 const WRITABLE_ENV_PREFIXES = [

--- a/companion/tests/analysis/notifications.test.ts
+++ b/companion/tests/analysis/notifications.test.ts
@@ -11,6 +11,7 @@ import {
   parseChannelInput,
   applyChannelPatch,
   redactChannel,
+  resolveTelegramBotToken,
   severityForPriority,
   SEVERITY_RANK,
   type NotificationChannel,
@@ -260,6 +261,121 @@ describe("parseChannelInput", () => {
 
   it("rejects an unknown type", () => {
     expect(parseChannelInput({ type: "sms" }).ok).toBe(false);
+  });
+});
+
+// The war-room bot's token (DFIR_TELEGRAM_BOT_TOKEN) doubles as the notification transport, so an
+// operator who already set it in .env does not type it a second time here. The env token is NEVER
+// copied into the stored channel — it stays the single source of truth, so rotating .env rotates
+// the channel too. This module stays pure: callers read env at their boundary and pass it in.
+describe("telegram bot token falling back to DFIR_TELEGRAM_BOT_TOKEN", () => {
+  const ENV_TOKEN = "999:ENVTOKEN";
+
+  const telegramChannel = (botToken: string, chatId = "-100") =>
+    channel({ type: "telegram", webhookUrl: undefined, telegram: { botToken, chatId } });
+
+  it("accepts a blank bot token when the env has one, without copying it into the draft", () => {
+    const r = parseChannelInput({ type: "telegram", telegram: { chatId: "-100" } }, undefined, {
+      envTelegramBotToken: ENV_TOKEN,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.draft?.telegram?.botToken).toBe("");
+    expect(r.draft?.telegram?.chatId).toBe("-100");
+  });
+
+  it("still rejects a blank token when neither the channel nor the env has one", () => {
+    expect(parseChannelInput({ type: "telegram", telegram: { chatId: "-100" } }).ok).toBe(false);
+    // Whitespace is not a token.
+    const blank = parseChannelInput({ type: "telegram", telegram: { chatId: "-100" } }, undefined, {
+      envTelegramBotToken: "   ",
+    });
+    expect(blank.ok).toBe(false);
+    expect(blank.error).toContain("bot token");
+  });
+
+  it("still requires a chat ID — the env supplies only the token", () => {
+    // Whitespace clears zod's min(1) and reaches the trim check, unlike "" which zod rejects first.
+    const r = parseChannelInput({ type: "telegram", telegram: { chatId: "   " } }, undefined, {
+      envTelegramBotToken: ENV_TOKEN,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("chat ID");
+  });
+
+  it("prefers a typed token, then the saved one, over the env token", () => {
+    const typed = parseChannelInput(
+      { type: "telegram", telegram: { botToken: "own", chatId: "-100" } },
+      undefined,
+      { envTelegramBotToken: ENV_TOKEN },
+    );
+    expect(typed.draft?.telegram?.botToken).toBe("own");
+
+    const saved = parseChannelInput(
+      { type: "telegram", telegram: { botToken: "", chatId: "-100" } },
+      telegramChannel("saved-token"),
+      { envTelegramBotToken: ENV_TOKEN },
+    );
+    expect(saved.draft?.telegram?.botToken).toBe("saved-token");
+  });
+
+  it("resolveTelegramBotToken: own token wins, env fills a blank, neither is empty", () => {
+    expect(resolveTelegramBotToken(telegramChannel("own"), ENV_TOKEN)).toBe("own");
+    expect(resolveTelegramBotToken(telegramChannel(""), ENV_TOKEN)).toBe(ENV_TOKEN);
+    expect(resolveTelegramBotToken(telegramChannel(""), "  ")).toBe("");
+    expect(resolveTelegramBotToken(telegramChannel(""))).toBe("");
+  });
+
+  it("redactChannel reports an env token as configured and flags where it came from", () => {
+    const blank = telegramChannel("", "@soc");
+    const withEnv = redactChannel(blank, { envTelegramBotToken: ENV_TOKEN });
+    expect(withEnv.telegram?.hasBotToken).toBe(true);
+    expect(withEnv.telegram?.usesEnvBotToken).toBe(true);
+
+    const without = redactChannel(blank);
+    expect(without.telegram?.hasBotToken).toBe(false);
+    expect(without.telegram?.usesEnvBotToken).toBe(false);
+
+    // A channel carrying its own token is never reported as using the env one.
+    const own = redactChannel(telegramChannel("own", "@soc"), { envTelegramBotToken: ENV_TOKEN });
+    expect(own.telegram?.hasBotToken).toBe(true);
+    expect(own.telegram?.usesEnvBotToken).toBe(false);
+    expect(Object.hasOwn(own.telegram!, "botToken")).toBe(false);
+  });
+
+  // An env-backed channel stores an EMPTY token, so once DFIR_TELEGRAM_BOT_TOKEN goes away
+  // (removed, rotated to blank, .env not loaded) a "requires a bot token" 400 would reject every
+  // later edit — including the dashboard's enable/disable toggle, whose PUT carries a blank token.
+  // ntfToggle ignores a non-2xx, so the checkbox would read "off" while the channel stayed ON in
+  // the store and resumed sending the moment the token came back. An existing channel is therefore
+  // always editable; a tokenless one simply cannot send, which the list already shows in red.
+  it("still allows editing and disabling an env-backed channel after the env token goes away", () => {
+    const existing = telegramChannel("");
+    const r = parseChannelInput(
+      { type: "telegram", enabled: false, telegram: { botToken: "", chatId: "-100" } },
+      existing,
+      { envTelegramBotToken: "" },
+    );
+    expect(r.ok).toBe(true);
+    expect(r.draft?.enabled).toBe(false);
+    expect(r.draft?.telegram?.botToken).toBe("");
+  });
+
+  it("still refuses to CREATE a tokenless telegram channel, or to convert a webhook one into it", () => {
+    expect(parseChannelInput({ type: "telegram", telegram: { chatId: "-100" } }).ok).toBe(false);
+    const slack = channel({ webhookUrl: "https://hooks.slack.com/x" });
+    const converted = parseChannelInput({ type: "telegram", telegram: { chatId: "-100" } }, slack);
+    expect(converted.ok).toBe(false);
+    expect(converted.error).toContain("bot token");
+  });
+
+  it("does not resurrect a token on update when the channel and the env are both empty", () => {
+    const existing = telegramChannel("");
+    const draft = parseChannelInput(
+      { type: "telegram", telegram: { botToken: "", chatId: "-100" } },
+      existing,
+      { envTelegramBotToken: ENV_TOKEN },
+    ).draft!;
+    expect(applyChannelPatch(existing, draft, NOW).telegram?.botToken).toBe("");
   });
 });
 

--- a/companion/tests/analysis/slashCommandStore.test.ts
+++ b/companion/tests/analysis/slashCommandStore.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mkdtemp, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SlashCommandChannelStore, bindingKey } from "../../src/analysis/slashCommandStore.js";
+import {
+  SlashCommandChannelStore,
+  bindingKey,
+  telegramChatsFromBindings,
+} from "../../src/analysis/slashCommandStore.js";
 
 let file: string;
 let store: SlashCommandChannelStore;
@@ -69,5 +73,40 @@ describe("SlashCommandChannelStore", () => {
   it("writes readable JSON (an operator may need to edit it by hand)", async () => {
     await store.bind("slack:C1", "case-1");
     expect(JSON.parse(await readFile(file, "utf8"))).toHaveProperty("slack:C1.caseId", "case-1");
+  });
+});
+
+// Feeds the notification channel form's Chat ID box, so the operator picks a chat the bot already
+// talks to instead of hunting the number out of this file.
+describe("telegramChatsFromBindings", () => {
+  it("keeps only telegram bindings, strips the prefix, and sorts", () => {
+    expect(
+      telegramChatsFromBindings({
+        "telegram:12345678": { caseId: "demo", boundAt: "2026-07-27T19:09:46.655Z" },
+        "slack:C123": { caseId: "other", boundAt: "2026-07-27T19:09:46.655Z" },
+        "teams:19:meeting": { caseId: "other", boundAt: "2026-07-27T19:09:46.655Z" },
+        "telegram:-1001234567890": { caseId: "INC-1", boundAt: "2026-07-28T00:00:00.000Z" },
+      }),
+    ).toEqual([
+      { chatId: "-1001234567890", caseId: "INC-1", boundAt: "2026-07-28T00:00:00.000Z" },
+      { chatId: "12345678", caseId: "demo", boundAt: "2026-07-27T19:09:46.655Z" },
+    ]);
+  });
+
+  it("keeps a channel id containing a colon whole", () => {
+    const r = telegramChatsFromBindings({
+      "telegram:@my:channel": { caseId: "c", boundAt: "2026-07-27T00:00:00.000Z" },
+    });
+    expect(r[0].chatId).toBe("@my:channel");
+  });
+
+  it("returns nothing for an empty or telegram-free map, and drops an empty chat id", () => {
+    expect(telegramChatsFromBindings({})).toEqual([]);
+    expect(
+      telegramChatsFromBindings({ "slack:C1": { caseId: "c", boundAt: "2026-07-27T00:00:00.000Z" } }),
+    ).toEqual([]);
+    expect(
+      telegramChatsFromBindings({ "telegram:": { caseId: "c", boundAt: "2026-07-27T00:00:00.000Z" } }),
+    ).toEqual([]);
   });
 });

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -224,6 +224,10 @@ export interface ValuesApi {
     telegram?: { botToken: string; chatId?: string };
     webhookUrl?: string;
   };
+  ntfChatPrefill(chats?: Array<{ chatId: string; caseId?: string }>): {
+    value: string;
+    options: Array<{ value: string; label: string }>;
+  };
   ntfEventsSummary(ev: Record<string, boolean | undefined>): string;
 }
 

--- a/companion/tests/dashboard/dashboardFragments.test.ts
+++ b/companion/tests/dashboard/dashboardFragments.test.ts
@@ -401,4 +401,11 @@ describe("ntfTargetSummary", () => {
     expect(f.ntfTargetSummary(ch)).toBe("token configured → chat: 5");
     expect(f.ntfTargetSummary(ch)).not.toContain("SECRET");
   });
+
+  // A borrowed war-room token is still a working channel, so it must not read as "no token" — but
+  // it says WHERE it came from, so nobody hunts for a token they never typed here.
+  it("names the .env token when the channel borrows the war-room bot's", () => {
+    const ch = { type: "telegram", telegram: { hasBotToken: true, usesEnvBotToken: true, chatId: "5" } };
+    expect(f.ntfTargetSummary(ch)).toBe("token from .env → chat: 5");
+  });
 });

--- a/companion/tests/dashboard/dashboardModules.test.ts
+++ b/companion/tests/dashboard/dashboardModules.test.ts
@@ -152,8 +152,8 @@ describe("every moved function still resolves at its call sites", () => {
     (name) => name !== "esc" && name !== "escAttr",
   );
 
-  it("moved 95 functions, so the check below is not vacuous", () => {
-    expect(MOVED.length).toBe(95);
+  it("moved 96 functions, so the check below is not vacuous", () => {
+    expect(MOVED.length).toBe(96);
   });
 
   it("provides every one of them as a global once the tagged scripts have run", async () => {

--- a/companion/tests/dashboard/dashboardValues.test.ts
+++ b/companion/tests/dashboard/dashboardValues.test.ts
@@ -319,6 +319,37 @@ describe("veloTimeScopeBody / veloTimeScopeIncomplete", () => {
 
 // The secret-blanking contract. A blank credential means "keep what is saved", so the dashboard
 // never round-trips a redacted value back to the server as if it were the real one.
+// The war-room bot already knows which chats it talks to (it saved them on `/dfir bind`), so the
+// Chat ID box offers them instead of making the analyst go dig the number out of a JSON file. A
+// destination is PRE-FILLED, never silently defaulted — notifications carry case content, so what
+// is about to receive it has to be on screen before Add.
+describe("ntfChatPrefill", () => {
+  const chats = [
+    { chatId: "12345678", caseId: "demo" },
+    { chatId: "-1001234567890", caseId: "INC-2026-004" },
+  ];
+
+  it("offers every known chat and pre-fills the first", () => {
+    const r = v.ntfChatPrefill(chats);
+    expect(r.value).toBe("12345678");
+    expect(r.options).toEqual([
+      { value: "12345678", label: "12345678 — bound to demo" },
+      { value: "-1001234567890", label: "-1001234567890 — bound to INC-2026-004" },
+    ]);
+  });
+
+  it("pre-fills nothing when the bot knows no chats", () => {
+    expect(v.ntfChatPrefill([])).toEqual({ value: "", options: [] });
+    expect(v.ntfChatPrefill(undefined)).toEqual({ value: "", options: [] });
+  });
+
+  it("survives a binding with no case id rather than rendering 'undefined'", () => {
+    const r = v.ntfChatPrefill([{ chatId: "5" }]);
+    expect(r.value).toBe("5");
+    expect(r.options[0].label).toBe("5");
+  });
+});
+
 describe("ntfChannelToBody", () => {
   it("blanks the telegram bot token so the server keeps the saved one", () => {
     const body = v.ntfChannelToBody({

--- a/companion/tests/dashboard/featureManifest.ts
+++ b/companion/tests/dashboard/featureManifest.ts
@@ -1161,7 +1161,7 @@ export const FEATURES: Feature[] = [
       "ntfToggle",
       "ntfTypeChanged",
     ],
-    private: ["ntfChannels", "NTF_TYPE_LABEL", "NTF_WEBHOOK_PLACEHOLDER"],
+    private: ["ntfChannels", "NTF_TYPE_LABEL", "NTF_WEBHOOK_PLACEHOLDER", "NTF_TG_TOKEN_PLACEHOLDER"],
   },
   {
     // Starred events. No initializer. Reported five escapes until the IOC view state that shared

--- a/companion/tests/integrations/notify.test.ts
+++ b/companion/tests/integrations/notify.test.ts
@@ -362,6 +362,97 @@ describe("dispatchEvent + createNotifier", () => {
     expect(r.error).toContain("no bot token");
   });
 
+  // A channel left tokenless falls back to the war-room bot's DFIR_TELEGRAM_BOT_TOKEN, injected as
+  // transport config so this stays env-free and unit-testable.
+  it("falls back to the transport's telegram bot token when the channel has none", async () => {
+    const sent: string[] = [];
+    const fetchFn = (async (url: string) => {
+      sent.push(String(url));
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const ch = channel({
+      id: "tg3",
+      type: "telegram",
+      webhookUrl: undefined,
+      telegram: { botToken: "", chatId: "-100" },
+    });
+    const [r] = await dispatchEvent([ch], event(), { fetchFn, telegramBotToken: "999:ENVTOKEN" });
+    expect(r.ok).toBe(true);
+    expect(sent[0]).toBe("https://api.telegram.org/bot999:ENVTOKEN/sendMessage");
+  });
+
+  // DFIR_TELEGRAM_API_BASE points the war-room bot at a self-hosted Bot API or an egress proxy.
+  // A channel borrowing that bot's token has to reach it the same way, or it silently posts to
+  // api.telegram.org — failing on a closed network, or bypassing the proxy the operator required.
+  it("sends through the configured Telegram API base, trailing slash and all", async () => {
+    const sent: string[] = [];
+    const fetchFn = (async (url: string) => {
+      sent.push(String(url));
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const ch = channel({
+      id: "tg5",
+      type: "telegram",
+      webhookUrl: undefined,
+      telegram: { botToken: "", chatId: "-100" },
+    });
+    const [r] = await dispatchEvent([ch], event(), {
+      fetchFn,
+      telegramBotToken: "999:ENVTOKEN",
+      telegramApiBase: "https://tg.example.com/",
+    });
+    expect(r.ok).toBe(true);
+    expect(sent[0]).toBe("https://tg.example.com/bot999:ENVTOKEN/sendMessage");
+  });
+
+  it("applies the API base to a channel carrying its own token too", async () => {
+    const sent: string[] = [];
+    const fetchFn = (async (url: string) => {
+      sent.push(String(url));
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const ch = channel({
+      id: "tg6",
+      type: "telegram",
+      webhookUrl: undefined,
+      telegram: { botToken: "123:OWN", chatId: "-100" },
+    });
+    await dispatchEvent([ch], event(), { fetchFn, telegramApiBase: "https://tg.example.com" });
+    expect(sent[0]).toBe("https://tg.example.com/bot123:OWN/sendMessage");
+  });
+
+  it("falls back to api.telegram.org when no API base is configured", async () => {
+    const sent: string[] = [];
+    const fetchFn = (async (url: string) => {
+      sent.push(String(url));
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const ch = channel({
+      id: "tg7",
+      type: "telegram",
+      webhookUrl: undefined,
+      telegram: { botToken: "123:OWN", chatId: "-100" },
+    });
+    await dispatchEvent([ch], event(), { fetchFn, telegramApiBase: "   " });
+    expect(sent[0]).toBe("https://api.telegram.org/bot123:OWN/sendMessage");
+  });
+
+  it("prefers the channel's own telegram token over the transport fallback", async () => {
+    const sent: string[] = [];
+    const fetchFn = (async (url: string) => {
+      sent.push(String(url));
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+    const ch = channel({
+      id: "tg4",
+      type: "telegram",
+      webhookUrl: undefined,
+      telegram: { botToken: "123:OWN", chatId: "-100" },
+    });
+    await dispatchEvent([ch], event(), { fetchFn, telegramBotToken: "999:ENVTOKEN" });
+    expect(sent[0]).toBe("https://api.telegram.org/bot123:OWN/sendMessage");
+  });
+
   it("reports email channels as failed when no SMTP transport is available", async () => {
     const fetchFn = (async () => new Response("ok")) as typeof fetch;
     const ch = channel({

--- a/companion/tests/server/notificationRoutes.test.ts
+++ b/companion/tests/server/notificationRoutes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +7,7 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { NotificationConfigStore } from "../../src/analysis/notificationStore.js";
+import { SlashCommandChannelStore } from "../../src/analysis/slashCommandStore.js";
 import { createNotifier } from "../../src/integrations/notify/notifyDispatch.js";
 
 async function harness() {
@@ -14,27 +15,55 @@ async function harness() {
   const store = new CaseStore(root);
   const stateStore = new StateStore(store);
   const notificationStore = new NotificationConfigStore(join(root, "notifications", "config.json"));
+  const slashCommandChannelStore = new SlashCommandChannelStore(
+    join(root, "notifications", "slash-command-bindings.json"),
+  );
   const sent: string[] = [];
   const fetchFn = (async (u: string) => {
     sent.push(String(u));
     return new Response("ok", { status: 200 });
   }) as typeof fetch;
-  const notifier = createNotifier({ store: notificationStore, fetchFn });
+  // Mirrors the production wiring in runtimeStores.ts: the war-room bot's token, read per send.
+  const notifier = createNotifier({
+    store: notificationStore,
+    fetchFn,
+    telegramBotToken: () => process.env.DFIR_TELEGRAM_BOT_TOKEN,
+  });
   const app = createApp(store, {
     stateStore,
     notificationStore,
+    slashCommandChannelStore,
     notifier,
     notifyEmailEnabled: true,
     dashboardBaseUrl: "http://127.0.0.1:4773",
   });
-  return { app, notificationStore, sent };
+  return { app, notificationStore, slashCommandChannelStore, sent };
 }
+
+// This file asserts on /notifications/status, which reads DFIR_TELEGRAM_BOT_TOKEN from the live
+// environment — so it must not inherit whatever the shell that launched vitest happens to export.
+// With the token set out there the route truthfully answers `true` and the default-state assertions
+// fail for a reason that has nothing to do with the code. Cleared before EVERY test and restored
+// after, which also gives the nested suite below a known floor to set its own value on top of.
+const ambientTelegramToken = process.env.DFIR_TELEGRAM_BOT_TOKEN;
+beforeEach(() => {
+  delete process.env.DFIR_TELEGRAM_BOT_TOKEN;
+});
+afterEach(() => {
+  if (ambientTelegramToken === undefined) delete process.env.DFIR_TELEGRAM_BOT_TOKEN;
+  else process.env.DFIR_TELEGRAM_BOT_TOKEN = ambientTelegramToken;
+});
 
 describe("notification channel CRUD routes", () => {
   it("status reports configured + email transport", async () => {
     const { app } = await harness();
     const r = await request(app).get("/notifications/status");
-    expect(r.body).toEqual({ configured: true, emailEnabled: true });
+    expect(r.body).toEqual({
+      configured: true,
+      emailEnabled: true,
+      telegramEnvToken: false,
+      telegramChats: [],
+    });
   });
 
   it("creates, lists (redacted), updates (secret-preserving), and deletes a Slack channel", async () => {
@@ -99,6 +128,79 @@ describe("notification channel CRUD routes", () => {
     expect(t.body.results).toHaveLength(1);
     expect(t.body.results[0].ok).toBe(true);
     expect(sent).toContain("https://hooks/test");
+  });
+
+  // #58 follow-up: an operator who already set DFIR_TELEGRAM_BOT_TOKEN for the war-room bot should
+  // not have to paste the same token into the notification channel form.
+  describe("telegram channels borrowing DFIR_TELEGRAM_BOT_TOKEN", () => {
+    const ENV_TOKEN = "999:ENVTOKEN";
+    // Runs after the file-level hook has cleared the ambient value, and the file-level afterEach
+    // puts the operator's own back — so this only has to set what these tests need.
+    beforeEach(() => {
+      process.env.DFIR_TELEGRAM_BOT_TOKEN = ENV_TOKEN;
+    });
+
+    it("status reports the env token so the form can say it is already set", async () => {
+      const { app } = await harness();
+      expect((await request(app).get("/notifications/status")).body.telegramEnvToken).toBe(true);
+    });
+
+    it("status offers the chats the war-room bot is already bound to", async () => {
+      const { app, slashCommandChannelStore } = await harness();
+      await slashCommandChannelStore.bind("telegram:12345678", "demo");
+      await slashCommandChannelStore.bind("slack:C1", "demo");
+      const r = await request(app).get("/notifications/status");
+      expect(r.body.telegramChats).toEqual([{ chatId: "12345678", caseId: "demo" }]);
+    });
+
+    it("offers no chats when the bindings store is not wired", async () => {
+      const root = await mkdtemp(join(tmpdir(), "dfir-notify-nobind-"));
+      const notificationStore = new NotificationConfigStore(join(root, "notifications", "config.json"));
+      const app = createApp(new CaseStore(root), { notificationStore });
+      expect((await request(app).get("/notifications/status")).body.telegramChats).toEqual([]);
+    });
+
+    it("accepts a channel with only a chat ID, and sends with the env token", async () => {
+      const { app, sent } = await harness();
+      const add = await request(app)
+        .post("/notifications")
+        .send({ type: "telegram", name: "SOC alerts", telegram: { chatId: "-100" } });
+      expect(add.status).toBe(201);
+      expect(add.body.telegram).toEqual({
+        chatId: "-100",
+        hasBotToken: true,
+        usesEnvBotToken: true,
+      });
+
+      const list = await request(app).get("/notifications");
+      expect(list.body[0].telegram.usesEnvBotToken).toBe(true);
+
+      const t = await request(app).post("/notifications/test").send({ channelId: add.body.id });
+      expect(t.body.results[0].ok).toBe(true);
+      expect(sent).toContain(`https://api.telegram.org/bot${ENV_TOKEN}/sendMessage`);
+    });
+
+    it("keeps the env token out of the stored channel so rotating .env rotates the channel", async () => {
+      const { app, notificationStore, sent } = await harness();
+      const add = await request(app)
+        .post("/notifications")
+        .send({ type: "telegram", telegram: { chatId: "-100" } });
+      const stored = await notificationStore.get(add.body.id);
+      expect(stored?.telegram?.botToken).toBe("");
+
+      process.env.DFIR_TELEGRAM_BOT_TOKEN = "111:ROTATED";
+      await request(app).post("/notifications/test").send({ channelId: add.body.id });
+      expect(sent).toContain("https://api.telegram.org/bot111:ROTATED/sendMessage");
+    });
+
+    it("still rejects a channel with no chat ID", async () => {
+      const { app } = await harness();
+      const r = await request(app)
+        .post("/notifications")
+        .send({ type: "telegram", telegram: { chatId: "  " } });
+      expect(r.status).toBe(400);
+      expect(r.body.error).toContain("chat ID");
+    });
   });
 
   it("returns 501 when notifications are not configured", async () => {

--- a/companion/tests/server/settingsReloadRebuild.test.ts
+++ b/companion/tests/server/settingsReloadRebuild.test.ts
@@ -47,6 +47,7 @@ const ALL_PREFIXES = [
   "DFIR_PUSH_TOKEN",
   "DFIR_NSRL_",
   "DFIR_TOOL_",
+  "DFIR_TELEGRAM_BOT_TOKEN",
 ];
 
 // Keys this file writes into the temp .env and therefore into the live process.env — cleared around
@@ -59,6 +60,7 @@ const TOUCHED = [
   "DFIR_CLICKUP_TOKEN",
   "DFIR_CLICKUP_LIST_ID",
   "DFIR_LEAKCHECK_KEY",
+  "DFIR_TELEGRAM_BOT_TOKEN",
 ];
 
 beforeEach(async () => {
@@ -113,6 +115,22 @@ describe("/settings/reload rebuilds the live client for the prefix (#178)", () =
     expect(control.body.providers.find((p: { name: string }) => p.name === "VirusTotal")?.configured).toBe(
       true,
     );
+  });
+
+  // A Telegram notification channel can borrow the war-room bot's DFIR_TELEGRAM_BOT_TOKEN, and both
+  // the route and the notifier read it live — but "live" only means "current process.env", which an
+  // edit to .env does not touch on its own. Without the key on this allowlist the reload 400s and
+  // the rotated token needs a full restart, so assert the token actually lands in the process.
+  it("applies a rotated Telegram bot token without a restart", async () => {
+    process.env.DFIR_TELEGRAM_BOT_TOKEN = "111:OLD";
+    expect((await request(app).get("/notifications/status")).body.telegramEnvToken).toBe(true);
+
+    await writeFile(envPath, "DFIR_TELEGRAM_BOT_TOKEN=222:ROTATED\n", "utf8");
+    const res = await reload("DFIR_TELEGRAM_BOT_TOKEN");
+
+    expect(res.status).toBe(200);
+    expect(res.body.applied).toContain("DFIR_TELEGRAM_BOT_TOKEN");
+    expect(process.env.DFIR_TELEGRAM_BOT_TOKEN).toBe("222:ROTATED");
   });
 
   it("rebuilds the customer-exposure provider set", async () => {

--- a/mkdocs-docs/reference/settings.md
+++ b/mkdocs-docs/reference/settings.md
@@ -309,6 +309,11 @@ Each channel has:
 !!! info
     Notification configs are stored in a global config file (not `.env`) and webhook URLs are redacted in all API responses.
 
+!!! tip "Telegram: leave the bot token blank to reuse the war-room bot's"
+    A Telegram channel with no token of its own falls back to `DFIR_TELEGRAM_BOT_TOKEN` from `.env`, and the token field
+    shows *(already set)*. Fill in only the chat ID. The token is never copied into the notification config, so rotating
+    it in `.env` rotates the channel too. Type a token here only to send through a *different* bot.
+
 ---
 
 ## War-Room Bot

--- a/mkdocs-docs/reference/war-room-bot.md
+++ b/mkdocs-docs/reference/war-room-bot.md
@@ -319,7 +319,7 @@ For Slack and Teams substitute their endpoint paths; the first two rows behave i
     Editing `.env` while the Companion is running changes nothing. Restart it. When in doubt, pass the variable inline — `DFIR_ALLOWED_HOSTS=… npm run dev` — which sidesteps any question of which `.env` is being read or whether a line got mangled.
 
 !!! note "The outbound Telegram notifier is a different thing"
-    If you already have Telegram alerts working, that's the notification channel, configured in the dashboard and stored in `notifications/config.json`. It shares nothing with the bot — it sets none of these variables and needs no tunnel, because it calls Telegram rather than being called.
+    If you already have Telegram alerts working, that's the notification channel, configured in the dashboard and stored in `notifications/config.json`. It needs no tunnel, because it calls Telegram rather than being called, and it sets none of these variables. The one thing the two share is the token: a notification channel saved with a blank bot token borrows `DFIR_TELEGRAM_BOT_TOKEN` from here at send time, so the same bot can carry alerts out and commands back in without the token being stored twice.
 
 Once the request is reaching the bot, the rest are ordinary replies:
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2425,8 +2425,10 @@
           <div id="ntfTelegramRows" data-safe-style="display:none;margin-bottom:6px">
             <div data-safe-style="display:flex;gap:6px;flex-wrap:wrap">
               <input id="ntfTgToken" type="password" placeholder="Bot token (123456789:AAF…)" autocomplete="new-password" data-safe-style="flex:1 1 220px" />
-              <input id="ntfTgChatId" placeholder="Chat ID (@channel or -1001234567890)" data-safe-style="flex:1 1 200px" />
+              <input id="ntfTgChatId" list="ntfTgChatList" placeholder="Chat ID (@channel or -1001234567890)" data-safe-style="flex:1 1 200px" />
+              <datalist id="ntfTgChatList"></datalist>
             </div>
+            <div class="sfield-hint" data-safe-style="margin-top:4px">Leave the token blank to reuse the war-room bot's <code>DFIR_TELEGRAM_BOT_TOKEN</code> from <code>.env</code>. The token stays in <code>.env</code> only — rotate it there and this channel follows. A token typed here overrides it, for a separate bot. The Chat ID offers the chats the bot is already bound to — check it points where you mean before adding, since notifications carry case content.</div>
           </div>
           <!-- Email (smtp) -->
           <div id="ntfSmtpRows" data-safe-style="display:none">

--- a/public/js/dashboard-fragments.js
+++ b/public/js/dashboard-fragments.js
@@ -183,7 +183,9 @@ function caseStatsBarChart(days) {
 
 function ntfTargetSummary(ch) {
   if (ch.type === "email" && ch.smtp) return `${esc(ch.smtp.host)}:${esc(String(ch.smtp.port))} → ${esc((ch.smtp.to || []).join(", "))}${ch.smtp.hasPassword ? " 🔑" : ""}`;
-  if (ch.type === "telegram" && ch.telegram) return `${ch.telegram.hasBotToken ? "token configured" : "<span data-safe-style='color:var(--tag-red-text)'>no token</span>"} → chat: ${esc(ch.telegram.chatId || "?")}`;
+  // usesEnvBotToken = borrowed from the war-room bot's DFIR_TELEGRAM_BOT_TOKEN rather than typed
+  // here. Named explicitly so the channel doesn't look mis-configured to whoever reads it next.
+  if (ch.type === "telegram" && ch.telegram) return `${ch.telegram.hasBotToken ? (ch.telegram.usesEnvBotToken ? "token from .env" : "token configured") : "<span data-safe-style='color:var(--tag-red-text)'>no token</span>"} → chat: ${esc(ch.telegram.chatId || "?")}`;
   return ch.hasWebhookUrl ? "webhook configured" : "<span data-safe-style='color:var(--tag-red-text)'>no webhook URL</span>";
 }
 

--- a/public/js/dashboard-notifications.js
+++ b/public/js/dashboard-notifications.js
@@ -27,6 +27,14 @@
     mattermost: "https://mattermost.example.com/hooks/…",
     discord: "https://discord.com/api/webhooks/…",
   };
+  // The war-room bot's DFIR_TELEGRAM_BOT_TOKEN doubles as the transport for telegram channels, so
+  // when .env already has one the field says so — otherwise an operator who configured the bot sees
+  // an empty box and pastes the same token a second time. Mirrors the "(already set)" wording the
+  // .env secret fields use (dashboard-env-settings.js).
+  const NTF_TG_TOKEN_PLACEHOLDER = {
+    own: "Bot token (123456789:AAF…)",
+    env: "Bot token — (already set) from .env, leave blank to use it",
+  };
   function ntfTypeChanged() {
     const t = document.getElementById("ntfType").value;
     const email = t === "email";
@@ -77,6 +85,40 @@
       .then((r) => r.json())
       .then(renderNotifications)
       .catch(() => {});
+    // Asked separately from the channel list because it must be answerable with NO channels
+    // configured — which is exactly when the empty token field is most confusing. The response
+    // carries a boolean, never the token.
+    fetch("/notifications/status")
+      .then((r) => r.json())
+      .then((s) => {
+        const el = document.getElementById("ntfTgToken");
+        if (el)
+          el.placeholder =
+            s && s.telegramEnvToken
+              ? NTF_TG_TOKEN_PLACEHOLDER.env
+              : NTF_TG_TOKEN_PLACEHOLDER.own;
+        ntfApplyChatPrefill((s && s.telegramChats) || []);
+      })
+      .catch(() => {});
+  }
+  // Pre-fill the Chat ID with a chat the war-room bot already talks to, and offer the rest through
+  // the datalist. Pre-filled, never silently defaulted: the value lands in a VISIBLE field the
+  // analyst can see and change before Add, because this is where case content will be sent. An
+  // analyst who has already typed something keeps it.
+  function ntfApplyChatPrefill(chats) {
+    const input = document.getElementById("ntfTgChatId");
+    const list = document.getElementById("ntfTgChatList");
+    if (!input || !list) return;
+    const { value, options } = ntfChatPrefill(chats);
+    list.replaceChildren(
+      ...options.map((o) => {
+        const opt = document.createElement("option");
+        opt.value = o.value;
+        opt.label = o.label;
+        return opt;
+      }),
+    );
+    if (!input.value) input.value = value;
   }
   function ntfAddChannel() {
     const type = document.getElementById("ntfType").value;

--- a/public/js/dashboard-values.js
+++ b/public/js/dashboard-values.js
@@ -180,6 +180,21 @@ function ntfChannelToBody(ch) {
   return body;
 }
 
+// Turn the chats the war-room bot is bound to into what the Chat ID box shows: the first as a
+// pre-filled value, all of them as pickable options labelled with the case each is bound to. The
+// label carries the case because a bare chat id is unrecognisable — "12345678" tells you nothing,
+// "12345678 — bound to demo" tells you which conversation it is.
+function ntfChatPrefill(chats) {
+  const list = Array.isArray(chats) ? chats.filter((c) => c && c.chatId) : [];
+  return {
+    value: list.length ? String(list[0].chatId) : "",
+    options: list.map((c) => ({
+      value: String(c.chatId),
+      label: c.caseId ? `${c.chatId} — bound to ${c.caseId}` : String(c.chatId),
+    })),
+  };
+}
+
 function ntfEventsSummary(ev) {
   const on = [];
   if (ev.critical_finding) on.push("findings");
@@ -215,5 +230,6 @@ window.DfirValues = {
   veloTimeScopeBody,
   veloTimeScopeIncomplete,
   ntfChannelToBody,
+  ntfChatPrefill,
   ntfEventsSummary,
 };


### PR DESCRIPTION
## The report

> "telegram is configured in .env but settings doesn't show 'already configured'"

Correct, and it was worse than a missing label: **Settings → Notifications → Telegram bot** asked for
a bot token and a chat ID the operator had already handed the war-room bot. The token is in `.env` as
`DFIR_TELEGRAM_BOT_TOKEN`; the chat is in `notifications/slash-command-bindings.json`, saved by
`/dfir bind`. The two subsystems shared nothing, so the form rendered blank and the reasonable
conclusion was that the companion had lost the config.

It had not. `notifications.ts` read no env at all, and `dashboard.html` carries 269 `env-DFIR_*`
inputs and none for `DFIR_TELEGRAM_*` — so `GET /settings/env` returned the token as the masked
sentinel and [the loader](public/js/dashboard-env-settings.js) dropped it for want of a field to put
it in. The `(already set)` affordance existed; nothing was wired to it.

## What changes

**Bot token.** A telegram channel saved with a **blank** token borrows `DFIR_TELEGRAM_BOT_TOKEN`, and
the field says *"(already set) from .env"*. Resolution happens at **send** time, so `.env` stays the
single copy: rotating it rotates the channel, and nothing lands in `notifications/config.json` to go
stale. A typed token still wins, for a second bot.

**Chat ID.** Pre-filled from the chats the bot is bound to, each labelled with its case, the rest
offered in a datalist. Pre-filled into a *visible* field, never silently defaulted — a notification
carries case content, and per that module's own opt-in rule the destination belongs on screen before
Add. That asymmetry with the token is deliberate: one is a credential, the other is a recipient.

`notifications.ts` stays pure — env is passed in by whoever sits at the boundary (the route, the
notifier) rather than read there, so its tests stay order-independent. The notifier takes thunks, not
values, so a token corrected after boot is not pinned to whatever was set at process start.

## Four defects an independent review found, all in the new code

1. **An env-backed channel could not be turned off.** Its stored token is empty, so once
   `DFIR_TELEGRAM_BOT_TOKEN` went away the "requires a bot token" guard rejected every later PUT —
   including the enable/disable toggle, which sends a blank token and ignores a non-2xx. The checkbox
   read *off* while the channel stayed **on** in the store, and would resume sending the moment the
   token came back. The token is now required to **create** a channel, never to keep editing one.
2. **Sends ignored `DFIR_TELEGRAM_API_BASE`.** A channel borrowing the bot's token still posted to
   `api.telegram.org` while the bot itself used the override — failing on a closed network, or
   slipping past a proxy put there on purpose. The base now applies to every telegram channel: it
   describes how to reach Telegram from this box, which belongs to the network, not the bot.
3. **The claimed no-restart rotation was unreachable.** Reading `process.env` live does not re-read
   the `.env` *file*, and `/settings/reload` refused the key. `DFIR_TELEGRAM_BOT_TOKEN` joins that
   allowlist as an **exact key** (the `DFIR_PUSH_TOKEN` shape). Its siblings stay off deliberately:
   `ACTION_USERS` and `SECRET_TOKEN` authorize the *inbound* bot and nothing outbound re-reads them.
   It also stays out of `WRITABLE_ENV_PREFIXES`, so the dashboard still cannot write the token —
   reload only re-applies what you edited by hand.
4. **A status test asserted `telegramEnvToken: false` unconditionally**, so it failed for anyone
   running vitest with `DFIR_TELEGRAM_BOT_TOKEN` exported. Cleared and restored around every test in
   the file. Reproduced before fixing, and confirmed passing both with and without the variable set.

## Verification

Full suite **9,445 tests / 601 files green** on the merge with master, plus `typecheck`, `lint`,
`format:check`, `check:size`, `check:imports`, `check:boundaries`.

Also driven in a real browser against a live case, because the DOM wiring has no unit test: both
fields populate, selecting *Telegram bot* reveals the right rows, and the console carries no error
from this change. That run is what caught defect 4's sibling — a dead server makes the UI look
identical to a broken fix, since the fetch failure is swallowed.

`ARCHITECTURE.md`'s cross-domain pair moved 1,726/1,765 → 1,727/1,766: the new
`pushNotify → slashCommandStore` edge complies, but `moduleMap.test.ts` asserts the prose against the
scan.

## Docs

README, `.env.example`, the settings reference and the war-room-bot page all said the two Telegram
setups shared nothing. They now say what is actually shared, and what is not.

## Late change: the reload allowlist moved

Adding `DFIR_TELEGRAM_BOT_TOKEN` pushed `routes/caseLifecycle.ts` past its file-size ledger cap
(929 vs 924). That ratchet is a freeze, not a budget, so the fix is to move code out rather than
raise the cap: the whole allowlist now lives in `settings/envManager.ts` as `RELOADABLE_ENV_PREFIXES`,
beside the `WRITABLE_ENV_PREFIXES` twin a comment had always described it as mirroring.
`caseLifecycle.ts` drops to 900 lines, and the two lists are finally readable against each other —
they are **not** the same list, and the difference is the point: the telegram token is reloadable but
not writable, because an operator editing `.env` may rotate it and the dashboard may not.

Caught by CI, not locally: the ledger only tripped once master's `caseIdentity` extraction was
merged in.
