### PR TITLE
feat(wizard): configure Presidio and Telegram from the setup wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
+- **The setup wizard configures Presidio and Telegram** — a Presidio step (analyzer URL, confidence floor, timeout) that warns on a non-local URL, tests the URL as typed, and says to restart because those keys are read at startup; and a Telegram bot option on the Notifications step, which can borrow the war-room bot's token from `.env` and offers the chats it is already bound to. Both were reachable only from Settings.
 
 ### Fixed
 - **Exporting a case on Windows no longer fails as a security refusal** — a sidecar save during the export was reported as a symlink attack.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ list of known compromised hosts and users.
 ## Features
 
 ### Onboarding
-- **Setup wizard** — guided multi-step dashboard overlay (auto-shown first-run; also in Settings → General / AI) to configure AI (extraction **and** synthesis model, separately), the integrations (Velociraptor, DFIR-IRIS, Timesketch, Notion, ClickUp), threat-intel enrichment + customer-exposure providers, push ingest, NSRL, and a notification webhook (Slack/Teams/Mattermost/Discord) — each with Save → apply-live → connection/status test, and a ✓/○ progress rail. Everything is optional and dismissible
+- **Setup wizard** — guided multi-step dashboard overlay (auto-shown first-run; also in Settings → General / AI) to configure AI (extraction **and** synthesis model, separately), the optional Presidio PII scan, the integrations (Velociraptor, DFIR-IRIS, Timesketch, Notion, ClickUp), threat-intel enrichment + customer-exposure providers, push ingest, NSRL, and a notification channel (Slack/Teams/Mattermost/Discord webhook, or a Telegram bot) — each with Save → apply-live → connection/status test, and a ✓/○ progress rail. Everything is optional and dismissible
 
 ### Capture & ingest
 - **Least-privilege MV3 browser extension** — zero site access at install, exact-origin console approval/revocation, one-off active-tab capture, timer + event-driven capture, local permission audit, offline queue + auto-sync

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -851,6 +851,8 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
         shodan: has("DFIR_SHODAN_KEY"),
       },
       nsrl: has("DFIR_NSRL_DB") || has("DFIR_NSRL_FILE") || !!options.nsrlStore,
+      // Not reloadable, so this turns true only after a restart: the tick means active, not typed.
+      presidio: has("DFIR_PRESIDIO_URL"),
     });
   });
   // Redirect root to the dashboard.

