### PR TITLE
fix(extension): persist the team service token as the analyst types it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The capture extension keeps the team service token** — the popup only saved it when you pressed Start, and picking a case wrote the stored token back over the one you typed, so every import went out unauthenticated and the companion answered 401. Every field now saves as you leave it.
+- **A rejected token no longer reads as "companion offline"** — the popup reported an HTTP 401 from the case list as an unreachable server, sending analysts to restart a companion that was answering.
 - **Exporting a case on Windows no longer fails as a security refusal** — a sidecar save during the export was reported as a symlink attack.
 - **`docker compose pull` fetches the current release again** — the compose image tag sat at 0.34.0 for the whole 0.35.x line, so users got a container a full release behind their checkout. A gate now fails when any of the six version-bearing files disagree.
 

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -30,7 +30,7 @@
   <label>
     Team service token
     <input id="serviceToken" type="password" autocomplete="off" />
-    <span class="hint">Optional case-scoped identity from Companion → Access. Stored only in this browser profile.</span>
+    <span class="hint">Only needed when the companion runs in team mode. Create a case-scoped token at Companion → /admin → Service identities; it needs <b>write</b> to import. Stored in this browser profile only.</span>
   </label>
   <button id="save">Save</button>
   <div id="msg"></div>

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -33,7 +33,7 @@
   </div>
   <label>Companion URL <input id="companionUrl" /></label>
   <label>Team service token <input id="serviceToken" type="password" autocomplete="off" /></label>
-  <div class="hint">Optional. Create a case-scoped token in Companion → Access. Stored only in this browser profile.</div>
+  <div class="hint">Only needed when the companion runs in team mode. Create a case-scoped token at Companion → /admin → Service identities; it needs <b>write</b> to import. Saved as you type, in this browser profile only.</div>
   <label>Interval (seconds) <input id="intervalSeconds" type="number" min="5" /></label>
   <label>Dedup threshold <input id="dedupThreshold" type="number" min="0" /></label>
   <div class="hint">

