### PR TITLE
fix(extension): declare data collection in the Firefox manifest, which AMO now requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
 
 ### Fixed
+- **The Firefox install instructions say what the add-on collects** — a temporary add-on loaded through `about:debugging` gets every permission silently and shows no data-collection notice, and that is the only install route the docs describe until the AMO listing exists.
 - **The Firefox add-on can be submitted to AMO again** — the generated manifest carried no `data_collection_permissions`, which AMO has required in every submission since 2025-11-03 and rejects the upload for omitting.
 - **The capture extension keeps the team service token** — the popup only saved it when you pressed Start, and picking a case wrote the stored token back over the one you typed, so every import went out unauthenticated and the companion answered 401. Every field now saves as you leave it.
 - **A rejected token no longer reads as "companion offline"** — the popup reported an HTTP 401 from the case list as an unreachable server, sending analysts to restart a companion that was answering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
 
 ### Fixed
+- **The extension's store description stops calling the companion local** — the address is a setting, and the listing sits beside the privacy policy that says so.
 - **The extension privacy policy stops promising data never leaves your machine** — it does on the default loopback companion, but the address is a setting and team mode exists for a companion another host can reach. The policy now says where evidence goes in both cases, covers Firefox as well as Chrome, and carries a current date.
 - **The Firefox install instructions say what the add-on collects** — a temporary add-on loaded through `about:debugging` gets every permission silently and shows no data-collection notice, and that is the only install route the docs describe until the AMO listing exists.
 - **The Firefox add-on can be submitted to AMO again** — the generated manifest carried no `data_collection_permissions`, which AMO has required in every submission since 2025-11-03 and rejects the upload for omitting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
 
 ### Fixed
+- **The extension privacy policy stops promising data never leaves your machine** — it does on the default loopback companion, but the address is a setting and team mode exists for a companion another host can reach. The policy now says where evidence goes in both cases, covers Firefox as well as Chrome, and carries a current date.
 - **The Firefox install instructions say what the add-on collects** — a temporary add-on loaded through `about:debugging` gets every permission silently and shows no data-collection notice, and that is the only install route the docs describe until the AMO listing exists.
 - **The Firefox add-on can be submitted to AMO again** — the generated manifest carried no `data_collection_permissions`, which AMO has required in every submission since 2025-11-03 and rejects the upload for omitting.
 - **The capture extension keeps the team service token** — the popup only saved it when you pressed Start, and picking a case wrote the stored token back over the one you typed, so every import went out unauthenticated and the companion answered 401. Every field now saves as you leave it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
 
 ### Fixed
+- **The extension privacy policy says where evidence goes after the companion receives it** — a configured vision model reads the screenshots, synthesis reads the pushed rows, enrichment queries reputation services. The policy previously implied the extension's local delivery was the end of the journey.
 - **The extension's store description stops calling the companion local** — the address is a setting, and the listing sits beside the privacy policy that says so.
 - **The extension privacy policy stops promising data never leaves your machine** — it does on the default loopback companion, but the address is a setting and team mode exists for a companion another host can reach. The policy now says where evidence goes in both cases, covers Firefox as well as Chrome, and carries a current date.
 - **The Firefox install instructions say what the add-on collects** — a temporary add-on loaded through `about:debugging` gets every permission silently and shows no data-collection notice, and that is the only install route the docs describe until the AMO listing exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
 
 ### Fixed
+- **The Firefox add-on can be submitted to AMO again** — the generated manifest carried no `data_collection_permissions`, which AMO has required in every submission since 2025-11-03 and rejects the upload for omitting.
 - **The capture extension keeps the team service token** — the popup only saved it when you pressed Start, and picking a case wrote the stored token back over the one you typed, so every import went out unauthenticated and the companion answered 401. Every field now saves as you leave it.
 - **A rejected token no longer reads as "companion offline"** — the popup reported an HTTP 401 from the case list as an unreachable server, sending analysts to restart a companion that was answering.
 - **Exporting a case on Windows no longer fails as a security refusal** — a sidecar save during the export was reported as a symlink attack.
 - **`docker compose pull` fetches the current release again** — the compose image tag sat at 0.34.0 for the whole 0.35.x line, so users got a container a full release behind their checkout. A gate now fails when any of the six version-bearing files disagree.
+
+### Changed
+- **The Firefox add-on now requires Firefox 140** (was 128) — 140 is the first release that shows the data-collection consent screen, and Mozilla does not permit collecting without one. 140 is itself an ESR and 128 ESR ended in September 2025.
 
 ## [0.35.1] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -724,8 +724,10 @@ attacker path, questions). Configure both via `.env` — see `companion/README.m
    > **What it collects, since a temporary load never asks.** Firefox shows its data-collection
    > notice only for a signed add-on installed normally; `about:debugging` grants everything
    > silently. The extension declares **browsing activity** (a capture carries the tab's URL and
-   > title) and **website content** (the screenshot, and the rows a Push scrapes). It goes to the
-   > companion address you configure — by default one on your own machine — and nowhere else. See
+   > title) and **website content** (the screenshot, and the rows a Push scrapes). The extension
+   > sends it to the companion address you configure and nowhere else; what that companion forwards
+   > afterwards — a vision model reads the screenshots, AI synthesis reads the rows, enrichment
+   > queries reputation services — is the companion's own configuration. See
    > [extension/PRIVACY.md](extension/PRIVACY.md).
 
    The popup only **attaches** to an existing case — you create cases in the dashboard.

