### PR TITLE
feat(velociraptor): split slow scans into a Best Practice - Big Hogs bundle

### DIFF
--- a/companion/src/analysis/artifactBundleStore.ts
+++ b/companion/src/analysis/artifactBundleStore.ts
@@ -110,7 +110,6 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
       "Windows.EventLogs.Chainsaw",
       "Windows.EventLogs.CondensedAccountUsage",
       "DetectRaptor.Generic.Detection.BrowserExtensions",
-      "DetectRaptor.Generic.Detection.YaraFile",
       "DetectRaptor.Generic.Detection.YaraWebshell",
       "DetectRaptor.Linux.Detection.YaraProcessLinux",
       "DetectRaptor.Macos.Detection.YaraProcessMacos",
@@ -141,7 +140,6 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
       "Windows.Persistence.PermanentWMIEvents",
       "Windows.Analysis.SuspiciousWMIConsumers",
       "Linux.Sigma.Triage",
-      "Generic.Scanner.ThorZIP",
       "Custom.Windows.System.Powershell.PSReadline.QuickWins",
       "Windows.System.DNSCache",
       "Generic.System.Pstree",
@@ -162,11 +160,23 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
         RuleStatus: "Stable and Experimental",
       },
     },
-    // Drop known-noisy rows at the source: YaraFile pagefile hits, and an in-development Evtx rule.
+    // Drop known-noisy rows at the source: an in-development Evtx rule.
     // (The Evtx column name is inferred — adjust in the editor if your results use a different one.)
     filters: {
-      "DetectRaptor.Generic.Detection.YaraFile": "NOT OSPath =~ 'pagefile'",
       "DetectRaptor.Windows.Detection.Evtx": "NOT Detection =~ 'Powershell large Base64 blob'",
+    },
+  },
+  {
+    id: "best-practice-big-hogs",
+    name: "Best Practice - Big Hogs",
+    description: "Slow full-disk/file scans split out of Best Practice (YaraFile, THOR ZIP)",
+    builtIn: true,
+    artifacts: ["DetectRaptor.Generic.Detection.YaraFile", "Generic.Scanner.ThorZIP"],
+    defaultWaitMinutes: 60, // these scan the whole disk — the 10-min Best Practice default collects too early
+    timeoutSeconds: 3600, // 1 hour default, well past the 600s Velociraptor default
+    // Drop known-noisy rows at the source: YaraFile pagefile hits.
+    filters: {
+      "DetectRaptor.Generic.Detection.YaraFile": "NOT OSPath =~ 'pagefile'",
     },
   },
   {

--- a/companion/tests/analysis/artifactBundleStore.test.ts
+++ b/companion/tests/analysis/artifactBundleStore.test.ts
@@ -247,7 +247,7 @@ describe("ArtifactBundleStore", () => {
     expect(bp?.params?.["Windows.Hayabusa.Rules"]?.RuleStatus).toBe("Stable and Experimental");
   });
 
-  it("persists per-artifact WHERE filters and ships them on the Best Practice built-in", async () => {
+  it("persists per-artifact WHERE filters and ships them on the Best Practice - Big Hogs built-in", async () => {
     const saved = await store.save({
       name: "F",
       description: "",
@@ -255,8 +255,22 @@ describe("ArtifactBundleStore", () => {
       filters: { "A.B": "NOT X =~ 'y'" },
     });
     expect(saved.filters).toEqual({ "A.B": "NOT X =~ 'y'" });
+    const bigHogs = await store.get("best-practice-big-hogs");
+    expect(bigHogs?.filters?.["DetectRaptor.Generic.Detection.YaraFile"]).toContain("pagefile");
+  });
+
+  it("ships Best Practice - Big Hogs with the slow artifacts and a 1-hour timeout", async () => {
+    const bigHogs = await store.get("best-practice-big-hogs");
+    expect(bigHogs).not.toBeNull();
+    expect(bigHogs?.builtIn).toBe(true);
+    expect(bigHogs?.artifacts).toEqual([
+      "DetectRaptor.Generic.Detection.YaraFile",
+      "Generic.Scanner.ThorZIP",
+    ]);
+    expect(bigHogs?.timeoutSeconds).toBe(3600);
     const bp = await store.get("best-practice");
-    expect(bp?.filters?.["DetectRaptor.Generic.Detection.YaraFile"]).toContain("pagefile");
+    expect(bp?.artifacts).not.toContain("DetectRaptor.Generic.Detection.YaraFile");
+    expect(bp?.artifacts).not.toContain("Generic.Scanner.ThorZIP");
   });
 
   it("sanitizes params — drops nested objects and coerces values to strings", async () => {


### PR DESCRIPTION
## Summary
- Move `DetectRaptor.Generic.Detection.YaraFile` and `Generic.Scanner.ThorZIP` out of the built-in **Best Practice** bundle into a new built-in **Best Practice - Big Hogs** bundle, with a 1-hour default collection timeout (and matching 60-min default wait) since these two do a full-disk/file scan and run far longer than the rest of Best Practice.
- The YaraFile pagefile-noise filter moves with the artifact into the new bundle.

## Test plan
- [x] `npx vitest run tests/analysis/artifactBundleStore.test.ts tests/server/superTimeline.test.ts tests/integrations/veloBundlePreflight.test.ts` — 62 passed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean