### PR TITLE
fix(velociraptor): correct event titles for DetectRaptor/startup artifacts

### DIFF
--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -443,6 +443,7 @@
     "velociraptorDownload.ts": "analysis/case",
     "velociraptorImport.ts": "analysis/ingest",
     "velociraptorRelease.ts": "analysis/case",
+    "velociraptorTitle.ts": "analysis/ingest",
     "wazuhImport.ts": "analysis/ingest",
     "workLogFilter.ts": "analysis/workflow",
     "yaraImport.ts": "analysis/ingest",

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -55,6 +55,7 @@ import {
 // downgrade a real Critical (e.g. "Security Audit Logs Cleared") to a keyword-guessed Medium.
 import { isFlatChainsawRow, mapFlatChainsawRow } from "./chainsawImport.js";
 import { detectTimestomp } from "./timestompDetect.js";
+import { withHostSuffix, titleSafe, isMangledUtf16 } from "./velociraptorTitle.js";
 
 type Row = Record<string, unknown>;
 
@@ -493,26 +494,6 @@ function pickHost(row: Row): string {
   return "";
 }
 
-// The row's own chip already shows the host, so appending it to `description` is purely for the
-// [details] panel — but dashboard-text.js's splitEventTitle only sends it there if a genuine
-// " - " precedes it. Several mappers below join their fields with "—"/": " and never emit that
-// literal ASCII " - ", so with a plain `+= " @ host"` the WHOLE description (host included)
-// becomes the title. Force the boundary whenever one isn't already guaranteed.
-function withHostSuffix(description: string, host: string): string {
-  if (!host || description.toLowerCase().includes(host.toLowerCase())) return description;
-  return description.includes(" - ") ? `${description} @ ${host}` : `${description} - @ ${host}`;
-}
-
-// A rule/verdict NAME (DetectRaptor's Detection.Name, a Sigma Rule.Title) is analyst-authored and
-// often carries its own " - " ("RMM - Microsoft Quick Assist Execution", "Suspicious Location -
-// Local Temp Executable or Script"). Interpolated raw as the FIRST thing in a description, that
-// internal dash is what splitEventTitle finds first — the title truncates to "RMM" and everything
-// after it (the actual subject, and the file/process this code goes on to promote into the title)
-// gets swallowed into [details]. Neutralize it to an em dash so only OUR intended boundary counts.
-function titleSafe(name: string): string {
-  return name.replace(/ - /g, " — ");
-}
-
 // ───────────────────────────── IOCs / hashes ─────────────────────────────
 
 function vrHashes(row: Row): { sha256?: string; md5?: string } {
@@ -868,11 +849,9 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
   if (win) {
     win.severity = worst(win.severity, severity);
     for (const m of v.mitre) if (!win.mitre.includes(m)) win.mitre.push(m);
-    // Same title-promotion as the non-event branch below: name the process the rule fired on
-    // right in the title, so several hits of the same rule stay distinguishable at a glance.
-    const winEd = isObject(flat!.rec.event_data) ? (flat!.rec.event_data as Row) : {};
+    const winEd = flat && isObject(flat.rec.event_data) ? flat.rec.event_data : {};
     const winImage = firstStr(winEd, ["Image", "NewProcessName", "TargetImage", "TargetFilename"]);
-    const winTag = winImage ? baseName(winImage) : "";
+    const winTag = baseName(winImage);
     win.description =
       `${label}: ${titleSafe(v.title)}${winTag ? ` — ${winTag}` : ""} - ${win.description}`.slice(0, 600);
     win.aggKey = `vr-det|${v.title.toLowerCase()}|${win.aggKey}`.slice(0, 400);
@@ -948,12 +927,7 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
   // " - " so the analyst can read them at a glance without knowing the artifact's column layout.
   // Content-centric detections (ISEAutoSave, PSReadline) get both the filename AND the evidence.
   let subject: string;
-  // The single most specific identifier (the process/pipe/file the rule actually fired on) gets
-  // promoted into the TITLE itself, not just the [details] panel: splitEventTitle only shows what
-  // sits before the first " - ", so a bare "<rule name>" title makes ten hits of the same rule
-  // (ten different RMM tools, say) indistinguishable without opening each one. The row's host chip
-  // already shows the host, so this stays purely about the finding's subject.
-  let titleTag = "";
+  let titleTag = ""; // most specific identifier (process/pipe/file), promoted into the TITLE itself
   if (salient) {
     subject = salient;
   } else {
@@ -973,9 +947,7 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
       // main signal — include it labeled so the analyst sees what the rule matched.
       parts.push(`${evidenceKey}: ${oneLine(evidence)}`);
     }
-    if (processName) titleTag = processName;
-    else if (pipe) titleTag = pipe;
-    else if (path && !isYmsPath(path)) titleTag = baseName(path);
+    titleTag = processName || pipe || (path && !isYmsPath(path) ? baseName(path) : "");
     subject = parts.join(" - ");
   }
 
@@ -1554,23 +1526,11 @@ function mapDownload(row: Row, host: string, sink: Map<string, SiemIoc>): Mapped
   };
 }
 
