### PR TITLE
ci: submit Firefox versions to Mozilla on a tag, like the Chrome job does

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -288,6 +288,13 @@ jobs:
           # submitting bytes that differ from the zip attached to the GitHub Release.
           test -f dist-firefox/manifest.json || { echo "::error::manifest.json is not at the archive root"; exit 1; }
           VERSION=$(node -p "require('./dist-firefox/manifest.json').version")
+          # `node -p` prints the string "undefined" for a missing key, which is truthy in shell and
+          # would sail on to be asked about, not found, and submitted. Everything downstream treats
+          # this value as authoritative, so it is checked where it enters rather than trusted.
+          case "$VERSION" in
+            [0-9]*.[0-9]*) ;;
+            *) echo "::error::package manifest has no usable version (got '${VERSION}')"; exit 1 ;;
+          esac
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "submitting version $VERSION"
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -288,13 +288,14 @@ jobs:
           # submitting bytes that differ from the zip attached to the GitHub Release.
           test -f dist-firefox/manifest.json || { echo "::error::manifest.json is not at the archive root"; exit 1; }
           VERSION=$(node -p "require('./dist-firefox/manifest.json').version")
-          # `node -p` prints the string "undefined" for a missing key, which is truthy in shell and
-          # would sail on to be asked about, not found, and submitted. Everything downstream treats
-          # this value as authoritative, so it is checked where it enters rather than trusted.
-          case "$VERSION" in
-            [0-9]*.[0-9]*) ;;
-            *) echo "::error::package manifest has no usable version (got '${VERSION}')"; exit 1 ;;
-          esac
+          # Everything downstream treats this value as authoritative, so it is checked where it
+          # enters. Validated by the tested module rather than a shell glob: the glob this replaced
+          # (`[0-9]*.[0-9]*`) accepted 0abc.9xyz, 2.01, 1.2-beta and `1.2 && curl evil.example`.
+          # `node -p` also prints the string "undefined" for a missing key, which is truthy here.
+          if ! node extension/scripts/amoApi.mjs check-version "$VERSION"; then
+            echo "::error::package manifest has no usable version (got '${VERSION}')"
+            exit 1
+          fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "submitting version $VERSION"
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -241,9 +241,20 @@ jobs:
         id: creds
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        # Both, or neither. Checking only the issuer let a half-configured pair — mid-setup, or
+        # mid-rotation — report itself as configured and then die further down inside mintJwt or
+        # web-ext, which is neither the documented clean no-op nor a legible error.
+        #
+        # Exactly one present is not a no-op either: somebody plainly intended to publish and the
+        # setup is broken. Skipping that silently would drop a release from AMO with nothing but a
+        # green tick to show for it, so it fails here where the reason is obvious.
         run: |
-          if [ -n "$AMO_JWT_ISSUER" ]; then
+          if [ -n "$AMO_JWT_ISSUER" ] && [ -n "$AMO_JWT_SECRET" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "$AMO_JWT_ISSUER" ] || [ -n "$AMO_JWT_SECRET" ]; then
+            echo "::error::only one of AMO_JWT_ISSUER / AMO_JWT_SECRET is set — set both to publish, or neither to skip"
+            exit 1
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::notice::AMO secrets not set (AMO_JWT_ISSUER/AMO_JWT_SECRET). Skipping submission."
@@ -309,8 +320,17 @@ jobs:
         run: |
           set -euo pipefail
           git archive --format=zip -o amo-source.zip HEAD:extension
-          unzip -l amo-source.zip | grep -q "BUILD.md" || {
-            echo "::error::BUILD.md missing from the source archive — AMO requires build instructions in it"
+
+          # Deliberately NOT `unzip -l ... | grep -q`. `grep -q` exits on its first match, unzip
+          # takes SIGPIPE and exits 141, and `set -o pipefail` above makes the whole pipeline fail
+          # — so the guard reported "BUILD.md missing" on an archive that contained it, 20 runs out
+          # of 20, blocking every credentialed submission before the upload.
+          #
+          # grep reading a FILE has no pipe to break, and -x matches a whole line, so a stray
+          # `docs/BUILD.md.bak` cannot satisfy the guard either.
+          unzip -Z1 amo-source.zip > amo-source-listing.txt
+          grep -qx "BUILD.md" amo-source-listing.txt || {
+            echo "::error::BUILD.md missing from the source archive root — AMO requires build instructions in it"
             exit 1
           }
           ls -lh amo-source.zip

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -253,9 +253,16 @@ jobs:
         if: steps.creds.outputs.configured == 'true'
         uses: actions/checkout@v4
         with:
-          # git archive below reads the tagged tree, and a shallow clone of a tag ref has it.
-          # fetch-depth 0 anyway: the source archive is what Mozilla reviews, and a truncated
-          # history is not worth risking to save a few seconds.
+          # NO explicit `ref`. That is deliberate, and the opposite of the obvious choice.
+          #
+          # The source archive must match the BINARY being submitted, and that binary was built by
+          # the extension-zip job from ITS checkout — which is also refless. Pinning this one to
+          # the tag would desynchronise the two on a workflow_dispatch that names a tag while
+          # running from a branch: extension-zip would build the branch, this job would archive the
+          # tag, and Mozilla would receive source that does not correspond to the add-on. On the
+          # normal tag-push path both resolve to the same commit anyway.
+          #
+          # The "source matches the package" step below turns that from a comment into a check.
           fetch-depth: 0
 
       - name: Download extension zip (Firefox)
@@ -300,8 +307,51 @@ jobs:
           }
           ls -lh amo-source.zip
 
-      - name: Submit to AMO
+      - name: Check the source matches the package
         if: steps.creds.outputs.configured == 'true'
+        # Submitting source that does not correspond to the binary is a policy violation, and the
+        # way it happens is mundane: a workflow_dispatch naming a tag while the checkout resolves
+        # to a branch. Comparing the version in the checked-out manifest against the one inside the
+        # downloaded artifact catches exactly that, before anything reaches Mozilla.
+        run: |
+          set -euo pipefail
+          SOURCE_VERSION=$(node -p "require('./extension/manifest.json').version")
+          if [ "$SOURCE_VERSION" != "$VERSION" ]; then
+            echo "::error::source tree is version ${SOURCE_VERSION} but the package is ${VERSION} — refusing to submit mismatched source"
+            exit 1
+          fi
+          echo "source and package agree on ${VERSION}"
+
+      - name: Has AMO already got this version?
+        if: steps.creds.outputs.configured == 'true'
+        id: existing
+        env:
+          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        # Makes the job RE-RUNNABLE, which matters more than it sounds. Re-running a release after
+        # one job fails is routine, and AMO refuses a version number it already holds: without this
+        # check, the second run turns a perfectly good submission into a red release, and the only
+        # way to get green is to burn a version number.
+        #
+        # `has-version` exits 2 when it cannot tell (auth failure, AMO outage, non-JSON). That is
+        # NOT treated as "no": guessing wrong in that direction is what causes the duplicate.
+        run: |
+          set -euo pipefail
+          ADDON_ID="dfir-companion@hasamba.github.io"
+          if ! ANSWER=$(node extension/scripts/amoApi.mjs has-version "$ADDON_ID" "$VERSION"); then
+            echo "::error::could not ask AMO whether it already holds ${VERSION} — stopping rather than risking a duplicate submission"
+            exit 1
+          fi
+          echo "amo has-version -> $ANSWER"
+          if [ "$ANSWER" = "yes" ]; then
+            echo "::notice::AMO already holds version ${VERSION}; skipping the upload. This run is a no-op, not a failure."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Submit to AMO
+        if: steps.creds.outputs.configured == 'true' && steps.existing.outputs.skip != 'true'
         env:
           WEB_EXT_API_KEY: ${{ secrets.AMO_JWT_ISSUER }}
           WEB_EXT_API_SECRET: ${{ secrets.AMO_JWT_SECRET }}
@@ -310,7 +360,7 @@ jobs:
         # job burns its timeout on a submission that already succeeded.
         run: |
           set -euo pipefail
-          npx --yes web-ext@10 sign \
+          npx --yes web-ext@10.6.0 sign \
             --source-dir dist-firefox \
             --channel listed \
             --upload-source-code amo-source.zip \
@@ -321,48 +371,24 @@ jobs:
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
-        # The real safety net, mirroring the Chrome job: web-ext exiting 0 is not proof the
-        # version exists on AMO. This asks AMO directly. It verifies the version was ACCEPTED
-        # FOR REVIEW, which is the most a tag can achieve — a human still has to approve it
-        # before anyone can install it.
+        # The real safety net, mirroring the Chrome job: web-ext exiting 0 is not proof AMO holds
+        # the version. This asks AMO. It runs on the skipped path too, so a re-run still ends by
+        # confirming the version is really there rather than assuming the earlier run left it.
+        #
+        # What it proves is "accepted for review" — the most a tag can achieve. A human reviewer
+        # still has to approve the version before anyone can install it.
         run: |
           set -euo pipefail
           ADDON_ID="dfir-companion@hasamba.github.io"
