### PR TITLE
test(import): list import-leapp in the import contract route table

### DIFF
--- a/companion/tests/e2e/workflows/importContract.spec.ts
+++ b/companion/tests/e2e/workflows/importContract.spec.ts
@@ -27,6 +27,7 @@ const ROUTES: ReadonlyArray<{ route: string; required: string }> = [
   { route: "import-network", required: "text" },
   { route: "import-kape", required: "text" },
   { route: "import-cybertriage", required: "text" },
+  { route: "import-leapp", required: "text" },
   { route: "import-aws", required: "text" },
   { route: "import-cloud-activity", required: "text" },
   { route: "import-m365", required: "text" },


### PR DESCRIPTION
`tests/e2e/workflows/importContract.spec.ts` has been failing on master — and therefore on every
branch cut from it — since #554.

## What broke

The spec's first test asserts that its hardcoded `ROUTES` table really is every
`app.post("/cases/:id/import*")` in `src/routes/import.ts`. #554 added `import-leapp`
(`import.ts:1847`) without adding the table row, so the comparison read 25 routes in source against
24 in the table and failed.

The fix is the one missing row. `required: "text"` is the body field the route's own 400 guard
demands (`import.ts:1850-1852`).

## The guard tests pass too

Adding the row also enrolls `import-leapp` in the file's other two table-driven tests, which is the
point of the table — so this is not just silencing the count check. Both pass against the route
exactly as #554 wrote it:

```
POST /cases/<demo>/import-leapp              -> 400   (whitespace-only body)
POST /cases/no-such-case-contract/import-leapp -> 404  (unknown case)
```

The 404 works because #554 *did* add `import-leapp` to `EVIDENCE_IMPORT_ROUTES`
(`src/routes/importCaseGuard.ts`), so the guard mounted ahead of all the import routes already
covered it. Only the e2e table was missed. No guard gap hiding behind the missing row.

## This is the second time

The comment at the top of the test records the same thing happening to `import-m365`, which the
table's original extracting regex dropped. The table is hand-maintained against a list that lives in
source, so it will drift again.

Worth a follow-up (deliberately not in this PR, which is a red-CI fix): `EVIDENCE_IMPORT_ROUTES` in
`importCaseGuard.ts` is already the single route list, and `tests/server/importMissingCase.test.ts`
walks the live Express router and fails if a new `import*` route is missing from it. If this spec
imported that constant instead of re-deriving the list by regex over source text, drift would surface
in the fast vitest suite the moment a route is added, rather than in the slow e2e run — and there
would be one list instead of three. Only `required` would stay hand-maintained; it is genuinely
per-route (`path`, `csv`, `json`, `text`).

## Verification

Full spec green — `3 passed (21.1s)`:

- the table below really is every import route
- every import route 404s an unknown case instead of conjuring one
- every import route 400s an empty payload

Plus `typecheck` (exit 0) and `format:check` on the changed file. Branch is one commit ahead of
`origin/master` with nothing to merge.