### PR TITLE
fix(e2e): build caseCreate ids from the shared helper, not a lossy copy

### DIFF
--- a/companion/tests/e2e/fixtures/test.ts
+++ b/companion/tests/e2e/fixtures/test.ts
@@ -1,4 +1,4 @@
-import { test as base } from "@playwright/test";
+import { test as base, type TestInfo } from "@playwright/test";
 import { seedDemoCase } from "./api.js";
 
 /**
@@ -13,18 +13,26 @@ import { seedDemoCase } from "./api.js";
  *
  * testId is unique per test and stable across a run; retry disambiguates attempts of the same
  * test, which is what the counter was originally added to fix. Together they need no shared state.
+ *
+ * EXPORTED because a spec that builds its own case id needs the same three inputs, and a private
+ * copy is what went wrong before: caseCreate.spec.ts grew a hand-rolled version that dropped
+ * workerIndex and retry AND truncated testId, so its creating test answered 409 on every CI retry.
+ * One helper, one set of traps.
  */
-function caseIdFor(testId: string, workerIndex: number, retry: number): string {
+export function caseIdFor(prefix: string, testInfo: TestInfo): string {
   // NOT truncated. Playwright's testId is <fileHash>-<indexWithinFile>, so cutting it to a fixed
   // prefix keeps the file hash and drops the part that distinguishes tests — every test in a file
   // then shares one case id, which is strictly worse than the counter this replaced.
-  const safe = testId.replace(/[^\w.-]/g, "");
-  return `e2e-demo-w${workerIndex}-r${retry}-${safe}`;
+  //
+  // isValidCaseId (src/storage/caseStore.ts) caps a case id at 80 characters, and the untruncated
+  // form runs about 60 with a short prefix, so keep prefixes short rather than trimming testId.
+  const safe = testInfo.testId.replace(/[^\w.-]/g, "");
+  return `${prefix}-w${testInfo.workerIndex}-r${testInfo.retry}-${safe}`;
 }
 
 export const test = base.extend<{ demoCase: string }>({
   demoCase: async ({ baseURL }, use, testInfo) => {
-    const caseId = caseIdFor(testInfo.testId, testInfo.workerIndex, testInfo.retry);
+    const caseId = caseIdFor("e2e-demo", testInfo);
     await seedDemoCase(baseURL ?? "http://127.0.0.1:4788", caseId);
     await use(caseId);
   },

--- a/companion/tests/e2e/workflows/caseCreate.spec.ts
+++ b/companion/tests/e2e/workflows/caseCreate.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../fixtures/test.js";
+import { test, expect, caseIdFor } from "../fixtures/test.js";
 import type { Locator, Page } from "@playwright/test";
 
 // Covers: US-002
@@ -48,13 +48,8 @@ async function openDashboard(page: Page): Promise<void> {
   await expect(page.locator("#newCaseBtn")).toBeEnabled();
 }
 
-/** Unique per test run; POST /cases rejects ids outside [A-Za-z0-9._-]. */
-function freshCaseId(prefix: string, testId: string): string {
-  return `${prefix}-${testId.replace(/[^\w.-]/g, "").slice(0, 10)}`;
-}
-
 test("creates a case through the dialog and connects to it", async ({ page }, testInfo) => {
-  const caseId = freshCaseId("e2e-ui", testInfo.testId);
+  const caseId = caseIdFor("e2e-ui", testInfo);
   await openDashboard(page);
 
   const dialog = await openNewCaseDialog(page);
@@ -115,7 +110,7 @@ test("refuses malformed case metadata without creating a case", async ({ page },
   ];
 
   for (const [index, entry] of malformed.entries()) {
-    const caseId = freshCaseId(`e2e-type-${index}`, testInfo.testId);
+    const caseId = caseIdFor(`e2e-type-${index}`, testInfo);
     const data: Record<string, unknown> = {
       caseId,
       name: "E2E boundary case",


### PR DESCRIPTION
## The problem

`caseCreate.spec.ts` built its case ids with a private helper that dropped both guards the
fixture's `caseIdFor()` documents at length:

```ts
function freshCaseId(prefix: string, testId: string): string {
  return `${prefix}-${testId.replace(/[^\w.-]/g, "").slice(0, 10)}`;
}
```

**No `workerIndex` or `retry`.** `playwright.config.ts` sets `retries: 1` in CI, and "creates a
case through the dialog" genuinely creates a case. On a retry the id repeated, `POST /cases`
answered 409, the dialog stayed open on "a case with that id already exists", and
`expect(dialog).not.toHaveClass(/\bopen\b/)` failed. The retry then buried whatever caused the
first attempt to fail — the exact opposite of what a retry is for.

**`.slice(0, 10)` truncated the wrong half.** Playwright's testId is `<fileHash>-<testHash>`, 41
characters in this repo. Cutting to 10 kept half the FILE hash and dropped the per-test half
entirely, so every test in the file collapsed onto one id.

The fixture's own comment warns about both traps. Comments do not travel with a copy.

## The fix

`caseIdFor()` is now exported from `tests/e2e/fixtures/test.ts` with a prefix parameter, and the
spec's private copy is deleted. Pasting the warnings into the second helper would have left two
definitions free to drift again, which is how this happened. No other file in `tests/e2e/` builds
a case id by hand.

Ids run 54 characters, well under the 80-character cap in `isValidCaseId`.

## Verification

Ran the forced-failure harness against **both** the old and the new helper — a green run of the
fixed code alone would not prove the reproduction ever fired. With
`if (testInfo.retry === 0) throw new Error("forced")` injected after the case is created:

| | attempt 0 | attempt 1 | result |
|---|---|---|---|
| before | `e2e-ui-3f8ff3b659` (17) | `e2e-ui-3f8ff3b659` (17) | **1 failed** — retry died on `not.toHaveClass(/open/)` |
| after | `e2e-ui-w0-r0-…` (54) | `e2e-ui-w1-r1-…` (54) | **1 flaky, 4 passed**, exit 0 |

With the probe removed: `caseCreate.spec.ts` 5 passed; `caseLifecycle.spec.ts` + `panels.spec.ts`
(both use the `demoCase` fixture) 31 passed. The fixture's own ids are byte-identical to before.

Found while adding `analystJourney.spec.ts`, whose case id was copied from this same helper.

## Analyst impact

None. This is test infrastructure only — no route, no dashboard surface, no report changes.