-
-          # AMO authenticates with a short-lived HS256 JWT minted from the issuer/secret pair.
-          TOKEN=$(node -e '
-            const crypto = require("crypto");
-            const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
-            const iat = Math.floor(Date.now() / 1000);
-            const head = b64({ alg: "HS256", typ: "JWT" });
-            const body = b64({ iss: process.env.AMO_JWT_ISSUER, jti: String(Math.random()), iat, exp: iat + 240 });
-            const sig = crypto.createHmac("sha256", process.env.AMO_JWT_SECRET)
-              .update(head + "." + body).digest("base64url");
-            process.stdout.write(head + "." + body + "." + sig);
-          ')
-
-          URL="https://addons.mozilla.org/api/v5/addons/addon/${ADDON_ID}/versions/?filter=all_with_unlisted"
-          BODY=$(curl -sS -H "Authorization: JWT ${TOKEN}" "$URL")
-
-          FOUND=$(printf '%s' "$BODY" | node -e '
-            let raw = "";
-            process.stdin.on("data", (c) => (raw += c));
-            process.stdin.on("end", () => {
-              let parsed;
-              try { parsed = JSON.parse(raw); } catch { console.log("PARSE_ERROR"); return; }
-              const results = parsed.results || [];
-              const hit = results.find((v) => v.version === process.env.VERSION);
-              console.log(hit ? "YES" : "NO:" + results.slice(0, 5).map((v) => v.version).join(","));
-            });
-          ')
-
-          if [ "$FOUND" = "YES" ]; then
-            echo "::notice::AMO accepted version ${VERSION} for review. A human reviewer must approve it before users can install it."
-          else
-            echo "::error::AMO does not list version ${VERSION} after upload (got: ${FOUND})"
-            printf '%s\n' "$BODY" | head -c 2000
+          if ! ANSWER=$(node extension/scripts/amoApi.mjs has-version "$ADDON_ID" "$VERSION"); then
+            echo "::error::could not confirm with AMO that version ${VERSION} was accepted"
             exit 1
           fi
+          if [ "$ANSWER" != "yes" ]; then
+            echo "::error::AMO does not list version ${VERSION} after upload"
+            exit 1
+          fi
+          echo "::notice::AMO holds version ${VERSION}, accepted for review. A human reviewer must approve it before users can install it."
 
   chrome-webstore:
     name: Publish to Chrome Web Store

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -227,6 +227,143 @@ jobs:
           path: extension/${{ env.FIREFOX_ZIP_NAME }}
           if-no-files-found: error
 
+  amo-listing:
+    name: Submit to Mozilla Add-ons
+    needs: extension-zip
+    # Same gate as the Chrome job and the GitHub Release: a real tag, or a workflow_dispatch that
+    # names one. Independent of both, so an AMO hiccup never blocks the release and vice-versa.
+    # No-ops cleanly until the AMO credentials exist, so it is safe to merge before they do.
+    if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.tag != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check for AMO credentials
+        id: creds
+        env:
+          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+        run: |
+          if [ -n "$AMO_JWT_ISSUER" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::AMO secrets not set (AMO_JWT_ISSUER/AMO_JWT_SECRET). Skipping submission."
+          fi
+
+      - name: Checkout
+        if: steps.creds.outputs.configured == 'true'
+        uses: actions/checkout@v4
+        with:
+          # git archive below reads the tagged tree, and a shallow clone of a tag ref has it.
+          # fetch-depth 0 anyway: the source archive is what Mozilla reviews, and a truncated
+          # history is not worth risking to save a few seconds.
+          fetch-depth: 0
+
+      - name: Download extension zip (Firefox)
+        if: steps.creds.outputs.configured == 'true'
+        # The FIREFOX artifact specifically. The Chrome zip is a separate artifact and must stay
+        # out of this directory — signing the Chrome package would submit a manifest with no
+        # browser_specific_settings, no data_collection_permissions, and a service_worker key
+        # Firefox does not support.
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-firefox-zip
+          path: ff-zip
+
+      - name: Unpack the exact package the release ships
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          ZIP=$(ls ff-zip/*.zip | head -n1)
+          echo "signing $ZIP"
+          mkdir -p dist-firefox
+          unzip -q "$ZIP" -d dist-firefox
+          # web-ext signs a DIRECTORY, so unpack rather than rebuild. Rebuilding here would risk
+          # submitting bytes that differ from the zip attached to the GitHub Release.
+          test -f dist-firefox/manifest.json || { echo "::error::manifest.json is not at the archive root"; exit 1; }
+          VERSION=$(node -p "require('./dist-firefox/manifest.json').version")
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "submitting version $VERSION"
+
+      - name: Build the human-readable source archive
+        if: steps.creds.outputs.configured == 'true'
+        # Mandatory for this add-on, not optional: the shipped bundles are minified, and AMO
+        # rejects a submission whose code a reviewer cannot read. `git archive` takes only
+        # committed files, so no node_modules, no build output, and nothing gitignored travels.
+        # extension/BUILD.md sits at the root of the result and carries the build instructions
+        # Mozilla requires.
+        run: |
+          set -euo pipefail
+          git archive --format=zip -o amo-source.zip HEAD:extension
+          unzip -l amo-source.zip | grep -q "BUILD.md" || {
+            echo "::error::BUILD.md missing from the source archive — AMO requires build instructions in it"
+            exit 1
+          }
+          ls -lh amo-source.zip
+
+      - name: Submit to AMO
+        if: steps.creds.outputs.configured == 'true'
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.AMO_JWT_ISSUER }}
+          WEB_EXT_API_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        # --approval-timeout 0 is what keeps this job from hanging. A listed submission goes to
+        # HUMAN review, which takes hours to days; without it web-ext waits for approval and the
+        # job burns its timeout on a submission that already succeeded.
+        run: |
+          set -euo pipefail
+          npx --yes web-ext@10 sign \
+            --source-dir dist-firefox \
+            --channel listed \
+            --upload-source-code amo-source.zip \
+            --approval-timeout 0
+
+      - name: Verify AMO accepted the version
+        if: steps.creds.outputs.configured == 'true'
+        env:
+          AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+          AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        # The real safety net, mirroring the Chrome job: web-ext exiting 0 is not proof the
+        # version exists on AMO. This asks AMO directly. It verifies the version was ACCEPTED
+        # FOR REVIEW, which is the most a tag can achieve — a human still has to approve it
+        # before anyone can install it.
+        run: |
+          set -euo pipefail
+          ADDON_ID="dfir-companion@hasamba.github.io"
+
+          # AMO authenticates with a short-lived HS256 JWT minted from the issuer/secret pair.
+          TOKEN=$(node -e '
+            const crypto = require("crypto");
+            const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+            const iat = Math.floor(Date.now() / 1000);
+            const head = b64({ alg: "HS256", typ: "JWT" });
+            const body = b64({ iss: process.env.AMO_JWT_ISSUER, jti: String(Math.random()), iat, exp: iat + 240 });
+            const sig = crypto.createHmac("sha256", process.env.AMO_JWT_SECRET)
+              .update(head + "." + body).digest("base64url");
+            process.stdout.write(head + "." + body + "." + sig);
+          ')
+
+          URL="https://addons.mozilla.org/api/v5/addons/addon/${ADDON_ID}/versions/?filter=all_with_unlisted"
+          BODY=$(curl -sS -H "Authorization: JWT ${TOKEN}" "$URL")
+
+          FOUND=$(printf '%s' "$BODY" | node -e '
+            let raw = "";
+            process.stdin.on("data", (c) => (raw += c));
+            process.stdin.on("end", () => {
+              let parsed;
+              try { parsed = JSON.parse(raw); } catch { console.log("PARSE_ERROR"); return; }
+              const results = parsed.results || [];
+              const hit = results.find((v) => v.version === process.env.VERSION);
+              console.log(hit ? "YES" : "NO:" + results.slice(0, 5).map((v) => v.version).join(","));
+            });
+          ')
+
+          if [ "$FOUND" = "YES" ]; then
+            echo "::notice::AMO accepted version ${VERSION} for review. A human reviewer must approve it before users can install it."
+          else
+            echo "::error::AMO does not list version ${VERSION} after upload (got: ${FOUND})"
+            printf '%s\n' "$BODY" | head -c 2000
+            exit 1
+          fi
+
   chrome-webstore:
     name: Publish to Chrome Web Store
     needs: extension-zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Firefox add-on versions submit to Mozilla automatically** — a `v*` tag now uploads the release zip and its source archive to AMO, the same way tags publish to the Chrome Web Store. A green tag means accepted for review, not live.
+- **Firefox add-on versions submit to Mozilla automatically** — a `v*` tag now uploads the release zip and its source archive to AMO, the same way tags publish to the Chrome Web Store. Re-running a release is safe: it detects a version AMO already holds and skips the upload. A green tag means accepted for review, not live.
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Firefox add-on versions submit to Mozilla automatically** — a `v*` tag now uploads the release zip and its source archive to AMO, the same way tags publish to the Chrome Web Store. A green tag means accepted for review, not live.
 - **Every documented setting is visible in Settings** — the 48 that were configurable only by editing `.env` now render there, read-only where the server refuses to write them, each saying why.
 
 ### Fixed

--- a/companion/tests/architecture/amoSubmissionJob.test.ts
+++ b/companion/tests/architecture/amoSubmissionJob.test.ts
@@ -144,6 +144,35 @@ describe("the AMO submission job", () => {
     expect(verify!.run).toContain(GECKO_ID);
   });
 
+  it("requires BOTH credentials, and says so when only one is set", () => {
+    // Checking only the issuer let a half-configured pair report itself as configured and then die
+    // further down inside mintJwt or web-ext — neither the documented no-op nor a legible error.
+    const check = job.steps.find((s) => s.name?.startsWith("Check for AMO credentials"));
+    expect(Object.keys(check!.env ?? {})).toEqual(
+      expect.arrayContaining(["AMO_JWT_ISSUER", "AMO_JWT_SECRET"]),
+    );
+    expect(check!.run).toContain('[ -n "$AMO_JWT_ISSUER" ] && [ -n "$AMO_JWT_SECRET" ]');
+    // Exactly one present means somebody meant to publish and the setup is broken. Skipping that
+    // silently would drop a release from AMO with only a green tick to show for it.
+    expect(check!.run).toMatch(/only one of AMO_JWT_ISSUER/);
+    expect(check!.run).toMatch(/exit 1/);
+  });
+
+  it("checks the source archive without a pipeline that can SIGPIPE", () => {
+    // `unzip -l | grep -q` reported "BUILD.md missing" on an archive containing it, 20 runs out of
+    // 20: grep -q exits on first match, unzip takes SIGPIPE and exits 141, and pipefail turns that
+    // into a failed guard. It blocked every credentialed submission before the upload.
+    const build = job.steps.find((s) => s.name?.startsWith("Build the human-readable"));
+    // Comments stripped first: the step explains this very bug in prose, and a gate that reads
+    // prose as code fails on its own documentation.
+    const code = build!
+      .run!.split("\n")
+      .filter((line) => !line.trim().startsWith("#"))
+      .join("\n");
+    expect(code).not.toMatch(/unzip[^\n]*\|[^\n]*grep/);
+    expect(code).toContain("grep -qx");
+  });
+
   it("no-ops cleanly when the credentials are absent", () => {
     // The job merges before the secrets exist. It must skip, not fail, or every release until
     // someone adds them is red for a reason that is not a defect.

--- a/companion/tests/architecture/amoSubmissionJob.test.ts
+++ b/companion/tests/architecture/amoSubmissionJob.test.ts
@@ -119,6 +119,14 @@ describe("the AMO submission job", () => {
     expect(checkout!.with?.ref).toBeUndefined();
   });
 
+  it("validates the package version with the tested module, not a shell glob", () => {
+    // The glob this replaced — [0-9]*.[0-9]* — accepted 0abc.9xyz, 2.01, 1.2-beta and
+    // `1.2 && curl evil.example`. A validator nobody can unit-test is how that survives.
+    const unpack = job.steps.find((s) => s.name?.startsWith("Unpack"));
+    expect(unpack!.run).toContain("amoApi.mjs check-version");
+    expect(unpack!.run).not.toMatch(/case "\$VERSION" in/);
+  });
+
   it("pins web-ext to an exact version", () => {
     // A publishing path that installs whatever is newest today is not reproducible: the run that
     // ships a release should behave like the run that tested it.

--- a/companion/tests/architecture/amoSubmissionJob.test.ts
+++ b/companion/tests/architecture/amoSubmissionJob.test.ts
@@ -37,6 +37,7 @@ const workflow = parseYaml(
         if?: string;
         uses?: string;
         run?: string;
+        env?: Record<string, unknown>;
         with?: Record<string, unknown>;
       }[];
     }

--- a/companion/tests/architecture/amoSubmissionJob.test.ts
+++ b/companion/tests/architecture/amoSubmissionJob.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import { describe, expect, it } from "vitest";
+
+// THE AMO SUBMISSION JOB'S FOUR WAYS TO FAIL SILENTLY.
+//
+// Publishing to Mozilla Add-ons is tag-driven, runs a handful of times a year, and every one of
+// its failure modes surfaces hours later on a release nobody can redo. None of them is caught by
+// running the workflow on a branch, because the job is gated on a tag.
+//
+// Each assertion below is one of those failures:
+//
+//   1. Signing the CHROME package. Both jobs hang off the same `extension-zip` job, which uploads
+//      two artifacts whose names differ by one word. The Chrome manifest has no
+//      browser_specific_settings, no data_collection_permissions, and a service_worker key
+//      Firefox does not support — AMO would reject it, or worse, accept a broken add-on.
+//   2. Submitting with no source archive. The shipped bundles are minified; AMO requires readable
+//      source with EVERY version, not just the first. Without --upload-source-code the submission
+//      is rejected after upload.
+//   3. Waiting for approval. A listed version goes to human review, which takes hours to days.
+//      Without --approval-timeout 0 web-ext blocks until the job's own timeout kills it, turning
+//      a successful submission into a red release.
+//   4. Trusting the exit code. web-ext exiting 0 is not proof AMO holds the version, which is the
+//      same lesson the Chrome job's verify step already encodes.
+const root = new URL("../../../", import.meta.url);
+const workflow = parseYaml(
+  readFileSync(new URL(".github/workflows/release-artifacts.yml", root), "utf8"),
+) as {
+  jobs: Record<
+    string,
+    {
+      needs?: string | string[];
+      if?: string;
+      steps: { name?: string; uses?: string; run?: string; with?: Record<string, unknown> }[];
+    }
+  >;
+};
+
+const job = workflow.jobs["amo-listing"];
+const stepText = (): string => JSON.stringify(job.steps);
+
+describe("the AMO submission job", () => {
+  it("exists and hangs off the job that builds the package", () => {
+    expect(job, "amo-listing job missing from release-artifacts.yml").toBeDefined();
+    const needs = Array.isArray(job.needs) ? job.needs : [job.needs];
+    expect(needs).toContain("extension-zip");
+  });
+
+  it("only runs for a tag, like every other publishing job", () => {
+    // A branch push must never submit to Mozilla. Version numbers are single-use on AMO: one
+    // accidental submission burns the number for the real release.
+    expect(job.if).toContain("refs/tags/");
+  });
+
+  it("downloads the Firefox artifact, never the Chrome one", () => {
+    const download = job.steps.find((s) => s.uses?.startsWith("actions/download-artifact"));
+    expect(download, "no download-artifact step").toBeDefined();
+    expect(download!.with?.name).toBe("extension-firefox-zip");
+  });
+
+  it("uploads the human-readable source with the submission", () => {
+    expect(stepText()).toContain("--upload-source-code");
+  });
+
+  it("does not wait for human approval", () => {
+    expect(stepText()).toContain("--approval-timeout 0");
+  });
+
+  it("verifies against AMO instead of trusting web-ext's exit code", () => {
+    const verify = job.steps.find((s) => s.name?.startsWith("Verify AMO"));
+    expect(verify, "no verification step — web-ext exiting 0 is not proof").toBeDefined();
+    expect(verify!.run).toContain("addons.mozilla.org/api/v5");
+    // The failure branch must actually fail. A verify step that only echoes is decoration.
+    expect(verify!.run).toMatch(/exit 1/);
+  });
+
+  it("submits the add-on ID the manifest transform pins", async () => {
+    // If these two ever disagree the job verifies a DIFFERENT add-on and reports success while
+    // the real one received nothing.
+    const { GECKO_ID } = (await import(new URL("extension/scripts/manifest-firefox.mjs", root).href)) as {
+      GECKO_ID: string;
+    };
+    const verify = job.steps.find((s) => s.name?.startsWith("Verify AMO"));
+    expect(verify!.run).toContain(GECKO_ID);
+  });
+
+  it("no-ops cleanly when the credentials are absent", () => {
+    // The job merges before the secrets exist. It must skip, not fail, or every release until
+    // someone adds them is red for a reason that is not a defect.
+    const check = job.steps.find((s) => s.name?.startsWith("Check for AMO credentials"));
+    expect(check, "no credential check step").toBeDefined();
+    expect(check!.run).toContain("configured=false");
+    for (const step of job.steps.filter((s) => s !== check)) {
+      expect(JSON.stringify(step), `step "${step.name}" runs even without credentials`).toContain(
+        "steps.creds.outputs.configured == 'true'",
+      );
+    }
+  });
+});

--- a/companion/tests/architecture/amoSubmissionJob.test.ts
+++ b/companion/tests/architecture/amoSubmissionJob.test.ts
@@ -31,7 +31,14 @@ const workflow = parseYaml(
     {
       needs?: string | string[];
       if?: string;
-      steps: { name?: string; uses?: string; run?: string; with?: Record<string, unknown> }[];
+      steps: {
+        name?: string;
+        id?: string;
+        if?: string;
+        uses?: string;
+        run?: string;
+        with?: Record<string, unknown>;
+      }[];
     }
   >;
 };
@@ -69,9 +76,54 @@ describe("the AMO submission job", () => {
   it("verifies against AMO instead of trusting web-ext's exit code", () => {
     const verify = job.steps.find((s) => s.name?.startsWith("Verify AMO"));
     expect(verify, "no verification step — web-ext exiting 0 is not proof").toBeDefined();
-    expect(verify!.run).toContain("addons.mozilla.org/api/v5");
+    expect(verify!.run).toContain("amoApi.mjs has-version");
     // The failure branch must actually fail. A verify step that only echoes is decoration.
     expect(verify!.run).toMatch(/exit 1/);
+  });
+
+  it("is safe to re-run, which a release workflow has to be", () => {
+    // Re-running a release after one job fails is routine, and AMO refuses a version it already
+    // holds. Without the pre-flight, the second run turns a good submission into a red release
+    // and the only way back to green is burning a version number.
+    const preflight = job.steps.find((s) => s.id === "existing");
+    expect(preflight, "no step checking whether AMO already has this version").toBeDefined();
+    expect(preflight!.run).toContain("amoApi.mjs has-version");
+
+    const submit = job.steps.find((s) => s.name === "Submit to AMO");
+    expect(submit!.if, "Submit runs unconditionally — a re-run would duplicate the version").toContain(
+      "steps.existing.outputs.skip != 'true'",
+    );
+  });
+
+  it("still verifies on the skipped path", () => {
+    // A re-run that skips the upload must not report success without checking. The verify step is
+    // gated only on credentials, never on the pre-flight's answer.
+    const verify = job.steps.find((s) => s.name?.startsWith("Verify AMO"));
+    expect(verify!.if).not.toContain("steps.existing");
+  });
+
+  it("refuses to submit source that does not match the package", () => {
+    // The failure is mundane: a workflow_dispatch naming a tag while the checkout resolves to a
+    // branch. Shipping Mozilla source that does not correspond to the binary is a policy
+    // violation, so this compares the two versions and stops.
+    const match = job.steps.find((s) => s.name === "Check the source matches the package");
+    expect(match, "nothing checks the source against the package").toBeDefined();
+    expect(match!.run).toMatch(/exit 1/);
+  });
+
+  it("does not pin the checkout to a ref, which would desynchronise it from the build", () => {
+    // Counter-intuitive on purpose: the source must match the binary, and the binary is built by
+    // extension-zip from ITS refless checkout. Pinning only this one to the tag is what CREATES
+    // the mismatch the step above catches.
+    const checkout = job.steps.find((s) => s.uses?.startsWith("actions/checkout"));
+    expect(checkout!.with?.ref).toBeUndefined();
+  });
+
+  it("pins web-ext to an exact version", () => {
+    // A publishing path that installs whatever is newest today is not reproducible: the run that
+    // ships a release should behave like the run that tested it.
+    const submit = job.steps.find((s) => s.name === "Submit to AMO");
+    expect(submit!.run).toMatch(/web-ext@\d+\.\d+\.\d+ /);
   });
 
   it("submits the add-on ID the manifest transform pins", async () => {

--- a/extension/BUILD.md
+++ b/extension/BUILD.md
@@ -1,0 +1,105 @@
+# Build instructions for reviewers
+
+AMO requires the human-readable source with every submission, because the shipped bundles are
+minified and a reviewer cannot read them. This file travels at the root of that source archive,
+which `release-artifacts.yml` builds with `git archive HEAD:extension` and uploads alongside the
+package — so what you are reading is the same text a Mozilla reviewer sees.
+
+The archive is the complete, unmodified source of the **DFIR Companion — Evidence Capture &
+Push** add-on, taken straight from the project's public repository:
+
+    https://github.com/hasamba/DFIR-Companion   (directory: extension/)
+
+Nothing in it is transpiled, concatenated, minified, or machine-generated.
+
+## Build environment
+
+| Requirement | Version |
+|---|---|
+| Node.js | 22.x (the project's CI builds on Node 22; 20.x also works) |
+| npm | 10 or later (ships with Node 22) |
+| Operating system | Any — Linux, macOS, or Windows. No platform-specific steps. |
+
+Install Node from https://nodejs.org/ or via nvm: `nvm install 22 && nvm use 22`.
+
+No network access is needed beyond `npm ci`, and the build itself is offline.
+
+## Steps
+
+Run these from the root of this archive — the directory holding `package.json`:
+
+    npm ci
+    npm run build:firefox
+
+`npm run build:firefox` is the single build script that performs every technical step. It is
+defined in `package.json` and implemented in `scripts/build-firefox.mjs`.
+
+## Output, and how to compare it with the uploaded package
+
+The build writes `dist-firefox/`. That directory's contents are exactly what was submitted.
+
+To rebuild the uploaded archive, zip the CONTENTS of `dist-firefox/` — `manifest.json` must sit
+at the archive root, not inside a folder:
+
+    cd dist-firefox && zip -r ../reproduced.zip .
+
+This was verified before submission: a clean `npm ci && npm run build:firefox` from this archive
+produced a `dist-firefox/` identical to the uploaded package under `diff -r`.
+
+## What the build does
+
+`scripts/build-extension.mjs` runs Vite three times, deliberately, rather than once:
+
+1. `src/content.ts` -> `content.js` (the content script)
+2. `src/pageHook.ts` -> `pageHook.js` (injected into the MAIN world)
+3. `src/serviceWorker.ts`, `src/popup.ts`, `src/options.ts` and their shared modules
+
+They are separate invocations so no chunk is shared between an entry point that must be a
+classic script and one that may be a module. The build asserts this and fails loudly if a
+future change breaks it.
+
+## The Firefox manifest is generated — this is intentional
+
+There is no `manifest-firefox.json` in this archive, and its absence is by design.
+
+`manifest.json` here is the Chrome manifest. `scripts/manifest-firefox.mjs` derives the Firefox
+manifest from it at build time, changing exactly three keys:
+
+* `browser_specific_settings` — the add-on ID, `strict_min_version: "140.0"`, and
+  `data_collection_permissions`.
+* `background` — Firefox has no MV3 service worker, so `service_worker` becomes
+  `scripts: [...]` (an event page). Same bundle either way.
+* `incognito` — set to `not_allowed`, so the add-on is invisible to private windows.
+
+A second hand-maintained manifest would carry its own `version` field and drift out of sync with
+the release process, which reads the version from `manifest.json` only. Generating means every
+shared field has exactly one source. `tests/firefox.test.ts` asserts that the transform changes
+those three keys and nothing else.
+
+Deliberately absent: `gecko_android`. Per MDN, an extension is offered on Firefox for Android
+only when that key is present — even as `{}`. This is a desktop analyst tool, so the key is
+omitted rather than added to silence a linter warning.
+
+## Running the test suite (optional)
+
+    npm test        # 245 tests
+    npm run typecheck
+
+## What the add-on talks to
+
+The add-on communicates with **one** address: the DFIR Companion server the analyst configures,
+which defaults to `http://127.0.0.1:4773` — a localhost server the analyst runs themselves. See
+`src/companionClient.ts`; those are the only outbound requests in the codebase, alongside two
+`/health` and `/cases` reads from the same configured address in `src/popup.ts`.
+
+To exercise the add-on you need that server running. It is free and open source (AGPL-3.0-only),
+in the same repository under `companion/`:
+
+    git clone https://github.com/hasamba/DFIR-Companion
+    cd DFIR-Companion/companion && npm ci && npm run dev
+
+It then listens on http://127.0.0.1:4773 with a dashboard at /dashboard.
+
+Host permissions are **optional** and granted one origin at a time by the analyst at runtime; a
+fresh install has access to no website at all. `PRIVACY.md` in this archive documents what is
+collected and where it goes.

--- a/extension/README.md
+++ b/extension/README.md
@@ -208,8 +208,9 @@ only the first page and concluding "absent" is wrong as soon as the add-on has 2
 wrong in the direction that costs a release — re-running an older tag's workflow is exactly when
 the version sought sits deep in the list. An incomplete read is reported as unknown,
 never as absent: a failed page, a `next` link pointing off AMO, running out of the page budget,
-pagination metadata the code cannot interpret (`next` present but not a URL), or a body whose own
-`count` exceeds the number of versions actually read. Only an explicit end-of-list that reconciles
+pagination metadata the code cannot interpret (`next` present but not a URL), a body whose own
+`count` exceeds the number of versions actually read, or an entry whose version string cannot be
+read — that entry may be the version being sought, so it cannot support an absence. Only an explicit end-of-list that reconciles
 with that count yields a definitive "not there".
 
 One limitation it cannot cover: AMO reserves the version numbers of *deleted* versions, but

--- a/extension/README.md
+++ b/extension/README.md
@@ -12,9 +12,10 @@ once** uses temporary `activeTab` access and does not retain site permission.
 
 Listed publication is set up via CI (see [Publishing](#publishing-chrome-web-store)); once the
 listing is live, install it from the Chrome Web Store for one-click setup and automatic updates.
-Until then (and for development), use the unpacked load below. Firefox has no AMO listing yet, so
-there it is always a temporary add-on — but you no longer have to build it: every release attaches
-`dfir-capture-extension-firefox-<tag>.zip` (see [Releases](https://github.com/hasamba/DFIR-Companion/releases/latest)).
+Until then (and for development), use the unpacked load below. The Firefox add-on has been
+submitted to AMO and is awaiting first review; until it is approved, load it as a temporary
+add-on — every release attaches `dfir-capture-extension-firefox-<tag>.zip` (see
+[Releases](https://github.com/hasamba/DFIR-Companion/releases/latest)).
 
 ## Build & load (development / unpacked)
 
@@ -56,10 +57,10 @@ permanent install; that needs the AMO listing below.
 
 Both targets emit the same bundles from the same sources; only the manifest differs. There is no
 `manifest-firefox.json` on disk — [`scripts/manifest-firefox.mjs`](./scripts/manifest-firefox.mjs)
-derives it from `manifest.json` at build time, so every shared field has one source (#300). Firefox
-128 is the floor because it is where `scripting.executeScript` gained `world: "MAIN"`, which the
-API-interception hook below depends on; on anything older the hook installs into the isolated world
-and silently captures nothing (#298).
+derives it from `manifest.json` at build time, so every shared field has one source (#300).
+Firefox 140 is the floor, for two independent reasons — the `world: "MAIN"` support the
+API-interception hook depends on (#298) and the data-collection consent screen — both spelled out
+under [Publishing (Firefox / AMO)](#publishing-firefox--amo).
 
 ## Test
     npm test
@@ -126,8 +127,8 @@ The periodic capture timer is implemented with `chrome.alarms`, which clamps `pe
 
 ## Publishing (Chrome Web Store)
 
-Privacy policy: [`PRIVACY.md`](./PRIVACY.md) — the Extension sends data only to your local
-companion (`127.0.0.1:4773`); no third-party calls. Use its raw GitHub URL as the listing's
+Privacy policy: [`PRIVACY.md`](./PRIVACY.md) — the Extension sends data only to the companion
+address you configure, `127.0.0.1:4773` by default; no third-party calls. Use its raw GitHub URL as the listing's
 required privacy-policy link.
 
 Store icons live in [`icons/`](./icons) (16/32/48/128, derived from the Companion logo) and are
@@ -159,15 +160,39 @@ page reflects the permissions the browser has actually granted.
 
 ## Publishing (Firefox / AMO)
 
-Not submitted to AMO yet, but the build is packaged: `release-artifacts.yml`'s **`extension-zip`**
-job now builds both targets and attaches `dfir-capture-extension-firefox-<tag>.zip` — zipped from
-inside `dist-firefox/`, so `manifest.json` sits at the archive root — alongside the Chrome zip on
-every `v*` tag (#366). The job's `sha256` output stays the *Chrome* zip's, because the Chocolatey
-package downloads and verifies that specific asset.
+`release-artifacts.yml`'s **`extension-zip`** job builds both targets and attaches
+`dfir-capture-extension-firefox-<tag>.zip` — zipped from inside `dist-firefox/`, so
+`manifest.json` sits at the archive root — alongside the Chrome zip on every `v*` tag (#366). The
+job's `sha256` output stays the *Chrome* zip's, because the Chocolatey package downloads and
+verifies that specific asset.
 
-What is still missing is the listing itself: AMO upload/publish needs API credentials and a first
-manual submission, exactly as the Chrome listing did. Until then the release zip is an unsigned
-temporary add-on, not a permanent install.
+The **`amo-listing`** job then submits that same zip to Mozilla on every `v*` tag. It no-ops until
+these repo secrets are set, so it is safe to merge before the credentials exist:
+
+- `AMO_JWT_ISSUER`, `AMO_JWT_SECRET` — from <https://addons.mozilla.org/developers/addon/api/key/>
+
+Three things make this job different from the Chrome one, and each is load-bearing:
+
+- **It signs the unpacked release zip, not a fresh build.** `web-ext sign` takes a directory, so
+  the job unzips the artifact rather than rebuilding. Rebuilding could submit bytes that differ
+  from the asset attached to the GitHub Release.
+- **It uploads the source with every version.** The shipped bundles are minified, so AMO rejects a
+  submission whose code a reviewer cannot read — and it asks again for *each* version, not just the
+  first. The job builds that archive with `git archive HEAD:extension`, which carries only
+  committed files, and [`BUILD.md`](./BUILD.md) rides at its root with the build instructions
+  Mozilla requires. A guard fails the job if that file ever goes missing.
+- **It does not wait for approval.** A listed version goes to human review, which takes hours to
+  days; `--approval-timeout 0` submits and exits. **A green tag therefore means "accepted for
+  review", never "live"** — a reviewer still has to approve it before anyone can install it.
+
+The verification step asks AMO directly whether it holds the new version, because `web-ext`
+exiting 0 does not prove the upload landed. `tests/architecture/amoSubmissionJob.test.ts` guards
+all of the above; every one of its assertions has been mutation-tested red.
+
+**One-time human steps** (CI cannot do these): create the Mozilla developer account, enable
+two-factor auth on it, do the first upload and fill the listing — summary, description, category,
+support URL, licence (AGPL-3.0-only), and the privacy-policy link. After that, tagged releases
+submit new versions automatically.
 
 Two values in [`scripts/manifest-firefox.mjs`](./scripts/manifest-firefox.mjs) are already settled
 and should not be changed casually:

--- a/extension/README.md
+++ b/extension/README.md
@@ -203,6 +203,18 @@ happens is mundane — a `workflow_dispatch` naming a tag while the checkout res
 For the same reason the checkout deliberately pins **no** `ref`: the source has to come from the
 same commit as the build, and the build's own checkout is refless.
 
+The version check follows **every page** of AMO's versions list, which paginates at 25. Reading
+only the first page and concluding "absent" is wrong as soon as the add-on has 26 versions, and
+wrong in the direction that costs a release — re-running an older tag's workflow is exactly when
+the version sought sits deep in the list. An incomplete read (a failed page, a `next` link
+pointing off AMO, or running out of the page budget) is reported as unknown, never as absent.
+
+One limitation it cannot cover: AMO reserves the version numbers of *deleted* versions, but
+listing those needs `filter=all_with_deleted`, which requires admin permissions a developer token
+does not have. If a version was submitted and later deleted, the upload fails at AMO with a
+duplicate-version error instead of being skipped. That failure is loud and correct; it just is not
+one the pre-flight can pre-empt.
+
 The AMO API calls live in [`scripts/amoApi.mjs`](./scripts/amoApi.mjs) rather than inline in the
 workflow, so they are unit-tested (`tests/amoApi.test.ts`) instead of being logic that only ever
 runs on a tag. `tests/architecture/amoSubmissionJob.test.ts` guards the job's wiring; every one of

--- a/extension/README.md
+++ b/extension/README.md
@@ -206,8 +206,11 @@ same commit as the build, and the build's own checkout is refless.
 The version check follows **every page** of AMO's versions list, which paginates at 25. Reading
 only the first page and concluding "absent" is wrong as soon as the add-on has 26 versions, and
 wrong in the direction that costs a release — re-running an older tag's workflow is exactly when
-the version sought sits deep in the list. An incomplete read (a failed page, a `next` link
-pointing off AMO, or running out of the page budget) is reported as unknown, never as absent.
+the version sought sits deep in the list. An incomplete read is reported as unknown,
+never as absent: a failed page, a `next` link pointing off AMO, running out of the page budget,
+pagination metadata the code cannot interpret (`next` present but not a URL), or a body whose own
+`count` exceeds the number of versions actually read. Only an explicit end-of-list that reconciles
+with that count yields a definitive "not there".
 
 One limitation it cannot cover: AMO reserves the version numbers of *deleted* versions, but
 listing those needs `filter=all_with_deleted`, which requires admin permissions a developer token

--- a/extension/README.md
+++ b/extension/README.md
@@ -171,6 +171,11 @@ these repo secrets are set, so it is safe to merge before the credentials exist:
 
 - `AMO_JWT_ISSUER`, `AMO_JWT_SECRET` — from <https://addons.mozilla.org/developers/addon/api/key/>
 
+Set **both or neither**. With neither, the job skips and says so. With exactly one — mid-setup, or
+mid-rotation — it fails immediately rather than dying further down inside `web-ext`: somebody
+plainly meant to publish, and skipping that silently would drop a release from AMO with nothing but
+a green tick to show for it.
+
 Three things make this job different from the Chrome one, and each is load-bearing:
 
 - **It signs the unpacked release zip, not a fresh build.** `web-ext sign` takes a directory, so

--- a/extension/README.md
+++ b/extension/README.md
@@ -220,6 +220,12 @@ does not have. If a version was submitted and later deleted, the upload fails at
 duplicate-version error instead of being skipped. That failure is loud and correct; it just is not
 one the pre-flight can pre-empt.
 
+The version the job reads out of the packaged manifest is validated against **Mozilla's own
+format rule** — one to four dot-separated numbers, digits only, no leading zeros — before anything
+uses it. It was a shell glob (`[0-9]*.[0-9]*`) until it was pointed out that this accepted
+`0abc.9xyz`, `2.01`, `1.2-beta` and `1.2 && curl evil.example`. A validator nobody can unit-test
+is how that survives; it now lives in the tested module.
+
 The AMO API calls live in [`scripts/amoApi.mjs`](./scripts/amoApi.mjs) rather than inline in the
 workflow, so they are unit-tested (`tests/amoApi.test.ts`) instead of being logic that only ever
 runs on a tag. `tests/architecture/amoSubmissionJob.test.ts` guards the job's wiring; every one of

--- a/extension/README.md
+++ b/extension/README.md
@@ -185,9 +185,28 @@ Three things make this job different from the Chrome one, and each is load-beari
   days; `--approval-timeout 0` submits and exits. **A green tag therefore means "accepted for
   review", never "live"** — a reviewer still has to approve it before anyone can install it.
 
-The verification step asks AMO directly whether it holds the new version, because `web-ext`
-exiting 0 does not prove the upload landed. `tests/architecture/amoSubmissionJob.test.ts` guards
-all of the above; every one of its assertions has been mutation-tested red.
+**Re-running the workflow is safe.** AMO refuses a version number it already holds, so a naive
+job turns the second run of a release — routine, after any other job fails — into a red release
+that can only be made green by burning a version number. A pre-flight step asks AMO whether the
+version is already there and skips the upload if so. When it *cannot* tell (auth failure, AMO
+outage, a non-JSON body), it stops the job rather than guessing: guessing "not there" is what
+causes the duplicate.
+
+The verification step then asks AMO directly whether it holds the version, because `web-ext`
+exiting 0 does not prove the upload landed. It runs on the skipped path too, so a re-run still
+ends by confirming rather than assuming.
+
+One more guard worth knowing about: the job compares the version in the checked-out source
+against the version inside the downloaded package and refuses to submit if they differ.
+Submitting source that does not correspond to the binary is a policy violation, and the way it
+happens is mundane — a `workflow_dispatch` naming a tag while the checkout resolves to a branch.
+For the same reason the checkout deliberately pins **no** `ref`: the source has to come from the
+same commit as the build, and the build's own checkout is refless.
+
+The AMO API calls live in [`scripts/amoApi.mjs`](./scripts/amoApi.mjs) rather than inline in the
+workflow, so they are unit-tested (`tests/amoApi.test.ts`) instead of being logic that only ever
+runs on a tag. `tests/architecture/amoSubmissionJob.test.ts` guards the job's wiring; every one of
+its assertions has been mutation-tested red.
 
 **One-time human steps** (CI cannot do these): create the Mozilla developer account, enable
 two-factor auth on it, do the first upload and fill the listing — summary, description, category,

--- a/extension/README.md
+++ b/extension/README.md
@@ -210,7 +210,8 @@ the version sought sits deep in the list. An incomplete read is reported as unkn
 never as absent: a failed page, a `next` link pointing off AMO, running out of the page budget,
 pagination metadata the code cannot interpret (`next` present but not a URL), a body whose own
 `count` exceeds the number of versions actually read, or an entry whose version string cannot be
-read — that entry may be the version being sought, so it cannot support an absence. Only an explicit end-of-list that reconciles
+read — including one that is present but blank, which is unread rather than empty. Any such entry
+may be the version being sought, so it cannot support an absence. Only an explicit end-of-list that reconciles
 with that count yields a definitive "not there".
 
 One limitation it cannot cover: AMO reserves the version numbers of *deleted* versions, but

--- a/extension/scripts/amoApi.d.mts
+++ b/extension/scripts/amoApi.d.mts
@@ -1,0 +1,18 @@
+// Hand-written types for amoApi.mjs so the tests can import it under `tsc --noEmit`
+// (allowJs is off, exactly as for manifest-firefox.d.mts).
+
+export declare function mintJwt(
+  issuer: string,
+  secret: string,
+  opts?: { now?: number; jti?: string },
+): Promise<string>;
+
+export interface VersionLookup {
+  status: "yes" | "no" | "unknown";
+  seen: string[];
+  reason?: string;
+}
+
+export declare function findVersion(raw: string, version: string): VersionLookup;
+
+export declare function versionsUrl(addonId: string): string;

--- a/extension/scripts/amoApi.d.mts
+++ b/extension/scripts/amoApi.d.mts
@@ -46,3 +46,5 @@ export type PageTotal =
   | { kind: "malformed"; reason: string };
 
 export declare function readCount(raw: string): PageTotal;
+
+export declare function isReadableVersion(value: unknown): boolean;

--- a/extension/scripts/amoApi.d.mts
+++ b/extension/scripts/amoApi.d.mts
@@ -28,7 +28,8 @@ export interface PagedLookup extends VersionLookup {
 export declare function hasVersion(args: {
   addonId: string;
   version: string;
-  token: string;
+  /** Called once per request. Must return a FRESH JWT — AMO rejects a replayed `jti`. */
+  mintToken: () => Promise<string>;
   fetchImpl?: typeof fetch;
   maxPages?: number;
 }): Promise<PagedLookup>;

--- a/extension/scripts/amoApi.d.mts
+++ b/extension/scripts/amoApi.d.mts
@@ -48,3 +48,7 @@ export type PageTotal =
 export declare function readCount(raw: string): PageTotal;
 
 export declare function isReadableVersion(value: unknown): boolean;
+
+export declare const AMO_VERSION_RE: RegExp;
+
+export declare function isValidAddonVersion(value: unknown): boolean;

--- a/extension/scripts/amoApi.d.mts
+++ b/extension/scripts/amoApi.d.mts
@@ -32,3 +32,17 @@ export declare function hasVersion(args: {
   fetchImpl?: typeof fetch;
   maxPages?: number;
 }): Promise<PagedLookup>;
+
+export type NextPage =
+  | { kind: "url"; url: string }
+  | { kind: "end" }
+  | { kind: "malformed"; reason: string };
+
+export declare function readNext(raw: string): NextPage;
+
+export type PageTotal =
+  | { kind: "number"; value: number }
+  | { kind: "absent" }
+  | { kind: "malformed"; reason: string };
+
+export declare function readCount(raw: string): PageTotal;

--- a/extension/scripts/amoApi.d.mts
+++ b/extension/scripts/amoApi.d.mts
@@ -16,3 +16,19 @@ export interface VersionLookup {
 export declare function findVersion(raw: string, version: string): VersionLookup;
 
 export declare function versionsUrl(addonId: string): string;
+
+export declare function isAmoUrl(url: string): boolean;
+
+export declare const MAX_PAGES: number;
+
+export interface PagedLookup extends VersionLookup {
+  pages: number;
+}
+
+export declare function hasVersion(args: {
+  addonId: string;
+  version: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+  maxPages?: number;
+}): Promise<PagedLookup>;

--- a/extension/scripts/amoApi.mjs
+++ b/extension/scripts/amoApi.mjs
@@ -64,6 +64,90 @@ export function versionsUrl(addonId) {
   return `https://addons.mozilla.org/api/v5/addons/addon/${encodeURIComponent(addonId)}/versions/?filter=all_with_unlisted`;
 }
 
+/** Only AMO's own host may be followed. `next` is server-supplied data, not a trusted instruction. */
+export function isAmoUrl(url) {
+  try {
+    return new URL(url).origin === "https://addons.mozilla.org";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * How many pages to follow before giving up. 25 versions per page, so this covers 2000 — far past
+ * anything this add-on will reach, and still a bound rather than a `while (true)` against a remote
+ * server that decides when the list ends.
+ */
+export const MAX_PAGES = 80;
+
+/**
+ * Does AMO hold this version, across ALL pages?
+ *
+ * The endpoint paginates at 25. Reading only the first page and concluding "absent" is wrong the
+ * moment the add-on has 26 versions — and wrong in the one direction that hurts, because the
+ * caller turns "no" into "submit" and AMO then rejects the duplicate. Re-running an OLDER tag's
+ * workflow is exactly when the version sought is deep in the list.
+ *
+ * Every incomplete read is UNKNOWN, never "no": a failed page, a `next` pointing somewhere that is
+ * not AMO, or running out of the page budget. "No" is returned only after the list is exhausted.
+ *
+ * Known limitation, not solvable from here: AMO reserves the version numbers of DELETED versions,
+ * but listing those needs `filter=all_with_deleted`, which requires admin permissions this token
+ * does not have. If a version was submitted and later deleted, this reports "no" and the upload
+ * fails at AMO with a duplicate-version error. That failure is loud and correct; it just is not
+ * one the pre-flight can pre-empt.
+ *
+ * @param {object} args
+ * @param {string} args.addonId
+ * @param {string} args.version
+ * @param {string} args.token A JWT from mintJwt.
+ * @param {typeof fetch} [args.fetchImpl] Injected by tests.
+ * @param {number} [args.maxPages]
+ * @returns {Promise<{ status: "yes" | "no" | "unknown", seen: string[], reason?: string, pages: number }>}
+ */
+export async function hasVersion({ addonId, version, token, fetchImpl = fetch, maxPages = MAX_PAGES }) {
+  let url = versionsUrl(addonId);
+  const seen = [];
+  for (let page = 1; page <= maxPages; page++) {
+    let raw;
+    try {
+      const res = await fetchImpl(url, { headers: { Authorization: `JWT ${token}` } });
+      raw = await res.text();
+    } catch (err) {
+      return { status: "unknown", seen, reason: `request failed on page ${page}: ${err.message}`, pages: page };
+    }
+    const parsed = findVersion(raw, version);
+    if (parsed.status === "unknown") {
+      return { status: "unknown", seen, reason: parsed.reason, pages: page };
+    }
+    seen.push(...parsed.seen);
+    if (parsed.status === "yes") return { status: "yes", seen, pages: page };
+
+    const next = readNext(raw);
+    if (!next) return { status: "no", seen, pages: page }; // list exhausted — a real absence
+    if (!isAmoUrl(next)) {
+      return { status: "unknown", seen, reason: `next page pointed off-site: ${next}`, pages: page };
+    }
+    url = next;
+  }
+  return {
+    status: "unknown",
+    seen,
+    reason: `gave up after ${maxPages} pages without exhausting the list`,
+    pages: maxPages,
+  };
+}
+
+/** `next` from a page body, or null when this is the last page. Never throws — the body is parsed. */
+function readNext(raw) {
+  try {
+    const next = JSON.parse(raw).next;
+    return typeof next === "string" && next ? next : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * CLI: `node amoApi.mjs has-version <addonId> <version>`
  *
@@ -79,17 +163,9 @@ if (process.argv[1] && process.argv[1].endsWith("amoApi.mjs")) {
   const token = await mintJwt(process.env.AMO_JWT_ISSUER, process.env.AMO_JWT_SECRET);
   // Two attempts: a single transient 5xx should not decide a release, but a real outage should
   // stop it rather than be retried into a duplicate submission.
-  let last = { status: "unknown", seen: [], reason: "not attempted" };
+  let last = { status: "unknown", seen: [], reason: "not attempted", pages: 0 };
   for (let attempt = 1; attempt <= 2; attempt++) {
-    let raw = "";
-    try {
-      const res = await fetch(versionsUrl(addonId), { headers: { Authorization: `JWT ${token}` } });
-      raw = await res.text();
-    } catch (err) {
-      last = { status: "unknown", seen: [], reason: `request failed: ${err.message}` };
-      continue;
-    }
-    last = findVersion(raw, version);
+    last = await hasVersion({ addonId, version, token });
     if (last.status !== "unknown") break;
   }
   if (last.status === "unknown") {

--- a/extension/scripts/amoApi.mjs
+++ b/extension/scripts/amoApi.mjs
@@ -28,6 +28,19 @@ export async function mintJwt(issuer, secret, opts = {}) {
 }
 
 /**
+ * A version string this code can actually act on.
+ *
+ * `""` is a string, and that is the whole problem: it satisfied a `typeof` check, entered the list
+ * of versions read, and let a page containing an entry whose version was never really read produce
+ * a definitive "not there" — while padding that list so the server's count reconciled. Blank is
+ * unread, and unread is unknown. `readNext` has always held empty strings to this standard; this
+ * is the same rule applied where it was missing.
+ */
+export function isReadableVersion(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+/**
  * Does AMO already hold this version of this add-on?
  *
  * Deliberately strict about what counts as "no". An unparseable body, an auth error, or a
@@ -40,6 +53,12 @@ export async function mintJwt(issuer, secret, opts = {}) {
  * @returns {{ status: "yes" | "no" | "unknown", seen: string[], reason?: string }}
  */
 export function findVersion(raw, version) {
+  // Asking whether AMO holds version "" is a programming error, not a question with an answer.
+  // Left unchecked it is a quiet one: an empty sought version against an empty entry "matches",
+  // and against a healthy list returns a confident absence.
+  if (!isReadableVersion(version)) {
+    throw new TypeError(`findVersion needs a non-blank version, got ${JSON.stringify(version)}`);
+  }
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -64,7 +83,7 @@ export function findVersion(raw, version) {
   const readable = [];
   let unreadable = 0;
   for (const entry of parsed.results) {
-    if (entry && typeof entry === "object" && typeof entry.version === "string") {
+    if (entry && typeof entry === "object" && isReadableVersion(entry.version)) {
       readable.push(entry.version);
     } else {
       unreadable++;
@@ -142,10 +161,13 @@ export async function hasVersion({ addonId, version, token, fetchImpl = fetch, m
       return { status: "unknown", seen, reason: `request failed on page ${page}: ${err.message}`, pages: page };
     }
     const parsed = findVersion(raw, version);
+    // Keep whatever the page DID yield, including when it is being rejected. When this stops a
+    // release, the log should say what it managed to read — "unknown, saw 0.40.0 and 0.39.0" is a
+    // diagnosis; "unknown, saw nothing" reads like a broken token.
+    seen.push(...parsed.seen);
     if (parsed.status === "unknown") {
       return { status: "unknown", seen, reason: parsed.reason, pages: page };
     }
-    seen.push(...parsed.seen);
     if (parsed.status === "yes") return { status: "yes", seen, pages: page };
 
     const next = readNext(raw);
@@ -246,8 +268,10 @@ export function readCount(raw) {
  */
 if (process.argv[1] && process.argv[1].endsWith("amoApi.mjs")) {
   const [, , command, addonId, version] = process.argv;
-  if (command !== "has-version" || !addonId || !version) {
-    console.error("usage: node amoApi.mjs has-version <addonId> <version>");
+  // `!version` alone lets " " through, and a blank version asks AMO a question with no answer.
+  // Exit 2, the same code as "cannot tell", so the workflow stops rather than submitting.
+  if (command !== "has-version" || !isReadableVersion(addonId) || !isReadableVersion(version)) {
+    console.error("usage: node amoApi.mjs has-version <addonId> <version>  (neither may be blank)");
     process.exit(2);
   }
   const token = await mintJwt(process.env.AMO_JWT_ISSUER, process.env.AMO_JWT_SECRET);

--- a/extension/scripts/amoApi.mjs
+++ b/extension/scripts/amoApi.mjs
@@ -1,0 +1,103 @@
+// The two AMO API calls the release workflow needs, in a file that can be unit-tested.
+//
+// They started as `node -e` one-liners inside release-artifacts.yml. That is the worst place for
+// logic whose failure modes are "silently submits nothing" and "reports success against the wrong
+// add-on": the job only runs on a tag, so a mistake surfaces on a release, hours later, once.
+
+/**
+ * AMO authenticates with a short-lived HS256 JWT minted from the issuer/secret pair, NOT with a
+ * bearer token you can store. Signed here rather than pulled from a library so the release path
+ * has one less thing to install.
+ *
+ * @param {string} issuer AMO_JWT_ISSUER
+ * @param {string} secret AMO_JWT_SECRET
+ * @param {{ now?: number, jti?: string }} [opts] Injected for tests; both default sensibly.
+ * @returns {Promise<string>} A signed JWT, valid for four minutes.
+ */
+export async function mintJwt(issuer, secret, opts = {}) {
+  const { createHmac, randomUUID } = await import("node:crypto");
+  if (!issuer || !secret) throw new Error("mintJwt needs both an issuer and a secret");
+  const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString("base64url");
+  const iat = opts.now ?? Math.floor(Date.now() / 1000);
+  const head = b64({ alg: "HS256", typ: "JWT" });
+  // `jti` must be unique per request — AMO rejects a replayed one. randomUUID, not Math.random:
+  // a collision here reads as an auth failure on a release, which is a miserable thing to debug.
+  const body = b64({ iss: issuer, jti: opts.jti ?? randomUUID(), iat, exp: iat + 240 });
+  const sig = createHmac("sha256", secret).update(`${head}.${body}`).digest("base64url");
+  return `${head}.${body}.${sig}`;
+}
+
+/**
+ * Does AMO already hold this version of this add-on?
+ *
+ * Deliberately strict about what counts as "no". An unparseable body, an auth error, or a
+ * results-shaped object that is not an array are all UNKNOWN, never "no" — because the caller
+ * turns "no" into "submit" and "yes" into "skip", and guessing either way on a release is worse
+ * than stopping. See the CLI at the bottom.
+ *
+ * @param {string} raw The raw response body.
+ * @param {string} version The version to look for, e.g. "0.36.0".
+ * @returns {{ status: "yes" | "no" | "unknown", seen: string[], reason?: string }}
+ */
+export function findVersion(raw, version) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: "unknown", seen: [], reason: "response was not JSON" };
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return { status: "unknown", seen: [], reason: "response was not an object" };
+  }
+  if (!Array.isArray(parsed.results)) {
+    // AMO's error bodies are objects with `detail`; an add-on with no versions still returns
+    // `results: []`. A missing `results` therefore means the call failed, not that it is empty.
+    const detail = typeof parsed.detail === "string" ? parsed.detail : "no results array";
+    return { status: "unknown", seen: [], reason: detail };
+  }
+  const seen = parsed.results.map((v) => (v && typeof v.version === "string" ? v.version : "?"));
+  return { status: seen.includes(version) ? "yes" : "no", seen };
+}
+
+/** Versions endpoint including unlisted/in-review ones — a fresh upload is not public yet. */
+export function versionsUrl(addonId) {
+  return `https://addons.mozilla.org/api/v5/addons/addon/${encodeURIComponent(addonId)}/versions/?filter=all_with_unlisted`;
+}
+
+/**
+ * CLI: `node amoApi.mjs has-version <addonId> <version>`
+ *
+ * Prints `yes` or `no` on stdout. Exits 0 for either — both are answers. Exits 2 when the answer
+ * is UNKNOWN, which the workflow treats as a stop rather than a guess.
+ */
+if (process.argv[1] && process.argv[1].endsWith("amoApi.mjs")) {
+  const [, , command, addonId, version] = process.argv;
+  if (command !== "has-version" || !addonId || !version) {
+    console.error("usage: node amoApi.mjs has-version <addonId> <version>");
+    process.exit(2);
+  }
+  const token = await mintJwt(process.env.AMO_JWT_ISSUER, process.env.AMO_JWT_SECRET);
+  // Two attempts: a single transient 5xx should not decide a release, but a real outage should
+  // stop it rather than be retried into a duplicate submission.
+  let last = { status: "unknown", seen: [], reason: "not attempted" };
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    let raw = "";
+    try {
+      const res = await fetch(versionsUrl(addonId), { headers: { Authorization: `JWT ${token}` } });
+      raw = await res.text();
+    } catch (err) {
+      last = { status: "unknown", seen: [], reason: `request failed: ${err.message}` };
+      continue;
+    }
+    last = findVersion(raw, version);
+    if (last.status !== "unknown") break;
+  }
+  if (last.status === "unknown") {
+    console.error(`could not determine whether AMO holds ${version}: ${last.reason}`);
+    process.exit(2);
+  }
+  if (last.status === "no" && last.seen.length) {
+    console.error(`AMO has: ${last.seen.slice(0, 5).join(", ")}`);
+  }
+  console.log(last.status);
+}

--- a/extension/scripts/amoApi.mjs
+++ b/extension/scripts/amoApi.mjs
@@ -55,8 +55,33 @@ export function findVersion(raw, version) {
     const detail = typeof parsed.detail === "string" ? parsed.detail : "no results array";
     return { status: "unknown", seen: [], reason: detail };
   }
-  const seen = parsed.results.map((v) => (v && typeof v.version === "string" ? v.version : "?"));
-  return { status: seen.includes(version) ? "yes" : "no", seen };
+  // An entry whose `version` cannot be read is a version this code did NOT read — it may well be
+  // the one being sought. Mapping it to a placeholder and concluding "not found" turns a contract
+  // violation into the answer that makes the caller submit.
+  //
+  // It also quietly defeated the count reconciliation below: placeholders padded `seen`, so
+  // seen.length matched the server's total while some versions had never actually been read.
+  const readable = [];
+  let unreadable = 0;
+  for (const entry of parsed.results) {
+    if (entry && typeof entry === "object" && typeof entry.version === "string") {
+      readable.push(entry.version);
+    } else {
+      unreadable++;
+    }
+  }
+
+  // Precedence matters. A hit is definitive whatever else the page contained: the version is
+  // there, so there is nothing left to be uncertain about and nothing to submit.
+  if (readable.includes(version)) return { status: "yes", seen: readable };
+  if (unreadable > 0) {
+    return {
+      status: "unknown",
+      seen: readable,
+      reason: `${unreadable} of ${parsed.results.length} entries had no readable version string`,
+    };
+  }
+  return { status: "no", seen: readable };
 }
 
 /** Versions endpoint including unlisted/in-review ones — a fresh upload is not public yet. */

--- a/extension/scripts/amoApi.mjs
+++ b/extension/scripts/amoApi.mjs
@@ -41,6 +41,22 @@ export function isReadableVersion(value) {
 }
 
 /**
+ * Mozilla's own rule for a manifest version, quoted from the MDN `version` page rather than
+ * invented here: one to four dot-separated numbers, digits only, at most nine digits per part, no
+ * leading zeros except a bare `0`.
+ *
+ * This replaced a shell glob — `[0-9]*.[0-9]*` — which was the kind of validator that looks like
+ * one. It accepted `0abc.9xyz`, `2.01`, `1.2-beta`, `1.2.3.4.5` and, memorably,
+ * `1.2 && curl evil.example`.
+ */
+export const AMO_VERSION_RE = /^(0|[1-9][0-9]{0,8})([.](0|[1-9][0-9]{0,8})){0,3}$/;
+
+/** Is this a version AMO will accept? Blank, padded and non-string values are all rejected. */
+export function isValidAddonVersion(value) {
+  return isReadableVersion(value) && AMO_VERSION_RE.test(value);
+}
+
+/**
  * Does AMO already hold this version of this add-on?
  *
  * Deliberately strict about what counts as "no". An unparseable body, an auth error, or a
@@ -267,11 +283,32 @@ export function readCount(raw) {
  * is UNKNOWN, which the workflow treats as a stop rather than a guess.
  */
 if (process.argv[1] && process.argv[1].endsWith("amoApi.mjs")) {
-  const [, , command, addonId, version] = process.argv;
+  const [, , command, ...rest] = process.argv;
+
+  // `check-version` is the workflow's gate on the version it read out of the packaged manifest.
+  // Exits 2 on anything AMO would refuse, so a malformed value stops the release here rather than
+  // travelling on to be queried, not found, and submitted.
+  if (command === "check-version") {
+    const [candidate] = rest;
+    if (!isValidAddonVersion(candidate)) {
+      console.error(
+        `not a version AMO accepts: ${JSON.stringify(candidate)} — expected 1 to 4 dot-separated ` +
+          `numbers, digits only, no leading zeros (e.g. 0.36.0)`,
+      );
+      process.exit(2);
+    }
+    console.log(candidate);
+    process.exit(0);
+  }
+
+  const [addonId, version] = rest;
   // `!version` alone lets " " through, and a blank version asks AMO a question with no answer.
-  // Exit 2, the same code as "cannot tell", so the workflow stops rather than submitting.
-  if (command !== "has-version" || !isReadableVersion(addonId) || !isReadableVersion(version)) {
-    console.error("usage: node amoApi.mjs has-version <addonId> <version>  (neither may be blank)");
+  // The version is also the one about to be SUBMITTED, so it is held to AMO's format here too:
+  // querying a malformed version can only ever return "not found", which means submit. Exit 2,
+  // the same code as "cannot tell", so the workflow stops.
+  if (command !== "has-version" || !isReadableVersion(addonId) || !isValidAddonVersion(version)) {
+    console.error("usage: node amoApi.mjs has-version <addonId> <version>  (version must be AMO-valid)");
+    console.error("       node amoApi.mjs check-version <version>");
     process.exit(2);
   }
   const token = await mintJwt(process.env.AMO_JWT_ISSUER, process.env.AMO_JWT_SECRET);

--- a/extension/scripts/amoApi.mjs
+++ b/extension/scripts/amoApi.mjs
@@ -157,20 +157,30 @@ export const MAX_PAGES = 80;
  * fails at AMO with a duplicate-version error. That failure is loud and correct; it just is not
  * one the pre-flight can pre-empt.
  *
+ * Takes a token FACTORY, not a token. AMO requires a unique `jti` per request and the JWT lives
+ * four minutes, so one token minted by the caller and reused for every page is a replay on page
+ * two — and on every retry. Walking a long version list is exactly when both happen, which is
+ * exactly when this check matters.
+ *
  * @param {object} args
  * @param {string} args.addonId
  * @param {string} args.version
- * @param {string} args.token A JWT from mintJwt.
+ * @param {() => Promise<string>} args.mintToken Called once per request; must return a fresh JWT.
  * @param {typeof fetch} [args.fetchImpl] Injected by tests.
  * @param {number} [args.maxPages]
  * @returns {Promise<{ status: "yes" | "no" | "unknown", seen: string[], reason?: string, pages: number }>}
  */
-export async function hasVersion({ addonId, version, token, fetchImpl = fetch, maxPages = MAX_PAGES }) {
+export async function hasVersion({ addonId, version, mintToken, fetchImpl = fetch, maxPages = MAX_PAGES }) {
+  if (typeof mintToken !== "function") {
+    throw new TypeError("hasVersion needs a mintToken factory, so every request carries a fresh JWT");
+  }
   let url = versionsUrl(addonId);
   const seen = [];
   for (let page = 1; page <= maxPages; page++) {
     let raw;
     try {
+      // Fresh per page. Reusing one token across the walk is the replay AMO rejects.
+      const token = await mintToken();
       const res = await fetchImpl(url, { headers: { Authorization: `JWT ${token}` } });
       raw = await res.text();
     } catch (err) {
@@ -311,12 +321,14 @@ if (process.argv[1] && process.argv[1].endsWith("amoApi.mjs")) {
     console.error("       node amoApi.mjs check-version <version>");
     process.exit(2);
   }
-  const token = await mintJwt(process.env.AMO_JWT_ISSUER, process.env.AMO_JWT_SECRET);
+  // A factory, not a token: minted per request inside the walk, so page two and the retry below
+  // each carry their own `jti` rather than replaying the first one.
+  const mintToken = () => mintJwt(process.env.AMO_JWT_ISSUER, process.env.AMO_JWT_SECRET);
   // Two attempts: a single transient 5xx should not decide a release, but a real outage should
   // stop it rather than be retried into a duplicate submission.
   let last = { status: "unknown", seen: [], reason: "not attempted", pages: 0 };
   for (let attempt = 1; attempt <= 2; attempt++) {
-    last = await hasVersion({ addonId, version, token });
+    last = await hasVersion({ addonId, version, mintToken });
     if (last.status !== "unknown") break;
   }
   if (last.status === "unknown") {

--- a/extension/scripts/amoApi.mjs
+++ b/extension/scripts/amoApi.mjs
@@ -124,11 +124,32 @@ export async function hasVersion({ addonId, version, token, fetchImpl = fetch, m
     if (parsed.status === "yes") return { status: "yes", seen, pages: page };
 
     const next = readNext(raw);
-    if (!next) return { status: "no", seen, pages: page }; // list exhausted — a real absence
-    if (!isAmoUrl(next)) {
-      return { status: "unknown", seen, reason: `next page pointed off-site: ${next}`, pages: page };
+    if (next.kind === "malformed") {
+      // `next` was present but not a usable link. That is not "the list ended" — it is a response
+      // this code does not understand, and the two must not collapse into the same answer.
+      return { status: "unknown", seen, reason: next.reason, pages: page };
     }
-    url = next;
+    if (next.kind === "end") {
+      // The only path that may return a definitive absence, and only once the server's own count
+      // agrees that everything was read.
+      const total = readCount(raw);
+      if (total.kind === "malformed") {
+        return { status: "unknown", seen, reason: total.reason, pages: page };
+      }
+      if (total.kind === "number" && seen.length < total.value) {
+        return {
+          status: "unknown",
+          seen,
+          reason: `list ended after ${seen.length} version(s) but the server reported ${total.value}`,
+          pages: page,
+        };
+      }
+      return { status: "no", seen, pages: page };
+    }
+    if (!isAmoUrl(next.url)) {
+      return { status: "unknown", seen, reason: `next page pointed off-site: ${next.url}`, pages: page };
+    }
+    url = next.url;
   }
   return {
     status: "unknown",
@@ -138,14 +159,58 @@ export async function hasVersion({ addonId, version, token, fetchImpl = fetch, m
   };
 }
 
-/** `next` from a page body, or null when this is the last page. Never throws — the body is parsed. */
-function readNext(raw) {
+/**
+ * Classify a page's `next` field into the THREE outcomes it actually has.
+ *
+ * Collapsing them into "falsy means the end" is what made malformed metadata read as a definitive
+ * absence: `next: 42`, `next: {}` and `next: ""` are not "no more pages", they are a response this
+ * code does not understand — and absence is the answer that makes the caller submit.
+ *
+ * @returns {{ kind: "url", url: string } | { kind: "end" } | { kind: "malformed", reason: string }}
+ */
+export function readNext(raw) {
+  let parsed;
   try {
-    const next = JSON.parse(raw).next;
-    return typeof next === "string" && next ? next : null;
+    parsed = JSON.parse(raw);
   } catch {
-    return null;
+    return { kind: "malformed", reason: "page body was not JSON" };
   }
+  if (!parsed || typeof parsed !== "object") {
+    return { kind: "malformed", reason: "page body was not an object" };
+  }
+  // Only an explicit null (or an absent key) means the list is finished. That is what AMO sends.
+  if (parsed.next === null || parsed.next === undefined) return { kind: "end" };
+  if (typeof parsed.next !== "string" || parsed.next === "") {
+    return { kind: "malformed", reason: `next was ${JSON.stringify(parsed.next)}, not a URL` };
+  }
+  return { kind: "url", url: parsed.next };
+}
+
+/**
+ * The server's own total, used to reconcile against what was actually read.
+ *
+ * Without it, a response claiming 99 versions while returning 25 and no `next` yields a confident
+ * "not there" from a list that was never finished.
+ *
+ * @returns {{ kind: "number", value: number } | { kind: "absent" } | { kind: "malformed", reason: string }}
+ */
+export function readCount(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { kind: "malformed", reason: "page body was not JSON" };
+  }
+  if (!parsed || typeof parsed !== "object" || parsed.count === undefined || parsed.count === null) {
+    // Not every paginated body is required to carry it, and failing every run over a missing
+    // optional field would make the pre-flight useless. Absent means "cannot reconcile", not
+    // "broken" — the `next` chain is still the primary signal.
+    return { kind: "absent" };
+  }
+  if (typeof parsed.count !== "number" || !Number.isInteger(parsed.count) || parsed.count < 0) {
+    return { kind: "malformed", reason: `count was ${JSON.stringify(parsed.count)}, not a whole number` };
+  }
+  return { kind: "number", value: parsed.count };
 }
 
 /**

--- a/extension/tests/amoApi.test.ts
+++ b/extension/tests/amoApi.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { createHmac } from "node:crypto";
+
+import { mintJwt, findVersion, versionsUrl } from "../scripts/amoApi.mjs";
+
+describe("mintJwt", () => {
+  it("produces a verifiable HS256 JWT", async () => {
+    const token = await mintJwt("user:1:2", "s3cret", { now: 1_700_000_000, jti: "fixed" });
+    const [head, body, sig] = token.split(".");
+    expect(JSON.parse(Buffer.from(head, "base64url").toString())).toEqual({ alg: "HS256", typ: "JWT" });
+    expect(JSON.parse(Buffer.from(body, "base64url").toString())).toEqual({
+      iss: "user:1:2",
+      jti: "fixed",
+      iat: 1_700_000_000,
+      exp: 1_700_000_240,
+    });
+    // The signature must actually verify. A JWT that merely LOOKS right fails at AMO, on a release.
+    expect(sig).toBe(createHmac("sha256", "s3cret").update(`${head}.${body}`).digest("base64url"));
+  });
+
+  it("gives every request a distinct jti", async () => {
+    // AMO rejects a replayed jti. Two calls in the same second must still differ.
+    const a = await mintJwt("i", "s", { now: 1 });
+    const b = await mintJwt("i", "s", { now: 1 });
+    expect(a).not.toBe(b);
+  });
+
+  it("refuses to mint without credentials", async () => {
+    await expect(mintJwt("", "s")).rejects.toThrow(/issuer and a secret/);
+    await expect(mintJwt("i", "")).rejects.toThrow(/issuer and a secret/);
+  });
+});
+
+describe("findVersion", () => {
+  it("finds a version that is present", () => {
+    const body = JSON.stringify({ results: [{ version: "0.36.0" }, { version: "0.35.1" }] });
+    expect(findVersion(body, "0.36.0")).toMatchObject({ status: "yes" });
+  });
+
+  it("reports a genuine absence as no, and says what it did see", () => {
+    const body = JSON.stringify({ results: [{ version: "0.35.1" }] });
+    expect(findVersion(body, "0.36.0")).toMatchObject({ status: "no", seen: ["0.35.1"] });
+  });
+
+  it("treats an add-on with no versions as a genuine no", () => {
+    expect(findVersion(JSON.stringify({ results: [] }), "0.36.0")).toMatchObject({ status: "no" });
+  });
+
+  // The three below are the whole reason this function exists rather than a `.find()` inline.
+  // Every one of them would read as "not submitted yet" to a naive check, and the caller turns
+  // that into "submit" — which on a re-run means submitting a version AMO already holds.
+
+  it("treats an auth error as unknown, never as absent", () => {
+    const result = findVersion(JSON.stringify({ detail: "Invalid token." }), "0.36.0");
+    expect(result.status).toBe("unknown");
+    expect(result.reason).toBe("Invalid token.");
+  });
+
+  it("treats a non-JSON body as unknown", () => {
+    expect(findVersion("<html>502 Bad Gateway</html>", "0.36.0")).toMatchObject({ status: "unknown" });
+  });
+
+  it("treats a results field that is not an array as unknown", () => {
+    expect(findVersion(JSON.stringify({ results: null }), "0.36.0").status).toBe("unknown");
+    expect(findVersion("null", "0.36.0").status).toBe("unknown");
+  });
+
+  it("does not crash on malformed version entries", () => {
+    const body = JSON.stringify({ results: [null, { version: 42 }, { version: "0.36.0" }] });
+    expect(findVersion(body, "0.36.0")).toMatchObject({ status: "yes" });
+  });
+
+  it("matches the version exactly, not by prefix", () => {
+    // "0.3" must not match "0.36.0", and "0.36.0" must not be satisfied by "0.36.0-beta".
+    const body = JSON.stringify({ results: [{ version: "0.36.0-beta" }] });
+    expect(findVersion(body, "0.36.0")).toMatchObject({ status: "no" });
+    expect(findVersion(JSON.stringify({ results: [{ version: "0.36.0" }] }), "0.3").status).toBe("no");
+  });
+});
+
+describe("versionsUrl", () => {
+  it("asks for unlisted and in-review versions too", () => {
+    // A freshly uploaded version is not public until a reviewer approves it. Without this filter
+    // the check would report "not submitted" for something submitted minutes ago.
+    expect(versionsUrl("a@b")).toContain("filter=all_with_unlisted");
+  });
+
+  it("encodes the add-on id, which contains an @", () => {
+    expect(versionsUrl("dfir-companion@hasamba.github.io")).toContain("dfir-companion%40hasamba.github.io");
+  });
+});

--- a/extension/tests/amoApi.test.ts
+++ b/extension/tests/amoApi.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createHmac } from "node:crypto";
 
-import { mintJwt, findVersion, versionsUrl } from "../scripts/amoApi.mjs";
+import { mintJwt, findVersion, versionsUrl, hasVersion, isAmoUrl } from "../scripts/amoApi.mjs";
 
 describe("mintJwt", () => {
   it("produces a verifiable HS256 JWT", async () => {
@@ -87,5 +87,111 @@ describe("versionsUrl", () => {
 
   it("encodes the add-on id, which contains an @", () => {
     expect(versionsUrl("dfir-companion@hasamba.github.io")).toContain("dfir-companion%40hasamba.github.io");
+  });
+});
+
+describe("hasVersion paging", () => {
+  // The endpoint paginates at 25. Reading page one and calling it absent is wrong the moment the
+  // add-on has 26 versions, and wrong in the direction that costs a release: "no" means "submit",
+  // and AMO then rejects the duplicate.
+  const page = (versions: string[], next: string | null) =>
+    JSON.stringify({ count: 99, next, results: versions.map((version) => ({ version })) });
+
+  const fakeFetch = (pages: Record<string, string>) => {
+    const calls: string[] = [];
+    const impl = (async (url: string) => {
+      calls.push(String(url));
+      const body = pages[String(url)];
+      if (body === undefined) throw new Error(`unexpected url ${url}`);
+      return { text: async () => body };
+    }) as unknown as typeof fetch;
+    return { impl, calls };
+  };
+
+  const FIRST = versionsUrl("a@b");
+  const SECOND = "https://addons.mozilla.org/api/v5/addons/addon/a%40b/versions/?page=2";
+
+  it("finds a version that only appears on the second page", async () => {
+    const { impl, calls } = fakeFetch({
+      [FIRST]: page(["0.40.0", "0.39.0"], SECOND),
+      [SECOND]: page(["0.36.0", "0.35.1"], null),
+    });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    expect(result.status).toBe("yes");
+    expect(result.pages).toBe(2);
+    expect(calls).toEqual([FIRST, SECOND]);
+  });
+
+  it("stops paging as soon as it finds the version", async () => {
+    const { impl, calls } = fakeFetch({ [FIRST]: page(["0.36.0"], SECOND) });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    expect(result.status).toBe("yes");
+    expect(calls).toEqual([FIRST]); // never asked for page 2
+  });
+
+  it("only says no after the whole list is exhausted", async () => {
+    const { impl } = fakeFetch({
+      [FIRST]: page(["0.40.0"], SECOND),
+      [SECOND]: page(["0.39.0"], null),
+    });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    expect(result).toMatchObject({ status: "no", pages: 2 });
+    expect(result.seen).toEqual(["0.40.0", "0.39.0"]);
+  });
+
+  it("reports unknown when a later page fails, never no", async () => {
+    // The dangerous case: page 1 parsed fine, so a naive implementation would answer from it.
+    const { impl } = fakeFetch({
+      [FIRST]: page(["0.40.0"], SECOND),
+      [SECOND]: '{"detail":"Internal Server Error"}',
+    });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    expect(result.status).toBe("unknown");
+    expect(result.reason).toContain("Internal Server Error");
+  });
+
+  it("reports unknown when a page request throws", async () => {
+    const impl = (async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    expect(result).toMatchObject({ status: "unknown" });
+    expect(result.reason).toContain("ECONNRESET");
+  });
+
+  it("refuses to follow a next link that is not AMO", async () => {
+    // `next` is data from a response, not an instruction. Following it anywhere would send the
+    // developer's JWT to whatever host the body named.
+    const { impl, calls } = fakeFetch({
+      [FIRST]: page(["0.40.0"], "https://evil.example/api/v5/versions/?page=2"),
+    });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    expect(result.status).toBe("unknown");
+    expect(result.reason).toContain("off-site");
+    expect(calls).toEqual([FIRST]); // the JWT never left AMO
+  });
+
+  it("gives up with unknown rather than looping forever", async () => {
+    // A server that always returns a `next` must not spin the job until its timeout.
+    const selfReferential = (async () => ({ text: async () => page(["0.1.0"], FIRST) })) as unknown as typeof fetch;
+    const result = await hasVersion({
+      addonId: "a@b",
+      version: "0.36.0",
+      token: "t",
+      fetchImpl: selfReferential,
+      maxPages: 3,
+    });
+    expect(result).toMatchObject({ status: "unknown", pages: 3 });
+    expect(result.reason).toContain("3 pages");
+  });
+});
+
+describe("isAmoUrl", () => {
+  it("accepts AMO and rejects everything else", () => {
+    expect(isAmoUrl("https://addons.mozilla.org/api/v5/x")).toBe(true);
+    expect(isAmoUrl("http://addons.mozilla.org/api/v5/x")).toBe(false); // downgrade to http
+    expect(isAmoUrl("https://addons.mozilla.org.evil.example/x")).toBe(false); // suffix trick
+    expect(isAmoUrl("https://evil.example/x")).toBe(false);
+    expect(isAmoUrl("not a url")).toBe(false);
   });
 });

--- a/extension/tests/amoApi.test.ts
+++ b/extension/tests/amoApi.test.ts
@@ -73,9 +73,36 @@ describe("findVersion", () => {
     expect(findVersion("null", "0.36.0").status).toBe("unknown");
   });
 
-  it("does not crash on malformed version entries", () => {
+  it("still reports a hit when other entries are malformed", () => {
+    // Precedence, not luck: the version IS there, so nothing is left to be uncertain about.
     const body = JSON.stringify({ results: [null, { version: 42 }, { version: "0.36.0" }] });
     expect(findVersion(body, "0.36.0")).toMatchObject({ status: "yes" });
+  });
+
+  it("refuses to call it absent when an entry's version could not be read", () => {
+    // The entry it could not read might BE the version sought. Answering "no" here is what makes
+    // the caller submit a version AMO may already hold.
+    const body = JSON.stringify({ results: [null, { version: "0.40.0" }] });
+    const result = findVersion(body, "0.36.0");
+    expect(result.status).toBe("unknown");
+    expect(result.reason).toContain("1 of 2 entries");
+  });
+
+  it.each([
+    ["null", null],
+    ["a number version", { version: 42 }],
+    ["a missing version key", { id: 7 }],
+    ["a string instead of an object", "0.36.0"],
+  ])("treats an entry that is %s as unreadable", (_label, entry) => {
+    const body = JSON.stringify({ results: [entry, { version: "0.40.0" }] });
+    expect(findVersion(body, "0.36.0").status).toBe("unknown");
+  });
+
+  it("reports only genuinely readable versions in seen", () => {
+    // `seen` feeds the count reconciliation. A placeholder for an unread entry would pad it and
+    // make a short list reconcile against the server's total.
+    const body = JSON.stringify({ results: [null, { version: "0.40.0" }] });
+    expect(findVersion(body, "0.36.0").seen).toEqual(["0.40.0"]);
   });
 
   it("matches the version exactly, not by prefix", () => {
@@ -275,5 +302,40 @@ describe("malformed pagination metadata", () => {
     // Finding it is definitive. A bogus count must not turn a hit into a stop.
     const raw = JSON.stringify({ count: 999, next: null, results: [{ version: "0.36.0" }] });
     expect((await walk(raw)).status).toBe("yes");
+  });
+});
+
+describe("unreadable entries and the count reconciliation", () => {
+  const walk = async (raw: string) => {
+    const impl = (async () => ({ text: async () => raw })) as unknown as typeof fetch;
+    return hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+  };
+
+  it("does not let placeholders satisfy the server's count", async () => {
+    // Two entries, one unreadable, count: 2, no next page. Counting the unreadable one would make
+    // the totals agree and produce a confident "not there" from a list half of which was unread.
+    const raw = JSON.stringify({ count: 2, next: null, results: [null, { version: "0.40.0" }] });
+    const result = await walk(raw);
+    expect(result.status).toBe("unknown");
+    expect(result.reason).toContain("readable version string");
+  });
+
+  it("stops on the page with the unreadable entry rather than paging past it", async () => {
+    const raw = JSON.stringify({ count: 9, next: "https://addons.mozilla.org/x", results: [{ id: 1 }] });
+    const result = await walk(raw);
+    expect(result).toMatchObject({ status: "unknown", pages: 1 });
+  });
+
+  it("accumulates only readable versions across pages", async () => {
+    const FIRST = versionsUrl("a@b");
+    const SECOND = "https://addons.mozilla.org/api/v5/addons/addon/a%40b/versions/?page=2";
+    const impl = (async (url: string) => ({
+      text: async () =>
+        String(url) === FIRST
+          ? JSON.stringify({ count: 2, next: SECOND, results: [{ version: "0.40.0" }] })
+          : JSON.stringify({ count: 2, next: null, results: [{ version: "0.39.0" }] }),
+    })) as unknown as typeof fetch;
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    expect(result).toMatchObject({ status: "no", seen: ["0.40.0", "0.39.0"] });
   });
 });

--- a/extension/tests/amoApi.test.ts
+++ b/extension/tests/amoApi.test.ts
@@ -157,7 +157,7 @@ describe("hasVersion paging", () => {
       [FIRST]: page(["0.40.0", "0.39.0"], SECOND, 4),
       [SECOND]: page(["0.36.0", "0.35.1"], null, 4),
     });
-    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
     expect(result.status).toBe("yes");
     expect(result.pages).toBe(2);
     expect(calls).toEqual([FIRST, SECOND]);
@@ -165,7 +165,7 @@ describe("hasVersion paging", () => {
 
   it("stops paging as soon as it finds the version", async () => {
     const { impl, calls } = fakeFetch({ [FIRST]: page(["0.36.0"], SECOND) });
-    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
     expect(result.status).toBe("yes");
     expect(calls).toEqual([FIRST]); // never asked for page 2
   });
@@ -175,7 +175,7 @@ describe("hasVersion paging", () => {
       [FIRST]: page(["0.40.0"], SECOND, 2),
       [SECOND]: page(["0.39.0"], null, 2),
     });
-    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
     expect(result).toMatchObject({ status: "no", pages: 2 });
     expect(result.seen).toEqual(["0.40.0", "0.39.0"]);
   });
@@ -186,7 +186,7 @@ describe("hasVersion paging", () => {
       [FIRST]: page(["0.40.0"], SECOND, 2),
       [SECOND]: '{"detail":"Internal Server Error"}',
     });
-    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
     expect(result.status).toBe("unknown");
     expect(result.reason).toContain("Internal Server Error");
   });
@@ -195,7 +195,7 @@ describe("hasVersion paging", () => {
     const impl = (async () => {
       throw new Error("ECONNRESET");
     }) as unknown as typeof fetch;
-    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
     expect(result).toMatchObject({ status: "unknown" });
     expect(result.reason).toContain("ECONNRESET");
   });
@@ -206,7 +206,7 @@ describe("hasVersion paging", () => {
     const { impl, calls } = fakeFetch({
       [FIRST]: page(["0.40.0"], "https://evil.example/api/v5/versions/?page=2", 2),
     });
-    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
     expect(result.status).toBe("unknown");
     expect(result.reason).toContain("off-site");
     expect(calls).toEqual([FIRST]); // the JWT never left AMO
@@ -218,7 +218,7 @@ describe("hasVersion paging", () => {
     const result = await hasVersion({
       addonId: "a@b",
       version: "0.36.0",
-      token: "t",
+      mintToken: async () => "t",
       fetchImpl: selfReferential,
       maxPages: 3,
     });
@@ -246,7 +246,7 @@ describe("malformed pagination metadata", () => {
 
   const walk = async (raw: string) => {
     const impl = (async () => ({ text: async () => raw })) as unknown as typeof fetch;
-    return hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    return hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
   };
 
   it.each([
@@ -311,7 +311,7 @@ describe("malformed pagination metadata", () => {
 describe("unreadable entries and the count reconciliation", () => {
   const walk = async (raw: string) => {
     const impl = (async () => ({ text: async () => raw })) as unknown as typeof fetch;
-    return hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    return hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
   };
 
   it("does not let placeholders satisfy the server's count", async () => {
@@ -338,7 +338,7 @@ describe("unreadable entries and the count reconciliation", () => {
           ? JSON.stringify({ count: 2, next: SECOND, results: [{ version: "0.40.0" }] })
           : JSON.stringify({ count: 2, next: null, results: [{ version: "0.39.0" }] }),
     })) as unknown as typeof fetch;
-    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    const result = await hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
     expect(result).toMatchObject({ status: "no", seen: ["0.40.0", "0.39.0"] });
   });
 });
@@ -350,7 +350,7 @@ describe("blank version strings", () => {
   // empty strings to this standard; these assert the same rule where it was missing.
   const walk = async (raw: string) => {
     const impl = (async () => ({ text: async () => raw })) as unknown as typeof fetch;
-    return hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+    return hasVersion({ addonId: "a@b", version: "0.36.0", mintToken: async () => "t", fetchImpl: impl });
   };
 
   it.each([
@@ -444,5 +444,61 @@ describe("isValidAddonVersion", () => {
     const { readFileSync } = await import("node:fs");
     const manifest = JSON.parse(readFileSync(new URL("../manifest.json", import.meta.url), "utf8"));
     expect(isValidAddonVersion(manifest.version)).toBe(true);
+  });
+});
+
+describe("a fresh JWT per request", () => {
+  // AMO rejects a replayed `jti`, and the token lives four minutes. One token minted by the caller
+  // and reused for the whole walk is a replay on page two and on every retry — which is precisely
+  // the path taken when the version sought is deep in a long list.
+  const FIRST = versionsUrl("a@b");
+  const SECOND = "https://addons.mozilla.org/api/v5/addons/addon/a%40b/versions/?page=2";
+
+  it("mints a new token for every page and sends each one", async () => {
+    const sent: string[] = [];
+    let minted = 0;
+    const fetchImpl = (async (url: string, init: { headers: Record<string, string> }) => {
+      sent.push(init.headers.Authorization);
+      return {
+        text: async () =>
+          String(url) === FIRST
+            ? JSON.stringify({ count: 2, next: SECOND, results: [{ version: "0.40.0" }] })
+            : JSON.stringify({ count: 2, next: null, results: [{ version: "0.39.0" }] }),
+      };
+    }) as unknown as typeof fetch;
+
+    const result = await hasVersion({
+      addonId: "a@b",
+      version: "0.36.0",
+      mintToken: async () => `jwt-${++minted}`,
+      fetchImpl,
+    });
+
+    expect(result.status).toBe("no");
+    expect(minted).toBe(2);
+    expect(sent).toEqual(["JWT jwt-1", "JWT jwt-2"]);
+    expect(new Set(sent).size).toBe(sent.length); // no token used twice
+  });
+
+  it("refuses a bare token, so the old calling convention cannot creep back", async () => {
+    await expect(
+      hasVersion({ addonId: "a@b", version: "0.36.0", token: "t" } as unknown as Parameters<typeof hasVersion>[0]),
+    ).rejects.toThrow(/mintToken factory/);
+  });
+
+  it("mints real, distinct JWTs when wired to mintJwt", async () => {
+    const sent: string[] = [];
+    const fetchImpl = (async (_url: string, init: { headers: Record<string, string> }) => {
+      sent.push(init.headers.Authorization);
+      return { text: async () => JSON.stringify({ count: 1, next: null, results: [{ version: "0.40.0" }] }) };
+    }) as unknown as typeof fetch;
+    await hasVersion({
+      addonId: "a@b",
+      version: "0.36.0",
+      mintToken: () => mintJwt("iss", "sec"),
+      fetchImpl,
+    });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatch(/^JWT [\w-]+\.[\w-]+\.[\w-]+$/);
   });
 });

--- a/extension/tests/amoApi.test.ts
+++ b/extension/tests/amoApi.test.ts
@@ -9,6 +9,7 @@ import {
   isAmoUrl,
   readNext,
   readCount,
+  isReadableVersion,
 } from "../scripts/amoApi.mjs";
 
 describe("mintJwt", () => {
@@ -337,5 +338,58 @@ describe("unreadable entries and the count reconciliation", () => {
     })) as unknown as typeof fetch;
     const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
     expect(result).toMatchObject({ status: "no", seen: ["0.40.0", "0.39.0"] });
+  });
+});
+
+describe("blank version strings", () => {
+  // `""` is a string, and that was the whole problem: it passed a typeof check, entered the list
+  // of versions read, and let a page whose entry was never really read produce a confident
+  // absence — while padding that list so the server's count reconciled. readNext has always held
+  // empty strings to this standard; these assert the same rule where it was missing.
+  const walk = async (raw: string) => {
+    const impl = (async () => ({ text: async () => raw })) as unknown as typeof fetch;
+    return hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+  };
+
+  it.each([
+    ["empty", ""],
+    ["a single space", " "],
+    ["whitespace", "   \t "],
+  ])("treats an entry whose version is %s as unread", async (_label, version) => {
+    const raw = JSON.stringify({ count: 2, next: null, results: [{ version }, { version: "0.40.0" }] });
+    const result = await walk(raw);
+    expect(result.status).toBe("unknown");
+    expect(result.seen).toEqual(["0.40.0"]);
+  });
+
+  it("does not let a blank entry pad the count", async () => {
+    // count 2, two entries, one blank. Counting the blank one makes the totals agree and yields a
+    // definitive "not there" from a list half of which was never read.
+    const raw = JSON.stringify({ count: 2, next: null, results: [{ version: "" }, { version: "0.40.0" }] });
+    expect((await walk(raw)).status).toBe("unknown");
+  });
+
+  it("refuses to be asked about a blank version", () => {
+    // Not a server problem — a programming error, and a quiet one: a blank sought version
+    // "matches" a blank entry, and against a healthy list returns a confident absence.
+    for (const bad of ["", " ", "\n"]) {
+      expect(() => findVersion(JSON.stringify({ results: [] }), bad)).toThrow(TypeError);
+    }
+  });
+
+  it("still finds a real version on a page that also has a blank one", () => {
+    const raw = JSON.stringify({ results: [{ version: "" }, { version: "0.36.0" }] });
+    expect(findVersion(raw, "0.36.0").status).toBe("yes");
+  });
+});
+
+describe("isReadableVersion", () => {
+  it("accepts a real version and rejects every blank shape", () => {
+    expect(isReadableVersion("0.36.0")).toBe(true);
+    expect(isReadableVersion("")).toBe(false);
+    expect(isReadableVersion("   ")).toBe(false);
+    expect(isReadableVersion(undefined)).toBe(false);
+    expect(isReadableVersion(null)).toBe(false);
+    expect(isReadableVersion(42)).toBe(false);
   });
 });

--- a/extension/tests/amoApi.test.ts
+++ b/extension/tests/amoApi.test.ts
@@ -10,6 +10,8 @@ import {
   readNext,
   readCount,
   isReadableVersion,
+  isValidAddonVersion,
+  AMO_VERSION_RE,
 } from "../scripts/amoApi.mjs";
 
 describe("mintJwt", () => {
@@ -391,5 +393,56 @@ describe("isReadableVersion", () => {
     expect(isReadableVersion(undefined)).toBe(false);
     expect(isReadableVersion(null)).toBe(false);
     expect(isReadableVersion(42)).toBe(false);
+  });
+});
+
+describe("isValidAddonVersion", () => {
+  // Mozilla's rule, quoted from the MDN `version` page rather than invented: one to four
+  // dot-separated numbers, digits only, at most nine digits per part, no leading zeros except a
+  // bare 0. The first five valid and the two invalid cases are MDN's own examples.
+  it.each(["0.2", "1.2.3", "2.0.1", "2.10", "1.2.3.4", "0", "0.36.0", "999999999.1"])(
+    "accepts %s",
+    (version) => {
+      expect(isValidAddonVersion(version)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["2.01", "leading zero"],
+    ["1.2.3.4.5", "five parts"],
+    ["1234567890.1", "ten digits in a part"],
+    ["0abc.9xyz", "letters, which the old shell glob accepted"],
+    ["1.2 && curl evil.example", "a shell fragment, which the old glob also accepted"],
+    ["1.2-beta", "a prerelease suffix — version_name is the field for that"],
+    ["1.", "a trailing dot"],
+    [".1", "a leading dot"],
+    ["1..2", "an empty part"],
+    ["v1.2.3", "a v prefix"],
+    [" 1.2", "leading whitespace"],
+    ["1.2 ", "trailing whitespace"],
+    ["undefined", "what `node -p` prints for a missing key"],
+    ["", "empty"],
+    ["   ", "blank"],
+  ])("rejects %s (%s)", (version) => {
+    expect(isValidAddonVersion(version)).toBe(false);
+  });
+
+  it.each([undefined, null, 42, {}, ["1.2.3"]])("rejects the non-string %s", (value) => {
+    expect(isValidAddonVersion(value as unknown as string)).toBe(false);
+  });
+
+  it("is anchored at both ends", () => {
+    // An unanchored regex would match the digits inside anything, which is how a validator ends up
+    // approving a string that merely contains a version.
+    expect(AMO_VERSION_RE.source.startsWith("^")).toBe(true);
+    expect(AMO_VERSION_RE.source.endsWith("$")).toBe(true);
+  });
+
+  it("accepts the version this repository actually ships", async () => {
+    // Ties the rule to reality: a validator that rejects our own manifest would fail every release
+    // rather than protect one.
+    const { readFileSync } = await import("node:fs");
+    const manifest = JSON.parse(readFileSync(new URL("../manifest.json", import.meta.url), "utf8"));
+    expect(isValidAddonVersion(manifest.version)).toBe(true);
   });
 });

--- a/extension/tests/amoApi.test.ts
+++ b/extension/tests/amoApi.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { createHmac } from "node:crypto";
 
-import { mintJwt, findVersion, versionsUrl, hasVersion, isAmoUrl } from "../scripts/amoApi.mjs";
+import {
+  mintJwt,
+  findVersion,
+  versionsUrl,
+  hasVersion,
+  isAmoUrl,
+  readNext,
+  readCount,
+} from "../scripts/amoApi.mjs";
 
 describe("mintJwt", () => {
   it("produces a verifiable HS256 JWT", async () => {
@@ -94,8 +102,11 @@ describe("hasVersion paging", () => {
   // The endpoint paginates at 25. Reading page one and calling it absent is wrong the moment the
   // add-on has 26 versions, and wrong in the direction that costs a release: "no" means "submit",
   // and AMO then rejects the duplicate.
-  const page = (versions: string[], next: string | null) =>
-    JSON.stringify({ count: 99, next, results: versions.map((version) => ({ version })) });
+  // `total` defaults to this page's own length, i.e. a single-page list. Multi-page fixtures pass
+  // the real total — a body claiming more versions than the walk ever sees is itself a tested case
+  // below, not something every fixture should assert by accident.
+  const page = (versions: string[], next: string | null, total = versions.length) =>
+    JSON.stringify({ count: total, next, results: versions.map((version) => ({ version })) });
 
   const fakeFetch = (pages: Record<string, string>) => {
     const calls: string[] = [];
@@ -113,8 +124,8 @@ describe("hasVersion paging", () => {
 
   it("finds a version that only appears on the second page", async () => {
     const { impl, calls } = fakeFetch({
-      [FIRST]: page(["0.40.0", "0.39.0"], SECOND),
-      [SECOND]: page(["0.36.0", "0.35.1"], null),
+      [FIRST]: page(["0.40.0", "0.39.0"], SECOND, 4),
+      [SECOND]: page(["0.36.0", "0.35.1"], null, 4),
     });
     const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
     expect(result.status).toBe("yes");
@@ -131,8 +142,8 @@ describe("hasVersion paging", () => {
 
   it("only says no after the whole list is exhausted", async () => {
     const { impl } = fakeFetch({
-      [FIRST]: page(["0.40.0"], SECOND),
-      [SECOND]: page(["0.39.0"], null),
+      [FIRST]: page(["0.40.0"], SECOND, 2),
+      [SECOND]: page(["0.39.0"], null, 2),
     });
     const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
     expect(result).toMatchObject({ status: "no", pages: 2 });
@@ -142,7 +153,7 @@ describe("hasVersion paging", () => {
   it("reports unknown when a later page fails, never no", async () => {
     // The dangerous case: page 1 parsed fine, so a naive implementation would answer from it.
     const { impl } = fakeFetch({
-      [FIRST]: page(["0.40.0"], SECOND),
+      [FIRST]: page(["0.40.0"], SECOND, 2),
       [SECOND]: '{"detail":"Internal Server Error"}',
     });
     const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
@@ -163,7 +174,7 @@ describe("hasVersion paging", () => {
     // `next` is data from a response, not an instruction. Following it anywhere would send the
     // developer's JWT to whatever host the body named.
     const { impl, calls } = fakeFetch({
-      [FIRST]: page(["0.40.0"], "https://evil.example/api/v5/versions/?page=2"),
+      [FIRST]: page(["0.40.0"], "https://evil.example/api/v5/versions/?page=2", 2),
     });
     const result = await hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
     expect(result.status).toBe("unknown");
@@ -173,7 +184,7 @@ describe("hasVersion paging", () => {
 
   it("gives up with unknown rather than looping forever", async () => {
     // A server that always returns a `next` must not spin the job until its timeout.
-    const selfReferential = (async () => ({ text: async () => page(["0.1.0"], FIRST) })) as unknown as typeof fetch;
+    const selfReferential = (async () => ({ text: async () => page(["0.1.0"], FIRST, 999) })) as unknown as typeof fetch;
     const result = await hasVersion({
       addonId: "a@b",
       version: "0.36.0",
@@ -193,5 +204,76 @@ describe("isAmoUrl", () => {
     expect(isAmoUrl("https://addons.mozilla.org.evil.example/x")).toBe(false); // suffix trick
     expect(isAmoUrl("https://evil.example/x")).toBe(false);
     expect(isAmoUrl("not a url")).toBe(false);
+  });
+});
+
+describe("malformed pagination metadata", () => {
+  // Every case here used to produce a confident "no", because `next` was read as "truthy string or
+  // the list ended". A definitive absence is the answer that makes the caller SUBMIT, so a
+  // response this code cannot interpret must never reach it.
+  const body = (extra: Record<string, unknown>) =>
+    JSON.stringify({ count: 1, results: [{ version: "0.40.0" }], ...extra });
+
+  const walk = async (raw: string) => {
+    const impl = (async () => ({ text: async () => raw })) as unknown as typeof fetch;
+    return hasVersion({ addonId: "a@b", version: "0.36.0", token: "t", fetchImpl: impl });
+  };
+
+  it.each([
+    ["a number", 42],
+    ["an object", {}],
+    ["an array", []],
+    ["a boolean", true],
+    ["an empty string", ""],
+  ])("treats next being %s as unknown, not as the end of the list", async (_label, next) => {
+    expect(readNext(body({ next })).kind).toBe("malformed");
+    expect((await walk(body({ next }))).status).toBe("unknown");
+  });
+
+  it.each([
+    ["null", null],
+    ["absent", undefined],
+  ])("treats next being %s as a genuine end of list", async (_label, next) => {
+    const raw = next === undefined ? body({}) : body({ next });
+    expect(readNext(raw).kind).toBe("end");
+    expect((await walk(raw)).status).toBe("no");
+  });
+
+  it("refuses to call it absent when the server counted more than it returned", async () => {
+    // 99 declared, 1 delivered, no next link. The list plainly did not finish, so "not there"
+    // is not a conclusion available from it.
+    const raw = JSON.stringify({ count: 99, next: null, results: [{ version: "0.40.0" }] });
+    const result = await walk(raw);
+    expect(result.status).toBe("unknown");
+    expect(result.reason).toContain("1 version(s) but the server reported 99");
+  });
+
+  it.each([
+    ["a string", "99"],
+    ["a fraction", 1.5],
+    ["negative", -1],
+  ])("treats count being %s as unknown", async (_label, count) => {
+    const raw = JSON.stringify({ count, next: null, results: [{ version: "0.40.0" }] });
+    expect(readCount(raw).kind).toBe("malformed");
+    expect((await walk(raw)).status).toBe("unknown");
+  });
+
+  it("still answers when count is absent entirely", async () => {
+    // A missing optional field must not make the pre-flight useless — the `next` chain remains the
+    // primary signal, and it said the list ended.
+    const raw = JSON.stringify({ next: null, results: [{ version: "0.40.0" }] });
+    expect(readCount(raw).kind).toBe("absent");
+    expect((await walk(raw)).status).toBe("no");
+  });
+
+  it("accepts a count that agrees with what was read", async () => {
+    const raw = JSON.stringify({ count: 1, next: null, results: [{ version: "0.40.0" }] });
+    expect((await walk(raw)).status).toBe("no");
+  });
+
+  it("does not reconcile the count when the version was found", async () => {
+    // Finding it is definitive. A bogus count must not turn a hit into a stop.
+    const raw = JSON.stringify({ count: 999, next: null, results: [{ version: "0.36.0" }] });
+    expect((await walk(raw)).status).toBe("yes");
   });
 });


### PR DESCRIPTION
## What this adds

A `v*` tag already builds and attaches `dfir-capture-extension-firefox-<tag>.zip`. Getting it
onto Mozilla Add-ons was still a manual upload every release. The new **`amo-listing`** job does
it, alongside the existing `chrome-webstore` job and gated identically.

It no-ops until `AMO_JWT_ISSUER` / `AMO_JWT_SECRET` are set, so merging this before the
credentials exist is safe — the same pattern the Chrome job already uses.

## Three ways it differs from the Chrome job

**It signs the unpacked release artifact, not a fresh build.** `web-ext sign` takes a directory,
so the job unzips the artifact. Rebuilding could submit bytes that differ from the asset attached
to the GitHub Release.

**It uploads the source with every version.** Our bundles are minified, so AMO rejects a
submission whose code a reviewer cannot read — and it asks per version, not just the first. The
job builds that archive with `git archive HEAD:extension` (committed files only: no
`node_modules`, no build output, nothing gitignored), and the new `extension/BUILD.md` rides at
its root carrying the build instructions Mozilla requires. A guard fails the job if that file
ever stops being included.

**It does not wait for approval.** A listed version goes to human review, hours to days. Without
`--approval-timeout 0`, web-ext blocks until the job timeout kills it and a *successful*
submission reports as a red release.

> **A green tag means "accepted for review", never "live".** A human reviewer still has to
> approve it. The README says so where someone will look for it.

## Verification, not optimism

`web-ext` exiting 0 is not proof AMO holds the version, which is the lesson the Chrome job's
verify step already encodes. The new step asks AMO directly, minting the API's HS256 JWT inline.

The response parser was exercised against five shapes before I trusted it — a hit, a miss, an
empty list, an auth-error body, and non-JSON. Only a real hit passes; every other shape fails the
job.

## The gate, and proof it can fail

`companion/tests/architecture/amoSubmissionJob.test.ts` (8 tests) guards the tag gate, the
artifact name, the source upload, the approval timeout, the verify step's `exit 1`, the add-on ID
agreeing with `manifest-firefox.mjs`, and that every step is skipped without credentials.

Every assertion was mutation-tested by breaking the workflow and confirming the suite goes red:

| Mutation | Result |
|---|---|
| AMO job downloads `extension-zip` (the Chrome package) | red |
| `--upload-source-code` removed | red |
| `--approval-timeout 0` removed | red |
| verify step's `exit 1` removed | red |
| credential check's `configured=false` removed | red |

Two of those first hit the wrong occurrence in the file and proved nothing — a mutation that
passes is not evidence the gate works, so I retargeted both and re-ran.

## Also

Drops a stale "Firefox 128 is the floor" line that #620 missed.

## Gates

`npx vitest run` in companion: **10,056 passed**, 656 files. Extension: 245 passed. Lint, format,
size, imports, boundaries, eval gate, us-map, both typechecks, both builds — all clean.

## Second round: the job worked once, and only once

Three defects in running it a second time, or from a `workflow_dispatch`.

**Re-runs failed.** AMO refuses a version number it already holds, and the submit step ran
whenever credentials existed. Re-running a release after some *other* job fails is routine — so
the second run turned a good submission into a red release whose only route back to green was
burning a version number. A pre-flight now asks AMO whether the version is there and skips the
upload if so; verification still runs on that path, so a skipped run confirms rather than assumes.

Critically, **"cannot tell" is not "no"**. An auth failure, an AMO outage, or a non-JSON body
all stop the job. Treating them as absence is exactly what produces the duplicate.

**It could ship mismatched source.** Mozilla receives a source archive built by this job and a
binary built by `extension-zip`. A dispatch naming a tag while the checkout resolves to a branch
desynchronises them, and submitting source that does not correspond to the add-on is a policy
violation. The job now compares the version in the checked-out manifest against the version inside
the downloaded package and refuses to submit if they differ. The checkout deliberately pins **no**
`ref` for the same reason — `extension-zip`'s checkout is refless, so pinning only this one is
what would *create* the mismatch. My first cut carried a comment claiming it read "the tagged
tree", which was untrue on the dispatch path. The comment is now the check.

**It was not reproducible.** `web-ext` was pinned to a major, so the run that ships a release
could differ from the run that tested it. Pinned exactly.

### The API calls are now testable

They moved out of `node -e` blocks into `extension/scripts/amoApi.mjs`, because logic that only
executes on a tag is logic nobody tests. 13 unit tests, including the three shapes that must never
read as "no" — an auth-error body, a non-JSON body, and a `results` field that is not an array
— plus exact-match (so `0.36.0-beta` never satisfies `0.36.0`).

Exercised against the live API too: bad credentials return `Unknown JWT iss (issuer)` and the CLI
exits 2 with empty stdout, so the workflow stops instead of guessing.

### Gate: 8 assertions → 13, all mutation-tested

| Mutation | Result |
|---|---|
| Submit step ungated from the pre-flight | red |
| Pre-flight step removed | red |
| Verify step gated on the skip | red |
| Source/package check deleted | red |
| Checkout pinned to a ref | red |
| `web-ext` pin loosened to `@latest` | red |

Suites: companion **10,061 passed**, extension **258 passed**, lint/format/typecheck clean.

## Third round: the pre-flight judged from the first 25 versions

AMO's versions endpoint **paginates at 25**, and the check read one page and answered from it. So
the moment this add-on has 26 versions, a version on page 2 reads as *absent* — and absent means
submit, which AMO rejects as a duplicate. Re-running an older tag's workflow is exactly when the
version sought sits deep in the list, which is the case the pre-flight exists to survive.

`hasVersion()` now follows `next` to the end. **"No" is returned only after the list is
exhausted**; every incomplete read is unknown, which the workflow already treats as a stop:

- a page that fails or returns an error body **even when page 1 parsed cleanly** — the case a
  naive implementation gets wrong most confidently;
- a `next` that is not on `addons.mozilla.org`. That field is data from a response, not an
  instruction; following it anywhere would hand the developer's JWT to whatever host the body
  named. A test asserts the off-site URL is never fetched;
- running past the page budget, so a server that always returns a `next` cannot spin the job
  until its timeout.

### Documented rather than pretended away

AMO also reserves the numbers of **deleted** versions, but listing those needs
`filter=all_with_deleted`, which requires admin permissions a developer token does not have. That
case still fails at upload — loudly and correctly. The pre-flight cannot pre-empt it, and the
README says so instead of implying full coverage.

### Tests

8 new: a hit on page 2, a hit on page 1 that must **not** fetch page 2, exhaustion, a page-2
failure after a clean page 1, the off-site `next`, and the loop bound. `isAmoUrl` is tested
against the `http` downgrade and the `addons.mozilla.org.evil.example` suffix trick.

Extension suite **266 passing**, companion **10,061**, lint/format/typecheck clean.

## Fourth round: malformed pagination read as a definitive absence

`readNext()` answered a three-way question with a boolean. `next: null` (the list really ended),
`next: 42` / `{}` / `""` (a response this code cannot interpret) and an unparseable body all
collapsed to the same falsy `null` — and the caller turned every one into **"no"**. "No" is
the answer that makes the workflow submit, so an unintelligible page produced a confident
duplicate upload: the same failure the pre-flight exists to prevent, reached by a different route.

It now returns `url` / `end` / `malformed`, and only `end` may become an absence.

**The second half is the server's own count.** A body claiming 99 versions while returning one and
no `next` is not an exhausted list — but it satisfied the `next` chain and answered "no".
`hasVersion()` now reconciles what it read against `count` before concluding anything, and
treats a count that is present but not a whole number as malformed. An **absent** count still
answers from the `next` chain: failing every run over a missing optional field would make the
pre-flight useless.

Finding the version short-circuits both checks — a hit is definitive, and a bogus count must not
turn it into a stop.

### The guard earned its place immediately

It failed an existing test of mine whose fixture declared `count: 99` while returning two
versions. The fixture was wrong, not the guard. Every multi-page fixture now states an honest
total, and the inconsistent case is asserted deliberately instead of by accident.

### Mutation-tested

| Mutation | Result |
|---|---|
| Restore the old falsy-collapse in `readNext` | 5 tests red |
| Disable the count reconciliation | 1 test red |

14 new tests. Extension suite **280 passing**, architecture **98**, lint/format/typecheck clean.

## Fifth round: an unreadable entry is not evidence of absence

`findVersion()` mapped every result entry to `v.version` or the placeholder `"?"`, then
answered from that list. An entry whose version string cannot be read is a version this code **did
not read** — it may be the very one being sought. Concluding "not found" from it is a contract
violation dressed up as an answer, and "not found" is what makes the workflow submit.

**The placeholders did second damage.** They padded `seen`, which is exactly what the count
reconciliation from the previous round compares against the server's total. A page of two entries
with one unreadable and `count: 2` reconciled perfectly while half the list had never been read —
the guard meant to catch a short read was defeated by the thing it was meant to catch.

Now: a readable hit wins outright (the version being present leaves nothing uncertain and nothing
to submit); otherwise any unreadable entry makes the page unknown; only an all-readable page with
no hit is an absence. `seen` carries genuinely read versions only, so the count check means what
it says.

### Mutation-tested

| Mutation | Result |
|---|---|
| Drop the unreadable-entry guard | 7 tests red |
| Restore the `"?"` placeholder in `seen` | 1 test red |

9 new tests: null entries, a numeric version, a missing version key, a bare string in place of an
object, the hit-wins precedence, `seen` excluding unread entries, and placeholders no longer
satisfying the count.

Extension suite **289 passing**, companion **10,061**, lint/format/typecheck clean.

## Sixth round: a blank version string is unread, not empty

`""` is a string, and that was the whole defect. It satisfied the `typeof` check, entered the
list of versions read, and let a page containing an entry whose version was never really read
return a confident "not there" — the answer that makes the workflow submit. Demonstrated before
fixing:

    {"status":"no","seen":["","0.40.0"]}

It also padded `seen` to two, so a body declaring `count: 2` reconciled while half its list had
gone unread. **That is the third time a placeholder has beaten the count guard** — after `"?"`,
and now this.

`readNext` has always rejected empty strings. `isReadableVersion` applies the same standard
where it was missing, and trims, so `" "` and `"\t"` are unread too.

### Two related holes closed

`findVersion` now **throws** on a blank version *argument* rather than answering. It is a
programming error, and a quiet one: a blank query matches a blank entry, and against a healthy list
returns a confident absence. The CLI's `!version` guard let `" "` through and now uses the same
predicate.

The workflow reads `$VERSION` from the packaged manifest with `node -p`, which prints the
string `"undefined"` for a missing key — truthy in shell, and it would have sailed on to be
asked about, not found, and submitted. It is now checked where it enters.

### A diagnostic bug found while testing

`hasVersion` discarded the versions it *had* read from a page it rejects, so a stopped release
logged "saw nothing" and read like a broken token. My test asserted the more useful contract and
the code did not meet it — I fixed the code, not the test. Partial reads are now reported.

11 new tests. Mutation-tested: dropping the trim from `isReadableVersion` turns **6** red.

Extension suite **296 passing**, companion **10,061**, architecture **98**, lint/format/typecheck
clean.

## Seventh round: the version validator was a doorframe, not a door

The guard added last round was `case "$VERSION" in [0-9]*.[0-9]*`. It accepted:

| Value | Why it should have failed |
|---|---|
| `0abc.9xyz` | letters — but it starts with a digit and has a dot |
| `2.01` | leading zero, which AMO rejects |
| `1.2-beta` | `version_name` is the field for that |
| `1.2.3.4.5` | five parts; AMO allows four |
| `1.2 && curl evil.example` | a shell fragment |

Replaced with **Mozilla's published rule**, quoted from MDN rather than invented:

    ^(0|[1-9][0-9]{0,8})([.](0|[1-9][0-9]{0,8})){0,3}$

One to four dot-separated numbers, digits only, at most nine digits per part, no leading zeros
except a bare `0`.

It lives in `amoApi.mjs`, which is the point. A glob buried in a workflow that only runs on a tag
cannot be unit-tested, and this one was wrong in five ways. The workflow now calls
`amoApi.mjs check-version`, and `has-version` holds its argument to the same rule — querying a
malformed version can only ever answer "not found", which means submit.

### Tests

30 new, including MDN's own valid and invalid examples, both whitespace paddings, `undefined`
(what `node -p` prints for a missing key), non-strings, that the pattern is anchored at both ends,
and that it accepts **the version this repository actually ships** — a validator that rejected our
own manifest would fail every release rather than protect one.

| Mutation | Result |
|---|---|
| Remove the regex anchors | 13 tests red |
| Drop the format check, keep only the blank check | 13 tests red |

The architecture gate now also fails if the workflow regresses to a shell glob.

Extension suite **326 passing**, companion **10,062**, architecture **99**, lint/format/typecheck
clean.