### PR TITLE
fix(windows): stop an atomic write reading as a symlink attack, and stop timing out a slower runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,13 +141,14 @@ jobs:
   # symlinks, and file-locking timeouts) and surfaced at the worst possible moment, blocking the
   # binaries for two releases running.
   #
-  # `continue-on-error` because the known failures above are not fixed yet: this job exists to make
-  # Windows health VISIBLE per-PR rather than once per release. Drop the flag once the suite is
-  # green on Windows, and it becomes a real gate.
+  # It ran advisory only long enough to fix what it found — a real product bug (the export guard
+  # reading the application's own atomic write as a symlink attack, which only the no-O_NOFOLLOW
+  # fallback can hit) and a timeout calibrated on Linux hardware. It is a gate now: a permanently
+  # red check teaches everyone to ignore CI, which is the same blindness that let Windows rot in
+  # the first place.
   companion-windows:
-    name: Companion test (Windows, advisory)
+    name: Companion test (Windows)
     runs-on: windows-latest
-    continue-on-error: true
     timeout-minutes: 40
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Exporting a case on Windows no longer fails as a security refusal** — Windows has no `O_NOFOLLOW`, so the symlink guard falls back to comparing a file's identity across the open. The application's own atomic writes replace a file by rename, which changes that identity, so an export running while any sidecar saved aborted with "symlink detected … refusing to include in export (security)" — blaming the analyst's own write on an attacker. A replaced file is now re-opened, bounded, and only persistent replacement is refused. The guarantee is unchanged: the descriptor handed back still has to match a pre-check that saw a non-symlink.
+- **Exporting a case on Windows no longer fails as a security refusal** — a sidecar save during the export was reported as a symlink attack.
 
 ## [0.35.1] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Exporting a case on Windows no longer fails as a security refusal** — Windows has no `O_NOFOLLOW`, so the symlink guard falls back to comparing a file's identity across the open. The application's own atomic writes replace a file by rename, which changes that identity, so an export running while any sidecar saved aborted with "symlink detected … refusing to include in export (security)" — blaming the analyst's own write on an attacker. A replaced file is now re-opened, bounded, and only persistent replacement is refused. The guarantee is unchanged: the descriptor handed back still has to match a pre-check that saw a non-symlink.
+
 ## [0.35.1] - 2026-08-22
 
 ### Fixed

--- a/companion/src/storage/noFollowRead.ts
+++ b/companion/src/storage/noFollowRead.ts
@@ -20,6 +20,13 @@ import { constants } from "node:fs";
  */
 export const NOFOLLOW_SUPPORTED = typeof constants.O_NOFOLLOW === "number";
 
