### PR TITLE
fix(test): resolve script paths with fileURLToPath so Windows CI can run them

### DIFF
--- a/companion/tests/architecture/dashboardInventory.test.ts
+++ b/companion/tests/architecture/dashboardInventory.test.ts
@@ -15,9 +15,12 @@ import { describe, expect, it } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { runScript, runScriptExpectingFailure } from "../helpers/runScript.js";
 
-const SCRIPT = new URL("../../scripts/dashboard-inventory.mjs", import.meta.url).pathname;
+// fileURLToPath, NOT `.pathname`: on Windows `.pathname` yields "/D:/a/..." and Node
+// resolves that against the drive as "D:\\D:\\a\\...", so the script is never found.
+const SCRIPT = fileURLToPath(new URL("../../scripts/dashboard-inventory.mjs", import.meta.url));
 
 const run = (): {
   inlineScript: { lines: number };

--- a/companion/tests/architecture/dashboardSectionSplit.test.ts
+++ b/companion/tests/architecture/dashboardSectionSplit.test.ts
@@ -10,9 +10,12 @@ import { describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { runScript, runScriptExpectingFailure } from "../helpers/runScript.js";
 
-const SCRIPT = new URL("../../scripts/dashboard-section-split.mjs", import.meta.url).pathname;
+// fileURLToPath, NOT `.pathname`: on Windows `.pathname` yields "/D:/a/..." and Node
+// resolves that against the drive as "D:\\D:\\a\\...", so the script is never found.
+const SCRIPT = fileURLToPath(new URL("../../scripts/dashboard-section-split.mjs", import.meta.url));
 
 /** Write a throwaway dashboard whose inline script is exactly `body`, one statement per line. */
 const dashboardWith = (body: string[]): { dir: string; path: string } => {


### PR DESCRIPTION
Two architecture suites resolved their script path with `new URL(..., import.meta.url).pathname`. On Windows that produces `/D:/a/...`, which Node then resolves against the drive as `D:\\D:\\a\\...`, so the script is never found and every case in both files fails.

That is what took the Windows EXE job down in the v0.35.0 tag build. Because "Attach to GitHub Release" is gated on it, **v0.35.0 published with no binaries** — the Linux AppImage and both extension zips built fine but were never attached.

`fileURLToPath` is the documented conversion and is correct on both platforms; Linux behaviour is unchanged.

Two things this does **not** fix, both pre-existing:
- The same Windows job also had several timeout-shaped failures (15005ms, 10662ms) on the slow runner. This may not be enough to make Windows green on its own.
- "Publish to Chrome Web Store" failed separately on an OAuth token exchange — a repository-secret problem, not code.

Relates to #488, which introduced the pattern.