### PR TITLE
fix(ci): put the Windows suite's temp root on the runner's fast disk

### DIFF
--- a/.github/workflows/windows-test-bench.yml
+++ b/.github/workflows/windows-test-bench.yml
@@ -1,4 +1,4 @@
-# TEMPORARY measurement harness for the "Companion test (Windows)" starvation false positives
+# Measurement harness for the "Companion test (Windows)" starvation false positives
 # (issue #173, PR #642). It exists to answer one question with numbers instead of guesses: WHICH
 # change removes the Windows-only timeouts — and at what cost in wall time.
 #
@@ -8,8 +8,8 @@
 # nothing: every leg runs 3 times and the legs are compared on their medians.
 #
 # It is kept rather than deleted because it is the only thing that can settle the next round of
-# this argument. It cannot fire on a PR or on master — only an explicit push to a bench/** branch
-# runs it — so it costs nothing until someone deliberately wants numbers.
+# this argument. It never runs unless someone deliberately asks for numbers on a bench/** branch —
+# see the trigger and the job guard below, which enforce that between them.
 #
 # Results that produced the current configuration (run 32940797230, medians of 3):
 #
@@ -26,9 +26,14 @@
 # overlaps its neighbours at n=3 and was not treated as a difference.
 name: Windows test bench
 
-# Pushing this branch pattern is the trigger: workflow_dispatch alone would not work, because
-# GitHub only registers a dispatchable workflow once it exists on the default branch, and this one
-# is deliberately never merged there.
+# Two ways in, and NEITHER is self-limiting on its own. `push` is filtered to bench/** here, but a
+# branch filter does not apply to a manual event: once this file is on the default branch GitHub
+# registers workflow_dispatch there, and dispatching it with the default master ref would launch all
+# 18 Windows legs. The `if` on the job below is what actually holds the line, so keep the two
+# together — the filter here is documentation, the guard there is the control.
+#
+# workflow_dispatch is kept rather than dropped because it is the only way to re-measure an existing
+# bench branch without pushing an empty commit to it.
 on:
   push:
     branches: ["bench/**"]
@@ -45,6 +50,10 @@ concurrency:
 jobs:
   bench:
     name: bench
+    # THE cost guard. 18 Windows legs is several hours of runner time, so this must never start by
+    # accident — a dispatch from master (the default ref in the Actions UI) skips every leg for free
+    # rather than billing for them. Pushing or dispatching a bench/** branch is the only way in.
+    if: startsWith(github.ref, 'refs/heads/bench/')
     runs-on: windows-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/windows-test-bench.yml
+++ b/.github/workflows/windows-test-bench.yml
@@ -7,7 +7,23 @@
 # IDENTICAL commit vary by 1.75x at the median per test file, so a single before/after pair proves
 # nothing: every leg runs 3 times and the legs are compared on their medians.
 #
-# Delete this workflow once the winning configuration has landed in ci.yml / vitest.config.ts.
+# It is kept rather than deleted because it is the only thing that can settle the next round of
+# this argument. It cannot fire on a PR or on master — only an explicit push to a bench/** branch
+# runs it — so it costs nothing until someone deliberately wants numbers.
+#
+# Results that produced the current configuration (run 32940797230, medians of 3):
+#
+#   config              wall      test phase   per-file p90   timeouts
+#   fastdisk            383.9s    567.4s         914ms        0/3     <- shipped
+#   fastdisk-cap2       419.1s    427.7s         626ms        0/3
+#   fastdisk-defender   437.5s    683.5s        1000ms        0/3
+#   defender            660.7s   1420.8s        5469ms        0/3
+#   baseline            748.8s   1667.9s        6381ms        0/3
+#   cap2                875.4s   1240.1s        4364ms        0/3
+#
+# Only the disk move is decisive: its wall-time range (260-445s) does not overlap baseline's
+# (651-768s). Capping the pool is decisively WORSE than baseline (828-956s). Everything else
+# overlaps its neighbours at n=3 and was not treated as a difference.
 name: Windows test bench
 
 # Pushing this branch pattern is the trigger: workflow_dispatch alone would not work, because