--- a/companion/tests/settings/setupWizardSteps.test.ts
+++ b/companion/tests/settings/setupWizardSteps.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, setServerLogger } from "../../src/server.js";
+import { createConsoleLogger } from "../../src/logging/logger.js";
+import { RELOADABLE_ENV_PREFIXES, validateEnvUpdates } from "../../src/settings/envManager.js";
+import { loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// The wizard's step table (public/js/dashboard-wizard-steps.js) is pure data that only the BROWSER
+// ever runs, and every entry in it is a claim about this server: that it will write these keys,
+// apply this prefix, and answer this status field. Nothing checked those claims, so a step could
+// be — and was — wired to a route that refuses it, with a fully green suite:
+//
+//   - the Presidio step's three keys are writable but DFIR_PRESIDIO_ is deliberately NOT on the
+//     /settings/reload allowlist (the analyzer client is built once at startup). A step declaring
+//     `reload: "DFIR_PRESIDIO_"` would 400 on every save, and the wizard's `.catch(() => {})`
+//     around that call means it would 400 SILENTLY, reporting "Saved & configured";
+//   - a step whose `status` key is absent from /setup/status renders as neither ✓ nor ○ forever.
+//
+// Both are one-line mistakes in a data table, and both are invisible until someone opens the
+// wizard and reads the rail.
+
+interface WizardField {
+  key: string;
+  label: string;
+  secret?: boolean;
+  hint?: string;
+}
+interface WizardProvider {
+  id: string;
+  reload?: string;
+  fields: WizardField[];
+}
+interface WizardStep {
+  id: string;
+  label: string;
+  status?: string;
+  kind?: string;
+  reload?: string;
+  fields?: WizardField[];
+  providers?: WizardProvider[];
+}
+interface WizardStepsApi {
+  wizardOrder: () => string[];
+  wizardStepById: (id: string) => WizardStep | undefined;
+}
+
+const wizard = loadDashboardModule<WizardStepsApi>("dashboard-wizard-steps.js");
+
+/** Every non-AI step, in rail order. "ai" is rendered statically and has no table entry. */
+const steps = (): WizardStep[] =>
+  wizard
+    .wizardOrder()
+    .map((id) => wizard.wizardStepById(id))
+    .filter((s): s is WizardStep => s !== undefined);
+
+/** Every (prefix, source) pair a step will POST to /settings/reload — steps and sub-providers. */
+const reloadPrefixes = (): Array<{ prefix: string; from: string }> =>
+  steps().flatMap((s) => [
+    ...(s.reload ? [{ prefix: s.reload, from: s.id }] : []),
+    ...(s.providers ?? [])
+      .filter((p) => p.reload)
+      .map((p) => ({ prefix: p.reload as string, from: `${s.id}/${p.id}` })),
+  ]);
+
+/** Every env key the wizard renders an input for. */
+const fieldKeys = (): Array<{ key: string; from: string }> =>
+  steps().flatMap((s) => [
+    ...(s.fields ?? []).map((f) => ({ key: f.key, from: s.id })),
+    ...(s.providers ?? []).flatMap((p) => p.fields.map((f) => ({ key: f.key, from: `${s.id}/${p.id}` }))),
+  ]);
+
+describe("the setup wizard's step table ⇄ the routes it calls", () => {
+  it("finds the step table at all", () => {
+    // Guards every assertion below: a rename of the published accessors would empty all of them.
+    expect(wizard.wizardOrder()[0], "the AI step is no longer first in the rail").toBe("ai");
+    expect(steps().length).toBeGreaterThan(5);
+  });
+
+  it("only saves keys POST /settings/env will accept", () => {
+    const rejected = fieldKeys().filter(({ key }) => validateEnvUpdates({ [key]: "x" }).length > 0);
+    expect(rejected, `wizard fields the server refuses to write: ${JSON.stringify(rejected)}`).toEqual([]);
+  });
+
+  it("only applies prefixes POST /settings/reload will accept", () => {
+    const rejected = reloadPrefixes().filter(({ prefix }) => !RELOADABLE_ENV_PREFIXES.has(prefix));
+    expect(rejected, `steps that would 400 on apply, silently: ${JSON.stringify(rejected)}`).toEqual([]);
+  });
+
+  // The Presidio step is the reason the check above is not a formality. Its keys are writable, so
+  // it renders and saves like any other step — but they reach the running server only through a
+  // restart, which is why the step declares no reload prefix and says "restart" after a save.
+  it("keeps the Presidio step off the reload path, because its keys need a restart", () => {
+    const presidio = wizard.wizardStepById("presidio");
+    expect(presidio, "the Presidio step is gone from the wizard").toBeDefined();
+    expect(presidio?.fields?.map((f) => f.key)).toEqual([
+      "DFIR_PRESIDIO_URL",
+      "DFIR_PRESIDIO_MIN_SCORE",
+      "DFIR_PRESIDIO_TIMEOUT_MS",
+    ]);
+    expect(presidio?.reload, "a Presidio reload prefix would 400 on every save").toBeUndefined();
+    expect(RELOADABLE_ENV_PREFIXES.has("DFIR_PRESIDIO_")).toBe(false);
+    expect(validateEnvUpdates({ DFIR_PRESIDIO_URL: "http://localhost:5002" })).toEqual([]);
+  });
+
+  it("answers /setup/status for every step that draws a rail tick", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-wizard-steps-"));
+    setServerLogger(createConsoleLogger("info"));
+    const res = await request(createApp(new CaseStore(root), {})).get("/setup/status");
+    expect(res.status).toBe(200);
+
+    const missing = steps()
+      .filter((s) => s.status)
+      .filter((s) => {
+        const value = (res.body as Record<string, unknown>)[s.status as string];
+        // The rail reads a plain boolean, or an object of them for the two provider steps.
+        return typeof value !== "boolean" && (value === null || typeof value !== "object");
+      })
+      .map((s) => s.status);
+    expect(missing, `rail ticks with no /setup/status field: ${missing.join(", ")}`).toEqual([]);
+    expect(typeof (res.body as Record<string, unknown>).presidio).toBe("boolean");
+  });
+});