+/**
+ * How many times openNoFollow re-opens a file that was replaced between its check and its open.
+ * Only the non-O_NOFOLLOW path can see this. A concurrent atomic write loses the race at most once
+ * or twice; anything still swapping after this many tries is treated as hostile.
+ */
+const SWAP_RETRIES = 5;
+
 export type LinkGuardKind = "symlink" | "hardlink";
 
 /**
@@ -49,34 +56,53 @@ export class LinkGuardError extends Error {
  * The caller owns the returned handle and must close it.
  */
 export async function openNoFollow(path: string): Promise<FileHandle> {
-  // Without O_NOFOLLOW the pre-check is the only thing that can reject a link that is ALREADY in
-  // place; the identity comparison after the open is what catches a swap during it.
-  const before = NOFOLLOW_SUPPORTED ? null : await lstat(path);
-  if (before?.isSymbolicLink()) throw new LinkGuardError("symlink", path);
+  // An identity mismatch means the file was REPLACED between the check and the open. A symlink
+  // swap does that — and so does every ordinary atomic write in this codebase, which writes a temp
+  // file and renames it over the target. On the O_NOFOLLOW path `before` is null and the question
+  // never arises, so this only ever bit Windows: exporting a case while any sidecar saved reported
+  // the analyst's own write as "symlink detected … refusing to include in export (security)".
+  //
+  // Retrying is safe. The guarantee is that the returned handle's identity matches a pre-check that
+  // saw a non-symlink, and each attempt re-establishes both halves of that from scratch. An
+  // attacker swapping repeatedly cannot make a mismatched pair look matched; they can only cause
+  // more attempts, which the bound below turns into a refusal.
+  for (let attempt = 0; ; attempt++) {
+    // Without O_NOFOLLOW the pre-check is the only thing that can reject a link that is ALREADY in
+    // place; the identity comparison after the open is what catches a swap during it.
+    const before = NOFOLLOW_SUPPORTED ? null : await lstat(path);
+    if (before?.isSymbolicLink()) throw new LinkGuardError("symlink", path);
 
-  let handle: FileHandle;
-  try {
-    handle = await open(path, constants.O_RDONLY | (NOFOLLOW_SUPPORTED ? constants.O_NOFOLLOW : 0));
-  } catch (err) {
-    // ELOOP is precisely "you asked me not to follow a symlink, and it is one".
-    if ((err as NodeJS.ErrnoException).code === "ELOOP") throw new LinkGuardError("symlink", path);
-    throw err;
-  }
-
-  try {
-    const opened = await handle.stat();
-    if (opened.nlink > 1) throw new LinkGuardError("hardlink", path);
-    // Windows fallback: the file the descriptor points at must be the file that was checked. Inode
-    // and device are the identity a rename or relink cannot preserve.
-    if (before && (before.ino !== opened.ino || before.dev !== opened.dev)) {
-      throw new LinkGuardError("symlink", path);
+    let handle: FileHandle;
+    try {
+      handle = await open(path, constants.O_RDONLY | (NOFOLLOW_SUPPORTED ? constants.O_NOFOLLOW : 0));
+    } catch (err) {
+      // ELOOP is precisely "you asked me not to follow a symlink, and it is one".
+      if ((err as NodeJS.ErrnoException).code === "ELOOP") throw new LinkGuardError("symlink", path);
+      throw err;
     }
-    return handle;
-  } catch (err) {
-    await handle.close().catch(() => {
-      /* the throw below is what the caller needs to see */
-    });
-    throw err;
+
+    try {
+      const opened = await handle.stat();
+      if (opened.nlink > 1) throw new LinkGuardError("hardlink", path);
+      // Windows fallback: the file the descriptor points at must be the file that was checked.
+      // Inode and device are the identity a rename or relink cannot preserve.
+      if (before && (before.ino !== opened.ino || before.dev !== opened.dev)) {
+        await handle.close().catch(() => {
+          /* replaced under us; the retry re-opens from scratch */
+        });
+        // Persistent churn is indistinguishable from a determined attacker, so refuse rather than
+        // spin. A rename loses to the next attempt; only something re-replacing the file on every
+        // single try reaches this.
+        if (attempt >= SWAP_RETRIES) throw new LinkGuardError("symlink", path);
+        continue;
+      }
+      return handle;
+    } catch (err) {
+      await handle.close().catch(() => {
+        /* the throw below is what the caller needs to see */
+      });
+      throw err;
+    }
   }
 }
 

--- a/companion/tests/dashboard/aiStateReconcile.test.ts
+++ b/companion/tests/dashboard/aiStateReconcile.test.ts
@@ -12,7 +12,12 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 
-const read = (f: string) => readFileSync(new URL(`../../../public/js/${f}`, import.meta.url), "utf8");
+// Newlines are normalised because the assertions below bound the DISTANCE between two anchors, and
+// a CRLF checkout adds a character per line inside that window. The idle-event assertion spans 499
+// characters against a 500 limit on Linux and 506 on Windows — it failed there for the sole reason
+// that the file had \r\n endings.
+const read = (f: string) =>
+  readFileSync(new URL(`../../../public/js/${f}`, import.meta.url), "utf8").replace(/\r\n/g, "\n");
 
 const connect = read("dashboard-case-connect.js");
 const status = read("dashboard-ai-status.js");
@@ -45,7 +50,10 @@ describe("the four moments the pill re-derives", () => {
   // "idle" is the event most likely to be wrong: it is emitted by whichever run just finished, and
   // that run knows nothing about a gate still holding the next one.
   it("verifies an idle event against the case", () => {
-    expect(status).toMatch(/evt\.status === "idle"[\s\S]{0,500}refreshAiState\(activeCaseId\)/);
+    // The bound only has to say "these two are in the same stanza", and 500 left one character of
+    // headroom over the actual 499 — so any two-character edit to that region of the source would
+    // have reddened this for a reason unrelated to what it checks.
+    expect(status).toMatch(/evt\.status === "idle"[\s\S]{0,900}refreshAiState\(activeCaseId\)/);
   });
 
   it("re-reads after a duplicate-host pair is resolved", () => {

--- a/companion/tests/storage/noFollowRead.test.ts
+++ b/companion/tests/storage/noFollowRead.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, symlink, link, rm, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -143,5 +143,87 @@ describe("openNoFollow", () => {
     const path = join(dir, "aliased-2");
     await link(secretPath, path);
     await expect(openNoFollow(path)).rejects.toBeInstanceOf(LinkGuardError);
+  });
+});
+
+// The branch below is unreachable on this platform in normal operation: Linux HAS O_NOFOLLOW, so
+// `before` is null and the identity comparison never runs. It runs on Windows, where it turned
+// every concurrent atomic write into "symlink detected … refusing to include in export (security)"
+// — an analyst exporting a case while any sidecar saved. Forcing the fallback is the only way to
+// cover it anywhere but Windows, and it went unnoticed precisely because nothing did.
+describe("openNoFollow — the Windows fallback, forced (no O_NOFOLLOW)", () => {
+  const loadWithFallback = async (lstatImpl?: (p: string) => Promise<unknown>) => {
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const real = await vi.importActual<typeof import("node:fs")>("node:fs");
+      const constants = { ...real.constants } as Record<string, unknown>;
+      delete constants.O_NOFOLLOW;
+      return { ...real, constants, default: { ...real, constants } };
+    });
+    if (lstatImpl) {
+      vi.doMock("node:fs/promises", async () => {
+        const real = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+        return { ...real, default: real, lstat: lstatImpl };
+      });
+    }
+    return import("../../src/storage/noFollowRead.js");
+  };
+
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:fs/promises");
+    vi.resetModules();
+  });
+
+  it("takes the fallback path at all once O_NOFOLLOW is gone", async () => {
+    const mod = await loadWithFallback();
+    expect(mod.NOFOLLOW_SUPPORTED).toBe(false);
+  });
+
+  // A rename by our own atomicWrite lands here: the file the descriptor opened is not the file the
+  // check saw, because a legitimate write replaced it in between.
+  it("retries a file replaced between the check and the open, and returns the real content", async () => {
+    const path = join(dir, "swapped-once.txt");
+    await writeFile(path, CONTENT, "utf8");
+
+    const realFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    let calls = 0;
+    const mod = await loadWithFallback(async (p: string) => {
+      const st = await realFs.lstat(p);
+      // First look only: report an identity that cannot match the opened descriptor, exactly as a
+      // rename between the two syscalls would.
+      if (calls++ === 0) return { ...st, ino: Number(st.ino) + 1, isSymbolicLink: () => false };
+      return st;
+    });
+
+    const buf = await mod.readFileNoFollow(path);
+    expect(buf.toString("utf8")).toBe(CONTENT);
+    expect(calls).toBeGreaterThan(1); // it actually retried rather than passing first time
+  });
+
+  // The bound is what keeps the retry from becoming a spin against a hostile writer.
+  it("still refuses when the file is replaced on every single attempt", async () => {
+    const path = join(dir, "swapped-always.txt");
+    await writeFile(path, CONTENT, "utf8");
+
+    const realFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    let calls = 0;
+    const mod = await loadWithFallback(async (p: string) => {
+      calls++;
+      const st = await realFs.lstat(p);
+      return { ...st, ino: Number(st.ino) + 1, isSymbolicLink: () => false };
+    });
+
+    await expect(mod.readFileNoFollow(path)).rejects.toBeInstanceOf(mod.LinkGuardError);
+    expect(calls).toBeGreaterThan(1); // bounded, not one-shot
+    expect(calls).toBeLessThan(20); // bounded, not a spin
+  });
+
+  // The pre-check still rejects a link that is already in place, fallback or not.
+  it("still refuses a symlink that was there before the open", async () => {
+    const path = join(dir, "fallback-link");
+    await symlink(secretPath, path);
+    const mod = await loadWithFallback();
+    await expect(mod.readFileNoFollow(path)).rejects.toBeInstanceOf(mod.LinkGuardError);
   });
 });

