### PR TITLE
docs: put the Velociraptor hunt bundles in the analyst walkthrough as step 3a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`docker compose pull` fetches the current release again** — the compose image tag sat at 0.34.0 for the whole 0.35.x line, so users got a container a full release behind their checkout. A gate now fails when any of the six version-bearing files disagree.
 
 ### Changed
+- **The analyst walkthrough now starts with the Velociraptor hunt bundles** — a new **Step 3a** covers running the built-in **Best Practice** sweep on every case and the optional **Super-Timeline Triage**, says where each one's results land (forensic timeline vs. super-timeline only), and gives the run procedure; importing artifact files becomes Step 3b. The Velociraptor integration reference also stops naming **Fast Triage** / **Full Triage**, two bundles the app replaced with Best Practice long ago.
 - **The Firefox add-on now requires Firefox 140** (was 128) — 140 is the first release that shows the data-collection consent screen, and Mozilla does not permit collecting without one. 140 is itself an ESR and 128 ESR ended in September 2025.
 
 ## [0.35.1] - 2026-08-22

--- a/README.md
+++ b/README.md
@@ -1080,8 +1080,9 @@ velociraptor --config server.config.yaml config api_client --name dfir --role ad
 | `DFIR_PBHUNT_SUGGEST_MAX` | `30` | Max number of **AI-suggested playbook hunts** returned per generation (one per endpoint-related task; needs an AI provider) |
 
 **Triage bundles** (**Settings → Velociraptor** tab): *Browse server artifacts* lists the server's collectable
