### PR TITLE
feat(notify): default milestone notifications to on

### DIFF
--- a/companion/src/analysis/notifications.ts
+++ b/companion/src/analysis/notifications.ts
@@ -347,10 +347,21 @@ export interface ParsedChannelInput {
   error?: string;
 }
 
+// Milestones default ON. They were off because they are lifecycle chatter — case opened, report
+// generated, drop import finished — and a channel that wanted findings did not want a feed. The
+// class changed when a milestone became the only push an analyst gets for a case that is BLOCKED:
+// the host near-duplicate gate stops synthesis and, with this off, said so to nobody. Defaulting
+// off made the quietest choice for the noisiest events and the loudest choice for the one that
+// matters. A channel that wants findings only still opts out per-kind, which is the point of the
+// toggle; what it no longer does is silently withhold "this case is on hold".
+//
+// This also reaches EXISTING channels: the default fills any kind a stored config never set, so a
+// channel saved before this change starts receiving milestones. That is intended — it is the same
+// upgrade every user would otherwise have to perform by hand — but it belongs in the release note.
 const defaultEvents = (): Record<NotificationEventKind, boolean> => ({
   critical_finding: true,
   playbook_update: true,
-  milestone: false,
+  milestone: true,
   mention: true,
 });
 

--- a/companion/tests/analysis/notifications.test.ts
+++ b/companion/tests/analysis/notifications.test.ts
@@ -203,6 +203,27 @@ describe("parseChannelInput", () => {
     expect(ok.draft?.minSeverity).toBe("High"); // default
   });
 
+  // The milestone default is load-bearing, not cosmetic: a milestone is the only push a BLOCKED
+  // case produces (the host near-duplicate gate stops synthesis and says so via one), so a default
+  // of false means nobody is told. Nothing pinned this before, which is how it sat off.
+  it("defaults milestone notifications ON when the input names no events", () => {
+    const ch = parseChannelInput({ type: "slack", webhookUrl: "https://hooks.slack.com/services/x" });
+    expect(ch.ok).toBe(true);
+    expect(ch.draft?.events.milestone).toBe(true);
+  });
+
+  // The other half of the contract: ON by default must still mean opt-OUT-able, or the default is
+  // not a default, it is a mandate.
+  it("keeps an explicit milestone opt-out", () => {
+    const ch = parseChannelInput({
+      type: "slack",
+      webhookUrl: "https://hooks.slack.com/services/x",
+      events: { critical_finding: true, playbook_update: true, milestone: false, mention: true },
+    });
+    expect(ch.ok).toBe(true);
+    expect(ch.draft?.events.milestone).toBe(false);
+  });
+
   it("treats mattermost + discord as webhook channels with default names", () => {
     expect(parseChannelInput({ type: "mattermost", webhookUrl: "not-a-url" }).ok).toBe(false);
     const mm = parseChannelInput({ type: "mattermost", webhookUrl: "https://mm.example.com/hooks/abc" });


### PR DESCRIPTION
## Why

Milestones were off by default because they are lifecycle chatter — case opened, report generated, drop import finished — and a channel that wanted findings did not want a feed. Reasonable when it was written.

It stopped holding in #572. The host near-duplicate gate **stops synthesis** when one machine appears under two hostnames, and announces that with a `milestone`. With the default off, a case could sit blocked and tell nobody — the quietest setting applied to the noisiest events, and to the one event that actually needed to reach someone.

## What changes

`defaultEvents()` now returns `milestone: true`.

**This reaches existing channels, not only new ones.** The default fills in any kind a stored config never explicitly set (`{ ...defaultEvents(), ...(v.events ?? {}) }`), so a channel saved before this change starts receiving milestones — including case-opened and report-generated, not just the blocked-case alert. That is intended: it is the same switch every user would otherwise flip by hand. **It belongs in the release note.**

A channel that wants findings only still opts out per-kind. That is what the toggle is for.

## Tests

The default had **no test** — `parseChannelInput` was covered for URL validation but nothing pinned what `events.milestone` came out as, which is how it sat off unnoticed. Two added:

- the default is ON when the input names no events
- an explicit `milestone: false` still wins, because on-by-default must stay opt-out-able

Both verified to discriminate: reverting the default reds exactly the first (1 failed / 38 passed); restoring gives 39/39.

## Verification

`tests/analysis` + `tests/server`: **441 files, 0 failures.** typecheck, lint, format:check, check:size all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)