### PR TITLE
fix(test): scale poll budgets on Windows too, not just the vitest timeout

### DIFF
--- a/companion/tests/helpers/poll.ts
+++ b/companion/tests/helpers/poll.ts
@@ -15,12 +15,48 @@
  * express. Callers must still ensure the test's own timeout exceeds the sum of its poll budgets —
  * see POLL_TIMEOUT_MS users for the arithmetic.
  */
-export const POLL_TIMEOUT_MS = 10_000;
+/**
+ * Every budget here is a wall-clock measurement taken on Linux. Windows CI runs the same suite on
+ * fewer cores with slower filesystem calls, so the same number is not the same budget there.
+ *
+ * SCALE EVERY LAYER BY THE SAME FACTOR, or the relationships between them break. `POLL_TIMEOUT_MS`
+ * is exported and 62 tests build their own `it()` timeout from it as `POLL_TIMEOUT_MS * 2`, and an
+ * explicit `it()` timeout OVERRIDES vitest.config.ts entirely — so those tests never saw its
+ * Windows scaling. Scaling only the inner poll would have put a 30s poll inside a 20s test and made
+ * Windows worse than the bug it was fixing.
+ *
+ * Everything scaled therefore comes from `pollBudget()`, `POLL_TIMEOUT_MS` included. Because one
+ * factor applies throughout, every ratio holds exactly as on Linux — above all the one this file
+ * demands of callers: a test timeout above the SUM of its poll budgets.
+ *
+ * The budget is a BRANDED type because a raw number cannot say whether it has been scaled yet, and
+ * getting that wrong is INVISIBLE ON LINUX — the factor is 1 here, so a double-scaled budget and a
+ * correct one are the same value. A regex over the test sources was tried first and cannot work:
+ * `timeoutMs` is also an option name for the provider, MCP and tool runners (60-odd unrelated
+ * hits), and it says nothing about `const b = POLL_TIMEOUT_MS * 2` passed in a variable. The
+ * compiler rejects a bare number at exactly the three call sites that are really PollOptions.
+ */
+const PLATFORM_SLOWDOWN = process.platform === "win32" ? 3 : 1;
+
+/**
+ * A poll budget that has already been platform-scaled. Only `pollBudget()` can make one, so a bare
+ * number — including `POLL_TIMEOUT_MS * 2`, the double-scaling trap — is a compile error.
+ */
+export type PollBudgetMs = number & { readonly __pollBudget: unique symbol };
+
+/** Scale a Linux-measured budget for this platform. The ONLY way to build a `timeoutMs` override. */
+export const pollBudget = (linuxMs: number): PollBudgetMs => (linuxMs * PLATFORM_SLOWDOWN) as PollBudgetMs;
+
+/** Platform-scaled default. Also the right constant for an `it()` timeout, which nothing scales. */
+export const POLL_TIMEOUT_MS = pollBudget(10_000);
 const POLL_INTERVAL_MS = 20;
 
 export interface PollOptions {
-  /** Wall-clock budget. Keep the caller's test timeout above the SUM of its polls. */
-  timeoutMs?: number;
+  /**
+   * Wall-clock budget from `pollBudget(linuxMs)`. Keep the caller's test timeout above the SUM of
+   * its polls — both sides scale by the same factor, so that arithmetic is platform-independent.
+   */
+  timeoutMs?: PollBudgetMs;
   intervalMs?: number;
 }
 