-`CLIENT` artifacts; assemble + save named **bundles** (a single **Best Practice** quick-wins sweep ships by
-default, stored globally next to `cases/` in `bundles/`). **Every bundle, built-ins included, is editable in
+`CLIENT` artifacts; assemble + save named **bundles** (three ship built-in — **Best Practice** (quick-wins
+sweep), **Super-Timeline Triage** (raw host artifacts, routed to the super-timeline only) and **Linux
+Triage** — stored globally next to `cases/` in `bundles/`). **Every bundle, built-ins included, is editable in
 place** — an edit saves an override; **Reset to default** discards it. **Run** one as a hunt (optionally scoped
 by include/exclude labels + OS, and a **minimum-severity** import floor). The **collection timeout** is a bundle
 setting (configured in the editor — bump it for slow artifacts like THOR; Velociraptor's default is 600 s) and is

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -204,9 +204,38 @@ For specifically recognized consoles (Security Onion Alerts/Hunt, Kibana, SO-CRA
 
 **What gets captured:** the full visible tab content (a screenshot) plus the URL and tab title. Evidence is stored to disk immediately — before any AI analysis.
 
-### Step 3 — Import artifact files
+### Step 3a — Run the Velociraptor hunt bundles
 
-While screenshots are great for consoles, you should also import raw artifact exports whenever possible. Raw exports give the AI more structured data.
+If Velociraptor is connected, start here. A hunt bundle collects a named set of artifacts from every enrolled endpoint and imports the results for you. No manual export, no file picker.
+
+Open **Settings → Velociraptor**. Three bundles ship built-in:
+
+| Bundle | What it collects | Where results land |
+|--------|------------------|--------------------|
+| **Best Practice** | The quick-wins detection sweep — DetectRaptor rules, Hayabusa, Chainsaw, THOR, condensed account usage, process and network state, persistence, scheduled tasks | Forensic timeline (the AI sees them) |
+| **Super-Timeline Triage** *(optional)* | Raw host artifacts — MFT, USN journal, prefetch, amcache, shellbags, SRUM, jump lists, registry, event logs | **Super-timeline only** |
+| **Linux Triage** | Linux host triage — users, persistence, network, packages, detection artifacts | Forensic timeline |
+
+**Run Best Practice on every case.** It is the fastest path from "a case exists" to "the dashboard has findings".
+
+**Super-Timeline Triage is optional.** Its artifacts hold hundreds of thousands of rows, so its results go to the super-timeline and never to the forensic timeline — they would drown synthesis. Run it when you need file-level or execution-level detail, then promote the rows that matter up from the **Super-Timeline** panel (Section 9). Skip it on a first pass.
+
+To run a bundle:
+
+1. Connect the case you want the results in. **▶ Run** stays disabled until a case is selected — a collection has to land somewhere.
+2. Click **▶ Run** on the bundle.
+3. Set the run options: wait minutes, hunt expiry (1 hour / 1 day / 1 week), client OS, minimum severity, time scope, and include/exclude labels. The defaults are fine for a first pass.
+4. Click **Run hunt**.
+
+The hunt runs on every enrolled client unless you set a label or OS filter. After the wait, the Companion collects the results, imports them, and synthesizes. Click **Collect now** on the job card to pull early.
+
+> **Tip — cut the volume before the hunt, not after.** Set a **time scope** (e.g. last 7 days) to bound the collection at the source, and a **minimum severity** to hold back low-value rows at import. Both controls are on the run form.
+
+Every bundle is editable, built-ins included. Open **Edit** to add or drop artifacts, raise the collection timeout for slow artifacts like THOR, or tune per-artifact parameters and exclude filters. **Reset to default** restores a shipped built-in.
+
+### Step 3b — Import artifact files
+
+Import raw artifact exports for anything a bundle did not collect — an offline host, a third-party tool's output, a phishing sample. Raw exports give the AI more structured data than a screenshot does.
 
 Click the **Import** button (toolbar, top of dashboard). A file picker opens. Drag or select any of the supported file types (see Section 7 for the full list). The server auto-detects the format and imports it.
 
@@ -1129,9 +1158,9 @@ Run fleet hunts, collect artifacts, and stream live monitoring events into cases
 - Custom VQL hunts from the dashboard
 - Per-hunt auto-collect (results import automatically after `DFIR_VELO_HUNT_WAIT_MIN`)
 - Live CLIENT_EVENT monitoring (see Section 15)
-- Triage bundles (Fast Triage / Full Triage / custom)
+- Triage bundles (Best Practice / Super-Timeline Triage / Linux Triage / custom)
 
-**Triage bundles:** Settings → Velociraptor → Bundles. Built-in bundles include Fast Triage (quick artifact set) and Full Triage (comprehensive). You can create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results.
+**Triage bundles:** Settings → Velociraptor. Three bundles ship built-in — **Best Practice** (quick-wins detection sweep), **Super-Timeline Triage** (raw host artifacts, super-timeline only), and **Linux Triage**. Every bundle is editable in place, and **Reset to default** restores a built-in. You can also create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results. See Section 4, Step 3a for the walkthrough.
 
 ### DFIR-IRIS
 

--- a/mkdocs-docs/reference/integrations.md
+++ b/mkdocs-docs/reference/integrations.md
@@ -31,11 +31,11 @@ Run fleet hunts, collect artifacts, and stream live monitoring events into cases
 - Custom VQL hunts from the dashboard
 - Per-hunt auto-collect (results import automatically after `DFIR_VELO_HUNT_WAIT_MIN`)
 - Live CLIENT_EVENT monitoring (see [Live Monitoring](live-monitoring.md))
-- Triage bundles (Fast Triage / Full Triage / custom)
+- Triage bundles (Best Practice / Super-Timeline Triage / Linux Triage / custom)
 
 ### Triage Bundles
 
-Settings → Velociraptor → Bundles. Built-in bundles include **Fast Triage** (quick artifact set) and **Full Triage** (comprehensive). You can create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results.
+Settings → Velociraptor. Three bundles ship built-in — **Best Practice** (the quick-wins detection sweep), **Super-Timeline Triage** (raw host artifacts; results go to the super-timeline only), and **Linux Triage**. Every bundle is editable in place, and **Reset to default** restores a built-in. You can also create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results. See [Step 3a of the walkthrough](../walkthrough.md) for the run procedure.
 
 #### Third-party tools
 

--- a/mkdocs-docs/walkthrough.md
+++ b/mkdocs-docs/walkthrough.md
@@ -34,9 +34,41 @@ For specifically recognised consoles (Security Onion Alerts/Hunt, Kibana, SO-CRA
 
 ---
 
-## Step 3 — Import artifact files
+## Step 3a — Run the Velociraptor hunt bundles
 
-While screenshots are great for consoles, you should also import raw artifact exports whenever possible. Raw exports give the AI more structured data.
+If Velociraptor is connected, start here. A hunt bundle collects a named set of artifacts from every enrolled endpoint and imports the results for you. No manual export, no file picker.
+
+Open **Settings → Velociraptor**. Three bundles ship built-in:
+
+| Bundle | What it collects | Where results land |
+|--------|------------------|--------------------|
+| **Best Practice** | The quick-wins detection sweep — DetectRaptor rules, Hayabusa, Chainsaw, THOR, condensed account usage, process and network state, persistence, scheduled tasks | Forensic timeline (the AI sees them) |
+| **Super-Timeline Triage** *(optional)* | Raw host artifacts — MFT, USN journal, prefetch, amcache, shellbags, SRUM, jump lists, registry, event logs | **Super-timeline only** |
+| **Linux Triage** | Linux host triage — users, persistence, network, packages, detection artifacts | Forensic timeline |
+
+**Run Best Practice on every case.** It is the fastest path from "a case exists" to "the dashboard has findings".
+
+**Super-Timeline Triage is optional.** Its artifacts hold hundreds of thousands of rows, so its results go to the super-timeline and never to the forensic timeline — they would drown synthesis. Run it when you need file-level or execution-level detail, then promote the rows that matter up from the [Super-Timeline panel](reference/dashboard.md). Skip it on a first pass.
+
+To run a bundle:
+
+1. Connect the case you want the results in. **▶ Run** stays disabled until a case is selected — a collection has to land somewhere.
+2. Click **▶ Run** on the bundle.
+3. Set the run options: wait minutes, hunt expiry (1 hour / 1 day / 1 week), client OS, minimum severity, time scope, and include/exclude labels. The defaults are fine for a first pass.
+4. Click **Run hunt**.
+
+The hunt runs on every enrolled client unless you set a label or OS filter. After the wait, the Companion collects the results, imports them, and synthesizes. Click **Collect now** on the job card to pull early.
+
+!!! tip "Cut the volume before the hunt, not after"
+    Set a **time scope** (e.g. last 7 days) to bound the collection at the source, and a **minimum severity** to hold back low-value rows at import. Both controls are on the run form.
+
+Every bundle is editable, built-ins included. Open **Edit** to add or drop artifacts, raise the collection timeout for slow artifacts like THOR, or tune per-artifact parameters and exclude filters. **Reset to default** restores a shipped built-in.
+
+---
+
+## Step 3b — Import artifact files
+
+Import raw artifact exports for anything a bundle did not collect — an offline host, a third-party tool's output, a phishing sample. Raw exports give the AI more structured data than a screenshot does.
 
 Click the **Import** button (toolbar, top of dashboard). A file picker opens. Drag or select any of the supported file types (see [Importing Evidence](reference/importing.md) for the full list). The server auto-detects the format and imports it.
 


### PR DESCRIPTION
## What

The analyst walkthrough sent you straight to the Import file picker. If Velociraptor is connected, a hunt bundle collects the same evidence with one click, and nothing in the walkthrough said so.

New **Step 3a — Run the Velociraptor hunt bundles**. The old Step 3 becomes **Step 3b**.

## Step 3a covers

- A table of the three built-ins and, critically, **where each one's results land**:
  - **Best Practice** → forensic timeline. Run it on every case.
  - **Super-Timeline Triage** *(optional)* → **super-timeline only**. `superTimelineOnly` keeps MFT/USN/prefetch/SRUM out of the forensic timeline; hundreds of thousands of rows would drown synthesis. You promote what matters from the Super-Timeline panel.
  - **Linux Triage** → forensic timeline.
- The run procedure, including that **▶ Run** stays disabled until a case is connected (`veloRunBlockedReason`, [#628](https://github.com/hasamba/DFIR-Companion/pull/628)).
- Time scope and minimum severity as the two volume controls, both bounding at the source.
- That every bundle is editable, with **Reset to default** for built-ins.

Step 3b's lead-in now says what it is for after a bundle run: offline hosts, third-party tool output, phishing samples.

## Stale docs fixed alongside

These contradicted the new step, so they had to move with it:

- `mkdocs-docs/reference/integrations.md` and `USER_MANUAL.md` §14 both advertised **Fast Triage** and **Full Triage**. Those bundles left `artifactBundleStore.ts` in `5087e58b`.
- `README.md` said "a single **Best Practice** quick-wins sweep ships by default". Three ship.

## Files

| File | Change |
|------|--------|
| `USER_MANUAL.md` | Step 3a added, Step 3 → 3b, §14 bundle names |
| `mkdocs-docs/walkthrough.md` | same, in mkdocs style |
| `mkdocs-docs/reference/integrations.md` | bundle names |
| `README.md` | built-in count |
| `CHANGELOG.md` | Unreleased → Changed |

Docs only. No source, no behavior change.

## Verification

| Gate | Result |
|------|--------|
| `lint` / `format:check` / `check:size` / `check:imports` / `check:boundaries` / `check:us-map` | exit 0 |
| `build` (tsc) / `typecheck` | exit 0 |
| `npm test` | 10170 passed, 2 failed |

The two failures are the known full-suite contention pattern, not this diff:

```
FAIL tests/analysis/caseExportArchive.test.ts > rejects a reserved Windows device name
FAIL tests/analysis/siemImport.test.ts > costs LINEAR time in the input, not quadratic
```

Both pass on re-run in isolation (122/122, exit 0). A markdown-only diff cannot reach either one.

`format:check` reports no changed files because `format-changed.mjs` excludes `.md` by design — the repo's markdown is hand-laid-out prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)