--- a/README.md
+++ b/README.md
@@ -724,8 +724,8 @@ attacker path, questions). Configure both via `.env` — see `companion/README.m
    > **What it collects, since a temporary load never asks.** Firefox shows its data-collection
    > notice only for a signed add-on installed normally; `about:debugging` grants everything
    > silently. The extension declares **browsing activity** (a capture carries the tab's URL and
-   > title) and **website content** (the screenshot, and the rows a Push scrapes). All of it goes
-   > to your own companion and nowhere else. See
+   > title) and **website content** (the screenshot, and the rows a Push scrapes). It goes to the
+   > companion address you configure — by default one on your own machine — and nowhere else. See
    > [extension/PRIVACY.md](extension/PRIVACY.md).
 
    The popup only **attaches** to an existing case — you create cases in the dashboard.

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ All importers are **deterministic (no AI call)**, read the artifact's own timest
 - **Configurable event ingestion cap** (`DFIR_MAX_EVENTS`) — overrides the default 2000-event-per-import safety cap
 - **Prompt regression / eval harness** — CI-safe and real-provider golden-output testing for AI extraction/synthesis quality
 - **Logging** — console + global session log + per-case audit trail; `DFIR_LOG_LEVEL` live toggle; `debug` traces AI/captures/OCR/anonymization
-- **Browser extension** — Chrome/Comet from the [Chrome Web Store](https://chromewebstore.google.com/detail/dfir-companion-%E2%80%94-evidence/jhlffkfnamlmfkijgpaopdnbmbajldmf), or Firefox 128+ from the `dfir-capture-extension-firefox-*.zip` on any [release](https://github.com/hasamba/DFIR-Companion/releases/latest); connects to the local server, no standalone function
+- **Browser extension** — Chrome/Comet from the [Chrome Web Store](https://chromewebstore.google.com/detail/dfir-companion-%E2%80%94-evidence/jhlffkfnamlmfkijgpaopdnbmbajldmf), or Firefox 140+ from the `dfir-capture-extension-firefox-*.zip` on any [release](https://github.com/hasamba/DFIR-Companion/releases/latest); connects to the local server, no standalone function
 - **Portable Windows EXE** — unzip + double-click, no Node required
 - **Chocolatey package** — `choco install dfir-companion`; downloads + verifies the portable build + bundles the capture extension, data in `%LOCALAPPDATA%`
 - **Docker / Compose** — `docker compose up`; evidence on host volume, no bundled AI backend
@@ -705,7 +705,7 @@ attacker path, questions). Configure both via `.env` — see `companion/README.m
 
    **Easiest:** install directly from the
    [Chrome Web Store](https://chromewebstore.google.com/detail/dfir-companion-%E2%80%94-evidence/jhlffkfnamlmfkijgpaopdnbmbajldmf).
-   On **Firefox 128+**, download `dfir-capture-extension-firefox-*.zip` from the
+   On **Firefox 140+**, download `dfir-capture-extension-firefox-*.zip` from the
    [latest release](https://github.com/hasamba/DFIR-Companion/releases/latest) and unzip it.
 
    Or build from source:
@@ -713,7 +713,7 @@ attacker path, questions). Configure both via `.env` — see `companion/README.m
    cd DFIR-Companion/extension
    npm install
    npm run build             # Chrome/Comet → load extension/dist as an unpacked extension
-   npm run build:firefox     # Firefox 128+ → load extension/dist-firefox/manifest.json
+   npm run build:firefox     # Firefox 140+ → load extension/dist-firefox/manifest.json
    ```
 
    On Firefox, load it from `about:debugging#/runtime/this-firefox` → **Load Temporary Add-on…**

--- a/README.md
+++ b/README.md
@@ -721,6 +721,13 @@ attacker path, questions). Configure both via `.env` — see `companion/README.m
    drops temporary add-ons on restart, so repeat that each session — there is no AMO listing yet,
    so the release zip is unsigned and cannot be installed permanently.
 
+   > **What it collects, since a temporary load never asks.** Firefox shows its data-collection
+   > notice only for a signed add-on installed normally; `about:debugging` grants everything
+   > silently. The extension declares **browsing activity** (a capture carries the tab's URL and
+   > title) and **website content** (the screenshot, and the rows a Push scrapes). All of it goes
+   > to your own companion and nowhere else. See
+   > [extension/PRIVACY.md](extension/PRIVACY.md).
+
    The popup only **attaches** to an existing case — you create cases in the dashboard.
 
 3. Open `http://127.0.0.1:4773/dashboard`, click **+ New case** to create your case (it

