### PR TITLE
chore: release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-08-21
+
+### Fixed
+- **The release build produces binaries again** — two architecture suites resolved their script path with `.pathname`, which on Windows yields `/D:/a/…` and resolves as `D:\D:\a\…`. Every case failed, taking the Windows EXE job down; because the release-attach step is gated on it, v0.35.0 published with no downloads even though the AppImage and extension zips had built.
+
 ### Changed
 - **Query Translator and Investigation Log join the Analyst view** — v0.35.0 made them reachable via Deep-Dive only; they now also sit in the analyst's densest workspace, where the rest of the panels are.
 
@@ -794,7 +799,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Localhost companion server; evidence-first ingest; two-phase AI analysis; provider abstraction; investigation scope; CSV (Velociraptor/EDR) import.
 
-[Unreleased]: https://github.com/hasamba/DFIR-Companion/compare/v0.35.0...HEAD
+[Unreleased]: https://github.com/hasamba/DFIR-Companion/compare/v0.35.1...HEAD
+[0.35.1]: https://github.com/hasamba/DFIR-Companion/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/hasamba/DFIR-Companion/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/hasamba/DFIR-Companion/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/hasamba/DFIR-Companion/compare/v0.32.0...v0.33.0

--- a/companion/package-lock.json
+++ b/companion/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dfir-companion",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dfir-companion",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "cross-spawn": "^7.0.6",

--- a/companion/package.json
+++ b/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dfir-companion",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",

--- a/docs/index.html
+++ b/docs/index.html
@@ -497,7 +497,7 @@
       <div class="hero-text">
         <div class="hero-badge animate">
           <span class="pulse"></span>
-          v0.35.0 — open source, AGPL-3.0 · Second pair of (A)eyes
+          v0.35.1 — open source, AGPL-3.0 · Second pair of (A)eyes
         </div>
         <h1 class="animate animate-d1">
           Second pair of<br>
@@ -522,7 +522,7 @@
           <div class="terminal-body">
             <span class="comment"># Start the companion</span><br>
             <span class="prompt">$</span> <span class="cmd">cd</span> companion && <span class="cmd">npm</span> run dev<br><br>
-            <span class="output">[DFIR] companion v0.35.0 — localhost only</span><br>
+            <span class="output">[DFIR] companion v0.35.1 — localhost only</span><br>
             <span class="output">[DFIR] cases root: ./cases</span><br>
             <span class="success">[DFIR] listening on http://127.0.0.1:4773</span><br>
             <span class="success">[DFIR] dashboard: http://127.0.0.1:4773/dashboard</span><br><br>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "DFIR Companion — Evidence Capture & Push",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Connects to your local DFIR Companion server. Captures screenshots and pushes detections from DFIR consoles to the dashboard.",
   "icons": {
     "16": "icons/icon16.png",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dfir-capture-extension",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dfir-capture-extension",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/chrome": "^0.0.268",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dfir-capture-extension",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "license": "AGPL-3.0-only",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Patch release whose purpose is to produce the binaries v0.35.0 never shipped.

v0.35.0 published with **no release assets**: the Windows EXE job failed on a script-path bug, and `Attach to GitHub Release` is gated on it, so the Linux AppImage and both extension zips were built and then discarded. #611 fixed the path bug; this tags a release that can actually carry them.

Contents:
- Version bumped across all five files, verified consistent.
- CHANGELOG `[Unreleased]` renamed to `[0.35.1]`, compare links updated, `[Unreleased]` kept alive.
- Landing page version strings bumped in the hero badge and terminal mock. Feature-card tags stay at v0.35.0 — they name the release those features landed in.

Pre-tag checklist re-run for the patch: no new `DFIR_*` settings, no new panels, no new importers, no wizard step, and the manual describes view profiles generically so the Analyst change needs no doc edit.

Gate green locally: typecheck, lint, format, and 653 files / 10,029 tests.

Known and **not** fixed here: `Publish to Chrome Web Store` fails on an OAuth token exchange against repository secrets. That needs a refreshed refresh-token and will fail again on this tag.