--- a/.github/workflows/windows-test-bench.yml
+++ b/.github/workflows/windows-test-bench.yml
@@ -1,0 +1,125 @@
+# TEMPORARY measurement harness for the "Companion test (Windows)" starvation false positives
+# (issue #173, PR #642). It exists to answer one question with numbers instead of guesses: WHICH
+# change removes the Windows-only timeouts — and at what cost in wall time.
+#
+# The config comment in companion/vitest.config.ts explicitly rejects "raise the timeout again" as
+# a fix, so any change here has to be justified against a measured baseline. Windows runs of an
+# IDENTICAL commit vary by 1.75x at the median per test file, so a single before/after pair proves
+# nothing: every leg runs 3 times and the legs are compared on their medians.
+#
+# Delete this workflow once the winning configuration has landed in ci.yml / vitest.config.ts.
+name: Windows test bench
+
+# Pushing this branch pattern is the trigger: workflow_dispatch alone would not work, because
+# GitHub only registers a dispatchable workflow once it exists on the default branch, and this one
+# is deliberately never merged there.
+on:
+  push:
+    branches: ["bench/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never cancel a bench run — a half-finished matrix has no comparable medians.
+concurrency:
+  group: windows-test-bench-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bench:
+    name: bench
+    runs-on: windows-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # fastdisk: put the vitest temp root on RUNNER_TEMP (D:, the VM's attached SSD) instead of
+        #           os.tmpdir() (C:, the network-attached Azure OS disk).
+        # defender: exclude the workspace and the temp root from real-time scanning.
+        # cap2:     hold the fork pool at 2 instead of vitest's default (availableParallelism - 1 = 3).
+        config:
+          [baseline, fastdisk, defender, fastdisk-defender, cap2, fastdisk-cap2]
+        run: [1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: companion/package-lock.json
+
+      - name: Install dependencies
+        working-directory: companion
+        run: npm ci
+
+      - name: Build (tsc type-check)
+        working-directory: companion
+        run: npm run build
+
+      # Measures the thing the fastdisk leg is betting on, so a wall-time win can be explained
+      # rather than just observed: per-file create+write+fsync+unlink latency on each disk, plus
+      # the core count that decides vitest's default fork pool.
+      - name: Probe disks
+        shell: bash
+        run: |
+          cat > probe.mjs <<'EOF'
+          import { mkdtempSync, writeFileSync, openSync, fsyncSync, closeSync, unlinkSync, rmSync } from "node:fs";
+          import { tmpdir, availableParallelism, cpus, totalmem } from "node:os";
+          import { join } from "node:path";
+          const N = 300;
+          function probe(label, base) {
+            if (!base) return console.log(`PROBE ${label} base=<unset> skipped`);
+            const dir = mkdtempSync(join(base, "probe-"));
+            const t0 = process.hrtime.bigint();
+            for (let i = 0; i < N; i++) {
+              const p = join(dir, `f${i}.txt`);
+              writeFileSync(p, "x".repeat(4096));
+              const fd = openSync(p, "r+"); fsyncSync(fd); closeSync(fd);
+              unlinkSync(p);
+            }
+            const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+            rmSync(dir, { recursive: true, force: true });
+            console.log(`PROBE ${label} base=${base} ${N} files in ${ms.toFixed(0)}ms = ${(ms / N).toFixed(3)}ms/file`);
+          }
+          console.log(`PROBE cpus=${cpus().length} availableParallelism=${availableParallelism()} totalmem=${(totalmem() / 2 ** 30).toFixed(1)}GiB`);
+          probe("os-tmpdir", tmpdir());
+          probe("runner-temp", process.env.RUNNER_TEMP);
+          probe("workspace", process.env.GITHUB_WORKSPACE);
+          EOF
+          node probe.mjs
+
+      # Best-effort: if the image or an org policy blocks Defender changes, the leg still runs and
+      # simply measures the same thing as its non-defender twin. It must never fail the matrix.
+      - name: Exclude runner disks from Defender real-time scanning
+        if: contains(matrix.config, 'defender')
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath "$env:RUNNER_TEMP", "$env:GITHUB_WORKSPACE", "C:\Users\runneradmin\AppData\Local\Temp"
+          Add-MpPreference -ExclusionProcess "node.exe"
+          Get-MpPreference | Select-Object -ExpandProperty ExclusionPath
+          Write-Host "RealtimeMonitoring disabled: $((Get-MpComputerStatus).RealTimeProtectionEnabled -eq $false)"
+
+      # Clearing RUNNER_TEMP makes vitest.config.ts fall back to os.tmpdir() — i.e. the pre-fix C:
+      # path. Legs whose name contains "fastdisk" leave it set and get D:. This is done inside the
+      # shell, not in a step `env:` block: the `env` context holds only workflow-declared variables,
+      # so `env.RUNNER_TEMP` would read as empty and silently put EVERY leg on the C: path.
+      - name: Test (vitest)
+        working-directory: companion
+        continue-on-error: true
+        shell: bash
+        run: |
+          CONFIG="${{ matrix.config }}"
+          case "$CONFIG" in
+            *fastdisk*) : ;;
+            *) export RUNNER_TEMP="" ;;
+          esac
+          echo "BENCH config=$CONFIG run=${{ matrix.run }} RUNNER_TEMP=[$RUNNER_TEMP]"
+          case "$CONFIG" in
+            *cap2*) npx vitest run --max-workers=2 --min-workers=2 ;;
+            *) npm test ;;
+          esac

