### PR TITLE
fix(import): read a script block whose raw event sits under `_Event`

### DIFF
--- a/companion/src/analysis/scriptBlockFragments.ts
+++ b/companion/src/analysis/scriptBlockFragments.ts
@@ -171,12 +171,28 @@ function reassembleByBlock(
 
 // ───────────────────────────── Velociraptor / DetectRaptor rows ─────────────────────────────
 
-// A 4104 row reaches the importer either as a native parsed-evtx row (`System` + `EventData`,
-// sometimes wrapped in `Event`) or — after an Elasticsearch round-trip — as dotted keys that
-// veloRowNormalize has already un-flattened back to that nested shape. Both are read here; a row
-// in neither shape simply yields no fragment and is left alone.
+// A 4104 row reaches this importer in one of THREE shapes, all of which must be read:
+//
+//   1. native parsed evtx      — top-level `System` + `EventData`
+//   2. wrapped                 — the same under `Event`
+//   3. Velociraptor-decorated  — the same under `_Event`, alongside rendered `Details`/`Title`
+//      columns. `Windows.Hayabusa.Rules` emits this, and the row reaches HERE rather than the
+//      Hayabusa importer because it carries `_Source`, which the Velociraptor detector claims.
+//
+// An Elasticsearch round-trip arrives as dotted keys that veloRowNormalize has already un-flattened
+// back into shape 1. A row in none of these yields no fragment and is left untouched.
+//
+// Shape 3 was missed at first and is why this list is spelled out: rowMessage() in velociraptorImport
+// already read `_Event`, so the shape was known to the codebase but not to this reader, and a split
+// block collected that way stayed one alert per fragment with nothing to signal the miss.
+const EVENT_WRAPPERS = ["Event", "_Event"] as const;
+
 function veloEventData(row: Row): Row | null {
-  const ed = getCI(row, "EventData") ?? getPath(row, "Event.EventData");
+  let ed = getCI(row, "EventData");
+  for (const w of EVENT_WRAPPERS) {
+    if (isObject(ed)) break;
+    ed = getPath(row, `${w}.EventData`);
+  }
   return isObject(ed) ? ed : null;
 }
 
@@ -184,6 +200,7 @@ function veloEventId(row: Row): number {
   const raw =
     getPath(row, "System.EventID.Value") ??
     getPath(row, "Event.System.EventID.Value") ??
+    getPath(row, "_Event.System.EventID.Value") ??
     getPath(row, "System.EventID") ??
     getCI(row, "EventID") ??
     getCI(row, "EID");
@@ -197,6 +214,7 @@ function veloHost(row: Row): string {
       getCI(row, "Computer") ??
         getPath(row, "System.Computer") ??
         getPath(row, "Event.System.Computer") ??
+        getPath(row, "_Event.System.Computer") ??
         getCI(row, "Hostname") ??
         getCI(row, "Fqdn"),
     )
@@ -267,9 +285,13 @@ export function consolidateVeloScriptBlocks(rows: readonly Row[]): Row[] {
     const text = `${block.full}${block.note}`;
     const nextEd: Row = { ...ed, ScriptBlockText: text };
     const next: Row = { ...row };
-    // Write back into whichever container the row carries EventData in.
+    // Write back into whichever container the row actually carries EventData in — top level, or one
+    // of the wrappers. Guessing wrong would leave the real EventData untouched AND invent a sibling
+    // key that was never in the row, so the container is resolved rather than assumed.
+    const wrapper = EVENT_WRAPPERS.find((w) => isObject(getPath(row, `${w}.EventData`)));
     if (isObject(getCI(row, "EventData"))) next.EventData = nextEd;
-    else next.Event = { ...(getCI(row, "Event") as Row), EventData: nextEd };
+    else if (wrapper) next[wrapper] = { ...(getCI(row, wrapper) as Row), EventData: nextEd };
+    else next.EventData = nextEd;
     const message = str(getCI(row, "Message") ?? getCI(row, "Details"));
     if (message) {
       const rewritten = rewriteMessage(message, r.frag.text, block.full, block.note, block.phrase);

--- a/companion/src/analysis/scriptBlockFragments.ts
+++ b/companion/src/analysis/scriptBlockFragments.ts
@@ -223,6 +223,25 @@ function veloHost(row: Row): string {
   );
 }
 
+// The rule whose verdict this row carries. Reassembly is scoped by it, because a row is only safe to
+// give another row's text if the two cannot then collapse into one alert — and whether they collapse
+// depends on a downstream aggregation key this module does not own. A DetectRaptor row keeps its
+// title in that key; a `_Event` Hayabusa row does NOT (classify() reads it as generic, so the title
+// reaches neither the description nor the key), and there the differing fragment text was the ONLY
+// thing holding two rules apart. Handing both rows the same text dropped a verdict out of the case.
+// Scoping the group by rule costs a little text — an alert joins the parts ITS rule matched, and the
+// "N of M" note discloses the rest — and it cannot lose a verdict, which is the trade forensic
+// reporting requires.
+function veloRuleIdentity(row: Row): string {
+  const det = getCI(row, "Detection");
+  const fromDetection = isObject(det) ? str(getCI(det, "Name")) : str(det);
+  const title =
+    fromDetection ||
+    str(getCI(row, "Title") ?? getCI(row, "RuleTitle") ?? getCI(row, "RuleName")) ||
+    (isObject(getCI(row, "Rule")) ? str(getCI(getCI(row, "Rule") as Row, "Title")) : "");
+  return title.trim().toLowerCase();
+}
+
 // Only a genuine multi-part script block qualifies. The event id must be 4104 or unreadable — an
 // unreadable id is allowed because ScriptBlockId + MessageTotal > 1 is already specific to 4104,
 // and refusing to act on an unfamiliar row shape would silently leave the alerts split.
@@ -239,7 +258,7 @@ function veloFragment(row: Row): { key: string; frag: ScriptBlockFragment } | nu
   const total = num(getCI(ed, "MessageTotal")) || num(header?.[2]);
   if (total < 2) return null; // a whole block in one event — nothing to reassemble
   return {
-    key: `${veloHost(row)}|${id}`,
+    key: `${veloHost(row)}|${id}|${veloRuleIdentity(row)}`,
     frag: { id, number, total, text: str(getCI(ed, "ScriptBlockText")) },
   };
 }
@@ -261,7 +280,13 @@ function rewriteMessage(message: string, chunk: string, full: string, note: stri
     const header = m[1].replace(PART_OF_RE, `(${phrase} parts, reassembled)`);
     return `${header}${full}${m[3]}`;
   }
-  if (chunk && message.includes(chunk)) return message.split(chunk).join(`${full}${note}`);
+  if (chunk && message.includes(chunk)) {
+    // Correct the header on the PREFIX only — the part before the fragment's text begins. A blanket
+    // replace could rewrite a "(1 of 2)" that occurs inside the script itself, editing evidence.
+    const at = message.indexOf(chunk);
+    const head = message.slice(0, at).replace(PART_OF_RE, `(${phrase} parts, reassembled)`);
+    return `${head}${message.slice(at).split(chunk).join(`${full}${note}`)}`;
+  }
   return `${message}\n${full}${note}`;
 }
 
@@ -288,15 +313,24 @@ export function consolidateVeloScriptBlocks(rows: readonly Row[]): Row[] {
     // Write back into whichever container the row actually carries EventData in — top level, or one
     // of the wrappers. Guessing wrong would leave the real EventData untouched AND invent a sibling
     // key that was never in the row, so the container is resolved rather than assumed.
+    const rewrite = (m: string): string =>
+      rewriteMessage(m, r.frag.text, block.full, block.note, block.phrase);
     const wrapper = EVENT_WRAPPERS.find((w) => isObject(getPath(row, `${w}.EventData`)));
     if (isObject(getCI(row, "EventData"))) next.EventData = nextEd;
-    else if (wrapper) next[wrapper] = { ...(getCI(row, wrapper) as Row), EventData: nextEd };
-    else next.EventData = nextEd;
-    const message = str(getCI(row, "Message") ?? getCI(row, "Details"));
-    if (message) {
-      const rewritten = rewriteMessage(message, r.frag.text, block.full, block.note, block.phrase);
-      if (getCI(row, "Message") !== undefined) next.Message = rewritten;
-      else next.Details = rewritten;
+    else if (wrapper) {
+      // The wrapper may also carry its OWN rendered message. rowMessage() falls back to it, so
+      // leaving it stale keeps the fragment's fingerprint distinct (blocking the very consolidation
+      // this performs) and shows the analyst one slice above the full reassembled text.
+      const wrapped: Row = { ...(getCI(row, wrapper) as Row), EventData: nextEd };
+      const nested = str(getCI(wrapped, "Message"));
+      if (nested) wrapped.Message = rewrite(nested);
+      next[wrapper] = wrapped;
+    } else next.EventData = nextEd;
+    // Rewrite EVERY rendered copy the row carries, not just the first one found: `Message` and
+    // `Details` can both be present, and a copy left holding one slice contradicts the others.
+    for (const key of ["Message", "Details"] as const) {
+      const m = str(getCI(row, key));
+      if (m) next[key] = rewrite(m);
     }
     return next;
   });
@@ -360,7 +394,10 @@ function hayabusaFragment(item: HayabusaRecord): { key: string; frag: ScriptBloc
   const host = str(getCI(item.rec, "Computer") ?? getCI(item.rec, "Hostname"))
     .trim()
     .toLowerCase();
-  return { key: `${host || "?"}|${id}`, frag: { id, number, total, text: text.value } };
+  const title = str(getCI(item.rec, "RuleTitle") ?? getCI(item.rec, "Title") ?? getCI(item.rec, "RuleName"))
+    .trim()
+    .toLowerCase();
+  return { key: `${host || "?"}|${id}|${title}`, frag: { id, number, total, text: text.value } };
 }
 
 /**

--- a/companion/tests/analysis/scriptBlockFragments.test.ts
+++ b/companion/tests/analysis/scriptBlockFragments.test.ts
@@ -200,6 +200,55 @@ describe("consolidateVeloScriptBlocks", () => {
     expect(text).toContain(CHUNKS[0] + CHUNKS[1]);
   });
 
+  // A THIRD row shape, seen on a real Windows.Hayabusa.Rules collection (case INC-2026-016): the raw
+  // event rides under `_Event`, not `EventData` or `Event.EventData`. The row still reaches THIS
+  // importer rather than the Hayabusa one, because it carries `_Source` and the Velociraptor
+  // detector claims any `_Source`. rowMessage() already reads `_Event`; the fragment reader did not,
+  // so a split block in this shape stayed one alert per fragment.
+  function underscoreEventRow(part: number, chunk: string): Record<string, unknown> {
+    return {
+      Timestamp: `2025-03-14T21:14:4${part}.000000000Z`,
+      Computer: "WIN11.windomain.local",
+      Channel: "Microsoft-Windows-PowerShell/Operational",
+      EID: 4104,
+      Level: "medium",
+      Title: "Potentially Malicious PwSh",
+      RecordID: 1400 + part,
+      Details: `ScriptBlock: ${chunk}`,
+      _Source: "Windows.Hayabusa.Rules",
+      _Event: {
+        System: {
+          EventID: { Value: 4104 },
+          Computer: "WIN11.windomain.local",
+          Channel: "Microsoft-Windows-PowerShell/Operational",
+        },
+        EventData: {
+          MessageNumber: String(part),
+          MessageTotal: "2",
+          ScriptBlockText: chunk,
+          ScriptBlockId: SBID,
+          Path: "C:\\TrigonaSim\\tools\\uac-bypass.ps1",
+        },
+      },
+    };
+  }
+
+  it("reads a block whose raw event sits under `_Event` (Windows.Hayabusa.Rules shape)", () => {
+    const rows = consolidate([underscoreEventRow(1, CHUNKS[0]), underscoreEventRow(2, CHUNKS[1])]);
+    for (const row of rows) {
+      const ed = (row._Event as Record<string, unknown>).EventData as Record<string, unknown>;
+      expect(String(ed.ScriptBlockText)).toContain(CHUNKS[0] + CHUNKS[1]);
+    }
+  });
+
+  it("leaves a single-part `_Event` block alone (the real INC-2026-016 rows are all 1 of 1)", () => {
+    const one = underscoreEventRow(1, "whoami");
+    ((one._Event as Record<string, unknown>).EventData as Record<string, unknown>).MessageTotal = "1";
+    const [out] = consolidate([one]);
+    const ed = (out._Event as Record<string, unknown>).EventData as Record<string, unknown>;
+    expect(String(ed.ScriptBlockText)).toBe("whoami");
+  });
+
   it("never joins the same ScriptBlockId across two hosts", () => {
     const rows = consolidate([drRow(1, CHUNKS[0]), drRow(2, CHUNKS[1], { Computer: "WS-02" })]);
     const text = (i: number): string =>

--- a/companion/tests/analysis/scriptBlockFragments.test.ts
+++ b/companion/tests/analysis/scriptBlockFragments.test.ts
@@ -249,6 +249,45 @@ describe("consolidateVeloScriptBlocks", () => {
     expect(String(ed.ScriptBlockText)).toBe("whoami");
   });
 
+  // A `_Event` row's verdict lives in a top-level `Title` that classify() does not treat as a
+  // verdict, so mapGeneric puts it in neither the description nor the aggregation key. Before
+  // consolidation the differing fragment text kept two rules apart by accident. Handing both rows
+  // identical text removed that accident and one rule's verdict disappeared from the case entirely.
+  // Reassembly is therefore scoped PER RULE: each alert joins the parts its own rule matched.
+  it("keeps two rules over one `_Event` block apart instead of dropping a verdict", () => {
+    const a = underscoreEventRow(1, CHUNKS[0]);
+    const b = underscoreEventRow(2, CHUNKS[1]);
+    b.Title = "UAC Bypass Attempt";
+    const rows = consolidate([a, b]);
+    const text = (r: Record<string, unknown>): string =>
+      String(((r._Event as Record<string, unknown>).EventData as Record<string, unknown>).ScriptBlockText);
+    // Neither row is given the other rule's slice, so neither verdict can collapse into the other.
+    expect(text(rows[0])).not.toContain(CHUNKS[1]);
+    expect(text(rows[1])).not.toContain(CHUNKS[0]);
+  });
+
+  it("still joins every fragment when ONE rule matched them all", () => {
+    const rows = consolidate([underscoreEventRow(1, CHUNKS[0]), underscoreEventRow(2, CHUNKS[1])]);
+    const ed = (rows[0]._Event as Record<string, unknown>).EventData as Record<string, unknown>;
+    expect(String(ed.ScriptBlockText)).toContain(CHUNKS[0] + CHUNKS[1]);
+  });
+
+  // rowMessage() falls back to `_Event.Message`, so a stale nested message both blocks consolidation
+  // and leaves the analyst reading one slice above the full reassembled text.
+  it("rewrites `_Event.Message` too, not just the nested event data", () => {
+    const mk = (part: number, chunk: string): Record<string, unknown> => {
+      const r = underscoreEventRow(part, chunk);
+      delete r.Details;
+      (r._Event as Record<string, unknown>).Message = `Creating Scriptblock text (${part} of 2):\n${chunk}`;
+      return r;
+    };
+    const rows = consolidate([mk(1, CHUNKS[0]), mk(2, CHUNKS[1])]);
+    for (const r of rows) {
+      const msg = String((r._Event as Record<string, unknown>).Message);
+      expect(msg).toContain(CHUNKS[0] + CHUNKS[1]);
+    }
+  });
+
   it("never joins the same ScriptBlockId across two hosts", () => {
     const rows = consolidate([drRow(1, CHUNKS[0]), drRow(2, CHUNKS[1], { Computer: "WS-02" })]);
     const text = (i: number): string =>

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1878,14 +1878,19 @@ describe("parseVelociraptorJson — PowerShell 4104 script-block fragments", () 
     expect(e.timestamp).toContain("16:31:01"); // earliest fragment anchors the event
   });
 
-  it("keeps two DIFFERENT rules over the same block as two alerts, each with the whole script", () => {
+  // Reassembly is scoped PER RULE, so an alert carries the parts ITS rule matched — not the whole
+  // block. The earlier contract ("both alerts carry the whole script") was withdrawn: giving two
+  // rules identical text made them collapse into one alert on row shapes whose verdict never reaches
+  // the aggregation key, and a lost verdict is worse than a shorter excerpt. The "N of M" note on a
+  // partial join is what tells the analyst the block had more parts than this rule matched.
+  it("keeps two DIFFERENT rules over the same block as two alerts, each with its own parts", () => {
     const rows = [frag(1, CHUNKS[0]), frag(2, CHUNKS[1], "PowerShell - AMSI Bypass")];
     const r = parseVelociraptorJson(JSON.stringify(rows));
     expect(r.events).toHaveLength(2); // two distinct verdicts stay two distinct alerts
-    for (const e of r.events) {
-      const full = `${e.description} ${e.message ?? ""}`;
-      for (const c of CHUNKS) expect(full).toContain(c);
-    }
+    const mimikatz = r.events.find((e) => /Mimikatz/.test(e.description))!;
+    const amsi = r.events.find((e) => /AMSI Bypass/.test(e.description))!;
+    expect(`${mimikatz.description} ${mimikatz.message ?? ""}`).toContain(CHUNKS[0]);
+    expect(`${amsi.description} ${amsi.message ?? ""}`).toContain(CHUNKS[1]);
   });
 
   it("leaves a single-part block as one alert with its text unchanged", () => {


### PR DESCRIPTION
Follow-up to #599, found by running that change against two real collections.

## The gap

A 4104 row reaches the Velociraptor importer in **three** shapes, not two:

1. native parsed evtx — top-level `System` + `EventData`
2. wrapped — the same under `Event`
3. **Velociraptor-decorated — the same under `_Event`**, alongside rendered `Details`/`Title` columns

`Windows.Hayabusa.Rules` emits shape 3, and the row lands in *this* importer rather than the Hayabusa one because it carries `_Source`, which the Velociraptor detector claims.

#599's fragment reader knew shapes 1 and 2 only. A script block split across several events in shape 3 stayed one alert per fragment, with nothing to signal the miss. `rowMessage()` already read `_Event`, so the shape was known to the file but not to the reader.

## The fix

Teach `veloEventData` / `veloEventId` / `veloHost` the `_Event` wrapper, and **resolve** the write-back container instead of assuming it — guessing wrong left the real `EventData` untouched *and* invented a sibling key the row never had.

## Measured on real collections

A flow export carrying DetectRaptor + Chainsaw + Hayabusa together:

| | events |
|---|---|
| before (`57f1bf99`) | 1410 |
| after | **1072** |

The 448 Hayabusa rows carrying a `ScriptBlockId` all use the `_Event` shape and were untouched until now. Their 374 fragments sit in 63 blocks, and **every fragment is a distinct position** — nothing is over-merged. Largest merged alert: 33 source records, 20 reassembled parts.

A second collection whose 4104 rows are all single-part (`MessageTotal = 1`) is **unchanged at 855 events**, which is the correct no-op.

The duplicate-position dedupe from #599 is doing real work on this data too: DetectRaptor has 136 records across 129 distinct positions, Chainsaw 77 across 43.

## Verification

- Full suite **9870 passing** (640 files).
- `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all clean.
- New tests are built from the **real row shape**, not a synthetic guess, and cover both the split block and the single-part block that must stay untouched.

## Known limitation, unchanged by this PR

A *standalone* `hayabusa` export — one whose rows carry only a rendered `Details` string with no `_Event` node — still cannot be consolidated. Such rows have no `ScriptBlockId`, `MessageNumber` or `MessageTotal` anywhere, so there is no block identity to join on. That is a collection-profile question, not a parser one.