### PR TITLE
fix(dashboard): collapse merged near-duplicate hosts in the Hosts filter

### DIFF
--- a/companion/tests/dashboard/featureManifest.ts
+++ b/companion/tests/dashboard/featureManifest.ts
@@ -951,6 +951,7 @@ export const FEATURES: Feature[] = [
       "iocTypeFacets",
       "sourceFacets",
       "hostFacets",
+      "hostFacetValue",
     ],
     // The two facet sentinels stayed in the page: renderTimelineEvents reads them too.
     private: ["IOC_TYPE_ORDER"],
@@ -1142,6 +1143,7 @@ export const FEATURES: Feature[] = [
       "renderAssetList",
       "hasAssetGraph",
       "assetGraphAssets",
+      "assetOverrideMerges",
       "loadAssetGraph",
       "loadAssetOverrides",
       "scheduleAssetGraphReload",

--- a/companion/tests/dashboard/hostFacetMerge.test.ts
+++ b/companion/tests/dashboard/hostFacetMerge.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// public/js/dashboard-facet-filters.js — the Hosts filter's near-duplicate-merge awareness.
+//
+// The near-duplicate host panel (dashboard-host-duplicates.js) lets an analyst merge, e.g.,
+// "DESKTOP-OPE297N" into "DESKTOP-OPE297N.localdomain". That merge is stored as an asset-override
+// (public/js/dashboard-asset-graph.js's assetOverrideMerges()) and does NOT touch the raw
+// ForensicEvent.asset values — so hostFacets() has to resolve each raw asset through the merge
+// chain itself, or the Hosts filter keeps showing both spellings as separate checkboxes even after
+// the analyst merges them.
+interface Api {
+  hostFacets(ft: Array<{ asset?: string }>): string[];
+  hostFacetValue(raw: string | undefined | null): string | null;
+}
+
+function load(merges: Record<string, string>): Api {
+  // dashboard-asset-graph.js only learns overrides through loadAssetOverrides(), which fetches —
+  // there is no seam to inject data directly, so the merge map is supplied the way js/dashboard-
+  // facet-filters.js actually reads it: as a global function, `typeof assetOverrideMerges ===
+  // "function"`, guarded exactly like the production code guards a module that hasn't loaded yet.
+  return loadDashboardModule<Api>("dashboard-facet-filters.js", ["dashboard-state.js"], {
+    assetOverrideMerges: () => merges,
+  });
+}
+
+const FT = [
+  { asset: "DESKTOP-OPE297N" },
+  { asset: "DESKTOP-OPE297N.localdomain" },
+  { asset: "WIN-UK1GV882OK6" },
+];
+
+describe("hostFacets groups a merged near-duplicate host into one entry", () => {
+  it("lists every raw spelling as its own facet before any merge", () => {
+    const { hostFacets } = load({});
+    expect(hostFacets(FT).sort()).toEqual(
+      ["DESKTOP-OPE297N", "DESKTOP-OPE297N.localdomain", "WIN-UK1GV882OK6"].sort(),
+    );
+  });
+
+  it("collapses the merged pair into the canonical spelling once merged", () => {
+    const merges = { "host:desktop-ope297n": "host:desktop-ope297n.localdomain" };
+    const { hostFacets } = load(merges);
+    expect(hostFacets(FT).sort()).toEqual(["DESKTOP-OPE297N.localdomain", "WIN-UK1GV882OK6"].sort());
+  });
+
+  it("resolves both raw spellings' events to the same facet value after a merge", () => {
+    const merges = { "host:desktop-ope297n": "host:desktop-ope297n.localdomain" };
+    const { hostFacets, hostFacetValue } = load(merges);
+    hostFacets(FT); // populates the raw->facet-value map hostFacetValue reads
+    expect(hostFacetValue("DESKTOP-OPE297N")).toBe("DESKTOP-OPE297N.localdomain");
+    expect(hostFacetValue("DESKTOP-OPE297N.localdomain")).toBe("DESKTOP-OPE297N.localdomain");
+    expect(hostFacetValue("WIN-UK1GV882OK6")).toBe("WIN-UK1GV882OK6");
+  });
+
+  it("is case- and trailing-dot-insensitive when reading raw asset spellings, matching the server's canonicalHostName", () => {
+    // companion/src/routes/hostDuplicates.ts's readPair() always runs both sides through
+    // canonicalHostName (lowercase, trimmed, trailing dot stripped) before storing a merge, so the
+    // merge map itself is always already canonical. What varies is the raw ForensicEvent.asset
+    // spelling an importer wrote — different case, or a trailing dot from a raw FQDN capture — and
+    // the client has to canonicalize THAT the same way before it will find the stored merge.
+    const merges = { "host:desktop-ope297n": "host:desktop-ope297n.localdomain" };
+    const ft = [
+      { asset: "Desktop-OPE297N" },
+      { asset: "DESKTOP-OPE297N.localdomain." },
+      { asset: "WIN-UK1GV882OK6" },
+    ];
+    const { hostFacets } = load(merges);
+    expect(hostFacets(ft)).toHaveLength(2);
+  });
+
+  it("never leaves the raw timeline events themselves touched — only the filter's grouping", () => {
+    const merges = { "host:desktop-ope297n": "host:desktop-ope297n.localdomain" };
+    load(merges);
+    expect(FT.map((e) => e.asset)).toEqual([
+      "DESKTOP-OPE297N",
+      "DESKTOP-OPE297N.localdomain",
+      "WIN-UK1GV882OK6",
+    ]);
+  });
+});

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4475,7 +4475,7 @@
       });
       const originFiltering = originHidden > 0;
       if (originFiltering) visible = visible.filter(e => !DfirFacets.origins.has(ftOriginOf(e)));