--- a/companion/tests/storage/noFollowRead.test.ts
+++ b/companion/tests/storage/noFollowRead.test.ts
@@ -58,6 +58,18 @@ describe("readFileNoFollow", () => {
     await expect(readFileNoFollow(join(dir, "dangling"))).rejects.toBeInstanceOf(LinkGuardError);
   });
 
+  // An open() that loses the race against the rm() below is not a finding — it is the race being run.
+  // POSIX reports that as ENOENT. Windows has a second state POSIX does not: between the unlink and
+  // the last handle closing, the entry still exists but is delete-pending, and opening it returns
+  // ERROR_ACCESS_DENIED (EPERM) or ERROR_SHARING_VIOLATION (EBUSY). Neither can be a leak — nothing
+  // was returned to read — so both belong with ENOENT rather than rethrown.
+  //
+  // The list was ENOENT-only until the suite's temp root moved onto the runner's fast disk, which cut
+  // per-file I/O ~10-30x and let this 200-iteration loop actually reach the delete-pending window;
+  // it then failed one leg of the bench matrix with an EPERM this handler rethrew. The bug was always
+  // here — the slow disk just never ran the loop fast enough to hit it.
+  const RACE_LOST = new Set(["ENOENT", "EPERM", "EBUSY"]);
+
   // THE RACE ITSELF. The path is swapped between a plain file and a symlink to the secret while
   // reads run against it. A check-then-read implementation loses this: it lstats the plain file,
   // the swap lands, and the read follows the link. Reading through the checked descriptor cannot —
