### PR TITLE
fix(velociraptor): decode mangled startup Details instead of discarding it

### DIFF
--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -55,7 +55,7 @@ import {
 // downgrade a real Critical (e.g. "Security Audit Logs Cleared") to a keyword-guessed Medium.
 import { isFlatChainsawRow, mapFlatChainsawRow } from "./chainsawImport.js";
 import { detectTimestomp } from "./timestompDetect.js";
-import { withHostSuffix, titleSafe, isMangledUtf16 } from "./velociraptorTitle.js";
+import { withHostSuffix, titleSafe, demangleUtf16Noise } from "./velociraptorTitle.js";
 
 type Row = Record<string, unknown>;
 
@@ -1529,8 +1529,7 @@ function mapDownload(row: Row, host: string, sink: Map<string, SiemIoc>): Mapped
 function mapStartup(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
   const name = str(getCI(row, "Name")).trim();
   const ospath = str(getCI(row, "OSPath")).trim();
-  const detailsRaw = str(getCI(row, "Details")).trim();
-  const details = isMangledUtf16(detailsRaw) ? "" : detailsRaw; // desktop.ini's [.ShellClassInfo] noise
+  const details = demangleUtf16Noise(str(getCI(row, "Details")).trim());
   const enabledRaw = str(getCI(row, "Enabled")).trim().toLowerCase();
   const enabled =
     enabledRaw === "enable" || enabledRaw === "enabled" || enabledRaw === "true" || enabledRaw === "1";

--- a/companion/src/analysis/velociraptorTitle.ts
+++ b/companion/src/analysis/velociraptorTitle.ts
@@ -18,10 +18,28 @@ export function titleSafe(name: string): string {
 }
 
 // A desktop.ini [.ShellClassInfo] entry's Details is raw UTF-16, NUL bytes rendered as "."
-// (".S.h.e.l.l.C.l.a.s.s.I.n.f.o......."). Registry noise, not an attacker command — drop it
-// rather than show it garbled.
-export function isMangledUtf16(s: string): boolean {
-  if (s.length < 12) return false;
+// (".S.h.e.l.l.C.l.a.s.s.I.n.f.o......."). Registry noise, not an attacker command.
+//
+// NEVER just drop a value that LOOKS mangled — a heuristic guess is not grounds to silently
+// discard evidence in a forensics tool, and any dot-heavy heuristic (version string, IP, a
+// deliberately char-separated LOLBIN evasion attempt) risks a false positive on something real.
+// Decode instead: split on ".", where a run of empty segments (a double/triple NUL) marks a
+// word boundary and becomes a space, and single-dot gaps between one-character segments just
+// collapse. Every original character survives — this only removes the mangling's own noise.
+export function demangleUtf16Noise(s: string): string {
+  if (s.length < 12 || /[^.]{2,}/.test(s)) return s; // has a real word (2+ chars run) → untouched
   const dots = (s.match(/\./g) || []).length;
-  return dots / s.length > 0.3;
+  if (dots / s.length <= 0.3) return s;
+  let out = "";
+  let boundary = false;
+  for (const part of s.split(".")) {
+    if (part === "") {
+      boundary = true;
+      continue;
+    }
+    if (boundary && out) out += " ";
+    boundary = false;
+    out += part;
+  }
+  return out.trim() || s;
 }

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1026,7 +1026,7 @@ describe("parseVelociraptorJson — startup rows (Windows.Sys.StartupItems)", ()
     expect(r.events[0].description).toContain("enabled");
   });
 
-  it("drops a mangled UTF-16-noise Details value (desktop.ini [.ShellClassInfo]) instead of showing it garbled", () => {
+  it("decodes a mangled UTF-16-noise Details value (desktop.ini [.ShellClassInfo]) instead of showing it garbled OR silently discarding it", () => {
     const mangled =
       "..........S.h.e.l.l.C.l.a.s.s.I.n.f.o.......L.o.c.a.l.i.z.e.d.R.e.s.o.u.r.c.e.N.a.m.e" +
       ".......S.y.s.t.e.m.R.o.o.t.....s.y.s.t.e.m.3.2.....s.h.e.l.l.3.2...d.l.l...2.1.7.8.7....";
@@ -1042,7 +1042,31 @@ describe("parseVelociraptorJson — startup rows (Windows.Sys.StartupItems)", ()
     const desc = r.events[0].description;
     expect(desc).not.toContain("S.h.e.l.l");
     expect(desc).not.toContain(".....");
+    // Decoded and readable, not just suppressed — no evidence silently vanishes.
+    expect(desc).toContain("ShellClassInfo");
+    expect(desc).toContain("LocalizedResourceName");
+    expect(desc).toContain("shell32");
     expect(desc).toContain("desktop.ini");
+  });
+
+  it("does NOT drop a legitimate dot-heavy command line — a bare dot-ratio check would false-positive on this", () => {
+    // "svc.1.2.3.4.exe" crosses the exact same >30% dot-ratio threshold the mangled desktop.ini
+    // value does (a bare ratio check WOULD have wrongly nulled it out), but it has real word runs
+    // ("svc", "exe") the UTF-16 mangling never has — there, every character sits alone between
+    // dots. Losing this would silently erase real startup evidence, not noise.
+    const legit = "svc.1.2.3.4.exe";
+    const r = parseVelociraptorJson(JSON.stringify([startupRow({ Details: legit })]));
+    expect(r.events[0].description).toContain("svc.1.2.3.4.exe");
+  });
+
+  it("never comes back empty for a value that DOES trip the mangled-shape check — every character is decoded, none discarded", () => {
+    // A short, single-digit-only sequence trips the same structural check the real desktop.ini
+    // noise does (no run of 2+ ordinary characters). Whether or not the guess is right, the fix is
+    // to decode — concatenating the digits back together — never to null the field out.
+    const ambiguous = "1.2.3.4.5.6.7.8.9.0.1.2.3.4";
+    const r = parseVelociraptorJson(JSON.stringify([startupRow({ Details: ambiguous })]));
+    const desc = r.events[0].description;
+    expect(desc).toContain("1234567890");
   });
 
   it("never puts the host inside the title — it falls in [details], behind the host's own chip", () => {


### PR DESCRIPTION
## Summary

Follow-up to #594. Codex's stop-time review flagged two rounds of issues with the mangled-UTF-16 detector added in that PR:

1. A bare dot-ratio threshold could false-positive on legitimate dot-heavy evidence (a version string, an IP) — fixed by requiring the actual structural signature of the mangling (no run of 2+ ordinary characters) before applying the ratio check.
2. Even with that narrower check, a value that *did* match the mangled shape was still silently dropped (`""`) — a heuristic guess is not grounds to discard evidence in a forensics tool. A deliberately char-separated LOLBIN evasion attempt, or a value the heuristic simply gets wrong, would vanish from the timeline with no trace.

This PR replaces the drop with a decode: `demangleUtf16Noise()` collapses the mangling's own dot-noise back into readable text (e.g. the real desktop.ini `[.ShellClassInfo]` value now renders as `ShellClassInfo LocalizedResourceName SystemRoot system32 shell32 dll 21787` instead of raw dots — or instead of vanishing). Every original character survives.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run check:size` / `check:boundaries` / `check:imports`
- [x] `npx vitest run tests/analysis/velociraptorImport.test.ts` (109 tests, incl. 3 new: decode-not-drop on the real mangled case, a legit dot-heavy value staying untouched, and an ambiguous mangled-shape value proving it's never returned empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)