--- a/mkdocs-docs/getting-started.md
+++ b/mkdocs-docs/getting-started.md
@@ -78,6 +78,7 @@ When you open the dashboard for the first time with no AI provider configured, a
 | Step | What you configure |
 |------|--------------------|
 | **AI analysis** | Provider (OpenAI, Anthropic/Claude, OpenRouter, Gemini, Ollama, LiteLLM), model name, API key. A "Save & test" button confirms the key works before you proceed. |
+| **Presidio PII scan** | Optional analyzer URL, confidence floor and timeout for the extra PII detector in front of the AI. Save, then restart — these keys are read at startup. |
 | **Velociraptor** | API config path for hunt-and-collect integration. |
 | **DFIR-IRIS** | URL + key for bidirectional case sync. |
 | **Timesketch** | URL + credentials to push the timeline to Timesketch. |
@@ -87,7 +88,7 @@ When you open the dashboard for the first time with no AI provider configured, a
 | **Customer exposure** | Keys for LeakCheck, HIBP, DeHashed. |
 | **Push ingest** | Token for the webhook endpoint. |
 | **NSRL** | Path to a known-good hash database. |
-| **Notifications** | Slack/Teams/Mattermost/Discord webhook for alert notifications. |
+| **Notifications** | Slack/Teams/Mattermost/Discord webhook, or a Telegram bot (token + chat ID), for alert notifications. |
 
 !!! tip
     Everything is optional. You can dismiss the wizard and add things later from **Settings**. You can reopen the wizard any time from **Settings → General → Open setup wizard**.

