### PR TITLE
fix(docker): bump the stale compose image tag, and gate the six version files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ companion/updates/
 **/.env
 
 # Node
-node_modules/
+node_modules
 dist/
 *.timestamp-*.mjs
 .gstack/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Maintainer note:** keep entries concise (one line each). Add changes under `[Unreleased]`
 > as you go; on release, rename it to the version + date, bump `companion/package.json`,
-> `extension/package.json`, `extension/manifest.json` (+ both `package-lock.json`), and tag `vX.Y.Z`.
+> `extension/package.json`, `extension/manifest.json` (+ both `package-lock.json`) and the `image:`
+> tag in `docker-compose.yml`, then tag `vX.Y.Z`. `tests/architecture/versionSync.test.ts` fails if
+> any of the six disagree.
 
 ## [Unreleased]
 
 ### Fixed
 - **Exporting a case on Windows no longer fails as a security refusal** — a sidecar save during the export was reported as a symlink attack.
+- **`docker compose pull` fetches the current release again** — the compose image tag sat at 0.34.0 for the whole 0.35.x line, so users got a container a full release behind their checkout. A gate now fails when any of the six version-bearing files disagree.
 
 ## [0.35.1] - 2026-08-22
 

--- a/companion/tests/architecture/versionSync.test.ts
+++ b/companion/tests/architecture/versionSync.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// EVERY FILE THAT CARRIES THE RELEASE VERSION MUST CARRY THE SAME ONE.
+//
+// The release ritual bumps the version by hand in five files. docker-compose.yml is a sixth, and
+// nobody knew it: its `image:` tag sat at 0.34.0 through the entire 0.35.x line. That tag is not
+// cosmetic. The compose file ships with `build:` enabled, so the tag names BOTH the image built
+// from local source and the image `docker compose pull` fetches from GHCR — a stale pin silently
+// hands a user a release-old container and labels a fresh source build with the wrong version.
+//
+// It surfaced only when a user watched `docker compose pull` download 0.34.0 on a 0.35.1 checkout.
+// Nothing compared the files, so the drift was invisible for two releases.
+//
+// A checklist line would not have caught it — the checklist already lists five files and the sixth
+// was never on it. This gate derives the truth from companion/package.json instead, so ANY new
+// version-bearing file is one entry away from being covered, and a partial bump fails by name.
+const root = new URL("../../../", import.meta.url);
+const read = (p: string): string => readFileSync(new URL(p, root), "utf8");
+const json = (p: string): Record<string, unknown> => JSON.parse(read(p));
+
+const EXPECTED = json("companion/package.json").version as string;
+
+/** Each source is a file plus how the version is spelled inside it. */
+const SOURCES: ReadonlyArray<{ file: string; label: string; read: () => string | undefined }> = [
+  {
+    file: "extension/package.json",
+    label: '"version"',
+    read: () => json("extension/package.json").version as string | undefined,
+  },
+  {
+    file: "extension/manifest.json",
+    label: '"version"',
+    read: () => json("extension/manifest.json").version as string | undefined,
+  },
+  {
+    file: "companion/package-lock.json",
+    label: 'top-level "version"',
+    read: () => json("companion/package-lock.json").version as string | undefined,
+  },
+  {
+    file: "companion/package-lock.json",
+    label: 'packages[""].version',
+    read: () => lockRootVersion("companion/package-lock.json"),
+  },
+  {
+    file: "extension/package-lock.json",
+    label: 'top-level "version"',
+    read: () => json("extension/package-lock.json").version as string | undefined,
+  },
+  {
+    file: "extension/package-lock.json",
+    label: 'packages[""].version',
+    read: () => lockRootVersion("extension/package-lock.json"),
+  },
+  {
+    file: "docker-compose.yml",
+    label: "the ghcr.io image tag",
+    read: () => /image:\s*ghcr\.io\/[^:\s]+:(\S+)/.exec(read("docker-compose.yml"))?.[1],
+  },
+];
+
+/** A lockfile records its own version twice; the `packages[""]` copy is the one npm rewrites. */
+function lockRootVersion(p: string): string | undefined {
+  const packages = json(p).packages as Record<string, { version?: string }> | undefined;
+  return packages?.[""]?.version;
+}
+
+describe("release version sync", () => {
+  it("companion/package.json carries a plain semver version", () => {
+    expect(EXPECTED).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it.each(SOURCES)("$file — $label matches companion/package.json", ({ file, label, read }) => {
+    const found = read();
+    expect(found, `${file}: could not find ${label} — did the file's shape change?`).toBeDefined();
+    expect(
+      found,
+      `${file} declares ${found} but companion/package.json declares ${EXPECTED}. ` +
+        `Bump ${label} in ${file} to ${EXPECTED}.`,
+    ).toBe(EXPECTED);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/hasamba/dfir-companion:0.34.0
+    image: ghcr.io/hasamba/dfir-companion:0.35.1
     container_name: dfir-companion
     restart: unless-stopped
     # HOST:CONTAINER — bound to 127.0.0.1 on the host so the dashboard is localhost-only.


### PR DESCRIPTION
## What broke

`docker compose pull` downloaded `0.34.0` on a `0.35.1` checkout.

`docker-compose.yml` pinned `ghcr.io/hasamba/dfir-companion:0.34.0` while all five version files
said `0.35.1`. GHCR had `0.35.1` published and correct — `0.35.1`, `0.35` and `latest` all resolve
to the same digest. The registry was fine; the pin was stale, and had been since the 0.35.0 release.

That tag is not cosmetic. The compose file ships with `build:` enabled, so `image:` names **both**
the image built from local source and the image pulled from GHCR. A stale pin hands users a
release-old container *and* mislabels a fresh source build with the wrong version.

## Why nothing caught it

The release ritual bumps the version by hand in five files. `docker-compose.yml` is a sixth and was
never on the list, so nothing compared them. The drift survived two releases and surfaced only when
a user watched the pull.

Adding a sixth line to the checklist would not have caught this one — the checklist already had
five entries and the sixth was the one nobody knew about.

## What this changes

- Bumps the compose tag to `0.35.1`.
- Adds `companion/tests/architecture/versionSync.test.ts`. It derives the expected version from
  `companion/package.json` and checks all six sources, including both `packages[""]` lockfile
  entries. On drift it fails naming the file and the value to set. A new version-bearing file is one
  entry away from being covered.
- Fixes `.gitignore`: `node_modules/` had a trailing slash, so it matched directories only. Linked
  worktrees symlink `node_modules` in, and a symlink is not a directory, so those links showed as
  untracked in every worktree. `companion/node_modules` had been patched into `.git/info/exclude`,
  which is per-clone and never travels; `extension/node_modules` was never patched at all.

## Verification

The gate was confirmed to fail, not just to pass: reverting the tag to `0.34.0` produces

```
docker-compose.yml declares 0.34.0 but companion/package.json declares 0.35.1.
Bump the ghcr.io image tag in docker-compose.yml to 0.35.1.
```

Full suite green: 654 files, 10041 tests, exit 0. `typecheck`, `lint`, `format:check` and
`check:size` all pass.