--- a/extension/src/popup.ts
+++ b/extension/src/popup.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_SETTINGS, normalizeCompanionUrl, type Settings } from "./types.js";
+import { caseListFailure, settingsFromForm } from "./popupSettings.js";
 import { ADAPTERS } from "./adapters/registry.js";
 import { OVERRIDE_NONE } from "./adapters/override.js";
 import {
@@ -180,14 +181,30 @@ async function save(settings: Settings): Promise<void> {
 }
 
 function readForm(running: boolean): Settings {
-  return {
-    caseId: caseSelect().value.trim(),
-    companionUrl: normalizeCompanionUrl($("companionUrl").value),
-    serviceToken: $("serviceToken").value.trim(),
-    intervalSeconds: Math.max(5, Number($("intervalSeconds").value) || 10),
-    dedupThreshold: Math.max(0, Number($("dedupThreshold").value) || 5),
+  return settingsFromForm(
+    {
+      caseId: caseSelect().value,
+      companionUrl: $("companionUrl").value,
+      serviceToken: $("serviceToken").value,
+      intervalSeconds: $("intervalSeconds").value,
+      dedupThreshold: $("dedupThreshold").value,
+    },
     running,
-  };
+  );
+}
+
+/**
+ * Persist the whole form, keeping the capture state the service worker owns.
+ *
+ * Every field edit routes through here. The popup is a transient window — it closes on the next
+ * click into the page — so a value that is only in the DOM is lost the moment the analyst looks
+ * away. That is how a typed Team service token used to disappear on a page reload.
+ */
+async function persistForm(): Promise<Settings> {
+  const stored = await load();
+  const next = readForm(stored.running);
+  await save(next);
+  return next;
 }
 
 async function refreshStatus(s: Settings): Promise<void> {
@@ -216,19 +233,23 @@ async function loadCases(
   companionUrl: string,
   selectedId: string,
   serviceToken: string,
-): Promise<boolean> {
+): Promise<{ ok: boolean; failure?: string }> {
   const sel = caseSelect();
+  // 0 means the fetch never got a response at all; any other value is the companion answering,
+  // which is a very different thing to tell the analyst (see caseListFailure).
+  let status = 0;
   try {
     const res = await fetch(`${companionUrl}/cases`, {
       method: "GET",
       headers: serviceToken ? { Authorization: `Bearer ${serviceToken}` } : {},
     });
+    status = res.status;
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const cases = (await res.json()) as Array<{ caseId: string; name: string }>;
     sel.innerHTML = "";
     if (cases.length === 0) {
       sel.appendChild(new Option("(no cases — create one in the dashboard)", ""));
-      return true;
+      return { ok: true };
     }
     sel.appendChild(new Option("— no case (push button hidden) —", ""));
     for (const c of cases) {
@@ -236,13 +257,15 @@ async function loadCases(
       sel.appendChild(new Option(label, c.caseId));
     }
     sel.value = cases.some((c) => c.caseId === selectedId) ? selectedId : "";
-    return true;
+    return { ok: true };
   } catch {
-    // Offline or endpoint missing — keep the last-used case selectable so Start works.
+    // Unreachable, unauthorized, or an endpoint the server does not have — keep the last-used case
+    // selectable either way so Start still works once the cause is fixed.
+    const failure = caseListFailure(status);
     sel.innerHTML = "";
-    if (selectedId) sel.appendChild(new Option(`${selectedId} (offline — last used)`, selectedId));
-    else sel.appendChild(new Option("(companion offline — start it, then Refresh)", ""));
-    return false;
+    if (selectedId) sel.appendChild(new Option(`${selectedId} (last used — ${failure})`, selectedId));
+    else sel.appendChild(new Option(`(${failure})`, ""));
+    return { ok: false, failure };
   }
 }
 
@@ -299,19 +322,30 @@ async function init() {
   await refreshSiteAccess();
   await initToolOverride();
 
-  // Auto-save the case selection immediately on change so the analyst can switch cases
-  // (or clear them) without pressing Start — screenshots stay in their current state.
-  caseSelect().addEventListener("change", async () => {
-    const current = await load();
-    await save({ ...current, caseId: caseSelect().value });
-  });
+  // Auto-save every field as soon as the analyst leaves it, so nothing depends on remembering to
+  // press Start. The popup closes on the next click into the page, and an unsaved value dies with
+  // it: that is what used to strand the Team service token and make imports 401.
+  //
+  // "change" rather than "input": it fires on blur for a text box and immediately for the case
+  // dropdown, which keeps the write count low without ever losing a value.
+  for (const id of ["caseId", "companionUrl", "serviceToken", "intervalSeconds", "dedupThreshold"]) {
+    document.getElementById(id)!.addEventListener("change", () => void persistForm());
+  }
 
   // Re-fetch the case list — e.g. after creating a case in the dashboard, or after
   // pointing Companion URL at a different instance.
   document.getElementById("refreshCases")!.onclick = async () => {
-    const url = normalizeCompanionUrl($("companionUrl").value);
-    const ok = await loadCases(url, caseSelect().value, $("serviceToken").value.trim());
-    statusEl().textContent = ok ? "case list refreshed" : `companion offline — check URL (${url})`;
+    // Persist first: the analyst has usually just pasted a token or a URL, and Refresh is the
+    // natural place to press before Start.
+    const saved = await persistForm();
+    const result = await loadCases(saved.companionUrl, saved.caseId, saved.serviceToken);
+    // Re-persist: a refresh can drop the stored case from the list (it was closed or archived, or
+    // the token is scoped elsewhere), which blanks the dropdown. Without this the service worker
+    // would keep capturing into a case the analyst can no longer see.
+    const settled = await persistForm();
+    statusEl().textContent = result.ok
+      ? "case list refreshed"
+      : `${result.failure} (${settled.companionUrl})`;
   };
   // Cases are created in the dashboard — open it in a new tab.
   document.getElementById("openDashboard")!.onclick = (e) => {

--- a/extension/src/popupSettings.ts
+++ b/extension/src/popupSettings.ts
@@ -1,0 +1,61 @@
+import {
+  DEFAULT_SETTINGS,
+  normalizeCompanionUrl,
+  type Settings,
+} from "./types.js";
+
+/**
+ * The popup's editable fields, as raw strings straight out of the DOM.
+ *
+ * `running` is deliberately absent: capture state is owned by the service worker, not by the
+ * form, so every caller supplies it from the stored settings instead of from an input.
+ */
+export interface PopupForm {
+  caseId: string;
+  companionUrl: string;
+  serviceToken: string;
+  intervalSeconds: string;
+  dedupThreshold: string;
+}
+
+/**
+ * Fold the popup form into the settings to persist.
+ *
+ * This is the ONLY shape the popup writes. It used to be possible to persist a mix — the case
+ * dropdown saved the STORED token beside the freshly picked case id — which silently discarded a
+ * token the analyst had just typed. Every import then went out with no Authorization header and
+ * the companion answered 401.
+ */
+export function settingsFromForm(form: PopupForm, running: boolean): Settings {
+  return {
+    caseId: form.caseId.trim(),
+    companionUrl: normalizeCompanionUrl(form.companionUrl),
+    serviceToken: form.serviceToken.trim(),
+    intervalSeconds: Math.max(
+      5,
+      Number(form.intervalSeconds) || DEFAULT_SETTINGS.intervalSeconds,
+    ),
+    dedupThreshold: Math.max(
+      0,
+      Number(form.dedupThreshold) || DEFAULT_SETTINGS.dedupThreshold,
+    ),
+    running,
+  };
+}
+
+/**
+ * Explain why the case list could not be read.
+ *
+ * A rejected credential is not an unreachable companion. The popup reported every failure as
+ * "companion offline", which sent analysts to restart a server that was answering perfectly — the
+ * companion was in team mode and the request carried no usable token.
+ *
+ * @param status The HTTP status, or 0 when the fetch itself failed (no response at all).
+ */
+export function caseListFailure(status: number): string {
+  if (status === 401) return "token rejected — check the Team service token";
+  if (status === 403)
+    return "token lacks access — check the token's case and permissions";
+  if (status === 0) return "companion offline — start it, then Refresh";
+  return `companion refused the case list (HTTP ${status})`;
+}

--- a/extension/tests/popupSettings.test.ts
+++ b/extension/tests/popupSettings.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS } from "../src/types.js";
+import {
+  caseListFailure,
+  settingsFromForm,
+  type PopupForm,
+} from "../src/popupSettings.js";
+
+function form(overrides: Partial<PopupForm> = {}): PopupForm {
+  return {
+    caseId: "CASE-1",
+    companionUrl: "http://127.0.0.1:4773",
+    serviceToken: "tok-abc",
+    intervalSeconds: "10",
+    dedupThreshold: "5",
+    ...overrides,
+  };
+}
+
+describe("settingsFromForm", () => {
+  // The bug this guards: the popup persisted the STORED token rather than the typed one, so a
+  // token entered in the popup vanished on the next read and every import went out unauthenticated.
+  it("keeps the token the analyst typed", () => {
+    expect(
+      settingsFromForm(form({ serviceToken: "fresh-token" }), false)
+        .serviceToken,
+    ).toBe("fresh-token");
+  });
+
+  it("trims a pasted token", () => {
+    expect(
+      settingsFromForm(form({ serviceToken: "  tok-abc\n" }), false)
+        .serviceToken,
+    ).toBe("tok-abc");
+  });
+
+  it("keeps a deliberately cleared token cleared", () => {
+    expect(
+      settingsFromForm(form({ serviceToken: "   " }), false).serviceToken,
+    ).toBe("");
+  });
+
+  it("carries the running flag the caller owns", () => {
+    expect(settingsFromForm(form(), true).running).toBe(true);
+    expect(settingsFromForm(form(), false).running).toBe(false);
+  });
+
+  it("normalizes the companion URL", () => {
+    expect(
+      settingsFromForm(
+        form({ companionUrl: " http://127.0.0.1:4773/// " }),
+        false,
+      ).companionUrl,
+    ).toBe("http://127.0.0.1:4773");
+  });
+
+  it("falls back to the default URL when the field is empty", () => {
+    expect(
+      settingsFromForm(form({ companionUrl: "" }), false).companionUrl,
+    ).toBe(DEFAULT_SETTINGS.companionUrl);
+  });
+
+  it("trims the case id", () => {
+    expect(settingsFromForm(form({ caseId: " CASE-1 " }), false).caseId).toBe(
+      "CASE-1",
+    );
+  });
+
+  it("clamps the interval to the 5-second floor", () => {
+    expect(
+      settingsFromForm(form({ intervalSeconds: "1" }), false).intervalSeconds,
+    ).toBe(5);
+  });
+
+  it("falls back to the default interval when the field is not a number", () => {
+    expect(
+      settingsFromForm(form({ intervalSeconds: "abc" }), false).intervalSeconds,
+    ).toBe(10);
+  });
+
+  it("clamps a negative dedup threshold to zero", () => {
+    expect(
+      settingsFromForm(form({ dedupThreshold: "-3" }), false).dedupThreshold,
+    ).toBe(0);
+  });
+});
+
+describe("caseListFailure", () => {
+  // A 401 is the companion answering, not the companion being down. Reporting it as "offline"
+  // sent analysts to restart a server that was already running.
+  it("names the token on 401 rather than blaming the connection", () => {
+    const message = caseListFailure(401);
+    expect(message).toMatch(/token/i);
+    expect(message).not.toMatch(/offline/i);
+  });
+
+  it("names the token's permissions on 403", () => {
+    const message = caseListFailure(403);
+    expect(message).toMatch(/token/i);
+    expect(message).not.toMatch(/offline/i);
+  });
+
+  it("reports offline when the fetch itself failed", () => {
+    expect(caseListFailure(0)).toMatch(/offline/i);
+  });
+
+  it("reports the status for any other rejection", () => {
+    expect(caseListFailure(500)).toContain("500");
+  });
+});


### PR DESCRIPTION
## What was wrong

The capture extension popup's **Team service token** box only reached storage when the analyst pressed **Start**, **Stop** or **Capture once**. Two paths lost it:

- **Refresh cases** read the box to build the request but never saved it.
- The case dropdown's auto-save merged the freshly picked case id over the **stored** settings, so choosing a case wrote the old, empty token back over the one just typed.

The popup is a transient window — it closes on the next click into the page. A token that lived only in the DOM was gone by the next page reload. Every capture and import the service worker sent afterwards carried no `Authorization` header, and on a companion in team mode that is an **HTTP 401 on import**, with nothing in the UI pointing at the credential as the cause.

Reported from a live Velociraptor import: the token had to be re-entered after every page refresh, and imports failed 401.

## What changed

- Every popup field persists on `change` through one shared fold, `settingsFromForm` — now the only settings shape the popup writes.
- A refresh re-persists after the case list settles, so a case that dropped out of the list cannot stay selected in storage while the dropdown shows blank. Without this the service worker would keep capturing into a case the analyst can no longer see.
- A rejected credential is no longer reported as an unreachable server. `loadCases` turned every failure into "companion offline", which sends analysts to restart a companion that was answering correctly. 401 and 403 now name the token; only a fetch that got no response at all is reported as offline.
- The token hints in the popup and the options page name the page that issues one (`/admin` → Service identities) and the `write` permission an import needs.

## Tests

`extension/tests/popupSettings.test.ts` — 14 new tests, written before the fix and confirmed failing first. They cover the token surviving the fold, trimming, a deliberately cleared token staying cleared, URL normalization, the interval and dedup clamps, and each `caseListFailure` branch asserting that a 401/403 names the token and does **not** say "offline".

All four extension CI gates pass on the merge result: `npm run typecheck`, `npm test` (236 passed), `npm run build`, `npm run build:firefox`.

## Notes

- `extension/src/popupSettings.ts` and its test are Prettier-clean, as the format gate requires of new files. The legacy files this touches were already unformatted and are left that way.