@@ -77,7 +89,7 @@ describe("readFileNoFollow", () => {
       const reading = readFileNoFollow(path).then(
         (buf) => buf.toString("utf8"),
         (err: unknown) => {
-          if (!(err instanceof LinkGuardError) && (err as NodeJS.ErrnoException).code !== "ENOENT") {
+          if (!(err instanceof LinkGuardError) && !RACE_LOST.has((err as NodeJS.ErrnoException).code ?? "")) {
             throw err;
           }
           return null;

--- a/companion/vitest.config.ts
+++ b/companion/vitest.config.ts
@@ -55,15 +55,16 @@ export default defineConfig({
     // an aggregate makes them look alike. The tail was the C: temp root above; moving it to D: is
     // what this file now does, measured over 6 configurations x 3 runs (see
     // .github/workflows/windows-test-bench.yml): wall 748.8s -> 383.9s, test phase 1667.9s ->
-    // 567.4s, per-file p90 6381ms -> 914ms (Linux is 708ms), and the slowest single test 46.5s ->
-    // 16.1s. The same matrix rejected the two other candidates on their numbers: capping the fork
-    // pool at 2 made it WORSE (875.4s, +17%), and a Defender exclusion bought 12% on its own but
-    // nothing once the I/O was already on the fast disk.
+    // 567.4s, and per-file p90 6381ms -> 914ms, against 708ms on Linux. The same matrix rejected
+    // the two other candidates on their numbers: capping the fork pool at 2 made it WORSE (875.4s,
+    // +17%), and a Defender exclusion bought 12% on its own but nothing once the I/O was already on
+    // the fast disk.
     //
-    // 45s stays. It is not a per-test allowance any test needs — the slowest single test on Windows
-    // is now 16.1s — it is the ceiling that keeps a hung test from burning the job's 40 minutes,
-    // and headroom against the 45s cliff went from roughly none to 29s. Tightening it is a separate
-    // change that needs its own run of the bench matrix, not a guess.
+    // 45s stays. It is the ceiling that keeps a hung test from burning the job's 40 minutes, not an
+    // allowance any test needs: the slowest test actually governed by it went 26.9s -> 16.1s, so
+    // headroom went 18.1s -> 28.9s. (Slower tests exist — the full-pipeline run reached 46.5s — but
+    // they pass their own timeout to it() and this number never applied to them.) Tightening 45s is
+    // a separate change that needs its own run of the bench matrix, not a guess.
     testTimeout: process.platform === "win32" ? 45_000 : 15_000,
     // Same reasoning for setup/teardown: a beforeEach doing mkdtemp + createApp() starves too, and
     // a hook timeout fails the whole file rather than one test.

--- a/companion/vitest.config.ts
+++ b/companion/vitest.config.ts
@@ -10,15 +10,16 @@ import { defineConfig } from "vitest/config";
 // deletes it when the run ends. Kept short ("dfir-vt-") because it prefixes every temp path in the
 // suite and Windows still has a 260-char limit in play.
 //
-// The BASE this root is created in matters as much as the root itself. GitHub's Windows runners
-// are Azure VMs with two disks: C: is the OS disk (a network-attached managed disk, IOPS-throttled
-// and burst-credited) and D: is the physically-attached ephemeral SSD. The checkout and
-// node_modules land on D:, but os.tmpdir() resolves to C:\Users\RUNNER~1\AppData\Local\Temp — so
-// every mkdtemp() in the suite wrote its case trees, zips and SQLite files to the SLOW disk while
-// module loading read from the fast one. RUNNER_TEMP is the runner's own scratch dir and is on the
-// same disk as the checkout on every hosted platform, so preferring it puts test I/O and module
-// I/O on one disk. Falsy-checked, not `??`: the bench workflow sets RUNNER_TEMP="" to reproduce the
-// pre-fix path, and an empty string must fall through to tmpdir().
+// WHICH DISK that root lands on matters more than anything else in this file. GitHub's Windows
+// runners are Azure VMs with two disks: C: is the OS disk (network-attached, IOPS-throttled) and
+// D: is the physically-attached ephemeral SSD. The checkout and node_modules are on D:, but
+// os.tmpdir() resolves to C:\Users\RUNNER~1\AppData\Local\Temp — so the suite read its modules
+// from the fast disk and wrote every case tree, zip and SQLite file to the slow one. Measured on
+// the runner (create + write + fsync + unlink, 300 files): C: 5.0-14.0ms/file against D:
+// 0.25-0.64ms/file, a 10-34x gap. RUNNER_TEMP is the runner's own scratch dir and sits on the same
+// disk as the checkout on every hosted platform, so preferring it puts test I/O and module I/O on
+// one disk; off CI it is unset and this is exactly the old behaviour. Falsy-checked rather than
+// `??` so the bench workflow can set RUNNER_TEMP="" to reproduce the pre-fix path.
 const runTempBase = process.env.RUNNER_TEMP || tmpdir();
 const runTempRoot = mkdtempSync(join(runTempBase, "dfir-vt-"));
 // Handed to the globalSetup teardown, which runs in this same (main) process.
@@ -31,20 +32,38 @@ export default defineConfig({
     environment: "node",
     include: ["tests/**/*.test.ts"],
     // Vitest's 5s default is not a statement about how long these tests take — it's a statement
-    // about how long they take ON AN IDLE MACHINE. The suite is ~384 files whose cost is dominated
-    // by module collection/transform, so a full parallel run saturates every core and a test doing
-    // <1s of real work can sit descheduled for >4s and "time out" (issue #173). That produced a
-    // different set of failures on every run, which trains everyone to dismiss real regressions as
-    // flake. 15s keeps genuinely-hung tests failing fast while removing the starvation false
+    // about how long they take ON AN IDLE MACHINE. A full parallel run of 670 files saturates the
+    // box, and a test doing <1s of real work can sit waiting for >4s and "time out" (issue #173).
+    // That produced a different set of failures on every run, which trains everyone to dismiss real
+    // regressions as flake. 15s keeps genuinely-hung tests failing fast while removing those false
     // positives — and removes the incentive to keep bumping timeouts one test at a time.
     //
-    // 15s is that reasoning measured on LINUX. The Windows runner has fewer cores, slower
-    // filesystem calls and a virus scanner in the path, and it reproduced the exact symptom this
-    // comment describes: consecutive runs failed a DIFFERENT set of files each time — stateStore,
-    // encryptedCaseRoutes, playbookHunts, veloImportExternal, backupManager, importWriterExclusion
-    // — nearly every one reporting "Test timed out in 15000ms" rather than an assertion. Applying
-    // the idle-Linux number to a slower platform re-creates the starvation false positives the
-    // number exists to remove, so it scales with the platform rather than per test.
+    // The Windows number was 45s for the same reason, and by #642 it had stopped being enough: runs
+    // of an IDENTICAL commit failed a different, disjoint set of files each time, every one of them
+    // a timeout rather than an assertion. Two claims this comment used to make were the reason the
+    // remedy kept being a bigger constant, and both were wrong when measured:
+    //
+    //   - "cost is dominated by module collection/transform". Not at 670 files. Same commit, Linux
+    //     vs Windows: collect 290s vs 340s and transform 15s vs 14s — near-identical. The entire
+    //     platform gap was test execution, 453s vs 1788s.
+    //   - "the Windows runner has fewer cores". It does not. Both report availableParallelism 4, so
+    //     both run vitest's default pool of 3 forks — and 3 workers on 4 cores cannot deschedule
+    //     anyone for 45 seconds. The stalls were never CPU.
+    //
+    // The distribution said the same thing: the median file went 38ms -> 44ms (1.16x) while p90
+    // went 708ms -> 6233ms (8.8x). Uniform slowness and a heavy tail need opposite fixes, and only
+    // an aggregate makes them look alike. The tail was the C: temp root above; moving it to D: is
+    // what this file now does, measured over 6 configurations x 3 runs (see
+    // .github/workflows/windows-test-bench.yml): wall 748.8s -> 383.9s, test phase 1667.9s ->
+    // 567.4s, per-file p90 6381ms -> 914ms (Linux is 708ms), and the slowest single test 46.5s ->
+    // 16.1s. The same matrix rejected the two other candidates on their numbers: capping the fork
+    // pool at 2 made it WORSE (875.4s, +17%), and a Defender exclusion bought 12% on its own but
+    // nothing once the I/O was already on the fast disk.
+    //
+    // 45s stays. It is not a per-test allowance any test needs — the slowest single test on Windows
+    // is now 16.1s — it is the ceiling that keeps a hung test from burning the job's 40 minutes,
+    // and headroom against the 45s cliff went from roughly none to 29s. Tightening it is a separate
+    // change that needs its own run of the bench matrix, not a guess.
     testTimeout: process.platform === "win32" ? 45_000 : 15_000,
     // Same reasoning for setup/teardown: a beforeEach doing mkdtemp + createApp() starves too, and
     // a hook timeout fails the whole file rather than one test.

--- a/companion/vitest.config.ts
+++ b/companion/vitest.config.ts
@@ -9,7 +9,18 @@ import { defineConfig } from "vitest/config";
 // into this root with no test change, and covers tests not written yet. tests/setup/tempRoot.ts
 // deletes it when the run ends. Kept short ("dfir-vt-") because it prefixes every temp path in the
 // suite and Windows still has a 260-char limit in play.
-const runTempRoot = mkdtempSync(join(tmpdir(), "dfir-vt-"));
+//
+// The BASE this root is created in matters as much as the root itself. GitHub's Windows runners
+// are Azure VMs with two disks: C: is the OS disk (a network-attached managed disk, IOPS-throttled
+// and burst-credited) and D: is the physically-attached ephemeral SSD. The checkout and
+// node_modules land on D:, but os.tmpdir() resolves to C:\Users\RUNNER~1\AppData\Local\Temp — so
+// every mkdtemp() in the suite wrote its case trees, zips and SQLite files to the SLOW disk while
+// module loading read from the fast one. RUNNER_TEMP is the runner's own scratch dir and is on the
+// same disk as the checkout on every hosted platform, so preferring it puts test I/O and module
+// I/O on one disk. Falsy-checked, not `??`: the bench workflow sets RUNNER_TEMP="" to reproduce the
+// pre-fix path, and an empty string must fall through to tmpdir().
+const runTempBase = process.env.RUNNER_TEMP || tmpdir();
+const runTempRoot = mkdtempSync(join(runTempBase, "dfir-vt-"));
 // Handed to the globalSetup teardown, which runs in this same (main) process.
 process.env.DFIR_TEST_TMP_ROOT = runTempRoot;
 


### PR DESCRIPTION
`Companion test (Windows)` was failing a different, disjoint set of files on every run of the same commit — every failure a 45s timeout, never an assertion. Measured rather than tuned.

## Root cause

`os.tmpdir()` on a GitHub Windows runner is `C:\Users\RUNNER~1\AppData\Local\Temp` — the Azure OS disk, network-attached and IOPS-throttled. The checkout and `node_modules` are on `D:`, the VM's attached SSD. The suite read its modules from the fast disk and wrote every case tree, zip and SQLite file to the slow one.

The in-job probe measures it: 300 create+write+fsync+unlink cycles cost **5.0–14.0 ms/file on C: against 0.25–0.64 ms/file on D:** — 10–34x.

This was not CPU starvation. Both runners report `availableParallelism` 4 and vitest already runs 3 forks; 3 workers on 4 cores cannot deschedule anyone for 45 seconds. The distribution said the same: the median file went 38ms → 44ms (1.16x) while p90 went 708ms → 6233ms (8.8x). A heavy tail, not uniform slowness.

## Measurement

Six configurations, three runs each ([run 32940797230](https://github.com/hasamba/DFIR-Companion/actions/runs/32940797230)), because two runs of an identical commit already differ 1.75x at the median — a single before/after pair proves nothing.

| config | wall (median) | test phase | per-file p90 | timeouts |
|---|---|---|---|---|
| **fastdisk** | **383.9s** | 567.4s | **914ms** | 0/3 |
| fastdisk-cap2 | 419.1s | 427.7s | 626ms | 0/3 |
| fastdisk-defender | 437.5s | 683.5s | 1000ms | 0/3 |
| defender | 660.7s | 1420.8s | 5469ms | 0/3 |
| baseline | 748.8s | 1667.9s | 6381ms | 0/3 |
| cap2 | 875.4s | 1240.1s | 4364ms | 0/3 |

Only the disk move is decisive: its wall range (260–445s) does not overlap baseline's (651–768s). Linux p90 is 708ms, so this closes the platform gap.

The six files that timed out in #642, baseline → fastdisk: `hostDuplicatesRoutes` 13.7s → 0.9s, `secondOpinion` 24.0s → 2.7s, `huntHostMerge` 6.9s → 0.4s, `falsePositiveSuggest` 5.1s → 0.4s, `hypothesisReview` 5.0s → 0.4s, `analystQueryHostMerge` 6.9s → 0.3s.

Of the tests actually governed by the global 45s timeout, the slowest went **26.9s → 16.1s** — headroom 18.1s → 28.9s. (Slower tests exist, e.g. the 46.5s full-pipeline run, but they pass their own timeout to `it()` and the global number never applied to them.)

## Rejected on the numbers

- **Cap the fork pool at 2** — decisively worse than baseline (875.4s, +17%). There was no CPU oversubscription to relieve.
- **Defender exclusion** — worth 12% alone, nothing once the I/O is on the fast disk (437.5s vs 383.9s, overlapping). The gate needs no privileged PowerShell step.
- **Raise 45s again** — 45s stays, but as a hang ceiling, not an allowance. Lowering it should re-run the matrix.

## Also in here

Two claims in `vitest.config.ts`'s own comment were false when measured, and are why the remedy kept being a bigger constant: "cost is dominated by module collection/transform" (Linux and Windows collect within 17% of each other; the entire gap was test execution, 453s vs 1788s) and "the Windows runner has fewer cores" (same four).

`noFollowRead`'s race test tolerated only `ENOENT` for a lost race. Windows has a second state POSIX does not — between the unlink and the last handle closing the entry is delete-pending and `open()` returns `EPERM`/`EBUSY` — and on the fast disk the 200-iteration loop finally runs fast enough to reach it. It failed one leg of the matrix. Neither code can be a leak, so both join `ENOENT`.

`windows-test-bench.yml` is kept — it is the only thing that can settle the next round of this argument. It costs nothing until someone wants numbers: the job carries `if: startsWith(github.ref, 'refs/heads/bench/')`, so pushing or dispatching a `bench/**` branch is the only way in and a dispatch from master skips all 18 legs rather than billing for them. (The `push` branch filter alone was not enough — a branch filter does not apply to a manual event, caught in review.)