-      if (hostHidden > 0) visible = visible.filter(e => !DfirFacets.hosts.has(e.asset || NO_HOST_FACET));
+      if (hostHidden > 0) visible = visible.filter(e => !DfirFacets.hosts.has((typeof hostFacetValue === "function" ? hostFacetValue(e.asset) : e.asset) || NO_HOST_FACET));
       // Corroboration lens (#35): count only DISTINCT sources the analyst is still looking at (excludes
       // ones unchecked in the Sources filter), so the two filters compose — isolating to a single source
       // under 2+ correctly shows nothing (you can't be corroborated by 2 distinct tools within 1).

--- a/public/js/dashboard-ai-status.js
+++ b/public/js/dashboard-ai-status.js
@@ -57,13 +57,23 @@
       // run just finished and that run knows nothing about a gate still holding the next one. Verify
       // it against the case rather than let a stale "up to date" sit over an unresolved decision.
       refreshAiState(activeCaseId);
+      // Every import path answers 202 before its background job lands the new events in the
+      // timeline (see js/dashboard-unified-import.js), so this "run just finished" event — not the
+      // fetch resolving — is the earliest safe point to re-check for a near-duplicate host (e.g.
+      // "HOST" vs "HOST.domain") the import just introduced. Runs on every idle, not only imports,
+      // but loadHostDuplicates is a cheap GET and this is the only reliable "import settled" signal
+      // available client-side, including when AI is off.
+      loadHostDuplicates(activeCaseId);
     } else if (evt.status === "blocked") {
       // A GATE, not a failure: the pipeline stopped on purpose and is waiting for a decision (a
       // Presidio approval, a duplicate-host merge). Both used to arrive as "error", which painted
       // a red "AI: error" over a question — analysts read it as a broken provider and never went
       // looking for the buttons that would release the run. Amber, and it says "on hold".
       hideImportProgress();
-      setAi("blocked", "on hold — " + (evt.detail || "waiting on your decision"));
+      setAi(
+        "blocked",
+        "on hold — " + (evt.detail || "waiting on your decision"),
+      );
       clearTransientStatus();
       // Refresh BOTH pending lists rather than parse the detail text: the two gates share this
       // status, each list is a cheap request, and whichever one is empty simply hides its chip.
@@ -123,9 +133,12 @@
     // so the pill names the work and appends the hold rather than hiding either one.
     const heldNote = s.holds && s.holds.length ? " (analysis on hold)" : "";
     if (s.state === "off") setAi("off", s.detail || "off");
-    else if (s.state === "blocked") setAi("blocked", "on hold — " + (s.detail || "waiting on your decision"));
-    else if (s.state === "error") setAi("error", "error — " + (s.detail || "see server log"));
-    else if (s.state === "analyzing") setAi("analyzing", (s.detail || "working…") + heldNote);
+    else if (s.state === "blocked")
+      setAi("blocked", "on hold — " + (s.detail || "waiting on your decision"));
+    else if (s.state === "error")
+      setAi("error", "error — " + (s.detail || "see server log"));
+    else if (s.state === "analyzing")
+      setAi("analyzing", (s.detail || "working…") + heldNote);
     else setAi("idle", s.detail || "up to date");
   }
 