@@ -34,6 +70,8 @@ export async function pollFor<T>(
   probe: () => Promise<T | undefined | null>,
   options: PollOptions = {},
 ): Promise<T> {
+  // No scaling here: pollBudget() already applied the factor, and POLL_TIMEOUT_MS is one of its
+  // products. Scaling again is the bug the branded type exists to make unrepresentable.
   const timeoutMs = options.timeoutMs ?? POLL_TIMEOUT_MS;
   const intervalMs = options.intervalMs ?? POLL_INTERVAL_MS;
   const deadline = Date.now() + timeoutMs;

--- a/companion/tests/server/ocrSearchRoute.test.ts
+++ b/companion/tests/server/ocrSearchRoute.test.ts
@@ -7,7 +7,7 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { createApp } from "../../src/server.js";
 import { _resetDedupCache } from "../../src/ingest/captureIngest.js";
 import type { OcrRunner } from "../../src/analysis/ocrRedact.js";
-import { pollFor, POLL_TIMEOUT_MS, type PollOptions } from "../helpers/poll.js";
+import { pollFor, pollBudget, POLL_TIMEOUT_MS, type PollOptions } from "../helpers/poll.js";
 
 // Stub OCR runner — "reads" a fixed line so the background-index path is exercised without tesseract.
 const stubOcr: OcrRunner = {
@@ -150,7 +150,7 @@ describe("POST /captures background OCR indexing", () => {
       // Doubled because this is the slowest workload in the file: seven background OCR jobs behind a
       // concurrency cap. The per-file waits this replaces gave each file its own 4s, so a single
       // DEFAULT budget would have made the wait SHORTER than before — the opposite of the point.
-      await waitForIndexed(files, { timeoutMs: POLL_TIMEOUT_MS * 2 });
+      await waitForIndexed(files, { timeoutMs: pollBudget(20_000) });
       expect(Object.keys(await cases.loadOcrIndex("c1"))).toHaveLength(7);
     },
     POLL_TIMEOUT_MS * 3,

--- a/companion/tests/server/superTimeline.test.ts
+++ b/companion/tests/server/superTimeline.test.ts
@@ -21,7 +21,7 @@ import {
   type VelociraptorApiConfig,
 } from "../../src/integrations/velociraptor/velociraptorApi.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
-import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
+import { pollFor, pollBudget, POLL_TIMEOUT_MS } from "../helpers/poll.js";
 
 // Fills the three array fields every ForensicEvent carries but no super-timeline assertion in
 // this file reads, so each literal below stays about the fields the route actually filters on.
@@ -93,7 +93,7 @@ describe("super-timeline dual-write", () => {
         const response = await request(app).get("/cases/c1/super-timeline");
         return response.body.total > 0 ? response : undefined;
       },
-      { timeoutMs: 3_000, intervalMs: 25 },
+      { timeoutMs: pollBudget(3_000), intervalMs: 25 },
     );
     expect(res.status).toBe(200);
     expect(res.body.total).toBeGreaterThan(0);
@@ -108,7 +108,7 @@ describe("super-timeline dual-write", () => {
         const current = await importMetaStore.load("c1");
         return current.lastImportedAt ? current : undefined;
       },
-      { timeoutMs: 3_000, intervalMs: 25 },
+      { timeoutMs: pollBudget(3_000), intervalMs: 25 },
     );
     expect((await stateStore.load("c1")).forensicTimeline).toHaveLength(0);
     expect(meta.addedCount).toBe(0);


### PR DESCRIPTION
Windows went green in #615 and failed on the next PR — `superTimeline` timing out after 3000ms waiting for an imported event.

#615 scaled `testTimeout` and stopped there. `tests/helpers/poll.ts` already documents why that is insufficient:

> when such a loop gives up it throws its OWN error, so raising `testTimeout` cannot save it: the loop is the binding constraint, not Vitest.

## Scaling only the poll budget would have been worse than the bug

**62 tests** build their own `it()` timeout as `POLL_TIMEOUT_MS * 2`, and an explicit `it()` timeout **overrides `vitest.config` entirely** — so tripling the inner budget alone puts a 30s poll inside a 20s test.

Everything scaled now comes from `pollBudget()`, `POLL_TIMEOUT_MS` included, and `pollFor` scales nothing. One factor applies throughout, so every ratio holds exactly as on Linux — including the one the file demands of callers, a test timeout above the SUM of its poll budgets. Measured across the suite, worst case is 0.80 and identical on both platforms.

## Why a branded type rather than a lint rule

```ts
export type PollBudgetMs = number & { readonly __pollBudget: unique symbol };
export const pollBudget = (linuxMs: number): PollBudgetMs => ...
```

A raw number cannot say whether it has been scaled yet, and getting that wrong is **invisible on Linux** — the factor is 1 here, so a double-scaled budget and a correct one are the same value. Only `pollBudget()` can produce the type, so the trap is a compile error rather than something a gate has to notice. Verified negatively: reintroducing `timeoutMs: POLL_TIMEOUT_MS * 2` fails to compile.

I tried a regex gate first and removed it. `timeoutMs` is also an option name for the provider, MCP and tool runners — 60-odd unrelated hits — and a regex says nothing about a budget passed in a variable. It also flagged its own explanatory comment. The compiler found the real call sites instead: **three**, where grep had suggested eight.

Linux is unaffected; the multiplier is 1 there.

Gate green locally: typecheck, lint, format, 653 files / 10,033 tests.

This blocks every PR while Windows is a required gate, so it is separate from the settings work in #616.