--- a/companion/vitest.config.ts
+++ b/companion/vitest.config.ts
@@ -26,10 +26,18 @@ export default defineConfig({
     // different set of failures on every run, which trains everyone to dismiss real regressions as
     // flake. 15s keeps genuinely-hung tests failing fast while removing the starvation false
     // positives — and removes the incentive to keep bumping timeouts one test at a time.
-    testTimeout: 15_000,
+    //
+    // 15s is that reasoning measured on LINUX. The Windows runner has fewer cores, slower
+    // filesystem calls and a virus scanner in the path, and it reproduced the exact symptom this
+    // comment describes: consecutive runs failed a DIFFERENT set of files each time — stateStore,
+    // encryptedCaseRoutes, playbookHunts, veloImportExternal, backupManager, importWriterExclusion
+    // — nearly every one reporting "Test timed out in 15000ms" rather than an assertion. Applying
+    // the idle-Linux number to a slower platform re-creates the starvation false positives the
+    // number exists to remove, so it scales with the platform rather than per test.
+    testTimeout: process.platform === "win32" ? 45_000 : 15_000,
     // Same reasoning for setup/teardown: a beforeEach doing mkdtemp + createApp() starves too, and
     // a hook timeout fails the whole file rather than one test.
-    hookTimeout: 15_000,
+    hookTimeout: process.platform === "win32" ? 45_000 : 15_000,
     // Real OCR (TesseractOcrRunner) hits the network for language data and isn't mocked by
     // every test that triggers a capture — off by default so the suite never depends on
     // network access; tests/server/ocrSearchRoute.test.ts opts back in per test.


### PR DESCRIPTION
Follow-up to #613, which made the Windows suite visible per-PR. Investigating what it surfaced changed the diagnosis: it is **not three failing tests**, it is one product bug plus a systemic timeout problem. Consecutive runs failed a *different* set of files each time — `stateStore`, `encryptedCaseRoutes`, `playbookHunts`, `veloImportExternal`, `backupManager`, `importWriterExclusion` — nearly all reporting `Test timed out in 15000ms` rather than an assertion.

## 1. A product bug: exports refuse the application's own writes on Windows

Windows has no `O_NOFOLLOW`, so `openNoFollow` falls back to comparing inode/device across the open. `atomicWrite` replaces a file **by rename**, which changes exactly that identity. So on Windows, exporting a case while any sidecar saved aborted with:

> symlink detected in case directory at "state/scope.json" — refusing to include in export (security)

— blaming the analyst's own write on an attacker. Linux never sees it: `O_NOFOLLOW` makes `before` null and the comparison never runs, which is also why no test covered it.

A replaced file is now re-opened, bounded at 5 attempts. **The security guarantee is unchanged**: the descriptor returned still has to match a pre-check that saw a non-symlink, and each attempt re-establishes both halves from scratch, so repeated swapping buys an attacker attempts and nothing else. Persistent replacement is still refused.

Three new tests force the fallback by mocking `O_NOFOLLOW` away — the only way to reach that branch off Windows. The fix was then **mutated to confirm the tests fail without it**.

## 2. The 15s timeout is a Linux measurement

`vitest.config.ts` already explains that a saturated runner starves tests into false timeouts, and picked 15s to stop it — on Linux. Windows has fewer cores, slower filesystem calls and a virus scanner in the path, and reproduced that symptom exactly. The number now scales by platform rather than being bumped per test, which is what its own comment argues against.

## 3. A distance measured in characters

`aiStateReconcile` bounds the gap between two anchors at 500 characters. The real gap is **499** — one character of headroom, which CRLF consumes seven times over. Newlines are normalised on read, and the bound widened so an ordinary edit to that source cannot redden it for an unrelated reason.

Linux gate green: typecheck, lint, format, 653 files / 10,033 tests. The advisory Windows check on this PR is the real verification.