--- a/public/js/dashboard-asset-graph.js
+++ b/public/js/dashboard-asset-graph.js
@@ -42,6 +42,16 @@
       .then((ov) => {
         assetOverridesData = ov;
         renderAssetList();
+        // js/dashboard-facet-filters.js's hostFacets() reads assetOverrideMerges() to collapse a
+        // merged host's near-duplicate spellings into one Hosts-filter entry — but that grouping is
+        // only rebuilt when the timeline itself repaints. Without this, a merge made in the
+        // duplicate-hosts panel (or one already saved when the case loads, if this fetch lands
+        // after the timeline's own render) leaves the Hosts menu and filter stale until some
+        // unrelated action re-renders the timeline. If the timeline hasn't rendered yet this is a
+        // no-op — its own first render already reads the now-current overrides.
+        if (DfirState.lastFt() && typeof renderTimelineEvents === "function") {
+          renderTimelineEvents(DfirState.lastFt());
+        }
       })
       .catch(() => {});
   }
@@ -337,9 +347,15 @@
   function assetGraphAssets() {
     return (assetGraphData && assetGraphData.assets) || [];
   }
+  // js/dashboard-facet-filters.js reads the merge map to collapse a merged host's near-duplicate
+  // spellings (e.g. "HOST" / "HOST.domain") into one Hosts-filter entry.
+  function assetOverrideMerges() {
+    return (assetOverridesData && assetOverridesData.merges) || {};
+  }
 
   window.hasAssetGraph = hasAssetGraph;
   window.assetGraphAssets = assetGraphAssets;
+  window.assetOverrideMerges = assetOverrideMerges;
   window.loadAssetGraph = loadAssetGraph;
   window.loadAssetOverrides = loadAssetOverrides;
   window.scheduleAssetGraphReload = scheduleAssetGraphReload;

--- a/public/js/dashboard-facet-filters.js
+++ b/public/js/dashboard-facet-filters.js
@@ -216,17 +216,78 @@
     return hiddenInView;
   }
 
+  // Mirrors the server's canonicalHostName (companion/src/analysis/hostAlias.ts): lowercase, trim,
+  // drop a trailing FQDN dot. Never strips the domain — "ws-042" and "ws-042.corp.local" stay
+  // distinct until an analyst merge (or fleet-inventory alias) links them.
+  function _canonicalHostKey(raw) {
+    return raw.trim().toLowerCase().replace(/\.+$/, "");
+  }
+  // Host-duplicate merges (companion/src/routes/hostDuplicates.ts, "Same host — merge") are stored
+  // as a chain of override ids keyed "host:<canonical name>" — not applied to the raw event data.
+  // Resolve one id through that chain to its final canonical id. Cycle-guarded, same as the server's
+  // resolveCanonical, so a bad merge can never hang the filter.
+  function _resolveHostMergeChain(id, merges) {
+    let cur = id;
+    const seen = new Set([cur]);
+    while (merges[cur] !== undefined) {
+      cur = merges[cur];
+      if (seen.has(cur)) return id;
+      seen.add(cur);
+    }
+    return cur;
+  }
+
+  // Raw asset string -> the Hosts-filter facet value it collapses into. Rebuilt by hostFacets() on
+  // every call; read by the caller (js/dashboard.html's renderTimelineEvents) applying the filter
+  // right after, so it is always fresh for the ft it was just built from.
+  let _hostFacetValueOf = new Map();
+  function hostFacetValue(raw) {
+    if (!raw) return null;
+    return _hostFacetValueOf.get(raw) || raw;
+  }
+
   // Forensic host filter (mirrors the source filter): the distinct affected hosts across the in-scope
   // timeline, plus a trailing "(no host)" pseudo-facet for events with no asset (so those are
