### PR TITLE
test(import): derive the import contract routes from the guard's own list

### DIFF
--- a/companion/tests/e2e/workflows/importContract.spec.ts
+++ b/companion/tests/e2e/workflows/importContract.spec.ts
@@ -1,6 +1,5 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { test, expect } from "../fixtures/test.js";
+import { EVIDENCE_IMPORT_ROUTES } from "../../../src/routes/importCaseGuard.js";
 
 // Covers: NO USER STORY EXISTS.
 // The shared contract every /cases/:id/import* route obeys — reject an unknown case, reject an
@@ -13,48 +12,52 @@ import { test, expect } from "../fixtures/test.js";
 // them, so a change that accidentally narrows its scope would otherwise only show up on whichever
 // single route someone happened to test.
 
-/** Every import route, with the body field its 400 guard requires. Extracted from src/routes/import.ts. */
-const ROUTES: ReadonlyArray<{ route: string; required: string }> = [
-  { route: "import", required: "text" },
-  { route: "import-file", required: "path" },
-  { route: "import-csv", required: "csv" },
-  { route: "import-log", required: "text" },
-  { route: "import-thor", required: "json" },
-  { route: "import-siem", required: "json" },
-  { route: "import-chainsaw", required: "json" },
-  { route: "import-hayabusa", required: "text" },
-  { route: "import-velociraptor", required: "text" },
-  { route: "import-network", required: "text" },
-  { route: "import-kape", required: "text" },
-  { route: "import-cybertriage", required: "text" },
-  { route: "import-leapp", required: "text" },
-  { route: "import-aws", required: "text" },
-  { route: "import-cloud-activity", required: "text" },
-  { route: "import-m365", required: "text" },
-  { route: "import-plaso", required: "text" },
-  { route: "import-sandbox", required: "text" },
-  { route: "import-memory", required: "text" },
-  { route: "import-email", required: "text" },
-  { route: "import-thehive", required: "text" },
-  { route: "import-auditd", required: "text" },
-  { route: "import-journald", required: "text" },
-  { route: "import-sysdig", required: "text" },
-  { route: "import-wazuh", required: "text" },
-];
+// The body field each route's own 400 guard demands, keyed by route.
+//
+// This file used to carry its own hand-written copy of the route list and check it with a regex
+// over src/routes/import.ts. The copy went stale TWICE while claiming to cover every route: the
+// original regex stopped at the first digit and silently dropped import-m365, and #554 added
+// import-leapp without adding the row. Both times a route sat with no contract coverage in the one
+// file whose whole point is that the guard covers all of them.
+//
+// So the list is no longer written down here. EVIDENCE_IMPORT_ROUTES is what actually mounts the
+// guard, and tests/server/importMissingCase.test.ts walks the LIVE Express router and fails if a
+// registered /cases/:id/import* route is missing from it — so the routes below cannot drift from
+// the app. Record<> then makes the remaining hand-maintained part self-enforcing: a route added to
+// that constant without a required field here is a `npm run typecheck` failure, in seconds, rather
+// than a red E2E run minutes later — or, as happened twice, no failure at all.
+const REQUIRED_FIELD: Record<(typeof EVIDENCE_IMPORT_ROUTES)[number], string> = {
+  import: "text",
+  "import-file": "path",
+  "import-csv": "csv",
+  "import-log": "text",
+  "import-thor": "json",
+  "import-siem": "json",
+  "import-chainsaw": "json",
+  "import-hayabusa": "text",
+  "import-velociraptor": "text",
+  "import-network": "text",
+  "import-kape": "text",
+  "import-cybertriage": "text",
+  "import-m365": "text",
+  "import-leapp": "text",
+  "import-aws": "text",
+  "import-cloud-activity": "text",
+  "import-plaso": "text",
+  "import-sandbox": "text",
+  "import-memory": "text",
+  "import-email": "text",
+  "import-thehive": "text",
+  "import-auditd": "text",
+  "import-journald": "text",
+  "import-sysdig": "text",
+  "import-wazuh": "text",
+};
 
