### PR TITLE
chore: second review pass — 15 more findings fixed, codex-clean again

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,7 +200,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,830 of the 1,869 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,839 of the 1,878 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -4,7 +4,9 @@
 (architecture, error handling, duplication/dead code, test coverage, VQL/parsing performance,
 Docker/dependencies), every finding independently re-verified against the code before inclusion.
 Only confirmed findings appear below; each will receive a corresponding fix commit on
-`chore/codebase-review`, after which its Status line is updated with the commit.*
+`chore/codebase-review`, after which its Status line is updated with the commit.
+A SECOND full review pass ran on 2026-08-21 over the post-fix tree (same method); its findings
+appear in per-section "Second pass" subsections and the Finding Index.*
 
 There is no Python source in this repository (the only `.py` files are vendored inside
 `node_modules`), so the "VQL/Python parsing" scope resolves to the hunt-query language parser
@@ -14,30 +16,35 @@ There is no Python source in this repository (the only `.py` files are vendored 
 
 ## 1. Architecture Overview
 
+*Refreshed in the second review pass (2026-08-21) to reflect this branch's container-hardening and module extractions.*
+
 ### What the system is
 
 DFIR Companion is a localhost-first, AI-assisted **post-detection triage layer** for incident response. It does not detect; it ingests verdicts and artifacts from tools that do (Velociraptor, Chainsaw, Hayabusa, EDR/SIEM exports, screenshots of investigation consoles) and correlates them into a per-case forensic timeline, findings, IOCs, an asset graph, and exportable reports. The OPSEC posture is explicit in code: the server binds `127.0.0.1` by default (`companion/src/server.ts`), evidence stays on disk, and the AI provider is pluggable (`companion/src/providers/` covers OpenAI, Anthropic, Gemini, Ollama, LiteLLM, OpenRouter, plus Claude Code/Codex CLI runners) — with deterministic detectors (`analysis/beaconDetect.ts` etc.) guaranteed to work when no provider is configured.
 
 ### Runtime topology
 
-Four pieces. (1) A Node 22 **TypeScript ESM Express server** (~135k lines, entry `companion/src/server.ts`, now a 642-line composition root after the #384/#416 decomposition). (2) A **no-bundler browser dashboard**: `public/dashboard.html` plus ~150 files in `public/js/` (~35k lines) served statically through a whitelist (`companion/src/http/staticAssets.ts`), updated live over WebSocket (`companion/src/live/hub.ts`, `wsGate.ts`); `public/sw.js` is a deliberately minimal PWA shell scoped to `/mobile` only. (3) An **MV3 browser extension** (`extension/manifest.json`) that captures screenshots and pushes detections into the local server. (4) **Upstream/downstream integrations**: Velociraptor inbound (`companion/src/integrations/velociraptor/velociraptorApi.ts` shells out to the `velociraptor` binary with `--api_config` rather than reimplementing gRPC+mTLS; the VQL runner is injectable for tests), outbound push clients (IRIS, MISP, Timesketch, Jira, ServiceNow, Notion, ClickUp), and an agentic MCP mode that spawns `claude -p` (`integrations/mcp/mcpAgentRunner.ts`). A 3-stage `Dockerfile` (node:22-slim) builds server, extension zip, and a slim runtime; compose maps the container port back to host loopback to preserve the localhost posture.
+Four pieces. (1) A Node 22 **TypeScript ESM Express server** (~135k lines, entry `companion/src/server.ts`, now a 642-line composition root after the #384/#416 decomposition). (2) A **no-bundler browser dashboard**: `public/dashboard.html` plus ~150 files in `public/js/` (~35k lines) served statically through a whitelist (`companion/src/http/staticAssets.ts`), updated live over WebSocket (`companion/src/live/hub.ts`, `wsGate.ts`); `public/sw.js` is a deliberately minimal PWA shell scoped to `/mobile` only. (3) An **MV3 browser extension** (`extension/manifest.json`) that captures screenshots and pushes detections into the local server. (4) **Upstream/downstream integrations**: Velociraptor inbound (`companion/src/integrations/velociraptor/velociraptorApi.ts` shells out to the `velociraptor` binary with `--api_config` rather than reimplementing gRPC+mTLS; the VQL runner is injectable for tests, and the pure enrolled-client primitives — client-id shape, record normalization, host→record matching — now live in a dependency-free sibling, `integrations/velociraptor/clientInventory.ts`), outbound push clients (IRIS, MISP, Timesketch, Jira, ServiceNow, Notion, ClickUp), and an agentic MCP mode that spawns `claude -p` (`integrations/mcp/mcpAgentRunner.ts`).
+
+The container stack was hardened materially on this branch. The 3-stage `Dockerfile` (server build, extension zip, slim runtime) now builds every stage from the **same digest-pinned** `node:22-slim` base, bakes an image-level `HEALTHCHECK` (probing `/health` on `PORT`/`DFIR_PORT` so plain `docker run`/Portainer users get liveness, not just compose), and no longer runs the server as root. Because Docker auto-creates missing bind mounts root-owned, a bare `USER` directive would break a clean-checkout `docker compose up`; instead `docker-entrypoint.sh` starts as root solely to hand writable mounts over, then `setpriv`-drops before `exec node dist/server.js` — running **as the owner of the cases-root mount** (falling back to the image's `node` uid only when the mount is root-owned), so a host operator's own files are never disowned. The chown handoffs are deliberately confined: `deny_chown` refuses `/`, the `/app` code tree, `/opt` (the bundled extension), and every OS directory; `chown_tree` uses a no-follow `find … -exec chown -h` so a compromised server cannot plant a symlink that a later root chown dereferences into protected targets; and the cases root's *parent* is never chowned — each known global store plus the `.dfir-auth-<hash>` dir is pre-created and handed off individually, with the hash derived from a lexical (non-dereferencing) normalization to match `authFactory`'s `path.resolve`. Dashboard-writable path overrides persisted to the settings dotenv are re-read by the entrypoint with a dotenv-mirroring parser, so they too pass confinement before any chown. `/app` stays root-owned on purpose (the server must not be able to rewrite its own code); all mutable state is steered onto the `/data` tree via `DFIR_OCR_CACHE=/data/ocr-cache` (tesseract.js model cache, honored by `analysis/ocrRedact.ts`) and `DFIR_ENV_FILE=/data/companion.env` (the Settings `.env` written atomically by `POST /settings/env`, `settings/envManager.ts`). `docker-compose.yml` still maps the port to host loopback only (`127.0.0.1:4773:4773`) and marks that exact posture with `DFIR_ALLOW_UNAUTHENTICATED_REMOTE: "container-loopback-proxy"`; an operator-supplied `user:` override skips the root handoff path entirely.
 
 ### Layering and data flow
 
-`ARCHITECTURE.md` describes a five-layer model (Composition → Delivery → Domain → Platform → Shared) and — unusually — it is *enforced*: `npm run check:boundaries` checks every file against `companion/scripts/module-map.json`, with a shrink-only ledger of 39 grandfathered violations, alongside `check:size` and `check:imports` ratchets. A test asserts the document matches the JSON. The doc is accurate to the code, with minor staleness (it says `src/analysis/` is 296 flat files; it is now ~326 entries, with only `analysis/ai/` and `analysis/ingest/` physically carved out so far).
+`ARCHITECTURE.md` describes a five-layer model (Composition → Delivery → Domain → Platform → Shared) and — unusually — it is *enforced*: `npm run check:boundaries` checks every file against `companion/scripts/module-map.json`, with a shrink-only ledger of 39 grandfathered violations (`companion/scripts/boundary-violations.json`), alongside `check:size` and `check:imports` ratchets. A test asserts the document matches the JSON, and the branch kept the asserted compliance figure current (now 1,830 of 1,869 cross-domain dependencies complying). The doc is accurate to the code, with minor staleness (it still says `src/analysis/` is 296 flat files; it is now ~327 flat files plus the `analysis/ai/` and `analysis/ingest/` directories — the only domains physically carved out so far).
 
-Data flows: capture/ingest (extension `POST /captures`, a drop-folder watcher, Velociraptor hunt/monitor pulls, ~40 `*Import.ts` parsers dispatched via `importDetect`) → serialized per-case by `analysis/importLock.ts` → canonical `ForensicEvent`s (`analysis/stateTypes.ts`, imported by 189 files) → `analysis/forensicGate.ts` partitions severity ≥ Low into the **forensic timeline** and Info telemetry into the **super-timeline** → deterministic detectors and optional AI synthesis (`analysis/pipeline.ts` is now a 758-line facade delegating to `analysis/ai/`) → per-case storage → ~60 route modules registered in a load-bearing order by `composition/routeRegistry.ts` → dashboard via REST + WS broadcast. The governing forensic rule — *the model reads the forensic timeline; nothing automatic reads the raw record* — is documented, tested (`tests/analysis/forensicBoundary.test.ts`), and honest about its one capped exception (`viewSummary`).
+Data flows: capture/ingest (extension `POST /captures`, a drop-folder watcher, Velociraptor hunt/monitor pulls, ~40 `*Import.ts` parsers dispatched via `importDetect`) → serialized per-case by `analysis/importLock.ts` → canonical `ForensicEvent`s (`analysis/stateTypes.ts`, imported by ~190 files) → `analysis/forensicGate.ts` partitions severity ≥ Low into the **forensic timeline** and Info telemetry into the **super-timeline** → deterministic detectors and optional AI synthesis (`analysis/pipeline.ts` is now a 758-line facade delegating to `analysis/ai/`) → per-case storage → ~60 route modules registered in a load-bearing order by `composition/routeRegistry.ts` → dashboard via REST + WS broadcast. The parsers themselves now share single-source utilities extracted on this branch: `analysis/bsdTime.ts` (the `MONTHS` table and RFC 3164 timestamp parser once copied byte-identically into the syslog and Cisco ASA importers), `analysis/internalIp.ts` (one `isInternalIpv4` range table replacing six drifted copies, re-exported through `siemImport.ts`), and `analysis/veloMessageFields.ts` (precompiled rendered-message field extraction for `velociraptorImport.ts`). The governing forensic rule — *the model reads the forensic timeline; nothing automatic reads the raw record* — is documented, tested (`tests/analysis/forensicBoundary.test.ts`), and honest about its one capped exception (`viewSummary`).
 
 ### Key decisions in evidence
 
-Per-case storage is a directory per case under `casesRoot` (`storage/caseStore.ts`): `case.json`, hash-chained evidence with custody listeners, `state/*.json` files enumerated in `analysis/investigationStateFiles.ts`, and `investigation.sqlite` as the primary indexed backend. SQLite uses Node's built-in `node:sqlite` (Node ≥ 22.5 floor, `analysis/sqliteRuntime.ts`) run inside a **worker thread** (`analysis/caseSqliteWorker.ts`) that opens the DB per transaction, keeping synchronous SQLite off the event loop. The frontend's classic-scripts-on-`window` pattern is a deliberate resilience choice — a feature module that 404s becomes a no-op, not a blank page (`public/js/dashboard-facade.js` documents and implements the stub layer) — with load order enforced by `tests/dashboard/dashboardLoadOrder.test.ts` instead of an import graph. Wiring is explicit dependency injection: `createApp` composes ~28 named factories from `companion/src/composition/` into a `RouteContext`, and `startServer` builds the ~120-member `AppOptions` bag (`composition/appWiring.ts`).
+Per-case storage is a directory per case under `casesRoot` (`storage/caseStore.ts`): `case.json`, hash-chained evidence with custody listeners, `state/*.json` files enumerated in `analysis/investigationStateFiles.ts`, and `investigation.sqlite` as the primary indexed backend. SQLite uses Node's built-in `node:sqlite` (Node ≥ 22.5 floor, `analysis/sqliteRuntime.ts`) run inside a **worker thread** (`analysis/caseSqliteWorker.ts`) that opens the DB per transaction, keeping synchronous SQLite off the event loop. The global stores (logs, templates, team-auth, etc.) sit beside the cases root as siblings (`runtimeStores.ts`) — a layout the container entrypoint now mirrors exactly, pre-creating each named store rather than chowning the shared parent. The frontend's classic-scripts-on-`window` pattern is a deliberate resilience choice — a feature module that 404s becomes a no-op, not a blank page (`public/js/dashboard-facade.js` documents and implements the stub layer) — with load order enforced by `tests/dashboard/dashboardLoadOrder.test.ts` instead of an import graph. Wiring is explicit dependency injection: `createApp` composes ~28 named factories from `companion/src/composition/` into a `RouteContext`, and `startServer` builds the ~120-member `AppOptions` bag (`composition/appWiring.ts`).
 
 ### Architectural tensions
 
 - **Everything meets at one seam.** `AppOptions` (~120 members) and `RouteContext` are very wide injection bags; construction order inside `createApp` is explicitly load-bearing, with thunks papering over genuine cycles. Tests pin it, but the whole system is coupled through two literals.
 - **The frontend's module graph is invisible to tooling.** 150-ish classic scripts resolve every cross-module name through `window` at call time; `check:imports` sees 138 nodes and 0 edges, and 32 runtime cycles exist by design. Correctness rests on bespoke tests (load order, feature manifest, stub coverage) rather than anything a bundler or type-checker can verify.
-- **The map is enforced; the geography lags it.** Eleven `analysis/` domains exist in `module-map.json` but ~320 files still sit flat, with a 39-entry violation ledger and `integrations/` straddling two layers (`velociraptorApi.ts` is Platform-shaped code filed under Delivery, as the doc itself concedes).
+- **The map is enforced; the geography lags it.** Eleven `analysis/` domains exist in `module-map.json` but ~327 files still sit flat, with a 39-entry violation ledger and `integrations/` straddling two layers (`velociraptorApi.ts` is Platform-shaped code filed under Delivery, as the doc itself concedes — though the branch's `clientInventory.ts` extraction shows the remedy pattern: peel the pure primitives out of the subprocess-owning module).
 - **A core capability rides an external binary.** Velociraptor hunting depends on spawning the `velociraptor` executable and parsing its stdout/stderr under output caps (`vqlDiagnostics.ts`) — pragmatic, injectable, and off by default, but a process-management and parsing surface where a native client would be a typed one.
+- **The privilege drop moved policy into shell.** `docker-entrypoint.sh` is now 249 lines of POSIX sh that must faithfully mirror server-side path semantics — `authFactory`'s lexical `path.resolve` hashing, `runtimeStores.ts`'s sibling layout, dotenv's parsing grammar, `expandHome()` — and each is annotated with why. The confinement logic is sound and was iteratively hardened, but it is a second implementation of the server's path model, in a language with no test harness of its own, that silently diverges if a new store type or env var lands on the TypeScript side alone (the entrypoint's `KNOWN_STORES` list is the canary).
 
 ## 2. Error Handling Gaps
 
@@ -128,6 +135,60 @@ The capture_once handler (and its activate_site/push_artifact siblings at lines 
 **Fix:** Give each of the three handlers a rejection arm that still answers the channel, e.g. `void captureActiveTab("manual", true).then(sendResponse, (e) => sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) }));` (activate_site can respond `false`, push_artifact `{ ok: false, error }`). Optionally also wrap popup.ts's captureOnce sendMessage in try/catch to write the failure into statusEl.
 
 **Status:** Fixed in e83eaf69.
+
+
+### Second pass (2026-08-21)
+
+The four first-pass defects (EH-1..EH-4) are genuinely fixed and pinned by new tests: `companion/src/composition/captureAnalysis.ts` now separates ENOENT from other read failures and skips malformed capture lines individually, `public/js/dashboard-host-scope.js` throws and alerts when a clearance decision fails to land, `public/js/dashboard-asset-graph.js` gained an `r.ok` guard plus a generation token, and `extension/src/serviceWorker.ts` answers every kept-open message channel on rejection. The branch's server-side rework (the `syslogImport.ts` streaming accumulator, `ocrRedact.ts` tesseractDataOptions, `velociraptorApi.ts` getFlowInfo, and the new bsdTime/internalIp/clientInventory/veloMessageFields modules) is clean from an error-handling standpoint — abort signals, per-line skips, and degrade-with-log conventions are all carried through. What remains sits exactly where the first pass said the weakness lives, the browser-side edges: the host-scope panel's *load* path still swallows failures its *decide* path now surfaces, and the asset-graph fix's own clearing logic does not run on the rejection arm it left as `.catch(() => {})`.
+
+#### EH2-1 — loadHostScope silently ignores a failed ledger read and keeps the previous case's clearance ledger on screen  `MEDIUM`
+
+**Location:** `public/js/dashboard-host-scope.js:228`
+
+loadHostScope (the sibling of the EH-2-fixed decideHostScope) still swallows every failure: `if (!r.ok) return;` drops server rejections without reading the error body, and the catch below contains network failures without repainting. Neither path clears `hostScopeLedger` or touches the DOM, and the per-case resets in dashboard-case-connect.js (lines ~291-330) do not reset this module's state. Consequence: (1) on a case switch where the new case's GET /cases/:id/host-scope fails, the panel keeps rendering the PREVIOUS case's clearance board — "Cleared"/"Confirmed" statuses for the wrong case on a surface analysts use for scoping calls, with no indication anything failed; (2) the 500 produced when HostScopeStore deliberately throws on a corrupt ledger file (routes/hostScope.ts:66-68 returns the error message) never reaches the analyst — the fail-loud corruption design is silenced at the last hop, and the analyst only discovers it if they happen to POST a new decision (whose EH-2 fix alerts).
+
+**Evidence:**
+```
+  async function loadHostScope(caseId) {
+    if (!caseId) return;
+    try {
+      const r = await fetch(`/cases/${encodeURIComponent(caseId)}/host-scope`);
+      if (!r.ok) return;
+      hostScopeLedger = await r.json();
+      paintHostScope();
+    } catch {
+      // A panel that cannot load must not take the dashboard down with it.
+    }
+  }
+```
+
+**Fix:** Add `let hostScopeLoadSeq = 0;` and in loadHostScope take `const seq = ++hostScopeLoadSeq;` before the fetch; in both the !r.ok path and the catch, bail if `seq !== hostScopeLoadSeq`. On !r.ok: `const e = await r.json().catch(() => ({})); hostScopeLedger = null;` then, for 501 (store not configured), just `paintHostScope()` (renders the default 'No scope data.' empty state); otherwise write the failure into the panel via `const el = document.getElementById("hostScopeBody"); if (el) el.innerHTML = `<p class="hs-empty">Host scope unavailable: ${esc(e.error || "HTTP " + r.status)}</p>`;` (null-guard required — paintHostScope guards the same lookup, and the unit-test harness stubs getElementById to return null). In the catch (after the seq check): `hostScopeLedger = null;` and the same guarded write with a generic 'Host scope could not be loaded.' message. Also guard the success assignment with the seq check so a late stale success cannot overwrite the newer case's ledger.
+
+**Status:** Open
+
+#### EH2-2 — loadAssetGraph's rejection arm bypasses the new generation-token clearing, leaving the stale cross-case graph the fix claims to prevent  `LOW`
+
+**Location:** `public/js/dashboard-asset-graph.js:53`
+
+The EH-3 fix added a generation token and an explicit invariant, stated in its own comment: for the LATEST load "a failure clears the graph and repaints empty, so a case switch whose graph fails cannot leave the previous case's assets on screen." But that logic lives only in the fulfilled arm; the chain still ends in a bare `.catch(() => {})`. A network-level failure (companion restarting mid-case-switch — the exact scenario EH-2's fix cites) or a 2xx response with a malformed body makes `fetch`/`r.json()` REJECT, skipping both `.then`s entirely: the seq token is never consulted, `assetGraphData` is never cleared, and no repaint happens. The previous case's graph stays rendered under the new case, and `hasAssetGraph()`/`assetGraphAssets()` keep serving the stale cross-case data to the refresh fan-out and to dashboard-asset-overrides' rename-candidate matching — precisely the outcome the fix's comment says cannot happen, restored through the one arm the fix did not cover.
+
+**Evidence:**
+```
+        if (!g || !Array.isArray(g.assets)) {
+          assetGraphData = null;
+          renderAssetGraph();
+          renderAssetList();
+          return;
+        }
+        assetGraphData = g;
+        renderAssetGraph();
+      })
+      .catch(() => {});
+```
+
+**Fix:** Give the catch the same latest-load semantics as the null branch: `.catch(() => { if (seq !== assetGraphLoadSeq) return; assetGraphData = null; renderAssetGraph(); renderAssetList(); });` — or extract the four-line failure block into a local `failed(seq)` helper called from both the `!g` branch and the catch, so a rejected fetch and an HTTP error degrade identically and a superseded load's late rejection still cannot touch state.
+
+**Status:** Open
 
 
 ## 3. Code Duplication and Dead Code
@@ -252,6 +313,118 @@ export function resolveIocAlias(value: string, map: IocAliasMap): string | undef
 **Status:** Fixed in b6af24c7 — dead `resolveIocAlias` deleted (the Fix's first option; the swap variant was implemented and rejected by `check:boundaries` as a new analysis/timeline → analysis/findings violation, and the read side is already trim-normalized via repairIocValue).
 
 
+### Second pass (2026-08-21)
+
+The first pass's consolidations landed cleanly: `SEVERITY_RANK` lives once in `stateTypes.ts`, all six importer IP-classifier copies now route through `internalIp.ts` via `siemImport.ts`'s re-export, `bsdTime.ts` owns the shared `MONTHS`/`parseBsdTime` pair, and every dead symbol named in DUP-4..6 is gone with the four `_reset*Cache` hooks wired into their loader tests. The branch's own extractions (`veloMessageFields.ts`, `clientInventory.ts`) are fully referenced, nothing was orphaned by the streaming-syslog or Docker-entrypoint rework, and the deliberate exclusions (inverted ranks in forensicGate/notifications/slashCommand, the dashboard `esc()` byte-identity pair) hold. What remains is residue at the edges of those sweeps: the internal-IPv4 canon stops short of `iocValue.ts`'s enrichment gate, two reports-layer files (`attackLayer.ts`, `iocBlocklist.ts`) still keep private inverted severity tables outside the sanctioned trio, and three tiny helpers — `escapeRegExp`, the worst-severity comparator, and the routes' streaming-import kind predicate — are still declared per-file.
+
+#### DUP2-1 — The internal-IPv4 consolidation stopped short of iocValue.ts — the enrichment SSRF gate still treats CGNAT 100.64/10 as public  `MEDIUM`
+
+**Location:** `companion/src/analysis/iocValue.ts:60`
+
+DUP-1's fix made internalIp.ts the one range table (RFC1918 + loopback + 0/8 + link-local + CGNAT) precisely because per-module copies had drifted on CGNAT, but iocValue.ts's isPrivateIpv4 — which backs the exported isInternalTarget() SSRF guard that enrichService.ts uses to decide what may be enriched — still lacks the 100.64/10 branch. So isInternalTarget("100.64.0.5", "ip") returns false and a CGNAT address (or a URL/IPv6-mapped host embedding one) is treated as a routable public target, while every importer now refuses to mint CGNAT IOCs, anonymize.ts classifies CGNAT as internal/victim, and providers/urlValidation.ts blocks CGNAT with a pinned test. anonymize.ts:199 even carries a comment explicitly working around this gap ("Classification still uses isInternalIp() (not iocValue.ts's isPrivateIpv4) so the CGNAT range stays covered here") — documentation of known drift, not intent. No test pins CGNAT as enrichable (iocValue.test.ts's public cases are 8.8.8.8/1.1.1.1 only).
+
+**Evidence:**
+```
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+```
+
+**Fix:** Do NOT import ./internalIp.js (analysis/findings tier 2 importing analysis/ingest tier 3 fails check:boundaries, and the ledger only shrinks). Instead add the missing branch to isPrivateIpv4 — `if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10` — extend the range comment at iocValue.ts:58-59, and pin it: isInternalTarget("100.64.0.5", "ip") === true plus a mapped/URL variant (e.g. "http://100.64.0.5/" and "::ffff:100.64.0.5"). This mirrors how urlValidation.ts and anonymize.ts, also below the ingest tier, each keep the range locally with a CGNAT-pinned test. Optionally soften the now-outdated parenthetical in anonymize.ts:199. Full consolidation would require first re-homing internalIp.ts to the shared domain in module-map.json's flatAnalysisFiles (it imports nothing, so it qualifies) — a separate architectural edit.
+
+**Status:** Open
+
+#### DUP2-2 — DUP-2's sweep missed two more local severity-rank tables: inverted encodings in reports/attackLayer.ts and reports/iocBlocklist.ts  `LOW`
+
+**Location:** `companion/src/reports/attackLayer.ts:60`
+
+The new canonical-table comment in stateTypes.ts:6-8 states that only forensicGate.ts, notifications.ts and slashCommand.ts "deliberately keep their own INVERTED encodings", but two more files re-declare a private SEVERITY_RANK with inverted (higher = worse) semantics: reports/attackLayer.ts:60 (Critical: 5 … Info: 1, used by its worse() at :80 and the sort at :157) and reports/iocBlocklist.ts:24 (Critical: 4 … Info: 0, used once at :93). Both escaped DUP-2's grep because they are multi-line and not the { Critical: 0 … } literal; neither is exported, tested against its numeric values, or named in the sanctioned exclusion set — unlike forensicGate's, which is a cross-module contract consumed by findingGrounding. Consequence: a future severity-tier change to the canonical table silently misses these two report generators, and the stateTypes comment's inventory of exceptions is already wrong.
+
+**Evidence:**
+```
+// Worst-wins ordering (higher = worse) when several findings/events touch the same technique.
+const SEVERITY_RANK: Record<Severity, number> = {
+  Critical: 5,
+  High: 4,
+  Medium: 3,
+  Low: 2,
+  Info: 1,
+};
+```
+
+**Fix:** In attackLayer.ts delete the local table, import SEVERITY_RANK from ../analysis/stateTypes.js (the file already imports Severity from there) and flip the two comparisons (worse(): `SEVERITY_RANK[a] <= SEVERITY_RANK[b] ? a : b`; the sort at :157: `SEVERITY_RANK[a[1].worst] - SEVERITY_RANK[b[1].worst]`). In iocBlocklist.ts delete its local table and flip the single comparison at :93 to `SEVERITY_RANK[iocSeverity(ioc)] > SEVERITY_RANK[minSev]`. Both swaps are behavior-preserving (SEVERITY_SCORE/SEVERITY_COLOR are untouched); existing report tests pin the output either way.
+
+**Status:** Open
+
+#### DUP2-3 — escapeRegExp is hand-rolled nine times across companion/src, including a fresh copy the branch carried into veloMessageFields.ts  `LOW`
+
+**Location:** `companion/src/analysis/veloMessageFields.ts:30`
+
+The byte-identical MDN regex-escape idiom `.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")` exists as five named function copies (analysis/anonymize.ts:96, analysis/assetGraph.ts:91, analysis/geoMap.ts:82, analysis/redactPaths.ts:65, reports/glossary.ts:58) and four inline uses (analysis/veloMessageFields.ts:30 — placed in this new module by the branch's extraction, analysis/fpCascade.ts:26, analysis/initialAccess.ts:38, analysis/lookalikeDomains.ts:336). This is exactly the small-helper duplication class DUP-1/DUP-3 consolidated for IP ranges and month tables, and it guards security-relevant surfaces (anonymize's tokenizer, redactPaths): a future correction — e.g. escaping `/` for a literal-embedded pattern, or the `u`-flag identity-escape caveat anonymize.ts:127 documents only locally — must be found and repeated in nine files, and any copy silently drifting weakens the guarantee where it drifts.
+
+**Evidence:**
+```
+function labelPattern(label: string): RegExp {
+  return new RegExp(`${label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*:[ \\t]*([^\\r\\n]+)`, "i");
+}
+```
+
+**Fix:** Create companion/src/analysis/regexEscape.ts exporting escapeRegExp with anonymize.ts's Unicode-mode safety comment, AND add "regexEscape.ts": "shared" to module-map.json's flatAnalysisFiles (the shared layer, rank 0, is importable from all nine sites including reports/glossary.ts — same classification stateTypes.ts already has; without the entry check:boundaries hard-errors on the unclassified file). Then swap the nine sites and run check:boundaries plus tests/architecture/moduleMap.test.ts.
+
+**Status:** Open
+
+#### DUP2-4 — The streaming-import kind predicate (evtxxml || syslog) is copied five times across the import routes and the resume handler  `LOW`
+
+**Location:** `companion/src/routes/import.ts:335`
+
+The branch's cancellable-syslog fix widened `kind === "evtxxml"` into the two-kind list `kind === "evtxxml" || kind === "syslog"` in five places: routes/import.ts:335 and :645 (cancellable in the twin /import and /import-file job registrations), :362 and :672 (the onParseProgress spread in the same twin blocks), and routes/importRecovery.ts:185 (cancellable for RESUMED jobs). These five literals must stay in lockstep — the next streaming importer (the same fix pattern is queued for other large formats per REVIEW.md's PERF notes) requires editing all five, and missing only importRecovery.ts:185 would produce a job that is cancellable on first run but silently uncancellable after a server restart resumes it, with no test tying the two files together.
+
+**Evidence:**
+```
+        cancellable: aiDependent || kind === "evtxxml" || kind === "syslog",
+...
+        ...(kind === "evtxxml" || kind === "syslog" ? { onParseProgress: tracking.onParseProgress } : {}),
+...
+// importRecovery.ts:185
+      cancellable: (job) => job.parameters?.kind === "evtxxml" || job.parameters?.kind === "syslog",
+```
+
+**Fix:** Hoist `export const PARSE_PROGRESS_KINDS = new Set(["evtxxml", "syslog"])` with a hasParseProgress(kind) helper into a new routes/importKinds.ts (auto-classified by the routes/** glob; avoid the name "streaming", which import.ts:587 already uses for plaso file-streaming), replace the five literals, and add a test asserting importRecovery's kind-driven cancellable component matches the registration's per kind (the registrations additionally OR in aiDependent, which the resume predicate intentionally lacks — assert only the kind part).
+
+**Status:** Open
+
+#### DUP2-5 — The worst-severity comparator is still declared in nine files although siemImport.ts already exports it as worst()  `LOW`
+
+**Location:** `companion/src/analysis/siemImport.ts:1201`
+
+DUP-2's fix consolidated the SEVERITY_RANK table but left its 2-line worst-wins comparator duplicated: siemImport.ts:1201 exports the canonical `worst` (imported by the syslog/combined-log importers), yet eight more files declare a byte-equivalent private copy over the now-shared table — assetGraph.ts:84, assetOverrides.ts:55, burstDetect.ts:34, correlate.ts:99 (the `<=` variant, same semantics), evidenceGraph.ts:72, exfilCorrelate.ts:18, geoMap.ts:85, initialAccess.ts:14 — plus attackLayer.ts:79's inverted-table variant (finding DUP2-2). This is the identical shape DUP-2 removed one level down: a canonical export exists while consumers re-declare it, because the graph/correlation modules may not import the importer-layer siemImport. Direction is easy to get backwards when copying (an inverted `<` silently returns the LESS severe value), and the drift can only be caught by eye since each copy compiles fine.
+
+**Evidence:**
+```
+// assetGraph.ts:84 (same two lines in 7 more files)
+function worse(a: Severity, b: Severity): Severity {
+  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
+}
+// siemImport.ts:1201 — the already-exported canonical
+export function worst(a: Severity, b: Severity): Severity {
+  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
+}
+```
+
+**Fix:** Apply the branch's own pattern one more time: add `export function worstSeverity(a: Severity, b: Severity): Severity` to stateTypes.ts beside SEVERITY_RANK (cycle-free — stateTypes has only type imports), delete the eight local copies in favor of it, and keep siemImport's `worst` as a one-line re-export (exactly how isInternalIpv4 is surfaced there) so the many existing importer call sites are untouched. attackLayer.ts picks it up as part of DUP2-2's swap.
+
+**Status:** Open
+
+
 ## 4. Test Coverage Gaps
 
 Test coverage in this repository is unusually strong for its riskiest surfaces: `companion/tests/analysis/zipExtract.test.ts` and `zipArchive.test.ts` exercise zip-slip, zip-bomb caps, and even AES-tamper-vs-wrong-password discrimination with real fixtures; `caseEncryption.test.ts` pins a frozen v1 container as a regression vector; and `http/originGuard.test.ts` covers DNS-rebinding from every angle. The remaining gaps cluster at the team-authentication trust boundary: the OIDC ID-token verifier (`companion/src/auth/oidcClient.ts`) has only a happy-path test and no forged/alg-none/wrong-nonce rejections, the `/auth/bootstrap` first-admin route (`companion/src/auth/authRoutes.ts`) has no refusal-branch tests, and the single-writer guard's corruption/release-safety branches are unexercised. One demonstrated crash branch in `zipExtract.ts`'s central-directory scan also lacks a corrupt-archive test.
@@ -345,6 +518,97 @@ let ptr = archive.readUInt32LE(eocd + 16);
 **Status:** Fixed in d566a138.
 
 
+### Second pass (2026-08-21)
+
+The first pass's five gaps (TC-1..TC-5) are genuinely closed, and most of this branch's fix commits arrived with their behavior pinned: `parseSyslogProgress`'s abort/progress contract (`companion/tests/analysis/syslogImport.test.ts`), all three `tesseractDataOptions` resolution branches (`ocrRedact.test.ts`), the `client_info() FROM scope()` projection in `getFlowInfo` (`tests/integrations/velociraptor.test.ts`), the backfill per-line skip (`tests/composition/backfillCaptureLog.test.ts`), the host-scope decision throw (`tests/dashboard/hostScopePanel.test.ts`), and the extracted `clientInventory.ts`/`veloMessageFields.ts`/`bsdTime.ts` modules all keep their pre-move coverage through re-exports. What remains untested clusters where a fix introduced a NEW invariant without a test to guard it — the consolidated IP classifier's IPv4-shape requirement in `siemImport.ts`, the asset-graph generation token in `public/js/dashboard-asset-graph.js`, and `huntQueryParser.ts`'s rewritten position arithmetic — plus one residual crash branch (`zipArchive.ts`'s local-header offset) that the TC-5 guard demonstrably does not reach. `docker-entrypoint.sh`'s run-as-mount-owner and confined-chown logic is POSIX shell and outside vitest's reach; its ~25 external-review fixes remain manually verified only.
+
+#### TC2-1 — isPublicIpv4's IPv4-shape requirement (blank/IPv6 logon sources count as internal) is pinned by zero tests — the naive-negation regression the code's own comment forbids passes the whole suite  `MEDIUM`
+
+**Location:** `companion/src/analysis/siemImport.ts:815`
+
+The DUP-1 consolidation rewrote isPublicIpv4 as a thin wrapper over the new shared isInternalIpv4, and both its comment (siemImport.ts:812-813) and internalIp.ts:6-8 warn that it must stay "IPv4-shaped AND not internal", never a plain !isInternalIpv4 — because isInternalIpv4 returns false (not-internal) for non-IPv4 strings. But no test anywhere exercises that property: the logonRisk suite (companion/tests/analysis/siemImport.test.ts:84-112) feeds only IPv4-shaped sources for types 3/10 (the empty-string calls are types 8/9, which are Medium unconditionally), the mapWindows end-to-end tests use "203.0.113.9" and "::ffff:10.10.200.11" (which cleanIp normalizes to IPv4 before logonRisk sees it), loginGraph.test.ts uses only IPv4s, and no test references isInternalIpv4 at all. If someone "simplifies" line 815 to `!isInternalIpv4(ip)` — the exact cleanup the comment forbids, natural now that the shared classifier sits one import away — every one of the 9,962 tests stays green while logonRisk grades every blank-source 4624 type-3 logon (IpAddress "-" is routine for local/service logons; cleanIp maps it to "") and every routable-IPv6 source (which cleanIp deliberately keeps, siemImport.ts:629) as an internet-facing logon: Medium + T1078, silently flooding the forensic timeline that AI synthesis reads with false external-access findings. The shared classifier's own range boundaries (172.15 vs 172.16, 100.63 vs 100.64, 0/8, 169.254) also have no direct unit spec — only CGNAT/0-8 are pinned indirectly via one emailImport Received-walk test.
+
+**Evidence:**
+```
+// so this must stay "IPv4-shaped AND not internal", never a plain !isInternalIpv4 (which would call
+// a blank/IPv6 source public and make logonRisk grade e.g. a blank-source type-3 logon external).
+function isPublicIpv4(ip: string): boolean {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(ip.trim()) && !isInternalIpv4(ip);
+}
+```
+
+**Fix:** Two small additions. (1) In companion/tests/analysis/siemImport.test.ts's "logonRisk — logon-type grading" describe, pin the shape requirement through the public surface: `expect(logonRisk(3, "").severity).toBeUndefined()` and `expect(logonRisk(3, "").mitre).toEqual([])`; same for logonRisk(3, "2001:db8::5") and logonRisk(10, "2001:db8::5") (typeName decoded, severity undefined); plus one mapWindows end-to-end case `parseSiemExport(elastic(logon4624("3", "-")))` asserting severity "Low" and mitreTechniques []. (2) Add companion/tests/analysis/internalIp.test.ts unit-speccing isInternalIpv4's full table: true for 10.0.0.1, 127.0.0.1, 0.1.2.3, 192.168.1.1, 172.16.0.1, 172.31.255.255, 169.254.10.10, 100.64.0.1, 100.127.255.255; false for the boundary neighbours 172.15.255.255, 172.32.0.1, 100.63.255.255, 100.128.0.1, 192.169.0.1, and for non-IPv4 inputs "", "-", "::1", "2001:db8::5", "10.0.0" (documenting that false means "not internal IPv4", not "public").
+
+**Status:** Open
+
+#### TC2-2 — The asset-graph generation-token race guard (commit 8f10ebd3) has no test — the harness can pin the out-of-order-response behavior but no test loads dashboard-asset-graph.js at all  `MEDIUM`
+
+**Location:** `public/js/dashboard-asset-graph.js:39`
+
+Commit 8f10ebd3 added assetGraphLoadSeq to loadAssetGraph so that when an analyst switches cases fast, a stale request's late response (success OR failure) cannot overwrite the newer case's graph, and so that the LATEST load's failure clears the cached graph instead of leaving the previous case's assets on screen with hasAssetGraph() wrongly true. None of this is tested: no file in companion/tests loads dashboard-asset-graph.js (hostFacetMerge.test.ts stubs assetOverrideMerges directly, and the only other mentions are comments), so both new branches — `seq !== assetGraphLoadSeq → ignore` and `!g || !Array.isArray(g.assets) → clear + repaint` — plus hasAssetGraph()'s trust in that state are invisible to the suite. The sibling fix from the same commit series (dashboard-host-scope.js's decideHostScope throw) DID get harness tests in hostScopePanel.test.ts, proving the vm-based loadDashboardModule pattern handles exactly this module shape (stubbed fetch + document). If the token logic regresses — e.g. a refactor to async/await drops the seq capture, or moves the ++ after the fetch — fast case switches silently paint case A's assets and IOC edges over case B again (cross-case evidence displayed under the wrong case id), and every test stays green. The module is load-clean (no module-scope DOM access; assetTypesEnabled is a local Set), so the test needs only fetch, document.getElementById, and DfirTimelineView stubs.
+
+**Evidence:**
+```
+    const seq = ++assetGraphLoadSeq;
+    fetch(`/cases/${caseId}/asset-graph${DfirTimelineView.timeQuery()}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((g) => {
+        if (seq !== assetGraphLoadSeq) return; // superseded by a newer load — ignore entirely
+        if (!g || !Array.isArray(g.assets)) {
+          assetGraphData = null;
+          renderAssetGraph();
+          renderAssetList();
+          return;
+        }
+        assetGraphData = g;
+```
+
+**Fix:** Add companion/tests/dashboard/assetGraphPanel.test.ts following hostScopePanel.test.ts's pattern: `loadDashboardModule<{loadAssetGraph(id: string): void; hasAssetGraph(): boolean; assetGraphAssets(): Array<{name: string}>}>("dashboard-asset-graph.js", ["dashboard-escape.js"], { fetch: fetchStub, document: { getElementById: () => ({ innerHTML: "", textContent: "", style: {} }), querySelectorAll: () => [] }, DfirTimelineView: { timeQuery: () => "" } })` where fetchStub records a manually-resolvable deferred per call. Three tests: (1) out-of-order success — call loadAssetGraph("case-a") then loadAssetGraph("case-b"); resolve B's deferred with `{ok: true, json: async () => ({assets: [{name: "b-host", type: "host", compromised: false}], iocs: [], edges: []})}`, flush microtasks, then resolve A with an a-host graph; assert assetGraphAssets() still returns b-host and hasAssetGraph() is true. (2) stale failure ignored — resolve the OLD load with `{ok: false}` after the new one succeeded; assert the graph survives. (3) latest failure clears — a single loadAssetGraph whose response is `{ok: false, json: async () => ({error: "boom"})}`; assert hasAssetGraph() returns false and assetGraphAssets() is empty (the error body must never be cached as graph data).
+
+**Status:** Open
+
+#### TC2-3 — readZip's local-header offset is unguarded and untested — a crafted zip passes the new TC-5 EOCD guard and still surfaces Node's raw ERR_OUT_OF_RANGE (demonstrated)  `LOW`
+
+**Location:** `companion/src/analysis/zipArchive.ts:193`
+
+The TC-5 fix bounded the central-directory pointer in archiveIsEncrypted (zipExtract.ts:73) with two tests, but its own fix text also called for the same bound "on localOffset + 30 before the local-header reads at lines 193-194" — and the fix commit never touched zipArchive.ts. The gap is real today, not speculative: I built a zip via the repo's own createZip, overwrote the central record's relative-offset-of-local-header field (ptr+42) with 0xffffff00, and called extractZipEntries — archiveIsEncrypted's guard passes (the central record itself is in bounds, signature and flags valid), then readZip line 193 throws `RangeError ERR_OUT_OF_RANGE: The value of "offset" is out of range. It must be >= 0 and <= 125. Received 4294967066`. Through the tools run-upload route (composition/externalTools.ts:256 → routes/tools.ts catch) the analyst again receives Node's internal offset message instead of the actionable "corrupt ZIP" wording — exactly the failure mode TC-5 existed to eliminate. readZip's own ptr walk (line 179) is also unguarded for its second caller, caseExportArchive.ts:496, which never runs archiveIsEncrypted first. No test in zipExtract.test.ts or zipArchive.test.ts crafts a bad localOffset, so the branch is invisible to the suite.
+
+**Evidence:**
+```
+    // Jump to the local header to find the actual data start (its name/extra lengths may differ).
+    const localNameLen = archive.readUInt16LE(localOffset + 26);
+    const localExtraLen = archive.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLen + localExtraLen;
+```
+
+**Fix:** In readZip, add two bounds inside the walk loop: `if (ptr + 46 > archive.length) throw new Error("corrupt ZIP: central directory out of bounds");` before the SIG_CENTRAL check at line 179 (covers the caseExportArchive.ts caller that skips archiveIsEncrypted), and `if (localOffset + 30 > archive.length) throw new Error("corrupt ZIP: local header out of bounds");` before line 193. Then add the test that demonstrated the defect to companion/tests/analysis/zipExtract.test.ts, mirroring the two existing crafted-EOCD tests: build createZip([{path: "sample.bin", data: Buffer.from("payload")}]), locate the EOCD (0x06054b50 scan), read the central-directory start from eocd+16, overwrite the localOffset field with `archive.writeUInt32LE(0xffffff00, ptr + 42)`, and expect extractZipEntries to throw /corrupt ZIP: local header/i — currently it throws the raw RangeError, so the test fails until the guard lands.
+
+**Status:** Open
+
+#### TC2-4 — location()'s binary-search rewrite (PF-2 fix) is only pinned at line 1, column 1 — no test asserts a multi-line or mid-line error position that could catch an off-by-one  `LOW`
+
+**Location:** `companion/src/analysis/huntQueryParser.ts:108`
+
+The PF-2 fix replaced location()'s trivially-correct slice/split with a precomputed newline-offset array, a one-slot module-level memo (newlineMemoText/newlineMemoOffsets), and hand-rolled binary-search arithmetic (`line: low + 1`, `lineStart = newlines[low-1] + 1`, `column: offset - lineStart + 1`). The fix's stated contract was "keeps error-path syntaxError() positions identical", but the only position assertion in companion/tests/analysis/huntQueryParser.test.ts is `line: 1, column: 1` for an error at offset 0 — the degenerate case that almost any wrong formula still satisfies (both `<` and `<=` in the comparison, and ±1 slips in lineStart, all produce 1/1 there). These positions are analyst-facing: hunt-workbench.js:325 renders `"— line ${typed.line}, column ${typed.column}"` next to the query editor on POST /hunt-query/validate and /execute failures. A regression in the comparison direction, the lineStart derivation, or a memo-staleness bug across consecutive parses of different texts would silently point every multi-line error at the wrong place while the entire suite stays green.
+
+**Evidence:**
+```
+  let low = 0;
+  let high = newlines.length;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (newlines[mid] < offset) low = mid + 1;
+    else high = mid;
+  }
+  const lineStart = low === 0 ? 0 : newlines[low - 1] + 1;
+  return { line: low + 1, column: offset - lineStart + 1 };
+```
+
+**Fix:** Extend companion/tests/analysis/huntQueryParser.test.ts with three verified cases (I probed each against the actual parser — two of the originally proposed inputs do not behave as described): (1) multi-line: parseHuntQuery("source.ip=192.0.2.1\n| group by sorce.ip") throws code "unknown_field" at { line: 2, column: 12 } — note the grammar is `| group by <field>`; the originally proposed "| group_by sorce.ip" instead throws unknown_stage at line 2, column 3 (usable as a second pin if wanted, but not for the field column). (2) first-line non-1 column: parseHuntQuery("source.ip=192.0.2.1 and sorce.ip=10.0.0.1") throws "unknown_field" at { line: 1, column: 25 } — the originally proposed "severity=Zigh" parses successfully (severity values are not validated at parse time) and must not be used. (3) memo staleness: in one test, parseHuntQuery("host.name=a\nand sorce.ip=1") throws at { line: 2, column: 5 }, then parseHuntQuery("host.name=a and\nsorce.ip=1") throws at { line: 2, column: 1 } — same error token, different newline layouts, pinning that newlineOffsets' one-slot memo re-keys on the second text. Each follows the existing try/catch + toMatchObject pattern at huntQueryParser.test.ts:62-75.
+
+**Status:** Open
+
+
 ## 5. Performance Concerns in VQL/Parsing Logic
 
 Parsing and VQL-adjacent code is largely in good shape: the Plaso/CSV pipeline streams multi-hundred-MB super-timelines with bounded memory (`companion/src/analysis/plasoImport.ts` + `csvImport.ts`), the hunt-query executor enforces scanned-row/duration/group/regex budgets with paged SQLite reads (`companion/src/analysis/huntQueryExecutor.ts`), and cross-source correlation uses hash-bucketed union-find instead of pairwise scans (`correlate.ts`). The remaining defects cluster in two patterns: per-row `new RegExp` construction inside million-iteration import loops, and one line-based importer (`syslogImport.ts`) that still materializes every mapped line before aggregating — the exact OOM pattern the Plaso path was rebuilt to avoid, on the same `/import-file` route that explicitly advertises 400 MB+ files. Note: there is no Python source in this repository (the only .py files are vendored under node_modules), so this dimension covers the TypeScript server only.
@@ -435,6 +699,70 @@ const rec = (await this.listClients()).find((c) => c.clientId === clientId);
 **Status:** Fixed in f27c41d9.
 
 
+### Second pass (2026-08-21)
+
+The first pass's five performance fixes hold up well under re-review: `huntQueryParser.ts`'s one-slot newline memo is correct under any call pattern (parsing is fully synchronous, every `location()` call in a parse passes the same string, and a text change merely recomputes), `veloMessageFields.ts` precompiles its label patterns with a sound lazy fallback, `evtxXmlImport.ts`'s memoized `elText`/`attr` maps carry no `lastIndex` state, and `getFlowInfo` now does a targeted `client_info()` lookup instead of enumerating the fleet. The second pass found one significant regression-shaped gap in the PF-1 streaming rework: `syslogImport.ts`'s accumulator buffers a full `MappedEvent` for every *failed* sshd auth line even though the brute-force correlation only ever rewrites *accepted* events — so the one input the feature targets (an auth.log flood) measured +526 MB peak and 2x parse time versus +2 MB for an equal-size non-sshd log. Two smaller residues of the same fixed classes remain: the hunt executor still compiles its `matches` RegExp per row (up to 50k throwaway compiles per query), and the evtx count loop the PF-3 fix introduced blocks the event loop ~0.4 s per 300 MB with no yield or abort check — the exact pattern commit b1360438 fixed for syslog's count. The other hunting grounds (`correlate.ts`, `superTimelineStore.ts`'s paged SQLite query, `huntQueryAggregation.ts`, `logAggregate.ts`, `veloRowNormalize.ts`, and the chainsaw/hayabusa/wazuh/k8s importers) came up clean.
+
+#### PF2-1 — Syslog accumulator buffers a full MappedEvent for every failed sshd auth line — a brute-force flood defeats the PF-1 streaming fix (526 MB peak, 2x parse time, measured)  `HIGH`
+
+**Location:** `companion/src/analysis/syslogImport.ts:238`
+
+createSyslogAccumulator.line() holds back BOTH outcomes of parseSshAuth — accepted and failed — as full MappedEvents in sshEvents[] until finish(), but markSshBruteForce() can only ever rewrite ACCEPTED events (sshBruteForce.ts:95-108: the failed branch just records ms into failuresByIp and `continue`s; hits are pushed exclusively from the accepted branch). Failed lines therefore gain nothing from being buffered as events, yet they are the dominant content of exactly the input this correlation targets: an auth.log from an internet-facing host under password guessing is line after line of `Failed password for ... from ...`. Measured on the real route path (parseSyslogProgress): a 2M-line / 212 MB sshd failed-password flood peaks +526 MB RSS and parses in 39.1 s, versus +2 MB and 19.4 s for a same-size non-sshd flood that streams through the aggregator — i.e. for the most plausible large plain-syslog file in IR, the PF-1 materialization (~260 B/line retained plus doubled parse time from allocation/GC churn) is reintroduced, scaling to ~1.3 GB extra at the route's ~512 MB input limit — an OOM kill in a memory-limited container on the same /cases/:id/import-file route PF-1 was rated HIGH for.
+
+**Evidence:**
+```
+if (/^sshd\b/i.test(p.app)) {
+        const auth = parseSshAuth(p.message);
+        if (auth) {
+          sshAuth.push({
+            key: sshEvents.push(m) - 1,
+            ms: Date.parse(p.timestamp) || 0,
+            ip: auth.ip,
+            result: auth.result,
+          });
+          return;
+        }
+      }
+      agg.add(m);
+```
+
+**Fix:** In line(), split by auth.result: for "failed", call agg.add(m) immediately (nothing ever rewrites a failed event) and push only the compact tuple { key: -1, ms, ip, result: "failed" } into sshAuth (markSshBruteForce never reads a failed event's key); keep buffering only "accepted" MappedEvents in sshEvents — bounded by real logins, which are rare. finish() is unchanged: markSshBruteForce hits still reference only accepted keys, so the rewrite/add of the accepted buffer works as today, and ordering stays within the already-documented three-way-tie tolerance of agg.finish()'s re-sort. Optionally go further and fold failures straight into a Map<ip, number[]> of timestamps as lines stream (markSshBruteForce builds exactly that internally), shrinking the flood's residual to raw numbers per IP; but eliminating the per-failure MappedEvent (description + aggKey strings dominate the 526 MB) is the essential, small diff.
+
+**Status:** Open
+
+#### PF2-2 — Hunt executor compiles the matches-predicate RegExp per row per evaluation — the one per-row compile the PF-3/PF-4 sweep missed  `LOW`
+
+**Location:** `companion/src/analysis/huntQueryExecutor.ts:249`
+
+compareScalar() constructs `new RegExp(String(expected ?? ""), predicate.regexFlags)` on every evaluation of a `matches` predicate, although the pattern and flags are per-query constants (a literal from the parsed AST or a resolved $parameter, already validated once by validateHuntRegex at parse time). With maxRegexEvaluations = 50,000 and maxScannedRows = 100,000, a single interactive /hunt-query/execute request performs up to 50k throwaway escape-free compiles of the same pattern: measured 61.4 ms vs 17.2 ms with a cached instance at the full budget — ~45 ms of pure compile waste plus 50k RegExp allocations of GC churn per query, repeated on every keystroke-driven /validate + /execute round-trip from the workbench. duringRange() in the same function similarly re-parses the constant time-window string and re-runs Date.parse(range.from/to) for every row of a `during` predicate. Same defect class as the fixed PF-3/PF-4, on the interactive VQL path instead of the import path.
+
+**Evidence:**
+```
+return new RegExp(String(expected ?? ""), predicate.regexFlags).test(String(actual ?? ""));
+```
+
+**Fix:** Cache per execution in the existing EvaluationContext: add `regexCache: Map<string, RegExp>` (key `${pattern} ${flags}`) created once in executeHuntQuery's state, and in compareScalar look up/compile-once before .test(). Give `during` the same treatment by caching the resolved {fromMs, toMs} per expected-string in the context (the anchorTime is fixed for the whole execution), replacing the per-row duringRange + double Date.parse. No behavior change; both caches die with the request.
+
+**Status:** Open
+
+#### PF2-3 — parseWinEventXmlProgress's event-count loop blocks the event loop ~0.4-0.7 s with no yield or abort check — the exact gap the branch fixed for syslog's count loop  `LOW`
+
+**Location:** `companion/src/analysis/evtxXmlImport.ts:171`
+
+The PF-3 fix replaced the allocating `text.match(/<Event\b/gi)` count with a counting exec loop, but the loop runs fully synchronously before the parse loop's first await: no setImmediate yield and no throwIfImportAborted between the top-of-function check and the end of the count. Measured: 417 ms of uninterrupted event-loop block counting 1M events in a 309 MB export (~0.7 s at the route's ~512 MB limit), during which every other request and any pending job cancellation stalls. The branch itself established that this class must yield — commit b1360438 added SYSLOG_COUNT_CHUNK to parseSyslogProgress with the comment "it MUST yield, or a multi-million-line input would block the event loop (and any pending cancellation) for the whole count before the parse loop's first await" — and the identical reasoning applies verbatim to this sibling counting loop on the same import route.
+
+**Evidence:**
+```
+let total = 0;
+  const countRe = /<Event\b/gi;
+  while (countRe.exec(text) !== null) total++;
+```
+
+**Fix:** Mirror the syslog count fix: every N matches (e.g. a COUNT_CHUNK of 100_000 — each iteration scans a whole event block, so a coarser budget than syslog's per-line 1M is appropriate) do `await new Promise<void>((resolve) => setImmediate(resolve)); throwIfImportAborted(signal);` inside the counting loop. ~5 lines, identical in shape to syslogImport.ts's SYSLOG_COUNT_CHUNK block.
+
+**Status:** Open
+
+
 ## 6. Docker and Dependency Risks
 
 The container story is mostly well-engineered: the 3-stage `Dockerfile` builds with `npm ci` against the lockfile and prunes dev deps, `.dockerignore` keeps evidence (`cases/`), `.env`, `node_modules`, and `.git` out of the build context, `docker-entrypoint.sh` uses `set -e`, quoted expansions, and `exec node` so the server runs as PID 1 with correct signal handling, and `docker-compose.yml` publishes the port to `127.0.0.1` only. The extension's production dependency surface audits clean, and no secrets are baked into the image or compose file. The gaps that remain are operational rather than architectural: the runtime stage never drops root (no `USER` directive) even though the process parses hostile forensic evidence and holds bind mounts back to the host, and `companion/package-lock.json` pins undici 8.3.0, which carries four HIGH advisories (including a TLS certificate-validation bypass) that a simple lockfile refresh within the existing `^8.3.0` range would clear. Image-level `HEALTHCHECK` and digest-pinned base tags round out the fix list.
@@ -506,6 +834,27 @@ FROM node:22-slim AS companion-build
 **Status:** Fixed in f1a45b61.
 
 
+### Second pass (2026-08-21)
+
+After the first pass's DD-1..4 fixes plus the ~14 external-review iterations, this dimension is in strong shape. Production dependencies are now clean: `npm audit --omit=dev` reports **0 vulnerabilities** in `companion/` and **0 HIGH/CRITICAL** in `extension/` (undici/nanoid of DD-2 are refreshed within-range; the extension's vite/vitest/postcss advisories are dev-only and never ship). All three `Dockerfile` stages are digest-pinned (`node:22-slim@sha256:d649c27…`), and `docker-entrypoint.sh` was re-read end-to-end: its lexical/realpath split, `deny_chown` confinement (incl. the new `/opt` denial), dotenv override parsing, and the `KNOWN_STORES` list were all cross-checked against the server's own resolution (`authFactory.ts:22-23`, `server.ts:606`, `runtimeStores.ts`) and found consistent — the auth-hash, cases-root, and store-sibling derivations match on both symlinked and relative roots. One residual inconsistency remains in the healthcheck story: the baked `Dockerfile` probe was deliberately pointed at the auth-exempt `/health` (DD-3), but `docker-compose.yml:61` still probes the auth-gated `/dashboard`.
+
+#### DD2-1 — Compose healthcheck probes auth-gated /dashboard, not /health — reports unhealthy under the recommended team mode  `LOW`
+
+**Location:** `docker-compose.yml:61`
+
+The DD-3 fix deliberately baked a Dockerfile HEALTHCHECK against /health because /health is the one endpoint exempt from both the host-check and the auth gate (PUBLIC_GET in companion/src/auth/policy.ts:14, HOST_CHECK_EXEMPT_PATHS in originGuard.ts:228). The compose healthcheck was left probing GET /dashboard, which is an AUTHENTICATED_SHELL (policy.ts:23). A compose healthcheck overrides the baked one, so compose users' liveness probe is the /dashboard one. In single-user mode (the shipped compose default) /dashboard returns 200 and the probe passes, but when the operator enables the multi-user config that railway.toml explicitly recommends for real cases (DFIR_AUTH_MODE=team), teamAuth.middleware() gates /dashboard: an unauthenticated request whose Accept header lacks text/html — exactly the case for the healthcheck's Node fetch(), which sends Accept: */* — takes the res.status(401).json(...) branch in teamAuth.ts:239 (not the HTML redirect). r.ok is then false, the probe exits 1, and Docker marks the fully-functional container permanently 'unhealthy' (which orchestrators like Portainer/Swarm may act on). The failure consequence is a healthy container reported unhealthy under the documented team-mode deployment.
+
+**Evidence:**
+```
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4773/dashboard').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+```
+
+**Fix:** In docker-compose.yml:61 change the probe URL from /dashboard to /health: test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4773/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]. If also de-hardcoding the port, read it from the environment inside the Node one-liner exactly as the Dockerfile HEALTHCHECK does ('http://127.0.0.1:'+(process.env.PORT||process.env.DFIR_PORT||4773)+'/health') — compose's CMD exec form performs no shell expansion, so $DFIR_PORT in the URL string would not work.
+
+**Status:** Open
+
+
 ## Finding Index
 
 | ID | Severity | Location | Title |
@@ -534,3 +883,18 @@ FROM node:22-slim AS companion-build
 | DD-2 | HIGH | `companion/package.json:83` | Lockfile pins undici 8.3.0 and nanoid 5.1.11, each carrying HIGH npm advisories with in-range fixes |
 | DD-3 | LOW | `Dockerfile:70` | No HEALTHCHECK baked into the image; only compose users get liveness checks |
 | DD-4 | LOW | `Dockerfile:11` | Base images use floating tags without digest pinning; compose pulls :latest |
+| EH2-1 | MEDIUM | `public/js/dashboard-host-scope.js:228` | loadHostScope silently ignores a failed ledger read and keeps the previous case's clearance ledger on screen |
+| EH2-2 | LOW | `public/js/dashboard-asset-graph.js:53` | loadAssetGraph's rejection arm bypasses the new generation-token clearing, leaving the stale cross-case graph the fix claims to prevent |
+| DUP2-1 | MEDIUM | `companion/src/analysis/iocValue.ts:60` | The internal-IPv4 consolidation stopped short of iocValue.ts — the enrichment SSRF gate still treats CGNAT 100.64/10 as public |
+| DUP2-2 | LOW | `companion/src/reports/attackLayer.ts:60` | DUP-2's sweep missed two more local severity-rank tables: inverted encodings in reports/attackLayer.ts and reports/iocBlocklist.ts |
+| DUP2-3 | LOW | `companion/src/analysis/veloMessageFields.ts:30` | escapeRegExp is hand-rolled nine times across companion/src, including a fresh copy the branch carried into veloMessageFields.ts |
+| DUP2-4 | LOW | `companion/src/routes/import.ts:335` | The streaming-import kind predicate (evtxxml || syslog) is copied five times across the import routes and the resume handler |
+| DUP2-5 | LOW | `companion/src/analysis/siemImport.ts:1201` | The worst-severity comparator is still declared in nine files although siemImport.ts already exports it as worst() |
+| TC2-1 | MEDIUM | `companion/src/analysis/siemImport.ts:815` | isPublicIpv4's IPv4-shape requirement (blank/IPv6 logon sources count as internal) is pinned by zero tests — the naive-negation regression the code's own comment forbids passes the whole suite |
+| TC2-2 | MEDIUM | `public/js/dashboard-asset-graph.js:39` | The asset-graph generation-token race guard (commit 8f10ebd3) has no test — the harness can pin the out-of-order-response behavior but no test loads dashboard-asset-graph.js at all |
+| TC2-3 | LOW | `companion/src/analysis/zipArchive.ts:193` | readZip's local-header offset is unguarded and untested — a crafted zip passes the new TC-5 EOCD guard and still surfaces Node's raw ERR_OUT_OF_RANGE (demonstrated) |
+| TC2-4 | LOW | `companion/src/analysis/huntQueryParser.ts:108` | location()'s binary-search rewrite (PF-2 fix) is only pinned at line 1, column 1 — no test asserts a multi-line or mid-line error position that could catch an off-by-one |
+| PF2-1 | HIGH | `companion/src/analysis/syslogImport.ts:238` | Syslog accumulator buffers a full MappedEvent for every failed sshd auth line — a brute-force flood defeats the PF-1 streaming fix (526 MB peak, 2x parse time, measured) |
+| PF2-2 | LOW | `companion/src/analysis/huntQueryExecutor.ts:249` | Hunt executor compiles the matches-predicate RegExp per row per evaluation — the one per-row compile the PF-3/PF-4 sweep missed |
+| PF2-3 | LOW | `companion/src/analysis/evtxXmlImport.ts:171` | parseWinEventXmlProgress's event-count loop blocks the event loop ~0.4-0.7 s with no yield or abort check — the exact gap the branch fixed for syslog's count loop |
+| DD2-1 | LOW | `docker-compose.yml:61` | Compose healthcheck probes auth-gated /dashboard, not /health — reports unhealthy under the recommended team mode |

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -164,7 +164,7 @@ loadHostScope (the sibling of the EH-2-fixed decideHostScope) still swallows eve
 
 **Fix:** Add `let hostScopeLoadSeq = 0;` and in loadHostScope take `const seq = ++hostScopeLoadSeq;` before the fetch; in both the !r.ok path and the catch, bail if `seq !== hostScopeLoadSeq`. On !r.ok: `const e = await r.json().catch(() => ({})); hostScopeLedger = null;` then, for 501 (store not configured), just `paintHostScope()` (renders the default 'No scope data.' empty state); otherwise write the failure into the panel via `const el = document.getElementById("hostScopeBody"); if (el) el.innerHTML = `<p class="hs-empty">Host scope unavailable: ${esc(e.error || "HTTP " + r.status)}</p>`;` (null-guard required — paintHostScope guards the same lookup, and the unit-test harness stubs getElementById to return null). In the catch (after the seq check): `hostScopeLedger = null;` and the same guarded write with a generic 'Host scope could not be loaded.' message. Also guard the success assignment with the seq check so a late stale success cannot overwrite the newer case's ledger.
 
-**Status:** Open
+**Status:** Fixed in cc5fc0a3.
 
 #### EH2-2 — loadAssetGraph's rejection arm bypasses the new generation-token clearing, leaving the stale cross-case graph the fix claims to prevent  `LOW`
 
@@ -188,7 +188,7 @@ The EH-3 fix added a generation token and an explicit invariant, stated in its o
 
 **Fix:** Give the catch the same latest-load semantics as the null branch: `.catch(() => { if (seq !== assetGraphLoadSeq) return; assetGraphData = null; renderAssetGraph(); renderAssetList(); });` — or extract the four-line failure block into a local `failed(seq)` helper called from both the `!g` branch and the catch, so a rejected fetch and an HTTP error degrade identically and a superseded load's late rejection still cannot touch state.
 
-**Status:** Open
+**Status:** Fixed in cc5fc0a3.
 
 
 ## 3. Code Duplication and Dead Code
@@ -341,7 +341,7 @@ function isPrivateIpv4(ip: string): boolean {
 
 **Fix:** Do NOT import ./internalIp.js (analysis/findings tier 2 importing analysis/ingest tier 3 fails check:boundaries, and the ledger only shrinks). Instead add the missing branch to isPrivateIpv4 — `if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10` — extend the range comment at iocValue.ts:58-59, and pin it: isInternalTarget("100.64.0.5", "ip") === true plus a mapped/URL variant (e.g. "http://100.64.0.5/" and "::ffff:100.64.0.5"). This mirrors how urlValidation.ts and anonymize.ts, also below the ingest tier, each keep the range locally with a CGNAT-pinned test. Optionally soften the now-outdated parenthetical in anonymize.ts:199. Full consolidation would require first re-homing internalIp.ts to the shared domain in module-map.json's flatAnalysisFiles (it imports nothing, so it qualifies) — a separate architectural edit.
 
-**Status:** Open
+**Status:** Fixed in e1d3c0d7.
 
 #### DUP2-2 — DUP-2's sweep missed two more local severity-rank tables: inverted encodings in reports/attackLayer.ts and reports/iocBlocklist.ts  `LOW`
 
@@ -363,7 +363,7 @@ const SEVERITY_RANK: Record<Severity, number> = {
 
 **Fix:** In attackLayer.ts delete the local table, import SEVERITY_RANK from ../analysis/stateTypes.js (the file already imports Severity from there) and flip the two comparisons (worse(): `SEVERITY_RANK[a] <= SEVERITY_RANK[b] ? a : b`; the sort at :157: `SEVERITY_RANK[a[1].worst] - SEVERITY_RANK[b[1].worst]`). In iocBlocklist.ts delete its local table and flip the single comparison at :93 to `SEVERITY_RANK[iocSeverity(ioc)] > SEVERITY_RANK[minSev]`. Both swaps are behavior-preserving (SEVERITY_SCORE/SEVERITY_COLOR are untouched); existing report tests pin the output either way.
 
-**Status:** Open
+**Status:** Fixed in e1d3c0d7.
 
 #### DUP2-3 — escapeRegExp is hand-rolled nine times across companion/src, including a fresh copy the branch carried into veloMessageFields.ts  `LOW`
 
@@ -380,7 +380,7 @@ function labelPattern(label: string): RegExp {
 
 **Fix:** Create companion/src/analysis/regexEscape.ts exporting escapeRegExp with anonymize.ts's Unicode-mode safety comment, AND add "regexEscape.ts": "shared" to module-map.json's flatAnalysisFiles (the shared layer, rank 0, is importable from all nine sites including reports/glossary.ts — same classification stateTypes.ts already has; without the entry check:boundaries hard-errors on the unclassified file). Then swap the nine sites and run check:boundaries plus tests/architecture/moduleMap.test.ts.
 
-**Status:** Open
+**Status:** Fixed in e1d3c0d7.
 
 #### DUP2-4 — The streaming-import kind predicate (evtxxml || syslog) is copied five times across the import routes and the resume handler  `LOW`
 
@@ -400,7 +400,7 @@ The branch's cancellable-syslog fix widened `kind === "evtxxml"` into the two-ki
 
 **Fix:** Hoist `export const PARSE_PROGRESS_KINDS = new Set(["evtxxml", "syslog"])` with a hasParseProgress(kind) helper into a new routes/importKinds.ts (auto-classified by the routes/** glob; avoid the name "streaming", which import.ts:587 already uses for plaso file-streaming), replace the five literals, and add a test asserting importRecovery's kind-driven cancellable component matches the registration's per kind (the registrations additionally OR in aiDependent, which the resume predicate intentionally lacks — assert only the kind part).
 
-**Status:** Open
+**Status:** Fixed in e1d3c0d7.
 
 #### DUP2-5 — The worst-severity comparator is still declared in nine files although siemImport.ts already exports it as worst()  `LOW`
 
@@ -422,7 +422,7 @@ export function worst(a: Severity, b: Severity): Severity {
 
 **Fix:** Apply the branch's own pattern one more time: add `export function worstSeverity(a: Severity, b: Severity): Severity` to stateTypes.ts beside SEVERITY_RANK (cycle-free — stateTypes has only type imports), delete the eight local copies in favor of it, and keep siemImport's `worst` as a one-line re-export (exactly how isInternalIpv4 is surfaced there) so the many existing importer call sites are untouched. attackLayer.ts picks it up as part of DUP2-2's swap.
 
-**Status:** Open
+**Status:** Fixed in e1d3c0d7.
 
 
 ## 4. Test Coverage Gaps
@@ -539,7 +539,7 @@ function isPublicIpv4(ip: string): boolean {
 
 **Fix:** Two small additions. (1) In companion/tests/analysis/siemImport.test.ts's "logonRisk — logon-type grading" describe, pin the shape requirement through the public surface: `expect(logonRisk(3, "").severity).toBeUndefined()` and `expect(logonRisk(3, "").mitre).toEqual([])`; same for logonRisk(3, "2001:db8::5") and logonRisk(10, "2001:db8::5") (typeName decoded, severity undefined); plus one mapWindows end-to-end case `parseSiemExport(elastic(logon4624("3", "-")))` asserting severity "Low" and mitreTechniques []. (2) Add companion/tests/analysis/internalIp.test.ts unit-speccing isInternalIpv4's full table: true for 10.0.0.1, 127.0.0.1, 0.1.2.3, 192.168.1.1, 172.16.0.1, 172.31.255.255, 169.254.10.10, 100.64.0.1, 100.127.255.255; false for the boundary neighbours 172.15.255.255, 172.32.0.1, 100.63.255.255, 100.128.0.1, 192.169.0.1, and for non-IPv4 inputs "", "-", "::1", "2001:db8::5", "10.0.0" (documenting that false means "not internal IPv4", not "public").
 
-**Status:** Open
+**Status:** Fixed in e1d3c0d7.
 
 #### TC2-2 — The asset-graph generation-token race guard (commit 8f10ebd3) has no test — the harness can pin the out-of-order-response behavior but no test loads dashboard-asset-graph.js at all  `MEDIUM`
 
@@ -565,7 +565,7 @@ Commit 8f10ebd3 added assetGraphLoadSeq to loadAssetGraph so that when an analys
 
 **Fix:** Add companion/tests/dashboard/assetGraphPanel.test.ts following hostScopePanel.test.ts's pattern: `loadDashboardModule<{loadAssetGraph(id: string): void; hasAssetGraph(): boolean; assetGraphAssets(): Array<{name: string}>}>("dashboard-asset-graph.js", ["dashboard-escape.js"], { fetch: fetchStub, document: { getElementById: () => ({ innerHTML: "", textContent: "", style: {} }), querySelectorAll: () => [] }, DfirTimelineView: { timeQuery: () => "" } })` where fetchStub records a manually-resolvable deferred per call. Three tests: (1) out-of-order success — call loadAssetGraph("case-a") then loadAssetGraph("case-b"); resolve B's deferred with `{ok: true, json: async () => ({assets: [{name: "b-host", type: "host", compromised: false}], iocs: [], edges: []})}`, flush microtasks, then resolve A with an a-host graph; assert assetGraphAssets() still returns b-host and hasAssetGraph() is true. (2) stale failure ignored — resolve the OLD load with `{ok: false}` after the new one succeeded; assert the graph survives. (3) latest failure clears — a single loadAssetGraph whose response is `{ok: false, json: async () => ({error: "boom"})}`; assert hasAssetGraph() returns false and assetGraphAssets() is empty (the error body must never be cached as graph data).
 
-**Status:** Open
+**Status:** Fixed in cc5fc0a3.
 
 #### TC2-3 — readZip's local-header offset is unguarded and untested — a crafted zip passes the new TC-5 EOCD guard and still surfaces Node's raw ERR_OUT_OF_RANGE (demonstrated)  `LOW`
 
@@ -583,7 +583,7 @@ The TC-5 fix bounded the central-directory pointer in archiveIsEncrypted (zipExt
 
 **Fix:** In readZip, add two bounds inside the walk loop: `if (ptr + 46 > archive.length) throw new Error("corrupt ZIP: central directory out of bounds");` before the SIG_CENTRAL check at line 179 (covers the caseExportArchive.ts caller that skips archiveIsEncrypted), and `if (localOffset + 30 > archive.length) throw new Error("corrupt ZIP: local header out of bounds");` before line 193. Then add the test that demonstrated the defect to companion/tests/analysis/zipExtract.test.ts, mirroring the two existing crafted-EOCD tests: build createZip([{path: "sample.bin", data: Buffer.from("payload")}]), locate the EOCD (0x06054b50 scan), read the central-directory start from eocd+16, overwrite the localOffset field with `archive.writeUInt32LE(0xffffff00, ptr + 42)`, and expect extractZipEntries to throw /corrupt ZIP: local header/i — currently it throws the raw RangeError, so the test fails until the guard lands.
 
-**Status:** Open
+**Status:** Fixed in e1d3c0d7.
 
 #### TC2-4 — location()'s binary-search rewrite (PF-2 fix) is only pinned at line 1, column 1 — no test asserts a multi-line or mid-line error position that could catch an off-by-one  `LOW`
 
@@ -606,7 +606,7 @@ The PF-2 fix replaced location()'s trivially-correct slice/split with a precompu
 
 **Fix:** Extend companion/tests/analysis/huntQueryParser.test.ts with three verified cases (I probed each against the actual parser — two of the originally proposed inputs do not behave as described): (1) multi-line: parseHuntQuery("source.ip=192.0.2.1\n| group by sorce.ip") throws code "unknown_field" at { line: 2, column: 12 } — note the grammar is `| group by <field>`; the originally proposed "| group_by sorce.ip" instead throws unknown_stage at line 2, column 3 (usable as a second pin if wanted, but not for the field column). (2) first-line non-1 column: parseHuntQuery("source.ip=192.0.2.1 and sorce.ip=10.0.0.1") throws "unknown_field" at { line: 1, column: 25 } — the originally proposed "severity=Zigh" parses successfully (severity values are not validated at parse time) and must not be used. (3) memo staleness: in one test, parseHuntQuery("host.name=a\nand sorce.ip=1") throws at { line: 2, column: 5 }, then parseHuntQuery("host.name=a and\nsorce.ip=1") throws at { line: 2, column: 1 } — same error token, different newline layouts, pinning that newlineOffsets' one-slot memo re-keys on the second text. Each follows the existing try/catch + toMatchObject pattern at huntQueryParser.test.ts:62-75.
 
-**Status:** Open
+**Status:** Fixed in fe7d205c.
 
 
 ## 5. Performance Concerns in VQL/Parsing Logic
@@ -728,7 +728,7 @@ if (/^sshd\b/i.test(p.app)) {
 
 **Fix:** In line(), split by auth.result: for "failed", call agg.add(m) immediately (nothing ever rewrites a failed event) and push only the compact tuple { key: -1, ms, ip, result: "failed" } into sshAuth (markSshBruteForce never reads a failed event's key); keep buffering only "accepted" MappedEvents in sshEvents — bounded by real logins, which are rare. finish() is unchanged: markSshBruteForce hits still reference only accepted keys, so the rewrite/add of the accepted buffer works as today, and ordering stays within the already-documented three-way-tie tolerance of agg.finish()'s re-sort. Optionally go further and fold failures straight into a Map<ip, number[]> of timestamps as lines stream (markSshBruteForce builds exactly that internally), shrinking the flood's residual to raw numbers per IP; but eliminating the per-failure MappedEvent (description + aggKey strings dominate the 526 MB) is the essential, small diff.
 
-**Status:** Open
+**Status:** Fixed in fe7d205c.
 
 #### PF2-2 — Hunt executor compiles the matches-predicate RegExp per row per evaluation — the one per-row compile the PF-3/PF-4 sweep missed  `LOW`
 
@@ -743,7 +743,7 @@ return new RegExp(String(expected ?? ""), predicate.regexFlags).test(String(actu
 
 **Fix:** Cache per execution in the existing EvaluationContext: add `regexCache: Map<string, RegExp>` (key `${pattern} ${flags}`) created once in executeHuntQuery's state, and in compareScalar look up/compile-once before .test(). Give `during` the same treatment by caching the resolved {fromMs, toMs} per expected-string in the context (the anchorTime is fixed for the whole execution), replacing the per-row duringRange + double Date.parse. No behavior change; both caches die with the request.
 
-**Status:** Open
+**Status:** Fixed in fe7d205c.
 
 #### PF2-3 — parseWinEventXmlProgress's event-count loop blocks the event loop ~0.4-0.7 s with no yield or abort check — the exact gap the branch fixed for syslog's count loop  `LOW`
 
@@ -760,7 +760,7 @@ let total = 0;
 
 **Fix:** Mirror the syslog count fix: every N matches (e.g. a COUNT_CHUNK of 100_000 — each iteration scans a whole event block, so a coarser budget than syslog's per-line 1M is appropriate) do `await new Promise<void>((resolve) => setImmediate(resolve)); throwIfImportAborted(signal);` inside the counting loop. ~5 lines, identical in shape to syslogImport.ts's SYSLOG_COUNT_CHUNK block.
 
-**Status:** Open
+**Status:** Fixed in fe7d205c.
 
 
 ## 6. Docker and Dependency Risks
@@ -852,7 +852,7 @@ The DD-3 fix deliberately baked a Dockerfile HEALTHCHECK against /health because
 
 **Fix:** In docker-compose.yml:61 change the probe URL from /dashboard to /health: test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4773/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]. If also de-hardcoding the port, read it from the environment inside the Node one-liner exactly as the Dockerfile HEALTHCHECK does ('http://127.0.0.1:'+(process.env.PORT||process.env.DFIR_PORT||4773)+'/health') — compose's CMD exec form performs no shell expansion, so $DFIR_PORT in the URL string would not work.
 
-**Status:** Open
+**Status:** Fixed in 196dc738.
 
 
 ## Finding Index

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -367,6 +367,7 @@
     "reconTechniques.ts": "analysis/intel",
     "redactPaths.ts": "analysis/privacy",
     "redactedExport.ts": "analysis/privacy",
+    "regexEscape.ts": "shared",
     "regexSafety.ts": "analysis/privacy",
     "responseSchema.ts": "shared",
     "sandboxImport.ts": "analysis/ingest",

--- a/companion/src/analysis/anonymize.ts
+++ b/companion/src/analysis/anonymize.ts
@@ -1,6 +1,7 @@
 import type { InvestigationState } from "./stateTypes.js";
 import { extractAccounts } from "./assetGraph.js";
 import { embeddedIpv4, expandIpv6Groups } from "./iocValue.js";
+import { escapeRegExp } from "./regexEscape.js";
 
 // Reversible anonymization of the TEXT sent to the LLM. Real values stay in state; only the
 // wire is tokenized. Typed numbered tokens keep the model's semantic understanding (it still
@@ -93,10 +94,6 @@ export interface Anonymizer {
 
 export const SECRET_PLACEHOLDER = "[REDACTED_SECRET]";
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 // Exact-match tokenizing of a KNOWN value (hostname, internal domain, analyst-added or
 // Presidio-approved custom entity) needs a word boundary so "DC01" doesn't fire inside "DC01X"
 // and "Jane" doesn't fire inside "Janes". JS `\b` CANNOT be used for that here: it is defined
@@ -124,9 +121,9 @@ function escapeRegExp(s: string): string {
 // or rely on known.internalDomains, which already handles the parent-domain case.
 //
 // The `u` flag
-// is required for \p{…} and is safe with escapeRegExp above: every character it escapes
-// (. * + ? ^ $ { } ( ) | [ ] \) is a SyntaxCharacter, i.e. a legal identity escape in Unicode
-// mode, so no escaped value can turn into an "Invalid regular expression" under `u`.
+// is required for \p{…} and is safe with escapeRegExp — see regexEscape.ts: every character it
+// escapes is a legal identity escape in Unicode mode, so no escaped value can turn into an
+// "Invalid regular expression" under `u`.
 const UNICODE_WORD = "\\p{L}\\p{N}_";
 function exactValueRegExp(value: string): RegExp {
   return new RegExp(`(?<![${UNICODE_WORD}])${escapeRegExp(value)}(?![${UNICODE_WORD}])`, "giu");
@@ -195,8 +192,9 @@ function nat64EmbeddedIpv4(groups: number[]): string | null {
 // embeddedIpv4() rather than re-deriving it here: a naive dotted-decimal-only regex misses the
 // hex-canonical spelling (e.g. "::ffff:127.0.0.1" as "::ffff:7f00:1") — a check that only
 // recognizes the dotted form would let a victim's internal IPv6 address in that spelling reach
-// the external AI provider unredacted. Classification still uses isInternalIp() (not
-// iocValue.ts's isPrivateIpv4) so the CGNAT range stays covered here.
+// the external AI provider unredacted. Classification uses the local isInternalIp() —
+// iocValue.ts's isPrivateIpv4 now agrees on CGNAT too, but the two tables serve different
+// callers and each is pinned by its own tests.
 export function isInternalIpv6(ip: string): boolean {
   const lower = ip.toLowerCase().replace(/^\[|\]$/g, "");
   if (lower === "::1" || lower === "::") return true;

--- a/companion/src/analysis/assetGraph.ts
+++ b/companion/src/analysis/assetGraph.ts
@@ -1,10 +1,12 @@
 import {
   SEVERITY_RANK,
+  worstSeverity,
   type InvestigationState,
   type IOC,
   type ForensicEvent,
   type Severity,
 } from "./stateTypes.js";
+import { escapeRegExp } from "./regexEscape.js";
 import { resolveHost, type HostAliasIndex } from "./hostAlias.js";
 
 // Derives the asset ↔ IoC graph from the investigation state. An "asset" is a victim
@@ -81,16 +83,9 @@ export function filterTimeline(events: readonly ForensicEvent[], w?: TimeWindow)
   return events.filter((e) => eventInWindow(e, w));
 }
 
-function worse(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
-}
-
 // Dotted-quad shape (loose — any 4 dot-separated 1-3 digit groups). Used only to decide whether an
 // IOC value needs boundary-aware description matching, not to validate octet ranges.
 const IPV4_SHAPE = /^\d{1,3}(?:\.\d{1,3}){3}$/;
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 // Per-IOC predicate for "does this IOC value appear in an event description". For IP-shaped values
 // a raw substring match over-links — IOC `1.1.1.1` matches inside `11.1.1.10` and `192.168.1.1`
@@ -276,7 +271,7 @@ export function buildAssetGraph(
     const refIocs = referencedIocs(e);
     for (const a of assetsForEvent) {
       a.eventCount++;
-      a.maxSeverity = worse(a.maxSeverity, e.severity);
+      a.maxSeverity = worstSeverity(a.maxSeverity, e.severity);
       for (const fid of e.relatedFindingIds) if (!a.findingIds.includes(fid)) a.findingIds.push(fid);
       for (const ioc of refIocs) link(a, ioc);
     }

--- a/companion/src/analysis/assetOverrides.ts
+++ b/companion/src/analysis/assetOverrides.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
 import type { AssetType, AssetGraph, GraphAsset, GraphIoc, AssetGraphEdge } from "./assetGraph.js";
-import { SEVERITY_RANK, type Severity } from "./stateTypes.js";
+import { SEVERITY_RANK, worstSeverity } from "./stateTypes.js";
 
 // Manual analyst edits to the asset ↔ IoC graph: renames, additions, suppressions, and link
 // overrides. Kept in `state/asset-overrides.json` — NOT in InvestigationState, so synthesis
@@ -52,9 +52,6 @@ function resolveCanonical(id: string, merges: Record<string, string>): string {
   return cur;
 }
 
-function worseSeverity(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
-}
 function uniqStrings(values: string[]): string[] {
   return [...new Set(values)];
 }
@@ -99,7 +96,7 @@ export function applyAssetOverrides(graph: AssetGraph, overrides: AssetOverrides
     if (!canonical) continue;
     canonical.findingIds = uniqStrings([...canonical.findingIds, ...dup.findingIds]);
     canonical.eventCount += dup.eventCount;
-    canonical.maxSeverity = worseSeverity(canonical.maxSeverity, dup.maxSeverity);
+    canonical.maxSeverity = worstSeverity(canonical.maxSeverity, dup.maxSeverity);
     assetMap.delete(dupId);
   }
   const redirect = (assetId: string): string => {

--- a/companion/src/analysis/burstDetect.ts
+++ b/companion/src/analysis/burstDetect.ts
@@ -1,4 +1,4 @@
-import { SEVERITY_RANK, type ForensicEvent, type Severity } from "./stateTypes.js";
+import { worstSeverity, type ForensicEvent, type Severity } from "./stateTypes.js";
 import { byEventTime } from "./forensicSort.js";
 import { tacticForTechniques, type IrisTactic } from "./mitreTactics.js";
 
@@ -30,10 +30,6 @@ export interface BurstOptions {
 }
 
 export const DEFAULT_GAP_SECONDS = 300;
-
-function worse(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
-}
 
 // Kill-chain order — used only to tie-break the dominant-tactic vote deterministically (the
 // earliest stage represented wins a tie, so a phase reads as the stage it leads with).
@@ -99,7 +95,7 @@ function summarizePhase(index: number, events: ForensicEvent[]): AttackPhase {
   for (const e of events) {
     for (const t of e.mitreTechniques) techniques.add(t);
     count += e.count && e.count > 1 ? e.count : 1;
-    maxSeverity = worse(maxSeverity, e.severity);
+    maxSeverity = worstSeverity(maxSeverity, e.severity);
     const ms = eventEndMs(e);
     if (ms > endMs) {
       endMs = ms;

--- a/companion/src/analysis/correlate.ts
+++ b/companion/src/analysis/correlate.ts
@@ -11,7 +11,7 @@
 // structured fields first, then extracted from the description text as a fallback so a
 // hash-bearing AI-extracted event still matches a structured THOR event.
 
-import { SEVERITY_RANK, type ForensicEvent, type Severity } from "./stateTypes.js";
+import { SEVERITY_RANK, worstSeverity, type ForensicEvent, type Severity } from "./stateTypes.js";
 import { trustForSources, type SourceTrustMap } from "./sourceTrust.js";
 import { computeChainSignature } from "./chainSignature.js";
 
@@ -94,10 +94,6 @@ class DSU {
       rb = this.find(b);
     if (ra !== rb) this.parent[Math.max(ra, rb)] = Math.min(ra, rb);
   }
-}
-
-function worse(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[a] <= SEVERITY_RANK[b] ? a : b;
 }
 
 // Match on the SHORT hostname: an EDR reports `FILE-BO-01` while the Windows log records the FQDN
@@ -190,7 +186,7 @@ function mergeGroup(events: ForensicEvent[], trustMap?: SourceTrustMap): Forensi
   const merged: ForensicEvent = {
     ...primary,
     description: cleanDescription(primary.description),
-    severity: events.reduce<Severity>((acc, e) => worse(acc, e.severity), "Info"),
+    severity: events.reduce<Severity>((acc, e) => worstSeverity(acc, e.severity), "Info"),
     timestamp: times[0] ?? primary.timestamp,
     mitreTechniques: uniq(events.flatMap((e) => e.mitreTechniques)),
     relatedFindingIds: uniq(events.flatMap((e) => e.relatedFindingIds)),

--- a/companion/src/analysis/evidenceGraph.ts
+++ b/companion/src/analysis/evidenceGraph.ts
@@ -1,4 +1,4 @@
-import { SEVERITY_RANK, type InvestigationState, type ForensicEvent, type Severity } from "./stateTypes.js";
+import { worstSeverity, type InvestigationState, type ForensicEvent, type Severity } from "./stateTypes.js";
 import { filterTimeline, type TimeWindow } from "./assetGraph.js";
 import { tacticForTechniques, type IrisTactic } from "./mitreTactics.js";
 import {
@@ -67,10 +67,6 @@ export interface EvidenceEdge {
 export interface EvidenceGraph {
   nodes: EvidenceNode[];
   edges: EvidenceEdge[];
-}
-
-function worse(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
 }
 
 // Kill-chain order — used only to tie-break the dominant-tactic vote deterministically (the
@@ -190,7 +186,7 @@ export function buildEvidenceGraph(state: InvestigationState, window?: TimeWindo
       n = { id, kind, label, asset, maxSeverity: "Info", eventIds: [] };
       nodeMap.set(id, n);
     }
-    n.maxSeverity = worse(n.maxSeverity, sev);
+    n.maxSeverity = worstSeverity(n.maxSeverity, sev);
     for (const eid of eventIds) if (!n.eventIds.includes(eid)) n.eventIds.push(eid);
     return n;
   }

--- a/companion/src/analysis/evtxXmlImport.ts
+++ b/companion/src/analysis/evtxXmlImport.ts
@@ -158,6 +158,12 @@ export function parseWinEventXml(text: string): Row[] {
   return records;
 }
 
+// Counting matches is far cheaper per iteration than parsing (each hit spans a whole event block),
+// so it yields on a coarser budget — but it MUST yield, or a multi-hundred-MB export would block
+// the event loop (and any pending cancellation) for the whole count before the parse loop's first
+// await. Mirrors syslogImport's SYSLOG_COUNT_CHUNK.
+const XML_COUNT_CHUNK = 100_000;
+
 export async function parseWinEventXmlProgress(
   text: string,
   onProgress?: (done: number, total: number) => void | Promise<void>,
@@ -168,7 +174,13 @@ export async function parseWinEventXmlProgress(
   // string per event across a multi-hundred-MB export just to take its length.
   let total = 0;
   const countRe = /<Event\b/gi;
-  while (countRe.exec(text) !== null) total++;
+  while (countRe.exec(text) !== null) {
+    total++;
+    if (total % XML_COUNT_CHUNK === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      throwIfImportAborted(signal);
+    }
+  }
   if (total === 0) {
     await onProgress?.(0, 0);
     return [];

--- a/companion/src/analysis/exfilCorrelate.ts
+++ b/companion/src/analysis/exfilCorrelate.ts
@@ -10,14 +10,10 @@
 // synthesis model to notice the pairing on its own.
 //
 // Conservative + idempotent: only a same-host, staging-then-upload pair within the window matches,
-// the marker is appended once, and severity uses a worst() floor — so re-running over an
+// the marker is appended once, and severity uses a worstSeverity() floor — so re-running over an
 // already-merged timeline is a no-op. No AI, no network.
 
-import { SEVERITY_RANK, type ForensicEvent, type Severity } from "./stateTypes.js";
-
-function worst(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
-}
+import { worstSeverity, type ForensicEvent } from "./stateTypes.js";
 
 const MARKER = "[confirmed exfiltration:";
 // Ransomware crews typically upload within minutes to a few hours of staging (the Meridian ground
@@ -55,7 +51,7 @@ export function linkArchiveToExfil(
     if (!Number.isFinite(t) || t < staged || t - staged > windowMs) return e;
     return {
       ...e,
-      severity: worst(e.severity, "High"),
+      severity: worstSeverity(e.severity, "High"),
       description: `${e.description ?? ""} ${MARKER} preceded by archive staging on ${e.asset}]`.slice(
         0,
         600,

--- a/companion/src/analysis/fpCascade.ts
+++ b/companion/src/analysis/fpCascade.ts
@@ -11,6 +11,7 @@
 // since that path IS the authoritative recompute, not an interim.
 
 import type { InvestigationQuestion, NextStep } from "./stateTypes.js";
+import { escapeRegExp } from "./regexEscape.js";
 
 // Pointer text shown on a question whose supporting finding was rejected. Identical wording the
 // synthesize() backstop has always used, so the two paths read the same.
@@ -23,7 +24,7 @@ export const FP_RESET_POINTER =
 // Escapes regex metacharacters since ids can contain them (e.g. "f-auto-e1").
 export function textMentionsFindingId(text: string | undefined, findingId: string): boolean {
   if (!text) return false;
-  const escaped = findingId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escaped = escapeRegExp(findingId);
   return new RegExp(`(?<![\\w-])${escaped}(?![\\w-])`, "i").test(text);
 }
 

--- a/companion/src/analysis/geoMap.ts
+++ b/companion/src/analysis/geoMap.ts
@@ -1,10 +1,12 @@
 import {
   SEVERITY_RANK,
+  worstSeverity,
   type InvestigationState,
   type IOC,
   type ForensicEvent,
   type Severity,
 } from "./stateTypes.js";
+import { escapeRegExp } from "./regexEscape.js";
 import { isInternalIp } from "./anonymize.js";
 import { countryCentroid } from "./countryCentroids.js";
 
@@ -77,13 +79,6 @@ export interface GeoMapOptions {
   maxMarkers?: number;
   maxFlows?: number;
   topCountries?: number;
-}
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-function worse(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
 }
 
 const VERDICT_ORDER = ["malicious", "suspicious", "harmless", "unknown"];
@@ -198,7 +193,7 @@ export function buildGeoMap(state: InvestigationState, opts: GeoMapOptions = {})
   for (const e of state.forensicTimeline) {
     for (const i of iocsForEvent(e)) {
       const a = ensure(i.id);
-      a.sev = worse(a.sev, e.severity);
+      a.sev = worstSeverity(a.sev, e.severity);
       a.count++;
       for (const s of e.sources ?? []) a.sources.add(s);
       if (!a.first || e.timestamp < a.first) a.first = e.timestamp;
@@ -209,7 +204,7 @@ export function buildGeoMap(state: InvestigationState, opts: GeoMapOptions = {})
   const ipById = new Map(ipIocs.map((i) => [i.id, i] as const));
   for (const f of state.findings) {
     for (const id of f.relatedIocs) {
-      if (ipById.has(id)) ensure(id).sev = worse(ensure(id).sev, f.severity);
+      if (ipById.has(id)) ensure(id).sev = worstSeverity(ensure(id).sev, f.severity);
     }
   }
 
@@ -265,7 +260,7 @@ export function buildGeoMap(state: InvestigationState, opts: GeoMapOptions = {})
       flowAgg.set(key, fa);
     }
     fa.count += e.count ?? 1;
-    fa.sev = worse(fa.sev, e.severity);
+    fa.sev = worstSeverity(fa.sev, e.severity);
   }
   const allFlows: GeoFlow[] = [...flowAgg.entries()]
     .map(([key, fa]) => {
@@ -306,7 +301,7 @@ export function buildGeoMap(state: InvestigationState, opts: GeoMapOptions = {})
       cAgg.set(m.country, c);
     }
     c.count++;
-    c.sev = worse(c.sev, m.severity);
+    c.sev = worstSeverity(c.sev, m.severity);
   }
   const countries: GeoCountry[] = [...cAgg.entries()]
     .map(([country, v]) => ({ country, count: v.count, severity: v.sev }))

--- a/companion/src/analysis/huntQueryExecutor.ts
+++ b/companion/src/analysis/huntQueryExecutor.ts
@@ -87,6 +87,12 @@ interface EvaluationContext {
   regexEvaluations: number;
   limits: HuntExecutionLimits;
   anchorTime: Date;
+  // Per-execution caches: a `matches` pattern/flags pair and a `during` window string are query
+  // constants, so compile/resolve them once instead of per scanned row. Hunt regex flags are
+  // restricted to [imsu] (no g/y), so a cached instance carries no lastIndex state between .test()
+  // calls. Both caches die with the request.
+  regexCache: Map<string, RegExp>;
+  duringCache: Map<string, { fromMs: number; toMs: number }>;
 }
 
 const DEFAULT_LIMITS: HuntExecutionLimits = {
@@ -231,22 +237,36 @@ function compareScalar(
   }
   if (predicate.operator === "during") {
     if (actual == null || typeof expected !== "string") return false;
-    const range = duringRange(expected, context.anchorTime);
-    if (!range) {
-      throw new HuntQueryExecutionError(
-        "invalid_time_window",
-        `Invalid time window ${JSON.stringify(expected)}`,
-      );
+    let window = context.duringCache.get(expected);
+    if (!window) {
+      const range = duringRange(expected, context.anchorTime);
+      if (!range) {
+        throw new HuntQueryExecutionError(
+          "invalid_time_window",
+          `Invalid time window ${JSON.stringify(expected)}`,
+        );
+      }
+      window = { fromMs: Date.parse(range.from), toMs: Date.parse(range.to) };
+      context.duringCache.set(expected, window);
     }
     const time = Date.parse(String(actual));
-    return Number.isFinite(time) && time >= Date.parse(range.from) && time <= Date.parse(range.to);
+    return Number.isFinite(time) && time >= window.fromMs && time <= window.toMs;
   }
   if (predicate.operator === "matches") {
     context.regexEvaluations++;
     if (context.regexEvaluations > context.limits.maxRegexEvaluations) {
       throw new HuntQueryLimitError("regex evaluations", context.limits.maxRegexEvaluations);
     }
-    return new RegExp(String(expected ?? ""), predicate.regexFlags).test(String(actual ?? ""));
+    const pattern = String(expected ?? "");
+    // NUL-joined so a pattern that itself ends in a flag letter can never collide with another
+    // pattern+flags pair (a regex pattern cannot contain a raw NUL).
+    const cacheKey = `${pattern}\u0000${predicate.regexFlags ?? ""}`;
+    let regex = context.regexCache.get(cacheKey);
+    if (!regex) {
+      regex = new RegExp(pattern, predicate.regexFlags);
+      context.regexCache.set(cacheKey, regex);
+    }
+    return regex.test(String(actual ?? ""));
   }
   if (predicate.operator === "contains") {
     return String(actual ?? "")
@@ -625,7 +645,13 @@ export async function executeHuntQuery(input: HuntExecutionOptions): Promise<Hun
     outputLimit,
     startedAt,
     signal: input.signal,
-    evaluation: { regexEvaluations: 0, limits, anchorTime },
+    evaluation: {
+      regexEvaluations: 0,
+      limits,
+      anchorTime,
+      regexCache: new Map(),
+      duringCache: new Map(),
+    },
   };
   const result = isAnalytical(input.parsed.pipeline)
     ? {

--- a/companion/src/analysis/initialAccess.ts
+++ b/companion/src/analysis/initialAccess.ts
@@ -7,13 +7,10 @@
 //
 // Conservative + idempotent: only email-sourced LINK domains are used (never the sender/recipient
 // domains), only same-or-later host events match, the marker is appended once, and severity uses a
-// worst() floor — so re-running over an already-merged timeline is a no-op. No AI, no network.
+// worstSeverity() floor — so re-running over an already-merged timeline is a no-op. No AI, no network.
 
-import { SEVERITY_RANK, type ForensicEvent, type Severity } from "./stateTypes.js";
-
-function worst(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
-}
+import { worstSeverity, type ForensicEvent } from "./stateTypes.js";
+import { escapeRegExp } from "./regexEscape.js";
 
 const DOMAIN_RE = /\b[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9-]+)+\b/gi;
 const MARKER = "[initial access:";
@@ -35,7 +32,7 @@ export function emailLinkDomains(e: ForensicEvent): string[] {
 
 // Boundary-aware containment so "evil.com" doesn't match "notevil.com" / "evil.com.au".
 function mentions(hay: string, domain: string): boolean {
-  const esc = domain.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const esc = escapeRegExp(domain);
   // The lookahead must exclude dots the same way the lookbehind does, so "evil.com" does NOT match
   // inside "evil.com.au" (the .au TLD continues the domain). Previously the lookahead was
   // [^a-z0-9-] which does NOT exclude dots — a dot matched, so "evil.com" matched inside
@@ -66,7 +63,7 @@ export function linkEmailDelivery(events: ForensicEvent[]): ForensicEvent[] {
         const mitre = [...new Set([...(e.mitreTechniques ?? []), "T1566.002", "T1204.002"])];
         return {
           ...e,
-          severity: worst(e.severity, "Medium"),
+          severity: worstSeverity(e.severity, "Medium"),
           mitreTechniques: mitre,
           description:
             `${e.description ?? ""} ${MARKER} host contacted email-delivered domain ${domain}]`.slice(0, 600),

--- a/companion/src/analysis/iocValue.ts
+++ b/companion/src/analysis/iocValue.ts
@@ -56,7 +56,10 @@ const IPV6_RE =
   /^(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}$|^(?:[0-9a-f]{1,4}:){1,7}:$|^(?:[0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}$|^(?:[0-9a-f]{1,4}:){1,5}(?::[0-9a-f]{1,4}){1,2}$|^(?:[0-9a-f]{1,4}:){1,4}(?::[0-9a-f]{1,4}){1,3}$|^(?:[0-9a-f]{1,4}:){1,3}(?::[0-9a-f]{1,4}){1,4}$|^(?:[0-9a-f]{1,4}:){1,2}(?::[0-9a-f]{1,4}){1,5}$|^[0-9a-f]{1,4}:(?:(?::[0-9a-f]{1,4}){1,6})$|^:(?:(?::[0-9a-f]{1,4}){1,7}|:)$/;
 
 // Private / internal / link-local IPv4 ranges that must NEVER be sent to enrichment providers.
-// 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 0.0.0.0/8, 169.254.0.0/16 (link-local / cloud metadata).
+// 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 0.0.0.0/8, 169.254.0.0/16 (link-local /
+// cloud metadata), 100.64.0.0/10 (CGNAT). Kept local on purpose — this module sits below the
+// ingest tier that owns internalIp.ts — so the range table must stay in lockstep with it (same
+// as urlValidation.ts and anonymize.ts, each pinned by a CGNAT test).
 function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split(".").map(Number);
   if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
@@ -67,6 +70,7 @@ function isPrivateIpv4(ip: string): boolean {
   if (a === 127) return true;
   if (a === 0) return true;
   if (a === 169 && b === 254) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64/10
   return false;
 }
 

--- a/companion/src/analysis/lookalikeDomains.ts
+++ b/companion/src/analysis/lookalikeDomains.ts
@@ -18,6 +18,7 @@
 // Exact brand matches and their own subdomains are never flagged. Pure, offline, unit-tested.
 
 import { domainToUnicode } from "node:url";
+import { escapeRegExp } from "./regexEscape.js";
 
 // Commonly-impersonated registrable domains (eTLD+1). Curated, not exhaustive — the analyst can add
 // their own org/customer domains via DFIR_LOOKALIKE_EXTRA_DOMAINS (comma-separated). Kept in
@@ -332,9 +333,7 @@ export function detectLookalike(host: string, opts: LookalikeOptions = {}): Look
     // 3. Impersonation — the brand label appears as a token in a different registrable domain.
     // Requires a boundary (separator or subdomain) so "amazon.com" doesn't match inside "amazonia".
     if (brandLabel.length >= 5) {
-      const tokenRe = new RegExp(
-        `(^|[.\\-_])${brandLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([.\\-_]|$)`,
-      );
+      const tokenRe = new RegExp(`(^|[.\\-_])${escapeRegExp(brandLabel)}([.\\-_]|$)`);
       if (tokenRe.test(cleaned)) {
         consider({
           brand,

--- a/companion/src/analysis/redactPaths.ts
+++ b/companion/src/analysis/redactPaths.ts
@@ -1,4 +1,5 @@
 import { homedir, tmpdir } from "node:os";
+import { escapeRegExp } from "./regexEscape.js";
 
 /**
  * Strip absolute filesystem paths out of strings bound for an HTTP client (#250).
@@ -61,10 +62,6 @@ const POSIX_FS_PATH_RE = new RegExp(String.raw`/(?:${FS_TOP_LEVEL.join("|")})(?:
 /** `C:\dir\file` and UNC `\\host\share\file`. Both require at least one segment, so a bare "C:" in
  * prose is left alone. */
 const WINDOWS_FS_PATH_RE = new RegExp(String.raw`(?:[A-Za-z]:\\|\\\\)${SEG}(?:\\${SEG})*\\?`, "g");
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 /** Known roots on THIS machine, longest first so a nested root wins over its parent. Relative and
  * single-character roots are dropped — replacing "/" globally would shred every message. */

--- a/companion/src/analysis/regexEscape.ts
+++ b/companion/src/analysis/regexEscape.ts
@@ -1,0 +1,13 @@
+// The MDN regex-escape idiom — ONE copy shared by every module that embeds a raw value in a
+// RegExp (anonymize's tokenizer, redactPaths, asset/geo/IOC description matching, the report
+// glossary…). The per-module copies were exactly the small-helper duplication class the
+// internal-IP and month-table consolidations removed: a future correction must land everywhere
+// at once, and several call sites guard security-relevant surfaces.
+//
+// Safe under the `u` flag: every character escaped here (. * + ? ^ $ { } ( ) | [ ] \) is a
+// SyntaxCharacter, i.e. a legal identity escape in Unicode mode, so no escaped value can turn
+// into an "Invalid regular expression" when the caller compiles with `u` (see anonymize.ts's
+// exactValueRegExp, which relies on this).
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -21,7 +21,7 @@
 // everything), so severity is DERIVED from the event type (WIN_EVENTS / SYSMON_EVENTS),
 // with a conservative bump for LOLBin / suspicious command lines and LSASS access.
 
-import { SEVERITY_RANK, type Severity } from "./stateTypes.js";
+import { SEVERITY_RANK, worstSeverity as worst, type Severity } from "./stateTypes.js";
 import { MONTHS, parseBsdTime } from "./bsdTime.js";
 import { isInternalIpv4 } from "./internalIp.js";
 import {
@@ -1198,9 +1198,9 @@ export function mapWindows(
   };
 }
 
-export function worst(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
-}
+// The worst-wins comparator lives beside SEVERITY_RANK in stateTypes.ts (worstSeverity);
+// re-exported under its historical name for the sibling importers, like isInternalIpv4 above.
+export { worst };
 
 // ───────────────────────────── generic record → event ─────────────────────────────
 

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -7,6 +7,12 @@ export type Severity = "Critical" | "High" | "Medium" | "Low" | "Info";
 // Severity must use (severityFloor, correlate, assetGraph, reports…). forensicGate.ts, notifications.ts
 // and slashCommand.ts deliberately keep their own INVERTED (higher = more severe) encodings.
 export const SEVERITY_RANK: Record<Severity, number> = { Critical: 0, High: 1, Medium: 2, Low: 3, Info: 4 };
+
+// Worst-wins comparator over the canonical table (ties keep `a`). The single copy every
+// severity floor/rollup must use — siemImport re-exports it as `worst` for the importer tier.
+export function worstSeverity(a: Severity, b: Severity): Severity {
+  return SEVERITY_RANK[b] < SEVERITY_RANK[a] ? b : a;
+}
 export type FindingStatus = "open" | "confirmed" | "dismissed";
 export type ThreadStatus = "open" | "closed";
 

--- a/companion/src/analysis/syslogImport.ts
+++ b/companion/src/analysis/syslogImport.ts
@@ -201,11 +201,15 @@ function mapParsedSyslog(p: ParsedSyslog, sink: Map<string, SiemIoc>): MappedEve
 
 // Streaming accumulator behind parseSyslog / parseSyslogProgress: each line is parsed, mapped, and
 // fed straight into the shared event aggregator, so memory is bounded by the distinct-key set — not
-// the row count. The ONE exception is an sshd auth outcome (login success/failure), which must be
-// buffered until the whole log has been seen: the brute-force-success correlation is a post-pass
-// that rewrites specific mapped events. finish() runs that correlation, folds the buffer into the
-// aggregator, and assembles the result. finish() re-sorts by severity/count/timestamp, so relative
-// to the pre-streaming line-order feed, ordering only shifts on exact three-way ties.
+// the row count. The ONE exception is an sshd login SUCCESS, which must be buffered until the whole
+// log has been seen: the brute-force-success correlation is a post-pass that rewrites specific
+// mapped events — and ONLY accepted ones, so successes are the only events held back (bounded by
+// real logins, which are rare). A login FAILURE streams into the aggregator like any other line and
+// contributes just a compact {ms, ip} tuple to the correlation — an auth.log flood of failed
+// passwords (exactly the input this correlation targets) must not re-materialize the mapped events
+// the streaming rework exists to avoid. finish() runs the correlation, folds the success buffer
+// into the aggregator, and assembles the result. finish() re-sorts by severity/count/timestamp, so
+// relative to the pre-streaming line-order feed, ordering only shifts on exact three-way ties.
 function createSyslogAccumulator(opts: SyslogImportOptions): {
   line(raw: string): void;
   finish(): SyslogParseResult;
@@ -218,8 +222,8 @@ function createSyslogAccumulator(opts: SyslogImportOptions): {
     minSeverity: opts.minSeverity,
     maxEvents: opts.maxEvents ?? maxEventsDefault(),
   });
-  const sshEvents: MappedEvent[] = []; // ONLY the sshd auth outcomes — everything else streams into agg
-  const sshAuth: SshAuthEvent<number>[] = []; // keyed by their index in `sshEvents`
+  const sshEvents: MappedEvent[] = []; // ONLY accepted sshd logins — everything else streams into agg
+  const sshAuth: SshAuthEvent<number>[] = []; // accepted keyed by index in `sshEvents`; failed carry key -1
   let total = 0;
 
   return {
@@ -230,17 +234,23 @@ function createSyslogAccumulator(opts: SyslogImportOptions): {
       if (!p) return;
       const m = mapParsedSyslog(p, sink);
       total++;
-      // Hold back sshd login successes/failures for the brute-force-success correlation in finish().
+      // Hold back sshd login SUCCESSES for the brute-force-success correlation in finish() — the
+      // only events markSshBruteForce ever rewrites. A FAILURE contributes just its {ms, ip} to the
+      // correlation (its key is never read; -1 marks "not buffered") and streams into the
+      // aggregator like any other line, so a failed-password flood cannot re-materialize the log.
       if (/^sshd\b/i.test(p.app)) {
         const auth = parseSshAuth(p.message);
-        if (auth) {
+        if (auth?.result === "accepted") {
           sshAuth.push({
             key: sshEvents.push(m) - 1,
             ms: Date.parse(p.timestamp) || 0,
             ip: auth.ip,
-            result: auth.result,
+            result: "accepted",
           });
           return;
+        }
+        if (auth) {
+          sshAuth.push({ key: -1, ms: Date.parse(p.timestamp) || 0, ip: auth.ip, result: "failed" });
         }
       }
       agg.add(m);
@@ -281,7 +291,7 @@ function createSyslogAccumulator(opts: SyslogImportOptions): {
 
 // Parse a plain syslog export into the shared SIEM result shape (aggregated + capped). Pure, no AI.
 // Lines are walked with an indexOf cursor — never split into an all-lines array — so peak retention
-// beyond the input text is the aggregator's distinct-key set plus the sshd auth buffer.
+// beyond the input text is the aggregator's distinct-key set plus the accepted-sshd-login buffer.
 export function parseSyslog(text: string, opts: SyslogImportOptions = {}): SyslogParseResult {
   const acc = createSyslogAccumulator(opts);
   let cursor = 0;

--- a/companion/src/analysis/veloMessageFields.ts
+++ b/companion/src/analysis/veloMessageFields.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from "./regexEscape.js";
+
 // High-signal labels in a RENDERED Windows event message (4688 process creation, Sysmon, service
 // install, etc.). When an artifact ships the event as free text — no structured EventData to map —
 // these carry the actual evidence (the LOLBIN binary + its command line), which the boilerplate
@@ -27,7 +29,7 @@ function cleanFieldValue(v: string): string {
 // RegExp per call cost ~1.7M throwaway compiles per capped ingest. The lazy fallback keeps any
 // future dynamic label working (compiled on first use, then cached).
 function labelPattern(label: string): RegExp {
-  return new RegExp(`${label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*:[ \\t]*([^\\r\\n]+)`, "i");
+  return new RegExp(`${escapeRegExp(label)}\\s*:[ \\t]*([^\\r\\n]+)`, "i");
 }
 const MSG_FIELD_RES = new Map<string, RegExp>(MSG_FIELD_LABELS.map((l) => [l, labelPattern(l)]));
 function fieldFromMessage(msg: string, label: string): string {

--- a/companion/src/analysis/zipArchive.ts
+++ b/companion/src/analysis/zipArchive.ts
@@ -176,6 +176,11 @@ export function readZip(archive: Buffer, opts: ReadZipOptions = {}): ZipEntry[] 
   let totalInflated = 0;
 
   for (let i = 0; i < total; i++) {
+    // The offset and entry count come straight from the EOCD, which the uploader controls. Without
+    // this bound a crafted value past the end of the buffer surfaces as Node's internal
+    // ERR_OUT_OF_RANGE from readUInt32LE (mirrors zipExtract's archiveIsEncrypted guard — and this
+    // walk is also reached by caseExportArchive, which never runs that scan first).
+    if (ptr + 46 > archive.length) throw new Error("corrupt ZIP: central directory out of bounds");
     if (archive.readUInt32LE(ptr) !== SIG_CENTRAL) throw new Error("corrupt ZIP: bad central header");
     const method = archive.readUInt16LE(ptr + 10);
     const flag = archive.readUInt16LE(ptr + 8);
@@ -190,6 +195,9 @@ export function readZip(archive: Buffer, opts: ReadZipOptions = {}): ZipEntry[] 
     const extra = archive.subarray(ptr + 46 + nameLen, ptr + 46 + nameLen + extraLen);
 
     // Jump to the local header to find the actual data start (its name/extra lengths may differ).
+    // The central record's relative-offset field is equally attacker-controlled — bound it the
+    // same way before the reads below walk off the end of the buffer.
+    if (localOffset + 30 > archive.length) throw new Error("corrupt ZIP: local header out of bounds");
     const localNameLen = archive.readUInt16LE(localOffset + 26);
     const localExtraLen = archive.readUInt16LE(localOffset + 28);
     const dataStart = localOffset + 30 + localNameLen + localExtraLen;

--- a/companion/src/reports/attackLayer.ts
+++ b/companion/src/reports/attackLayer.ts
@@ -1,4 +1,9 @@
-import type { InvestigationState, Severity } from "../analysis/stateTypes.js";
+import {
+  SEVERITY_RANK,
+  worstSeverity,
+  type InvestigationState,
+  type Severity,
+} from "../analysis/stateTypes.js";
 
 // Build a MITRE ATT&CK Navigator layer (https://mitre-attack.github.io/attack-navigator/) from
 // the case state — a deterministic transform, no AI. The layer JSON drops straight into the
@@ -56,15 +61,6 @@ const SEVERITY_SCORE: Record<Severity, number> = {
   Info: 10,
 };
 
-// Worst-wins ordering (higher = worse) when several findings/events touch the same technique.
-const SEVERITY_RANK: Record<Severity, number> = {
-  Critical: 5,
-  High: 4,
-  Medium: 3,
-  Low: 2,
-  Info: 1,
-};
-
 const SEVERITIES: Severity[] = ["Critical", "High", "Medium", "Low", "Info"];
 
 // A technique ("T1059") or sub-technique ("T1059.001") id, anchored so a tactic id (TA0001) or
@@ -74,10 +70,6 @@ const TECHNIQUE_RE = /^T\d{4}(?:\.\d{3})?$/;
 function normalizeTechnique(id: string): string | null {
   const t = id.trim().toUpperCase();
   return TECHNIQUE_RE.test(t) ? t : null;
-}
-
-function worse(a: Severity, b: Severity): Severity {
-  return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
 }
 
 // Parent technique id of a sub-technique ("T1059.001" → "T1059"), or null for a base technique.
@@ -127,7 +119,7 @@ export function buildAttackLayer(state: InvestigationState, opts: AttackLayerOpt
     const id = normalizeTechnique(rawId);
     if (!id) return;
     const cur = acc.get(id) ?? { worst: "Info" as Severity, findingTitles: [], eventCount: 0 };
-    cur.worst = worse(cur.worst, severity);
+    cur.worst = worstSeverity(cur.worst, severity);
     if (findingTitle) {
       const title = findingTitle.trim();
       if (title && !cur.findingTitles.includes(title)) cur.findingTitles.push(title);
@@ -152,9 +144,10 @@ export function buildAttackLayer(state: InvestigationState, opts: AttackLayerOpt
   }
 
   const techniques: NavigatorTechnique[] = [];
-  // Scored entries first, sorted worst→least-severe then by id, for a stable, readable layer.
+  // Scored entries first, sorted worst→least-severe then by id, for a stable, readable layer
+  // (canonical SEVERITY_RANK: lower = more severe, so ascending rank is worst-first).
   const scored = [...acc.entries()].sort((a, b) => {
-    const rank = SEVERITY_RANK[b[1].worst] - SEVERITY_RANK[a[1].worst];
+    const rank = SEVERITY_RANK[a[1].worst] - SEVERITY_RANK[b[1].worst];
     return rank !== 0 ? rank : a[0].localeCompare(b[0]);
   });
   for (const [id, info] of scored) {

--- a/companion/src/reports/glossary.ts
+++ b/companion/src/reports/glossary.ts
@@ -1,4 +1,5 @@
 import type { InvestigationState } from "../analysis/stateTypes.js";
+import { escapeRegExp } from "../analysis/regexEscape.js";
 import type { GlossaryEntry } from "./reportMeta.js";
 
 // A curated dictionary of DFIR / security terms and acronyms. The report's glossary (2.4)
@@ -54,10 +55,6 @@ export const GLOSSARY_DICTIONARY: Record<string, string> = {
   THOR: "Nextron's APT/IOC scanner.",
   Velociraptor: "An open-source endpoint-visibility and DFIR collection tool.",
 };
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 // All free-text in the investigation a term could plausibly appear in. IOC values (hashes,
 // IPs) are excluded — they're not prose and would only cause false matches.

--- a/companion/src/reports/iocBlocklist.ts
+++ b/companion/src/reports/iocBlocklist.ts
@@ -1,5 +1,11 @@
 import { createHash } from "node:crypto";
-import type { InvestigationState, IOC, IocEnrichment, Severity } from "../analysis/stateTypes.js";
+import {
+  SEVERITY_RANK,
+  type InvestigationState,
+  type IOC,
+  type IocEnrichment,
+  type Severity,
+} from "../analysis/stateTypes.js";
 import { iocToStixPattern } from "./stix.js";
 import type { StixBundle, StixObject } from "./stix.js";
 
@@ -20,14 +26,6 @@ export interface IocBlocklistOptions {
 }
 
 // ── Severity helpers ──────────────────────────────────────────────────────────
-
-const SEVERITY_RANK: Record<Severity, number> = {
-  Critical: 4,
-  High: 3,
-  Medium: 2,
-  Low: 1,
-  Info: 0,
-};
 
 const VERDICT_RANK: Record<IocEnrichment["verdict"], number> = {
   malicious: 3,
@@ -90,7 +88,8 @@ export function filterBlocklistIocs(
   for (const ioc of iocs) {
     const eff = effectiveType(ioc);
     if (!eff || !types.includes(eff)) continue;
-    if (SEVERITY_RANK[iocSeverity(ioc)] < SEVERITY_RANK[minSev]) continue;
+    // Canonical SEVERITY_RANK: lower = more severe, so "below the floor" is a GREATER rank.
+    if (SEVERITY_RANK[iocSeverity(ioc)] > SEVERITY_RANK[minSev]) continue;
     if (verdictOnly) {
       const v = worstVerdict(ioc);
       if (v !== "malicious" && v !== "suspicious") continue;

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -47,6 +47,7 @@ import type { RouteContext } from "./context.js";
 import { recordImportRun } from "./importRunRecorder.js";
 import { registerImportResumeHandler } from "./importRecovery.js";
 import { registerImportCaseGuard } from "./importCaseGuard.js";
+import { hasParseProgress, isAiDependent } from "./importKinds.js";
 import { createImportJobTracking, IMPORT_JOB_PENDING_DETAIL } from "./importJobTracking.js";
 import { beginImportSection, type ImportSection } from "./importSection.js";
 
@@ -309,13 +310,8 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         bytes: Buffer.byteLength(text, "utf8"),
       });
 
-      // CSV/log imports are themselves an LLM call (free-form data the model must interpret), so
-      // they respect the per-case AI toggle exactly like screenshot analysis + synthesis: with AI
-      // OFF, the evidence is saved (above) but NOT sent to the model. Deterministic imports have no
-      // LLM call, so they proceed and populate the timeline + IOCs regardless (synthesis still waits
-      // for AI — see resynthesizeInBackground). This keeps "AI off" meaning no LLM call / nothing
-      // leaves for the model, and stops the dashboard from claiming the AI is analyzing while off.
-      const aiDependent = kind === "csv" || kind === "log";
+      // AI-dependent imports respect the per-case AI toggle — rationale on isAiDependent().
+      const aiDependent = isAiDependent(kind);
       if (aiDependent && !(await getControl(caseId)).enabled) {
         options.onAiStatus?.(caseId, {
           status: "idle",
@@ -332,7 +328,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         kind: "import",
         label: `${kind}: ${storedName}`,
         detail: IMPORT_JOB_PENDING_DETAIL,
-        cancellable: aiDependent || kind === "evtxxml" || kind === "syslog",
+        cancellable: aiDependent || hasParseProgress(kind),
         resumable: true,
         maxRetries: 2,
         parameters: {
@@ -359,7 +355,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         idPrefix: `${seq}`,
         importedAt,
         onProgress: tracking.onProgress,
-        ...(kind === "evtxxml" || kind === "syslog" ? { onParseProgress: tracking.onParseProgress } : {}),
+        ...(hasParseProgress(kind) ? { onParseProgress: tracking.onParseProgress } : {}),
         minSeverity,
         ...(job?.signal ? { signal: job.signal } : {}),
       };
@@ -624,7 +620,8 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         bytes: size,
       });
 
-      const aiDependent = kind === "csv" || kind === "log";
+      // Same AI-off gate as /import above — rationale on isAiDependent().
+      const aiDependent = isAiDependent(kind);
       if (aiDependent && !(await getControl(caseId)).enabled) {
         options.onAiStatus?.(caseId, {
           status: "idle",
@@ -642,7 +639,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         kind: "import",
         label: `${kind}: ${storedName}`,
         detail: IMPORT_JOB_PENDING_DETAIL,
-        cancellable: aiDependent || kind === "evtxxml" || kind === "syslog",
+        cancellable: aiDependent || hasParseProgress(kind),
         resumable: true,
         maxRetries: 2,
         parameters: {
@@ -669,7 +666,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         idPrefix: `${seq}`,
         importedAt,
         onProgress: tracking.onProgress,
-        ...(kind === "evtxxml" || kind === "syslog" ? { onParseProgress: tracking.onParseProgress } : {}),
+        ...(hasParseProgress(kind) ? { onParseProgress: tracking.onParseProgress } : {}),
         minSeverity,
         ...(job?.signal ? { signal: job.signal } : {}),
       };

--- a/companion/src/routes/importKinds.ts
+++ b/companion/src/routes/importKinds.ts
@@ -1,0 +1,24 @@
+// The import kinds whose parsers STREAM: they report parse progress and honor the abort signal
+// mid-parse, so their jobs are cancellable even without an AI dependency. One list shared by the
+// twin /import + /import-file registrations (import.ts) and the resume handler's cancellable
+// predicate (importRecovery.ts) — these must stay in lockstep, or a resumed job silently loses
+// the cancel button its first run had. The next streaming importer is added HERE, nowhere else.
+// (Named after the parse-progress capability, not "streaming" — import.ts already uses a
+// `streaming` parameter for plaso file-streaming, which is a different thing.)
+export const PARSE_PROGRESS_KINDS: ReadonlySet<string> = new Set(["evtxxml", "syslog"]);
+
+// Accepts unknown so the resume handler can pass `job.parameters?.kind` unvalidated.
+export function hasParseProgress(kind: unknown): boolean {
+  return typeof kind === "string" && PARSE_PROGRESS_KINDS.has(kind);
+}
+
+// CSV/log imports are themselves an LLM call (free-form data the model must interpret), so they
+// respect the per-case AI toggle exactly like screenshot analysis + synthesis: with AI OFF, the
+// evidence is saved but NOT sent to the model. Deterministic imports have no LLM call, so they
+// proceed and populate the timeline + IOCs regardless (synthesis still waits for AI — see
+// resynthesizeInBackground). This keeps "AI off" meaning no LLM call / nothing leaves for the
+// model, and stops the dashboard from claiming the AI is analyzing while off. Shared by the twin
+// /import + /import-file registrations, which also OR it into their jobs' cancellable flag.
+export function isAiDependent(kind: string): boolean {
+  return kind === "csv" || kind === "log";
+}

--- a/companion/src/routes/importRecovery.ts
+++ b/companion/src/routes/importRecovery.ts
@@ -7,6 +7,7 @@ import { lastCommittedImportBatch } from "../analysis/importResume.js";
 import { parseMinSeverity } from "../analysis/severityFloor.js";
 import { addedForensicEvents, diffTimeline } from "../analysis/timelineDiff.js";
 import type { ImportBase, RouteContext } from "./context.js";
+import { hasParseProgress } from "./importKinds.js";
 import { recordImportRun } from "./importRunRecorder.js";
 
 const importParametersSchema = z.object({
@@ -182,7 +183,7 @@ export function registerImportResumeHandler(ctx: RouteContext): void {
       }
     },
     {
-      cancellable: (job) => job.parameters?.kind === "evtxxml" || job.parameters?.kind === "syslog",
+      cancellable: (job) => hasParseProgress(job.parameters?.kind),
     },
   );
 }

--- a/companion/tests/analysis/huntQueryParser.test.ts
+++ b/companion/tests/analysis/huntQueryParser.test.ts
@@ -74,6 +74,70 @@ describe("hunt query parser", () => {
     }
   });
 
+  // location() binary-searches a precomputed newline-offset array; line 1 / column 1 is the one
+  // position almost any wrong formula still gets right, so the cases below pin the arithmetic
+  // (comparison direction, lineStart derivation) at hand-derived multi-line and mid-line offsets.
+  it("locates an error on the second line of a multi-line query", () => {
+    try {
+      // Line 2 is "| group by sorce.ip": "| group by " spans columns 1-11, the bad field starts at 12.
+      parseHuntQuery("source.ip=192.0.2.1\n| group by sorce.ip");
+      throw new Error("expected parsing to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HuntQuerySyntaxError);
+      expect(error).toMatchObject({ code: "unknown_field", line: 2, column: 12, length: 8 });
+    }
+  });
+
+  it("locates an error mid-way through the first line", () => {
+    try {
+      // "source.ip=192.0.2.1" is columns 1-19, " and " ends at 24, the bad field starts at 25.
+      parseHuntQuery("source.ip=192.0.2.1 and sorce.ip=10.0.0.1");
+      throw new Error("expected parsing to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HuntQuerySyntaxError);
+      expect(error).toMatchObject({ code: "unknown_field", line: 1, column: 25, length: 8 });
+    }
+  });
+
+  it("locates an error at a non-1 column on the third line", () => {
+    try {
+      // Line 3 is "and sorce.ip=10.0.0.1": "and " spans columns 1-4, the bad field starts at 5.
+      parseHuntQuery("source.ip=192.0.2.1\nand host.name=DC01\nand sorce.ip=10.0.0.1");
+      throw new Error("expected parsing to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HuntQuerySyntaxError);
+      expect(error).toMatchObject({ code: "unknown_field", line: 3, column: 5, length: 8 });
+    }
+  });
+
+  it("locates an error when the query's first line is empty", () => {
+    try {
+      // The leading newline sits at offset 0, so the token at offset 1 must be line 2, column 1.
+      parseHuntQuery("\nsorce.ip=192.0.2.1");
+      throw new Error("expected parsing to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HuntQuerySyntaxError);
+      expect(error).toMatchObject({ code: "unknown_field", line: 2, column: 1, length: 8 });
+    }
+  });
+
+  it("re-keys the newline memo across consecutive parses of different texts", () => {
+    // Same error token under two different newline layouts, parsed back to back: a stale one-slot
+    // memo from the first text would misplace the second text's positions.
+    try {
+      parseHuntQuery("host.name=a\nand sorce.ip=1");
+      throw new Error("expected parsing to fail");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "unknown_field", line: 2, column: 5 });
+    }
+    try {
+      parseHuntQuery("host.name=a and\nsorce.ip=1");
+      throw new Error("expected parsing to fail");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "unknown_field", line: 2, column: 1 });
+    }
+  });
+
   it.each([
     "description matches /(a+)+$/",
     "description matches /(?=evil)/",

--- a/companion/tests/analysis/internalIp.test.ts
+++ b/companion/tests/analysis/internalIp.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { isInternalIpv4 } from "../../src/analysis/internalIp.js";
+
+// Direct unit spec of the ONE shared range table (TC2-1). Every importer that keeps only public
+// IPs as IOCs, plus siemImport's logon-risk grading, routes through this — before this file its
+// range boundaries were pinned only indirectly, via one emailImport Received-walk test.
+describe("isInternalIpv4 — the shared internal-range table", () => {
+  it("classifies every internal range as internal", () => {
+    expect(isInternalIpv4("10.0.0.1")).toBe(true); // RFC1918 10/8
+    expect(isInternalIpv4("127.0.0.1")).toBe(true); // loopback
+    expect(isInternalIpv4("0.1.2.3")).toBe(true); // 0.0.0.0/8 "this network"
+    expect(isInternalIpv4("192.168.1.1")).toBe(true); // RFC1918 192.168/16
+    expect(isInternalIpv4("172.16.0.1")).toBe(true); // RFC1918 172.16/12 lower edge
+    expect(isInternalIpv4("172.31.255.255")).toBe(true); // RFC1918 172.16/12 upper edge
+    expect(isInternalIpv4("169.254.10.10")).toBe(true); // link-local
+    expect(isInternalIpv4("100.64.0.1")).toBe(true); // CGNAT 100.64/10 lower edge
+    expect(isInternalIpv4("100.127.255.255")).toBe(true); // CGNAT 100.64/10 upper edge
+  });
+
+  it("leaves the boundary neighbours of each range public", () => {
+    expect(isInternalIpv4("172.15.255.255")).toBe(false); // below 172.16/12
+    expect(isInternalIpv4("172.32.0.1")).toBe(false); // above 172.16/12
+    expect(isInternalIpv4("100.63.255.255")).toBe(false); // below CGNAT
+    expect(isInternalIpv4("100.128.0.1")).toBe(false); // above CGNAT
+    expect(isInternalIpv4("192.169.0.1")).toBe(false); // beside 192.168/16
+  });
+
+  // False here means "not internal IPv4", NOT "public": a caller that needs "public IPv4" must
+  // also require the IPv4 shape (see siemImport's isPublicIpv4 and its comment) — a plain
+  // negation would call blank and IPv6 sources public.
+  it("returns false for non-IPv4 shapes — blank, placeholder, IPv6, truncated", () => {
+    expect(isInternalIpv4("")).toBe(false);
+    expect(isInternalIpv4("-")).toBe(false);
+    expect(isInternalIpv4("::1")).toBe(false);
+    expect(isInternalIpv4("2001:db8::5")).toBe(false);
+    expect(isInternalIpv4("10.0.0")).toBe(false);
+  });
+});

--- a/companion/tests/analysis/iocValue.test.ts
+++ b/companion/tests/analysis/iocValue.test.ts
@@ -159,6 +159,19 @@ describe("isInternalTarget (SSRF guard)", () => {
     expect(isInternalTarget("2001:4860:4860::8888", "ip")).toBe(false);
   });
 
+  // CGNAT 100.64/10 is a victim-side range like RFC1918 — every importer refuses to mint it as an
+  // IOC and anonymize.ts classifies it internal, so the enrichment gate must refuse it too. The
+  // range was the one branch iocValue's local table had drifted on (DUP2-1).
+  it("blocks CGNAT 100.64/10 as internal — bare, URL-host, and IPv4-mapped forms", () => {
+    expect(isInternalTarget("100.64.0.5", "ip")).toBe(true);
+    expect(isInternalTarget("100.127.255.254", "ip")).toBe(true);
+    expect(isInternalTarget("http://100.64.0.5/", "url")).toBe(true);
+    expect(isInternalTarget("::ffff:100.64.0.5", "ip")).toBe(true);
+    // Boundary neighbours stay public: 100.63/10 below, 100.128 above.
+    expect(isInternalTarget("100.63.255.255", "ip")).toBe(false);
+    expect(isInternalTarget("100.128.0.1", "ip")).toBe(false);
+  });
+
   it("blocks URLs pointing at internal hosts", () => {
     expect(isInternalTarget("http://169.254.169.254/latest/meta-data/", "url")).toBe(true);
     expect(isInternalTarget("http://10.0.0.1/admin", "url")).toBe(true);

--- a/companion/tests/analysis/siemImport.test.ts
+++ b/companion/tests/analysis/siemImport.test.ts
@@ -110,6 +110,24 @@ describe("logonRisk — logon-type grading", () => {
     expect(logonRisk(8, "")).toMatchObject({ severity: "Medium", mitre: ["T1078"] });
     expect(logonRisk(9, "")).toMatchObject({ severity: "Medium", mitre: ["T1550.002"] });
   });
+
+  // Pins isPublicIpv4's IPv4-shape requirement (TC2-1): "public" must mean "IPv4-shaped AND not
+  // internal", never a plain !isInternalIpv4 — that "simplification" would grade every blank-source
+  // 4624 (IpAddress "-" is routine for local/service logons; cleanIp maps it to "") and every
+  // routable-IPv6 source as an internet-facing logon, flooding the forensic timeline with false
+  // Medium/T1078 external-access findings.
+  it("keeps a blank source internal — a type-3 logon with no IP is not external", () => {
+    expect(logonRisk(3, "").severity).toBeUndefined();
+    expect(logonRisk(3, "").mitre).toEqual([]);
+  });
+
+  it("keeps a routable IPv6 source internal — non-IPv4-shaped never counts as public", () => {
+    expect(logonRisk(3, "2001:db8::5").severity).toBeUndefined();
+    expect(logonRisk(3, "2001:db8::5").mitre).toEqual([]);
+    const rdp = logonRisk(10, "2001:db8::5");
+    expect(rdp.typeName).toBe("RemoteInteractive/RDP");
+    expect(rdp.severity).toBeUndefined();
+  });
 });
 
 describe("mapWindows — 4624 logon-type overlay end to end", () => {
@@ -127,6 +145,13 @@ describe("mapWindows — 4624 logon-type overlay end to end", () => {
     expect(e.severity).toBe("Low");
     expect(e.mitreTechniques).toEqual([]);
     expect(e.description).toMatch(/Network from 10\.10\.200\.11/);
+  });
+
+  it("keeps a blank-source ('-') network 4624 at Low with no technique (TC2-1)", () => {
+    const r = parseSiemExport(elastic(logon4624("3", "-")));
+    const e = r.events[0];
+    expect(e.severity).toBe("Low");
+    expect(e.mitreTechniques).toEqual([]);
   });
 });
 

--- a/companion/tests/analysis/syslogImport.test.ts
+++ b/companion/tests/analysis/syslogImport.test.ts
@@ -179,4 +179,32 @@ describe("parseSyslogProgress", () => {
 
     expect(progress).toEqual([5000, 10_000, 12_000]);
   });
+
+  // Failed sshd auth lines stream straight into the aggregator (only accepted logins are buffered
+  // for the brute-force post-pass), so the correlation must still see every failure — including a
+  // flood larger than a progress chunk — and the flood itself must aggregate, not multiply events.
+  it("correlates a brute-force success across a failure flood longer than a progress chunk", async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 6000; i++) {
+      const at = i * 10; // 10 ms apart — the whole flood fits inside the 1-hour lookback window
+      const ss = String(Math.floor(at / 1000)).padStart(2, "0");
+      const ms = String(at % 1000).padStart(3, "0");
+      lines.push(
+        `<86>1 2024-05-16T13:00:${ss}.${ms}Z web01 sshd 9000 - - Failed password for invalid user admin from 203.0.113.9 port 41022 ssh2`,
+      );
+    }
+    lines.push(
+      "<86>1 2024-05-16T13:02:00.000000Z web01 sshd 9100 - - Accepted password for admin from 203.0.113.9 port 41099 ssh2",
+    );
+    const text = lines.join("\n");
+
+    const r = await parseSyslogProgress(text, { assumeYear: 2024 });
+    const success = r.events.find((e) => e.mitreTechniques.includes("T1110.001"));
+    expect(success, "expected a brute-force-success event").toBeTruthy();
+    expect(success?.severity).toBe("Medium");
+    expect(success?.description).toContain("succeeded after 6000 failed attempts from 203.0.113.9");
+    // The 6000 identical failures collapse into one counted aggregation row.
+    expect(r.events.find((e) => e.count === 6000)?.description).toContain("Failed password");
+    expect(r).toEqual(parseSyslog(text, { assumeYear: 2024 }));
+  });
 });

--- a/companion/tests/analysis/zipExtract.test.ts
+++ b/companion/tests/analysis/zipExtract.test.ts
@@ -169,4 +169,23 @@ describe("extractZipEntries", () => {
 
     expect(() => extractZipEntries(archive, "crafted.zip")).toThrow(/corrupt ZIP: central directory/i);
   });
+
+  // The central record's relative-offset-of-local-header field is just as attacker-controlled as
+  // the EOCD pointer above, and it passes the archiveIsEncrypted guard (the central record itself
+  // is in bounds, signature and flags valid) — readZip's local-header reads used to surface Node's
+  // raw ERR_OUT_OF_RANGE from that field (TC2-3).
+  it("reports a crafted out-of-bounds local-header offset as a corrupt ZIP, not a RangeError", () => {
+    const archive = createZip([{ path: "sample.bin", data: Buffer.from("payload") }]);
+    let eocd = -1;
+    for (let i = archive.length - 22; i >= 0; i--) {
+      if (archive.readUInt32LE(i) === 0x06054b50) {
+        eocd = i;
+        break;
+      }
+    }
+    const ptr = archive.readUInt32LE(eocd + 16); // central directory start
+    archive.writeUInt32LE(0xffffff00, ptr + 42); // local header "sits" ~4 GB into a tiny file
+
+    expect(() => extractZipEntries(archive, "crafted.zip")).toThrow(/corrupt ZIP: local header/i);
+  });
 });

--- a/companion/tests/dashboard/assetGraphPanel.test.ts
+++ b/companion/tests/dashboard/assetGraphPanel.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// The generation-token race guard (commit 8f10ebd3). When an analyst switches cases fast, a stale
+// request's late response — success OR failure — must not overwrite the newer case's graph, and
+// the LATEST load's failure must clear the cached graph instead of leaving the previous case's
+// assets on screen with hasAssetGraph() wrongly true. Both failure arms matter: an HTTP error
+// takes the fulfilled branch, but a network-level rejection (the companion restarting mid-switch)
+// or a malformed 2xx body REJECTS, and a bare `.catch(() => {})` there restored the stale
+// cross-case graph the token exists to prevent.
+
+interface AssetGraphApi {
+  loadAssetGraph(id: string): void;
+  hasAssetGraph(): boolean;
+  assetGraphAssets(): Array<{ name: string }>;
+}
+
+interface PendingFetch {
+  url: string;
+  resolve(response: unknown): void;
+  reject(reason: unknown): void;
+}
+
+// A fetch stub whose responses are settled BY THE TEST, in the order the test chooses — the whole
+// point is answering request A after request B.
+function deferredFetch() {
+  const pending: PendingFetch[] = [];
+  const fetch = (url: string) =>
+    new Promise((resolve, reject) => {
+      pending.push({ url, resolve, reject });
+    });
+  return { pending, fetch };
+}
+
+// One macrotask turn, so every already-settled promise chain runs to completion.
+const drain = () => new Promise((r) => setImmediate(r));
+
+function graphPanel(fetchStub: unknown) {
+  return loadDashboardModule<AssetGraphApi>("dashboard-asset-graph.js", ["dashboard-escape.js"], {
+    fetch: fetchStub,
+    // The renderers write into whatever element they find; the module must stay load-clean and
+    // render-safe against a bare stub — no DfirGraphView means the "library not loaded" text path.
+    document: {
+      getElementById: () => ({ innerHTML: "", textContent: "", style: {} }),
+      querySelectorAll: () => [],
+    },
+    DfirTimelineView: { timeQuery: () => "" },
+  });
+}
+
+function graphFor(name: string) {
+  return {
+    assets: [{ id: `host:${name}`, name, type: "host", compromised: false }],
+    iocs: [],
+    edges: [],
+  };
+}
+
+function okGraph(name: string) {
+  return { ok: true, json: async () => graphFor(name) };
+}
+
+describe("asset graph case-switch race (generation token)", () => {
+  it("ignores a stale load's late success — the newer case's graph survives", async () => {
+    const { pending, fetch } = deferredFetch();
+    const p = graphPanel(fetch);
+    p.loadAssetGraph("case-a");
+    p.loadAssetGraph("case-b");
+    pending[1].resolve(okGraph("b-host"));
+    await drain();
+    expect(p.hasAssetGraph()).toBe(true);
+    pending[0].resolve(okGraph("a-host"));
+    await drain();
+    expect(p.assetGraphAssets().map((a) => a.name)).toEqual(["b-host"]);
+    expect(p.hasAssetGraph()).toBe(true);
+  });
+
+  it("ignores a stale load's late HTTP failure — the newer case's graph survives", async () => {
+    const { pending, fetch } = deferredFetch();
+    const p = graphPanel(fetch);
+    p.loadAssetGraph("case-a");
+    p.loadAssetGraph("case-b");
+    pending[1].resolve(okGraph("b-host"));
+    await drain();
+    pending[0].resolve({ ok: false, status: 500, json: async () => ({ error: "boom" }) });
+    await drain();
+    expect(p.assetGraphAssets().map((a) => a.name)).toEqual(["b-host"]);
+  });
+
+  it("ignores a stale load's late network rejection — the newer case's graph survives", async () => {
+    const { pending, fetch } = deferredFetch();
+    const p = graphPanel(fetch);
+    p.loadAssetGraph("case-a");
+    p.loadAssetGraph("case-b");
+    pending[1].resolve(okGraph("b-host"));
+    await drain();
+    pending[0].reject(new Error("network down"));
+    await drain();
+    expect(p.assetGraphAssets().map((a) => a.name)).toEqual(["b-host"]);
+    expect(p.hasAssetGraph()).toBe(true);
+  });
+
+  it("clears the previous case's graph when the latest load fails with an HTTP error", async () => {
+    const { pending, fetch } = deferredFetch();
+    const p = graphPanel(fetch);
+    p.loadAssetGraph("case-a");
+    pending[0].resolve(okGraph("a-host"));
+    await drain();
+    expect(p.hasAssetGraph()).toBe(true);
+    p.loadAssetGraph("case-b");
+    // The error body must never be cached as graph data — hasAssetGraph() trusts the cache.
+    pending[1].resolve({ ok: false, status: 500, json: async () => ({ error: "boom" }) });
+    await drain();
+    expect(p.hasAssetGraph()).toBe(false);
+    expect(p.assetGraphAssets()).toEqual([]);
+  });
+
+  it("clears the previous case's graph when the latest load REJECTS at the network level", async () => {
+    // The arm the bare `.catch(() => {})` used to skip: a rejected fetch never reaches the
+    // fulfilled branch, so without seq-guarded clearing in the catch, case A's assets stayed
+    // rendered under case B and hasAssetGraph() kept answering true.
+    const { pending, fetch } = deferredFetch();
+    const p = graphPanel(fetch);
+    p.loadAssetGraph("case-a");
+    pending[0].resolve(okGraph("a-host"));
+    await drain();
+    expect(p.hasAssetGraph()).toBe(true);
+    p.loadAssetGraph("case-b");
+    pending[1].reject(new Error("ECONNREFUSED"));
+    await drain();
+    expect(p.hasAssetGraph()).toBe(false);
+    expect(p.assetGraphAssets()).toEqual([]);
+  });
+
+  it("clears when the latest load's 2xx body is malformed (json() rejects)", async () => {
+    const { pending, fetch } = deferredFetch();
+    const p = graphPanel(fetch);
+    p.loadAssetGraph("case-a");
+    pending[0].resolve(okGraph("a-host"));
+    await drain();
+    p.loadAssetGraph("case-b");
+    pending[1].resolve({
+      ok: true,
+      json: async () => {
+        throw new Error("unexpected end of JSON input");
+      },
+    });
+    await drain();
+    expect(p.hasAssetGraph()).toBe(false);
+    expect(p.assetGraphAssets()).toEqual([]);
+  });
+});

--- a/companion/tests/dashboard/hostScopePanel.test.ts
+++ b/companion/tests/dashboard/hostScopePanel.test.ts
@@ -198,3 +198,130 @@ describe("recording a host-scope decision", () => {
     await expect(p.decideHostScope("c1", "ws-099", "cleared", "covered")).resolves.toBe(true);
   });
 });
+
+// The ledger read is raced by case switches, and the per-case resets in dashboard-case-connect.js
+// never touch this module's state — so a stale response must not overwrite the newer case's
+// ledger, and the LATEST load's failure must clear and repaint rather than leave the PREVIOUS
+// case's clearance board ("Cleared"/"Confirmed" for the wrong case) on a surface analysts use for
+// scoping calls. Same generation-token contract as loadAssetGraph, pinned the same way.
+interface HostScopeLoadApi {
+  loadHostScope(caseId: string): Promise<void>;
+}
+
+interface PendingFetch {
+  url: string;
+  resolve(response: unknown): void;
+  reject(reason: unknown): void;
+}
+
+// A fetch stub whose responses are settled BY THE TEST, in the order the test chooses — the whole
+// point is answering request A after request B.
+function deferredFetch() {
+  const pending: PendingFetch[] = [];
+  const fetch = (url: string) =>
+    new Promise((resolve, reject) => {
+      pending.push({ url, resolve, reject });
+    });
+  return { pending, fetch };
+}
+
+// One macrotask turn, so every already-settled promise chain runs to completion.
+const drain = () => new Promise((r) => setImmediate(r));
+
+// The panel body the module paints into: enough element for paintHostScope (innerHTML, the
+// bind-once dataset flag, the delegated listener) and for the failure writes.
+function panelWithBody(fetchStub: unknown) {
+  const body = { innerHTML: "", dataset: {} as Record<string, string>, addEventListener: () => {} };
+  const p = loadDashboardModule<HostScopeLoadApi>("dashboard-host-scope.js", ["dashboard-escape.js"], {
+    fetch: fetchStub,
+    document: { getElementById: (id: string) => (id === "hostScopeBody" ? body : null) },
+  });
+  return { p, body };
+}
+
+function okLedger(name: string) {
+  return { ok: true, status: 200, json: async () => ledger({ hosts: [host({ name })] }) };
+}
+
+describe("loading the host-scope ledger under case switches", () => {
+  it("ignores a stale load's late success — the newer case's board survives", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    void p.loadHostScope("case-b");
+    pending[1].resolve(okLedger("host-b"));
+    await drain();
+    expect(body.innerHTML).toContain("host-b");
+    pending[0].resolve(okLedger("host-a"));
+    await drain();
+    expect(body.innerHTML).toContain("host-b");
+    expect(body.innerHTML).not.toContain("host-a");
+  });
+
+  it("ignores a stale load's late failure — the newer case's board survives", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    void p.loadHostScope("case-b");
+    pending[1].resolve(okLedger("host-b"));
+    await drain();
+    pending[0].resolve({ ok: false, status: 500, json: async () => ({ error: "boom" }) });
+    await drain();
+    expect(body.innerHTML).toContain("host-b");
+    expect(body.innerHTML).not.toContain("unavailable");
+  });
+
+  it("clears the previous case's board when the new case's read fails, and says why", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    pending[0].resolve(okLedger("host-a"));
+    await drain();
+    expect(body.innerHTML).toContain("host-a");
+    void p.loadHostScope("case-b");
+    // The 500 routes/hostScope.ts produces on a corrupt ledger file carries the error message —
+    // fail-loud by design, and the panel must not silence it at the last hop.
+    pending[1].resolve({ ok: false, status: 500, json: async () => ({ error: "scope ledger corrupt" }) });
+    await drain();
+    expect(body.innerHTML).toContain("Host scope unavailable: scope ledger corrupt");
+    expect(body.innerHTML).not.toContain("host-a");
+  });
+
+  it("falls back to the HTTP status when the failure body is unreadable", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    pending[0].resolve({
+      ok: false,
+      status: 502,
+      json: async () => {
+        throw new Error("not json");
+      },
+    });
+    await drain();
+    expect(body.innerHTML).toContain("Host scope unavailable: HTTP 502");
+  });
+
+  it("clears the previous case's board on a network-level rejection too", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    pending[0].resolve(okLedger("host-a"));
+    await drain();
+    void p.loadHostScope("case-b");
+    pending[1].reject(new Error("ECONNREFUSED"));
+    await drain();
+    expect(body.innerHTML).toContain("Host scope could not be loaded.");
+    expect(body.innerHTML).not.toContain("host-a");
+  });
+
+  it("renders the default empty state when the store is not configured (501)", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    pending[0].resolve({ ok: false, status: 501, json: async () => ({ error: "not configured" }) });
+    await drain();
+    expect(body.innerHTML).toContain("No scope data.");
+    expect(body.innerHTML).not.toContain("unavailable");
+  });
+});

--- a/companion/tests/dashboard/hostScopePanel.test.ts
+++ b/companion/tests/dashboard/hostScopePanel.test.ts
@@ -206,6 +206,7 @@ describe("recording a host-scope decision", () => {
 // scoping calls. Same generation-token contract as loadAssetGraph, pinned the same way.
 interface HostScopeLoadApi {
   loadHostScope(caseId: string): Promise<void>;
+  decideHostScope(caseId: string, host: string, to: string, reason: string): Promise<boolean>;
 }
 
 interface PendingFetch {
@@ -323,5 +324,27 @@ describe("loading the host-scope ledger under case switches", () => {
     await drain();
     expect(body.innerHTML).toContain("No scope data.");
     expect(body.innerHTML).not.toContain("unavailable");
+  });
+
+  it("a decision's late response does not resurrect the previous case's board after a switch", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    pending[0].resolve(okLedger("host-a"));
+    await drain();
+    expect(body.innerHTML).toContain("host-a");
+    // A clearance decision for case A is still in flight when the analyst switches to case B.
+    const decided = p.decideHostScope("case-a", "host-a", "cleared", "covered");
+    void p.loadHostScope("case-b");
+    pending[2].resolve(okLedger("host-b"));
+    await drain();
+    expect(body.innerHTML).toContain("host-b");
+    // The decision's response carries case A's ledger — it landed server-side (resolves true),
+    // but must not repaint case B's board with the superseded case's clearance state.
+    pending[1].resolve(okLedger("host-a"));
+    await drain();
+    await expect(decided).resolves.toBe(true);
+    expect(body.innerHTML).toContain("host-b");
+    expect(body.innerHTML).not.toContain("host-a");
   });
 });

--- a/companion/tests/dashboard/hostScopePanel.test.ts
+++ b/companion/tests/dashboard/hostScopePanel.test.ts
@@ -346,5 +346,32 @@ describe("loading the host-scope ledger under case switches", () => {
     await expect(decided).resolves.toBe(true);
     expect(body.innerHTML).toContain("host-b");
     expect(body.innerHTML).not.toContain("host-a");
+    // A DIFFERENT-case supersession must not reconcile — reloading case A would clobber case B.
+    expect(pending.length).toBe(3);
+  });
+
+  it("reconciles with a fresh load when a same-case reload supersedes a decision", async () => {
+    const { pending, fetch } = deferredFetch();
+    const { p, body } = panelWithBody(fetch);
+    void p.loadHostScope("case-a");
+    pending[0].resolve(okLedger("host-a"));
+    await drain();
+    // A decision and a SAME-case reload race; the reload's read predates the append, so its
+    // ledger is the pre-decision state.
+    const decided = p.decideHostScope("case-a", "host-a", "cleared", "covered");
+    void p.loadHostScope("case-a");
+    pending[2].resolve(okLedger("host-a"));
+    await drain();
+    expect(body.innerHTML).toContain("host-a");
+    // The decision's post-append ledger arrives superseded: it must not paint directly, but a
+    // recorded decision must not stay invisible either — a reconciling load is issued and its
+    // (post-append) response is what paints.
+    pending[1].resolve(okLedger("host-a-cleared"));
+    await drain();
+    await expect(decided).resolves.toBe(true);
+    expect(pending.length).toBe(4);
+    pending[3].resolve(okLedger("host-a-cleared"));
+    await drain();
+    expect(body.innerHTML).toContain("host-a-cleared");
   });
 });

--- a/companion/tests/server/importKinds.test.ts
+++ b/companion/tests/server/importKinds.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
+import { PARSE_PROGRESS_KINDS, hasParseProgress } from "../../src/routes/importKinds.js";
+
+// DUP2-4: the streaming-import kind predicate used to be five copied literals across the twin
+// /import + /import-file registrations and the resume handler — and missing only the resume copy
+// produced a job that was cancellable on first run but silently uncancellable after a restart
+// resumed it. These tests pin the shared helper AND that both files actually route through it.
+describe("importKinds — the streaming-import kind predicate", () => {
+  it("marks exactly the streaming kinds as parse-progress capable", () => {
+    expect([...PARSE_PROGRESS_KINDS].sort()).toEqual(["evtxxml", "syslog"]);
+    expect(hasParseProgress("evtxxml")).toBe(true);
+    expect(hasParseProgress("syslog")).toBe(true);
+    expect(hasParseProgress("csv")).toBe(false);
+    expect(hasParseProgress("log")).toBe(false);
+    expect(hasParseProgress("plaso")).toBe(false);
+  });
+
+  it("rejects non-string kinds, so the resume handler can pass job.parameters?.kind raw", () => {
+    expect(hasParseProgress(undefined)).toBe(false);
+    expect(hasParseProgress(null)).toBe(false);
+    expect(hasParseProgress(42)).toBe(false);
+    expect(hasParseProgress({})).toBe(false);
+  });
+
+  // The kind-driven cancellable component must be the SAME expression in the registrations and
+  // the resume predicate (the registrations additionally OR in aiDependent, which the resume
+  // predicate intentionally lacks). With the helper consolidated, lockstep regresses only if a
+  // literal creeps back in — so assert both files delegate and neither re-inlines the kind list.
+  it("keeps import.ts and importRecovery.ts on the shared predicate, with no inline kind literals", async () => {
+    for (const file of ["import.ts", "importRecovery.ts"]) {
+      const src = await readFile(new URL(`../../src/routes/${file}`, import.meta.url), "utf8");
+      expect(src, `${file} should use hasParseProgress`).toContain("hasParseProgress(");
+      expect(src, `${file} re-inlines the streaming-kind literal`).not.toMatch(
+        /kind\s*===\s*"(?:evtxxml|syslog)"/,
+      );
+    }
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,10 @@ services:
       - ./cases:/data/cases     # forensic evidence + case state (persists across restarts)
       - ./addon:/out            # pre-built browser add-on → Chrome/Comet "Load unpacked" ./addon/dist
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4773/dashboard').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      # Probe /health, not /dashboard: /health is auth- and host-check-exempt, so the probe stays
+      # green in team mode too (an unauthenticated /dashboard fetch gets a 401 there, and this
+      # compose healthcheck OVERRIDES the image's baked /health probe).
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4773/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,9 +92,10 @@ if [ "$(id -u)" = "0" ]; then
       *) return 1 ;;
     esac
   }
-  # mkdir + recursively hand an app-dedicated tree to node (creating it if missing, migrating a
-  # legacy root-owned one). Normalizes and confines first, so it is safe even for a dashboard-
-  # supplied path. Recursing is safe: after confinement these are the app's OWN directories.
+  # mkdir + recursively hand an app-dedicated tree over (creating it if missing, migrating a
+  # legacy root-owned one). Normalizes and confines first. TRUSTED variant: only for paths the
+  # OPERATOR configured in the real container environment (or the image defaults) — never for a
+  # value read from the dashboard-writable dotenv file.
   handoff_dir() {
     _d="$(abspath_raw "$1")"
     if deny_chown "$_d"; then
@@ -105,7 +106,8 @@ if [ "$(id -u)" = "0" ]; then
     chown_tree "$_d"
   }
   # Hand over just a directory ENTRY (not its contents) — for a possibly-shared dir the server only
-  # needs to create a file in (an explicit log dir, the .env dir). Same confinement.
+  # needs to create a file in (an explicit log dir, the .env dir). Same confinement; trusted-source
+  # values only.
   handoff_entry() {
     _d="$(abspath_raw "$1")"
     if deny_chown "$_d"; then
@@ -115,6 +117,35 @@ if [ "$(id -u)" = "0" ]; then
     mkdir -p "$_d" 2>/dev/null || true
     chown -h "$run_uid:$run_gid" "$_d" 2>/dev/null || true
   }
+  # UNTRUSTED variants, for paths whose value came from the dotenv file the unprivileged server can
+  # WRITE (Settings). Root must never transfer ownership of pre-existing data on the say-so of that
+  # file — a compromised server could name another bind mount (/mnt, /evidence) and wait for a
+  # restart, a confused deputy the deny-list alone cannot close. Rules: inside /data (the image's
+  # dedicated data tree) recursion stays enabled — there is nothing there but the app's own data;
+  # elsewhere, CREATE the directory when absent (a fresh empty dir disowns nothing) and hand over
+  # only that entry, but leave an EXISTING dir not already owned by the run user untouched, telling
+  # the operator to set the variable in the real container environment for an actual migration.
+  handoff_dir_untrusted() {
+    _d="$(abspath_raw "$1")"
+    if deny_chown "$_d"; then
+      echo "dfir-entrypoint: refusing to hand off '$1' -> '$_d' (filesystem root, /app code tree, or a system directory); ignoring" >&2
+      return 0
+    fi
+    case "$_d" in
+      /data | /data/*)
+        mkdir -p "$_d" 2>/dev/null || true
+        chown_tree "$_d"
+        return 0
+        ;;
+    esac
+    if [ ! -e "$_d" ]; then
+      mkdir -p "$_d" 2>/dev/null || true
+      chown -h "$run_uid:$run_gid" "$_d" 2>/dev/null || true
+    elif [ "$(stat -c %u "$_d" 2>/dev/null)" != "$run_uid" ]; then
+      echo "dfir-entrypoint: not changing ownership of existing '$_d' — its location comes from the dashboard-writable settings file; set the variable in the container environment (compose/docker -e) to hand it off" >&2
+    fi
+  }
+  handoff_entry_untrusted() { handoff_dir_untrusted "$1"; }
   # The GLOBAL store subdirectories the server creates beside the cases root (runtimeStores.ts);
   # team-auth lives at DFIR_AUTH_DATA_DIR or a sibling .dfir-auth-<hash>.
   KNOWN_STORES="bundles dashboard-views diagnostics importers incident-types kev logs notifications nsrl report-templates tagger templates tools updates velociraptor whitelist"
@@ -139,12 +170,23 @@ if [ "$(id -u)" = "0" ]; then
     esac
     printf '%s' "$v"
   }
-  : "${DFIR_CASES_ROOT:=$(env_file_get DFIR_CASES_ROOT)}"
-  : "${DFIR_AUTH_DATA_DIR:=$(env_file_get DFIR_AUTH_DATA_DIR)}"
-  : "${DFIR_IMPORTERS_DIR:=$(env_file_get DFIR_IMPORTERS_DIR)}"
-  : "${DFIR_LOG_DIR:=$(env_file_get DFIR_LOG_DIR)}"
-  : "${DFIR_OCR_CACHE:=$(env_file_get DFIR_OCR_CACHE)}"
-  : "${DFIR_OCR_DEBUG_DIR:=$(env_file_get DFIR_OCR_DEBUG_DIR)}"
+  # Track PROVENANCE while merging: a value already present in the real environment (operator- or
+  # image-set) is trusted; one that only exists in the dotenv file is dashboard-writable and gets
+  # the untrusted handoff rules above. In the shipped image DFIR_CASES_ROOT / DFIR_OCR_CACHE /
+  # DFIR_ENV_FILE are Dockerfile ENVs, so they are always trusted unless an operator strips them.
+  from_env_file=""
+  load_env_file_var() {
+    eval "_cur=\${$1:-}"
+    [ -n "$_cur" ] && return 0
+    _v="$(env_file_get "$1")"
+    [ -n "$_v" ] || return 0
+    eval "$1=\$_v"
+    from_env_file="$from_env_file $1"
+  }
+  is_from_env_file() { case " $from_env_file " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+  for _var in DFIR_CASES_ROOT DFIR_AUTH_DATA_DIR DFIR_IMPORTERS_DIR DFIR_LOG_DIR DFIR_OCR_CACHE DFIR_OCR_DEBUG_DIR; do
+    load_env_file_var "$_var"
+  done
 
   # Resolve the cases root two ways: the DEREFERENCED real dir (for chowning — following symlinks to
   # the actual inode), and a LEXICAL path (for deriving parent/sibling/auth locations — the server
@@ -181,7 +223,10 @@ if [ "$(id -u)" = "0" ]; then
 
   # Hand over the evidence/case store itself ONCE (a legacy root-written tree and large evidence
   # dirs both need the recursive walk). The parent handling below never re-walks this subtree.
-  handoff_dir "$cases_root"
+  # Trust follows the value's provenance: a dotenv-sourced cases root (possible only when the
+  # operator stripped the image's DFIR_CASES_ROOT ENV) gets the no-disown untrusted rules.
+  if is_from_env_file DFIR_CASES_ROOT; then cases_handoff=handoff_dir_untrusted; else cases_handoff=handoff_dir; fi
+  "$cases_handoff" "$cases_root"
 
   # The server also creates the global stores as subdirectories of the cases root's PARENT. NEVER
   # chown the parent itself: on a shared bind mount that would let the server rename or delete
@@ -195,12 +240,12 @@ if [ "$(id -u)" = "0" ]; then
       echo "dfir-entrypoint: DFIR_CASES_ROOT=${DFIR_CASES_ROOT:-/data/cases} resolves under the root-owned /app code tree ($cases_lexical); its sibling stores (logs, templates, team-auth) will be unwritable — set DFIR_CASES_ROOT to an absolute path on a mounted volume (e.g. /data/cases)" >&2
       ;;
     *)
-      for name in $KNOWN_STORES; do handoff_dir "${data_root%/}/$name"; done
+      for name in $KNOWN_STORES; do "$cases_handoff" "${data_root%/}/$name"; done
       if [ -z "${DFIR_AUTH_DATA_DIR:-}" ]; then
         # authFactory: .dfir-auth-<sha256(path.resolve(casesRoot))[:12]> beside the lexically
         # resolved cases root — path.resolve does not dereference symlinks, so use cases_lexical.
         auth_hash="$(printf '%s' "$cases_lexical" | sha256sum 2>/dev/null | cut -c1-12)"
-        [ -n "$auth_hash" ] && handoff_dir "${data_root%/}/.dfir-auth-$auth_hash"
+        [ -n "$auth_hash" ] && "$cases_handoff" "${data_root%/}/.dfir-auth-$auth_hash"
       fi
       case "$data_root" in
         / | . | "")
@@ -215,25 +260,30 @@ if [ "$(id -u)" = "0" ]; then
   # matching authFactory/runtimeStores). handoff_dir confines each before chowning.
   if [ -n "${DFIR_AUTH_DATA_DIR:-}" ]; then
     case "$DFIR_AUTH_DATA_DIR" in /*) d="$DFIR_AUTH_DATA_DIR" ;; *) d="${data_root%/}/$DFIR_AUTH_DATA_DIR" ;; esac
-    handoff_dir "$d"
+    if is_from_env_file DFIR_AUTH_DATA_DIR; then handoff_dir_untrusted "$d"; else handoff_dir "$d"; fi
   fi
   if [ -n "${DFIR_IMPORTERS_DIR:-}" ]; then
     case "$DFIR_IMPORTERS_DIR" in /*) d="$DFIR_IMPORTERS_DIR" ;; *) d="${data_root%/}/$DFIR_IMPORTERS_DIR" ;; esac
-    handoff_dir "$d"
+    if is_from_env_file DFIR_IMPORTERS_DIR; then handoff_dir_untrusted "$d"; else handoff_dir "$d"; fi
   fi
 
   # OCR cache (app-dedicated; default /data/ocr-cache) and the optional OCR debug-dump dir — both
-  # read raw by the server (no ~ expansion). handoff_dir confines each.
-  handoff_dir "${DFIR_OCR_CACHE:-/data/ocr-cache}"
-  if [ -n "${DFIR_OCR_DEBUG_DIR:-}" ]; then handoff_dir "$DFIR_OCR_DEBUG_DIR"; fi
+  # read raw by the server (no ~ expansion), each confined by trust-appropriate handoff.
+  if is_from_env_file DFIR_OCR_CACHE; then handoff_dir_untrusted "${DFIR_OCR_CACHE:-/data/ocr-cache}"; else handoff_dir "${DFIR_OCR_CACHE:-/data/ocr-cache}"; fi
+  if [ -n "${DFIR_OCR_DEBUG_DIR:-}" ]; then
+    if is_from_env_file DFIR_OCR_DEBUG_DIR; then handoff_dir_untrusted "$DFIR_OCR_DEBUG_DIR"; else handoff_dir "$DFIR_OCR_DEBUG_DIR"; fi
+  fi
 
   # The Settings/setup .env dir must be writable so POST /settings/env's atomic write succeeds.
+  # (DFIR_ENV_FILE cannot come from the dotenv file it locates, so it is always trusted.)
   handoff_entry "$(dirname "$env_file")"
 
   # An explicit DFIR_LOG_DIR may point at a SHARED host log directory: the logger only needs to
   # CREATE its session file there, so hand over the directory entry only — never its (possibly
   # unrelated) contents. (Unset → logs/ beside the cases root, already handed over above.)
-  if [ -n "${DFIR_LOG_DIR:-}" ]; then handoff_entry "$(abspath "$DFIR_LOG_DIR")"; fi
+  if [ -n "${DFIR_LOG_DIR:-}" ]; then
+    if is_from_env_file DFIR_LOG_DIR; then handoff_entry_untrusted "$(abspath "$DFIR_LOG_DIR")"; else handoff_entry "$(abspath "$DFIR_LOG_DIR")"; fi
+  fi
   # setpriv execs in place, so Node stays PID 1 and docker stop signals it directly. --clear-groups
   # sheds root's supplementary groups (and works for an arbitrary numeric run_uid that has no passwd
   # entry, unlike --init-groups). setpriv changes credentials but NOT HOME/USER/LOGNAME, so set HOME

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
 set -e
 
-# The browser add-on (extension) runs INSIDE your browser, not in this container. Copy the
-# pre-built, unpacked add-on (and a zip) to /out so you can load it via your browser's
-# Extensions page -> "Load unpacked" -> ./addon/dist on the host (mapped to /out here).
-if [ -d /opt/dfir-extension ]; then
-  cp -R /opt/dfir-extension/. /out/ 2>/dev/null || true
+# The browser add-on (extension) runs INSIDE your browser, not in this container. It is copied
+# to /out so you can load it via your browser's Extensions page -> "Load unpacked" ->
+# ./addon/dist on the host (mapped to /out here). The copy always runs UNPRIVILEGED — /out is
+# writable by the (potentially compromised) server, and a root cp would follow a destination
+# symlink planted there (e.g. dfir-companion-extension.zip -> /app/companion/dist/server.js)
+# into the root-owned code tree on the next boot. So: the root path below does it via setpriv
+# AFTER deciding the run user; the already-unprivileged path copies here.
+copy_addon() {
+  if [ -d /opt/dfir-extension ] && [ -d /out ]; then
+    cp -R /opt/dfir-extension/. /out/ 2>/dev/null || true
+  fi
+}
+if [ "$(id -u)" != "0" ]; then
+  copy_addon
 fi
 
 # Railway (and similar PaaS) inject PORT; map it to DFIR_PORT so our server binds there.
@@ -84,7 +93,7 @@ if [ "$(id -u)" = "0" ]; then
   deny_chown() {
     case "$1" in
       "" | /) return 0 ;;
-      # /app is the server code; /opt holds the bundled extension the root cp copies to /out —
+      # /app is the server code; /opt holds the bundled extension the entrypoint copies to /out —
       # both are code the server must never be able to rewrite. chown_tree recurses, so denying an
       # ancestor (e.g. /opt) also protects everything under it (/opt/dfir-extension).
       /app | /app/* | /opt | /opt/*) return 0 ;;
@@ -208,18 +217,26 @@ if [ "$(id -u)" = "0" ]; then
   # Only a ROOT-owned root (a fresh Docker-created mount, or the legacy root image's data) falls
   # back to `node`, where chowning is safe because there is no host-owned data to disown.
   mkdir -p "$cases_root" 2>/dev/null || true
-  owner="$(stat -c '%u:%g' "$cases_root" 2>/dev/null || printf '0:0')"
-  run_uid="${owner%:*}"
-  run_gid="${owner#*:}"
+  run_uid="$(stat -c '%u' "$cases_root" 2>/dev/null || printf '0')"
   if [ -z "$run_uid" ] || [ "$run_uid" = "0" ]; then
     run_uid="$node_uid"
-    run_gid="$node_gid"
   fi
+  # NEVER adopt the mount's GID: a numeric host GID has unrelated, possibly privileged semantics
+  # inside this image (42 is shadow, 0 is root), so a mount owned by 1001:42 would hand the
+  # evidence parser group-readable /etc/shadow. The run group is always the image's unprivileged
+  # `node` group; the mount owner still has full access through the preserved UID.
+  run_gid="$node_gid"
 
-  # /out holds the pre-built add-on the root cp above wrote; the server never writes it, but the
-  # HOST user manages ./addon, so hand it over — via chown_tree, never `chown -R`, so a symlink
-  # planted here can never redirect the chown into /app.
-  if [ -d /out ]; then chown_tree /out; fi
+  # /out holds the pre-built add-on; the server never writes it, but the HOST user manages
+  # ./addon, so hand it over — via chown_tree, never `chown -R`, so a symlink planted here can
+  # never redirect the chown into /app — and only THEN copy the add-on in, as the run user, so
+  # the copy cannot be deputized through a planted destination symlink either (an unprivileged
+  # cp that follows one just gets EACCES on the root-owned target).
+  if [ -d /out ]; then
+    chown_tree /out
+    setpriv --reuid="$run_uid" --regid="$run_gid" --clear-groups \
+      sh -c 'if [ -d /opt/dfir-extension ]; then cp -R /opt/dfir-extension/. /out/ 2>/dev/null || true; fi' || true
+  fi
 
   # Hand over the evidence/case store itself ONCE (a legacy root-written tree and large evidence
   # dirs both need the recursive walk). The parent handling below never re-walks this subtree.

--- a/public/js/dashboard-asset-graph.js
+++ b/public/js/dashboard-asset-graph.js
@@ -33,24 +33,31 @@
     // when the user switches cases fast, an older request's late response (success OR failure)
     // must not overwrite or erase the newer case's graph. Only the latest load may mutate state.
     const seq = ++assetGraphLoadSeq;
+    // A non-2xx error body must never be cached as graph data (which hasAssetGraph() and
+    // renderAssetGraph() both trust). For the LATEST load, a failure clears the graph and repaints
+    // empty, so a case switch whose graph fails cannot leave the previous case's assets on screen.
+    // ONE helper for both failure arms: the HTTP-error branch and the rejection handler must
+    // degrade identically, because a network-level failure (the companion restarting mid-case-
+    // switch) or a malformed 2xx body REJECTS — it never reaches the fulfilled arm, and a bare
+    // `.catch(() => {})` there left exactly the stale cross-case graph this token exists to prevent.
+    const failed = () => {
+      if (seq !== assetGraphLoadSeq) return; // superseded by a newer load — ignore entirely
+      assetGraphData = null;
+      renderAssetGraph();
+      renderAssetList();
+    };
     fetch(`/cases/${caseId}/asset-graph${DfirTimelineView.timeQuery()}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((g) => {
         if (seq !== assetGraphLoadSeq) return; // superseded by a newer load — ignore entirely
-        // A non-2xx error body must never be cached as graph data (which hasAssetGraph() and
-        // renderAssetGraph() both trust). For the LATEST load, a failure clears the graph and
-        // repaints empty, so a case switch whose graph fails cannot leave the previous case's
-        // assets on screen.
         if (!g || !Array.isArray(g.assets)) {
-          assetGraphData = null;
-          renderAssetGraph();
-          renderAssetList();
+          failed();
           return;
         }
         assetGraphData = g;
         renderAssetGraph();
       })
-      .catch(() => {});
+      .catch(failed);
   }
   function loadAssetOverrides(caseId) {
     fetch(`/cases/${caseId}/asset-overrides`)

--- a/public/js/dashboard-host-scope.js
+++ b/public/js/dashboard-host-scope.js
@@ -17,6 +17,7 @@
 (function () {
   let hostScopeLedger = null;
   let hostScopeLoadSeq = 0; // generation token: only the latest load may mutate the ledger
+  let hostScopeLoadCase = null; // which case the latest load belongs to (decides decision reconciliation)
   let hostScopeFilter = "all";
 
   const STATUS_LABEL = {
@@ -233,6 +234,7 @@
     // case, on the surface analysts use for scoping calls. A transient same-case failure stays
     // harmless: the panel shows the failure until the next successful reload repaints it.
     const seq = ++hostScopeLoadSeq;
+    hostScopeLoadCase = caseId;
     try {
       const r = await fetch(`/cases/${encodeURIComponent(caseId)}/host-scope`);
       if (!r.ok) {
@@ -297,6 +299,13 @@
     if (seq === hostScopeLoadSeq) {
       hostScopeLedger = ledger;
       paintHostScope();
+    } else if (hostScopeLoadCase === caseId) {
+      // A SAME-case reload superseded this response — but that reload's read may predate the
+      // append this decision just made, so dropping silently could leave a recorded decision
+      // invisible on the board. Reconcile with a fresh load: it takes the latest token, reads
+      // post-append state, and wins or loses the token race correctly. A DIFFERENT-case
+      // supersession stays dropped — reloading the old case would clobber the new one.
+      void loadHostScope(caseId);
     }
     return true;
   }

--- a/public/js/dashboard-host-scope.js
+++ b/public/js/dashboard-host-scope.js
@@ -16,6 +16,7 @@
 // published names below by bare name.
 (function () {
   let hostScopeLedger = null;
+  let hostScopeLoadSeq = 0; // generation token: only the latest load may mutate the ledger
   let hostScopeFilter = "all";
 
   const STATUS_LABEL = {
@@ -223,13 +224,50 @@
 
   async function loadHostScope(caseId) {
     if (!caseId) return;
+    // A generation token, bumped per load, guards the ledger against out-of-order responses — the
+    // same pattern as loadAssetGraph: when the analyst switches cases fast, an older request's
+    // late response (success OR failure) must not overwrite or erase the newer case's ledger.
+    // And for the LATEST load a failure must CLEAR the ledger and repaint: the per-case resets in
+    // js/dashboard-case-connect.js never touch this module's state, so a swallowed failure here
+    // kept the PREVIOUS case's clearance board on screen — "Cleared"/"Confirmed" for the wrong
+    // case, on the surface analysts use for scoping calls. A transient same-case failure stays
+    // harmless: the panel shows the failure until the next successful reload repaints it.
+    const seq = ++hostScopeLoadSeq;
     try {
       const r = await fetch(`/cases/${encodeURIComponent(caseId)}/host-scope`);
-      if (!r.ok) return;
-      hostScopeLedger = await r.json();
+      if (!r.ok) {
+        const e = await r.json().catch(() => ({}));
+        if (seq !== hostScopeLoadSeq) return; // superseded by a newer load — ignore entirely
+        hostScopeLedger = null;
+        // 501 means the store is not configured — the default "No scope data." empty state is the
+        // honest rendering, not an error. Everything else surfaces: routes/hostScope.ts
+        // deliberately 500s with the error message when the ledger file is corrupt (fail-loud),
+        // and swallowing that here silenced the design at its last hop.
+        if (r.status === 501) {
+          paintHostScope();
+          return;
+        }
+        // Null-guarded like paintHostScope: the unit-test harness stubs getElementById to null.
+        const el = document.getElementById("hostScopeBody");
+        if (el) {
+          el.innerHTML = `<p class="hs-empty">Host scope unavailable: ${esc(e.error || "HTTP " + r.status)}</p>`;
+        }
+        return;
+      }
+      const ledger = await r.json();
+      if (seq !== hostScopeLoadSeq) return; // a stale success must not overwrite the newer case
+      hostScopeLedger = ledger;
       paintHostScope();
     } catch {
-      // A panel that cannot load must not take the dashboard down with it.
+      // A panel that cannot load must not take the dashboard down with it — but the LATEST load's
+      // network failure still clears and repaints, so a case switch while the companion restarts
+      // cannot leave the previous case's clearance decisions on screen.
+      if (seq !== hostScopeLoadSeq) return; // superseded by a newer load — ignore entirely
+      hostScopeLedger = null;
+      const el = document.getElementById("hostScopeBody");
+      if (el) {
+        el.innerHTML = `<p class="hs-empty">Host scope could not be loaded.</p>`;
+      }
     }
   }
 

--- a/public/js/dashboard-host-scope.js
+++ b/public/js/dashboard-host-scope.js
@@ -272,6 +272,12 @@
   }
 
   async function decideHostScope(caseId, host, to, reason) {
+    // Capture the generation token: if a newer ledger load starts while this decision is in
+    // flight (a case switch, or a reload), the response's ledger belongs to the superseded state
+    // and must not overwrite the newer one — the same rule loadHostScope enforces. The decision
+    // itself still landed server-side, so the caller's success flow is unaffected; only the
+    // local cache and pane are protected from being repainted with the old case's board.
+    const seq = hostScopeLoadSeq;
     const r = await fetch(
       `/cases/${encodeURIComponent(caseId)}/host-scope/${encodeURIComponent(host)}`,
       {
@@ -287,8 +293,11 @@
       const e = await r.json().catch(() => ({}));
       throw new Error(e.error || "HTTP " + r.status);
     }
-    hostScopeLedger = await r.json();
-    paintHostScope();
+    const ledger = await r.json();
+    if (seq === hostScopeLoadSeq) {
+      hostScopeLedger = ledger;
+      paintHostScope();
+    }
     return true;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #603 (merged mid-stream): the **second full review cycle** over the post-fix tree. Same method — six-dimension multi-agent review with adversarial verification, fixes for every finding, then `codex review --base main` driven back to **zero findings** (pass 18), plus two stop-time review fixes.

`REVIEW.md` now documents **39 findings (24 first pass + 15 second pass), all Fixed** with their commits, and a refreshed architecture overview covering the container hardening.

## Second-pass findings fixed (15)

- **HIGH (perf):** an sshd brute-force *failure flood* defeated the pass-1 syslog streaming fix — every failed line was buffered as a full event (~231MB/1M lines measured). Failures now stream through with only a compact tuple retained; 91% peak-memory reduction, byte-identical output.
- **SSRF gate:** `iocValue.ts`'s `isPrivateIpv4` (backing enrichment's `isInternalTarget`) was missing the CGNAT 100.64/10 range the importer consolidation fixed.
- **Dashboard races:** the host-scope panel gained the asset graph's generation-token guard; the asset graph's rejection arm now routes through the same seq-guarded clear; 12 race tests added (7 fail pre-fix).
- **Compose healthcheck** probed auth-gated `/dashboard`, marking healthy team-mode containers unhealthy — now probes `/health`.
- **More dedup/tests:** one `escapeRegExp` (9 copies), one `worstSeverity` (9), one streaming-kind list (5), two leftover inverted rank tables; `readZip` bounds guards; hunt-executor per-execution predicate caches; EVTX count-loop yield; multi-line parser-position tests.

## Codex passes 16–17 (container hardening)

- **Trust-by-provenance handoffs:** dashboard-writable dotenv paths can no longer deputize root into chowning another host mount — dotenv-sourced values only receive freshly created directories outside `/data`.
- The add-on copy into `/out` now always runs **unprivileged** (a planted destination symlink gets EACCES instead of overwriting root-owned code).
- The run user keeps the cases-mount **UID but never its GID** (a host GID like 42 maps to `shadow` in-container).

## Stop-time review fixes

- `decideHostScope` writes are now token-guarded (a slow decision response can't repaint the old case's board), and a **same-case** reload superseding a decision triggers a reconciling load so a recorded clearance never silently disappears. Both pinned by deferred-fetch race tests.

## Test plan

- [x] Full companion suite: 647 files / 9,991+ tests green (codex re-ran it during its final review)
- [x] Extension suite: 221 tests green
- [x] typecheck / lint / check:imports / check:boundaries / check:size / format — all clean
- [x] `codex review --base main` — zero findings (pass 18) + stop-gate findings fixed
- [ ] Live Docker build + `compose up` smoke test (daemon unavailable in the review sandbox; entrypoint verified by `sh -n`, hash-parity checks, and behavior simulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cRPcXep9vqVxjkL53BARA
