### PR TITLE
Add Windows.Sysinternals.Autoruns to Best Practice bundle

### DIFF
--- a/companion/src/analysis/artifactBundleStore.ts
+++ b/companion/src/analysis/artifactBundleStore.ts
@@ -136,6 +136,7 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
       "Windows.Mounted.Mass.Storage",
       "Windows.Analysis.EvidenceOfDownload",
       "Windows.Sys.StartupItems",
+      "Windows.Sysinternals.Autoruns",
       "Windows.System.TaskScheduler",
       "Windows.Persistence.PermanentWMIEvents",
       "Windows.Analysis.SuspiciousWMIConsumers",


### PR DESCRIPTION
## Summary
- Adds `Windows.Sysinternals.Autoruns` to the Best Practice Velociraptor artifact bundle, next to the existing `Windows.Sys.StartupItems` persistence check.

## Test plan
- [x] `npm run build`
- [x] `npx vitest run tests/analysis/artifactBundleStore.test.ts` (27 passed)