--- a/public/js/dashboard-setup-wizard.js
+++ b/public/js/dashboard-setup-wizard.js
@@ -80,6 +80,27 @@
   }
 
   function wizRenderStep(step) {
+    if (step.kind === "presidio") {
+      return (
+        "<h3>" +
+        step.icon +
+        " " +
+        esc(step.label) +
+        "</h3>" +
+        '<p class="wiz-sub">' +
+        esc(step.blurb) +
+        "</p>" +
+        (step.note
+          ? '<div class="wiz-note">🛡️ ' + esc(step.note) + "</div>"
+          : "") +
+        wizRenderFields(step.fields) +
+        '<div id="wizPresidioWarn" class="wiz-note" data-safe-style="display:none;border-left-color:#e0a458"></div>' +
+        '<div class="wiz-actions"><button class="wiz-btn" id="wizPresidioSaveBtn">Save</button>' +
+        '<button class="wiz-btn secondary" id="wizPresidioTestBtn">Test connection</button>' +
+        '<span data-safe-style="font-size:11px;color:var(--text-muted)">Saved to your local .env (gitignored), and read at startup.</span></div>' +
+        '<div id="wizPresidioResult" class="wiz-result"></div>'
+      );
+    }
     if (step.kind === "notifications") {
       return (
         "<h3>" +
@@ -93,9 +114,15 @@
         (step.note
           ? '<div class="wiz-note">🔔 ' + esc(step.note) + "</div>"
           : "") +
-        '<div class="wiz-field"><label>Channel type<span class="wiz-hint">Slack / Teams / Mattermost / Discord — all use an incoming-webhook URL.</span></label>' +
-        '<select id="wizNotifType"><option value="slack">Slack</option><option value="teams">MS Teams</option><option value="mattermost">Mattermost</option><option value="discord">Discord</option></select></div>' +
-        '<div class="wiz-field"><label>Webhook URL</label><input id="wizNotifUrl" placeholder="https://hooks.slack.com/services/…" autocomplete="off" /></div>' +
+        '<div class="wiz-field"><label>Channel type<span class="wiz-hint">Slack / Teams / Mattermost / Discord use an incoming-webhook URL. Telegram uses a bot token and a chat ID.</span></label>' +
+        '<select id="wizNotifType"><option value="slack">Slack</option><option value="teams">MS Teams</option><option value="mattermost">Mattermost</option><option value="discord">Discord</option><option value="telegram">Telegram bot</option></select></div>' +
+        '<div class="wiz-field" id="wizNotifUrlRow"><label>Webhook URL</label><input id="wizNotifUrl" placeholder="https://hooks.slack.com/services/…" autocomplete="off" /></div>' +
+        '<div id="wizNotifTgRows" data-safe-style="display:none">' +
+        '<div class="wiz-field"><label>Bot token<span class="wiz-hint">From @BotFather. Leave it blank to reuse the war-room bot\'s DFIR_TELEGRAM_BOT_TOKEN — the token then lives in .env only, and rotating it there is enough.</span></label>' +
+        '<input id="wizNotifTgToken" type="password" placeholder="Bot token (123456789:AAF…)" autocomplete="new-password" /></div>' +
+        '<div class="wiz-field"><label>Chat ID<span class="wiz-hint">A @channel name, or a numeric id like -1001234567890. Check it points where you mean — notifications carry case content.</span></label>' +
+        '<input id="wizNotifTgChatId" list="wizNotifTgChats" placeholder="Chat ID" autocomplete="off" /><datalist id="wizNotifTgChats"></datalist></div>' +
+        "</div>" +
         '<div class="wiz-field"><label>Minimum severity<span class="wiz-hint">Only findings at or above this severity notify (milestones always do).</span></label>' +
         '<select id="wizNotifSev"><option value="Critical">Critical</option><option value="High" selected>High</option><option value="Medium">Medium</option><option value="Low">Low</option><option value="Info">Info</option></select></div>' +
         '<div class="wiz-actions"><button class="wiz-btn" id="wizNotifSaveBtn">Add &amp; send test</button>' +
@@ -184,6 +211,7 @@
     test,
     resultEl,
     btn,
+    okText,
   ) {
     const updates = wizCollect(fields);
     if (Object.keys(updates).length === 0) {
@@ -259,7 +287,7 @@
       }
     } else {
       resultEl.style.color = "#5ad17a";
-      resultEl.textContent = "✓ Saved.";
+      resultEl.textContent = okText || "✓ Saved.";
     }
     if (btn) btn.disabled = false;
     await wizRefreshStatus();
@@ -290,6 +318,13 @@
     } else if (step.kind === "notifications") {
       const btn = wizEl("wizNotifSaveBtn");
       if (btn) btn.onclick = wizSaveNotification;
+      wizEl("wizNotifType").onchange = wizNotifTypeChanged;
+      wizNotifTypeChanged();
+      wizLoadNotifTelegramHints();
+    } else if (step.kind === "presidio") {
+      wizEl("wizPresidioSaveBtn").onclick = wizSavePresidio;
+      wizEl("wizPresidioTestBtn").onclick = wizTestPresidio;
+      wizEl(wizFieldId("DFIR_PRESIDIO_URL")).oninput = wizPresidioLocalWarning;
     } else {
       const btn = wizEl("wizStepSaveBtn"),
         res = wizEl("wizStepResult");
@@ -301,19 +336,155 @@
     wizUpdateNav();
   }
 
+  // ── Presidio step ──
+  // Everything here exists because DFIR_PRESIDIO_ is the one family in the step table that
+  // /settings/reload will not apply: the analyzer client is built once at startup, so a save is
+  // only half the job and the step has to say so. Hence Save and Test are separate buttons — Test
+  // probes the URL as TYPED (nothing is saved), and Save reports "restart" rather than "connected".
+  function wizPresidioUrl() {
+    const el = wizEl(wizFieldId("DFIR_PRESIDIO_URL"));
+    return el ? el.value.trim() : "";
+  }
+  // The same warning Settings → AI shows, for the same reason: Presidio reads the case text —
+  // masked, but still the timeline — so a non-local analyzer sends that text off this machine.
+  function wizPresidioLocalWarning() {
+    const warn = wizEl("wizPresidioWarn");
+    if (!warn) return;
+    const url = wizPresidioUrl().toLowerCase();
+    const isLocal =
+      !url ||
+      /(?:\/\/|@)(?:localhost|127\.0\.0\.1|\[::1\]|0\.0\.0\.0)(?::|\/|$)/.test(
+        url,
+      );
+    warn.style.display = isLocal ? "none" : "block";
+    warn.textContent =
+      "⚠ This Presidio URL is not local. Presidio reads your case text — masked, but still " +
+      "your timeline. Pointing it at a remote host sends that text off this machine.";
+  }
+  // Runs the FIXED synthetic sample (never case data) through the URL currently in the box, so the
+  // analyst can confirm the container answers before committing anything to .env.
+  async function wizTestPresidio() {
+    const res = wizEl("wizPresidioResult");
+    const btn = wizEl("wizPresidioTestBtn");
+    const url = wizPresidioUrl();
+    if (!url) {
+      res.style.color = "#ffb05a";
+      res.textContent = "Enter the analyzer URL first.";
+      return;
+    }
+    btn.disabled = true;
+    res.style.color = "#9aa4b2";
+    res.textContent = "Testing…";
+    try {
+      const r = await fetch("/system/presidio-test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      });
+      const body = await r.json().catch(() => ({}));
+      if (body.error) {
+        res.style.color = "#ff9f9f";
+        // Node's fetch reports a refused or unroutable host as the bare string "fetch failed",
+        // which reads as "Failed: fetch failed" — say what actually happened instead.
+        res.textContent = /^fetch failed$/i.test(body.error)
+          ? "✗ Failed — could not reach that URL"
+          : "✗ Failed: " + esc(body.error);
+        btn.disabled = false;
+        return;
+      }
+      res.style.color = "#5ad17a";
+      res.textContent =
+        "✓ Connected — now Save, then restart the server to activate it.";
+    } catch (e) {
+      res.style.color = "#ff9f9f";
+      res.textContent = "Could not reach the server: " + esc(e.message);
+    }
+    btn.disabled = false;
+  }
+  async function wizSavePresidio() {
+    await wizSaveAndTestGeneric(
+      wizardStepById("presidio").fields,
+      null, // NOT reloadable — /settings/reload rejects this prefix by design
+      null, // and testing the SAVED value would need a restart first, so Test is its own button
+      wizEl("wizPresidioResult"),
+      wizEl("wizPresidioSaveBtn"),
+      "✓ Saved to .env. Restart the server to activate the layer — these three keys are read at startup.",
+    );
+  }
+
+  // ── Notifications step ──
+  // Telegram takes a bot token and a chat ID instead of a webhook URL, so the two field groups
+  // swap. Severity, the add, and the test send are shared.
+  function wizNotifTypeChanged() {
+    const telegram = wizEl("wizNotifType").value === "telegram";
+    wizEl("wizNotifUrlRow").style.display = telegram ? "none" : "";
+    wizEl("wizNotifTgRows").style.display = telegram ? "" : "none";
+  }
+  // Ask /notifications/status the two things the Telegram fields cannot answer for themselves:
+  // whether .env already carries a bot token (else an operator who configured the war-room bot
+  // sees an empty box and pastes the same token twice), and which chats that bot is already bound
+  // to. Best-effort: typing both values by hand still works if this never answers.
+  async function wizLoadNotifTelegramHints() {
+    let status;
+    try {
+      status = await (await fetch("/notifications/status")).json();
+    } catch {
+      return;
+    }
+    // The await above outlives the pane: a click on another rail item replaced this markup, and
+    // the ids below would then resolve to nothing or, worse, to a re-rendered pane's fields.
+    if (wizCurrent !== "notifications") return;
+    const token = wizEl("wizNotifTgToken");
+    if (token && status.telegramEnvToken)
+      token.placeholder =
+        "Bot token — (already set) in .env, leave blank to use it";
+    const input = wizEl("wizNotifTgChatId");
+    const list = wizEl("wizNotifTgChats");
+    if (!input || !list) return;
+    const prefill = ntfChatPrefill(status.telegramChats || []);
+    list.replaceChildren(
+      ...prefill.options.map((o) => {
+        const opt = document.createElement("option");
+        opt.value = o.value;
+        opt.label = o.label;
+        return opt;
+      }),
+    );
+    // Pre-filled into a VISIBLE field, never silently defaulted — this is where case content will
+    // be sent, so the analyst sees the destination and can change it before Add.
+    if (!input.value) input.value = prefill.value;
+  }
+
   // Notifications step: add a webhook channel via the dedicated /notifications API (NOT /settings/env —
   // notifications live in a global config file), then send a test message to it. On 501 the feature is
   // off (no notificationStore); surface that. Refreshes /setup/status so the rail flips ✓.
   async function wizSaveNotification() {
     const type = wizEl("wizNotifType").value;
-    const url = wizEl("wizNotifUrl").value.trim();
     const minSeverity = wizEl("wizNotifSev").value;
     const res = wizEl("wizNotifResult"),
       btn = wizEl("wizNotifSaveBtn");
-    if (!/^https?:\/\//i.test(url)) {
-      res.style.color = "#ffb05a";
-      res.textContent = "Enter the incoming-webhook URL (https://…).";
-      return;
+    // `payload`, not `body`: the try below declares its own `const body` for the RESPONSE, in the
+    // same block as this send — which puts this name in that block's temporal dead zone and throws
+    // "Cannot access 'body' before initialization" on every add.
+    const payload = { type, minSeverity };
+    if (type === "telegram") {
+      const chatId = wizEl("wizNotifTgChatId").value.trim();
+      if (!chatId) {
+        res.style.color = "#ffb05a";
+        res.textContent = "Enter the chat ID the bot should post to.";
+        return;
+      }
+      // A blank token is legitimate — the server falls back to DFIR_TELEGRAM_BOT_TOKEN, and 400s
+      // with its own message when there is nothing to fall back to.
+      payload.telegram = { botToken: wizEl("wizNotifTgToken").value, chatId };
+    } else {
+      const url = wizEl("wizNotifUrl").value.trim();
+      if (!/^https?:\/\//i.test(url)) {
+        res.style.color = "#ffb05a";
+        res.textContent = "Enter the incoming-webhook URL (https://…).";
+        return;
+      }
+      payload.webhookUrl = url;
     }
     btn.disabled = true;
     res.style.color = "#9aa4b2";
@@ -323,7 +494,7 @@
       const add = await fetch("/notifications", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type, webhookUrl: url, minSeverity }),
+        body: JSON.stringify(payload),
       });
       const body = await add.json().catch(() => ({}));
       if (add.status === 501) {

--- a/public/js/dashboard-wizard-steps.js
+++ b/public/js/dashboard-wizard-steps.js
@@ -12,6 +12,32 @@
 
   const F = (key, label, opts) => Object.assign({ key, label }, opts || {});
   const WIZARD_STEPS = [
+    // Presidio comes first because it is a boundary ON step 1: it decides what the AI provider is
+    // allowed to see. Its three keys are also the only ones in this table /settings/reload cannot
+    // apply — DFIR_PRESIDIO_ is deliberately off that allowlist, because the analyzer client is
+    // built once at startup — so kind:"presidio" saves, tests the URL as typed, and says "restart"
+    // instead of the save -> apply-live -> test every other step runs.
+    {
+      id: "presidio",
+      icon: "🕵️",
+      label: "Presidio PII scan",
+      status: "presidio",
+      kind: "presidio",
+      blurb:
+        "OPTIONAL — a second PII detector in front of the AI. It scans text the built-in patterns have ALREADY masked, and catches the names and IDs a regex cannot.",
+      note: "Presidio reads your case text — masked, but still your timeline. Run the analyzer yourself, on this machine or your own network. These three values are read at STARTUP: save them here, then restart the server.",
+      fields: [
+        F("DFIR_PRESIDIO_URL", "Analyzer URL", {
+          hint: "http://localhost:5002 — a Presidio Analyzer container you run yourself. Blank = the layer is off.",
+        }),
+        F("DFIR_PRESIDIO_MIN_SCORE", "Confidence floor", {
+          hint: "0–1, default 0.6. Findings the analyzer scores below this are ignored.",
+        }),
+        F("DFIR_PRESIDIO_TIMEOUT_MS", "Request timeout (ms)", {
+          hint: "Budget for ONE scan request, default 60000. Raise it for a slow or shared analyzer.",
+        }),
+      ],
+    },
     {
       id: "velociraptor",
       icon: "🦖",
@@ -266,9 +292,10 @@
       ],
     },
     // Notifications are stored in a GLOBAL config file (not .env), so this step uses the dedicated
-    // /notifications API (add channel → test), NOT /settings/env. The wizard handles the common
-    // webhook case (Slack/Teams/Mattermost/Discord — one URL); email/Telegram (multi-field) stay in
-    // Settings → Notifications. kind:"notifications" routes to its own handler.
+    // /notifications API (add channel → test), NOT /settings/env. It covers the webhook case
+    // (Slack/Teams/Mattermost/Discord — one URL) and Telegram (a bot token + a chat id); email
+    // needs a whole SMTP block and stays in Settings → Notifications. kind:"notifications" routes
+    // to its own handler.
     {
       id: "notifications",
       icon: "🔔",
@@ -276,8 +303,8 @@
       status: "notifications",
       kind: "notifications",
       blurb:
-        "Get a Slack / Teams / Mattermost / Discord ping on new findings, playbook updates, and milestones.",
-      note: "Adds a webhook channel + sends a test message. Email & Telegram (more fields) live in Settings → Notifications.",
+        "Get a Slack / Teams / Mattermost / Discord / Telegram ping on new findings, playbook updates, and milestones.",
+      note: "Adds a channel + sends a test message. Email (a full SMTP block) lives in Settings → Notifications.",
     },
   ];
 


### PR DESCRIPTION
The first-run setup wizard was missing two things an analyst has to decide early, and both were reachable only from Settings: what the AI provider is allowed to see, and where findings get pushed.

## Presidio PII scan

A new step, placed straight after AI because it is a boundary *on* that step.

- Three fields — analyzer URL, confidence floor, request timeout.
- **Test connection** posts the URL *as typed* to `/system/presidio-test`. Nothing is saved, and only the fixed synthetic sample is sent, never case data. An unreachable analyzer reports "could not reach that URL" rather than the bare `fetch failed` Node hands back.
- **Save** writes `.env` and says to restart. It deliberately does **not** call `/settings/reload`: `DFIR_PRESIDIO_` is off that allowlist because the analyzer client is built once at startup. A step declaring that prefix would 400 on every save, and the wizard's `.catch(() => {})` around the call would swallow it and report "Saved & configured".
- A non-local URL raises the same warning Settings already shows. Presidio reads the case timeline — masked, but still the timeline.

`/setup/status` gains a `presidio` flag read from live env, so the rail ticks when the layer is **active**, not when a value was typed.

## Telegram notifications

The Notifications step gains a Telegram channel type. Picking it swaps the webhook URL field for a bot token and a chat ID.

- A blank token borrows the war-room bot's `DFIR_TELEGRAM_BOT_TOKEN`, so the token stays in `.env` only and rotating it there is enough.
- `/notifications/status` fills the token placeholder when `.env` already has one, and offers the chats that bot is already bound to — pre-filled into a visible field, because this is where case content will be sent.
- Email still needs a whole SMTP block, so it stays in Settings.

## The gate this had none of

`tests/settings/setupWizardSteps.test.ts` checks the step table against the routes it calls: every field key must be writable, every reload prefix must be on the `/settings/reload` allowlist, and every step's status key must exist in `/setup/status`. Both failure modes are one-line mistakes in a data table and both are invisible until someone opens the wizard — a rejected reload is silent, and a missing status key renders as neither tick nor circle forever. All three assertions were mutation-checked before being trusted.

## Verified in a running dashboard

Local warning toggles on a remote URL; Test connection reports an unreachable analyzer; Save writes `.env` and the rail correctly stays unticked until restart; the Telegram field swap works and the server's own "requires a bot token" error reaches the screen.

One bug was found this way and fixed: the notification payload variable was named `body`, which the response handler further down the same block also declares — every add threw `Cannot access 'body' before initialization`.

## Not changed

The root `USER_MANUAL.md` is superseded per CLAUDE.md §1, so only the published manual (`mkdocs-docs/`) was updated.

## Gates

Companion lint, format:check, size, imports, boundaries, eval change gate, us-map, build, typecheck, and the full suite (655 files, 10,047 tests). Extension typecheck, tests (236), Chrome and Firefox builds. All green locally against `master` merged in.
