### PR TITLE
test(import): make the empty-payload test prove it tested the right field

### DIFF
--- a/companion/tests/e2e/workflows/importContract.spec.ts
+++ b/companion/tests/e2e/workflows/importContract.spec.ts
@@ -87,6 +87,7 @@ test("every import route 400s an empty payload", async ({ page, demoCase }) => {
   await page.goto(`/dashboard?caseId=${encodeURIComponent(demoCase)}`);
 
   const wrong: string[] = [];
+  const misnamed: string[] = [];
   for (const { route, required } of ROUTES) {
     const res = await page.request.post(`/cases/${demoCase}/${route}`, {
       data: { [required]: "   ", filename: "empty.txt" },
@@ -94,8 +95,26 @@ test("every import route 400s an empty payload", async ({ page, demoCase }) => {
     // A whitespace-only payload is the shape a mis-wired dashboard upload sends. It must be
     // refused rather than recorded as a zero-event import, which would leave a custody entry
     // claiming evidence was ingested when none was.
-    if (res.status() !== 400) wrong.push(`${route} -> ${res.status()}`);
+    if (res.status() !== 400) {
+      wrong.push(`${route} -> ${res.status()}`);
+      continue;
+    }
+
+    // ...and the 400 must be the BLANK-payload rejection, not an "I never saw that field" one.
+    // Those are different behaviours and only the first is what this test claims to check. A wrong
+    // REQUIRED_FIELD entry drops the blank into a box the route never reads, so the route rejects
+    // an ABSENT field, still answers 400, and the test stays green while silently checking the
+    // weaker of the two — the typo is invisible. Every route names the field it wanted in the
+    // message ("text is required", "path is required (…)"), so requiring the name back pins
+    // REQUIRED_FIELD to what the route actually reads.
+    const error = String(((await res.json()) as { error?: unknown }).error ?? "");
+    if (!error.includes(required)) misnamed.push(`${route} sent ${required}, answered "${error}"`);
   }
 
   expect(wrong, `routes that accepted an empty payload: ${wrong.join(", ")}`).toEqual([]);
+  expect(
+    misnamed,
+    `routes whose 400 did not name the field REQUIRED_FIELD sent — the entry is wrong, so the ` +
+      `blank never reached the field being tested: ${misnamed.join("; ")}`,
+  ).toEqual([]);
 });


### PR DESCRIPTION
Last soft spot in `importContract.spec.ts`, after #569 (the missing route) and #570 (the derived
route list).

## The hole

The test posts a whitespace-only value into each route's required body field and expects 400. Which
field that is comes from the `REQUIRED_FIELD` map — and a wrong entry there was **invisible**.

A wrong entry drops the blank into a box the route never reads. The route then rejects an *absent*
field and still answers 400, so the test stays green. But it is no longer testing what it says: it
checked "rejects a missing field" instead of "rejects a blank field". Those are different
behaviours, and only the second is the one that matters — a whitespace payload is the shape a
mis-wired dashboard upload sends, and accepting it would write a custody entry claiming evidence was
ingested when none was.

So the map was the one part of this file with no gate on it. #570 made the route *list*
self-enforcing via `Record<>`; the field *names* were still free to be wrong.

## The fix

Every route already names the field it wanted in its rejection — `"text is required"`,
`"csv is required"`, `"json is required"`, `"path is required (absolute path to a file on the
server)"`. So the 400's message is asserted to contain the field that was sent. That pins
`REQUIRED_FIELD` to what the route actually reads, with no per-format fixtures and no second request
per route.

Failures are reported as a batch, matching the existing style, and say which way it is wrong rather
than just failing an equality.

## Verification

Mutated one entry to a wrong field name and re-ran:

```
"import-csv": "text"

✘ every import route 400s an empty payload
  Error: routes whose 400 did not name the field REQUIRED_FIELD sent — the entry is wrong, so the
  blank never reached the field being tested: import-csv sent text, answered "csv is required"
```

The server log for that run shows `POST /cases/<demo>/import-csv -> 400` — the route **still
answered 400** under the mutation, which is precisely why the old assertion could not see it.

Entry restored, both tests green (`2 passed (8.0s)`), all 25 routes' messages name their field. Also
green: `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`. Branch
is cut from current `origin/master` and is not behind it.