-// Windows.Sys.StartupItems' Details column is Velociraptor's own decoding of the registry/INI
-// value — usually a real command line ("wscript ... bginfo.vbs"), but for a desktop.ini
-// [.ShellClassInfo] entry it's the raw UTF-16 string still carrying its inter-character NUL
-// bytes, rendered as "." (".S.h.e.l.l.C.l.a.s.s.I.n.f.o......."). That's registry noise, not an
-// attacker-controlled command — over a third of the string being literal dots is the signal, and
-// it adds nothing worth a title, so it's dropped entirely rather than shown garbled.
-function isMangledUtf16(s: string): boolean {
-  if (s.length < 12) return false;
-  const dots = (s.match(/\./g) || []).length;
-  return dots / s.length > 0.3;
-}
-
 function mapStartup(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
   const name = str(getCI(row, "Name")).trim();
   const ospath = str(getCI(row, "OSPath")).trim();
   const detailsRaw = str(getCI(row, "Details")).trim();
-  const details = isMangledUtf16(detailsRaw) ? "" : detailsRaw;
+  const details = isMangledUtf16(detailsRaw) ? "" : detailsRaw; // desktop.ini's [.ShellClassInfo] noise
   const enabledRaw = str(getCI(row, "Enabled")).trim().toLowerCase();
   const enabled =
     enabledRaw === "enable" || enabledRaw === "enabled" || enabledRaw === "true" || enabledRaw === "1";

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -493,6 +493,26 @@ function pickHost(row: Row): string {
   return "";
 }
 
+// The row's own chip already shows the host, so appending it to `description` is purely for the
+// [details] panel — but dashboard-text.js's splitEventTitle only sends it there if a genuine
+// " - " precedes it. Several mappers below join their fields with "—"/": " and never emit that
+// literal ASCII " - ", so with a plain `+= " @ host"` the WHOLE description (host included)
+// becomes the title. Force the boundary whenever one isn't already guaranteed.
+function withHostSuffix(description: string, host: string): string {
+  if (!host || description.toLowerCase().includes(host.toLowerCase())) return description;
+  return description.includes(" - ") ? `${description} @ ${host}` : `${description} - @ ${host}`;
+}
+
+// A rule/verdict NAME (DetectRaptor's Detection.Name, a Sigma Rule.Title) is analyst-authored and
+// often carries its own " - " ("RMM - Microsoft Quick Assist Execution", "Suspicious Location -
+// Local Temp Executable or Script"). Interpolated raw as the FIRST thing in a description, that
+// internal dash is what splitEventTitle finds first — the title truncates to "RMM" and everything
+// after it (the actual subject, and the file/process this code goes on to promote into the title)
+// gets swallowed into [details]. Neutralize it to an em dash so only OUR intended boundary counts.
+function titleSafe(name: string): string {
+  return name.replace(/ - /g, " — ");
+}
+
 // ───────────────────────────── IOCs / hashes ─────────────────────────────
 
 function vrHashes(row: Row): { sha256?: string; md5?: string } {
@@ -750,11 +770,10 @@ function mapYara(row: Row, artifact: string, host: string, sink: Map<string, Sie
 
   const mitre = mitreFromText(flatStr(getCI(row, "Meta")), flatStr(getCI(row, "Tags")), ruleName);
 
-  let description = `Velociraptor YARA: ${ruleName}`;
+  let description = `Velociraptor YARA: ${titleSafe(ruleName)}`;
   if (procName) description += ` - ${baseName(procName)}${pid ? ` (pid ${pid})` : ""}`;
   else if (path) description += ` - ${path}`;
-  if (host) description += ` @ ${host}`;
-  description = description.slice(0, 600);
+  description = withHostSuffix(description, host).slice(0, 600);
 
   return {
     timestamp: pickTime(row),
@@ -794,7 +813,7 @@ function mapSigma(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEve
   if (win) {
     if (sev) win.severity = worst(win.severity, sev);
     for (const m of tags) if (!win.mitre.includes(m)) win.mitre.push(m);
-    win.description = `Velociraptor Sigma: ${title} - ${win.description}`.slice(0, 600);
+    win.description = `Velociraptor Sigma: ${titleSafe(title)} - ${win.description}`.slice(0, 600);
     win.aggKey = `vr-sigma|${title.toLowerCase()}|${win.aggKey}`;
     win.sources = ["Velociraptor"];
     if (!win.timestamp) win.timestamp = pickTime(row);
@@ -806,9 +825,9 @@ function mapSigma(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEve
   scrapeEvidence(row, sink);
   const message = rowMessage(row);
   const detail = salientFromMessage(message) || (message ? oneLine(message).slice(0, 400) : "");
-  let description = `Velociraptor Sigma: ${title}`;
+  let description = `Velociraptor Sigma: ${titleSafe(title)}`;
   if (detail) description += ` - ${detail}`;
-  if (host) description += ` @ ${host}`;
+  description = withHostSuffix(description, host);
   return {
     timestamp: pickTime(row),
     description: description.slice(0, 600),
@@ -849,7 +868,13 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
   if (win) {
     win.severity = worst(win.severity, severity);
     for (const m of v.mitre) if (!win.mitre.includes(m)) win.mitre.push(m);
-    win.description = `${label}: ${v.title} - ${win.description}`.slice(0, 600);
+    // Same title-promotion as the non-event branch below: name the process the rule fired on
+    // right in the title, so several hits of the same rule stay distinguishable at a glance.
+    const winEd = isObject(flat!.rec.event_data) ? (flat!.rec.event_data as Row) : {};
+    const winImage = firstStr(winEd, ["Image", "NewProcessName", "TargetImage", "TargetFilename"]);
+    const winTag = winImage ? baseName(winImage) : "";
+    win.description =
+      `${label}: ${titleSafe(v.title)}${winTag ? ` — ${winTag}` : ""} - ${win.description}`.slice(0, 600);
     win.aggKey = `vr-det|${v.title.toLowerCase()}|${win.aggKey}`.slice(0, 400);
     win.sources = ["Velociraptor"];
     if (!win.timestamp) win.timestamp = pickTime(row);
@@ -923,6 +948,12 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
   // " - " so the analyst can read them at a glance without knowing the artifact's column layout.
   // Content-centric detections (ISEAutoSave, PSReadline) get both the filename AND the evidence.
   let subject: string;
+  // The single most specific identifier (the process/pipe/file the rule actually fired on) gets
+  // promoted into the TITLE itself, not just the [details] panel: splitEventTitle only shows what
+  // sits before the first " - ", so a bare "<rule name>" title makes ten hits of the same rule
+  // (ten different RMM tools, say) indistinguishable without opening each one. The row's host chip
+  // already shows the host, so this stays purely about the finding's subject.
+  let titleTag = "";
   if (salient) {
     subject = salient;
   } else {
@@ -942,14 +973,17 @@ function mapDetection(row: Row, artifact: string, host: string, sink: Map<string
       // main signal — include it labeled so the analyst sees what the rule matched.
       parts.push(`${evidenceKey}: ${oneLine(evidence)}`);
     }
+    if (processName) titleTag = processName;
+    else if (pipe) titleTag = pipe;
+    else if (path && !isYmsPath(path)) titleTag = baseName(path);
     subject = parts.join(" - ");
   }
 
-  let description = `${label}: ${v.title}`;
+  let description = `${label}: ${titleSafe(v.title)}`;
+  if (titleTag) description += ` — ${titleTag}`;
   if (subject) description += ` - ${subject}`;
   if (fileDeleted) description += ` [deleted]`;
-  if (host) description += ` @ ${host}`;
-  description = description.slice(0, 4000);
+  description = withHostSuffix(description, host).slice(0, 4000);
 
   const aggKey =
     `vr-det|${v.title.toLowerCase()}|${(path || processName || pipe || subject).toLowerCase()}|${host.toLowerCase()}`
@@ -1047,8 +1081,7 @@ function mapGeneric(row: Row, artifact: string, host: string, sink: Map<string, 
   const path = firstStr(row, ["OSPath", "FullPath", "_FullPath", "FilePath"]);
 
   let description = `Velociraptor${artifact ? ` [${artifact}]` : ""}: ${base}`.slice(0, 600);
-  if (host && !description.toLowerCase().includes(host.toLowerCase()))
-    description = `${description} @ ${host}`.slice(0, 600);
+  description = withHostSuffix(description, host).slice(0, 600);
 
   const aggKey = `vr|${artifact.toLowerCase()}|${host.toLowerCase()}|${base.toLowerCase()}`
     .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/g, "<guid>")
@@ -1099,8 +1132,7 @@ function mapUsn(row: Row, artifact: string, host: string): MappedEvent {
     0,
     600,
   );
-  if (host && !description.toLowerCase().includes(host.toLowerCase()))
-    description = `${description} @ ${host}`.slice(0, 600);
+  description = withHostSuffix(description, host).slice(0, 600);
   const aggKey = `vr|usn|${host.toLowerCase()}|${reason.toLowerCase()}|${path.toLowerCase()}`
     .replace(/\d+/g, "#")
     .slice(0, 400);
@@ -1171,8 +1203,7 @@ function mapMft(row: Row, artifact: string, host: string): MappedEvent[] {
       0,
       600,
     );
-    if (host && !description.toLowerCase().includes(host.toLowerCase()))
-      description = `${description} @ ${host}`.slice(0, 600);
+    description = withHostSuffix(description, host).slice(0, 600);
     const aggKey = `vr|mft|${host.toLowerCase()}|${macb.toLowerCase()}|${path.toLowerCase()}`
       .replace(/\d+/g, "#")
       .slice(0, 400);
@@ -1229,8 +1260,7 @@ function actionEvent(o: {
       0,
       600,
     );
-  if (o.host && !description.toLowerCase().includes(o.host.toLowerCase()))
-    description = `${description} @ ${o.host}`.slice(0, 600);
+  description = withHostSuffix(description, o.host).slice(0, 600);
   const aggKey =
     `vr|${o.artifact.toLowerCase()}|${o.host.toLowerCase()}|${o.action.toLowerCase()}|${(o.aggSubject ?? o.subject).toLowerCase()}`
       .replace(/\d+/g, "#")
@@ -1408,8 +1438,7 @@ function mapPslist(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEv
   if (callChain && callChain !== name) description += ` [${callChain}]`;
   const subject = cmdline || exe;
   if (subject) description += `: ${oneLine(subject).slice(0, 300)}`;
-  if (host) description += ` @ ${host}`;
-  description = description.slice(0, 600);
+  description = withHostSuffix(description, host).slice(0, 600);
 
   const aggKey =
     `vr-pslist|${name.toLowerCase()}|${ppid}|${host.toLowerCase()}|${(cmdline || exe || name).toLowerCase()}`
@@ -1505,8 +1534,7 @@ function mapDownload(row: Row, host: string, sink: Map<string, SiemIoc>): Mapped
   // Prefix with "Velociraptor:" so the artifact-name injection in the main loop can insert
   // [_Source] right after "Velociraptor" (consistent with every other mapper).
   let description = `Velociraptor: Downloaded ${name || rawPath || "file"} from ${urlDisplay}`;
-  if (host) description += ` @ ${host}`;
-  description = description.slice(0, 600);
+  description = withHostSuffix(description, host).slice(0, 600);
 
   const aggKey = `vr-download|${name.toLowerCase()}|${urlDisplay.toLowerCase()}|${host.toLowerCase()}`
     .replace(/\d+/g, "#")
@@ -1526,10 +1554,23 @@ function mapDownload(row: Row, host: string, sink: Map<string, SiemIoc>): Mapped
   };
 }
 
+// Windows.Sys.StartupItems' Details column is Velociraptor's own decoding of the registry/INI
+// value — usually a real command line ("wscript ... bginfo.vbs"), but for a desktop.ini
+// [.ShellClassInfo] entry it's the raw UTF-16 string still carrying its inter-character NUL
+// bytes, rendered as "." (".S.h.e.l.l.C.l.a.s.s.I.n.f.o......."). That's registry noise, not an
+// attacker-controlled command — over a third of the string being literal dots is the signal, and
+// it adds nothing worth a title, so it's dropped entirely rather than shown garbled.
+function isMangledUtf16(s: string): boolean {
+  if (s.length < 12) return false;
+  const dots = (s.match(/\./g) || []).length;
+  return dots / s.length > 0.3;
+}
+
 function mapStartup(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
   const name = str(getCI(row, "Name")).trim();
   const ospath = str(getCI(row, "OSPath")).trim();
-  const details = str(getCI(row, "Details")).trim();
+  const detailsRaw = str(getCI(row, "Details")).trim();
+  const details = isMangledUtf16(detailsRaw) ? "" : detailsRaw;
   const enabledRaw = str(getCI(row, "Enabled")).trim().toLowerCase();
   const enabled =
     enabledRaw === "enable" || enabledRaw === "enabled" || enabledRaw === "true" || enabledRaw === "1";
@@ -1542,8 +1583,7 @@ function mapStartup(row: Row, host: string, sink: Map<string, SiemIoc>): MappedE
   const enabledLabel = enabled ? "enabled" : "disabled";
   const subject = details && details !== name ? oneLine(details).slice(0, 300) : ospath;
   let description = `Velociraptor: Startup [${name || "item"}] — ${subject} (${enabledLabel})`;
-  if (host) description += ` @ ${host}`;
-  description = description.slice(0, 600);
+  description = withHostSuffix(description, host).slice(0, 600);
 
   // Active persistence is worth surfacing; disabled items are informational.
   const severity: Severity = enabled ? "Low" : "Info";
@@ -1587,8 +1627,7 @@ function mapTaskScheduler(row: Row, host: string, sink: Map<string, SiemIoc>): M
   let description = `Velociraptor: Scheduled Task [${taskName || "task"}]`;
   if (cmd) description += ` — ${oneLine(cmd).slice(0, 250)}`;
   if (userLabel) description += ` (${userLabel}${runLevel ? `, ${runLevel}` : ""})`;
-  if (host) description += ` @ ${host}`;
-  description = description.slice(0, 600);
+  description = withHostSuffix(description, host).slice(0, 600);
 
   const aggKey = `vr-task|${taskName.toLowerCase()}|${host.toLowerCase()}`.replace(/\d+/g, "#").slice(0, 400);
 

--- a/companion/src/analysis/velociraptorTitle.ts
+++ b/companion/src/analysis/velociraptorTitle.ts
@@ -1,0 +1,27 @@
+// Small, pure helpers for building Velociraptor event titles/descriptions — split out of
+// velociraptorImport.ts (see #384's file-size ledger) rather than grown in place.
+//
+// dashboard-text.js's splitEventTitle keeps only the text before the FIRST literal " - " as the
+// row's TITLE; everything after it collapses into the [details] panel. Both helpers below exist
+// to keep that boundary where the importer actually intends it.
+
+// The host chip already shows the host, so force it behind a guaranteed " - " boundary.
+export function withHostSuffix(description: string, host: string): string {
+  if (!host || description.toLowerCase().includes(host.toLowerCase())) return description;
+  return description.includes(" - ") ? `${description} @ ${host}` : `${description} - @ ${host}`;
+}
+
+// A rule/verdict NAME can itself contain " - " ("RMM - Microsoft Quick Assist Execution"), which
+// would be mistaken for that same boundary and truncate the title. Swap it for an em dash.
+export function titleSafe(name: string): string {
+  return name.replace(/ - /g, " — ");
+}
+
+// A desktop.ini [.ShellClassInfo] entry's Details is raw UTF-16, NUL bytes rendered as "."
+// (".S.h.e.l.l.C.l.a.s.s.I.n.f.o......."). Registry noise, not an attacker command — drop it
+// rather than show it garbled.
+export function isMangledUtf16(s: string): boolean {
+  if (s.length < 12) return false;
+  const dots = (s.match(/\./g) || []).length;
+  return dots / s.length > 0.3;
+}

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -4,6 +4,15 @@ import {
   parseVelociraptorJsonProgress,
 } from "../../src/analysis/velociraptorImport.js";
 
+// Mirrors public/js/dashboard-text.js's splitEventTitle: the row's displayed TITLE is everything
+// before the first " - "; the rest collapses into the [details] panel. Tests below use this to
+// assert what an analyst actually sees on the row without expanding it — e.g. that the host
+// (already shown in its own chip) never leaks into the title.
+function splitEventTitle(desc: string): { title: string; rest: string } {
+  const i = desc.indexOf(" - ");
+  return i < 0 ? { title: desc, rest: "" } : { title: desc.slice(0, i), rest: desc.slice(i + 3) };
+}
+
 // ── A Velociraptor Sigma detection row (parsed evtx event + matched rule).
 function sigmaRow(): object {
   return {
@@ -166,8 +175,14 @@ describe("parseVelociraptorJson — Elastic-indexed Velociraptor (Kibana push)",
     expect(r.events).toHaveLength(1);
     const e = r.events[0];
     expect(e.severity).toBe("Medium"); // honors Detection.Criticality over the psexec keyword
-    expect(e.description).toContain("Execution - PsExec");
+    // The rule NAME itself has an internal " - " ("Execution - PsExec"); it's neutralized to an
+    // em dash so the dashboard's title/detail split doesn't truncate on it (see titleSafe).
+    expect(e.description).toContain("Execution — PsExec");
+    expect(e.description).not.toContain("Execution - PsExec");
     expect(e.description).toContain("DetectRaptor Amcache detection:");
+    // The triggering file is promoted into the title too, distinguishing this from other hits.
+    const title = splitEventTitle(e.description).title;
+    expect(title).toContain("psexec.exe"); // basename of EntryPath, lowercased in the CSV row
     expect(e.description).not.toContain("-1"); // "-" cells dropped, not rendered
     expect(e.timestamp).toContain("2026-05-07T16:31:04"); // Kibana "@" date → ISO
     expect(e.sources).toEqual(["Velociraptor"]);
@@ -438,6 +453,50 @@ describe("parseVelociraptorJson — DetectRaptor detection rows", () => {
     expect(r.iocs.some((i) => i.type === "file" && i.value.includes("kprocesshacker.sys"))).toBe(true);
   });
 
+  it("promotes the triggering file into the TITLE itself, so two hits of the same rule stay distinguishable without opening [details]", () => {
+    const quickAssist = {
+      _Source: "DetectRaptor.Windows.Detection.Amcache",
+      Computer: "DESKTOP-OPE297N.localdomain",
+      Detection: { Name: "RMM" },
+      EntryPath: "c:\\program files\\microsoft quick assist\\quickassist.exe",
+    };
+    const anydesk = {
+      _Source: "DetectRaptor.Windows.Detection.Amcache",
+      Computer: "DESKTOP-OPE297N.localdomain",
+      Detection: { Name: "RMM" },
+      EntryPath: "c:\\program files (x86)\\anydesk\\anydesk.exe",
+    };
+    const r = parseVelociraptorJson(JSON.stringify([quickAssist, anydesk]));
+    const [qa, ad] = r.events;
+    const qaTitle = splitEventTitle(qa.description).title;
+    const adTitle = splitEventTitle(ad.description).title;
+    expect(qaTitle).toContain("quickassist.exe");
+    expect(adTitle).toContain("anydesk.exe");
+    expect(qaTitle).not.toBe(adTitle); // same rule, same label — the file is what tells them apart
+    // The host chip already shows the host — it must not also sit inside the title text.
+    expect(qaTitle).not.toContain("DESKTOP-OPE297N");
+    expect(adTitle).not.toContain("DESKTOP-OPE297N");
+  });
+
+  it("keeps the full rule NAME in the title even when the name itself contains a ' - ' (DetectRaptor's own naming convention)", () => {
+    // Real DetectRaptor rule names ("RMM - Microsoft Quick Assist Execution", "Suspicious
+    // Location - Local Temp Executable or Script") embed a " - " — the exact separator
+    // splitEventTitle uses to find the title/detail boundary. Left unhandled, the FIRST " - "
+    // (inside the rule name) wins, and the title truncates to "RMM" before the promoted file tag
+    // ever renders — a bug only visible once the string is actually split, not just substring-matched.
+    const row = {
+      _Source: "DetectRaptor.Windows.Detection.Amcache",
+      Computer: "DESKTOP-OPE297N.localdomain",
+      Detection: { Name: "RMM - Microsoft Quick Assist Execution" },
+      OSPath: "c:\\program files\\windowsapps\\...\\quickassist.exe",
+    };
+    const r = parseVelociraptorJson(JSON.stringify([row]));
+    const { title } = splitEventTitle(r.events[0].description);
+    expect(title).toContain("RMM");
+    expect(title).toContain("Microsoft Quick Assist Execution");
+    expect(title).toContain("quickassist.exe");
+  });
+
   it("surfaces the matched Content of a PSReadline/ISE detection, not just the rule name", () => {
     const row = {
       Detection: {
@@ -503,7 +562,9 @@ describe("parseVelociraptorJson — DetectRaptor detection rows", () => {
     const r = parseVelociraptorJson(JSON.stringify([row]));
     const e = r.events[0];
     expect(e.severity).toBe("Low");
-    expect(e.description).toContain("Powershell encoded command - IN DEVELOPMENT");
+    // The rule NAME has its own internal " - "; neutralized to an em dash (titleSafe) so it
+    // doesn't get mistaken for the title/detail boundary and truncate the title early.
+    expect(e.description).toContain("Powershell encoded command — IN DEVELOPMENT");
     expect(e.description).not.toContain("nc*o*d*e*d"); // the rule Regex must not leak into the description
     expect(r.iocs.some((i) => i.type === "ip" && i.value === "192.168.56.50")).toBe(true); // scraped from Content
   });
@@ -963,6 +1024,33 @@ describe("parseVelociraptorJson — startup rows (Windows.Sys.StartupItems)", ()
     );
     expect(r.events[0].description).toContain("bginfo");
     expect(r.events[0].description).toContain("enabled");
+  });
+
+  it("drops a mangled UTF-16-noise Details value (desktop.ini [.ShellClassInfo]) instead of showing it garbled", () => {
+    const mangled =
+      "..........S.h.e.l.l.C.l.a.s.s.I.n.f.o.......L.o.c.a.l.i.z.e.d.R.e.s.o.u.r.c.e.N.a.m.e" +
+      ".......S.y.s.t.e.m.R.o.o.t.....s.y.s.t.e.m.3.2.....s.h.e.l.l.3.2...d.l.l...2.1.7.8.7....";
+    const r = parseVelociraptorJson(
+      JSON.stringify([
+        startupRow({
+          Name: "desktop.ini",
+          OSPath: "C:\\Users\\bob\\Desktop\\desktop.ini",
+          Details: mangled,
+        }),
+      ]),
+    );
+    const desc = r.events[0].description;
+    expect(desc).not.toContain("S.h.e.l.l");
+    expect(desc).not.toContain(".....");
+    expect(desc).toContain("desktop.ini");
+  });
+
+  it("never puts the host inside the title — it falls in [details], behind the host's own chip", () => {
+    const r = parseVelociraptorJson(
+      JSON.stringify([{ ...startupRow(), Computer: "DESKTOP-OPE297N.localdomain" }]),
+    );
+    const { title } = splitEventTitle(r.events[0].description);
+    expect(title).not.toContain("DESKTOP-OPE297N");
   });
 });
 


### PR DESCRIPTION
## Summary
- No hostname in any Velociraptor artifact title — the row's chip already shows it. Several mappers (Startup, MFT, USN, generic, pslist, download, task scheduler, and the shared `actionEvent` used by Amcache/Shimcache/Shellbags/UserAssist/Prefetch/LNK/browser history) never emitted the literal `" - "` the dashboard's title/detail splitter looks for, so the whole description — host included — rendered as the title. A new `withHostSuffix()` helper guarantees the host always lands behind that boundary, in `[details]`.
- DetectRaptor/Sigma/YARA rule names often carry their own `" - "` (e.g. `"RMM - Microsoft Quick Assist Execution"`), which the splitter picked up first, truncating the title to just `"RMM"` before the triggering file/process (now promoted into the title) ever rendered. A `titleSafe()` helper neutralizes internal `" - "` to an em dash so only the intended boundary counts.
- `Windows.Sys.StartupItems`' `Details` value is dropped when it's mangled UTF-16 noise (an undecoded desktop.ini `[.ShellClassInfo]` string), falling back to the readable `OSPath` instead of showing it garbled.

Verified against a real case's imported DetectRaptor Amcache/MFT artifacts, e.g.:
- `DetectRaptor Amcache detection: RMM` → `DetectRaptor Amcache detection: RMM — Microsoft Quick Assist Execution — quickassist.exe`
- `DetectRaptor MFT detection: Attacker Tool` → `DetectRaptor MFT detection: Attacker Tool — NetExec — nxc.exe`

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run tests/analysis/velociraptorImport.test.ts` (107 tests, incl. new regression coverage for the host-leak and rule-name-truncation bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)