-  // controllable and "None" truly empties the timeline).
+  // controllable and "None" truly empties the timeline). Hosts an analyst has merged in the
+  // near-duplicate-host panel (e.g. "DESKTOP-OPE297N" + "DESKTOP-OPE297N.localdomain") collapse into
+  // one entry here, same as they already do in host ranking and AI synthesis — the raw timeline
+  // events themselves are untouched, only this filter's grouping changes.
   function hostFacets(ft) {
-    const set = new Set();
+    const merges =
+      typeof assetOverrideMerges === "function" ? assetOverrideMerges() : {};
+    const rawAssets = new Set();
     let hasNone = false;
     for (const e of ft || []) {
-      if (e.asset) set.add(e.asset);
+      if (e.asset) rawAssets.add(e.asset);
       else hasNone = true;
     }
-    const list = [...set].sort((a, b) => a.localeCompare(b));
+    // Group raw spellings by their resolved merge target.
+    const groups = new Map(); // resolved key -> [raw, raw, ...]
+    for (const raw of rawAssets) {
+      const key = _resolveHostMergeChain(
+        "host:" + _canonicalHostKey(raw),
+        merges,
+      );
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(raw);
+    }
+    const valueOf = new Map();
+    const display = [];
+    for (const raws of groups.values()) {
+      // The merge target's own spelling (the one nothing in the group redirects further) is the
+      // clearest label; when it isn't present among this ft's events, the longest spelling (usually
+      // the FQDN) is the more informative fallback.
+      const canonicalRaw =
+        raws.find(
+          (r) =>
+            _resolveHostMergeChain("host:" + _canonicalHostKey(r), merges) ===
+            "host:" + _canonicalHostKey(r),
+        ) || raws.reduce((a, b) => (b.length > a.length ? b : a));
+      for (const r of raws) valueOf.set(r, canonicalRaw);
+      display.push(canonicalRaw);
+    }
+    _hostFacetValueOf = valueOf;
+    const list = display.sort((a, b) => a.localeCompare(b));
     if (hasNone) list.push(NO_HOST_FACET);
     return list;
   }
@@ -277,4 +338,5 @@
   window.iocTypeFacets = iocTypeFacets;
   window.sourceFacets = sourceFacets;
   window.hostFacets = hostFacets;
+  window.hostFacetValue = hostFacetValue;
 })();

--- a/public/js/dashboard-unified-import.js
+++ b/public/js/dashboard-unified-import.js
@@ -237,6 +237,11 @@
       if (dataFail) parts.push(`${dataFail} file(s) failed / unrecognized`);
       statusEl.textContent = parts.join(" · ") || "nothing imported";
       e.target.value = ""; // allow re-selecting the same files
+      // Near-duplicate hosts (e.g. "HOST" vs "HOST.domain") are refreshed off the "idle" AI-status
+      // event (js/dashboard-ai-status.js), not here: /import and /import-file both answer 202 before
+      // the background import job actually lands the new events in the timeline, so a refresh at
+      // this point would read pre-import state. "idle" is emitted once that background run finishes,
+      // for every import kind — including with AI off, which is what this deterministic check needs.
     };
   }
 


### PR DESCRIPTION
## Summary
- A plain (non-AI) import left the Forensic Timeline's Hosts filter listing a short hostname and its FQDN as two separate hosts (e.g. `DESKTOP-OPE297N` vs `DESKTOP-OPE297N.localdomain`), since `hostFacets()` read raw `event.asset` values with no awareness of the near-duplicate-host merge panel.
- `hostFacets()` now resolves each raw asset through the case's asset-override merges before deduping, so merging a pair in the duplicate-hosts panel collapses them into one filter entry (raw timeline events themselves are left untouched).
- The Hosts filter now refreshes when asset overrides change, instead of only on an unrelated timeline render.
- The duplicate-hosts check now fires off the AI-status `"idle"` event — the point at which an import's background job has actually landed its events — instead of racing the import request's `202 accepted` response, which returns before processing finishes.

## Test plan
- [x] `npx vitest run tests/dashboard/` — 2212/2212 passing (includes new `hostFacetMerge.test.ts`)
- [x] `npx prettier --check` on all changed files