### PR TITLE
fix(settings): reorganize AI and integration groups

### DIFF
--- a/companion/tests/settings/settingsEnvFields.test.ts
+++ b/companion/tests/settings/settingsEnvFields.test.ts
@@ -21,14 +21,44 @@ interface EnvField {
   readOnly: boolean;
 }
 
+async function dashboardHtml(): Promise<string> {
+  return readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+}
+
+function settingsPane(html: string, id: string): string {
+  const start = html.indexOf(`id="stab-${id}"`);
+  const end = html.indexOf('<div class="stab-pane"', start + 1);
+  return html.slice(start, end < 0 ? undefined : end);
+}
+
 async function envFields(): Promise<EnvField[]> {
-  const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+  const html = await dashboardHtml();
   const out: EnvField[] = [];
   for (const m of html.matchAll(FIELD_TAG)) {
     out.push({ key: m[2], readOnly: /\breadonly\b/i.test(m[0]) || /\bdisabled\b/i.test(m[0]) });
   }
   return out;
 }
+
+describe("Settings modal group placement", () => {
+  it("labels the vision model and places synthesis grouping after every model", async () => {
+    const ai = settingsPane(await dashboardHtml(), "ai");
+    const visionHeading = ai.indexOf('<div class="settings-group-head" data-essential>Vision model');
+    const visionProvider = ai.indexOf('id="env-DFIR_VISION_PROVIDER"');
+    const secondOpinion = ai.indexOf('id="env-DFIR_AI_SECOND_OPINION_BASE_URL"');
+    const synthesisGrouping = ai.indexOf("Synthesis detection-burst grouping");
+
+    expect(visionHeading).toBeGreaterThan(-1);
+    expect(visionProvider).toBeGreaterThan(visionHeading);
+    expect(synthesisGrouping).toBeGreaterThan(secondOpinion);
+  });
+
+  it("places the Presidio integration outside the AI pane", async () => {
+    const html = await dashboardHtml();
+    expect(settingsPane(html, "ai")).not.toContain('id="env-DFIR_PRESIDIO_URL"');
+    expect(settingsPane(html, "integrations")).toContain('id="env-DFIR_PRESIDIO_URL"');
+  });
+});
 
 describe("Settings modal ⇄ POST /settings/env allowlist", () => {
   it("renders every env-* field the modal reads", async () => {

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -2,7 +2,7 @@
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>DFIR Companion code map</title>
 <style>body{font:14px system-ui;margin:24px;background:#10151d;color:#e7edf5}input{width:100%;padding:10px;box-sizing:border-box;background:#18212d;color:inherit;border:1px solid #44536a;border-radius:6px}table{width:100%;border-collapse:collapse;margin-top:16px}th,td{padding:8px;border-bottom:1px solid #2b3544;text-align:left;vertical-align:top}code{color:#a8d8ff}.muted{color:#99a6b7}</style></head>
-<body><h1>DFIR Companion code map</h1><p class="muted">792 modules · 476 routes. Search a path, route, dependency, or test.</p><input id="q" type="search" placeholder="Search code map…"><table><thead><tr><th>Module</th><th>Calls / imports</th><th>Affects / imported by</th><th>Tests</th></tr></thead><tbody id="rows"></tbody></table>
+<body><h1>DFIR Companion code map</h1><p class="muted">800 modules · 476 routes. Search a path, route, dependency, or test.</p><input id="q" type="search" placeholder="Search code map…"><table><thead><tr><th>Module</th><th>Calls / imports</th><th>Affects / imported by</th><th>Tests</th></tr></thead><tbody id="rows"></tbody></table>
 <script type="application/json" id="data">{
   "schemaVersion": 1,
   "roots": [
@@ -11,7 +11,7 @@
     "extension/src",
     "public/dashboard.html"
   ],
-  "moduleCount": 792,
+  "moduleCount": 800,
   "routeCount": 476,
   "modules": [
     {
@@ -1114,10 +1114,11 @@
     {
       "path": "companion/src/analysis/anonymize.ts",
       "kind": "module",
-      "lines": 850,
+      "lines": 848,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/iocValue.ts",
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -1216,6 +1217,7 @@
       "lines": 306,
       "imports": [
         "companion/src/analysis/hostAlias.ts",
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -1252,7 +1254,7 @@
     {
       "path": "companion/src/analysis/assetOverrides.ts",
       "kind": "module",
-      "lines": 300,
+      "lines": 296,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/stateTypes.ts",
@@ -1342,7 +1344,7 @@
     {
       "path": "companion/src/analysis/auditdImport.ts",
       "kind": "module",
-      "lines": 602,
+      "lines": 601,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/siemImport.ts",
@@ -1418,9 +1420,20 @@
       ]
     },
     {
+      "path": "companion/src/analysis/bsdTime.ts",
+      "kind": "module",
+      "lines": 33,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/siemImport.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/analysis/burstDetect.ts",
       "kind": "module",
-      "lines": 150,
+      "lines": 145,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/mitreTactics.ts",
@@ -1640,6 +1653,21 @@
       ]
     },
     {
+      "path": "companion/src/analysis/chainSignature.ts",
+      "kind": "module",
+      "lines": 72,
+      "imports": [
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/correlate.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/chainSignature.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/chainsawImport.ts",
       "kind": "module",
       "lines": 374,
@@ -1658,24 +1686,9 @@
       ]
     },
     {
-      "path": "companion/src/analysis/chainSignature.ts",
-      "kind": "module",
-      "lines": 72,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/correlate.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/chainSignature.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/ciscoAsaImport.ts",
       "kind": "module",
-      "lines": 234,
+      "lines": 198,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -1843,6 +1856,23 @@
       ]
     },
     {
+      "path": "companion/src/analysis/collectSatisfaction.ts",
+      "kind": "module",
+      "lines": 135,
+      "imports": [
+        "companion/src/analysis/collectDirective.ts",
+        "companion/src/analysis/iocAnchors.ts",
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/synthesisPromptBlocks.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/collectSatisfaction.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/collectionPlan.ts",
       "kind": "module",
       "lines": 186,
@@ -1882,26 +1912,9 @@
       ]
     },
     {
-      "path": "companion/src/analysis/collectSatisfaction.ts",
-      "kind": "module",
-      "lines": 135,
-      "imports": [
-        "companion/src/analysis/collectDirective.ts",
-        "companion/src/analysis/iocAnchors.ts",
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/synthesisPromptBlocks.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/collectSatisfaction.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/combinedLogImport.ts",
       "kind": "module",
-      "lines": 252,
+      "lines": 238,
       "imports": [
         "companion/src/analysis/secretSpillRules.ts",
         "companion/src/analysis/siemImport.ts",
@@ -2033,7 +2046,7 @@
     {
       "path": "companion/src/analysis/correlate.ts",
       "kind": "module",
-      "lines": 465,
+      "lines": 459,
       "imports": [
         "companion/src/analysis/chainSignature.ts",
         "companion/src/analysis/sourceTrust.ts",
@@ -2121,7 +2134,7 @@
     {
       "path": "companion/src/analysis/custody.ts",
       "kind": "module",
-      "lines": 409,
+      "lines": 415,
       "imports": [
         "companion/src/analysis/stateLock.ts",
         "companion/src/auth/identityContext.ts",
@@ -2310,24 +2323,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/dashboardViews.ts",
-      "kind": "module",
-      "lines": 416,
-      "imports": [
-        "companion/src/reports/reportTemplate.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/dashboardViewStore.ts",
-        "companion/src/integrations/misp/mispPush.ts",
-        "companion/src/routes/templatesViews.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/dashboardViewStore.test.ts",
-        "companion/tests/analysis/dashboardViews.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/dashboardViewStore.ts",
       "kind": "module",
       "lines": 124,
@@ -2345,6 +2340,24 @@
         "companion/tests/analysis/dashboardViewStore.test.ts",
         "companion/tests/server/storeIdTraversalRoutes.test.ts",
         "companion/tests/storage/storeIdTraversal.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/dashboardViews.ts",
+      "kind": "module",
+      "lines": 416,
+      "imports": [
+        "companion/src/reports/reportTemplate.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/dashboardViewStore.ts",
+        "companion/src/integrations/misp/mispPush.ts",
+        "companion/src/routes/templatesViews.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/dashboardViewStore.test.ts",
+        "companion/tests/analysis/dashboardViews.test.ts"
       ]
     },
     {
@@ -2372,7 +2385,7 @@
     {
       "path": "companion/src/analysis/deepPass.ts",
       "kind": "module",
-      "lines": 261,
+      "lines": 262,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/promptBudget.ts",
@@ -2555,7 +2568,7 @@
     {
       "path": "companion/src/analysis/ecarImport.ts",
       "kind": "module",
-      "lines": 528,
+      "lines": 514,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/reconTechniques.ts",
@@ -2577,7 +2590,7 @@
     {
       "path": "companion/src/analysis/emailImport.ts",
       "kind": "module",
-      "lines": 688,
+      "lines": 676,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/siemImport.ts",
@@ -2609,7 +2622,7 @@
     {
       "path": "companion/src/analysis/evidenceGraph.ts",
       "kind": "module",
-      "lines": 860,
+      "lines": 855,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/canonicalEvent.ts",
@@ -2637,7 +2650,7 @@
     {
       "path": "companion/src/analysis/evtxXmlImport.ts",
       "kind": "module",
-      "lines": 194,
+      "lines": 228,
       "imports": [
         "companion/src/analysis/siemBuildProgress.ts",
         "companion/src/analysis/siemImport.ts"
@@ -2654,7 +2667,7 @@
     {
       "path": "companion/src/analysis/exfilCorrelate.ts",
       "kind": "module",
-      "lines": 67,
+      "lines": 62,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -2745,7 +2758,7 @@
     {
       "path": "companion/src/analysis/findingGrounding.ts",
       "kind": "module",
-      "lines": 458,
+      "lines": 467,
       "imports": [
         "companion/src/analysis/forensicGate.ts",
         "companion/src/analysis/hostAlias.ts",
@@ -2786,6 +2799,27 @@
       ]
     },
     {
+      "path": "companion/src/analysis/findingWorkflow.ts",
+      "kind": "module",
+      "lines": 114,
+      "imports": [
+        "companion/src/storage/atomicWrite.ts",
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/cockpit.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/routes/findings.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/findingWorkflow.test.ts",
+        "companion/tests/server/cockpitRoutes.test.ts",
+        "companion/tests/server/findingWorkflow.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/findingsDiff.ts",
       "kind": "module",
       "lines": 57,
@@ -2805,27 +2839,6 @@
         "companion/tests/analysis/findingsDiff.test.ts",
         "companion/tests/analysis/notifications.test.ts",
         "companion/tests/analysis/synthMeta.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/findingWorkflow.ts",
-      "kind": "module",
-      "lines": 114,
-      "imports": [
-        "companion/src/storage/atomicWrite.ts",
-        "companion/src/storage/caseStore.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/cockpit.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/routes/findings.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/findingWorkflow.test.ts",
-        "companion/tests/server/cockpitRoutes.test.ts",
-        "companion/tests/server/findingWorkflow.test.ts"
       ]
     },
     {
@@ -2903,8 +2916,9 @@
     {
       "path": "companion/src/analysis/fpCascade.ts",
       "kind": "module",
-      "lines": 135,
+      "lines": 136,
       "imports": [
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -2938,7 +2952,7 @@
     {
       "path": "companion/src/analysis/gapDetect.ts",
       "kind": "module",
-      "lines": 455,
+      "lines": 460,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -2982,10 +2996,11 @@
     {
       "path": "companion/src/analysis/geoMap.ts",
       "kind": "module",
-      "lines": 338,
+      "lines": 339,
       "imports": [
         "companion/src/analysis/anonymize.ts",
         "companion/src/analysis/countryCentroids.ts",
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -3019,7 +3034,7 @@
     {
       "path": "companion/src/analysis/graphContext.ts",
       "kind": "module",
-      "lines": 82,
+      "lines": 80,
       "imports": [
         "companion/src/analysis/evidenceGraph.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -3242,7 +3257,6 @@
       "lines": 142,
       "imports": [
         "companion/src/analysis/hostAlias.ts",
-        "companion/src/analysis/severityFloor.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -3265,7 +3279,7 @@
         "companion/src/analysis/collectionPlan.ts",
         "companion/src/analysis/hostScopeAggregate.ts",
         "companion/src/analysis/mitreTactics.ts",
-        "companion/src/analysis/severityFloor.ts"
+        "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
         "companion/src/analysis/hostScope.ts"
@@ -3330,28 +3344,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/huntOutcomes.ts",
-      "kind": "module",
-      "lines": 329,
-      "imports": [
-        "companion/src/analysis/huntRunDiff.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/hunts.ts",
-        "companion/src/analysis/ai/synthesisInputs.ts",
-        "companion/src/analysis/huntOutcomeStore.ts",
-        "companion/src/composition/veloHunts.ts",
-        "companion/src/routes/context.ts",
-        "companion/src/routes/playbookHunts.ts",
-        "companion/src/routes/velociraptor.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/huntOutcomes.test.ts",
-        "companion/tests/server/huntOutcomes.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/huntOutcomeStore.ts",
       "kind": "module",
       "lines": 41,
@@ -3371,6 +3363,28 @@
       "tests": [
         "companion/tests/analysis/synthesizeCharacterisation.test.ts",
         "companion/tests/server/collectDirective.test.ts",
+        "companion/tests/server/huntOutcomes.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/huntOutcomes.ts",
+      "kind": "module",
+      "lines": 329,
+      "imports": [
+        "companion/src/analysis/huntRunDiff.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/hunts.ts",
+        "companion/src/analysis/ai/synthesisInputs.ts",
+        "companion/src/analysis/huntOutcomeStore.ts",
+        "companion/src/composition/veloHunts.ts",
+        "companion/src/routes/context.ts",
+        "companion/src/routes/playbookHunts.ts",
+        "companion/src/routes/velociraptor.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/huntOutcomes.test.ts",
         "companion/tests/server/huntOutcomes.test.ts"
       ]
     },
@@ -3425,7 +3439,7 @@
     {
       "path": "companion/src/analysis/huntQueryExecutor.ts",
       "kind": "module",
-      "lines": 644,
+      "lines": 670,
       "imports": [
         "companion/src/analysis/huntQueryAggregation.ts",
         "companion/src/analysis/huntQueryCursor.ts",
@@ -3462,10 +3476,11 @@
     {
       "path": "companion/src/analysis/huntQueryParser.ts",
       "kind": "module",
-      "lines": 661,
+      "lines": 691,
       "imports": [
         "companion/src/analysis/huntQueryFields.ts",
-        "companion/src/analysis/huntQueryTypes.ts"
+        "companion/src/analysis/huntQueryTypes.ts",
+        "companion/src/analysis/regexSafety.ts"
       ],
       "importedBy": [
         "companion/src/routes/huntWorkbench.ts"
@@ -3543,7 +3558,7 @@
     {
       "path": "companion/src/analysis/huntSuggest.ts",
       "kind": "module",
-      "lines": 146,
+      "lines": 136,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -3699,56 +3714,6 @@
       "tests": []
     },
     {
-      "path": "companion/src/analysis/importerSpec.ts",
-      "kind": "module",
-      "lines": 215,
-      "imports": [
-        "companion/src/analysis/regexSafety.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/prompts/extraction.ts",
-        "companion/src/analysis/declarativeImporter.ts",
-        "companion/src/analysis/importerStore.ts",
-        "companion/src/routes/caseLifecycle.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/declarativeImporter.test.ts",
-        "companion/tests/analysis/importDetect.test.ts",
-        "companion/tests/analysis/importerSpec.test.ts",
-        "companion/tests/analysis/importerStore.test.ts",
-        "companion/tests/analysis/prompts.test.ts",
-        "companion/tests/server/analysisRunImport.test.ts",
-        "companion/tests/server/importerRoutes.test.ts",
-        "companion/tests/server/superTimeline.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/importerStore.ts",
-      "kind": "module",
-      "lines": 110,
-      "imports": [
-        "companion/src/analysis/declarativeImporter.ts",
-        "companion/src/analysis/importerSpec.ts",
-        "companion/src/analysis/redactPaths.ts",
-        "companion/src/storage/atomicWrite.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/diagnostics.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/importIngest.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/routes/context.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/importerStore.test.ts",
-        "companion/tests/server/analysisRunImport.test.ts",
-        "companion/tests/server/importerRoutes.test.ts",
-        "companion/tests/server/superTimeline.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/importLock.ts",
       "kind": "module",
       "lines": 47,
@@ -3853,6 +3818,82 @@
       ]
     },
     {
+      "path": "companion/src/analysis/importerSpec.ts",
+      "kind": "module",
+      "lines": 215,
+      "imports": [
+        "companion/src/analysis/regexSafety.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/prompts/extraction.ts",
+        "companion/src/analysis/declarativeImporter.ts",
+        "companion/src/analysis/importerStore.ts",
+        "companion/src/routes/caseLifecycle.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/declarativeImporter.test.ts",
+        "companion/tests/analysis/importDetect.test.ts",
+        "companion/tests/analysis/importerSpec.test.ts",
+        "companion/tests/analysis/importerStore.test.ts",
+        "companion/tests/analysis/prompts.test.ts",
+        "companion/tests/server/analysisRunImport.test.ts",
+        "companion/tests/server/importerRoutes.test.ts",
+        "companion/tests/server/superTimeline.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/importerStore.ts",
+      "kind": "module",
+      "lines": 110,
+      "imports": [
+        "companion/src/analysis/declarativeImporter.ts",
+        "companion/src/analysis/importerSpec.ts",
+        "companion/src/analysis/redactPaths.ts",
+        "companion/src/storage/atomicWrite.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/diagnostics.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/importIngest.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/routes/context.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/importerStore.test.ts",
+        "companion/tests/server/analysisRunImport.test.ts",
+        "companion/tests/server/importerRoutes.test.ts",
+        "companion/tests/server/superTimeline.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/incidentTypeStore.ts",
+      "kind": "module",
+      "lines": 107,
+      "imports": [
+        "companion/src/analysis/incidentTypes.ts",
+        "companion/src/analysis/incidentTypesData.ts",
+        "companion/src/storage/atomicWrite.ts",
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/pipelineOptions.ts",
+        "companion/src/analysis/ai/synthesisInputs.ts",
+        "companion/src/composition/aiProviders.ts",
+        "companion/src/composition/aiRuntime.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/runtimeStores.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/incidentTypeSynthesis.test.ts",
+        "companion/tests/analysis/synthesizeCharacterisation.test.ts",
+        "companion/tests/server/collectionPlanRoutes.test.ts",
+        "companion/tests/server/incidentTypeRoutes.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/incidentTypes.ts",
       "kind": "module",
       "lines": 190,
@@ -3888,32 +3929,6 @@
       "tests": [
         "companion/tests/analysis/incidentTypePlans.test.ts",
         "companion/tests/analysis/incidentTypes.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/incidentTypeStore.ts",
-      "kind": "module",
-      "lines": 107,
-      "imports": [
-        "companion/src/analysis/incidentTypes.ts",
-        "companion/src/analysis/incidentTypesData.ts",
-        "companion/src/storage/atomicWrite.ts",
-        "companion/src/storage/caseStore.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/pipelineOptions.ts",
-        "companion/src/analysis/ai/synthesisInputs.ts",
-        "companion/src/composition/aiProviders.ts",
-        "companion/src/composition/aiRuntime.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/runtimeStores.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/incidentTypeSynthesis.test.ts",
-        "companion/tests/analysis/synthesizeCharacterisation.test.ts",
-        "companion/tests/server/collectionPlanRoutes.test.ts",
-        "companion/tests/server/incidentTypeRoutes.test.ts"
       ]
     },
     {
@@ -4033,7 +4048,7 @@
     {
       "path": "companion/src/analysis/ingest/logImports.ts",
       "kind": "module",
-      "lines": 432,
+      "lines": 436,
       "imports": [
         "companion/src/analysis/auditdImport.ts",
         "companion/src/analysis/bashHistoryImport.ts",
@@ -4127,8 +4142,9 @@
     {
       "path": "companion/src/analysis/initialAccess.ts",
       "kind": "module",
-      "lines": 80,
+      "lines": 76,
       "imports": [
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -4155,6 +4171,19 @@
       ]
     },
     {
+      "path": "companion/src/analysis/internalIp.ts",
+      "kind": "module",
+      "lines": 20,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/siemImport.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/internalIp.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/investigationStateFiles.ts",
       "kind": "module",
       "lines": 34,
@@ -4170,7 +4199,7 @@
     {
       "path": "companion/src/analysis/iocAlias.ts",
       "kind": "module",
-      "lines": 70,
+      "lines": 65,
       "imports": [
         "companion/src/storage/atomicWrite.ts",
         "companion/src/storage/caseStore.ts"
@@ -4253,6 +4282,7 @@
       "kind": "module",
       "lines": 109,
       "imports": [
+        "companion/src/analysis/regexSafety.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -4356,31 +4386,9 @@
       ]
     },
     {
-      "path": "companion/src/analysis/iocsDiff.ts",
-      "kind": "module",
-      "lines": 44,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/importMeta.ts",
-        "companion/src/composition/importIngest.ts",
-        "companion/src/composition/veloExternalIngest.ts",
-        "companion/src/composition/veloHunts.ts",
-        "companion/src/routes/import.ts",
-        "companion/src/routes/importRecovery.ts",
-        "companion/src/routes/reportVersions.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/importMeta.test.ts",
-        "companion/tests/analysis/iocsDiff.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/iocValue.ts",
       "kind": "module",
-      "lines": 263,
+      "lines": 267,
       "imports": [],
       "importedBy": [
         "companion/src/analysis/anonymize.ts",
@@ -4398,9 +4406,10 @@
     {
       "path": "companion/src/analysis/iocWhitelist.ts",
       "kind": "module",
-      "lines": 200,
+      "lines": 203,
       "imports": [
         "companion/src/analysis/csvImport.ts",
+        "companion/src/analysis/regexSafety.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -4432,6 +4441,28 @@
         "companion/tests/server.test.ts",
         "companion/tests/server/iocRisk.test.ts",
         "companion/tests/server/iocWhitelistRoutes.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/iocsDiff.ts",
+      "kind": "module",
+      "lines": 44,
+      "imports": [
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/importMeta.ts",
+        "companion/src/composition/importIngest.ts",
+        "companion/src/composition/veloExternalIngest.ts",
+        "companion/src/composition/veloHunts.ts",
+        "companion/src/routes/import.ts",
+        "companion/src/routes/importRecovery.ts",
+        "companion/src/routes/reportVersions.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/importMeta.test.ts",
+        "companion/tests/analysis/iocsDiff.test.ts"
       ]
     },
     {
@@ -4715,24 +4746,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/learnedPatterns.ts",
-      "kind": "module",
-      "lines": 155,
-      "imports": [
-        "companion/src/analysis/falsePositive.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/synthesisPromptBlocks.ts",
-        "companion/src/analysis/learnedPatternStore.ts",
-        "companion/src/routes/findings.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/learnedPatterns.test.ts",
-        "companion/tests/server/learnedPatterns.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/learnedPatternStore.ts",
       "kind": "module",
       "lines": 44,
@@ -4750,6 +4763,24 @@
       ],
       "routes": [],
       "tests": [
+        "companion/tests/server/learnedPatterns.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/learnedPatterns.ts",
+      "kind": "module",
+      "lines": 155,
+      "imports": [
+        "companion/src/analysis/falsePositive.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/synthesisPromptBlocks.ts",
+        "companion/src/analysis/learnedPatternStore.ts",
+        "companion/src/routes/findings.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/learnedPatterns.test.ts",
         "companion/tests/server/learnedPatterns.test.ts"
       ]
     },
@@ -4804,8 +4835,10 @@
     {
       "path": "companion/src/analysis/lookalikeDomains.ts",
       "kind": "module",
-      "lines": 351,
-      "imports": [],
+      "lines": 350,
+      "imports": [
+        "companion/src/analysis/regexEscape.ts"
+      ],
       "importedBy": [
         "companion/src/enrichment/lookalikeDomain.ts"
       ],
@@ -4894,7 +4927,7 @@
     {
       "path": "companion/src/analysis/memoryNextStep.ts",
       "kind": "module",
-      "lines": 147,
+      "lines": 143,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -4954,7 +4987,6 @@
       "kind": "module",
       "lines": 239,
       "imports": [
-        "companion/src/analysis/severityFloor.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -5013,6 +5045,27 @@
       ]
     },
     {
+      "path": "companion/src/analysis/notificationStore.ts",
+      "kind": "module",
+      "lines": 144,
+      "imports": [
+        "companion/src/analysis/notifications.ts",
+        "companion/src/storage/atomicWrite.ts"
+      ],
+      "importedBy": [
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/integrations/notify/notifyDispatch.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/notifications.test.ts",
+        "companion/tests/integrations/notify.test.ts",
+        "companion/tests/server.test.ts",
+        "companion/tests/server/notificationRoutes.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/notifications.ts",
       "kind": "module",
       "lines": 531,
@@ -5047,27 +5100,6 @@
       "tests": [
         "companion/tests/analysis/notifications.test.ts",
         "companion/tests/integrations/notify.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/notificationStore.ts",
-      "kind": "module",
-      "lines": 144,
-      "imports": [
-        "companion/src/analysis/notifications.ts",
-        "companion/src/storage/atomicWrite.ts"
-      ],
-      "importedBy": [
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/integrations/notify/notifyDispatch.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/notifications.test.ts",
-        "companion/tests/integrations/notify.test.ts",
-        "companion/tests/server.test.ts",
-        "companion/tests/server/notificationRoutes.test.ts"
       ]
     },
     {
@@ -5131,7 +5163,7 @@
     {
       "path": "companion/src/analysis/ocrRedact.ts",
       "kind": "module",
-      "lines": 139,
+      "lines": 173,
       "imports": [
         "companion/src/analysis/anonymize.ts"
       ],
@@ -5531,7 +5563,7 @@
     {
       "path": "companion/src/analysis/playbookHunt.ts",
       "kind": "module",
-      "lines": 384,
+      "lines": 374,
       "imports": [
         "companion/src/analysis/playbook.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -5640,7 +5672,6 @@
       "kind": "module",
       "lines": 310,
       "imports": [
-        "companion/src/analysis/severityFloor.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -5876,6 +5907,24 @@
       ]
     },
     {
+      "path": "companion/src/analysis/redactPaths.ts",
+      "kind": "module",
+      "lines": 108,
+      "imports": [
+        "companion/src/analysis/regexEscape.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/importerStore.ts",
+        "companion/src/composition/diagnosticsRings.ts",
+        "companion/src/composition/httpStack.ts",
+        "companion/src/routes/slashCommand.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/redactPaths.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/redactedExport.ts",
       "kind": "module",
       "lines": 344,
@@ -5898,29 +5947,36 @@
       ]
     },
     {
-      "path": "companion/src/analysis/redactPaths.ts",
+      "path": "companion/src/analysis/regexEscape.ts",
       "kind": "module",
-      "lines": 111,
+      "lines": 14,
       "imports": [],
       "importedBy": [
-        "companion/src/analysis/importerStore.ts",
-        "companion/src/composition/diagnosticsRings.ts",
-        "companion/src/composition/httpStack.ts",
-        "companion/src/routes/slashCommand.ts"
+        "companion/src/analysis/anonymize.ts",
+        "companion/src/analysis/assetGraph.ts",
+        "companion/src/analysis/fpCascade.ts",
+        "companion/src/analysis/geoMap.ts",
+        "companion/src/analysis/initialAccess.ts",
+        "companion/src/analysis/lookalikeDomains.ts",
+        "companion/src/analysis/redactPaths.ts",
+        "companion/src/analysis/veloMessageFields.ts",
+        "companion/src/reports/glossary.ts"
       ],
       "routes": [],
-      "tests": [
-        "companion/tests/analysis/redactPaths.test.ts"
-      ]
+      "tests": []
     },
     {
       "path": "companion/src/analysis/regexSafety.ts",
       "kind": "module",
-      "lines": 423,
+      "lines": 464,
       "imports": [],
       "importedBy": [
         "companion/src/analysis/declarativeImporter.ts",
-        "companion/src/analysis/importerSpec.ts"
+        "companion/src/analysis/huntQueryParser.ts",
+        "companion/src/analysis/importerSpec.ts",
+        "companion/src/analysis/iocExclude.ts",
+        "companion/src/analysis/iocWhitelist.ts",
+        "companion/src/analysis/taggerRules.ts"
       ],
       "routes": [],
       "tests": [
@@ -6246,7 +6302,7 @@
     {
       "path": "companion/src/analysis/sessionSegmentation.ts",
       "kind": "module",
-      "lines": 275,
+      "lines": 273,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/loginGraph.ts",
@@ -6267,7 +6323,7 @@
     {
       "path": "companion/src/analysis/severityFloor.ts",
       "kind": "module",
-      "lines": 67,
+      "lines": 64,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -6275,16 +6331,12 @@
         "companion/src/analysis/ai/deepPassRun.ts",
         "companion/src/analysis/ai/extraction.ts",
         "companion/src/analysis/deepPass.ts",
-        "companion/src/analysis/hostScopeAggregate.ts",
-        "companion/src/analysis/hostScopeEligibility.ts",
         "companion/src/analysis/ingest/cloudImports.ts",
         "companion/src/analysis/ingest/endpointImports.ts",
         "companion/src/analysis/ingest/importState.ts",
         "companion/src/analysis/ingest/logImports.ts",
         "companion/src/analysis/ingest/networkImports.ts",
         "companion/src/analysis/ingest/platformImports.ts",
-        "companion/src/analysis/mobileSummary.ts",
-        "companion/src/analysis/presentation.ts",
         "companion/src/composition/veloExternalIngest.ts",
         "companion/src/composition/veloHunts.ts",
         "companion/src/routes/aiSynthesis.ts",
@@ -6328,7 +6380,8 @@
         "companion/src/analysis/siemImport.ts"
       ],
       "importedBy": [
-        "companion/src/analysis/evtxXmlImport.ts"
+        "companion/src/analysis/evtxXmlImport.ts",
+        "companion/src/analysis/syslogImport.ts"
       ],
       "routes": [],
       "tests": []
@@ -6336,9 +6389,11 @@
     {
       "path": "companion/src/analysis/siemImport.ts",
       "kind": "module",
-      "lines": 1778,
+      "lines": 1762,
       "imports": [
+        "companion/src/analysis/bsdTime.ts",
         "companion/src/analysis/canonicalEvent.ts",
+        "companion/src/analysis/internalIp.ts",
         "companion/src/analysis/reconTechniques.ts",
         "companion/src/analysis/secretSpillRules.ts",
         "companion/src/analysis/stateTypes.ts",
@@ -6481,7 +6536,7 @@
     {
       "path": "companion/src/analysis/snortImport.ts",
       "kind": "module",
-      "lines": 168,
+      "lines": 157,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -6499,7 +6554,7 @@
     {
       "path": "companion/src/analysis/socratesImport.ts",
       "kind": "module",
-      "lines": 344,
+      "lines": 343,
       "imports": [
         "companion/src/analysis/networkImport.ts",
         "companion/src/analysis/siemImport.ts",
@@ -6845,7 +6900,7 @@
     {
       "path": "companion/src/analysis/stateTypes.ts",
       "kind": "module",
-      "lines": 360,
+      "lines": 371,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/iocExclude.ts"
@@ -6934,6 +6989,7 @@
         "companion/src/analysis/hostDuplicateGate.ts",
         "companion/src/analysis/hostRanking.ts",
         "companion/src/analysis/hostScopeAggregate.ts",
+        "companion/src/analysis/hostScopeEligibility.ts",
         "companion/src/analysis/hostScopeLoad.ts",
         "companion/src/analysis/huntQueryAggregation.ts",
         "companion/src/analysis/huntQueryExecutor.ts",
@@ -7524,7 +7580,7 @@
     {
       "path": "companion/src/analysis/synthSelect.ts",
       "kind": "module",
-      "lines": 449,
+      "lines": 450,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/burstDetect.ts",
@@ -7593,9 +7649,10 @@
     {
       "path": "companion/src/analysis/syslogImport.ts",
       "kind": "module",
-      "lines": 295,
+      "lines": 355,
       "imports": [
         "companion/src/analysis/secretSpillRules.ts",
+        "companion/src/analysis/siemBuildProgress.ts",
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/sshBruteForce.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -7654,27 +7711,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/taggerRules.ts",
-      "kind": "module",
-      "lines": 256,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/nextSteps.ts",
-        "companion/src/analysis/tagger.ts",
-        "companion/src/analysis/taggerRuleSuggest.ts",
-        "companion/src/analysis/taggerRun.ts",
-        "companion/src/analysis/taggerStore.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/tagger.test.ts",
-        "companion/tests/analysis/taggerRuleSuggest.test.ts",
-        "companion/tests/analysis/taggerRules.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/taggerRuleSuggest.ts",
       "kind": "module",
       "lines": 75,
@@ -7689,6 +7725,28 @@
       "tests": [
         "companion/tests/analysis/taggerRuleSuggest.test.ts",
         "companion/tests/server/taggerRoutes.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/taggerRules.ts",
+      "kind": "module",
+      "lines": 260,
+      "imports": [
+        "companion/src/analysis/regexSafety.ts",
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/nextSteps.ts",
+        "companion/src/analysis/tagger.ts",
+        "companion/src/analysis/taggerRuleSuggest.ts",
+        "companion/src/analysis/taggerRun.ts",
+        "companion/src/analysis/taggerStore.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/tagger.test.ts",
+        "companion/tests/analysis/taggerRuleSuggest.test.ts",
+        "companion/tests/analysis/taggerRules.test.ts"
       ]
     },
     {
@@ -7818,7 +7876,7 @@
     {
       "path": "companion/src/analysis/thorImport.ts",
       "kind": "module",
-      "lines": 281,
+      "lines": 279,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -7850,9 +7908,41 @@
       ]
     },
     {
+      "path": "companion/src/analysis/timeUtc.ts",
+      "kind": "module",
+      "lines": 31,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/manualEntry.ts",
+        "companion/src/analysis/siemImport.ts",
+        "companion/src/analysis/stateMerge.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/timeUtc.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/timeYearClamp.ts",
+      "kind": "module",
+      "lines": 124,
+      "imports": [
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ingest/logImports.ts",
+        "companion/src/analysis/ingest/networkImports.ts",
+        "companion/src/analysis/stateMerge.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/timeYearClamp.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/timelineAnomalies.ts",
       "kind": "module",
-      "lines": 226,
+      "lines": 225,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -7900,38 +7990,6 @@
       "routes": [],
       "tests": [
         "companion/tests/analysis/timestompDetect.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/timeUtc.ts",
-      "kind": "module",
-      "lines": 31,
-      "imports": [],
-      "importedBy": [
-        "companion/src/analysis/manualEntry.ts",
-        "companion/src/analysis/siemImport.ts",
-        "companion/src/analysis/stateMerge.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/timeUtc.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/timeYearClamp.ts",
-      "kind": "module",
-      "lines": 124,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ingest/logImports.ts",
-        "companion/src/analysis/ingest/networkImports.ts",
-        "companion/src/analysis/stateMerge.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/timeYearClamp.test.ts"
       ]
     },
     {
@@ -8039,99 +8097,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/velociraptorClientStore.ts",
-      "kind": "module",
-      "lines": 45,
-      "imports": [
-        "companion/src/integrations/velociraptor/velociraptorApi.ts",
-        "companion/src/storage/atomicWrite.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/aiContext.ts",
-        "companion/src/analysis/ai/analystQueries.ts",
-        "companion/src/analysis/ai/caseReports.ts",
-        "companion/src/analysis/ai/hunts.ts",
-        "companion/src/analysis/ai/pipelineOptions.ts",
-        "companion/src/analysis/ai/synthesis.ts",
-        "companion/src/analysis/hostScopeLoad.ts",
-        "companion/src/composition/aiRuntime.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/maintenanceTasks.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/reports/reportWriter.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/velociraptorClientStore.test.ts",
-        "companion/tests/server/playbookHunts.test.ts",
-        "companion/tests/server/veloReconnect.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/velociraptorDownload.ts",
-      "kind": "module",
-      "lines": 68,
-      "imports": [
-        "companion/src/analysis/updateCheck.ts",
-        "companion/src/analysis/velociraptorRelease.ts"
-      ],
-      "importedBy": [
-        "companion/src/routes/velociraptorSettings.ts"
-      ],
-      "routes": [],
-      "tests": []
-    },
-    {
-      "path": "companion/src/analysis/velociraptorImport.ts",
-      "kind": "module",
-      "lines": 1869,
-      "imports": [
-        "companion/src/analysis/chainsawImport.ts",
-        "companion/src/analysis/csvImport.ts",
-        "companion/src/analysis/scriptBlockFragments.ts",
-        "companion/src/analysis/siemImport.ts",
-        "companion/src/analysis/stateTypes.ts",
-        "companion/src/analysis/thorRowMap.ts",
-        "companion/src/analysis/timestompDetect.ts",
-        "companion/src/analysis/veloRowNormalize.ts",
-        "companion/src/analysis/velociraptorTitle.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ingest/endpointImports.ts",
-        "companion/src/composition/veloExternalIngest.ts",
-        "companion/src/composition/veloHunts.ts",
-        "companion/src/routes/import.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/velociraptorImport.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/velociraptorRelease.ts",
-      "kind": "module",
-      "lines": 55,
-      "imports": [],
-      "importedBy": [
-        "companion/src/analysis/velociraptorDownload.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/velociraptorRelease.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/velociraptorTitle.ts",
-      "kind": "module",
-      "lines": 46,
-      "imports": [],
-      "importedBy": [
-        "companion/src/analysis/velociraptorImport.ts"
-      ],
-      "routes": [],
-      "tests": []
-    },
-    {
       "path": "companion/src/analysis/veloHuntStore.ts",
       "kind": "module",
       "lines": 165,
@@ -8161,6 +8126,19 @@
         "companion/tests/server/veloCollectImportSlot.test.ts",
         "companion/tests/server/veloTimeScope.test.ts"
       ]
+    },
+    {
+      "path": "companion/src/analysis/veloMessageFields.ts",
+      "kind": "module",
+      "lines": 62,
+      "imports": [
+        "companion/src/analysis/regexEscape.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/velociraptorImport.ts"
+      ],
+      "routes": [],
+      "tests": []
     },
     {
       "path": "companion/src/analysis/veloMonitorStore.ts",
@@ -8231,6 +8209,100 @@
       ]
     },
     {
+      "path": "companion/src/analysis/velociraptorClientStore.ts",
+      "kind": "module",
+      "lines": 45,
+      "imports": [
+        "companion/src/integrations/velociraptor/velociraptorApi.ts",
+        "companion/src/storage/atomicWrite.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/aiContext.ts",
+        "companion/src/analysis/ai/analystQueries.ts",
+        "companion/src/analysis/ai/caseReports.ts",
+        "companion/src/analysis/ai/hunts.ts",
+        "companion/src/analysis/ai/pipelineOptions.ts",
+        "companion/src/analysis/ai/synthesis.ts",
+        "companion/src/analysis/hostScopeLoad.ts",
+        "companion/src/composition/aiRuntime.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/maintenanceTasks.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/reports/reportWriter.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/velociraptorClientStore.test.ts",
+        "companion/tests/server/playbookHunts.test.ts",
+        "companion/tests/server/veloReconnect.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/velociraptorDownload.ts",
+      "kind": "module",
+      "lines": 68,
+      "imports": [
+        "companion/src/analysis/updateCheck.ts",
+        "companion/src/analysis/velociraptorRelease.ts"
+      ],
+      "importedBy": [
+        "companion/src/routes/velociraptorSettings.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
+      "path": "companion/src/analysis/velociraptorImport.ts",
+      "kind": "module",
+      "lines": 1822,
+      "imports": [
+        "companion/src/analysis/chainsawImport.ts",
+        "companion/src/analysis/csvImport.ts",
+        "companion/src/analysis/scriptBlockFragments.ts",
+        "companion/src/analysis/siemImport.ts",
+        "companion/src/analysis/stateTypes.ts",
+        "companion/src/analysis/thorRowMap.ts",
+        "companion/src/analysis/timestompDetect.ts",
+        "companion/src/analysis/veloMessageFields.ts",
+        "companion/src/analysis/veloRowNormalize.ts",
+        "companion/src/analysis/velociraptorTitle.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ingest/endpointImports.ts",
+        "companion/src/composition/veloExternalIngest.ts",
+        "companion/src/composition/veloHunts.ts",
+        "companion/src/routes/import.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/velociraptorImport.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/velociraptorRelease.ts",
+      "kind": "module",
+      "lines": 55,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/velociraptorDownload.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/velociraptorRelease.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/velociraptorTitle.ts",
+      "kind": "module",
+      "lines": 46,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/velociraptorImport.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/analysis/wazuhImport.ts",
       "kind": "module",
       "lines": 276,
@@ -8282,7 +8354,7 @@
     {
       "path": "companion/src/analysis/zipArchive.ts",
       "kind": "module",
-      "lines": 282,
+      "lines": 290,
       "imports": [
         "companion/src/analysis/zipCrypto.ts"
       ],
@@ -8322,7 +8394,7 @@
     {
       "path": "companion/src/analysis/zipExtract.ts",
       "kind": "module",
-      "lines": 144,
+      "lines": 149,
       "imports": [
         "companion/src/analysis/zipArchive.ts",
         "companion/src/analysis/zipCrypto.ts"
@@ -8482,7 +8554,7 @@
     {
       "path": "companion/src/auth/policy.ts",
       "kind": "module",
-      "lines": 206,
+      "lines": 239,
       "imports": [
         "companion/src/auth/types.ts"
       ],
@@ -8648,7 +8720,7 @@
     {
       "path": "companion/src/composition/aiRateLimit.ts",
       "kind": "module",
-      "lines": 59,
+      "lines": 91,
       "imports": [
         "companion/src/http/rateLimiter.ts"
       ],
@@ -8656,7 +8728,9 @@
         "companion/src/composition/routeRegistry.ts"
       ],
       "routes": [],
-      "tests": []
+      "tests": [
+        "companion/tests/architecture/aiRouteCoverage.test.ts"
+      ]
     },
     {
       "path": "companion/src/composition/aiRuntime.ts",
@@ -8813,6 +8887,7 @@
       ],
       "routes": [],
       "tests": [
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/composition/enrichmentCoalescing.test.ts",
         "companion/tests/composition/gatedSynthesisAnnounce.test.ts",
         "companion/tests/composition/hostDuplicateGateStatus.test.ts",
@@ -8853,13 +8928,14 @@
     {
       "path": "companion/src/composition/captureAnalysis.ts",
       "kind": "module",
-      "lines": 500,
+      "lines": 520,
       "imports": [
         "companion/src/analysis/aiControl.ts",
         "companion/src/analysis/hostDuplicateGate.ts",
         "companion/src/analysis/hostScopeLoad.ts",
         "companion/src/analysis/notifications.ts",
         "companion/src/composition/appOptions.ts",
+        "companion/src/logging/serverLogger.ts",
         "companion/src/routes/presidioApproval.ts",
         "companion/src/storage/caseStore.ts",
         "companion/src/types.ts"
@@ -8871,6 +8947,7 @@
       "tests": [
         "companion/tests/analysis/analystGateReporting.test.ts",
         "companion/tests/analysis/hostDuplicateImportNotify.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/composition/gatedSynthesisAnnounce.test.ts",
         "companion/tests/composition/hostDuplicateGateStatus.test.ts",
         "companion/tests/composition/ocrlessBackfill.test.ts",
@@ -8912,6 +8989,19 @@
       ],
       "importedBy": [
         "companion/src/server.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
+      "path": "companion/src/composition/caseWriteGuard.ts",
+      "kind": "module",
+      "lines": 57,
+      "imports": [
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/composition/routeRegistry.ts"
       ],
       "routes": [],
       "tests": []
@@ -9181,9 +9271,10 @@
     {
       "path": "companion/src/composition/routeRegistry.ts",
       "kind": "module",
-      "lines": 146,
+      "lines": 153,
       "imports": [
         "companion/src/composition/aiRateLimit.ts",
+        "companion/src/composition/caseWriteGuard.ts",
         "companion/src/routes/aiState.ts",
         "companion/src/routes/aiSynthesis.ts",
         "companion/src/routes/analysisGraph.ts",
@@ -11031,6 +11122,17 @@
       ]
     },
     {
+      "path": "companion/src/integrations/velociraptor/clientInventory.ts",
+      "kind": "module",
+      "lines": 61,
+      "imports": [],
+      "importedBy": [
+        "companion/src/integrations/velociraptor/velociraptorApi.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/integrations/velociraptor/huntStatusPoller.ts",
       "kind": "module",
       "lines": 79,
@@ -11063,12 +11165,13 @@
     {
       "path": "companion/src/integrations/velociraptor/velociraptorApi.ts",
       "kind": "module",
-      "lines": 1291,
+      "lines": 1247,
       "imports": [
         "companion/src/integrations/childOutput.ts",
         "companion/src/integrations/velociraptor/artifactCatalog.ts",
         "companion/src/integrations/velociraptor/artifactRefs.ts",
         "companion/src/integrations/velociraptor/artifactTools.ts",
+        "companion/src/integrations/velociraptor/clientInventory.ts",
         "companion/src/integrations/velociraptor/vqlDiagnostics.ts"
       ],
       "importedBy": [
@@ -11183,6 +11286,7 @@
         "companion/tests/analysis/presidioPipeline.test.ts",
         "companion/tests/analysis/slackSocketMode.test.ts",
         "companion/tests/analysis/telegramPoller.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/logging/logger.test.ts",
         "companion/tests/logging/uncaughtExceptionNet.test.ts",
         "companion/tests/logging/unhandledRejectionNet.test.ts",
@@ -11208,6 +11312,7 @@
       ],
       "importedBy": [
         "companion/src/composition/aiRuntime.ts",
+        "companion/src/composition/captureAnalysis.ts",
         "companion/src/composition/caseNotifier.ts",
         "companion/src/composition/dropFolder.ts",
         "companion/src/composition/enrichment.ts",
@@ -11228,6 +11333,7 @@
       ],
       "routes": [],
       "tests": [
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/logging/uncaughtExceptionNet.test.ts",
         "companion/tests/logging/unhandledRejectionNet.test.ts"
       ]
@@ -11610,7 +11716,7 @@
     {
       "path": "companion/src/reports/attackLayer.ts",
       "kind": "module",
-      "lines": 211,
+      "lines": 204,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -11682,8 +11788,9 @@
     {
       "path": "companion/src/reports/glossary.ts",
       "kind": "module",
-      "lines": 88,
+      "lines": 85,
       "imports": [
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts",
         "companion/src/reports/reportMeta.ts"
       ],
@@ -11731,7 +11838,7 @@
     {
       "path": "companion/src/reports/interactiveHtml.ts",
       "kind": "module",
-      "lines": 433,
+      "lines": 432,
       "imports": [
         "companion/src/analysis/stateTypes.ts",
         "companion/src/http/securityHeaders.ts",
@@ -11751,7 +11858,7 @@
     {
       "path": "companion/src/reports/iocBlocklist.ts",
       "kind": "module",
-      "lines": 261,
+      "lines": 260,
       "imports": [
         "companion/src/analysis/stateTypes.ts",
         "companion/src/reports/stix.ts"
@@ -11768,7 +11875,7 @@
     {
       "path": "companion/src/reports/markdown.ts",
       "kind": "module",
-      "lines": 1597,
+      "lines": 1592,
       "imports": [
         "companion/src/analysis/adversaryEmulation.ts",
         "companion/src/analysis/adversaryGroupsData.ts",
@@ -11991,7 +12098,7 @@
     {
       "path": "companion/src/reports/reportTemplate.ts",
       "kind": "module",
-      "lines": 313,
+      "lines": 306,
       "imports": [
         "companion/src/analysis/stateTypes.ts",
         "companion/src/reports/reportMeta.ts"
@@ -12518,6 +12625,19 @@
       ]
     },
     {
+      "path": "companion/src/routes/caseCreateBody.ts",
+      "kind": "module",
+      "lines": 33,
+      "imports": [
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/routes/caseLifecycle.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/routes/caseIdentity.ts",
       "kind": "module",
       "lines": 91,
@@ -12536,7 +12656,7 @@
     {
       "path": "companion/src/routes/caseLifecycle.ts",
       "kind": "module",
-      "lines": 904,
+      "lines": 901,
       "imports": [
         "companion/src/analysis/activityLog.ts",
         "companion/src/analysis/caseArchive.ts",
@@ -12557,6 +12677,7 @@
         "companion/src/auth/types.ts",
         "companion/src/http/securityHeaders.ts",
         "companion/src/reports/iocBlocklist.ts",
+        "companion/src/routes/caseCreateBody.ts",
         "companion/src/routes/caseIdentity.ts",
         "companion/src/routes/casePush.ts",
         "companion/src/routes/context.ts",
@@ -13137,7 +13258,7 @@
     {
       "path": "companion/src/routes/import.ts",
       "kind": "module",
-      "lines": 3203,
+      "lines": 3200,
       "imports": [
         "companion/src/analysis/activityLog.ts",
         "companion/src/analysis/auditdImport.ts",
@@ -13177,6 +13298,7 @@
         "companion/src/routes/context.ts",
         "companion/src/routes/importCaseGuard.ts",
         "companion/src/routes/importJobTracking.ts",
+        "companion/src/routes/importKinds.ts",
         "companion/src/routes/importRecovery.ts",
         "companion/src/routes/importRunRecorder.ts",
         "companion/src/routes/importSection.ts",
@@ -13260,9 +13382,23 @@
       ]
     },
     {
+      "path": "companion/src/routes/importKinds.ts",
+      "kind": "module",
+      "lines": 25,
+      "imports": [],
+      "importedBy": [
+        "companion/src/routes/import.ts",
+        "companion/src/routes/importRecovery.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/server/importKinds.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/routes/importRecovery.ts",
       "kind": "module",
-      "lines": 189,
+      "lines": 190,
       "imports": [
         "companion/src/analysis/importResume.ts",
         "companion/src/analysis/iocsDiff.ts",
@@ -13270,6 +13406,7 @@
         "companion/src/analysis/taggerAuto.ts",
         "companion/src/analysis/timelineDiff.ts",
         "companion/src/routes/context.ts",
+        "companion/src/routes/importKinds.ts",
         "companion/src/routes/importRunRecorder.ts"
       ],
       "importedBy": [
@@ -13520,7 +13657,7 @@
     {
       "path": "companion/src/routes/pushNotify.ts",
       "kind": "module",
-      "lines": 244,
+      "lines": 250,
       "imports": [
         "companion/src/analysis/notifications.ts",
         "companion/src/analysis/pushAuth.ts",
@@ -13548,45 +13685,6 @@
       ],
       "tests": [
         "companion/tests/analysis/caseIdGate.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/routes/reportsExport.ts",
-      "kind": "module",
-      "lines": 393,
-      "imports": [
-        "companion/src/analysis/activityLog.ts",
-        "companion/src/analysis/custodyManifest.ts",
-        "companion/src/analysis/notifications.ts",
-        "companion/src/http/securityHeaders.ts",
-        "companion/src/integrations/iris/irisExportStore.ts",
-        "companion/src/integrations/iris/irisImportFetch.ts",
-        "companion/src/reports/html.ts",
-        "companion/src/routes/context.ts",
-        "companion/src/settings/envManager.ts"
-      ],
-      "importedBy": [
-        "companion/src/composition/routeRegistry.ts"
-      ],
-      "routes": [
-        "POST /cases/:id/report",
-        "GET /cases/:id/report/:file",
-        "GET /cases/:id/report.docx",
-        "GET /cases/:id/export/stix",
-        "GET /cases/:id/report-meta",
-        "PUT /cases/:id/report-meta",
-        "GET /cases/:id/report-template",
-        "PUT /cases/:id/report-template",
-        "GET /iris/status",
-        "POST /iris/reconnect",
-        "GET /iris/cases",
-        "GET /cases/:id/iris-export",
-        "POST /cases/:id/iris-import",
-        "GET /cases/:id/clickup-export"
-      ],
-      "tests": [
-        "companion/tests/e2e/workflows/reports.spec.ts",
-        "companion/tests/server/interactiveReportRoute.test.ts"
       ]
     },
     {
@@ -13626,6 +13724,45 @@
         "GET /cases/:id/report-releases/:releaseId/packs/:pack"
       ],
       "tests": []
+    },
+    {
+      "path": "companion/src/routes/reportsExport.ts",
+      "kind": "module",
+      "lines": 393,
+      "imports": [
+        "companion/src/analysis/activityLog.ts",
+        "companion/src/analysis/custodyManifest.ts",
+        "companion/src/analysis/notifications.ts",
+        "companion/src/http/securityHeaders.ts",
+        "companion/src/integrations/iris/irisExportStore.ts",
+        "companion/src/integrations/iris/irisImportFetch.ts",
+        "companion/src/reports/html.ts",
+        "companion/src/routes/context.ts",
+        "companion/src/settings/envManager.ts"
+      ],
+      "importedBy": [
+        "companion/src/composition/routeRegistry.ts"
+      ],
+      "routes": [
+        "POST /cases/:id/report",
+        "GET /cases/:id/report/:file",
+        "GET /cases/:id/report.docx",
+        "GET /cases/:id/export/stix",
+        "GET /cases/:id/report-meta",
+        "PUT /cases/:id/report-meta",
+        "GET /cases/:id/report-template",
+        "PUT /cases/:id/report-template",
+        "GET /iris/status",
+        "POST /iris/reconnect",
+        "GET /iris/cases",
+        "GET /cases/:id/iris-export",
+        "POST /cases/:id/iris-import",
+        "GET /cases/:id/clickup-export"
+      ],
+      "tests": [
+        "companion/tests/e2e/workflows/reports.spec.ts",
+        "companion/tests/server/interactiveReportRoute.test.ts"
+      ]
     },
     {
       "path": "companion/src/routes/seedDemo.ts",
@@ -14485,6 +14622,7 @@
         "companion/src/composition/aiRuntime.ts",
         "companion/src/composition/captureAnalysis.ts",
         "companion/src/composition/caseAppliers.ts",
+        "companion/src/composition/caseWriteGuard.ts",
         "companion/src/composition/dropFolder.ts",
         "companion/src/composition/enrichment.ts",
         "companion/src/composition/externalTools.ts",
@@ -14514,6 +14652,7 @@
         "companion/src/reports/reportWriter.ts",
         "companion/src/routes/anonymization.ts",
         "companion/src/routes/captures.ts",
+        "companion/src/routes/caseCreateBody.ts",
         "companion/src/routes/caseLifecycle.ts",
         "companion/src/routes/casePassword.ts",
         "companion/src/routes/context.ts",
@@ -14602,6 +14741,7 @@
         "companion/tests/analysis/veloHuntStore.test.ts",
         "companion/tests/analysis/veloMonitorStore.test.ts",
         "companion/tests/architecture/routeInventory.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/composition/enrichmentCoalescing.test.ts",
         "companion/tests/composition/gatedSynthesisAnnounce.test.ts",
         "companion/tests/composition/hostDuplicateGateStatus.test.ts",
@@ -14834,6 +14974,7 @@
         "companion/tests/analysis/operationalMetrics.test.ts",
         "companion/tests/analysis/pipeline.test.ts",
         "companion/tests/analysis/presidioPipeline.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/e2e/workflows/captures.spec.ts",
         "companion/tests/eval/fixtures.ts",
         "companion/tests/eval/harness.ts",
@@ -15331,7 +15472,7 @@
     {
       "path": "extension/src/serviceWorker.ts",
       "kind": "module",
-      "lines": 413,
+      "lines": 419,
       "imports": [
         "extension/src/actionIcon.ts",
         "extension/src/adapters/artifactName.ts",
@@ -15403,7 +15544,7 @@
     {
       "path": "public/dashboard.html",
       "kind": "page",
-      "lines": 5391,
+      "lines": 5392,
       "imports": [
         "public/js/a11y/announcer.js",
         "public/js/a11y/describe-as-table.js",
@@ -15874,7 +16015,7 @@
     {
       "path": "public/js/dashboard-asset-graph.js",
       "kind": "browser",
-      "lines": 367,
+      "lines": 390,
       "imports": [],
       "importedBy": [
         "public/dashboard.html"
@@ -16574,7 +16715,7 @@
     {
       "path": "public/js/dashboard-host-scope.js",
       "kind": "browser",
-      "lines": 299,
+      "lines": 367,
       "imports": [],
       "importedBy": [
         "public/dashboard.html"
@@ -17041,7 +17182,7 @@
     {
       "path": "public/js/dashboard-push-token.js",
       "kind": "browser",
-      "lines": 120,
+      "lines": 147,
       "imports": [],
       "importedBy": [
         "public/dashboard.html"

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -6,7 +6,7 @@
     "extension/src",
     "public/dashboard.html"
   ],
-  "moduleCount": 792,
+  "moduleCount": 800,
   "routeCount": 476,
   "modules": [
     {
@@ -1109,10 +1109,11 @@
     {
       "path": "companion/src/analysis/anonymize.ts",
       "kind": "module",
-      "lines": 850,
+      "lines": 848,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/iocValue.ts",
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -1211,6 +1212,7 @@
       "lines": 306,
       "imports": [
         "companion/src/analysis/hostAlias.ts",
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -1247,7 +1249,7 @@
     {
       "path": "companion/src/analysis/assetOverrides.ts",
       "kind": "module",
-      "lines": 300,
+      "lines": 296,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/stateTypes.ts",
@@ -1337,7 +1339,7 @@
     {
       "path": "companion/src/analysis/auditdImport.ts",
       "kind": "module",
-      "lines": 602,
+      "lines": 601,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/siemImport.ts",
@@ -1413,9 +1415,20 @@
       ]
     },
     {
+      "path": "companion/src/analysis/bsdTime.ts",
+      "kind": "module",
+      "lines": 33,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/siemImport.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/analysis/burstDetect.ts",
       "kind": "module",
-      "lines": 150,
+      "lines": 145,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/mitreTactics.ts",
@@ -1635,6 +1648,21 @@
       ]
     },
     {
+      "path": "companion/src/analysis/chainSignature.ts",
+      "kind": "module",
+      "lines": 72,
+      "imports": [
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/correlate.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/chainSignature.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/chainsawImport.ts",
       "kind": "module",
       "lines": 374,
@@ -1653,24 +1681,9 @@
       ]
     },
     {
-      "path": "companion/src/analysis/chainSignature.ts",
-      "kind": "module",
-      "lines": 72,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/correlate.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/chainSignature.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/ciscoAsaImport.ts",
       "kind": "module",
-      "lines": 234,
+      "lines": 198,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -1838,6 +1851,23 @@
       ]
     },
     {
+      "path": "companion/src/analysis/collectSatisfaction.ts",
+      "kind": "module",
+      "lines": 135,
+      "imports": [
+        "companion/src/analysis/collectDirective.ts",
+        "companion/src/analysis/iocAnchors.ts",
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/synthesisPromptBlocks.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/collectSatisfaction.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/collectionPlan.ts",
       "kind": "module",
       "lines": 186,
@@ -1877,26 +1907,9 @@
       ]
     },
     {
-      "path": "companion/src/analysis/collectSatisfaction.ts",
-      "kind": "module",
-      "lines": 135,
-      "imports": [
-        "companion/src/analysis/collectDirective.ts",
-        "companion/src/analysis/iocAnchors.ts",
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/synthesisPromptBlocks.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/collectSatisfaction.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/combinedLogImport.ts",
       "kind": "module",
-      "lines": 252,
+      "lines": 238,
       "imports": [
         "companion/src/analysis/secretSpillRules.ts",
         "companion/src/analysis/siemImport.ts",
@@ -2028,7 +2041,7 @@
     {
       "path": "companion/src/analysis/correlate.ts",
       "kind": "module",
-      "lines": 465,
+      "lines": 459,
       "imports": [
         "companion/src/analysis/chainSignature.ts",
         "companion/src/analysis/sourceTrust.ts",
@@ -2116,7 +2129,7 @@
     {
       "path": "companion/src/analysis/custody.ts",
       "kind": "module",
-      "lines": 409,
+      "lines": 415,
       "imports": [
         "companion/src/analysis/stateLock.ts",
         "companion/src/auth/identityContext.ts",
@@ -2305,24 +2318,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/dashboardViews.ts",
-      "kind": "module",
-      "lines": 416,
-      "imports": [
-        "companion/src/reports/reportTemplate.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/dashboardViewStore.ts",
-        "companion/src/integrations/misp/mispPush.ts",
-        "companion/src/routes/templatesViews.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/dashboardViewStore.test.ts",
-        "companion/tests/analysis/dashboardViews.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/dashboardViewStore.ts",
       "kind": "module",
       "lines": 124,
@@ -2340,6 +2335,24 @@
         "companion/tests/analysis/dashboardViewStore.test.ts",
         "companion/tests/server/storeIdTraversalRoutes.test.ts",
         "companion/tests/storage/storeIdTraversal.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/dashboardViews.ts",
+      "kind": "module",
+      "lines": 416,
+      "imports": [
+        "companion/src/reports/reportTemplate.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/dashboardViewStore.ts",
+        "companion/src/integrations/misp/mispPush.ts",
+        "companion/src/routes/templatesViews.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/dashboardViewStore.test.ts",
+        "companion/tests/analysis/dashboardViews.test.ts"
       ]
     },
     {
@@ -2367,7 +2380,7 @@
     {
       "path": "companion/src/analysis/deepPass.ts",
       "kind": "module",
-      "lines": 261,
+      "lines": 262,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/promptBudget.ts",
@@ -2550,7 +2563,7 @@
     {
       "path": "companion/src/analysis/ecarImport.ts",
       "kind": "module",
-      "lines": 528,
+      "lines": 514,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/reconTechniques.ts",
@@ -2572,7 +2585,7 @@
     {
       "path": "companion/src/analysis/emailImport.ts",
       "kind": "module",
-      "lines": 688,
+      "lines": 676,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/siemImport.ts",
@@ -2604,7 +2617,7 @@
     {
       "path": "companion/src/analysis/evidenceGraph.ts",
       "kind": "module",
-      "lines": 860,
+      "lines": 855,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/canonicalEvent.ts",
@@ -2632,7 +2645,7 @@
     {
       "path": "companion/src/analysis/evtxXmlImport.ts",
       "kind": "module",
-      "lines": 194,
+      "lines": 228,
       "imports": [
         "companion/src/analysis/siemBuildProgress.ts",
         "companion/src/analysis/siemImport.ts"
@@ -2649,7 +2662,7 @@
     {
       "path": "companion/src/analysis/exfilCorrelate.ts",
       "kind": "module",
-      "lines": 67,
+      "lines": 62,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -2740,7 +2753,7 @@
     {
       "path": "companion/src/analysis/findingGrounding.ts",
       "kind": "module",
-      "lines": 458,
+      "lines": 467,
       "imports": [
         "companion/src/analysis/forensicGate.ts",
         "companion/src/analysis/hostAlias.ts",
@@ -2781,6 +2794,27 @@
       ]
     },
     {
+      "path": "companion/src/analysis/findingWorkflow.ts",
+      "kind": "module",
+      "lines": 114,
+      "imports": [
+        "companion/src/storage/atomicWrite.ts",
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/cockpit.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/routes/findings.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/findingWorkflow.test.ts",
+        "companion/tests/server/cockpitRoutes.test.ts",
+        "companion/tests/server/findingWorkflow.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/findingsDiff.ts",
       "kind": "module",
       "lines": 57,
@@ -2800,27 +2834,6 @@
         "companion/tests/analysis/findingsDiff.test.ts",
         "companion/tests/analysis/notifications.test.ts",
         "companion/tests/analysis/synthMeta.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/findingWorkflow.ts",
-      "kind": "module",
-      "lines": 114,
-      "imports": [
-        "companion/src/storage/atomicWrite.ts",
-        "companion/src/storage/caseStore.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/cockpit.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/routes/findings.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/findingWorkflow.test.ts",
-        "companion/tests/server/cockpitRoutes.test.ts",
-        "companion/tests/server/findingWorkflow.test.ts"
       ]
     },
     {
@@ -2898,8 +2911,9 @@
     {
       "path": "companion/src/analysis/fpCascade.ts",
       "kind": "module",
-      "lines": 135,
+      "lines": 136,
       "imports": [
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -2933,7 +2947,7 @@
     {
       "path": "companion/src/analysis/gapDetect.ts",
       "kind": "module",
-      "lines": 455,
+      "lines": 460,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -2977,10 +2991,11 @@
     {
       "path": "companion/src/analysis/geoMap.ts",
       "kind": "module",
-      "lines": 338,
+      "lines": 339,
       "imports": [
         "companion/src/analysis/anonymize.ts",
         "companion/src/analysis/countryCentroids.ts",
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -3014,7 +3029,7 @@
     {
       "path": "companion/src/analysis/graphContext.ts",
       "kind": "module",
-      "lines": 82,
+      "lines": 80,
       "imports": [
         "companion/src/analysis/evidenceGraph.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -3237,7 +3252,6 @@
       "lines": 142,
       "imports": [
         "companion/src/analysis/hostAlias.ts",
-        "companion/src/analysis/severityFloor.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -3260,7 +3274,7 @@
         "companion/src/analysis/collectionPlan.ts",
         "companion/src/analysis/hostScopeAggregate.ts",
         "companion/src/analysis/mitreTactics.ts",
-        "companion/src/analysis/severityFloor.ts"
+        "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
         "companion/src/analysis/hostScope.ts"
@@ -3325,28 +3339,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/huntOutcomes.ts",
-      "kind": "module",
-      "lines": 329,
-      "imports": [
-        "companion/src/analysis/huntRunDiff.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/hunts.ts",
-        "companion/src/analysis/ai/synthesisInputs.ts",
-        "companion/src/analysis/huntOutcomeStore.ts",
-        "companion/src/composition/veloHunts.ts",
-        "companion/src/routes/context.ts",
-        "companion/src/routes/playbookHunts.ts",
-        "companion/src/routes/velociraptor.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/huntOutcomes.test.ts",
-        "companion/tests/server/huntOutcomes.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/huntOutcomeStore.ts",
       "kind": "module",
       "lines": 41,
@@ -3366,6 +3358,28 @@
       "tests": [
         "companion/tests/analysis/synthesizeCharacterisation.test.ts",
         "companion/tests/server/collectDirective.test.ts",
+        "companion/tests/server/huntOutcomes.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/huntOutcomes.ts",
+      "kind": "module",
+      "lines": 329,
+      "imports": [
+        "companion/src/analysis/huntRunDiff.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/hunts.ts",
+        "companion/src/analysis/ai/synthesisInputs.ts",
+        "companion/src/analysis/huntOutcomeStore.ts",
+        "companion/src/composition/veloHunts.ts",
+        "companion/src/routes/context.ts",
+        "companion/src/routes/playbookHunts.ts",
+        "companion/src/routes/velociraptor.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/huntOutcomes.test.ts",
         "companion/tests/server/huntOutcomes.test.ts"
       ]
     },
@@ -3420,7 +3434,7 @@
     {
       "path": "companion/src/analysis/huntQueryExecutor.ts",
       "kind": "module",
-      "lines": 644,
+      "lines": 670,
       "imports": [
         "companion/src/analysis/huntQueryAggregation.ts",
         "companion/src/analysis/huntQueryCursor.ts",
@@ -3457,10 +3471,11 @@
     {
       "path": "companion/src/analysis/huntQueryParser.ts",
       "kind": "module",
-      "lines": 661,
+      "lines": 691,
       "imports": [
         "companion/src/analysis/huntQueryFields.ts",
-        "companion/src/analysis/huntQueryTypes.ts"
+        "companion/src/analysis/huntQueryTypes.ts",
+        "companion/src/analysis/regexSafety.ts"
       ],
       "importedBy": [
         "companion/src/routes/huntWorkbench.ts"
@@ -3538,7 +3553,7 @@
     {
       "path": "companion/src/analysis/huntSuggest.ts",
       "kind": "module",
-      "lines": 146,
+      "lines": 136,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -3694,56 +3709,6 @@
       "tests": []
     },
     {
-      "path": "companion/src/analysis/importerSpec.ts",
-      "kind": "module",
-      "lines": 215,
-      "imports": [
-        "companion/src/analysis/regexSafety.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/prompts/extraction.ts",
-        "companion/src/analysis/declarativeImporter.ts",
-        "companion/src/analysis/importerStore.ts",
-        "companion/src/routes/caseLifecycle.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/declarativeImporter.test.ts",
-        "companion/tests/analysis/importDetect.test.ts",
-        "companion/tests/analysis/importerSpec.test.ts",
-        "companion/tests/analysis/importerStore.test.ts",
-        "companion/tests/analysis/prompts.test.ts",
-        "companion/tests/server/analysisRunImport.test.ts",
-        "companion/tests/server/importerRoutes.test.ts",
-        "companion/tests/server/superTimeline.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/importerStore.ts",
-      "kind": "module",
-      "lines": 110,
-      "imports": [
-        "companion/src/analysis/declarativeImporter.ts",
-        "companion/src/analysis/importerSpec.ts",
-        "companion/src/analysis/redactPaths.ts",
-        "companion/src/storage/atomicWrite.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/diagnostics.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/importIngest.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/routes/context.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/importerStore.test.ts",
-        "companion/tests/server/analysisRunImport.test.ts",
-        "companion/tests/server/importerRoutes.test.ts",
-        "companion/tests/server/superTimeline.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/importLock.ts",
       "kind": "module",
       "lines": 47,
@@ -3848,6 +3813,82 @@
       ]
     },
     {
+      "path": "companion/src/analysis/importerSpec.ts",
+      "kind": "module",
+      "lines": 215,
+      "imports": [
+        "companion/src/analysis/regexSafety.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/prompts/extraction.ts",
+        "companion/src/analysis/declarativeImporter.ts",
+        "companion/src/analysis/importerStore.ts",
+        "companion/src/routes/caseLifecycle.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/declarativeImporter.test.ts",
+        "companion/tests/analysis/importDetect.test.ts",
+        "companion/tests/analysis/importerSpec.test.ts",
+        "companion/tests/analysis/importerStore.test.ts",
+        "companion/tests/analysis/prompts.test.ts",
+        "companion/tests/server/analysisRunImport.test.ts",
+        "companion/tests/server/importerRoutes.test.ts",
+        "companion/tests/server/superTimeline.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/importerStore.ts",
+      "kind": "module",
+      "lines": 110,
+      "imports": [
+        "companion/src/analysis/declarativeImporter.ts",
+        "companion/src/analysis/importerSpec.ts",
+        "companion/src/analysis/redactPaths.ts",
+        "companion/src/storage/atomicWrite.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/diagnostics.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/importIngest.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/routes/context.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/importerStore.test.ts",
+        "companion/tests/server/analysisRunImport.test.ts",
+        "companion/tests/server/importerRoutes.test.ts",
+        "companion/tests/server/superTimeline.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/incidentTypeStore.ts",
+      "kind": "module",
+      "lines": 107,
+      "imports": [
+        "companion/src/analysis/incidentTypes.ts",
+        "companion/src/analysis/incidentTypesData.ts",
+        "companion/src/storage/atomicWrite.ts",
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/pipelineOptions.ts",
+        "companion/src/analysis/ai/synthesisInputs.ts",
+        "companion/src/composition/aiProviders.ts",
+        "companion/src/composition/aiRuntime.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/runtimeStores.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/incidentTypeSynthesis.test.ts",
+        "companion/tests/analysis/synthesizeCharacterisation.test.ts",
+        "companion/tests/server/collectionPlanRoutes.test.ts",
+        "companion/tests/server/incidentTypeRoutes.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/incidentTypes.ts",
       "kind": "module",
       "lines": 190,
@@ -3883,32 +3924,6 @@
       "tests": [
         "companion/tests/analysis/incidentTypePlans.test.ts",
         "companion/tests/analysis/incidentTypes.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/incidentTypeStore.ts",
-      "kind": "module",
-      "lines": 107,
-      "imports": [
-        "companion/src/analysis/incidentTypes.ts",
-        "companion/src/analysis/incidentTypesData.ts",
-        "companion/src/storage/atomicWrite.ts",
-        "companion/src/storage/caseStore.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/pipelineOptions.ts",
-        "companion/src/analysis/ai/synthesisInputs.ts",
-        "companion/src/composition/aiProviders.ts",
-        "companion/src/composition/aiRuntime.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/runtimeStores.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/incidentTypeSynthesis.test.ts",
-        "companion/tests/analysis/synthesizeCharacterisation.test.ts",
-        "companion/tests/server/collectionPlanRoutes.test.ts",
-        "companion/tests/server/incidentTypeRoutes.test.ts"
       ]
     },
     {
@@ -4028,7 +4043,7 @@
     {
       "path": "companion/src/analysis/ingest/logImports.ts",
       "kind": "module",
-      "lines": 432,
+      "lines": 436,
       "imports": [
         "companion/src/analysis/auditdImport.ts",
         "companion/src/analysis/bashHistoryImport.ts",
@@ -4122,8 +4137,9 @@
     {
       "path": "companion/src/analysis/initialAccess.ts",
       "kind": "module",
-      "lines": 80,
+      "lines": 76,
       "imports": [
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -4150,6 +4166,19 @@
       ]
     },
     {
+      "path": "companion/src/analysis/internalIp.ts",
+      "kind": "module",
+      "lines": 20,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/siemImport.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/internalIp.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/investigationStateFiles.ts",
       "kind": "module",
       "lines": 34,
@@ -4165,7 +4194,7 @@
     {
       "path": "companion/src/analysis/iocAlias.ts",
       "kind": "module",
-      "lines": 70,
+      "lines": 65,
       "imports": [
         "companion/src/storage/atomicWrite.ts",
         "companion/src/storage/caseStore.ts"
@@ -4248,6 +4277,7 @@
       "kind": "module",
       "lines": 109,
       "imports": [
+        "companion/src/analysis/regexSafety.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -4351,31 +4381,9 @@
       ]
     },
     {
-      "path": "companion/src/analysis/iocsDiff.ts",
-      "kind": "module",
-      "lines": 44,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/importMeta.ts",
-        "companion/src/composition/importIngest.ts",
-        "companion/src/composition/veloExternalIngest.ts",
-        "companion/src/composition/veloHunts.ts",
-        "companion/src/routes/import.ts",
-        "companion/src/routes/importRecovery.ts",
-        "companion/src/routes/reportVersions.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/importMeta.test.ts",
-        "companion/tests/analysis/iocsDiff.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/iocValue.ts",
       "kind": "module",
-      "lines": 263,
+      "lines": 267,
       "imports": [],
       "importedBy": [
         "companion/src/analysis/anonymize.ts",
@@ -4393,9 +4401,10 @@
     {
       "path": "companion/src/analysis/iocWhitelist.ts",
       "kind": "module",
-      "lines": 200,
+      "lines": 203,
       "imports": [
         "companion/src/analysis/csvImport.ts",
+        "companion/src/analysis/regexSafety.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -4427,6 +4436,28 @@
         "companion/tests/server.test.ts",
         "companion/tests/server/iocRisk.test.ts",
         "companion/tests/server/iocWhitelistRoutes.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/iocsDiff.ts",
+      "kind": "module",
+      "lines": 44,
+      "imports": [
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/importMeta.ts",
+        "companion/src/composition/importIngest.ts",
+        "companion/src/composition/veloExternalIngest.ts",
+        "companion/src/composition/veloHunts.ts",
+        "companion/src/routes/import.ts",
+        "companion/src/routes/importRecovery.ts",
+        "companion/src/routes/reportVersions.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/importMeta.test.ts",
+        "companion/tests/analysis/iocsDiff.test.ts"
       ]
     },
     {
@@ -4710,24 +4741,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/learnedPatterns.ts",
-      "kind": "module",
-      "lines": 155,
-      "imports": [
-        "companion/src/analysis/falsePositive.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/synthesisPromptBlocks.ts",
-        "companion/src/analysis/learnedPatternStore.ts",
-        "companion/src/routes/findings.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/learnedPatterns.test.ts",
-        "companion/tests/server/learnedPatterns.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/learnedPatternStore.ts",
       "kind": "module",
       "lines": 44,
@@ -4745,6 +4758,24 @@
       ],
       "routes": [],
       "tests": [
+        "companion/tests/server/learnedPatterns.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/learnedPatterns.ts",
+      "kind": "module",
+      "lines": 155,
+      "imports": [
+        "companion/src/analysis/falsePositive.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/synthesisPromptBlocks.ts",
+        "companion/src/analysis/learnedPatternStore.ts",
+        "companion/src/routes/findings.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/learnedPatterns.test.ts",
         "companion/tests/server/learnedPatterns.test.ts"
       ]
     },
@@ -4799,8 +4830,10 @@
     {
       "path": "companion/src/analysis/lookalikeDomains.ts",
       "kind": "module",
-      "lines": 351,
-      "imports": [],
+      "lines": 350,
+      "imports": [
+        "companion/src/analysis/regexEscape.ts"
+      ],
       "importedBy": [
         "companion/src/enrichment/lookalikeDomain.ts"
       ],
@@ -4889,7 +4922,7 @@
     {
       "path": "companion/src/analysis/memoryNextStep.ts",
       "kind": "module",
-      "lines": 147,
+      "lines": 143,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -4949,7 +4982,6 @@
       "kind": "module",
       "lines": 239,
       "imports": [
-        "companion/src/analysis/severityFloor.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -5008,6 +5040,27 @@
       ]
     },
     {
+      "path": "companion/src/analysis/notificationStore.ts",
+      "kind": "module",
+      "lines": 144,
+      "imports": [
+        "companion/src/analysis/notifications.ts",
+        "companion/src/storage/atomicWrite.ts"
+      ],
+      "importedBy": [
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/integrations/notify/notifyDispatch.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/notifications.test.ts",
+        "companion/tests/integrations/notify.test.ts",
+        "companion/tests/server.test.ts",
+        "companion/tests/server/notificationRoutes.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/notifications.ts",
       "kind": "module",
       "lines": 531,
@@ -5042,27 +5095,6 @@
       "tests": [
         "companion/tests/analysis/notifications.test.ts",
         "companion/tests/integrations/notify.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/notificationStore.ts",
-      "kind": "module",
-      "lines": 144,
-      "imports": [
-        "companion/src/analysis/notifications.ts",
-        "companion/src/storage/atomicWrite.ts"
-      ],
-      "importedBy": [
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/integrations/notify/notifyDispatch.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/notifications.test.ts",
-        "companion/tests/integrations/notify.test.ts",
-        "companion/tests/server.test.ts",
-        "companion/tests/server/notificationRoutes.test.ts"
       ]
     },
     {
@@ -5126,7 +5158,7 @@
     {
       "path": "companion/src/analysis/ocrRedact.ts",
       "kind": "module",
-      "lines": 139,
+      "lines": 173,
       "imports": [
         "companion/src/analysis/anonymize.ts"
       ],
@@ -5526,7 +5558,7 @@
     {
       "path": "companion/src/analysis/playbookHunt.ts",
       "kind": "module",
-      "lines": 384,
+      "lines": 374,
       "imports": [
         "companion/src/analysis/playbook.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -5635,7 +5667,6 @@
       "kind": "module",
       "lines": 310,
       "imports": [
-        "companion/src/analysis/severityFloor.ts",
         "companion/src/analysis/stateTypes.ts"
       ],
       "importedBy": [
@@ -5871,6 +5902,24 @@
       ]
     },
     {
+      "path": "companion/src/analysis/redactPaths.ts",
+      "kind": "module",
+      "lines": 108,
+      "imports": [
+        "companion/src/analysis/regexEscape.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/importerStore.ts",
+        "companion/src/composition/diagnosticsRings.ts",
+        "companion/src/composition/httpStack.ts",
+        "companion/src/routes/slashCommand.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/redactPaths.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/redactedExport.ts",
       "kind": "module",
       "lines": 344,
@@ -5893,29 +5942,36 @@
       ]
     },
     {
-      "path": "companion/src/analysis/redactPaths.ts",
+      "path": "companion/src/analysis/regexEscape.ts",
       "kind": "module",
-      "lines": 111,
+      "lines": 14,
       "imports": [],
       "importedBy": [
-        "companion/src/analysis/importerStore.ts",
-        "companion/src/composition/diagnosticsRings.ts",
-        "companion/src/composition/httpStack.ts",
-        "companion/src/routes/slashCommand.ts"
+        "companion/src/analysis/anonymize.ts",
+        "companion/src/analysis/assetGraph.ts",
+        "companion/src/analysis/fpCascade.ts",
+        "companion/src/analysis/geoMap.ts",
+        "companion/src/analysis/initialAccess.ts",
+        "companion/src/analysis/lookalikeDomains.ts",
+        "companion/src/analysis/redactPaths.ts",
+        "companion/src/analysis/veloMessageFields.ts",
+        "companion/src/reports/glossary.ts"
       ],
       "routes": [],
-      "tests": [
-        "companion/tests/analysis/redactPaths.test.ts"
-      ]
+      "tests": []
     },
     {
       "path": "companion/src/analysis/regexSafety.ts",
       "kind": "module",
-      "lines": 423,
+      "lines": 464,
       "imports": [],
       "importedBy": [
         "companion/src/analysis/declarativeImporter.ts",
-        "companion/src/analysis/importerSpec.ts"
+        "companion/src/analysis/huntQueryParser.ts",
+        "companion/src/analysis/importerSpec.ts",
+        "companion/src/analysis/iocExclude.ts",
+        "companion/src/analysis/iocWhitelist.ts",
+        "companion/src/analysis/taggerRules.ts"
       ],
       "routes": [],
       "tests": [
@@ -6241,7 +6297,7 @@
     {
       "path": "companion/src/analysis/sessionSegmentation.ts",
       "kind": "module",
-      "lines": 275,
+      "lines": 273,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/loginGraph.ts",
@@ -6262,7 +6318,7 @@
     {
       "path": "companion/src/analysis/severityFloor.ts",
       "kind": "module",
-      "lines": 67,
+      "lines": 64,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -6270,16 +6326,12 @@
         "companion/src/analysis/ai/deepPassRun.ts",
         "companion/src/analysis/ai/extraction.ts",
         "companion/src/analysis/deepPass.ts",
-        "companion/src/analysis/hostScopeAggregate.ts",
-        "companion/src/analysis/hostScopeEligibility.ts",
         "companion/src/analysis/ingest/cloudImports.ts",
         "companion/src/analysis/ingest/endpointImports.ts",
         "companion/src/analysis/ingest/importState.ts",
         "companion/src/analysis/ingest/logImports.ts",
         "companion/src/analysis/ingest/networkImports.ts",
         "companion/src/analysis/ingest/platformImports.ts",
-        "companion/src/analysis/mobileSummary.ts",
-        "companion/src/analysis/presentation.ts",
         "companion/src/composition/veloExternalIngest.ts",
         "companion/src/composition/veloHunts.ts",
         "companion/src/routes/aiSynthesis.ts",
@@ -6323,7 +6375,8 @@
         "companion/src/analysis/siemImport.ts"
       ],
       "importedBy": [
-        "companion/src/analysis/evtxXmlImport.ts"
+        "companion/src/analysis/evtxXmlImport.ts",
+        "companion/src/analysis/syslogImport.ts"
       ],
       "routes": [],
       "tests": []
@@ -6331,9 +6384,11 @@
     {
       "path": "companion/src/analysis/siemImport.ts",
       "kind": "module",
-      "lines": 1778,
+      "lines": 1762,
       "imports": [
+        "companion/src/analysis/bsdTime.ts",
         "companion/src/analysis/canonicalEvent.ts",
+        "companion/src/analysis/internalIp.ts",
         "companion/src/analysis/reconTechniques.ts",
         "companion/src/analysis/secretSpillRules.ts",
         "companion/src/analysis/stateTypes.ts",
@@ -6476,7 +6531,7 @@
     {
       "path": "companion/src/analysis/snortImport.ts",
       "kind": "module",
-      "lines": 168,
+      "lines": 157,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -6494,7 +6549,7 @@
     {
       "path": "companion/src/analysis/socratesImport.ts",
       "kind": "module",
-      "lines": 344,
+      "lines": 343,
       "imports": [
         "companion/src/analysis/networkImport.ts",
         "companion/src/analysis/siemImport.ts",
@@ -6840,7 +6895,7 @@
     {
       "path": "companion/src/analysis/stateTypes.ts",
       "kind": "module",
-      "lines": 360,
+      "lines": 371,
       "imports": [
         "companion/src/analysis/canonicalEvent.ts",
         "companion/src/analysis/iocExclude.ts"
@@ -6929,6 +6984,7 @@
         "companion/src/analysis/hostDuplicateGate.ts",
         "companion/src/analysis/hostRanking.ts",
         "companion/src/analysis/hostScopeAggregate.ts",
+        "companion/src/analysis/hostScopeEligibility.ts",
         "companion/src/analysis/hostScopeLoad.ts",
         "companion/src/analysis/huntQueryAggregation.ts",
         "companion/src/analysis/huntQueryExecutor.ts",
@@ -7519,7 +7575,7 @@
     {
       "path": "companion/src/analysis/synthSelect.ts",
       "kind": "module",
-      "lines": 449,
+      "lines": 450,
       "imports": [
         "companion/src/analysis/assetGraph.ts",
         "companion/src/analysis/burstDetect.ts",
@@ -7588,9 +7644,10 @@
     {
       "path": "companion/src/analysis/syslogImport.ts",
       "kind": "module",
-      "lines": 295,
+      "lines": 355,
       "imports": [
         "companion/src/analysis/secretSpillRules.ts",
+        "companion/src/analysis/siemBuildProgress.ts",
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/sshBruteForce.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -7649,27 +7706,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/taggerRules.ts",
-      "kind": "module",
-      "lines": 256,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/nextSteps.ts",
-        "companion/src/analysis/tagger.ts",
-        "companion/src/analysis/taggerRuleSuggest.ts",
-        "companion/src/analysis/taggerRun.ts",
-        "companion/src/analysis/taggerStore.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/tagger.test.ts",
-        "companion/tests/analysis/taggerRuleSuggest.test.ts",
-        "companion/tests/analysis/taggerRules.test.ts"
-      ]
-    },
-    {
       "path": "companion/src/analysis/taggerRuleSuggest.ts",
       "kind": "module",
       "lines": 75,
@@ -7684,6 +7720,28 @@
       "tests": [
         "companion/tests/analysis/taggerRuleSuggest.test.ts",
         "companion/tests/server/taggerRoutes.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/taggerRules.ts",
+      "kind": "module",
+      "lines": 260,
+      "imports": [
+        "companion/src/analysis/regexSafety.ts",
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/nextSteps.ts",
+        "companion/src/analysis/tagger.ts",
+        "companion/src/analysis/taggerRuleSuggest.ts",
+        "companion/src/analysis/taggerRun.ts",
+        "companion/src/analysis/taggerStore.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/tagger.test.ts",
+        "companion/tests/analysis/taggerRuleSuggest.test.ts",
+        "companion/tests/analysis/taggerRules.test.ts"
       ]
     },
     {
@@ -7813,7 +7871,7 @@
     {
       "path": "companion/src/analysis/thorImport.ts",
       "kind": "module",
-      "lines": 281,
+      "lines": 279,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -7845,9 +7903,41 @@
       ]
     },
     {
+      "path": "companion/src/analysis/timeUtc.ts",
+      "kind": "module",
+      "lines": 31,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/manualEntry.ts",
+        "companion/src/analysis/siemImport.ts",
+        "companion/src/analysis/stateMerge.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/timeUtc.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/timeYearClamp.ts",
+      "kind": "module",
+      "lines": 124,
+      "imports": [
+        "companion/src/analysis/stateTypes.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ingest/logImports.ts",
+        "companion/src/analysis/ingest/networkImports.ts",
+        "companion/src/analysis/stateMerge.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/timeYearClamp.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/analysis/timelineAnomalies.ts",
       "kind": "module",
-      "lines": 226,
+      "lines": 225,
       "imports": [
         "companion/src/analysis/forensicSort.ts",
         "companion/src/analysis/stateTypes.ts"
@@ -7895,38 +7985,6 @@
       "routes": [],
       "tests": [
         "companion/tests/analysis/timestompDetect.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/timeUtc.ts",
-      "kind": "module",
-      "lines": 31,
-      "imports": [],
-      "importedBy": [
-        "companion/src/analysis/manualEntry.ts",
-        "companion/src/analysis/siemImport.ts",
-        "companion/src/analysis/stateMerge.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/timeUtc.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/timeYearClamp.ts",
-      "kind": "module",
-      "lines": 124,
-      "imports": [
-        "companion/src/analysis/stateTypes.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ingest/logImports.ts",
-        "companion/src/analysis/ingest/networkImports.ts",
-        "companion/src/analysis/stateMerge.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/timeYearClamp.test.ts"
       ]
     },
     {
@@ -8034,99 +8092,6 @@
       ]
     },
     {
-      "path": "companion/src/analysis/velociraptorClientStore.ts",
-      "kind": "module",
-      "lines": 45,
-      "imports": [
-        "companion/src/integrations/velociraptor/velociraptorApi.ts",
-        "companion/src/storage/atomicWrite.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ai/aiContext.ts",
-        "companion/src/analysis/ai/analystQueries.ts",
-        "companion/src/analysis/ai/caseReports.ts",
-        "companion/src/analysis/ai/hunts.ts",
-        "companion/src/analysis/ai/pipelineOptions.ts",
-        "companion/src/analysis/ai/synthesis.ts",
-        "companion/src/analysis/hostScopeLoad.ts",
-        "companion/src/composition/aiRuntime.ts",
-        "companion/src/composition/appOptions.ts",
-        "companion/src/composition/maintenanceTasks.ts",
-        "companion/src/composition/runtimeStores.ts",
-        "companion/src/reports/reportWriter.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/velociraptorClientStore.test.ts",
-        "companion/tests/server/playbookHunts.test.ts",
-        "companion/tests/server/veloReconnect.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/velociraptorDownload.ts",
-      "kind": "module",
-      "lines": 68,
-      "imports": [
-        "companion/src/analysis/updateCheck.ts",
-        "companion/src/analysis/velociraptorRelease.ts"
-      ],
-      "importedBy": [
-        "companion/src/routes/velociraptorSettings.ts"
-      ],
-      "routes": [],
-      "tests": []
-    },
-    {
-      "path": "companion/src/analysis/velociraptorImport.ts",
-      "kind": "module",
-      "lines": 1869,
-      "imports": [
-        "companion/src/analysis/chainsawImport.ts",
-        "companion/src/analysis/csvImport.ts",
-        "companion/src/analysis/scriptBlockFragments.ts",
-        "companion/src/analysis/siemImport.ts",
-        "companion/src/analysis/stateTypes.ts",
-        "companion/src/analysis/thorRowMap.ts",
-        "companion/src/analysis/timestompDetect.ts",
-        "companion/src/analysis/veloRowNormalize.ts",
-        "companion/src/analysis/velociraptorTitle.ts"
-      ],
-      "importedBy": [
-        "companion/src/analysis/ingest/endpointImports.ts",
-        "companion/src/composition/veloExternalIngest.ts",
-        "companion/src/composition/veloHunts.ts",
-        "companion/src/routes/import.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/velociraptorImport.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/velociraptorRelease.ts",
-      "kind": "module",
-      "lines": 55,
-      "imports": [],
-      "importedBy": [
-        "companion/src/analysis/velociraptorDownload.ts"
-      ],
-      "routes": [],
-      "tests": [
-        "companion/tests/analysis/velociraptorRelease.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/analysis/velociraptorTitle.ts",
-      "kind": "module",
-      "lines": 46,
-      "imports": [],
-      "importedBy": [
-        "companion/src/analysis/velociraptorImport.ts"
-      ],
-      "routes": [],
-      "tests": []
-    },
-    {
       "path": "companion/src/analysis/veloHuntStore.ts",
       "kind": "module",
       "lines": 165,
@@ -8156,6 +8121,19 @@
         "companion/tests/server/veloCollectImportSlot.test.ts",
         "companion/tests/server/veloTimeScope.test.ts"
       ]
+    },
+    {
+      "path": "companion/src/analysis/veloMessageFields.ts",
+      "kind": "module",
+      "lines": 62,
+      "imports": [
+        "companion/src/analysis/regexEscape.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/velociraptorImport.ts"
+      ],
+      "routes": [],
+      "tests": []
     },
     {
       "path": "companion/src/analysis/veloMonitorStore.ts",
@@ -8226,6 +8204,100 @@
       ]
     },
     {
+      "path": "companion/src/analysis/velociraptorClientStore.ts",
+      "kind": "module",
+      "lines": 45,
+      "imports": [
+        "companion/src/integrations/velociraptor/velociraptorApi.ts",
+        "companion/src/storage/atomicWrite.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ai/aiContext.ts",
+        "companion/src/analysis/ai/analystQueries.ts",
+        "companion/src/analysis/ai/caseReports.ts",
+        "companion/src/analysis/ai/hunts.ts",
+        "companion/src/analysis/ai/pipelineOptions.ts",
+        "companion/src/analysis/ai/synthesis.ts",
+        "companion/src/analysis/hostScopeLoad.ts",
+        "companion/src/composition/aiRuntime.ts",
+        "companion/src/composition/appOptions.ts",
+        "companion/src/composition/maintenanceTasks.ts",
+        "companion/src/composition/runtimeStores.ts",
+        "companion/src/reports/reportWriter.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/velociraptorClientStore.test.ts",
+        "companion/tests/server/playbookHunts.test.ts",
+        "companion/tests/server/veloReconnect.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/velociraptorDownload.ts",
+      "kind": "module",
+      "lines": 68,
+      "imports": [
+        "companion/src/analysis/updateCheck.ts",
+        "companion/src/analysis/velociraptorRelease.ts"
+      ],
+      "importedBy": [
+        "companion/src/routes/velociraptorSettings.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
+      "path": "companion/src/analysis/velociraptorImport.ts",
+      "kind": "module",
+      "lines": 1822,
+      "imports": [
+        "companion/src/analysis/chainsawImport.ts",
+        "companion/src/analysis/csvImport.ts",
+        "companion/src/analysis/scriptBlockFragments.ts",
+        "companion/src/analysis/siemImport.ts",
+        "companion/src/analysis/stateTypes.ts",
+        "companion/src/analysis/thorRowMap.ts",
+        "companion/src/analysis/timestompDetect.ts",
+        "companion/src/analysis/veloMessageFields.ts",
+        "companion/src/analysis/veloRowNormalize.ts",
+        "companion/src/analysis/velociraptorTitle.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/ingest/endpointImports.ts",
+        "companion/src/composition/veloExternalIngest.ts",
+        "companion/src/composition/veloHunts.ts",
+        "companion/src/routes/import.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/velociraptorImport.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/velociraptorRelease.ts",
+      "kind": "module",
+      "lines": 55,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/velociraptorDownload.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/analysis/velociraptorRelease.test.ts"
+      ]
+    },
+    {
+      "path": "companion/src/analysis/velociraptorTitle.ts",
+      "kind": "module",
+      "lines": 46,
+      "imports": [],
+      "importedBy": [
+        "companion/src/analysis/velociraptorImport.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/analysis/wazuhImport.ts",
       "kind": "module",
       "lines": 276,
@@ -8277,7 +8349,7 @@
     {
       "path": "companion/src/analysis/zipArchive.ts",
       "kind": "module",
-      "lines": 282,
+      "lines": 290,
       "imports": [
         "companion/src/analysis/zipCrypto.ts"
       ],
@@ -8317,7 +8389,7 @@
     {
       "path": "companion/src/analysis/zipExtract.ts",
       "kind": "module",
-      "lines": 144,
+      "lines": 149,
       "imports": [
         "companion/src/analysis/zipArchive.ts",
         "companion/src/analysis/zipCrypto.ts"
@@ -8477,7 +8549,7 @@
     {
       "path": "companion/src/auth/policy.ts",
       "kind": "module",
-      "lines": 206,
+      "lines": 239,
       "imports": [
         "companion/src/auth/types.ts"
       ],
@@ -8643,7 +8715,7 @@
     {
       "path": "companion/src/composition/aiRateLimit.ts",
       "kind": "module",
-      "lines": 59,
+      "lines": 91,
       "imports": [
         "companion/src/http/rateLimiter.ts"
       ],
@@ -8651,7 +8723,9 @@
         "companion/src/composition/routeRegistry.ts"
       ],
       "routes": [],
-      "tests": []
+      "tests": [
+        "companion/tests/architecture/aiRouteCoverage.test.ts"
+      ]
     },
     {
       "path": "companion/src/composition/aiRuntime.ts",
@@ -8808,6 +8882,7 @@
       ],
       "routes": [],
       "tests": [
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/composition/enrichmentCoalescing.test.ts",
         "companion/tests/composition/gatedSynthesisAnnounce.test.ts",
         "companion/tests/composition/hostDuplicateGateStatus.test.ts",
@@ -8848,13 +8923,14 @@
     {
       "path": "companion/src/composition/captureAnalysis.ts",
       "kind": "module",
-      "lines": 500,
+      "lines": 520,
       "imports": [
         "companion/src/analysis/aiControl.ts",
         "companion/src/analysis/hostDuplicateGate.ts",
         "companion/src/analysis/hostScopeLoad.ts",
         "companion/src/analysis/notifications.ts",
         "companion/src/composition/appOptions.ts",
+        "companion/src/logging/serverLogger.ts",
         "companion/src/routes/presidioApproval.ts",
         "companion/src/storage/caseStore.ts",
         "companion/src/types.ts"
@@ -8866,6 +8942,7 @@
       "tests": [
         "companion/tests/analysis/analystGateReporting.test.ts",
         "companion/tests/analysis/hostDuplicateImportNotify.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/composition/gatedSynthesisAnnounce.test.ts",
         "companion/tests/composition/hostDuplicateGateStatus.test.ts",
         "companion/tests/composition/ocrlessBackfill.test.ts",
@@ -8907,6 +8984,19 @@
       ],
       "importedBy": [
         "companion/src/server.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
+      "path": "companion/src/composition/caseWriteGuard.ts",
+      "kind": "module",
+      "lines": 57,
+      "imports": [
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/composition/routeRegistry.ts"
       ],
       "routes": [],
       "tests": []
@@ -9176,9 +9266,10 @@
     {
       "path": "companion/src/composition/routeRegistry.ts",
       "kind": "module",
-      "lines": 146,
+      "lines": 153,
       "imports": [
         "companion/src/composition/aiRateLimit.ts",
+        "companion/src/composition/caseWriteGuard.ts",
         "companion/src/routes/aiState.ts",
         "companion/src/routes/aiSynthesis.ts",
         "companion/src/routes/analysisGraph.ts",
@@ -11026,6 +11117,17 @@
       ]
     },
     {
+      "path": "companion/src/integrations/velociraptor/clientInventory.ts",
+      "kind": "module",
+      "lines": 61,
+      "imports": [],
+      "importedBy": [
+        "companion/src/integrations/velociraptor/velociraptorApi.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/integrations/velociraptor/huntStatusPoller.ts",
       "kind": "module",
       "lines": 79,
@@ -11058,12 +11160,13 @@
     {
       "path": "companion/src/integrations/velociraptor/velociraptorApi.ts",
       "kind": "module",
-      "lines": 1291,
+      "lines": 1247,
       "imports": [
         "companion/src/integrations/childOutput.ts",
         "companion/src/integrations/velociraptor/artifactCatalog.ts",
         "companion/src/integrations/velociraptor/artifactRefs.ts",
         "companion/src/integrations/velociraptor/artifactTools.ts",
+        "companion/src/integrations/velociraptor/clientInventory.ts",
         "companion/src/integrations/velociraptor/vqlDiagnostics.ts"
       ],
       "importedBy": [
@@ -11178,6 +11281,7 @@
         "companion/tests/analysis/presidioPipeline.test.ts",
         "companion/tests/analysis/slackSocketMode.test.ts",
         "companion/tests/analysis/telegramPoller.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/logging/logger.test.ts",
         "companion/tests/logging/uncaughtExceptionNet.test.ts",
         "companion/tests/logging/unhandledRejectionNet.test.ts",
@@ -11203,6 +11307,7 @@
       ],
       "importedBy": [
         "companion/src/composition/aiRuntime.ts",
+        "companion/src/composition/captureAnalysis.ts",
         "companion/src/composition/caseNotifier.ts",
         "companion/src/composition/dropFolder.ts",
         "companion/src/composition/enrichment.ts",
@@ -11223,6 +11328,7 @@
       ],
       "routes": [],
       "tests": [
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/logging/uncaughtExceptionNet.test.ts",
         "companion/tests/logging/unhandledRejectionNet.test.ts"
       ]
@@ -11605,7 +11711,7 @@
     {
       "path": "companion/src/reports/attackLayer.ts",
       "kind": "module",
-      "lines": 211,
+      "lines": 204,
       "imports": [
         "companion/src/analysis/stateTypes.ts"
       ],
@@ -11677,8 +11783,9 @@
     {
       "path": "companion/src/reports/glossary.ts",
       "kind": "module",
-      "lines": 88,
+      "lines": 85,
       "imports": [
+        "companion/src/analysis/regexEscape.ts",
         "companion/src/analysis/stateTypes.ts",
         "companion/src/reports/reportMeta.ts"
       ],
@@ -11726,7 +11833,7 @@
     {
       "path": "companion/src/reports/interactiveHtml.ts",
       "kind": "module",
-      "lines": 433,
+      "lines": 432,
       "imports": [
         "companion/src/analysis/stateTypes.ts",
         "companion/src/http/securityHeaders.ts",
@@ -11746,7 +11853,7 @@
     {
       "path": "companion/src/reports/iocBlocklist.ts",
       "kind": "module",
-      "lines": 261,
+      "lines": 260,
       "imports": [
         "companion/src/analysis/stateTypes.ts",
         "companion/src/reports/stix.ts"
@@ -11763,7 +11870,7 @@
     {
       "path": "companion/src/reports/markdown.ts",
       "kind": "module",
-      "lines": 1597,
+      "lines": 1592,
       "imports": [
         "companion/src/analysis/adversaryEmulation.ts",
         "companion/src/analysis/adversaryGroupsData.ts",
@@ -11986,7 +12093,7 @@
     {
       "path": "companion/src/reports/reportTemplate.ts",
       "kind": "module",
-      "lines": 313,
+      "lines": 306,
       "imports": [
         "companion/src/analysis/stateTypes.ts",
         "companion/src/reports/reportMeta.ts"
@@ -12513,6 +12620,19 @@
       ]
     },
     {
+      "path": "companion/src/routes/caseCreateBody.ts",
+      "kind": "module",
+      "lines": 33,
+      "imports": [
+        "companion/src/storage/caseStore.ts"
+      ],
+      "importedBy": [
+        "companion/src/routes/caseLifecycle.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/routes/caseIdentity.ts",
       "kind": "module",
       "lines": 91,
@@ -12531,7 +12651,7 @@
     {
       "path": "companion/src/routes/caseLifecycle.ts",
       "kind": "module",
-      "lines": 904,
+      "lines": 901,
       "imports": [
         "companion/src/analysis/activityLog.ts",
         "companion/src/analysis/caseArchive.ts",
@@ -12552,6 +12672,7 @@
         "companion/src/auth/types.ts",
         "companion/src/http/securityHeaders.ts",
         "companion/src/reports/iocBlocklist.ts",
+        "companion/src/routes/caseCreateBody.ts",
         "companion/src/routes/caseIdentity.ts",
         "companion/src/routes/casePush.ts",
         "companion/src/routes/context.ts",
@@ -13132,7 +13253,7 @@
     {
       "path": "companion/src/routes/import.ts",
       "kind": "module",
-      "lines": 3203,
+      "lines": 3200,
       "imports": [
         "companion/src/analysis/activityLog.ts",
         "companion/src/analysis/auditdImport.ts",
@@ -13172,6 +13293,7 @@
         "companion/src/routes/context.ts",
         "companion/src/routes/importCaseGuard.ts",
         "companion/src/routes/importJobTracking.ts",
+        "companion/src/routes/importKinds.ts",
         "companion/src/routes/importRecovery.ts",
         "companion/src/routes/importRunRecorder.ts",
         "companion/src/routes/importSection.ts",
@@ -13255,9 +13377,23 @@
       ]
     },
     {
+      "path": "companion/src/routes/importKinds.ts",
+      "kind": "module",
+      "lines": 25,
+      "imports": [],
+      "importedBy": [
+        "companion/src/routes/import.ts",
+        "companion/src/routes/importRecovery.ts"
+      ],
+      "routes": [],
+      "tests": [
+        "companion/tests/server/importKinds.test.ts"
+      ]
+    },
+    {
       "path": "companion/src/routes/importRecovery.ts",
       "kind": "module",
-      "lines": 189,
+      "lines": 190,
       "imports": [
         "companion/src/analysis/importResume.ts",
         "companion/src/analysis/iocsDiff.ts",
@@ -13265,6 +13401,7 @@
         "companion/src/analysis/taggerAuto.ts",
         "companion/src/analysis/timelineDiff.ts",
         "companion/src/routes/context.ts",
+        "companion/src/routes/importKinds.ts",
         "companion/src/routes/importRunRecorder.ts"
       ],
       "importedBy": [
@@ -13515,7 +13652,7 @@
     {
       "path": "companion/src/routes/pushNotify.ts",
       "kind": "module",
-      "lines": 244,
+      "lines": 250,
       "imports": [
         "companion/src/analysis/notifications.ts",
         "companion/src/analysis/pushAuth.ts",
@@ -13543,45 +13680,6 @@
       ],
       "tests": [
         "companion/tests/analysis/caseIdGate.test.ts"
-      ]
-    },
-    {
-      "path": "companion/src/routes/reportsExport.ts",
-      "kind": "module",
-      "lines": 393,
-      "imports": [
-        "companion/src/analysis/activityLog.ts",
-        "companion/src/analysis/custodyManifest.ts",
-        "companion/src/analysis/notifications.ts",
-        "companion/src/http/securityHeaders.ts",
-        "companion/src/integrations/iris/irisExportStore.ts",
-        "companion/src/integrations/iris/irisImportFetch.ts",
-        "companion/src/reports/html.ts",
-        "companion/src/routes/context.ts",
-        "companion/src/settings/envManager.ts"
-      ],
-      "importedBy": [
-        "companion/src/composition/routeRegistry.ts"
-      ],
-      "routes": [
-        "POST /cases/:id/report",
-        "GET /cases/:id/report/:file",
-        "GET /cases/:id/report.docx",
-        "GET /cases/:id/export/stix",
-        "GET /cases/:id/report-meta",
-        "PUT /cases/:id/report-meta",
-        "GET /cases/:id/report-template",
-        "PUT /cases/:id/report-template",
-        "GET /iris/status",
-        "POST /iris/reconnect",
-        "GET /iris/cases",
-        "GET /cases/:id/iris-export",
-        "POST /cases/:id/iris-import",
-        "GET /cases/:id/clickup-export"
-      ],
-      "tests": [
-        "companion/tests/e2e/workflows/reports.spec.ts",
-        "companion/tests/server/interactiveReportRoute.test.ts"
       ]
     },
     {
@@ -13621,6 +13719,45 @@
         "GET /cases/:id/report-releases/:releaseId/packs/:pack"
       ],
       "tests": []
+    },
+    {
+      "path": "companion/src/routes/reportsExport.ts",
+      "kind": "module",
+      "lines": 393,
+      "imports": [
+        "companion/src/analysis/activityLog.ts",
+        "companion/src/analysis/custodyManifest.ts",
+        "companion/src/analysis/notifications.ts",
+        "companion/src/http/securityHeaders.ts",
+        "companion/src/integrations/iris/irisExportStore.ts",
+        "companion/src/integrations/iris/irisImportFetch.ts",
+        "companion/src/reports/html.ts",
+        "companion/src/routes/context.ts",
+        "companion/src/settings/envManager.ts"
+      ],
+      "importedBy": [
+        "companion/src/composition/routeRegistry.ts"
+      ],
+      "routes": [
+        "POST /cases/:id/report",
+        "GET /cases/:id/report/:file",
+        "GET /cases/:id/report.docx",
+        "GET /cases/:id/export/stix",
+        "GET /cases/:id/report-meta",
+        "PUT /cases/:id/report-meta",
+        "GET /cases/:id/report-template",
+        "PUT /cases/:id/report-template",
+        "GET /iris/status",
+        "POST /iris/reconnect",
+        "GET /iris/cases",
+        "GET /cases/:id/iris-export",
+        "POST /cases/:id/iris-import",
+        "GET /cases/:id/clickup-export"
+      ],
+      "tests": [
+        "companion/tests/e2e/workflows/reports.spec.ts",
+        "companion/tests/server/interactiveReportRoute.test.ts"
+      ]
     },
     {
       "path": "companion/src/routes/seedDemo.ts",
@@ -14480,6 +14617,7 @@
         "companion/src/composition/aiRuntime.ts",
         "companion/src/composition/captureAnalysis.ts",
         "companion/src/composition/caseAppliers.ts",
+        "companion/src/composition/caseWriteGuard.ts",
         "companion/src/composition/dropFolder.ts",
         "companion/src/composition/enrichment.ts",
         "companion/src/composition/externalTools.ts",
@@ -14509,6 +14647,7 @@
         "companion/src/reports/reportWriter.ts",
         "companion/src/routes/anonymization.ts",
         "companion/src/routes/captures.ts",
+        "companion/src/routes/caseCreateBody.ts",
         "companion/src/routes/caseLifecycle.ts",
         "companion/src/routes/casePassword.ts",
         "companion/src/routes/context.ts",
@@ -14597,6 +14736,7 @@
         "companion/tests/analysis/veloHuntStore.test.ts",
         "companion/tests/analysis/veloMonitorStore.test.ts",
         "companion/tests/architecture/routeInventory.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/composition/enrichmentCoalescing.test.ts",
         "companion/tests/composition/gatedSynthesisAnnounce.test.ts",
         "companion/tests/composition/hostDuplicateGateStatus.test.ts",
@@ -14829,6 +14969,7 @@
         "companion/tests/analysis/operationalMetrics.test.ts",
         "companion/tests/analysis/pipeline.test.ts",
         "companion/tests/analysis/presidioPipeline.test.ts",
+        "companion/tests/composition/backfillCaptureLog.test.ts",
         "companion/tests/e2e/workflows/captures.spec.ts",
         "companion/tests/eval/fixtures.ts",
         "companion/tests/eval/harness.ts",
@@ -15326,7 +15467,7 @@
     {
       "path": "extension/src/serviceWorker.ts",
       "kind": "module",
-      "lines": 413,
+      "lines": 419,
       "imports": [
         "extension/src/actionIcon.ts",
         "extension/src/adapters/artifactName.ts",
@@ -15398,7 +15539,7 @@
     {
       "path": "public/dashboard.html",
       "kind": "page",
-      "lines": 5391,
+      "lines": 5392,
       "imports": [
         "public/js/a11y/announcer.js",
         "public/js/a11y/describe-as-table.js",
@@ -15869,7 +16010,7 @@
     {
       "path": "public/js/dashboard-asset-graph.js",
       "kind": "browser",
-      "lines": 367,
+      "lines": 390,
       "imports": [],
       "importedBy": [
         "public/dashboard.html"
@@ -16569,7 +16710,7 @@
     {
       "path": "public/js/dashboard-host-scope.js",
       "kind": "browser",
-      "lines": 299,
+      "lines": 367,
       "imports": [],
       "importedBy": [
         "public/dashboard.html"
@@ -17036,7 +17177,7 @@
     {
       "path": "public/js/dashboard-push-token.js",
       "kind": "browser",
-      "lines": 120,
+      "lines": 147,
       "imports": [],
       "importedBy": [
         "public/dashboard.html"

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "bd6ce846347de1c410d492e8e90efb1ef4ac88f92b64b05f9e67f4764b588f68",
-  "moduleCount": 792,
+  "sha256": "301b857944d4bbe4218c333b7a416ceb7c8e2778e13d0a6507758ef2985575e8",
+  "moduleCount": 800,
   "routeCount": 476
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1324,20 +1324,7 @@
       <div class="stab-pane" id="stab-ai">
         <div class="srestart-note" data-essential>⚠ All AI settings require a server restart to take effect</div>
         <p class="rm-hint" data-essential data-safe-style="font-size:11px;color:var(--text-muted);margin:2px 0 8px">New here? <a href="#" id="rerunAiWizard" data-safe-style="color:var(--accent-solid)">Re-run the setup wizard</a> for a guided provider/model/key flow with a built-in connection test (#181).</p>
-        <div class="settings-group-head">Presidio (optional external PII detector)</div>
-        <div class="sfield-row">
-          <div class="sfield">
-            <label>Presidio analyzer URL<span class="sfield-hint">DFIR_PRESIDIO_URL — Optional. A Presidio Analyzer container you run yourself. It scans text that has ALREADY been masked, to catch names and IDs the built-in patterns cannot. Leave blank to disable.</span></label>
-            <input id="env-DFIR_PRESIDIO_URL" placeholder="http://localhost:5002" />
-          </div>
-          <div class="sfield"><label>Presidio confidence floor<span class="sfield-hint">DFIR_PRESIDIO_MIN_SCORE</span></label><input id="env-DFIR_PRESIDIO_MIN_SCORE" placeholder="0.6" /></div>
-          <div class="sfield"><label>Presidio request timeout (ms)<span class="sfield-hint">DFIR_PRESIDIO_TIMEOUT_MS — Budget for ONE scan request; a scan is split into 50,000-character chunks and each chunk gets the full budget. It has to cover queueing, not just analysis: the stock container runs a single worker, so a chunk that takes ~2s alone can take ~10s with other scans in flight. Raise this on a slow or shared analyzer. Needs a restart.</span></label><input id="env-DFIR_PRESIDIO_TIMEOUT_MS" placeholder="60000" /></div>
-        </div>
-        <div id="presidioLocalWarning" data-safe-style="display:none;margin:2px 0 8px;padding:8px;border-radius:6px;background:var(--warning-bg);color:var(--tag-orange-text);font-size:12px"></div>
-        <div class="sfield" data-safe-style="margin:0 0 8px">
-          <button type="button" id="presidioTestBtn">Test connection</button>
-          <span id="presidioTestResult" data-safe-style="margin-left:8px;font-size:12px;color:var(--text-muted)"></span>
-        </div>
+        <div class="settings-group-head" data-essential>Vision model (screenshots)</div>
         <div class="sfield-row" data-essential>
           <div class="sfield" data-essential>
             <label>Provider (screenshots)<span class="sfield-hint">DFIR_VISION_PROVIDER</span></label>
@@ -1428,12 +1415,6 @@
               <option value="auto">auto</option>
             </select>
           </div>
-        </div>
-        <div class="settings-group-head">Synthesis detection-burst grouping</div>
-        <div class="sfield-row3">
-          <div class="sfield"><label>Enable grouping<span class="sfield-hint">DFIR_SYNTH_GROUP — collapse repeated hits of the SAME detection/severity into ONE prompt row (hit count, host spread, time span); set 0 to send one row per occurrence (default on)</span></label><input id="env-DFIR_SYNTH_GROUP" placeholder="1" /></div>
-          <div class="sfield"><label>Grouping gap (s)<span class="sfield-hint">DFIR_SYNTH_GROUP_GAP_SECONDS — max gap between consecutive hits before a NEW burst starts (default 3600)</span></label><input id="env-DFIR_SYNTH_GROUP_GAP_SECONDS" placeholder="3600" /></div>
-          <div class="sfield"><label>Grouping min repeats<span class="sfield-hint">DFIR_SYNTH_GROUP_MIN_REPEATS — minimum hits before a burst is collapsed (default 4)</span></label><input id="env-DFIR_SYNTH_GROUP_MIN_REPEATS" placeholder="4" /></div>
         </div>
         <div class="sfield-row">
           <div class="sfield"><label>Include Info events in synthesis<span class="sfield-hint">DFIR_SYNTH_INCLUDE_INFO — send Info-severity events prompt seats too (default off; they'd otherwise crowd out graded detections). Info events always remain in the case/timeline/coverage report either way</span></label><input id="env-DFIR_SYNTH_INCLUDE_INFO" placeholder="0" /></div>
@@ -1558,6 +1539,12 @@
         <div class="sfield-row" data-essential>
           <div class="sfield" data-essential><label>2nd-opinion API key<span class="sfield-hint">DFIR_AI_SECOND_OPINION_KEY</span></label><input id="env-DFIR_AI_SECOND_OPINION_KEY" type="password" placeholder="(reuses main AI key)" autocomplete="new-password" /></div>
           <div class="sfield" data-essential><label>2nd-opinion base URL<span class="sfield-hint">DFIR_AI_SECOND_OPINION_BASE_URL</span></label><input id="env-DFIR_AI_SECOND_OPINION_BASE_URL" /></div>
+        </div>
+        <div class="settings-group-head">Synthesis detection-burst grouping</div>
+        <div class="sfield-row3">
+          <div class="sfield"><label>Enable grouping<span class="sfield-hint">DFIR_SYNTH_GROUP — collapse repeated hits of the SAME detection/severity into ONE prompt row (hit count, host spread, time span); set 0 to send one row per occurrence (default on)</span></label><input id="env-DFIR_SYNTH_GROUP" placeholder="1" /></div>
+          <div class="sfield"><label>Grouping gap (s)<span class="sfield-hint">DFIR_SYNTH_GROUP_GAP_SECONDS — max gap between consecutive hits before a NEW burst starts (default 3600)</span></label><input id="env-DFIR_SYNTH_GROUP_GAP_SECONDS" placeholder="3600" /></div>
+          <div class="sfield"><label>Grouping min repeats<span class="sfield-hint">DFIR_SYNTH_GROUP_MIN_REPEATS — minimum hits before a burst is collapsed (default 4)</span></label><input id="env-DFIR_SYNTH_GROUP_MIN_REPEATS" placeholder="4" /></div>
         </div>
         <div class="settings-group-head">Debugging & custom prompts</div>
         <div class="sfield-row">
@@ -1777,6 +1764,20 @@
       <!-- Integrations -->
       <div class="stab-pane" id="stab-integrations">
         <div class="srestart-note" data-essential>⚠ All integration settings require a server restart to take effect</div>
+        <div class="settings-group-head">Presidio (optional external PII detector)</div>
+        <div class="sfield-row">
+          <div class="sfield">
+            <label>Presidio analyzer URL<span class="sfield-hint">DFIR_PRESIDIO_URL — Optional. A Presidio Analyzer container you run yourself. It scans text that has ALREADY been masked, to catch names and IDs the built-in patterns cannot. Leave blank to disable.</span></label>
+            <input id="env-DFIR_PRESIDIO_URL" placeholder="http://localhost:5002" />
+          </div>
+          <div class="sfield"><label>Presidio confidence floor<span class="sfield-hint">DFIR_PRESIDIO_MIN_SCORE</span></label><input id="env-DFIR_PRESIDIO_MIN_SCORE" placeholder="0.6" /></div>
+          <div class="sfield"><label>Presidio request timeout (ms)<span class="sfield-hint">DFIR_PRESIDIO_TIMEOUT_MS — Budget for ONE scan request; a scan is split into 50,000-character chunks and each chunk gets the full budget. It has to cover queueing, not just analysis: the stock container runs a single worker, so a chunk that takes ~2s alone can take ~10s with other scans in flight. Raise this on a slow or shared analyzer. Needs a restart.</span></label><input id="env-DFIR_PRESIDIO_TIMEOUT_MS" placeholder="60000" /></div>
+        </div>
+        <div id="presidioLocalWarning" data-safe-style="display:none;margin:2px 0 8px;padding:8px;border-radius:6px;background:var(--warning-bg);color:var(--tag-orange-text);font-size:12px"></div>
+        <div class="sfield" data-safe-style="margin:0 0 8px">
+          <button type="button" id="presidioTestBtn">Test connection</button>
+          <span id="presidioTestResult" data-safe-style="margin-left:8px;font-size:12px;color:var(--text-muted)"></span>
+        </div>
         <div class="settings-group-head" data-essential>DFIR-IRIS</div>
         <div class="sfield-row" data-essential>
           <div class="sfield" data-essential><label>IRIS URL<span class="sfield-hint">DFIR_IRIS_URL</span></label><input id="env-DFIR_IRIS_URL" placeholder="https://iris.example.org" /></div>


### PR DESCRIPTION
## Summary

- add a consistent blue heading for the vision model settings
- place synthesis detection-burst grouping after the second-opinion model
- move Presidio settings from AI to Integrations
- refresh the stale code map and add settings-placement regression coverage

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:size`
- `npm run check:imports`
- `npm test` — 647 files, 9,995 tests
- verified the settings layout in the browser