--- a/companion/tests/architecture/temporaryInstallDisclosure.test.ts
+++ b/companion/tests/architecture/temporaryInstallDisclosure.test.ts
@@ -1,0 +1,101 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// A TEMPORARY INSTALL NEVER ASKS, SO THE DOCS HAVE TO TELL.
+//
+// The Firefox manifest declares data collection (browsingActivity, websiteContent), and Firefox 140+
+// turns that declaration into a consent screen — but only when installing a SIGNED add-on. An
+// unsigned build loaded through about:debugging → "Load Temporary Add-on…" gets every permission
+// granted silently and shows no notice at all: "if the extension makes installation time permission
+// requests, these are not displayed as part of the temporary installation process".
+//
+// That route is not an edge case here. It is the ONLY route the project documents, because there is
+// no AMO listing yet. So every analyst who follows our instructions installs a screenshot tool that
+// Firefox never discloses. Raising the version floor did not fix that and could not: the floor
+// decides whether Firefox CAN show the notice, not whether this install path does.
+//
+// The gate: any document that teaches the temporary-install route must state, in prose, every
+// category the add-on declares. Derived from the manifest transform rather than hard-coded, so
+// adding a category fails here until the prose catches up — the same shape as nodeEngineDocs.
+const root = new URL("../../../", import.meta.url);
+const read = (p: string): string => readFileSync(new URL(p, root), "utf8");
+
+/** The literal `required: [...]` from the transform, which is the single source for what ships. */
+function declaredCategories(): string[] {
+  const src = read("extension/scripts/manifest-firefox.mjs");
+  const block =
+    /export const DATA_COLLECTION_PERMISSIONS[\s\S]*?required:\s*Object\.freeze\(\[([^\]]*)\]/.exec(src);
+  expect(block, "DATA_COLLECTION_PERMISSIONS.required not found in manifest-firefox.mjs").not.toBeNull();
+  return [...block![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+/**
+ * "browsingActivity" → /browsing\s+activity/i. The docs are written for analysts, so they say
+ * "browsing activity", not the manifest's camelCase — match the words, not the key.
+ */
+function prosePattern(category: string): RegExp {
+  const words = category
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(" ");
+  return new RegExp(words.join("\\s+"), "i");
+}
+
+const DOC_DIRS = [".", "extension", "mkdocs-docs", "mkdocs-docs/reference"];
+
+/**
+ * USER_MANUAL.md is superseded by mkdocs-docs/ and is not maintained; CLAUDE.md says explicitly not
+ * to update it. Gating on it would force an edit the project has decided against, so it is named
+ * here rather than silently skipped by a pattern nobody can see.
+ */
+const NOT_MAINTAINED = ["USER_MANUAL.md"];
+
+function docsTeachingTemporaryInstall(): string[] {
+  const hits: string[] = [];
+  for (const dir of DOC_DIRS) {
+    const abs = fileURLToPath(new URL(dir, root));
+    let entries: string[];
+    try {
+      entries = readdirSync(abs);
+    } catch {
+      continue; // a docs directory that does not exist yet is not a failure
+    }
+    for (const name of entries) {
+      const rel = dir === "." ? name : `${dir}/${name}`;
+      if (!name.endsWith(".md") || NOT_MAINTAINED.includes(name)) continue;
+      if (!statSync(fileURLToPath(new URL(rel, root))).isFile()) continue;
+      if (read(rel).includes("Load Temporary Add-on")) hits.push(rel);
+    }
+  }
+  return hits;
+}
+
+describe("the temporary-install instructions disclose what Firefox will not", () => {
+  const categories = declaredCategories();
+  const docs = docsTeachingTemporaryInstall();
+
+  it("finds the documents that teach the route at all", () => {
+    // If this drops to zero the rest of the suite passes vacuously, which is exactly how a gate
+    // stops guarding anything without ever going red.
+    expect(docs.length).toBeGreaterThan(0);
+    expect(docs).toContain("README.md");
+    expect(docs).toContain("extension/README.md");
+  });
+
+  it("declares at least one category to disclose", () => {
+    expect(categories.length).toBeGreaterThan(0);
+    expect(categories).not.toContain("none");
+  });
+
+  it.each(docsTeachingTemporaryInstall())("%s names every declared category in prose", (doc) => {
+    const text = read(doc);
+    for (const category of categories) {
+      expect(
+        prosePattern(category).test(text),
+        `${doc} teaches "Load Temporary Add-on…" but never says "${category}" in prose. Firefox ` +
+          `shows no notice on that path, so this file is the only place the analyst can learn it.`,
+      ).toBe(true);
+    }
+  });
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -1021,7 +1021,7 @@
               <span class="line"><span class="cmd">npm</span> install && <span class="cmd">npm</span> run build</span>
               <span class="line"><span class="comment"># → Load extension/dist as unpacked</span></span>
               <span class="line"></span>
-              <span class="line"><span class="comment"># Firefox 128+ instead of Chrome</span></span>
+              <span class="line"><span class="comment"># Firefox 140+ instead of Chrome</span></span>
               <span class="line"><span class="cmd">npm</span> run build:firefox</span>
               <span class="line"><span class="comment"># → about:debugging → Load Temporary</span></span>
               <span class="line"><span class="comment">#   Add-on → dist-firefox/manifest.json</span></span>

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -63,6 +63,21 @@ The Extension supports a forensic investigation workflow in two ways:
 - Settings and the offline queue stay in your browser's local extension storage and are
   never uploaded anywhere except your own companion.
 
+## What the Firefox install prompt says
+
+Firefox shows a data-collection notice when you install the Extension. It names
+**browsing activity** and **website content**, because a capture sends the tab's URL and title
+along with the screenshot itself, and Mozilla counts any hand-off outside the browser as
+collection — including one to a server on your own computer.
+
+The Extension requires Firefox 140 or later for this reason: 140 is the first release that can
+show that notice, and shipping to an older one would mean collecting what is described here while
+the install prompt said nothing.
+
+That notice describes what the Extension sends **to your own DFIR Companion**, and nothing else.
+It is not a disclosure of data reaching the authors or any third party; as stated above, none
+does. The Extension declares no telemetry of any kind.
+
 ## Permissions and why they are needed
 
 | Permission | Why |

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -63,20 +63,29 @@ The Extension supports a forensic investigation workflow in two ways:
 - Settings and the offline queue stay in your browser's local extension storage and are
   never uploaded anywhere except your own companion.
 
-## What the Firefox install prompt says
+## What the Extension declares it collects
 
-Firefox shows a data-collection notice when you install the Extension. It names
-**browsing activity** and **website content**, because a capture sends the tab's URL and title
-along with the screenshot itself, and Mozilla counts any hand-off outside the browser as
-collection — including one to a server on your own computer.
+The Extension declares two categories of data collection, in the words Mozilla requires:
 
-The Extension requires Firefox 140 or later for this reason: 140 is the first release that can
-show that notice, and shipping to an older one would mean collecting what is described here while
-the install prompt said nothing.
+- **Browsing activity** — a capture carries the tab's URL and title.
+- **Website content** — the screenshot itself, and the rows a console Push scrapes.
 
-That notice describes what the Extension sends **to your own DFIR Companion**, and nothing else.
-It is not a disclosure of data reaching the authors or any third party; as stated above, none
-does. The Extension declares no telemetry of any kind.
+Mozilla counts any hand-off outside the browser as collection, including one to a server on
+your own computer, which is why these are declared rather than `none`. Both describe what the
+Extension sends **to your own DFIR Companion**, and nothing else. Nothing reaches the authors
+or any third party, and the Extension declares no telemetry of any kind.
+
+**When Firefox shows you this, and when it does not.** Firefox 140 and later display a
+data-collection notice as you install a signed add-on — from Mozilla Add-ons, or from a signed
+file. The Extension requires 140 for that reason: shipping the declaration to an older Firefox
+would mean collecting what is described here behind a prompt that said nothing.
+
+A **temporary** add-on is different. Loading an unsigned build through
+`about:debugging` → "Load Temporary Add-on…" — the route the project's own install
+instructions describe, because there is no Mozilla Add-ons listing yet — displays **no prompt at
+all**. Firefox grants every permission silently and shows no data-collection notice. Until the
+listing exists, this policy is the disclosure, which is why the install instructions repeat the
+two categories above rather than leaving Firefox to state them.
 
 ## Permissions and why they are needed
 

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -10,12 +10,20 @@ is licensed AGPL-3.0-only.
 ## Summary
 
 **The Extension sends data to exactly one destination at a time: the DFIR Companion server
-address you configure. By default that is `http://127.0.0.1:4773` — a server on your own
-machine — and for a single analyst working locally, nothing the Extension handles ever leaves
-the machine. If you point the Extension at a team Companion instead, captures go to that host,
-because that is what you asked it to do. In either case it makes no calls to the extension
-authors, to any analytics service, or to any other third party. There is no tracking, no
-telemetry, and no remote logging.**
+address you configure. By default that is `http://127.0.0.1:4773`, a server on your own machine;
+point it at a team Companion instead and captures go to that host. The Extension sends data
+nowhere else — no calls to the extension authors, to any analytics service, or to any other
+third party, and no tracking, telemetry, or remote logging.**
+
+**Where the Extension's promise ends.** It ends at the Companion, and this is the part worth
+reading twice. What that server does next is its own configuration, not the Extension's. With a
+vision provider configured, the Companion sends **the screenshots themselves** to that model to
+read them into the timeline. With a synthesis provider configured, it sends timeline content —
+including the rows you pushed — to that model. With enrichment enabled, IOCs drawn from those
+rows go to third-party reputation services. Each needs a provider you set up, so none of it
+happens on a Companion you have not configured that way; all of it is governed by the
+Companion's own documentation, not by this policy. The Extension cannot promise on the
+Companion's behalf, so it does not.
 
 You — the analyst — are always in control of what is sent and when. A fresh installation has
 **no access to any website**. Persistent access is granted one console origin at a time.
@@ -59,7 +67,9 @@ The Extension supports a forensic investigation workflow in two ways:
 
 - All captured screenshots and pushed detections are transmitted **only** to the DFIR
   Companion server address you configure. The default is `http://127.0.0.1:4773`, a server on
-  your own computer, and on that default nothing the Extension handles leaves your machine.
+  your own computer; on that default the Extension puts nothing on the network beyond your own
+  machine. What the Companion forwards afterwards is its configuration, not the Extension's —
+  see "Where the Extension's promise ends" above.
 - **The address is yours to change, and changing it changes where the evidence goes.** Team
   mode exists for exactly that: a Companion another person or machine can reach. Point the
   Extension at one — which is also what the optional team service token is for — and captures

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -9,12 +9,13 @@ is licensed AGPL-3.0-only.
 
 ## Summary
 
-**The Extension sends data to one place: the DFIR Companion server address you configure. By
-default that is `http://127.0.0.1:4773` — a server on your own machine — and for a single
-analyst working locally, nothing ever leaves the machine. If you point the Extension at a team
-Companion instead, captures go to that host, because that is what you asked it to do. It makes
-no calls to the extension authors, to any analytics service, or to any other third party in
-either case. There is no tracking, no telemetry, and no remote logging.**
+**The Extension sends data to exactly one destination at a time: the DFIR Companion server
+address you configure. By default that is `http://127.0.0.1:4773` — a server on your own
+machine — and for a single analyst working locally, nothing the Extension handles ever leaves
+the machine. If you point the Extension at a team Companion instead, captures go to that host,
+because that is what you asked it to do. In either case it makes no calls to the extension
+authors, to any analytics service, or to any other third party. There is no tracking, no
+telemetry, and no remote logging.**
 
 You — the analyst — are always in control of what is sent and when. A fresh installation has
 **no access to any website**. Persistent access is granted one console origin at a time.
@@ -31,13 +32,13 @@ The Extension supports a forensic investigation workflow in two ways:
    security tool's web console (for example **Splunk**, **Velociraptor**, **Elastic/Kibana**,
    or **CrowdStrike Falcon**), the Extension can extract the **structured results you are
    looking at** (the JSON the console already fetched, or the visible results table) and push
-   those rows to your local DFIR Companion when you click the **"📤 Push → DFIR-Companion"**
+   those rows to the Companion you configured when you click the **"📤 Push → DFIR-Companion"**
    button. This step only ever runs on your explicit click — nothing is sent automatically
    from these pages.
 
 3. **Right-click "Send to DFIR-Companion".** On a page where you invoke the menu, you can send a text
    selection, a table, or a link and choose "Send to DFIR-Companion" to push that selected
-   text, the nearest table's rows, or the link's URL to your local companion. Like the Push
+   text, the nearest table's rows, or the link's URL to that same Companion. Like the Push
    button above, this only ever runs when you explicitly choose it from the menu.
 
 ## What data is handled
@@ -67,8 +68,10 @@ The Extension supports a forensic investigation workflow in two ways:
 - The Extension contains **no third-party SDKs, analytics, advertising, or crash/usage
   reporting.** It does not sell or share data with anyone, and the developers receive no
   data from it.
-- Settings and the offline queue stay in your browser's local extension storage and are
-  never uploaded anywhere except the Companion you configured.
+- Your settings and the permission audit stay in the browser's extension storage and are
+  never uploaded anywhere at all. The offline queue is stored there too; what leaves it are the
+  queued captures themselves, delivered to the Companion you configured once it is reachable
+  again.
 
 ## What the Extension declares it collects
 
@@ -124,8 +127,9 @@ late message from that page.
 ## Data retention
 
 The Extension itself does not retain forensic data beyond the local send-queue needed to
-deliver captures to your companion. Once delivered, evidence is stored and managed by **your**
-DFIR Companion server, under your control. Clearing the Extension's storage (or removing the
+deliver captures to the Companion. Once delivered, evidence is stored and managed by that
+DFIR Companion server, under the control of whoever runs it — you, on the default local
+address; your team and its retention rules, if you pointed the Extension at a team Companion. Clearing the Extension's storage (or removing the
 Extension) clears its settings, permission audit, and any undelivered queued captures. Approved
 origins can be revoked from the popup, the Extension options page, or the browser's extension
 permission controls.

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -1,18 +1,20 @@
 # Privacy Policy — DFIR Companion: Evidence Capture & Push
 
-_Last updated: 2026-07-31_
+_Last updated: 2026-08-22_
 
 This is the privacy policy for the **DFIR Companion — Evidence Capture & Push** browser
-extension (the "Extension"), published for Chrome and other Chromium browsers. It is part of
-the open-source [DFIR Companion](https://github.com/hasamba/DFIR-Companion) project and is
-licensed AGPL-3.0-only.
+extension (the "Extension"), published for Firefox, Chrome, and other Chromium browsers. It is
+part of the open-source [DFIR Companion](https://github.com/hasamba/DFIR-Companion) project and
+is licensed AGPL-3.0-only.
 
 ## Summary
 
-**The Extension sends data only to a DFIR Companion server running on your own machine
-(`http://127.0.0.1:4773` by default, a `localhost` address). It makes no calls to the
-extension authors, to any analytics service, or to any other third party. There is no
-tracking, no telemetry, and no remote logging.**
+**The Extension sends data to one place: the DFIR Companion server address you configure. By
+default that is `http://127.0.0.1:4773` — a server on your own machine — and for a single
+analyst working locally, nothing ever leaves the machine. If you point the Extension at a team
+Companion instead, captures go to that host, because that is what you asked it to do. It makes
+no calls to the extension authors, to any analytics service, or to any other third party in
+either case. There is no tracking, no telemetry, and no remote logging.**
 
 You — the analyst — are always in control of what is sent and when. A fresh installation has
 **no access to any website**. Persistent access is granted one console origin at a time.
@@ -55,13 +57,18 @@ The Extension supports a forensic investigation workflow in two ways:
 ## Where the data goes
 
 - All captured screenshots and pushed detections are transmitted **only** to the DFIR
-  Companion server address you configure — by default `http://127.0.0.1:4773`, i.e. a server
-  on your own computer. No data leaves your machine via the Extension.
+  Companion server address you configure. The default is `http://127.0.0.1:4773`, a server on
+  your own computer, and on that default nothing the Extension handles leaves your machine.
+- **The address is yours to change, and changing it changes where the evidence goes.** Team
+  mode exists for exactly that: a Companion another person or machine can reach. Point the
+  Extension at one — which is also what the optional team service token is for — and captures
+  travel to that host over your network. The Extension does not restrict the address, so read
+  it as the destination it is.
 - The Extension contains **no third-party SDKs, analytics, advertising, or crash/usage
   reporting.** It does not sell or share data with anyone, and the developers receive no
   data from it.
 - Settings and the offline queue stay in your browser's local extension storage and are
-  never uploaded anywhere except your own companion.
+  never uploaded anywhere except the Companion you configured.
 
 ## What the Extension declares it collects
 
@@ -70,10 +77,12 @@ The Extension declares two categories of data collection, in the words Mozilla r
 - **Browsing activity** — a capture carries the tab's URL and title.
 - **Website content** — the screenshot itself, and the rows a console Push scrapes.
 
-Mozilla counts any hand-off outside the browser as collection, including one to a server on
-your own computer, which is why these are declared rather than `none`. Both describe what the
-Extension sends **to your own DFIR Companion**, and nothing else. Nothing reaches the authors
-or any third party, and the Extension declares no telemetry of any kind.
+Mozilla counts any hand-off outside the browser as collection — including one to a server on
+your own computer — which is why these are declared rather than `none`. The declaration would
+be required for the default loopback address alone; a team Companion on another host only makes
+it plainer. Both categories describe what the Extension sends **to the Companion you
+configured**, and nothing else. Nothing reaches the authors or any third party, and the
+Extension declares no telemetry of any kind.
 
 **When Firefox shows you this, and when it does not.** Firefox 140 and later display a
 data-collection notice as you install a signed add-on — from Mozilla Add-ons, or from a signed

--- a/extension/README.md
+++ b/extension/README.md
@@ -37,8 +37,9 @@ there it is always a temporary add-on — but you no longer have to build it: ev
 > **What it collects, since a temporary load never asks.** Firefox shows its data-collection
 > notice only for a signed add-on installed normally; `about:debugging` grants everything silently.
 > This add-on declares **browsing activity** (a capture carries the tab's URL and title) and
-> **website content** (the screenshot, and the rows a Push scrapes). All of it goes to your own
-> companion and nowhere else. See [PRIVACY.md](PRIVACY.md).
+> **website content** (the screenshot, and the rows a Push scrapes). It goes to the companion
+> address you configure — by default one on your own machine, or a team companion on another host
+> if you point it there — and nowhere else. See [PRIVACY.md](PRIVACY.md).
 
 Not developing? Unzip `dfir-capture-extension-firefox-<tag>.zip` from the
 [latest release](https://github.com/hasamba/DFIR-Companion/releases/latest) and point the same

--- a/extension/README.md
+++ b/extension/README.md
@@ -34,6 +34,12 @@ there it is always a temporary add-on — but you no longer have to build it: ev
 `about:debugging#/runtime/this-firefox` → **Load Temporary Add-on…** → select
 `extension/dist-firefox/manifest.json` — the manifest **file**, not the folder Chrome asks for.
 
+> **What it collects, since a temporary load never asks.** Firefox shows its data-collection
+> notice only for a signed add-on installed normally; `about:debugging` grants everything silently.
+> This add-on declares **browsing activity** (a capture carries the tab's URL and title) and
+> **website content** (the screenshot, and the rows a Push scrapes). All of it goes to your own
+> companion and nowhere else. See [PRIVACY.md](PRIVACY.md).
+
 Not developing? Unzip `dfir-capture-extension-firefox-<tag>.zip` from the
 [latest release](https://github.com/hasamba/DFIR-Companion/releases/latest) and point the same
 **Load Temporary Add-on…** dialog at the `manifest.json` inside it — the archive holds exactly what

--- a/extension/README.md
+++ b/extension/README.md
@@ -27,7 +27,7 @@ there it is always a temporary add-on — but you no longer have to build it: ev
 `chrome://extensions` → enable **Developer mode** → **Load unpacked** → select the
 `extension/dist` **folder**.
 
-**Firefox 128+**
+**Firefox 140+**
 
     npm run build:firefox
 
@@ -169,5 +169,13 @@ and should not be changed casually:
   existing installs stop receiving updates, and every analyst's saved settings (companion URL,
   active case, dragged button position) are orphaned. `tests/firefox.test.ts` fails if it is ever
   set back to a reserved documentation domain.
-- **`MIN_FIREFOX_VERSION`** (`128.0`) — the MAIN-world floor described under
-  [Build & load](#build--load-development--unpacked). Lowering it makes capture fail silently.
+- **`MIN_FIREFOX_VERSION`** (`140.0`) — two floors in one number. 128 is where
+  `scripting.executeScript` gained `world: "MAIN"`; below it, capture fails silently. 140 is where
+  Firefox reads `data_collection_permissions` and shows the consent screen it drives; below it, the
+  add-on would collect what it declares while the install prompt said nothing, which is not one of
+  the three ways Mozilla permits shipping to older releases. Lowering it breaks one or the other.
+- **`DATA_COLLECTION_PERMISSIONS`** (`browsingActivity`, `websiteContent`) — mandatory in every AMO
+  submission since 2025-11-03; without it the upload is rejected outright. It is not `none` because
+  Mozilla counts any hand-off outside the browser as collection, and a capture POSTs the tab URL,
+  its title and a screenshot to the companion process. There is deliberately no `gecko_android`
+  key: any value there — `{}` included — would publish this desktop tool to Firefox for Android.

--- a/extension/README.md
+++ b/extension/README.md
@@ -37,9 +37,11 @@ there it is always a temporary add-on — but you no longer have to build it: ev
 > **What it collects, since a temporary load never asks.** Firefox shows its data-collection
 > notice only for a signed add-on installed normally; `about:debugging` grants everything silently.
 > This add-on declares **browsing activity** (a capture carries the tab's URL and title) and
-> **website content** (the screenshot, and the rows a Push scrapes). It goes to the companion
-> address you configure — by default one on your own machine, or a team companion on another host
-> if you point it there — and nowhere else. See [PRIVACY.md](PRIVACY.md).
+> **website content** (the screenshot, and the rows a Push scrapes). The extension sends it to the
+> companion address you configure and nowhere else; what that companion forwards afterwards — a
+> vision model reads the screenshots, AI synthesis reads the rows, enrichment queries reputation
+> services — is the companion's own configuration. See
+> [PRIVACY.md](PRIVACY.md).
 
 Not developing? Unzip `dfir-capture-extension-firefox-<tag>.zip` from the
 [latest release](https://github.com/hasamba/DFIR-Companion/releases/latest) and point the same

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "DFIR Companion — Evidence Capture & Push",
   "version": "0.35.1",
-  "description": "Connects to your local DFIR Companion server. Captures screenshots and pushes detections from DFIR consoles to the dashboard.",
+  "description": "Connects to the DFIR Companion you configure, local by default. Captures screenshots and pushes detections from DFIR consoles.",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/extension/scripts/manifest-firefox.d.mts
+++ b/extension/scripts/manifest-firefox.d.mts
@@ -5,8 +5,45 @@ export declare const GECKO_ID: string;
 export declare const MIN_FIREFOX_VERSION: string;
 export declare const FIREFOX_ONLY_KEYS: string[];
 
+/** Every category AMO accepts in `required`. `technicalAndInteraction` is optional-only. */
+export type DataCollectionCategory =
+  | "none"
+  | "authenticationInfo"
+  | "bookmarksInfo"
+  | "browsingActivity"
+  | "financialAndPaymentInfo"
+  | "healthInfo"
+  | "locationInfo"
+  | "personalCommunications"
+  | "personallyIdentifyingInfo"
+  | "searchTerms"
+  | "websiteActivity"
+  | "websiteContent";
+
+export interface DataCollectionPermissions {
+  required: DataCollectionCategory[];
+  optional?: (Exclude<DataCollectionCategory, "none"> | "technicalAndInteraction")[];
+}
+
+export declare const DATA_COLLECTION_PERMISSIONS: {
+  readonly required: readonly DataCollectionCategory[];
+};
+
 export interface FirefoxManifest {
-  browser_specific_settings: { gecko: { id: string; strict_min_version: string } };
+  browser_specific_settings: {
+    gecko: {
+      id: string;
+      strict_min_version: string;
+      // Not optional. AMO rejects a submission that omits it, so a build that could type-check
+      // without it would be a build that type-checks its way to an upload failure.
+      data_collection_permissions: DataCollectionPermissions;
+    };
+    // Always-undefined for the same reason `service_worker` below is: presence is the whole
+    // meaning. Any `gecko_android` value — `{}` included — publishes the add-on to Firefox for
+    // Android, so declaring it as never-present makes adding one a type error rather than a
+    // one-line manifest edit nobody reviews.
+    gecko_android?: undefined;
+  };
   // `service_worker?: undefined` is deliberate: Firefox has no MV3 service worker, so the key must
   // never be present. Declaring it as always-undefined lets callers assert that at runtime while
   // still making any attempt to populate it a type error.

--- a/extension/scripts/manifest-firefox.mjs
+++ b/extension/scripts/manifest-firefox.mjs
@@ -22,12 +22,59 @@
 export const GECKO_ID = "dfir-companion@hasamba.github.io";
 
 /**
- * Firefox 128 (the current ESR) is the floor because it is where scripting.executeScript gained
- * world: "MAIN". serviceWorker.ts injects pageHook.js into MAIN unconditionally; on an older
- * Firefox that call would quietly land in the isolated world, wrap a `fetch` no page script calls,
- * report ready, and then capture nothing (#298). Do not lower this.
+ * Two independent floors, and the higher one wins.
+ *
+ * 128 is where scripting.executeScript gained world: "MAIN". serviceWorker.ts injects pageHook.js
+ * into MAIN unconditionally; on an older Firefox that call would quietly land in the isolated
+ * world, wrap a `fetch` no page script calls, report ready, and then capture nothing (#298).
+ *
+ * 140 is where Firefox learned to READ data_collection_permissions below and show the consent
+ * screen it drives. Mozilla gives exactly three ways to ship a data-collecting add-on to older
+ * releases — raise the floor, turn the collection off there, or build a replacement consent screen
+ * — and "declare it and let the old prompt say nothing" is not among them. Turning collection off
+ * would mean shipping an add-on that cannot capture, which is the whole product; a hand-rolled
+ * consent screen is real UI in the one component that touches evidence, written for browsers
+ * nobody should still be running. So the floor moves, which is also what Mozilla recommends for a
+ * first submission.
+ *
+ * The users this costs are close to none: 140 is itself an ESR, and 128 ESR went end-of-life in
+ * September 2025, so an enterprise pinned to ESR is already at or above this line.
+ *
+ * Do not lower this. Below 140 the add-on collects without disclosing; below 128 it silently
+ * captures nothing.
  */
-export const MIN_FIREFOX_VERSION = "128.0";
+export const MIN_FIREFOX_VERSION = "140.0";
+
+/**
+ * AMO has required a data-collection declaration in every submission since 2025-11-03; a package
+ * without one is rejected by the validator ("The data_collection_permissions property is missing"),
+ * not merely flagged. Firefox 140+ turns it into the install-time consent screen; older Firefox
+ * ignores the key, which is why the 128 floor below can stay where it is.
+ *
+ * `none` would be the easier claim and it is the wrong one. Mozilla scopes collection to data
+ * "handled outside the add-on or the local browser" — not to data that leaves the machine — and
+ * every capture POSTs the tab URL, its title and a full screenshot to a separate process. That the
+ * process is the analyst's own companion on 127.0.0.1 is what PRIVACY.md says, and it stays true;
+ * it is not what this key asks. A reviewer reading companionClient.ts next to a `none` declaration
+ * would be reading a false statement.
+ *
+ * - browsingActivity — CapturePayload carries `url` and `tabTitle` for every capture.
+ * - websiteContent   — the screenshot itself, plus the console rows a Push scrapes.
+ *
+ * Deliberately absent: `websiteActivity` (a capture's `triggerType` records why the capture fired,
+ * never what the analyst clicked or typed) and `technicalAndInteraction` (no telemetry exists to
+ * declare, and PRIVACY.md promises there never will be).
+ */
+/*
+ * There is deliberately no `gecko_android` key. Omitting it is what keeps the add-on desktop-only:
+ * per MDN, an extension is offered on Firefox for Android only if the key is present, even as an
+ * empty object. Adding one to silence web-ext's Android version warning would opt a screenshot-and
+ * -context-menu tool into a browser it was never built or tested for — and since no Android user
+ * can install it, the consent floor Android would need (142) is moot.
+ */
+export const DATA_COLLECTION_PERMISSIONS = Object.freeze({
+  required: Object.freeze(["browsingActivity", "websiteContent"]),
+});
 
 /** The manifest keys this transform is allowed to change. Asserted by tests/firefox.test.ts. */
 export const FIREFOX_ONLY_KEYS = ["browser_specific_settings", "background", "incognito"];
@@ -52,7 +99,13 @@ export function toFirefoxManifest(base) {
     out[key] = value;
     if (key === "manifest_version") {
       out.browser_specific_settings = {
-        gecko: { id: GECKO_ID, strict_min_version: MIN_FIREFOX_VERSION },
+        gecko: {
+          id: GECKO_ID,
+          strict_min_version: MIN_FIREFOX_VERSION,
+          // Cloned, not referenced: the exported constant is frozen, and handing callers a live
+          // reference to it would make one build's manifest mutable through another's import.
+          data_collection_permissions: { required: [...DATA_COLLECTION_PERMISSIONS.required] },
+        },
       };
       // Chrome rejects `not_allowed`; Firefox supports it and then makes private windows entirely
       // invisible to the add-on. Chrome stays excluded by default and the runtime independently

--- a/extension/scripts/manifest-firefox.mjs
+++ b/extension/scripts/manifest-firefox.mjs
@@ -52,11 +52,12 @@ export const MIN_FIREFOX_VERSION = "140.0";
  * ignores the key, which is why the 128 floor below can stay where it is.
  *
  * `none` would be the easier claim and it is the wrong one. Mozilla scopes collection to data
- * "handled outside the add-on or the local browser" — not to data that leaves the machine — and
- * every capture POSTs the tab URL, its title and a full screenshot to a separate process. That the
- * process is the analyst's own companion on 127.0.0.1 is what PRIVACY.md says, and it stays true;
- * it is not what this key asks. A reviewer reading companionClient.ts next to a `none` declaration
- * would be reading a false statement.
+ * "handled outside the add-on or the local browser" — not to data that leaves the machine — so the
+ * default 127.0.0.1 companion already settles it: every capture POSTs the tab URL, its title and a
+ * full screenshot to a separate process. The companion address is also just a setting, and team
+ * mode exists for a companion another machine can reach, so the destination is not even reliably
+ * local. A reviewer reading companionClient.ts next to a `none` declaration would be reading a
+ * false statement.
  *
  * - browsingActivity — CapturePayload carries `url` and `tabTitle` for every capture.
  * - websiteContent   — the screenshot itself, plus the console rows a Push scrapes.

--- a/extension/tests/firefox.test.ts
+++ b/extension/tests/firefox.test.ts
@@ -3,7 +3,13 @@ import { readdirSync, readFileSync, statSync } from "fs";
 import { resolve, dirname, relative } from "path";
 import { fileURLToPath } from "url";
 
-import { toFirefoxManifest, FIREFOX_ONLY_KEYS, MIN_FIREFOX_VERSION, GECKO_ID } from "../scripts/manifest-firefox.mjs";
+import {
+  toFirefoxManifest,
+  FIREFOX_ONLY_KEYS,
+  MIN_FIREFOX_VERSION,
+  GECKO_ID,
+  DATA_COLLECTION_PERMISSIONS,
+} from "../scripts/manifest-firefox.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const read = (name: string) => JSON.parse(readFileSync(resolve(__dirname, "..", name), "utf-8"));
@@ -28,6 +34,75 @@ describe("the generated Firefox manifest", () => {
     const id = firefoxManifest.browser_specific_settings.gecko.id;
     expect(id).not.toMatch(/@(example\.(com|net|org)|(.+\.)?(test|invalid|localhost))$/);
     expect(id).toBe(GECKO_ID);
+  });
+
+  it("declares data collection, which AMO rejects the package for omitting", () => {
+    // Mandatory in every AMO submission since 2025-11-03. The validator's message is
+    // "The data_collection_permissions property is missing", and it blocks the upload.
+    const dcp = firefoxManifest.browser_specific_settings.gecko.data_collection_permissions;
+    expect(dcp).toBeDefined();
+    expect(Array.isArray(dcp.required)).toBe(true);
+    expect(dcp.required.length).toBeGreaterThan(0);
+    expect(dcp.required).toEqual([...DATA_COLLECTION_PERMISSIONS.required]);
+  });
+
+  it("does not claim `none`, which the capture payload would contradict", () => {
+    // `none` asserts the add-on neither collects nor transmits. CapturePayload POSTs the tab URL,
+    // its title and a screenshot to a separate process, which is collection under Mozilla's
+    // definition however local that process is. Declaring `none` next to companionClient.ts is the
+    // kind of mismatch that costs an add-on its listing, not just a review round.
+    const required: string[] = firefoxManifest.browser_specific_settings.gecko.data_collection_permissions.required;
+    expect(required).not.toContain("none");
+    expect(required).toContain("browsingActivity"); // CapturePayload.url / .tabTitle
+    expect(required).toContain("websiteContent"); // the screenshot, and scraped console rows
+  });
+
+  it("declares no telemetry, matching the promise PRIVACY.md makes", () => {
+    const gecko = firefoxManifest.browser_specific_settings.gecko;
+    const declared: string[] = [
+      ...gecko.data_collection_permissions.required,
+      ...(gecko.data_collection_permissions.optional ?? []),
+    ];
+    expect(declared).not.toContain("technicalAndInteraction");
+  });
+
+  it("only ever declares categories AMO recognises", () => {
+    // A typo here is not a test failure anywhere else — it is an upload rejection at submission
+    // time, i.e. the slowest possible place to find it.
+    const VALID_REQUIRED = [
+      "none",
+      "authenticationInfo",
+      "bookmarksInfo",
+      "browsingActivity",
+      "financialAndPaymentInfo",
+      "healthInfo",
+      "locationInfo",
+      "personalCommunications",
+      "personallyIdentifyingInfo",
+      "searchTerms",
+      "websiteActivity",
+      "websiteContent",
+    ];
+    const gecko = firefoxManifest.browser_specific_settings.gecko;
+    for (const value of gecko.data_collection_permissions.required) {
+      expect(VALID_REQUIRED).toContain(value);
+    }
+    // `technicalAndInteraction` is the one value that may appear in `optional` but never `required`.
+    for (const value of gecko.data_collection_permissions.optional ?? []) {
+      expect([...VALID_REQUIRED.filter((v) => v !== "none"), "technicalAndInteraction"]).toContain(value);
+    }
+  });
+
+  it("keeps the exported declaration immune to mutation through the built manifest", () => {
+    // Both builds import the same frozen constant. Handing out a live reference would let a caller
+    // that edits its own manifest silently change what the other build ships.
+    const other = toFirefoxManifest(chromeManifest);
+    firefoxManifest.browser_specific_settings.gecko.data_collection_permissions.required.push("healthInfo");
+    expect(other.browser_specific_settings.gecko.data_collection_permissions.required).toEqual([
+      ...DATA_COLLECTION_PERMISSIONS.required,
+    ]);
+    // Undo, so later assertions in this file still see the shipped value.
+    firefoxManifest.browser_specific_settings.gecko.data_collection_permissions.required.pop();
   });
 
   it("uses background.scripts instead of service_worker", () => {
@@ -62,6 +137,24 @@ describe("the generated Firefox manifest", () => {
     const min = firefoxManifest.browser_specific_settings.gecko.strict_min_version;
     expect(min).toMatch(/^\d+(\.\d+)*$/);
     expect(Number.parseInt(min, 10)).toBeGreaterThanOrEqual(128);
+  });
+
+  it("requires Firefox 140+, so no install can collect data without the consent screen", () => {
+    // The floor and the declaration are one decision, not two. Firefox reads
+    // data_collection_permissions from 140; on 128–139 the key is ignored and the add-on would
+    // install with the pre-2025 prompt, collecting exactly what the declaration says it collects
+    // while telling the analyst nothing. Mozilla's three sanctioned answers are raise the floor,
+    // disable collection there, or ship a replacement consent screen — this is the first.
+    const min = firefoxManifest.browser_specific_settings.gecko.strict_min_version;
+    expect(Number.parseInt(min, 10)).toBeGreaterThanOrEqual(140);
+  });
+
+  it("stays desktop-only, which is what settles the Android consent floor", () => {
+    // An extension reaches Firefox for Android only if gecko_android is present — even `{}` opts
+    // in. Its absence is load-bearing twice over: it keeps a screenshot-and-context-menu tool out
+    // of a browser it was never built for, and it makes Android's own 142 consent floor moot,
+    // because nothing can install there to need it.
+    expect(firefoxManifest.browser_specific_settings.gecko_android).toBeUndefined();
   });
 
   it("injects pageHook into the MAIN world unconditionally", () => {

--- a/extension/tests/manifest.test.ts
+++ b/extension/tests/manifest.test.ts
@@ -6,6 +6,26 @@ import { fileURLToPath } from "url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const manifest = JSON.parse(readFileSync(resolve(__dirname, "../manifest.json"), "utf-8"));
 
+describe("manifest.json store listing", () => {
+  // Chrome Web Store caps the manifest description at 132 characters and rejects the package on
+  // 133 — at upload, after the build passed, which is the slowest place to learn it. This branch
+  // hit exactly that: rewording the description to stop calling the companion "local" pushed it to
+  // 133 and nothing in the repo would have said so.
+  const CHROME_DESCRIPTION_LIMIT = 132;
+
+  it("keeps the description within the Chrome Web Store limit", () => {
+    expect(manifest.description.length).toBeLessThanOrEqual(CHROME_DESCRIPTION_LIMIT);
+  });
+
+  it("does not promise the companion is local, because the address is a setting", () => {
+    // PRIVACY.md stopped claiming evidence never leaves the machine: the companion URL is a plain
+    // setting and team mode exists for a companion on another host. The store listing sits beside
+    // that policy on the add-on's page, so it must not re-make the claim the policy retracted.
+    expect(manifest.description).not.toMatch(/your local (DFIR )?Companion/i);
+    expect(manifest.description).toMatch(/you configure/i);
+  });
+});
+
 describe("manifest.json commands", () => {
   it("defines toggle-capture with Ctrl+Shift+S", () => {
     expect(manifest.commands["toggle-capture"]).toBeDefined();

--- a/mkdocs-docs/getting-started.md
+++ b/mkdocs-docs/getting-started.md
@@ -125,7 +125,7 @@ The capture extension lets you screenshot any browser tab with a keyboard shortc
 
     !!! info "What it collects, since a temporary load never asks"
 
-        Firefox shows its data-collection notice only for a signed add-on installed normally; `about:debugging` grants everything silently. The extension declares **browsing activity** (a capture carries the tab's URL and title) and **website content** (the screenshot, and the rows a Push scrapes). It goes to the companion address you configure — by default one on your own machine, or a team companion on another host if you point it there — and nowhere else.
+        Firefox shows its data-collection notice only for a signed add-on installed normally; `about:debugging` grants everything silently. The extension declares **browsing activity** (a capture carries the tab's URL and title) and **website content** (the screenshot, and the rows a Push scrapes). The extension sends it to the companion address you configure and nowhere else; what that companion forwards afterwards — a vision model reads the screenshots, AI synthesis reads the rows, enrichment queries reputation services — is the companion's own configuration.
     4. The extension icon appears in the toolbar.
 
     !!! note "Temporary add-ons don't survive a restart"

--- a/mkdocs-docs/getting-started.md
+++ b/mkdocs-docs/getting-started.md
@@ -122,6 +122,10 @@ The capture extension lets you screenshot any browser tab with a keyboard shortc
     1. Download `dfir-capture-extension-firefox-*.zip` from the [latest GitHub release](https://github.com/hasamba/DFIR-Companion/releases/latest) and unzip it. (Building from source instead? Run `npm run build:firefox` inside `extension/` — it writes the same files to `extension/dist-firefox/`.)
     2. In Firefox, go to `about:debugging#/runtime/this-firefox`.
     3. Click **Load Temporary Add-on…** and select the `manifest.json` inside the unzipped folder — the manifest **file**, not the folder. (Chrome asks for a folder here; Firefox asks for the manifest inside it.)
+
+    !!! info "What it collects, since a temporary load never asks"
+
+        Firefox shows its data-collection notice only for a signed add-on installed normally; `about:debugging` grants everything silently. The extension declares **browsing activity** (a capture carries the tab's URL and title) and **website content** (the screenshot, and the rows a Push scrapes). All of it goes to your own companion and nowhere else.
     4. The extension icon appears in the toolbar.
 
     !!! note "Temporary add-ons don't survive a restart"

--- a/mkdocs-docs/getting-started.md
+++ b/mkdocs-docs/getting-started.md
@@ -117,7 +117,7 @@ The capture extension lets you screenshot any browser tab with a keyboard shortc
 
 === "Firefox"
 
-    Needs **Firefox 128 or later**. There is no Mozilla Add-ons listing yet, so it loads as a temporary add-on:
+    Needs **Firefox 140 or later**. There is no Mozilla Add-ons listing yet, so it loads as a temporary add-on:
 
     1. Download `dfir-capture-extension-firefox-*.zip` from the [latest GitHub release](https://github.com/hasamba/DFIR-Companion/releases/latest) and unzip it. (Building from source instead? Run `npm run build:firefox` inside `extension/` — it writes the same files to `extension/dist-firefox/`.)
     2. In Firefox, go to `about:debugging#/runtime/this-firefox`.

--- a/mkdocs-docs/getting-started.md
+++ b/mkdocs-docs/getting-started.md
@@ -125,7 +125,7 @@ The capture extension lets you screenshot any browser tab with a keyboard shortc
 
     !!! info "What it collects, since a temporary load never asks"
 
-        Firefox shows its data-collection notice only for a signed add-on installed normally; `about:debugging` grants everything silently. The extension declares **browsing activity** (a capture carries the tab's URL and title) and **website content** (the screenshot, and the rows a Push scrapes). All of it goes to your own companion and nowhere else.
+        Firefox shows its data-collection notice only for a signed add-on installed normally; `about:debugging` grants everything silently. The extension declares **browsing activity** (a capture carries the tab's URL and title) and **website content** (the screenshot, and the rows a Push scrapes). It goes to the companion address you configure — by default one on your own machine, or a team companion on another host if you point it there — and nowhere else.
     4. The extension icon appears in the toolbar.
 
     !!! note "Temporary add-ons don't survive a restart"


### PR DESCRIPTION
## What broke

Submitting the Firefox add-on to AMO fails validation:

> The "data_collection_permissions" property is missing.

Mozilla has required a data-collection declaration in **every** AMO submission since
2025-11-03. Our generated Firefox manifest predates the rule, so the add-on cannot be
uploaded at all — listed or self-hosted.

## What this declares, and why not `none`

`none` is the easier claim and it is the wrong one. Mozilla scopes collection to data
handled *outside the add-on or the local browser* — not to data that leaves the machine —
and every capture POSTs the tab URL, its title and a full screenshot to a separate process.
That the process is the analyst's own companion on `127.0.0.1` is what `PRIVACY.md`
promises, and it stays true; it is not what this key asks. A reviewer reading
`companionClient.ts` beside a `none` declaration would be reading a false statement.

| Declared | Why |
|---|---|
| `browsingActivity` | `CapturePayload` carries `url` and `tabTitle` on every capture. |
| `websiteContent` | The screenshot itself, plus the rows a console Push scrapes. |

Deliberately absent: `websiteActivity` (a capture's `triggerType` records why the capture
fired, never what the analyst clicked or typed) and `technicalAndInteraction` (no telemetry
exists to declare, and `PRIVACY.md` promises there never will be).

## The floor moves 128 → 140

The declaration alone was not enough, and shipping it alone would have been worse than the
bug. Firefox reads `data_collection_permissions` from 140. On 128–139 the key is ignored,
so the add-on would have installed behind the pre-2025 prompt and collected exactly what
this PR declares while telling the analyst nothing.

Mozilla sanctions three answers for releases that cannot show the consent screen: raise the
floor, turn the collection off there, or ship a replacement consent screen. Shipping without
one is not among them.

- **Turning collection off** means an add-on that cannot capture. That is the product.
- **A hand-rolled consent screen** is new UI in the one component that touches evidence,
  written for browsers nobody should still be running.
- **Raising the floor** is what Mozilla recommends for a first submission, and it costs
  close to nothing: 140 is itself an ESR, and 128 ESR ended in September 2025, so an
  enterprise pinned to ESR is already at or above the line.

The MAIN-world reason for the old 128 floor (#298) is unchanged and still documented —
140 clears it comfortably.

## No `gecko_android`, on purpose

`web-ext` also warns that Android needs 142. The fix is *not* to add the key: per MDN an
extension reaches Firefox for Android only if `gecko_android` is present, `{}` included.
Adding one to silence a warning would publish a screenshot-and-context-menu tool to a
browser it was never built or tested for. Its absence is why the warning is inert — nothing
can install on Android to need that consent floor. The `.d.mts` now types the key as
never-present, so adding one later is a type error rather than a one-line manifest edit.

## What the analyst sees

The install prompt now names browsing activity and website content. `PRIVACY.md` gains a
short section saying plainly that this describes what the extension sends **to your own
companion**, that nothing reaches the authors or any third party, and why 140 is required.
README, `extension/README.md`, the manual and the landing page move off 128.

## Verification

- `web-ext lint --source-dir dist-firefox` → **0 errors** (was 1); 1 warning, inert per above.
- `npm test` → 243 passed, `npm run typecheck` clean, `npm run build:firefox` clean.
- Eight new tests in `tests/firefox.test.ts`: the key's presence, the `none` mismatch, no
  telemetry, category-name validity, immutability of the exported constant through a built
  manifest, the 140 floor, and that `gecko_android` stays absent.

## Follow-up: the temporary-install path (second review round)

The declaration plus the 140 floor guarantee a consent screen only for a **signed** add-on. An
unsigned build loaded through `about:debugging` → **Load Temporary Add-on…** is granted every
permission silently — Mozilla: "if the extension makes installation time permission requests,
these are not displayed as part of the temporary installation process".

That is not an edge case here. It is the **only** route this project documents, because there is
no AMO listing yet. So every analyst following our own instructions installed a screenshot tool
Firefox never disclosed — and `PRIVACY.md` had just begun claiming the opposite.

`README.md`, `extension/README.md`, the manual and `PRIVACY.md` now name both categories at
the point where they teach the temporary load, and `PRIVACY.md` separates the signed path from
the temporary one instead of promising a notice only one of them shows.

New gate: `companion/tests/architecture/temporaryInstallDisclosure.test.ts`, in the same shape as
`nodeEngineDocs` — the categories are read from the manifest transform, not hard-coded, so
declaring a third one fails until the prose catches up. Verified to go red **both** ways: by
deleting the disclosure from one doc, and by adding a category the prose does not mention.

## Follow-up: the privacy policy itself (third review round)

Preparing an AMO submission means the policy gets read against the code. Three things did not survive that:

- **"No data leaves your machine via the Extension"** — false. True on the default 127.0.0.1
  companion; but the address is a plain setting (`normalizeCompanionUrl` only trims), and team
  mode exists for "a companion another person or machine can reach", which is what the
  extension's optional service token is for. Point it at a team Companion and every screenshot
  goes to that host. The policy said the opposite, in bold.
- **"published for Chrome and other Chromium browsers"** — on the branch preparing the Firefox
  submission the policy is filed against.
- **`Last updated: 2026-07-31`** — after this branch had already rewritten the policy. Its own
  "Changes to this policy" section promises material changes are dated.

The Summary and "Where the data goes" now state both destinations plainly and keep the claim
that matters: nothing reaches the authors, an analytics service, or any third party, either way.
The four temporary-install disclosures move from "your own companion" to "the companion you
configure" for the same reason.

### Completing it (fourth round)

The summary was corrected; four other passages were not, so the policy contradicted itself —
"push those rows to your **local** DFIR Companion", "the link's URL to your **local**
companion", "evidence is stored and managed by **your** Companion, under your control" (a team
Companion is under the control of whoever runs it), and a bullet implying settings are uploaded
at all (they never leave the browser; the queued captures do).

`extension/manifest.json` carried the same retracted claim — "Connects to your local DFIR
Companion server" — and that string is the store listing rendered beside this policy on the
add-on's page. Rewording it first produced a **133-character** description; the Chrome Web Store
caps that field at 132 and rejects the package at upload, after every local build and test
passes. `tests/manifest.test.ts` now gates both the length and the wording, verified red at 133.

### Scoping the promise (fifth round)

Two claims this branch introduced were end-to-end promises the extension has no standing to make:
"nothing the Extension handles ever leaves the machine" (Summary) and the same again under
"Where the data goes".

Both are false on a Companion with AI configured. `analyzeWindow()` calls
`requireProvider("screenshot analysis")` and loads each capture through `imageLoader`, so the
**screenshots themselves** go to the vision model; synthesis sends timeline content including the
rows a Push scraped; enrichment sends IOCs to third-party reputation services. An analyst reading
the old sentence could believe a screenshot of a compromised host never left the box while a cloud
model was reading it.

The claim is now scoped to what the Extension itself does — one configured destination, nothing
else, no telemetry — followed by a section stating where the evidence can travel afterwards and
that those are the Companion's settings, not this policy's.

Checked in both directions: a first pass dropped the vision claim after grepping `images:` and
finding every call site passing `[]`. The README's "windowed AI vision analysis" contradicted
that, and the real path is `analysis/ai/extraction.ts` via `imageLoader`. Understating what
leaves is the same defect as overstating it.