### PR TITLE
fix(dashboard): add Query Translator and Investigation Log to the Analyst view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Query Translator and Investigation Log join the Analyst view** — v0.35.0 made them reachable via Deep-Dive only; they now also sit in the analyst's densest workspace, where the rest of the panels are.
+
 ## [0.35.0] - 2026-08-21
 
 ### Added

--- a/companion/src/analysis/dashboardViews.ts
+++ b/companion/src/analysis/dashboardViews.ts
@@ -131,6 +131,7 @@ export const BUILT_IN_DASHBOARD_VIEWS: readonly DashboardView[] = [
     sections: [
       "sec-now",
       "sec-ask",
+      "sec-nlquery",
       "sec-exec",
       "sec-narrative",
       "sec-findings",
@@ -172,6 +173,7 @@ export const BUILT_IN_DASHBOARD_VIEWS: readonly DashboardView[] = [
       "sec-hypotheses",
       "sec-notebook",
       "sec-mcp",
+      "sec-inv-log",
       "sec-custody",
       "sec-case-details",
     ],

--- a/companion/tests/analysis/dashboardViews.test.ts
+++ b/companion/tests/analysis/dashboardViews.test.ts
@@ -78,15 +78,21 @@ describe("dashboardViews — seed integrity", () => {
     const analyst = getDashboardView("analyst");
     expect(analyst).toBeDefined();
     // Curated to match the default onboarding layout — excludes the handful of sections that are
-    // opt-in/secondary (Query Translator, Recommended Next Steps, Investigation Log, Activity
-    // Log). Everything else is shown, in the app's canonical reading order.
-    const excluded = ["sec-nlquery", "sec-next-steps", "sec-inv-log", "sec-activity"];
+    // opt-in/secondary. Everything else is shown, in the app's canonical reading order.
+    //
+    // Query Translator and Investigation Log used to be excluded here too, on the same
+    // opt-in/secondary reasoning. That was reversed by an explicit product decision: both were
+    // reachable from NO built-in view at all, and the fix was to put them in the analyst's densest
+    // workspace rather than only in Deep-Dive. Recommended Next Steps and Activity Log stay out
+    // because they are already carried by other profiles (Lead/Triage/Hunt-Prep and Deep-Dive).
+    const excluded = ["sec-next-steps", "sec-activity"];
     for (const id of excluded) {
       expect(analyst!.sections.includes(id), `analyst excludes ${id}`).toBe(false);
     }
     expect(analyst!.sections).toEqual([
       "sec-now",
       "sec-ask",
+      "sec-nlquery",
       "sec-exec",
       "sec-narrative",
       "sec-findings",
@@ -128,6 +134,7 @@ describe("dashboardViews — seed integrity", () => {
       "sec-hypotheses",
       "sec-notebook",
       "sec-mcp",
+      "sec-inv-log",
       "sec-custody",
       "sec-case-details",
     ]);


### PR DESCRIPTION
v0.35.0 fixed six panels that were registered but reachable from no built-in view. Four went into Analyst; Query Translator and Investigation Log went into Deep-Dive only, because the Analyst seed test recorded their exclusion as deliberate curation.

That deferred to the test over an explicit product decision to show them in the analyst's densest workspace. This restores that decision and updates the seed test to match.

Recommended Next Steps and Activity Log stay excluded from Analyst — unlike these two, they were never orphaned; Lead/Triage/Hunt-Prep and Deep-Dive already carry them.

Lands after the v0.35.0 tag, so it is filed under `[Unreleased]`.