-test("the table below really is every import route", () => {
-  // This spec claims to cover EVERY import route. That claim was false the moment it was written:
-  // the table was built with a regex that stopped at the first digit, so /cases/:id/import-m365 was
-  // silently absent — a route with no contract coverage, in a file whose whole point is that the
-  // guard applies to all of them. Checking the table against the source makes the claim testable
-  // instead of aspirational.
-  const src = readFileSync(join(import.meta.dirname, "..", "..", "..", "src", "routes", "import.ts"), "utf8");
-  const inSource = [...src.matchAll(/app\.post\("\/cases\/:id\/(import[A-Za-z0-9-]*)"/g)]
-    .map((m) => m[1])
-    .sort();
-  const inTable = ROUTES.map((r) => r.route).sort();
-  expect(inTable).toEqual(inSource);
-});
+const ROUTES: ReadonlyArray<{ route: string; required: string }> = EVIDENCE_IMPORT_ROUTES.map((route) => ({
+  route,
+  required: REQUIRED_FIELD[route],
+}));
 
 test("every import route 404s an unknown case instead of conjuring one", async ({ page, demoCase }) => {
   test.setTimeout(120_000);


### PR DESCRIPTION
Follow-up to #569, which fixed the symptom. This removes the cause.

## The problem

`importContract.spec.ts` kept a **third** copy of the import route list — after the live Express
router and `EVIDENCE_IMPORT_ROUTES` — and policed it with a regex over `src/routes/import.ts`. The
copy went stale twice while the file claimed to cover every route:

- the original regex stopped at the first digit, so `import-m365` was silently absent
- #554 added `import-leapp` and the row was never added, which left the spec red on master until #569

Both times a route sat with no contract coverage, in the one file whose whole point is that the
guard covers all of them. A hand-maintained copy of a list that lives elsewhere will keep drifting.

## The change

`ROUTES` is now derived from `EVIDENCE_IMPORT_ROUTES`. That constant is what actually mounts the
guard, and `tests/server/importMissingCase.test.ts` already walks the **live** Express router and
fails if a registered `/cases/:id/import*` route is missing from it — so the list here cannot drift
from the app, and the drift surfaces in the fast vitest suite rather than a slow E2E run.

The regex test is deleted along with the copy it policed. Nothing it asserted is now unchecked:
router ↔ constant is the vitest test, constant ↔ this spec is the type below.

What stays hand-maintained is `required` (genuinely per-route: `path`, `csv`, `json`, `text`), and
`Record<(typeof EVIDENCE_IMPORT_ROUTES)[number], string>` makes that self-enforcing at compile time.

## Verification

The type gate is only worth having if it bites, so both directions were checked by mutating
`EVIDENCE_IMPORT_ROUTES` and re-running `npm run typecheck` (the constant was restored byte-identical
afterwards):

| mutation | result |
| --- | --- |
| add `"import-newthing"` | `TS2741: Property '"import-newthing"' is missing ... importContract.spec.ts(29,7)` |
| remove `"import-sysdig"` | `TS2353: '"import-sysdig"' does not exist in type ... importContract.spec.ts(53,3)` |

Coverage is unchanged — the two remaining tests issue 50 requests, 25 routes x 2, `import-leapp`
among them:

```
2 passed (13.2s)
POST /cases/no-such-case-contract/import-leapp -> 404
POST /cases/<demo>/import-leapp -> 400
```

Also green: `tests/server/importMissingCase.test.ts` (28 tests), `typecheck`, `lint`, `format:check`,
`check:size`, `check:imports`, `check:boundaries`. Branch is cut from current `origin/master`.

## Note on the src import

`tests/e2e/workflows/exports.spec.ts` already imports from `src/`, so an E2E spec reaching into
`src/` is an established pattern here; `check:imports` and `check:boundaries` both pass.