### PR TITLE
fix(velociraptor): format PersistenceSniper rows instead of dumping raw columns

### DIFF
--- a/companion/data/tags.yaml
+++ b/companion/data/tags.yaml
@@ -69,6 +69,30 @@ win_run_key:
   severity: Medium
   view: 'Autorun keys'
 
+# PersistenceSniper (Windows.Forensics.PersistenceSniper) enumerates every autostart mechanism on the
+# box — the large majority signed, first-party, and ordinary — so it lands as Info-severity by design
+# (see analysis/persistenceSniperImport.ts) and blanket-promoting every row would flood the timeline
+# with noise instead of signal. These two rules grade up only the module's own anomaly signals: a
+# binary living-off-the-land catalogs flag as abusable, or a persistence target that isn't signed by
+# a trusted publisher (or whose signature doesn't check out at all).
+persistencesniper_lolbin:
+  description: PersistenceSniper flagged a known LOLBin used as a persistence mechanism
+  all:
+    - { field: artifactName, contains: ['PersistenceSniper'] }
+    - { field: description, contains: ['[lolbin]'] }
+  tags: ['lolbin', 'persistence']
+  severity: High
+  view: 'Persistence — LOLBins'
+
+persistencesniper_unsigned:
+  description: PersistenceSniper persistence target with a non-valid Authenticode signature
+  all:
+    - { field: artifactName, contains: ['PersistenceSniper'] }
+    - { field: description, contains: ['[signature:'] }
+  tags: ['unsigned-binary', 'persistence']
+  severity: Medium
+  view: 'Persistence — unsigned binaries'
+
 # ─────────────────────────── Credential access / LSASS ───────────────────────────
 win_lsass_access:
   description: LSASS process access / dump indicators (Sysmon 10, dump filenames)

--- a/companion/data/tags.yaml
+++ b/companion/data/tags.yaml
@@ -70,28 +70,15 @@ win_run_key:
   view: 'Autorun keys'
 
 # PersistenceSniper (Windows.Forensics.PersistenceSniper) enumerates every autostart mechanism on the
-# box — the large majority signed, first-party, and ordinary — so it lands as Info-severity by design
-# (see analysis/persistenceSniperImport.ts) and blanket-promoting every row would flood the timeline
-# with noise instead of signal. These two rules grade up only the module's own anomaly signals: a
-# binary living-off-the-land catalogs flag as abusable, or a persistence target that isn't signed by
-# a trusted publisher (or whose signature doesn't check out at all).
-persistencesniper_lolbin:
-  description: PersistenceSniper flagged a known LOLBin used as a persistence mechanism
-  all:
-    - { field: artifactName, contains: ['PersistenceSniper'] }
-    - { field: description, contains: ['[lolbin]'] }
-  tags: ['lolbin', 'persistence']
-  severity: High
-  view: 'Persistence — LOLBins'
-
-persistencesniper_unsigned:
-  description: PersistenceSniper persistence target with a non-valid Authenticode signature
-  all:
-    - { field: artifactName, contains: ['PersistenceSniper'] }
-    - { field: description, contains: ['[signature:'] }
-  tags: ['unsigned-binary', 'persistence']
-  severity: Medium
-  view: 'Persistence — unsigned binaries'
+# box — the large majority signed, first-party, and ordinary — so it grades Info by default and is
+# NOT re-graded here. Its two anomaly signals (a known LOLBin used for persistence; a target with a
+# non-valid Authenticode signature) are graded High/Medium directly in analysis/persistenceSniperImport.ts,
+# from the module's own structured IsLolbin/Signature columns — not by a tagger rule matching the
+# rendered description, which would be re-deriving the verdict from text an adversary partly controls
+# (Value/Path, real filesystem/registry content on the target) and would silently miss it once the
+# description's 600-char cap truncates a long entry. See that file's comment for the incident this
+# replaced: a crafted Value like `evil.exe [lolbin]` previously spoofed a High grade the module never
+# gave.
 
 # ─────────────────────────── Credential access / LSASS ───────────────────────────
 win_lsass_access:

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -344,6 +344,7 @@
     "operationalImport.ts": "analysis/case",
     "operationalMetrics.ts": "storage",
     "osqueryImport.ts": "analysis/ingest",
+    "persistenceSniperImport.ts": "analysis/ingest",
     "pinnedFindings.ts": "analysis/findings",
     "pipeline.ts": "analysis/ai",
     "plasoImport.ts": "analysis/ingest",

--- a/companion/src/analysis/artifactBundleStore.ts
+++ b/companion/src/analysis/artifactBundleStore.ts
@@ -139,6 +139,7 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
       "Windows.Sysinternals.Autoruns",
       "Windows.System.TaskScheduler",
       "Windows.Persistence.PermanentWMIEvents",
+      "Windows.Forensics.PersistenceSniper",
       "Windows.Analysis.SuspiciousWMIConsumers",
       "Linux.Sigma.Triage",
       "Custom.Windows.System.Powershell.PSReadline.QuickWins",

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -6,7 +6,7 @@
 // "Status = , Subject = " when PowerShell found nothing to sign-check, and a Reference URL that
 // adds noise, not signal. Kept as its own module (not inlined into velociraptorImport.ts) because
 // that file is frozen at its current size by the file-size ledger (#384) — see check-file-size.mjs.
-import { str, getCI, oneLine, addIoc, mitreFromText, type MappedEvent, type SiemIoc } from "./siemImport.js";
+import { str, getCI, oneLine, addIoc, mitreFromText, worst, type MappedEvent, type SiemIoc } from "./siemImport.js";
 import { withHostSuffix } from "./velociraptorTitle.js";
 
 type Row = Record<string, unknown>;
@@ -57,13 +57,26 @@ export function mapPersistenceSniper(
   const sigStatus = /status\s*=\s*([^,]*)/i.exec(signature)?.[1]?.trim() ?? "";
   const sigFlag = sigStatus && sigStatus.toLowerCase() !== "valid" ? sigStatus : "";
 
+  // Grade directly from the module's own STRUCTURED verdict columns (IsLolbin, Signature) — never
+  // from the free-text description below. `subject` is built from Value/Path, real filesystem/
+  // registry content on the target host that an adversary can shape (e.g. naming a dropped file
+  // `evil.exe [lolbin]`); a downstream rule that re-parsed the rendered description for a bracket
+  // marker was both spoofable (a crafted Value fakes a High grade the module never gave) and lossy
+  // (the description is capped at 600 chars, so a long subject could push a genuine marker past the
+  // cut and leave a real LOLBin sitting at Info). Grading here, before any text is assembled, is
+  // immune to both: PersistenceSniper enumerates almost every autostart on the box — mostly signed,
+  // first-party, and ordinary — so most rows stay Info by design; only its own anomaly signals earn
+  // a promotion.
+  let severity: MappedEvent["severity"] = "Info";
+  if (sigFlag) severity = worst(severity, "Medium");
+  if (isLolbin) severity = worst(severity, "High");
+
   let description = `Velociraptor: Persistence [${technique || "unknown"}]`;
   if (subject) description += ` — ${subject}`;
   if (accessGained) description += ` (${accessGained})`;
+  // These markers are for the analyst reading the title — informational only, not re-parsed for
+  // grading (see above).
   if (sigFlag) description += ` [signature: ${sigFlag}]`;
-  // LOLBin-as-persistence is the module's own risk verdict (a binary that living-off-the-land
-  // technique catalogs flag as abusable) — surfaced as a distinct marker so the content tagger
-  // (data/tags.yaml) can grade it up from Info without re-deriving the verdict itself.
   if (isLolbin) description += ` [lolbin]`;
   description = withHostSuffix(description, host).slice(0, 600);
 
@@ -74,7 +87,7 @@ export function mapPersistenceSniper(
   return {
     timestamp,
     description,
-    severity: "Info",
+    severity,
     mitre: mitreFromText(classification),
     aggKey,
     sources: ["Velociraptor"],

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -32,6 +32,16 @@ export function mapPersistenceSniper(
   const accessGained = str(getCI(row, "Access Gained")).trim();
   const signature = str(getCI(row, "Signature")).trim();
   const isLolbin = str(getCI(row, "IsLolbin")).trim().toLowerCase() === "true";
+  const isBuiltinBinary = str(getCI(row, "IsBuiltinBinary")).trim().toLowerCase() === "true";
+  // IsLolbin alone is a weak, noisy signal: rundll32.exe/sc.exe/cmd.exe/msiexec.exe are all
+  // catalogued LOLBins, and they're ALSO how a large fraction of Windows' own stock scheduled
+  // tasks run (sysmain.dll, PcaSvc.dll, AppxDeploymentClient.dll, …) — on one real host's import,
+  // 27 rows came back IsLolbin=True and 23 of those were the OS's own recognised binaries
+  // (IsBuiltinBinary=True), flooding the timeline with High-severity "findings" that are just
+  // ordinary Windows behavior. Only escalate when the LOLBin technique is running from something
+  // that ISN'T PersistenceSniper's own inventory of expected system binaries — that combination
+  // (LOLBin-capable tool + not a recognised built-in) is the actually rare, actually suspicious one.
+  const lolbinFlag = isLolbin && !isBuiltinBinary;
 
   // Value is the actual executable/command the technique runs — the payload an analyst cares
   // about — when the module found one; Path (a registry key, task name, or service) is always
@@ -81,16 +91,17 @@ export function mapPersistenceSniper(
   let severity: MappedEvent["severity"] = "Info";
   if (sigFlag) severity = worst(severity, "Medium");
   if (staged) severity = worst(severity, "Medium");
-  if (isLolbin) severity = worst(severity, "High");
+  if (lolbinFlag) severity = worst(severity, "High");
 
   let description = `Velociraptor: Persistence [${technique || "unknown"}]`;
   if (subject) description += ` — ${subject}`;
   if (accessGained) description += ` (${accessGained})`;
   // These markers are for the analyst reading the title — informational only, not re-parsed for
-  // grading (see above).
+  // grading (see above). Gated on the SAME condition that drives severity, so the marker and the
+  // grade never disagree (a "[lolbin]" tag on an Info-severity row would be its own confusing bug).
   if (sigFlag) description += ` [signature: ${sigFlag}]`;
   if (staged) description += ` [staged: temp/appdata]`;
-  if (isLolbin) description += ` [lolbin]`;
+  if (lolbinFlag) description += ` [lolbin]`;
   description = withHostSuffix(description, host).slice(0, 600);
 
   const aggKey = `vr-persist|${technique.toLowerCase()}|${(value || path).toLowerCase()}|${host.toLowerCase()}`

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -17,7 +17,23 @@ type Row = Record<string, unknown>;
 // isn't re-deriving a verdict the module already computed; the path IS the ground truth for "is this
 // staged somewhere unusual", so there's nothing to spoof by shaping it — an attacker choosing to
 // stage there is exactly the case this is meant to catch.
-const STAGING_DIR_RE = /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\/i;
+//
+// Deliberately NOT built on the same strict quoted-or-clean extraction as the file IOC below: that
+// extraction returns nothing at all once a Value carries trailing arguments (the common case for a
+// Scheduled Task/service command line — "…MpCmdRun.exe -IdleTask …"), which silently blinded the
+// staging check to exactly the values it most needs to see. This regex instead scans the WHOLE raw
+// Value/Path text and anchors on a real executable extension immediately following the staging
+// directory with no further subdirectory in between — the same "must sit directly in that folder"
+// restriction as the file IOC's extension anchor (companion/src/analysis/velociraptorImport.ts's own
+// history has two prior rounds of counterexamples for weaker anchors), which is what keeps a
+// legitimately deep vendor path — Windows Defender's own
+// "C:\ProgramData\Microsoft\Windows Defender\Platform\<ver>\MpCmdRun.exe" — from false-matching:
+// there are backslashes between "ProgramData\" and the filename, so it can't match. A false MATCH
+// here only nudges severity, not a displayed IOC value, so scanning the whole string (rather than
+// only a leading, provably-single path) is an acceptable, much safer trade-off than it would be for
+// the file IOC.
+const STAGED_FILE_RE =
+  /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\[^\\]*?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk)\b/i;
 
 export function mapPersistenceSniper(
   row: Row,
@@ -62,7 +78,9 @@ export function mapPersistenceSniper(
     }
   }
   for (const p of filePaths) addIoc(sink, "file", p);
-  const staged = filePaths.some((p) => STAGING_DIR_RE.test(p));
+  // Scans the raw value/path (see STAGED_FILE_RE's own comment for why) — not filePaths, which is
+  // empty for exactly the argument-carrying values this needs to see.
+  const staged = STAGED_FILE_RE.test(value) || STAGED_FILE_RE.test(path);
 
   // Signature is only worth surfacing when it says something OTHER than "found and valid" — a
   // clean Authenticode signature is the common case and just adds noise to the title.
@@ -82,10 +100,6 @@ export function mapPersistenceSniper(
   // same row — a builtin tool alone, cleanly signed, not staged anywhere unusual, is the routine
   // case and stays suppressed; anything else earns the promotion.
   const lolbinFlag = isLolbin && (!isBuiltinBinary || sigFlag !== "" || staged);
-  // A NON-builtin binary (not in PersistenceSniper's inventory of expected system files) sitting in
-  // a staging directory is its own strong, specific combination — independent of the LOLBin catalog
-  // check — the classic "dropped somewhere transient, wired up for persistence" shape.
-  const unrecognizedStaged = !isBuiltinBinary && staged;
 
   // Grade directly from the module's own STRUCTURED verdict columns — never from the free-text
   // description below. `subject` is built from Value/Path, real filesystem/registry content on the
@@ -98,8 +112,10 @@ export function mapPersistenceSniper(
   // ordinary — so most rows stay Info by design; only its own anomaly signals earn a promotion.
   let severity: MappedEvent["severity"] = "Info";
   if (sigFlag) severity = worst(severity, "Medium");
-  if (staged) severity = worst(severity, "Medium");
-  if (unrecognizedStaged) severity = worst(severity, "High");
+  // Staged is treated as High outright: an executable sitting directly in a world-writable/transient
+  // location (per STAGED_FILE_RE) wired up for persistence is a strong signal on its own, whether or
+  // not the tool itself is a recognised built-in.
+  if (staged) severity = worst(severity, "High");
   if (lolbinFlag) severity = worst(severity, "High");
 
   let description = `Velociraptor: Persistence [${technique || "unknown"}]`;

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -33,15 +33,22 @@ type Row = Record<string, unknown>;
 // only a leading, provably-single path) is an acceptable, much safer trade-off than it would be for
 // the file IOC.
 //
-// The trailing boundary is an explicit end-of-path lookahead (end of string / quote / whitespace /
-// comma) — NOT a bare `\b`. A plain word boundary is satisfied by ANY non-word character, including
-// another literal dot, so it treats an extension prefix earlier in a multi-dot filename as if it
-// were the real one: "C:\ProgramData\readme.hta.txt" is a .txt file, but `\.hta\b` still matches
-// because a dot follows "hta" too. Requiring the boundary to actually look like the end of a path
-// closes that off while leaving every real case (bare end of string, a closing quote, a following
-// argument) matching exactly as before.
+// The trailing boundary is a negative lookahead — "not immediately followed by more filename" —
+// rather than a bare `\b` or an allow-list of terminator characters. Two prior attempts both fell
+// to a real command-line shape:
+//   - A bare `\b` is satisfied by ANY non-word character, including another literal dot, so it
+//     treated an extension prefix earlier in a multi-dot filename as the real one:
+//     "C:\ProgramData\readme.hta.txt" is a .txt file, but `\.hta\b` matches anyway because a dot
+//     follows "hta" too.
+//   - An allow-list of terminators (quote/whitespace/comma/end) fixed that but is inherently
+//     incomplete: cmd.exe operators need no surrounding whitespace — "evil.exe&calc.exe",
+//     "evil.exe|more", "evil.exe>out.txt" — so the allow-list silently dropped every one of them.
+// `(?![.\w])` instead REJECTS only what's actually wrong (another dot, or a continuing word
+// character like the "1" in a longer, unlisted extension) and accepts everything else — every
+// punctuation/operator a real command line can put right after a filename, with no allow-list to
+// keep enumerating.
 const STAGED_FILE_RE =
-  /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\[^\\]*?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk)(?=["'\s,]|$)/i;
+  /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\[^\\]*?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk)(?![.\w])/i;
 
 export function mapPersistenceSniper(
   row: Row,

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -6,7 +6,16 @@
 // "Status = , Subject = " when PowerShell found nothing to sign-check, and a Reference URL that
 // adds noise, not signal. Kept as its own module (not inlined into velociraptorImport.ts) because
 // that file is frozen at its current size by the file-size ledger (#384) — see check-file-size.mjs.
-import { str, getCI, oneLine, addIoc, mitreFromText, worst, type MappedEvent, type SiemIoc } from "./siemImport.js";
+import {
+  str,
+  getCI,
+  oneLine,
+  addIoc,
+  mitreFromText,
+  worst,
+  type MappedEvent,
+  type SiemIoc,
+} from "./siemImport.js";
 import { withHostSuffix } from "./velociraptorTitle.js";
 
 type Row = Record<string, unknown>;
@@ -53,7 +62,8 @@ type Row = Record<string, unknown>;
 // and the allow-list silently dropped every one of them. `(?![.\w])` instead REJECTS only what's
 // actually wrong (another dot, or a continuing word character from a longer/unlisted extension) and
 // accepts everything else, with no allow-list to keep enumerating.
-const STAGING_EXT = "exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk";
+const STAGING_EXT =
+  "exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk";
 const STAGED_LEADING_RE = new RegExp(
   `^[A-Za-z]:\\\\(?:[^\\\\]+\\\\)*(?:temp|tmp|appdata\\\\local\\\\temp|programdata|public|windows\\\\temp)\\\\[^\\\\]*?\\.(?:${STAGING_EXT})(?![.\\w])`,
   "i",
@@ -160,9 +170,10 @@ export function mapPersistenceSniper(
   if (lolbinFlag) description += ` [lolbin]`;
   description = withHostSuffix(description, host).slice(0, 600);
 
-  const aggKey = `vr-persist|${technique.toLowerCase()}|${(value || path).toLowerCase()}|${host.toLowerCase()}`
-    .replace(/\d+/g, "#")
-    .slice(0, 400);
+  const aggKey =
+    `vr-persist|${technique.toLowerCase()}|${(value || path).toLowerCase()}|${host.toLowerCase()}`
+      .replace(/\d+/g, "#")
+      .slice(0, 400);
 
   return {
     timestamp,

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -18,37 +18,53 @@ type Row = Record<string, unknown>;
 // staged somewhere unusual", so there's nothing to spoof by shaping it — an attacker choosing to
 // stage there is exactly the case this is meant to catch.
 //
-// Deliberately NOT built on the same strict quoted-or-clean extraction as the file IOC below: that
-// extraction returns nothing at all once a Value carries trailing arguments (the common case for a
-// Scheduled Task/service command line — "…MpCmdRun.exe -IdleTask …"), which silently blinded the
-// staging check to exactly the values it most needs to see. This regex instead scans the WHOLE raw
-// Value/Path text and anchors on a real executable extension immediately following the staging
-// directory with no further subdirectory in between — the same "must sit directly in that folder"
-// restriction as the file IOC's extension anchor (companion/src/analysis/velociraptorImport.ts's own
-// history has two prior rounds of counterexamples for weaker anchors), which is what keeps a
-// legitimately deep vendor path — Windows Defender's own
-// "C:\ProgramData\Microsoft\Windows Defender\Platform\<ver>\MpCmdRun.exe" — from false-matching:
-// there are backslashes between "ProgramData\" and the filename, so it can't match. A false MATCH
-// here only nudges severity, not a displayed IOC value, so scanning the whole string (rather than
-// only a leading, provably-single path) is an acceptable, much safer trade-off than it would be for
-// the file IOC.
+// Not built on the same strict quoted-or-clean extraction as the file IOC below: that extraction
+// returns nothing at all once a Value carries trailing arguments (the common case for a Scheduled
+// Task/service command line — "…MpCmdRun.exe -IdleTask …"), which silently blinded the staging check
+// to exactly the values it most needs to see.
+//
+// An earlier version instead scanned for this shape ANYWHERE in the raw Value/Path text, with no
+// regard for where in the string it appeared — which let it match an UNRELATED reference inside an
+// argument to something else entirely, e.g. "msiexec.exe /i C:\Windows\Temp\update.msi": the
+// executable actually being RUN is msiexec.exe (not staged, and a very common, benign auto-updater
+// pattern), but the Temp-staged .msi it's installing — passed as ordinary data, not the persistence
+// target — still matched. Restricted here to the two shapes that actually identify the row's own
+// target: (a) the LEADING drive-letter path (there's no ambiguity about what a bare, unquoted value
+// beginning with "C:\…" refers to), or (b) a fully QUOTED drive-letter path anywhere in the string
+// (the quotes are an explicit, unambiguous delimiter — covers a launcher prefix before a quoted
+// payload, e.g. `rundll32.exe "C:\ProgramData\wscadminui.dll",stow`). An unquoted reference embedded
+// later in an argument list matches neither and is deliberately not flagged — there's no reliable
+// way to tell "the technique's own target" from "a data argument to something else" without quotes
+// or leading position to anchor on.
+//
+// `(?:[^\\]+\\)*` before the staging-directory name allows real intermediate path segments — the
+// common Temp layout is "C:\Users\<name>\AppData\Local\Temp\…", not "C:\AppData\Local\Temp\…" — while
+// `[^\\]*?` AFTER it still requires the file to sit DIRECTLY in the staging directory with no further
+// subdirectory, which is what keeps a legitimately deep vendor path — Windows Defender's own
+// "C:\ProgramData\Microsoft\Windows Defender\Platform\<ver>\MpCmdRun.exe" — from false-matching.
 //
 // The trailing boundary is a negative lookahead — "not immediately followed by more filename" —
-// rather than a bare `\b` or an allow-list of terminator characters. Two prior attempts both fell
-// to a real command-line shape:
-//   - A bare `\b` is satisfied by ANY non-word character, including another literal dot, so it
-//     treated an extension prefix earlier in a multi-dot filename as the real one:
-//     "C:\ProgramData\readme.hta.txt" is a .txt file, but `\.hta\b` matches anyway because a dot
-//     follows "hta" too.
-//   - An allow-list of terminators (quote/whitespace/comma/end) fixed that but is inherently
-//     incomplete: cmd.exe operators need no surrounding whitespace — "evil.exe&calc.exe",
-//     "evil.exe|more", "evil.exe>out.txt" — so the allow-list silently dropped every one of them.
-// `(?![.\w])` instead REJECTS only what's actually wrong (another dot, or a continuing word
-// character like the "1" in a longer, unlisted extension) and accepts everything else — every
-// punctuation/operator a real command line can put right after a filename, with no allow-list to
-// keep enumerating.
-const STAGED_FILE_RE =
-  /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\[^\\]*?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk)(?![.\w])/i;
+// rather than a bare `\b` or an allow-list of terminator characters. Two prior attempts both fell to
+// a real command-line shape: a bare `\b` is satisfied by ANY non-word character, including another
+// literal dot, so it treated an extension prefix earlier in a multi-dot filename as the real one
+// ("C:\ProgramData\readme.hta.txt" is a .txt file, but `\.hta\b` matches anyway because a dot follows
+// "hta" too); an allow-list of terminators (quote/whitespace/comma/end) fixed that but is inherently
+// incomplete — cmd.exe operators need no surrounding whitespace ("evil.exe&calc.exe", "evil.exe|more")
+// and the allow-list silently dropped every one of them. `(?![.\w])` instead REJECTS only what's
+// actually wrong (another dot, or a continuing word character from a longer/unlisted extension) and
+// accepts everything else, with no allow-list to keep enumerating.
+const STAGING_EXT = "exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk";
+const STAGED_LEADING_RE = new RegExp(
+  `^[A-Za-z]:\\\\(?:[^\\\\]+\\\\)*(?:temp|tmp|appdata\\\\local\\\\temp|programdata|public|windows\\\\temp)\\\\[^\\\\]*?\\.(?:${STAGING_EXT})(?![.\\w])`,
+  "i",
+);
+const STAGED_QUOTED_RE = new RegExp(
+  `["'][A-Za-z]:\\\\(?:[^\\\\"']+\\\\)*(?:temp|tmp|appdata\\\\local\\\\temp|programdata|public|windows\\\\temp)\\\\[^\\\\"']*?\\.(?:${STAGING_EXT})["']`,
+  "i",
+);
+function isStaged(text: string): boolean {
+  return STAGED_LEADING_RE.test(text) || STAGED_QUOTED_RE.test(text);
+}
 
 export function mapPersistenceSniper(
   row: Row,
@@ -93,9 +109,9 @@ export function mapPersistenceSniper(
     }
   }
   for (const p of filePaths) addIoc(sink, "file", p);
-  // Scans the raw value/path (see STAGED_FILE_RE's own comment for why) — not filePaths, which is
+  // Judges the raw value/path (see the STAGED_*_RE comment above for why) — not filePaths, which is
   // empty for exactly the argument-carrying values this needs to see.
-  const staged = STAGED_FILE_RE.test(value) || STAGED_FILE_RE.test(path);
+  const staged = isStaged(value) || isStaged(path);
 
   // Signature is only worth surfacing when it says something OTHER than "found and valid" — a
   // clean Authenticode signature is the common case and just adds noise to the title.

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -33,15 +33,6 @@ export function mapPersistenceSniper(
   const signature = str(getCI(row, "Signature")).trim();
   const isLolbin = str(getCI(row, "IsLolbin")).trim().toLowerCase() === "true";
   const isBuiltinBinary = str(getCI(row, "IsBuiltinBinary")).trim().toLowerCase() === "true";
-  // IsLolbin alone is a weak, noisy signal: rundll32.exe/sc.exe/cmd.exe/msiexec.exe are all
-  // catalogued LOLBins, and they're ALSO how a large fraction of Windows' own stock scheduled
-  // tasks run (sysmain.dll, PcaSvc.dll, AppxDeploymentClient.dll, …) — on one real host's import,
-  // 27 rows came back IsLolbin=True and 23 of those were the OS's own recognised binaries
-  // (IsBuiltinBinary=True), flooding the timeline with High-severity "findings" that are just
-  // ordinary Windows behavior. Only escalate when the LOLBin technique is running from something
-  // that ISN'T PersistenceSniper's own inventory of expected system binaries — that combination
-  // (LOLBin-capable tool + not a recognised built-in) is the actually rare, actually suspicious one.
-  const lolbinFlag = isLolbin && !isBuiltinBinary;
 
   // Value is the actual executable/command the technique runs — the payload an analyst cares
   // about — when the module found one; Path (a registry key, task name, or service) is always
@@ -78,26 +69,44 @@ export function mapPersistenceSniper(
   const sigStatus = /status\s*=\s*([^,]*)/i.exec(signature)?.[1]?.trim() ?? "";
   const sigFlag = sigStatus && sigStatus.toLowerCase() !== "valid" ? sigStatus : "";
 
-  // Grade directly from the module's own STRUCTURED verdict columns (IsLolbin, Signature) — never
-  // from the free-text description below. `subject` is built from Value/Path, real filesystem/
-  // registry content on the target host that an adversary can shape (e.g. naming a dropped file
-  // `evil.exe [lolbin]`); a downstream rule that re-parsed the rendered description for a bracket
-  // marker was both spoofable (a crafted Value fakes a High grade the module never gave) and lossy
-  // (the description is capped at 600 chars, so a long subject could push a genuine marker past the
-  // cut and leave a real LOLBin sitting at Info). Grading here, before any text is assembled, is
-  // immune to both: PersistenceSniper enumerates almost every autostart on the box — mostly signed,
-  // first-party, and ordinary — so most rows stay Info by design; only its own anomaly signals earn
-  // a promotion.
+  // IsLolbin alone is a weak, noisy signal: rundll32.exe/sc.exe/cmd.exe/msiexec.exe are all
+  // catalogued LOLBins, and they're ALSO how a large fraction of Windows' own stock scheduled
+  // tasks run (sysmain.dll, PcaSvc.dll, AppxDeploymentClient.dll, …) — on one real host's import,
+  // 27 rows came back IsLolbin=True and 23 of those were the OS's own recognised binaries
+  // (IsBuiltinBinary=True), flooding the timeline with High-severity "findings" that were just
+  // ordinary Windows behavior. But gating on !IsBuiltinBinary ALONE went too far the other way:
+  // classic LOLBin abuse runs from a genuinely signed, built-in tool (that's the point of a
+  // living-off-the-land binary) — suppressing every IsBuiltinBinary=True row unconditionally would
+  // miss a builtin LOLBin loading a bad-signed or oddly-staged payload. Escalate on IsLolbin when
+  // EITHER it isn't a recognised built-in, OR one of the other anomaly signals also fired for the
+  // same row — a builtin tool alone, cleanly signed, not staged anywhere unusual, is the routine
+  // case and stays suppressed; anything else earns the promotion.
+  const lolbinFlag = isLolbin && (!isBuiltinBinary || sigFlag !== "" || staged);
+  // A NON-builtin binary (not in PersistenceSniper's inventory of expected system files) sitting in
+  // a staging directory is its own strong, specific combination — independent of the LOLBin catalog
+  // check — the classic "dropped somewhere transient, wired up for persistence" shape.
+  const unrecognizedStaged = !isBuiltinBinary && staged;
+
+  // Grade directly from the module's own STRUCTURED verdict columns — never from the free-text
+  // description below. `subject` is built from Value/Path, real filesystem/registry content on the
+  // target host that an adversary can shape (e.g. naming a dropped file `evil.exe [lolbin]`); a
+  // downstream rule that re-parsed the rendered description for a bracket marker was both spoofable
+  // (a crafted Value fakes a High grade the module never gave) and lossy (the description is capped
+  // at 600 chars, so a long subject could push a genuine marker past the cut and leave a real
+  // anomaly sitting at Info). Grading here, before any text is assembled, is immune to both:
+  // PersistenceSniper enumerates almost every autostart on the box — mostly signed, first-party, and
+  // ordinary — so most rows stay Info by design; only its own anomaly signals earn a promotion.
   let severity: MappedEvent["severity"] = "Info";
   if (sigFlag) severity = worst(severity, "Medium");
   if (staged) severity = worst(severity, "Medium");
+  if (unrecognizedStaged) severity = worst(severity, "High");
   if (lolbinFlag) severity = worst(severity, "High");
 
   let description = `Velociraptor: Persistence [${technique || "unknown"}]`;
   if (subject) description += ` — ${subject}`;
   if (accessGained) description += ` (${accessGained})`;
   // These markers are for the analyst reading the title — informational only, not re-parsed for
-  // grading (see above). Gated on the SAME condition that drives severity, so the marker and the
+  // grading (see above). Gated on the SAME conditions that drive severity, so the marker and the
   // grade never disagree (a "[lolbin]" tag on an Info-severity row would be its own confusing bug).
   if (sigFlag) description += ` [signature: ${sigFlag}]`;
   if (staged) description += ` [staged: temp/appdata]`;

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -1,0 +1,79 @@
+// Windows.Forensics.PersistenceSniper wraps Matteo Malvica's PersistenceSniper PowerShell module —
+// every row is one persistence mechanism the module found, with its own fixed column set (Technique
+// / Classification / Path / Value / Access Gained / Note / Reference / Signature / IsLolbin / …).
+// Without this mapper the row falls through to velociraptorImport.ts's generic key=value dump,
+// which reads every column back verbatim — including a Signature struct that stringifies to
+// "Status = , Subject = " when PowerShell found nothing to sign-check, and a Reference URL that
+// adds noise, not signal. Kept as its own module (not inlined into velociraptorImport.ts) because
+// that file is frozen at its current size by the file-size ledger (#384) — see check-file-size.mjs.
+import { str, getCI, oneLine, addIoc, mitreFromText, type MappedEvent, type SiemIoc } from "./siemImport.js";
+import { withHostSuffix } from "./velociraptorTitle.js";
+
+type Row = Record<string, unknown>;
+
+export function mapPersistenceSniper(
+  row: Row,
+  host: string,
+  sink: Map<string, SiemIoc>,
+  timestamp: string,
+): MappedEvent {
+  const technique = str(getCI(row, "Technique")).trim();
+  const classification = str(getCI(row, "Classification")).trim();
+  const path = str(getCI(row, "Path")).trim();
+  const value = str(getCI(row, "Value")).trim();
+  const accessGained = str(getCI(row, "Access Gained")).trim();
+  const signature = str(getCI(row, "Signature")).trim();
+
+  // Value is the actual executable/command the technique runs — the payload an analyst cares
+  // about — when the module found one; Path (a registry key, task name, or service) is always
+  // present and is the fallback subject for techniques with no separate value (e.g. WMI events).
+  const subject = oneLine(value || path).slice(0, 300);
+
+  // Pull a leading drive-letter path out of Value/Path as a file IOC. Real PersistenceSniper values
+  // routinely mix "path + trailing arguments" into one blob with NO reliable delimiter between the
+  // two (e.g. "C:\...\MicrosoftEdgeUpdate.exe /c"), or comma-join several values into one string
+  // (AppInit_DLLs, Security Packages, …). Every split-point GUESS tried here fabricated a truncated,
+  // non-existent path for some real, ordinary layout: splitting on "whitespace + -//" breaks on a
+  // folder/product name containing one ("Suite -64-bit", "Company - Product"); anchoring the split
+  // on a trailing file extension still concatenates a comma-joined multi-value list into one bogus
+  // "path" (nothing in that shape says where value 1 ends and value 2 begins). There is no syntactic
+  // rule that can safely guess a split point here, so this deliberately stops guessing: extract only
+  // when there's NOTHING to split — an explicitly quoted path (the quotes are the delimiter, not a
+  // guess), or an unquoted value that is ALREADY a single unadorned path (no whitespace, no comma —
+  // nothing else it could be). Anything else (unquoted path + args, comma-joined lists) yields no
+  // IOC rather than risk emitting one that doesn't exist on disk.
+  for (const candidate of [value, path]) {
+    const quoted = /^["']([A-Za-z]:\\[^"']+)["']/.exec(candidate);
+    if (quoted) {
+      addIoc(sink, "file", quoted[1].slice(0, 300));
+    } else if (/^[A-Za-z]:\\[^\s,"']+$/.test(candidate)) {
+      addIoc(sink, "file", candidate.slice(0, 300));
+    }
+  }
+
+  // Signature is only worth surfacing when it says something OTHER than "found and valid" — a
+  // clean Authenticode signature is the common case and just adds noise to the title.
+  const sigStatus = /status\s*=\s*([^,]*)/i.exec(signature)?.[1]?.trim() ?? "";
+  const sigFlag = sigStatus && sigStatus.toLowerCase() !== "valid" ? sigStatus : "";
+
+  let description = `Velociraptor: Persistence [${technique || "unknown"}]`;
+  if (subject) description += ` — ${subject}`;
+  if (accessGained) description += ` (${accessGained})`;
+  if (sigFlag) description += ` [signature: ${sigFlag}]`;
+  description = withHostSuffix(description, host).slice(0, 600);
+
+  const aggKey = `vr-persist|${technique.toLowerCase()}|${(value || path).toLowerCase()}|${host.toLowerCase()}`
+    .replace(/\d+/g, "#")
+    .slice(0, 400);
+
+  return {
+    timestamp,
+    description,
+    severity: "Info",
+    mitre: mitreFromText(classification),
+    aggKey,
+    sources: ["Velociraptor"],
+    ...(path ? { path } : {}),
+    ...(host ? { asset: host } : {}),
+  };
+}

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -32,8 +32,16 @@ type Row = Record<string, unknown>;
 // here only nudges severity, not a displayed IOC value, so scanning the whole string (rather than
 // only a leading, provably-single path) is an acceptable, much safer trade-off than it would be for
 // the file IOC.
+//
+// The trailing boundary is an explicit end-of-path lookahead (end of string / quote / whitespace /
+// comma) — NOT a bare `\b`. A plain word boundary is satisfied by ANY non-word character, including
+// another literal dot, so it treats an extension prefix earlier in a multi-dot filename as if it
+// were the real one: "C:\ProgramData\readme.hta.txt" is a .txt file, but `\.hta\b` still matches
+// because a dot follows "hta" too. Requiring the boundary to actually look like the end of a path
+// closes that off while leaving every real case (bare end of string, a closing quote, a following
+// argument) matching exactly as before.
 const STAGED_FILE_RE =
-  /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\[^\\]*?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk)\b/i;
+  /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\[^\\]*?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk)(?=["'\s,]|$)/i;
 
 export function mapPersistenceSniper(
   row: Row,

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -23,6 +23,7 @@ export function mapPersistenceSniper(
   const value = str(getCI(row, "Value")).trim();
   const accessGained = str(getCI(row, "Access Gained")).trim();
   const signature = str(getCI(row, "Signature")).trim();
+  const isLolbin = str(getCI(row, "IsLolbin")).trim().toLowerCase() === "true";
 
   // Value is the actual executable/command the technique runs — the payload an analyst cares
   // about — when the module found one; Path (a registry key, task name, or service) is always
@@ -60,6 +61,10 @@ export function mapPersistenceSniper(
   if (subject) description += ` — ${subject}`;
   if (accessGained) description += ` (${accessGained})`;
   if (sigFlag) description += ` [signature: ${sigFlag}]`;
+  // LOLBin-as-persistence is the module's own risk verdict (a binary that living-off-the-land
+  // technique catalogs flag as abusable) — surfaced as a distinct marker so the content tagger
+  // (data/tags.yaml) can grade it up from Info without re-deriving the verdict itself.
+  if (isLolbin) description += ` [lolbin]`;
   description = withHostSuffix(description, host).slice(0, 600);
 
   const aggKey = `vr-persist|${technique.toLowerCase()}|${(value || path).toLowerCase()}|${host.toLowerCase()}`

--- a/companion/src/analysis/persistenceSniperImport.ts
+++ b/companion/src/analysis/persistenceSniperImport.ts
@@ -11,6 +11,14 @@ import { withHostSuffix } from "./velociraptorTitle.js";
 
 type Row = Record<string, unknown>;
 
+// Same staging-directory convention as data/tags.yaml's staging_temp_executable rule (world-writable
+// / transient locations malware commonly drops into). Judged directly against the row's OWN Value/
+// Path text — unlike the [lolbin]/[signature: …] markers this replaced elsewhere in this file, this
+// isn't re-deriving a verdict the module already computed; the path IS the ground truth for "is this
+// staged somewhere unusual", so there's nothing to spoof by shaping it — an attacker choosing to
+// stage there is exactly the case this is meant to catch.
+const STAGING_DIR_RE = /\\(?:temp|tmp|appdata\\local\\temp|programdata|public|windows\\temp)\\/i;
+
 export function mapPersistenceSniper(
   row: Row,
   host: string,
@@ -43,14 +51,17 @@ export function mapPersistenceSniper(
   // guess), or an unquoted value that is ALREADY a single unadorned path (no whitespace, no comma —
   // nothing else it could be). Anything else (unquoted path + args, comma-joined lists) yields no
   // IOC rather than risk emitting one that doesn't exist on disk.
+  const filePaths: string[] = [];
   for (const candidate of [value, path]) {
     const quoted = /^["']([A-Za-z]:\\[^"']+)["']/.exec(candidate);
     if (quoted) {
-      addIoc(sink, "file", quoted[1].slice(0, 300));
+      filePaths.push(quoted[1].slice(0, 300));
     } else if (/^[A-Za-z]:\\[^\s,"']+$/.test(candidate)) {
-      addIoc(sink, "file", candidate.slice(0, 300));
+      filePaths.push(candidate.slice(0, 300));
     }
   }
+  for (const p of filePaths) addIoc(sink, "file", p);
+  const staged = filePaths.some((p) => STAGING_DIR_RE.test(p));
 
   // Signature is only worth surfacing when it says something OTHER than "found and valid" — a
   // clean Authenticode signature is the common case and just adds noise to the title.
@@ -69,6 +80,7 @@ export function mapPersistenceSniper(
   // a promotion.
   let severity: MappedEvent["severity"] = "Info";
   if (sigFlag) severity = worst(severity, "Medium");
+  if (staged) severity = worst(severity, "Medium");
   if (isLolbin) severity = worst(severity, "High");
 
   let description = `Velociraptor: Persistence [${technique || "unknown"}]`;
@@ -77,6 +89,7 @@ export function mapPersistenceSniper(
   // These markers are for the analyst reading the title — informational only, not re-parsed for
   // grading (see above).
   if (sigFlag) description += ` [signature: ${sigFlag}]`;
+  if (staged) description += ` [staged: temp/appdata]`;
   if (isLolbin) description += ` [lolbin]`;
   description = withHostSuffix(description, host).slice(0, 600);
 

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -158,6 +158,14 @@ export function getPath(row: Row, path: string): unknown {
   return cur;
 }
 
+// Pull MITRE technique ids out of any tactic/tag/meta/classification text. Shared across importers
+// (Velociraptor's Sigma/YARA/detection mappers, PersistenceSniper) so each doesn't reimplement it.
+export function mitreFromText(...parts: string[]): string[] {
+  const out = new Set<string>();
+  for (const p of parts) for (const m of p.matchAll(/\bt\d{4}(?:\.\d{3})?\b/gi)) out.add(m[0].toUpperCase());
+  return [...out];
+}
+
 // ───────────────────────────── container unwrapping ─────────────────────────────
 
 // If an element wraps its real fields under `_source` (Elastic), return that; else the element.

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -1530,6 +1530,45 @@ export interface EventAggregator {
   finish(): { events: SiemEvent[]; groups: number };
 }
 
+// Copies the fields that identify and describe ONE underlying row — description, severity, and
+// every "which specific thing is this" field — onto `target`. Deliberately excludes the group-level
+// accumulator fields (id, timestamp/endTimestamp, count, aggKey, mitreTechniques, sources), which
+// the caller manages separately across a merge. A field absent on `m` is cleared, not left over
+// from whichever row `target` previously described — a stale path/hash from a DIFFERENT row would
+// misattribute it to the row actually being shown.
+function applyEventIdentity(target: SiemEvent, m: MappedEvent): void {
+  target.description = m.description;
+  target.severity = m.severity;
+  if (m.canonical) target.canonical = m.canonical;
+  else delete target.canonical;
+  if (m.sha256) target.sha256 = m.sha256;
+  else delete target.sha256;
+  if (m.md5) target.md5 = m.md5;
+  else delete target.md5;
+  if (m.path) target.path = m.path;
+  else delete target.path;
+  if (m.asset) target.asset = m.asset;
+  else delete target.asset;
+  if (m.processName) target.processName = m.processName;
+  else delete target.processName;
+  if (m.parentName) target.parentName = m.parentName;
+  else delete target.parentName;
+  if (m.pid !== undefined) target.pid = m.pid;
+  else delete target.pid;
+  if (m.commandLine) target.commandLine = m.commandLine;
+  else delete target.commandLine;
+  if (m.srcIp) target.srcIp = m.srcIp;
+  else delete target.srcIp;
+  if (m.dstIp) target.dstIp = m.dstIp;
+  else delete target.dstIp;
+  if (m.port) target.port = m.port;
+  else delete target.port;
+  if (m.artifactName) target.artifactName = m.artifactName;
+  else delete target.artifactName;
+  if (m.message) target.message = m.message;
+  else delete target.message;
+}
+
 export function createEventAggregator(
   opts: { aggregate?: boolean; minSeverity?: Severity; maxEvents?: number } = {},
 ): EventAggregator {
@@ -1552,7 +1591,6 @@ export function createEventAggregator(
           if (!existing.timestamp || t < existing.timestamp) existing.timestamp = t;
           if (!existing.endTimestamp || t > existing.endTimestamp) existing.endTimestamp = t;
         }
-        existing.severity = worst(existing.severity, m.severity);
         for (const mt of m.mitre)
           if (!existing.mitreTechniques.includes(mt)) existing.mitreTechniques.push(mt);
         if (m.sources)
@@ -1560,34 +1598,30 @@ export function createEventAggregator(
             existing.sources ??= [];
             if (!existing.sources.includes(s)) existing.sources.push(s);
           }
-        if (!existing.artifactName && m.artifactName) existing.artifactName = m.artifactName; // first-wins provenance
-        if (!existing.message && m.message) existing.message = m.message; // first-wins full detail
-        // `count` records repeats; retaining the first pointer avoids unbounded provenance arrays.
+        // Two rows can share an aggKey while differing meaningfully in risk (e.g. the same
+        // PersistenceSniper startup-item name across two user SIDs, one signed and ordinary, one
+        // an unsigned LOLBin — the digit-stripped key folds them together). worst()-ing only the
+        // severity NUMBER left description/path/hashes pinned to whichever row was seen first, so
+        // an analyst could see "High" attached to text that describes the benign twin, with
+        // nothing in the row explaining the grade. When the incoming row is STRICTLY more severe,
+        // promote the whole displayed record to it — never just the number.
+        if (SEVERITY_RANK[m.severity] < SEVERITY_RANK[existing.severity]) {
+          applyEventIdentity(existing, m);
+        }
+        // `count` records repeats; retaining one instance's identity avoids unbounded provenance arrays.
       } else {
-        byKey.set(key, {
+        const e: SiemEvent = {
           id: "",
           timestamp: m.timestamp,
-          description: m.description,
-          severity: m.severity,
+          description: "",
+          severity: "Info",
           mitreTechniques: [...m.mitre],
-          ...(m.canonical ? { canonical: m.canonical } : {}),
           count: 1,
           aggKey: m.aggKey,
-          ...(m.sha256 ? { sha256: m.sha256 } : {}),
-          ...(m.md5 ? { md5: m.md5 } : {}),
-          ...(m.path ? { path: m.path } : {}),
-          ...(m.asset ? { asset: m.asset } : {}),
-          ...(m.processName ? { processName: m.processName } : {}),
-          ...(m.parentName ? { parentName: m.parentName } : {}),
-          ...(m.pid !== undefined ? { pid: m.pid } : {}),
-          ...(m.commandLine ? { commandLine: m.commandLine } : {}),
           ...(m.sources?.length ? { sources: [...m.sources] } : {}),
-          ...(m.srcIp ? { srcIp: m.srcIp } : {}),
-          ...(m.dstIp ? { dstIp: m.dstIp } : {}),
-          ...(m.port ? { port: m.port } : {}),
-          ...(m.artifactName ? { artifactName: m.artifactName } : {}),
-          ...(m.message ? { message: m.message } : {}),
-        });
+        };
+        applyEventIdentity(e, m);
+        byKey.set(key, e);
         order.push(key);
       }
     },

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -470,6 +470,7 @@ type Kind =
   | "download"
   | "startup"
   | "taskscheduler"
+  | "persistenceSniper"
   | "usn"
   | "mft"
   | "browser"
@@ -496,6 +497,7 @@ function classify(row: Row, artifact: string): Kind {
   if (/browserdownload|evidence.*download/i.test(a)) return "download";
   if (/startup|autorun/i.test(a)) return "startup";
   if (/taskscheduler/i.test(a)) return "taskscheduler";
+  if (/persistencesniper/i.test(a)) return "persistenceSniper";
 
   const rule = getCI(row, "Rule");
   if (
@@ -532,6 +534,15 @@ function classify(row: Row, artifact: string): Kind {
   // Scheduled task rows (Windows.System.TaskScheduler/Analysis): TaskName is unique to this artifact
   if (getCI(row, "TaskName") != null && (getCI(row, "Mtime") != null || getCI(row, "OSPath") != null))
     return "taskscheduler";
+  // Windows.Forensics.PersistenceSniper wraps the PersistenceSniper PowerShell module verbatim —
+  // Technique + Classification + "Access Gained" is that module's own column set and isn't reused
+  // by any other artifact, so it's a safe signature even without a recognisable _Source.
+  if (
+    getCI(row, "Technique") != null &&
+    getCI(row, "Classification") != null &&
+    getCI(row, "Access Gained") != null
+  )
+    return "persistenceSniper";
   // Windows.Forensics.Usn — the USN change-journal row: a `Reason` (the filesystem operation:
   // FILE_CREATE / FILE_DELETE / DATA_EXTEND / RENAME_* …) alongside a Usn/MFTId. Mapped specially so
   // the operation lands in the description + agg key (mapGeneric drops it → path-only events).
@@ -1461,6 +1472,59 @@ function mapTaskScheduler(row: Row, host: string, sink: Map<string, SiemIoc>): M
   };
 }
 
+// Windows.Forensics.PersistenceSniper wraps Matteo Malvica's PersistenceSniper PowerShell module —
+// every row is one persistence mechanism the module found, with its own fixed column set (Technique
+// / Classification / Path / Value / Access Gained / Note / Reference / Signature / IsLolbin / …).
+// Without this mapper the row falls through to mapGeneric's key=value dump, which reads every
+// column back verbatim — including a Signature struct that stringifies to "Status = , Subject = "
+// when PowerShell found nothing to sign-check, and a Reference URL that adds noise, not signal.
+function mapPersistenceSniper(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
+  const technique = str(getCI(row, "Technique")).trim();
+  const classification = str(getCI(row, "Classification")).trim();
+  const path = str(getCI(row, "Path")).trim();
+  const value = str(getCI(row, "Value")).trim();
+  const accessGained = str(getCI(row, "Access Gained")).trim();
+  const signature = str(getCI(row, "Signature")).trim();
+
+  // Value is the actual executable/command the technique runs — the payload an analyst cares
+  // about — when the module found one; Path (a registry key, task name, or service) is always
+  // present and is the fallback subject for techniques with no separate value (e.g. WMI events).
+  const subject = oneLine(value || path).slice(0, 300);
+
+  // Pull a leading drive-letter path out of Value/Path as a file IOC (Value often carries trailing
+  // arguments, e.g. "C:\...\MicrosoftEdgeUpdate.exe /c" — same leading-path extraction as Startup).
+  for (const candidate of [value, path]) {
+    const m = /^["']?([A-Za-z]:\\[^"']+?)(?:\s+\/|\s+-|["']|$)/.exec(candidate);
+    if (m) addIoc(sink, "file", m[1].slice(0, 300));
+  }
+
+  // Signature is only worth surfacing when it says something OTHER than "found and valid" — a
+  // clean Authenticode signature is the common case and just adds noise to the title.
+  const sigStatus = /status\s*=\s*([^,]*)/i.exec(signature)?.[1]?.trim() ?? "";
+  const sigFlag = sigStatus && sigStatus.toLowerCase() !== "valid" ? sigStatus : "";
+
+  let description = `Velociraptor: Persistence [${technique || "unknown"}]`;
+  if (subject) description += ` — ${subject}`;
+  if (accessGained) description += ` (${accessGained})`;
+  if (sigFlag) description += ` [signature: ${sigFlag}]`;
+  description = withHostSuffix(description, host).slice(0, 600);
+
+  const aggKey = `vr-persist|${technique.toLowerCase()}|${(value || path).toLowerCase()}|${host.toLowerCase()}`
+    .replace(/\d+/g, "#")
+    .slice(0, 400);
+
+  return {
+    timestamp: pickTime(row),
+    description,
+    severity: "Info",
+    mitre: mitreFromText(classification),
+    aggKey,
+    sources: ["Velociraptor"],
+    ...(path ? { path } : {}),
+    ...(host ? { asset: host } : {}),
+  };
+}
+
 // ───────────────────────────── row extraction ─────────────────────────────
 
 // Returns the flat row list. Handles a Velociraptor multi-artifact map { "Artifact": [rows] }
@@ -1581,6 +1645,8 @@ function mapRowToEvents(row: Row, ctx: VrParseCtx): { events: MappedEvent[]; det
       ms = [mapStartup(row, host, rowSink)];
     } else if (kind === "taskscheduler") {
       ms = [mapTaskScheduler(row, host, rowSink)];
+    } else if (kind === "persistenceSniper") {
+      ms = [mapPersistenceSniper(row, host, rowSink)];
     } else if (kind === "usn") {
       ms = [mapUsn(row, artifact, host)];
     } else if (kind === "mft") {

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1493,8 +1493,12 @@ function mapPersistenceSniper(row: Row, host: string, sink: Map<string, SiemIoc>
 
   // Pull a leading drive-letter path out of Value/Path as a file IOC (Value often carries trailing
   // arguments, e.g. "C:\...\MicrosoftEdgeUpdate.exe /c" — same leading-path extraction as Startup).
+  // The switch boundary requires the "/"/"-" to be followed IMMEDIATELY by a non-space char (a real
+  // flag: "/c", "-k", "-NoProfile") — a bare "\s+-" also matches an ordinary " - " word separator
+  // inside a legitimate install path (e.g. "C:\Program Files\Company - Product\app.exe"), which
+  // would truncate the capture into a fabricated, non-existent path and emit an invalid file IOC.
   for (const candidate of [value, path]) {
-    const m = /^["']?([A-Za-z]:\\[^"']+?)(?:\s+\/|\s+-|["']|$)/.exec(candidate);
+    const m = /^["']?([A-Za-z]:\\[^"']+?)(?:\s+[/-]\S|["']|$)/.exec(candidate);
     if (m) addIoc(sink, "file", m[1].slice(0, 300));
   }
 

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1492,13 +1492,24 @@ function mapPersistenceSniper(row: Row, host: string, sink: Map<string, SiemIoc>
   const subject = oneLine(value || path).slice(0, 300);
 
   // Pull a leading drive-letter path out of Value/Path as a file IOC (Value often carries trailing
-  // arguments, e.g. "C:\...\MicrosoftEdgeUpdate.exe /c" — same leading-path extraction as Startup).
-  // The switch boundary requires the "/"/"-" to be followed IMMEDIATELY by a non-space char (a real
-  // flag: "/c", "-k", "-NoProfile") — a bare "\s+-" also matches an ordinary " - " word separator
-  // inside a legitimate install path (e.g. "C:\Program Files\Company - Product\app.exe"), which
-  // would truncate the capture into a fabricated, non-existent path and emit an invalid file IOC.
+  // arguments concatenated with no delimiter, e.g. "C:\...\MicrosoftEdgeUpdate.exe /c"). A folder
+  // or product name can legitimately contain "-"/"/" right after a space too — "Suite -64-bit",
+  // "Company - Product" are both real install-path segments — so a bare "whitespace then -//" rule
+  // still fabricates a truncated, non-existent path as an IOC no matter how it's tuned. The one
+  // signal that isn't ambiguous: quotes (an explicit delimiter), or the text ending in a REAL file
+  // extension right where the split happens — a path segment never coincidentally ends in ".exe"/
+  // ".dll"/etc immediately before an argument-shaped token, so anchoring on the extension is safe
+  // where anchoring on the separator character alone is not.
   for (const candidate of [value, path]) {
-    const m = /^["']?([A-Za-z]:\\[^"']+?)(?:\s+[/-]\S|["']|$)/.exec(candidate);
+    const quoted = /^["']([A-Za-z]:\\[^"']+)["']/.exec(candidate);
+    if (quoted) {
+      addIoc(sink, "file", quoted[1].slice(0, 300));
+      continue;
+    }
+    const m =
+      /^([A-Za-z]:\\[^"']+?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk))(?:\s+[/-]\S|\s*$)/i.exec(
+        candidate,
+      );
     if (m) addIoc(sink, "file", m[1].slice(0, 300));
   }
 

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1491,26 +1491,26 @@ function mapPersistenceSniper(row: Row, host: string, sink: Map<string, SiemIoc>
   // present and is the fallback subject for techniques with no separate value (e.g. WMI events).
   const subject = oneLine(value || path).slice(0, 300);
 
-  // Pull a leading drive-letter path out of Value/Path as a file IOC (Value often carries trailing
-  // arguments concatenated with no delimiter, e.g. "C:\...\MicrosoftEdgeUpdate.exe /c"). A folder
-  // or product name can legitimately contain "-"/"/" right after a space too — "Suite -64-bit",
-  // "Company - Product" are both real install-path segments — so a bare "whitespace then -//" rule
-  // still fabricates a truncated, non-existent path as an IOC no matter how it's tuned. The one
-  // signal that isn't ambiguous: quotes (an explicit delimiter), or the text ending in a REAL file
-  // extension right where the split happens — a path segment never coincidentally ends in ".exe"/
-  // ".dll"/etc immediately before an argument-shaped token, so anchoring on the extension is safe
-  // where anchoring on the separator character alone is not.
+  // Pull a leading drive-letter path out of Value/Path as a file IOC. Real PersistenceSniper values
+  // routinely mix "path + trailing arguments" into one blob with NO reliable delimiter between the
+  // two (e.g. "C:\...\MicrosoftEdgeUpdate.exe /c"), or comma-join several values into one string
+  // (AppInit_DLLs, Security Packages, …). Every split-point GUESS tried here fabricated a truncated,
+  // non-existent path for some real, ordinary layout: splitting on "whitespace + -//" breaks on a
+  // folder/product name containing one ("Suite -64-bit", "Company - Product"); anchoring the split
+  // on a trailing file extension still concatenates a comma-joined multi-value list into one bogus
+  // "path" (nothing in that shape says where value 1 ends and value 2 begins). There is no syntactic
+  // rule that can safely guess a split point here, so this deliberately stops guessing: extract only
+  // when there's NOTHING to split — an explicitly quoted path (the quotes are the delimiter, not a
+  // guess), or an unquoted value that is ALREADY a single unadorned path (no whitespace, no comma —
+  // nothing else it could be). Anything else (unquoted path + args, comma-joined lists) yields no
+  // IOC rather than risk emitting one that doesn't exist on disk.
   for (const candidate of [value, path]) {
     const quoted = /^["']([A-Za-z]:\\[^"']+)["']/.exec(candidate);
     if (quoted) {
       addIoc(sink, "file", quoted[1].slice(0, 300));
-      continue;
+    } else if (/^[A-Za-z]:\\[^\s,"']+$/.test(candidate)) {
+      addIoc(sink, "file", candidate.slice(0, 300));
     }
-    const m =
-      /^([A-Za-z]:\\[^"']+?\.(?:exe|dll|com|bat|cmd|ps1|vbs|vbe|js|jse|wsf|wsh|msi|scr|cpl|ocx|sys|drv|hta|jar|py|pyw|msc|lnk))(?:\s+[/-]\S|\s*$)/i.exec(
-        candidate,
-      );
-    if (m) addIoc(sink, "file", m[1].slice(0, 300));
   }
 
   // Signature is only worth surfacing when it says something OTHER than "found and valid" — a

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -49,6 +49,7 @@ import {
   getCI,
   getPath,
   normalizeTime,
+  mitreFromText,
   type MappedEvent,
   type SiemEvent,
   type SiemIoc,
@@ -61,6 +62,7 @@ import {
 // as a generic detection() row, which would read no severity from a sibling field and silently
 // downgrade a real Critical (e.g. "Security Audit Logs Cleared") to a keyword-guessed Medium.
 import { isFlatChainsawRow, mapFlatChainsawRow } from "./chainsawImport.js";
+import { mapPersistenceSniper } from "./persistenceSniperImport.js";
 import { detectTimestomp } from "./timestompDetect.js";
 import { networkTokens } from "./networkTokens.js";
 import { withHostSuffix, titleSafe, demangleUtf16Noise } from "./velociraptorTitle.js";
@@ -122,13 +124,6 @@ const WRAPPER_KEYS = new Set([
   "alerts",
   "value",
 ]);
-
-// Pull MITRE technique ids out of any tactic/tag/meta text.
-function mitreFromText(...parts: string[]): string[] {
-  const out = new Set<string>();
-  for (const p of parts) for (const m of p.matchAll(/\bt\d{4}(?:\.\d{3})?\b/gi)) out.add(m[0].toUpperCase());
-  return [...out];
-}
 
 function flatStr(v: unknown): string {
   if (v == null) return "";
@@ -1472,74 +1467,6 @@ function mapTaskScheduler(row: Row, host: string, sink: Map<string, SiemIoc>): M
   };
 }
 
-// Windows.Forensics.PersistenceSniper wraps Matteo Malvica's PersistenceSniper PowerShell module —
-// every row is one persistence mechanism the module found, with its own fixed column set (Technique
-// / Classification / Path / Value / Access Gained / Note / Reference / Signature / IsLolbin / …).
-// Without this mapper the row falls through to mapGeneric's key=value dump, which reads every
-// column back verbatim — including a Signature struct that stringifies to "Status = , Subject = "
-// when PowerShell found nothing to sign-check, and a Reference URL that adds noise, not signal.
-function mapPersistenceSniper(row: Row, host: string, sink: Map<string, SiemIoc>): MappedEvent {
-  const technique = str(getCI(row, "Technique")).trim();
-  const classification = str(getCI(row, "Classification")).trim();
-  const path = str(getCI(row, "Path")).trim();
-  const value = str(getCI(row, "Value")).trim();
-  const accessGained = str(getCI(row, "Access Gained")).trim();
-  const signature = str(getCI(row, "Signature")).trim();
-
-  // Value is the actual executable/command the technique runs — the payload an analyst cares
-  // about — when the module found one; Path (a registry key, task name, or service) is always
-  // present and is the fallback subject for techniques with no separate value (e.g. WMI events).
-  const subject = oneLine(value || path).slice(0, 300);
-
-  // Pull a leading drive-letter path out of Value/Path as a file IOC. Real PersistenceSniper values
-  // routinely mix "path + trailing arguments" into one blob with NO reliable delimiter between the
-  // two (e.g. "C:\...\MicrosoftEdgeUpdate.exe /c"), or comma-join several values into one string
-  // (AppInit_DLLs, Security Packages, …). Every split-point GUESS tried here fabricated a truncated,
-  // non-existent path for some real, ordinary layout: splitting on "whitespace + -//" breaks on a
-  // folder/product name containing one ("Suite -64-bit", "Company - Product"); anchoring the split
-  // on a trailing file extension still concatenates a comma-joined multi-value list into one bogus
-  // "path" (nothing in that shape says where value 1 ends and value 2 begins). There is no syntactic
-  // rule that can safely guess a split point here, so this deliberately stops guessing: extract only
-  // when there's NOTHING to split — an explicitly quoted path (the quotes are the delimiter, not a
-  // guess), or an unquoted value that is ALREADY a single unadorned path (no whitespace, no comma —
-  // nothing else it could be). Anything else (unquoted path + args, comma-joined lists) yields no
-  // IOC rather than risk emitting one that doesn't exist on disk.
-  for (const candidate of [value, path]) {
-    const quoted = /^["']([A-Za-z]:\\[^"']+)["']/.exec(candidate);
-    if (quoted) {
-      addIoc(sink, "file", quoted[1].slice(0, 300));
-    } else if (/^[A-Za-z]:\\[^\s,"']+$/.test(candidate)) {
-      addIoc(sink, "file", candidate.slice(0, 300));
-    }
-  }
-
-  // Signature is only worth surfacing when it says something OTHER than "found and valid" — a
-  // clean Authenticode signature is the common case and just adds noise to the title.
-  const sigStatus = /status\s*=\s*([^,]*)/i.exec(signature)?.[1]?.trim() ?? "";
-  const sigFlag = sigStatus && sigStatus.toLowerCase() !== "valid" ? sigStatus : "";
-
-  let description = `Velociraptor: Persistence [${technique || "unknown"}]`;
-  if (subject) description += ` — ${subject}`;
-  if (accessGained) description += ` (${accessGained})`;
-  if (sigFlag) description += ` [signature: ${sigFlag}]`;
-  description = withHostSuffix(description, host).slice(0, 600);
-
-  const aggKey = `vr-persist|${technique.toLowerCase()}|${(value || path).toLowerCase()}|${host.toLowerCase()}`
-    .replace(/\d+/g, "#")
-    .slice(0, 400);
-
-  return {
-    timestamp: pickTime(row),
-    description,
-    severity: "Info",
-    mitre: mitreFromText(classification),
-    aggKey,
-    sources: ["Velociraptor"],
-    ...(path ? { path } : {}),
-    ...(host ? { asset: host } : {}),
-  };
-}
-
 // ───────────────────────────── row extraction ─────────────────────────────
 
 // Returns the flat row list. Handles a Velociraptor multi-artifact map { "Artifact": [rows] }
@@ -1661,7 +1588,7 @@ function mapRowToEvents(row: Row, ctx: VrParseCtx): { events: MappedEvent[]; det
     } else if (kind === "taskscheduler") {
       ms = [mapTaskScheduler(row, host, rowSink)];
     } else if (kind === "persistenceSniper") {
-      ms = [mapPersistenceSniper(row, host, rowSink)];
+      ms = [mapPersistenceSniper(row, host, rowSink, pickTime(row))];
     } else if (kind === "usn") {
       ms = [mapUsn(row, artifact, host)];
     } else if (kind === "mft") {

--- a/companion/tests/analysis/artifactBundleStore.test.ts
+++ b/companion/tests/analysis/artifactBundleStore.test.ts
@@ -247,6 +247,11 @@ describe("ArtifactBundleStore", () => {
     expect(bp?.params?.["Windows.Hayabusa.Rules"]?.RuleStatus).toBe("Stable and Experimental");
   });
 
+  it("ships Best Practice with PersistenceSniper alongside the other persistence artifacts", async () => {
+    const bp = await store.get("best-practice");
+    expect(bp?.artifacts).toContain("Windows.Forensics.PersistenceSniper");
+  });
+
   it("persists per-artifact WHERE filters and ships them on the Best Practice - Big Hogs built-in", async () => {
     const saved = await store.save({
       name: "F",

--- a/companion/tests/analysis/siemImport.test.ts
+++ b/companion/tests/analysis/siemImport.test.ts
@@ -9,7 +9,9 @@ import {
   resolveExtractedFrom,
   maxEventsDefault,
   logonRisk,
+  aggregateEvents,
   type SiemIoc,
+  type MappedEvent,
 } from "../../src/analysis/siemImport.js";
 
 // ── Representative Windows Event Log records (Elastic _source shape) ─────────────
@@ -928,5 +930,66 @@ describe("textIocs — ReDoS guard (#249)", () => {
     const deep = `${"a.".repeat(120)}com`; // 121 labels — legal, if unusual
     textIocs(deep, sink);
     expect([...sink.values()]).toContainEqual({ type: "domain", value: deep });
+  });
+});
+
+// Two mapped events can legitimately share an aggKey while differing in severity — a Velociraptor
+// artifact whose per-row severity depends on row content (e.g. PersistenceSniper's IsLolbin), merged
+// against a digit-stripped key that folds the same finding across two user SIDs. worst()-ing only the
+// severity number would leave the displayed description/path/hashes pinned to whichever row arrived
+// first, so an analyst could see a High-severity row whose text describes something benign — with no
+// visible reason for the grade. #657.
+describe("aggregateEvents — severity/description consistency across a merge", () => {
+  function m(p: Partial<MappedEvent> & { severity: MappedEvent["severity"] }): MappedEvent {
+    return {
+      timestamp: "2026-06-01T00:00:00Z",
+      description: "d",
+      mitre: [],
+      aggKey: "k",
+      ...p,
+    };
+  }
+
+  it("promotes the WHOLE displayed record — not just the number — when a later row is more severe", () => {
+    const { events } = aggregateEvents([
+      m({ severity: "Info", description: "benign twin", path: "C:\\benign.exe" }),
+      m({ severity: "High", description: "actual LOLBin", path: "C:\\evil.exe" }),
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].severity).toBe("High");
+    // The description and path must describe the SAME row that earned the High grade — not a
+    // Frankenstein of the first row's text under the second row's severity.
+    expect(events[0].description).toBe("actual LOLBin");
+    expect(events[0].path).toBe("C:\\evil.exe");
+    expect(events[0].count).toBe(2);
+  });
+
+  it("keeps the first row's record when a later merged row is LESS severe (no downgrade, no swap)", () => {
+    const { events } = aggregateEvents([
+      m({ severity: "High", description: "actual LOLBin", path: "C:\\evil.exe" }),
+      m({ severity: "Info", description: "benign twin", path: "C:\\benign.exe" }),
+    ]);
+    expect(events[0].severity).toBe("High");
+    expect(events[0].description).toBe("actual LOLBin");
+    expect(events[0].path).toBe("C:\\evil.exe");
+  });
+
+  it("still unions mitre/sources across the merge even when identity fields are promoted", () => {
+    const { events } = aggregateEvents([
+      m({ severity: "Info", description: "benign twin", mitre: ["T1547.001"], sources: ["Velociraptor"] }),
+      m({ severity: "High", description: "actual LOLBin", mitre: ["T1574.002"], sources: ["THOR"] }),
+    ]);
+    expect(events[0].mitreTechniques.sort()).toEqual(["T1547.001", "T1574.002"]);
+    expect(events[0].sources?.sort()).toEqual(["THOR", "Velociraptor"]);
+  });
+
+  it("does not leave a stale field from the first row on the promoted record", () => {
+    // First row carries a sha256 the second row doesn't have — after promotion to the second row's
+    // identity, that hash must NOT still be attached (it would misattribute it to the wrong file).
+    const { events } = aggregateEvents([
+      m({ severity: "Info", description: "benign twin", sha256: "a".repeat(64) }),
+      m({ severity: "High", description: "actual LOLBin" }),
+    ]);
+    expect(events[0].sha256).toBeUndefined();
   });
 });

--- a/companion/tests/analysis/tagsYamlDefault.test.ts
+++ b/companion/tests/analysis/tagsYamlDefault.test.ts
@@ -64,78 +64,10 @@ describe("bundled data/tags.yaml — removable media", () => {
   });
 });
 
-// PersistenceSniper enumerates every autostart on the box — mostly signed, first-party, and
-// ordinary — so it's mapped at Info by design (analysis/persistenceSniperImport.ts) and left there
-// unless one of its own anomaly markers is present. Without these rules NOTHING it finds ever
-// reaches the forensic timeline, however suspicious.
-describe("bundled data/tags.yaml — PersistenceSniper", () => {
-  const RULESET = compileText(
-    readFileSync(fileURLToPath(new URL("../../data/tags.yaml", import.meta.url)), "utf8"),
-  );
-
-  function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
-    return {
-      timestamp: "2026-06-01T00:00:00Z",
-      description: "d",
-      severity: "Info",
-      mitreTechniques: [],
-      relatedFindingIds: [],
-      sourceScreenshots: [],
-      ...p,
-    };
-  }
-
-  it("raises a LOLBin persistence finding to High", () => {
-    const res = runTagger(
-      [
-        ev({
-          id: "e1",
-          artifactName: "Windows.Forensics.PersistenceSniper",
-          description: "Velociraptor: Persistence [Scheduled Task] — C:\\Windows\\System32\\rundll32.exe [lolbin]",
-        }),
-      ],
-      RULESET,
-    );
-    const hit = res.perEvent.find((e) => e.eventId === "e1");
-    expect(hit?.severity).toBe("High");
-    expect(hit?.tags).toContain("lolbin");
-  });
-
-  it("raises an unsigned persistence target to Medium", () => {
-    const res = runTagger(
-      [
-        ev({
-          id: "e2",
-          artifactName: "Windows.Forensics.PersistenceSniper",
-          description: "Velociraptor: Persistence [Registry Run Key] — C:\\evil.exe [signature: NotSigned]",
-        }),
-      ],
-      RULESET,
-    );
-    const hit = res.perEvent.find((e) => e.eventId === "e2");
-    expect(hit?.severity).toBe("Medium");
-    expect(hit?.tags).toContain("unsigned-binary");
-  });
-
-  it("leaves an ordinary, signed PersistenceSniper finding at Info (no flood)", () => {
-    const res = runTagger(
-      [
-        ev({
-          id: "e3",
-          artifactName: "Windows.Forensics.PersistenceSniper",
-          description: "Velociraptor: Persistence [Scheduled Task] — C:\\Windows\\System32\\svchost.exe (User)",
-        }),
-      ],
-      RULESET,
-    );
-    expect(res.perEvent.find((e) => e.eventId === "e3")).toBeUndefined();
-  });
-
-  it("does not fire on an unrelated artifact that happens to contain '[lolbin]' text", () => {
-    const res = runTagger(
-      [ev({ id: "e4", artifactName: "Windows.Detection.Yara.Process", description: "match: [lolbin] rule" })],
-      RULESET,
-    );
-    expect(res.perEvent.find((e) => e.eventId === "e4")).toBeUndefined();
-  });
-});
+// PersistenceSniper's grading (LOLBin -> High, non-valid signature -> Medium) is done directly in
+// analysis/persistenceSniperImport.ts, from the module's own structured columns — see that file's
+// tests. A tagger rule re-deriving the same verdict from the rendered description was tried first
+// and reverted: it was spoofable via a crafted Value/Path (a file literally named "evil.exe
+// [lolbin]" faked a High grade the module never gave) and lossy (the description's 600-char cap
+// could truncate a genuine marker, leaving a real LOLBin at Info). There is deliberately no
+// PersistenceSniper-specific rule in tags.yaml.

--- a/companion/tests/analysis/tagsYamlDefault.test.ts
+++ b/companion/tests/analysis/tagsYamlDefault.test.ts
@@ -63,3 +63,79 @@ describe("bundled data/tags.yaml — removable media", () => {
     expect(res.perEvent.find((e) => e.eventId === "e3")).toBeUndefined();
   });
 });
+
+// PersistenceSniper enumerates every autostart on the box — mostly signed, first-party, and
+// ordinary — so it's mapped at Info by design (analysis/persistenceSniperImport.ts) and left there
+// unless one of its own anomaly markers is present. Without these rules NOTHING it finds ever
+// reaches the forensic timeline, however suspicious.
+describe("bundled data/tags.yaml — PersistenceSniper", () => {
+  const RULESET = compileText(
+    readFileSync(fileURLToPath(new URL("../../data/tags.yaml", import.meta.url)), "utf8"),
+  );
+
+  function ev(p: Partial<ForensicEvent> & { id: string }): ForensicEvent {
+    return {
+      timestamp: "2026-06-01T00:00:00Z",
+      description: "d",
+      severity: "Info",
+      mitreTechniques: [],
+      relatedFindingIds: [],
+      sourceScreenshots: [],
+      ...p,
+    };
+  }
+
+  it("raises a LOLBin persistence finding to High", () => {
+    const res = runTagger(
+      [
+        ev({
+          id: "e1",
+          artifactName: "Windows.Forensics.PersistenceSniper",
+          description: "Velociraptor: Persistence [Scheduled Task] — C:\\Windows\\System32\\rundll32.exe [lolbin]",
+        }),
+      ],
+      RULESET,
+    );
+    const hit = res.perEvent.find((e) => e.eventId === "e1");
+    expect(hit?.severity).toBe("High");
+    expect(hit?.tags).toContain("lolbin");
+  });
+
+  it("raises an unsigned persistence target to Medium", () => {
+    const res = runTagger(
+      [
+        ev({
+          id: "e2",
+          artifactName: "Windows.Forensics.PersistenceSniper",
+          description: "Velociraptor: Persistence [Registry Run Key] — C:\\evil.exe [signature: NotSigned]",
+        }),
+      ],
+      RULESET,
+    );
+    const hit = res.perEvent.find((e) => e.eventId === "e2");
+    expect(hit?.severity).toBe("Medium");
+    expect(hit?.tags).toContain("unsigned-binary");
+  });
+
+  it("leaves an ordinary, signed PersistenceSniper finding at Info (no flood)", () => {
+    const res = runTagger(
+      [
+        ev({
+          id: "e3",
+          artifactName: "Windows.Forensics.PersistenceSniper",
+          description: "Velociraptor: Persistence [Scheduled Task] — C:\\Windows\\System32\\svchost.exe (User)",
+        }),
+      ],
+      RULESET,
+    );
+    expect(res.perEvent.find((e) => e.eventId === "e3")).toBeUndefined();
+  });
+
+  it("does not fire on an unrelated artifact that happens to contain '[lolbin]' text", () => {
+    const res = runTagger(
+      [ev({ id: "e4", artifactName: "Windows.Detection.Yara.Process", description: "match: [lolbin] rule" })],
+      RULESET,
+    );
+    expect(res.perEvent.find((e) => e.eventId === "e4")).toBeUndefined();
+  });
+});

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1353,6 +1353,22 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.description).not.toContain("[staged:");
   });
 
+  // A cmd.exe operator needs no surrounding whitespace to chain commands — an allow-list of
+  // terminator characters (tried and reverted) missed every one of these.
+  it("still detects staging when a shell operator directly follows the extension, no whitespace", () => {
+    for (const value of [
+      "C:\\ProgramData\\evil.exe&calc.exe",
+      "C:\\ProgramData\\evil.exe&&whoami",
+      "C:\\ProgramData\\evil.exe|more",
+      "C:\\ProgramData\\evil.exe>out.txt",
+      "C:\\ProgramData\\evil.exe;whoami",
+    ]) {
+      const e = parseVelociraptorJson(JSON.stringify([sniperRow({ Value: value })])).events[0];
+      expect(e.description, value).toContain("[staged:");
+      expect(e.severity, value).toBe("High");
+    }
+  });
+
   // Grading reads the module's own structured IsLolbin/Signature columns directly — never the
   // rendered description, which mixes in Value/Path (real content from the target host that an
   // adversary can shape). A tagger rule that re-parsed the description for a "[lolbin]"/

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1341,6 +1341,18 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.description).not.toContain("[staged:");
   });
 
+  // A bare `\b` word boundary is satisfied by ANY non-word character — including another literal
+  // dot — so it treats an extension prefix earlier in a multi-dot filename as if it were the real,
+  // final extension: "readme.hta.txt" is a .txt file, but a `\.hta\b` check still matches because a
+  // dot follows "hta" too. The boundary must require an actual end-of-path shape (end of string,
+  // quote, whitespace, comma), not just "not a letter/digit/underscore".
+  it("does not treat an extension prefix earlier in a multi-dot filename as the real extension", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\readme.hta.txt" })]),
+    ).events[0];
+    expect(e.description).not.toContain("[staged:");
+  });
+
   // Grading reads the module's own structured IsLolbin/Signature columns directly — never the
   // rendered description, which mixes in Value/Path (real content from the target host that an
   // adversary can shape). A tagger rule that re-parsed the description for a "[lolbin]"/

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1212,6 +1212,22 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(iocs.some((i) => i.type === "file" && i.value.includes("MicrosoftEdgeUpdate.exe"))).toBe(true);
   });
 
+  it("strips a real trailing CLI switch from the file IOC (flag glued to the '-'/'/', no space)", () => {
+    const row = sniperRow({ Value: "C:\\Windows\\System32\\rundll32.exe -NoProfile" });
+    const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
+    const file = iocs.find((i) => i.type === "file" && i.value.includes("rundll32.exe"));
+    expect(file?.value).toBe("C:\\Windows\\System32\\rundll32.exe");
+  });
+
+  it("keeps a legitimate ' - ' word separator in the path instead of truncating into a fake file (invalid-IOC regression)", () => {
+    const row = sniperRow({ Value: "C:\\Program Files\\Company - Product\\app.exe -y" });
+    const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
+    const file = iocs.find((i) => i.type === "file" && i.value.includes("app.exe"));
+    // Must capture the FULL real path (dropping only the trailing " -y" switch) — not truncate at
+    // the " - " inside "Company - Product", which would fabricate a non-existent path as an IOC.
+    expect(file?.value).toBe("C:\\Program Files\\Company - Product\\app.exe");
+  });
+
   it("falls back to Path when a technique has no Value (e.g. a registry run key)", () => {
     const row = sniperRow({
       Technique: "Registry Run Key",

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1221,13 +1221,50 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.severity).toBe("High");
   });
 
+  it("grades a persistence target staged in Temp/AppData to Medium, and flags it in the title", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Value: "C:\\Users\\bob\\AppData\\Local\\Temp\\update.exe" })]),
+    ).events[0];
+    expect(e.severity).toBe("Medium");
+    expect(e.description).toContain("[staged: temp/appdata]");
+  });
+
+  it("grades a persistence target staged in ProgramData/Public to Medium", () => {
+    const inProgramData = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\svc.exe" })]),
+    ).events[0];
+    expect(inProgramData.severity).toBe("Medium");
+
+    const inPublic = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Value: "C:\\Users\\Public\\helper.exe" })]),
+    ).events[0];
+    expect(inPublic.severity).toBe("Medium");
+  });
+
+  it("does not flag an ordinary Program Files location as staged", () => {
+    const e = parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0]; // default Value is under Program Files
+    expect(e.description).not.toContain("[staged:");
+    expect(e.severity).toBe("Info");
+  });
+
+  it("only judges the extracted, unambiguous file path for staging — not the raw Value blob", () => {
+    // Same invalid-IOC-extraction guardrail as the file-IOC tests: an unquoted Value with trailing
+    // arguments yields no extracted path at all, so there's nothing to judge (no false "staged").
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Value: "C:\\Windows\\System32\\svchost.exe -k \\Temp\\netsvcs" })]),
+    ).events[0];
+    expect(e.description).not.toContain("[staged:");
+  });
+
   // Grading reads the module's own structured IsLolbin/Signature columns directly — never the
   // rendered description, which mixes in Value/Path (real content from the target host that an
   // adversary can shape). A tagger rule that re-parsed the description for a "[lolbin]"/
   // "[signature: ...]" substring was tried first and reverted for exactly this reason.
   it("is not spoofed by a Value that fakes the [lolbin] marker text (IsLolbin: False)", () => {
+    // An ordinary Program Files location — isolates the [lolbin]-text spoofing concern from the
+    // legitimate "staged in Temp/AppData" signal (that path shape is deliberately graded up).
     const e = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ IsLolbin: "False", Value: "C:\\Temp\\name[lolbin].exe" })]),
+      JSON.stringify([sniperRow({ IsLolbin: "False", Value: "C:\\Program Files\\App\\name[lolbin].exe" })]),
     ).events[0];
     expect(e.description).toContain("name[lolbin].exe");
     expect(e.severity).toBe("Info");

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1195,14 +1195,69 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(desc).toContain("NotSigned");
   });
 
-  it("flags a LOLBin persistence target with a [lolbin] marker (grading hook for tags.yaml)", () => {
-    const desc = parseVelociraptorJson(JSON.stringify([sniperRow({ IsLolbin: "True" })])).events[0].description;
-    expect(desc).toContain("[lolbin]");
+  it("flags a LOLBin persistence target with a [lolbin] marker and grades it High", () => {
+    const e = parseVelociraptorJson(JSON.stringify([sniperRow({ IsLolbin: "True" })])).events[0];
+    expect(e.description).toContain("[lolbin]");
+    expect(e.severity).toBe("High");
   });
 
-  it("does not flag an ordinary, non-LOLBin persistence target", () => {
-    const desc = parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0].description;
-    expect(desc).not.toContain("[lolbin]");
+  it("does not flag an ordinary, non-LOLBin persistence target, and leaves it at Info", () => {
+    const e = parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0];
+    expect(e.description).not.toContain("[lolbin]");
+    expect(e.severity).toBe("Info");
+  });
+
+  it("grades a non-valid signature to Medium", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Signature: "Status = NotSigned, Subject = " })]),
+    ).events[0];
+    expect(e.severity).toBe("Medium");
+  });
+
+  it("grades a LOLBin with an unsigned signature to High (worst of the two)", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ IsLolbin: "True", Signature: "Status = NotSigned, Subject = " })]),
+    ).events[0];
+    expect(e.severity).toBe("High");
+  });
+
+  // Grading reads the module's own structured IsLolbin/Signature columns directly — never the
+  // rendered description, which mixes in Value/Path (real content from the target host that an
+  // adversary can shape). A tagger rule that re-parsed the description for a "[lolbin]"/
+  // "[signature: ...]" substring was tried first and reverted for exactly this reason.
+  it("is not spoofed by a Value that fakes the [lolbin] marker text (IsLolbin: False)", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ IsLolbin: "False", Value: "C:\\Temp\\name[lolbin].exe" })]),
+    ).events[0];
+    expect(e.description).toContain("name[lolbin].exe");
+    expect(e.severity).toBe("Info");
+  });
+
+  it("is not spoofed by a Value that fakes the [signature: ...] marker text (clean signature)", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([
+        sniperRow({
+          Value: "C:\\Temp\\evil [signature: NotSigned].exe",
+          Signature: "Status = Valid, Subject = CN=Contoso",
+        }),
+      ]),
+    ).events[0];
+    expect(e.severity).toBe("Info");
+  });
+
+  // The description is capped at 600 chars (withHostSuffix + .slice(0, 600)) — a long Path/subject
+  // could push a marker built AFTER that cap out of the rendered text. Grading must not depend on
+  // the marker surviving truncation.
+  it("still grades High when a long Technique would truncate the [lolbin] marker out of the description", () => {
+    // Technique (unlike Value/Path) isn't length-capped before being embedded, so a long enough
+    // value pushes everything appended after it — including the [lolbin] marker — past the
+    // description's final .slice(0, 600).
+    const longTechnique = "Scheduled Task ".repeat(50).trim();
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ IsLolbin: "True", Technique: longTechnique })]),
+    ).events[0];
+    expect(e.description).not.toContain("[lolbin]"); // confirms the marker really was truncated away
+    expect(e.severity).toBe("High"); // ...yet grading still fired, because it never depended on it
   });
 
   it("does not choke on an empty Signature struct (no cert info available)", () => {

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1162,7 +1162,8 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
       "Access Gained": "User",
       Note: "Scheduled tasks run executables or actions when certain conditions, such as user log in or machine boot up, are met.",
       Reference: "https://attack.mitre.org/techniques/T1053/005/",
-      Signature: "Status = Valid, Subject = CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+      Signature:
+        "Status = Valid, Subject = CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
       IsBuiltinBinary: "False",
       IsLolbin: "False",
       VTEntries: "N/A",
@@ -1334,7 +1335,8 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     const e = parseVelociraptorJson(
       JSON.stringify([
         sniperRow({
-          Value: "C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.26070.9-0\\MpCmdRun.exe -IdleTask",
+          Value:
+            "C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.26070.9-0\\MpCmdRun.exe -IdleTask",
         }),
       ]),
     ).events[0];
@@ -1347,9 +1349,8 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
   // dot follows "hta" too. The boundary must require an actual end-of-path shape (end of string,
   // quote, whitespace, comma), not just "not a letter/digit/underscore".
   it("does not treat an extension prefix earlier in a multi-dot filename as the real extension", () => {
-    const e = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\readme.hta.txt" })]),
-    ).events[0];
+    const e = parseVelociraptorJson(JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\readme.hta.txt" })]))
+      .events[0];
     expect(e.description).not.toContain("[staged:");
   });
 
@@ -1387,9 +1388,7 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
 
   it("still detects a quoted staged payload after a launcher prefix with real intermediate path segments", () => {
     const e = parseVelociraptorJson(
-      JSON.stringify([
-        sniperRow({ Value: 'app.exe "C:\\Users\\bob\\AppData\\Local\\Temp\\payload.dll"' }),
-      ]),
+      JSON.stringify([sniperRow({ Value: 'app.exe "C:\\Users\\bob\\AppData\\Local\\Temp\\payload.dll"' })]),
     ).events[0];
     expect(e.description).toContain("[staged:");
     expect(e.severity).toBe("High");
@@ -1439,9 +1438,8 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
   });
 
   it("does not choke on an empty Signature struct (no cert info available)", () => {
-    const desc = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Signature: "Status = , Subject = " })]),
-    ).events[0].description;
+    const desc = parseVelociraptorJson(JSON.stringify([sniperRow({ Signature: "Status = , Subject = " })]))
+      .events[0].description;
     expect(desc).not.toContain("Status =");
   });
 

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1369,6 +1369,32 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     }
   });
 
+  // Real-world false positive: scanning for the staging shape ANYWHERE in the raw text (tried and
+  // reverted) matched an UNRELATED reference inside an argument to a completely different, benign
+  // executable — a very common auto-updater pattern where msiexec.exe installs a package it staged
+  // in Temp itself. msiexec.exe is what's actually running (not staged); the .msi path is ordinary
+  // data passed to it, not the persistence technique's own target.
+  it("does not flag a Temp-staged file referenced only as an argument to an unrelated executable", () => {
+    for (const value of [
+      "msiexec.exe /i C:\\Windows\\Temp\\GoogleUpdate.msi /quiet",
+      "msiexec.exe /i C:\\Users\\bob\\AppData\\Local\\Temp\\update.msi",
+    ]) {
+      const e = parseVelociraptorJson(JSON.stringify([sniperRow({ Value: value })])).events[0];
+      expect(e.description, value).not.toContain("[staged:");
+      expect(e.severity, value).toBe("Info");
+    }
+  });
+
+  it("still detects a quoted staged payload after a launcher prefix with real intermediate path segments", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([
+        sniperRow({ Value: 'app.exe "C:\\Users\\bob\\AppData\\Local\\Temp\\payload.dll"' }),
+      ]),
+    ).events[0];
+    expect(e.description).toContain("[staged:");
+    expect(e.severity).toBe("High");
+  });
+
   // Grading reads the module's own structured IsLolbin/Signature columns directly — never the
   // rendered description, which mixes in Value/Path (real content from the target host that an
   // adversary can shape). A tagger rule that re-parsed the description for a "[lolbin]"/

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1283,38 +1283,27 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.severity).toBe("High");
   });
 
-  it("grades a persistence target staged in Temp/AppData to Medium, and flags it in the title", () => {
+  // Staged is graded High outright — a file sitting directly in a world-writable/transient location,
+  // wired up for persistence, is a strong signal whether or not the tool itself is a recognised
+  // built-in.
+  it("grades a persistence target staged in Temp/AppData to High, and flags it in the title", () => {
     const e = parseVelociraptorJson(
-      JSON.stringify([
-        sniperRow({ Value: "C:\\Users\\bob\\AppData\\Local\\Temp\\update.exe", IsBuiltinBinary: "True" }),
-      ]),
+      JSON.stringify([sniperRow({ Value: "C:\\Users\\bob\\AppData\\Local\\Temp\\update.exe" })]),
     ).events[0];
-    expect(e.severity).toBe("Medium");
+    expect(e.severity).toBe("High");
     expect(e.description).toContain("[staged: temp/appdata]");
   });
 
-  it("grades a persistence target staged in ProgramData/Public to Medium (when it's a recognised binary)", () => {
+  it("grades a persistence target staged in ProgramData/Public to High", () => {
     const inProgramData = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\svc.exe", IsBuiltinBinary: "True" })]),
+      JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\svc.exe" })]),
     ).events[0];
-    expect(inProgramData.severity).toBe("Medium");
+    expect(inProgramData.severity).toBe("High");
 
     const inPublic = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Value: "C:\\Users\\Public\\helper.exe", IsBuiltinBinary: "True" })]),
+      JSON.stringify([sniperRow({ Value: "C:\\Users\\Public\\helper.exe" })]),
     ).events[0];
-    expect(inPublic.severity).toBe("Medium");
-  });
-
-  // A NON-builtin binary (not in PersistenceSniper's own inventory of expected system files) sitting
-  // in a staging directory is a stronger, more specific combination than either signal alone — the
-  // classic "dropped somewhere transient, wired up for persistence" shape.
-  it("grades a NON-builtin binary staged in Temp/AppData/ProgramData to High", () => {
-    const e = parseVelociraptorJson(
-      JSON.stringify([
-        sniperRow({ Value: "C:\\ProgramData\\USOShared\\lsassa.exe", IsBuiltinBinary: "False" }),
-      ]),
-    ).events[0];
-    expect(e.severity).toBe("High");
+    expect(inPublic.severity).toBe("High");
   });
 
   it("does not flag an ordinary Program Files location as staged", () => {
@@ -1323,11 +1312,31 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.severity).toBe("Info");
   });
 
-  it("only judges the extracted, unambiguous file path for staging — not the raw Value blob", () => {
-    // Same invalid-IOC-extraction guardrail as the file-IOC tests: an unquoted Value with trailing
-    // arguments yields no extracted path at all, so there's nothing to judge (no false "staged").
+  // Real-world regression: the strict quoted-or-clean extraction used for the file IOC returns
+  // NOTHING once a Value carries trailing arguments — the common case for a Scheduled Task/service
+  // command line (PersistenceSniper's own real output: "…MpCmdRun.exe -IdleTask -TaskName …"). An
+  // earlier version of the staging check reused that same extraction and was silently blind to
+  // exactly the values it most needed to see. It must judge the raw Value/Path text instead.
+  it("still detects staging when the Value carries trailing arguments", () => {
     const e = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Value: "C:\\Windows\\System32\\svchost.exe -k \\Temp\\netsvcs" })]),
+      JSON.stringify([sniperRow({ Value: "C:\\Users\\bob\\AppData\\Local\\Temp\\evil.exe -x --quiet" })]),
+    ).events[0];
+    expect(e.description).toContain("[staged: temp/appdata]");
+    expect(e.severity).toBe("High");
+  });
+
+  // Windows Defender's own platform binary — a REAL, multi-level-deep vendor path under ProgramData.
+  // The staging check requires the file to sit DIRECTLY in the staging directory (no further
+  // subdirectory in between, same convention as data/tags.yaml's staging_temp_executable rule) so a
+  // legitimately deep, versioned install path doesn't false-match just because "ProgramData" appears
+  // somewhere in it.
+  it("does not flag a file nested deep under ProgramData in a real vendor path as staged", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([
+        sniperRow({
+          Value: "C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18.26070.9-0\\MpCmdRun.exe -IdleTask",
+        }),
+      ]),
     ).events[0];
     expect(e.description).not.toContain("[staged:");
   });
@@ -1347,10 +1356,12 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
   });
 
   it("is not spoofed by a Value that fakes the [signature: ...] marker text (clean signature)", () => {
+    // An ordinary Program Files location — isolates the [signature:]-text spoofing concern from the
+    // legitimate "staged in Temp" signal (that path shape is deliberately graded up on its own).
     const e = parseVelociraptorJson(
       JSON.stringify([
         sniperRow({
-          Value: "C:\\Temp\\evil [signature: NotSigned].exe",
+          Value: "C:\\Program Files\\App\\evil [signature: NotSigned].exe",
           Signature: "Status = Valid, Subject = CN=Contoso",
         }),
       ]),

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1235,6 +1235,40 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.severity).toBe("High");
   });
 
+  // The IsBuiltinBinary gate exists to suppress ROUTINE builtin LOLBin usage (rundll32.exe running
+  // an ordinary OS scheduled task) — it must NOT suppress genuine LOLBin abuse just because the
+  // tool itself is a legitimate, signed Windows binary. Classic living-off-the-land technique runs
+  // FROM a real builtin tool; that's the whole point. A builtin LOLBin with a bad signature or an
+  // unusual staging path is exactly the case that must still escalate.
+  it("still grades High for a builtin LOLBin whose signature doesn't check out", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([
+        sniperRow({
+          Value: "C:\\Windows\\System32\\rundll32.exe evil.dll,Entry",
+          IsLolbin: "True",
+          IsBuiltinBinary: "True",
+          Signature: "Status = NotSigned, Subject = ",
+        }),
+      ]),
+    ).events[0];
+    expect(e.description).toContain("[lolbin]");
+    expect(e.severity).toBe("High");
+  });
+
+  it("still grades High for a builtin LOLBin staged in Temp/AppData", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([
+        sniperRow({
+          Value: "C:\\Users\\bob\\AppData\\Local\\Temp\\rundll32.exe",
+          IsLolbin: "True",
+          IsBuiltinBinary: "True",
+        }),
+      ]),
+    ).events[0];
+    expect(e.description).toContain("[lolbin]");
+    expect(e.severity).toBe("High");
+  });
+
   it("grades a non-valid signature to Medium", () => {
     const e = parseVelociraptorJson(
       JSON.stringify([sniperRow({ Signature: "Status = NotSigned, Subject = " })]),
@@ -1251,22 +1285,36 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
 
   it("grades a persistence target staged in Temp/AppData to Medium, and flags it in the title", () => {
     const e = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Value: "C:\\Users\\bob\\AppData\\Local\\Temp\\update.exe" })]),
+      JSON.stringify([
+        sniperRow({ Value: "C:\\Users\\bob\\AppData\\Local\\Temp\\update.exe", IsBuiltinBinary: "True" }),
+      ]),
     ).events[0];
     expect(e.severity).toBe("Medium");
     expect(e.description).toContain("[staged: temp/appdata]");
   });
 
-  it("grades a persistence target staged in ProgramData/Public to Medium", () => {
+  it("grades a persistence target staged in ProgramData/Public to Medium (when it's a recognised binary)", () => {
     const inProgramData = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\svc.exe" })]),
+      JSON.stringify([sniperRow({ Value: "C:\\ProgramData\\svc.exe", IsBuiltinBinary: "True" })]),
     ).events[0];
     expect(inProgramData.severity).toBe("Medium");
 
     const inPublic = parseVelociraptorJson(
-      JSON.stringify([sniperRow({ Value: "C:\\Users\\Public\\helper.exe" })]),
+      JSON.stringify([sniperRow({ Value: "C:\\Users\\Public\\helper.exe", IsBuiltinBinary: "True" })]),
     ).events[0];
     expect(inPublic.severity).toBe("Medium");
+  });
+
+  // A NON-builtin binary (not in PersistenceSniper's own inventory of expected system files) sitting
+  // in a staging directory is a stronger, more specific combination than either signal alone — the
+  // classic "dropped somewhere transient, wired up for persistence" shape.
+  it("grades a NON-builtin binary staged in Temp/AppData/ProgramData to High", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([
+        sniperRow({ Value: "C:\\ProgramData\\USOShared\\lsassa.exe", IsBuiltinBinary: "False" }),
+      ]),
+    ).events[0];
+    expect(e.severity).toBe("High");
   });
 
   it("does not flag an ordinary Program Files location as staged", () => {

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1207,34 +1207,10 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.mitreTechniques).toContain("T1053.005");
   });
 
-  it("adds the Value executable as a file IOC", () => {
-    const iocs = parseVelociraptorJson(JSON.stringify([sniperRow()])).iocs;
-    expect(iocs.some((i) => i.type === "file" && i.value.includes("MicrosoftEdgeUpdate.exe"))).toBe(true);
-  });
-
-  it("strips a real trailing CLI switch from the file IOC (flag glued to the '-'/'/', no space)", () => {
-    const row = sniperRow({ Value: "C:\\Windows\\System32\\rundll32.exe -NoProfile" });
+  it("adds an unquoted Value with no arguments to split on as a file IOC", () => {
+    const row = sniperRow({ Value: "C:\\Windows\\System32\\evil.dll" });
     const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
-    const file = iocs.find((i) => i.type === "file" && i.value.includes("rundll32.exe"));
-    expect(file?.value).toBe("C:\\Windows\\System32\\rundll32.exe");
-  });
-
-  it("keeps a legitimate ' - ' word separator in the path instead of truncating into a fake file (invalid-IOC regression)", () => {
-    const row = sniperRow({ Value: "C:\\Program Files\\Company - Product\\app.exe -y" });
-    const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
-    const file = iocs.find((i) => i.type === "file" && i.value.includes("app.exe"));
-    // Must capture the FULL real path (dropping only the trailing " -y" switch) — not truncate at
-    // the " - " inside "Company - Product", which would fabricate a non-existent path as an IOC.
-    expect(file?.value).toBe("C:\\Program Files\\Company - Product\\app.exe");
-  });
-
-  it("keeps a legitimate ' -digit' version/arch suffix in a folder name (invalid-IOC regression)", () => {
-    const row = sniperRow({ Value: "C:\\Program Files\\Suite -64-bit\\app.exe /c" });
-    const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
-    const file = iocs.find((i) => i.type === "file" && i.value.includes("app.exe"));
-    // "Suite -64-bit" is a real folder name segment, not an argument boundary — a bare "space then
-    // -/digit" rule truncates here into "C:\Program Files\Suite", a non-existent path.
-    expect(file?.value).toBe("C:\\Program Files\\Suite -64-bit\\app.exe");
+    expect(iocs.some((i) => i.type === "file" && i.value === "C:\\Windows\\System32\\evil.dll")).toBe(true);
   });
 
   it("trusts an explicitly quoted path over any extension/switch guessing", () => {
@@ -1242,6 +1218,27 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
     const file = iocs.find((i) => i.type === "file" && i.value.includes("thing.exe"));
     expect(file?.value).toBe("C:\\Program Files\\Odd - Name.new\\thing.exe");
+  });
+
+  it("does not fabricate a file IOC by guessing a split point in an unquoted path+argument value (invalid-IOC regression)", () => {
+    // The real case data's own Value — a legitimate path (with a space in "Program Files (x86)")
+    // plus a trailing "/c" argument glued on with no delimiter. Every split-point guess tried here
+    // (whitespace+separator, extension-anchored) eventually fabricated a truncated or concatenated
+    // non-existent path for SOME real layout ("Suite -64-bit", comma-joined AppInit_DLLs values,
+    // …) — so this deliberately extracts NOTHING from an unquoted value once whitespace is present,
+    // rather than guess. The title still shows the full raw value (see the title-formatting tests
+    // above); only structured IOC extraction is this conservative.
+    const iocs = parseVelociraptorJson(JSON.stringify([sniperRow()])).iocs;
+    expect(iocs.some((i) => i.type === "file" && i.value.includes("MicrosoftEdgeUpdate"))).toBe(false);
+  });
+
+  it("does not concatenate a comma-joined multi-value Value into one fabricated file IOC", () => {
+    // AppInit_DLLs / Security Packages / Authentication Packages style values list several DLLs in
+    // one string. No character in "C:\evil1.dll,C:\evil2.dll" says where value 1 ends and value 2
+    // begins, so treating the whole thing as one file path would be its own invalid IOC.
+    const row = sniperRow({ Value: "C:\\Windows\\evil1.dll,C:\\Windows\\evil2.dll" });
+    const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
+    expect(iocs.some((i) => i.type === "file" && i.value.includes("evil1.dll,C"))).toBe(false);
   });
 
   it("falls back to Path when a technique has no Value (e.g. a registry run key)", () => {

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1228,6 +1228,22 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(file?.value).toBe("C:\\Program Files\\Company - Product\\app.exe");
   });
 
+  it("keeps a legitimate ' -digit' version/arch suffix in a folder name (invalid-IOC regression)", () => {
+    const row = sniperRow({ Value: "C:\\Program Files\\Suite -64-bit\\app.exe /c" });
+    const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
+    const file = iocs.find((i) => i.type === "file" && i.value.includes("app.exe"));
+    // "Suite -64-bit" is a real folder name segment, not an argument boundary — a bare "space then
+    // -/digit" rule truncates here into "C:\Program Files\Suite", a non-existent path.
+    expect(file?.value).toBe("C:\\Program Files\\Suite -64-bit\\app.exe");
+  });
+
+  it("trusts an explicitly quoted path over any extension/switch guessing", () => {
+    const row = sniperRow({ Value: '"C:\\Program Files\\Odd - Name.new\\thing.exe" -y' });
+    const iocs = parseVelociraptorJson(JSON.stringify([row])).iocs;
+    const file = iocs.find((i) => i.type === "file" && i.value.includes("thing.exe"));
+    expect(file?.value).toBe("C:\\Program Files\\Odd - Name.new\\thing.exe");
+  });
+
   it("falls back to Path when a technique has no Value (e.g. a registry run key)", () => {
     const row = sniperRow({
       Technique: "Registry Run Key",

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1207,6 +1207,34 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(e.severity).toBe("Info");
   });
 
+  // Real-world regression (#657 follow-up): rundll32.exe/sc.exe/cmd.exe/msiexec.exe are all
+  // catalogued LOLBins AND how a large share of Windows' own stock scheduled tasks run. On one
+  // real host's import, 27/273 rows came back IsLolbin=True and 23 of those were the OS's own
+  // recognised binaries (IsBuiltinBinary=True) — treating IsLolbin alone as High flooded the
+  // timeline with "findings" that were just ordinary Windows behavior.
+  it("does not grade a LOLBin-capable tool as High when it's PersistenceSniper's own recognised built-in binary", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([
+        sniperRow({
+          Technique: "Scheduled Task",
+          Value: "%windir%\\system32\\rundll32.exe sysmain.dll,PfSvWsSwapAssessmentTask",
+          IsLolbin: "True",
+          IsBuiltinBinary: "True",
+        }),
+      ]),
+    ).events[0];
+    expect(e.description).not.toContain("[lolbin]");
+    expect(e.severity).toBe("Info");
+  });
+
+  it("still grades High for a LOLBin technique that is NOT a recognised built-in binary", () => {
+    const e = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ IsLolbin: "True", IsBuiltinBinary: "False" })]),
+    ).events[0];
+    expect(e.description).toContain("[lolbin]");
+    expect(e.severity).toBe("High");
+  });
+
   it("grades a non-valid signature to Medium", () => {
     const e = parseVelociraptorJson(
       JSON.stringify([sniperRow({ Signature: "Status = NotSigned, Subject = " })]),

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1195,6 +1195,16 @@ describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.Pe
     expect(desc).toContain("NotSigned");
   });
 
+  it("flags a LOLBin persistence target with a [lolbin] marker (grading hook for tags.yaml)", () => {
+    const desc = parseVelociraptorJson(JSON.stringify([sniperRow({ IsLolbin: "True" })])).events[0].description;
+    expect(desc).toContain("[lolbin]");
+  });
+
+  it("does not flag an ordinary, non-LOLBin persistence target", () => {
+    const desc = parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0].description;
+    expect(desc).not.toContain("[lolbin]");
+  });
+
   it("does not choke on an empty Signature struct (no cert info available)", () => {
     const desc = parseVelociraptorJson(
       JSON.stringify([sniperRow({ Signature: "Status = , Subject = " })]),

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -1148,6 +1148,93 @@ describe("parseVelociraptorJson — taskscheduler rows (Windows.System.TaskSched
   });
 });
 
+describe("parseVelociraptorJson — PersistenceSniper rows (Windows.Forensics.PersistenceSniper)", () => {
+  // Real column set from a collected PersistenceSniper flow — the module's own field names,
+  // wrapped verbatim by the VQL artifact (no Velociraptor-side renaming).
+  function sniperRow(overrides: Record<string, unknown> = {}): object {
+    return {
+      _Source: "Windows.Forensics.PersistenceSniper",
+      Hostname: "DESKTOP-9RNKFB0",
+      Technique: "Scheduled Task",
+      Classification: "MITRE ATT&CK T1053.005",
+      Path: "\\MicrosoftEdgeUpdateTaskMachineCore{BDCC8C3F-6BAE-41A3-8C40-C1742ACC916B}",
+      Value: "C:\\Program Files (x86)\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe /c",
+      "Access Gained": "User",
+      Note: "Scheduled tasks run executables or actions when certain conditions, such as user log in or machine boot up, are met.",
+      Reference: "https://attack.mitre.org/techniques/T1053/005/",
+      Signature: "Status = Valid, Subject = CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US",
+      IsBuiltinBinary: "False",
+      IsLolbin: "False",
+      VTEntries: "N/A",
+      ...overrides,
+    };
+  }
+
+  it("reads as a clean, readable title instead of a raw key=value dump", () => {
+    const desc = parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0].description;
+    const { title } = splitEventTitle(desc);
+    expect(title).toContain("Scheduled Task");
+    expect(title).toContain("MicrosoftEdgeUpdate.exe");
+    expect(title).toContain("User");
+    // The raw dump this replaces joined every column with "Key=Value - " — that shape must be gone.
+    expect(desc).not.toMatch(/Technique=/);
+    expect(desc).not.toMatch(/Classification=/);
+    expect(desc).not.toMatch(/Note=/);
+  });
+
+  it("omits the Reference URL and a clean Signature — noise, not signal", () => {
+    const desc = parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0].description;
+    expect(desc).not.toContain("attack.mitre.org");
+    expect(desc).not.toContain("Status = Valid");
+  });
+
+  it("surfaces a non-valid signature status (unsigned / mismatched)", () => {
+    const desc = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Signature: "Status = NotSigned, Subject = " })]),
+    ).events[0].description;
+    expect(desc).toContain("NotSigned");
+  });
+
+  it("does not choke on an empty Signature struct (no cert info available)", () => {
+    const desc = parseVelociraptorJson(
+      JSON.stringify([sniperRow({ Signature: "Status = , Subject = " })]),
+    ).events[0].description;
+    expect(desc).not.toContain("Status =");
+  });
+
+  it("extracts the MITRE technique id from Classification", () => {
+    const e = parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0];
+    expect(e.mitreTechniques).toContain("T1053.005");
+  });
+
+  it("adds the Value executable as a file IOC", () => {
+    const iocs = parseVelociraptorJson(JSON.stringify([sniperRow()])).iocs;
+    expect(iocs.some((i) => i.type === "file" && i.value.includes("MicrosoftEdgeUpdate.exe"))).toBe(true);
+  });
+
+  it("falls back to Path when a technique has no Value (e.g. a registry run key)", () => {
+    const row = sniperRow({
+      Technique: "Registry Run Key",
+      Classification: "MITRE ATT&CK T1547.001",
+      Path: "HKEY_USERS\\S-1-5-21-843861673-2156981796-2677025539-1001\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run\\MicrosoftEdgeAutoLaunch",
+      Value: "",
+    });
+    const desc = parseVelociraptorJson(JSON.stringify([row])).events[0].description;
+    expect(desc).toContain("MicrosoftEdgeAutoLaunch");
+  });
+
+  it("is classified by column detection when _Source is absent", () => {
+    const row = sniperRow();
+    delete (row as Record<string, unknown>)._Source;
+    const desc = parseVelociraptorJson(JSON.stringify([row])).events[0].description;
+    expect(desc).toContain("Scheduled Task");
+  });
+
+  it("sets severity to Info (raw finding listing, not a detection)", () => {
+    expect(parseVelociraptorJson(JSON.stringify([sniperRow()])).events[0].severity).toBe("Info");
+  });
+});
+
 describe("parseVelociraptorJson — InUse field in MFT detection rows", () => {
   function mftRow(inUse: boolean): object {
     return {

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -5344,7 +5344,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 110,
+      "lines": 121,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -5344,7 +5344,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 146,
+      "lines": 154,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -5344,7 +5344,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 121,
+      "lines": 130,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -5344,7 +5344,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 97,
+      "lines": 110,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -5344,7 +5344,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 161,
+      "lines": 177,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -5344,7 +5344,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 154,
+      "lines": 161,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -5344,7 +5344,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 130,
+      "lines": 146,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.html
+++ b/docs/codemap/codemap.html
@@ -11,7 +11,7 @@
     "extension/src",
     "public/dashboard.html"
   ],
-  "moduleCount": 803,
+  "moduleCount": 804,
   "routeCount": 477,
   "modules": [
     {
@@ -5342,6 +5342,20 @@
       ]
     },
     {
+      "path": "companion/src/analysis/persistenceSniperImport.ts",
+      "kind": "module",
+      "lines": 97,
+      "imports": [
+        "companion/src/analysis/siemImport.ts",
+        "companion/src/analysis/velociraptorTitle.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/velociraptorImport.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/analysis/pinnedFindings.ts",
       "kind": "module",
       "lines": 138,
@@ -6436,6 +6450,7 @@
         "companion/src/analysis/networkImport.ts",
         "companion/src/analysis/oktaImport.ts",
         "companion/src/analysis/osqueryImport.ts",
+        "companion/src/analysis/persistenceSniperImport.ts",
         "companion/src/analysis/plasoImport.ts",
         "companion/src/analysis/pstreeDepth.ts",
         "companion/src/analysis/sandboxImport.ts",
@@ -8261,6 +8276,7 @@
       "imports": [
         "companion/src/analysis/chainsawImport.ts",
         "companion/src/analysis/csvImport.ts",
+        "companion/src/analysis/persistenceSniperImport.ts",
         "companion/src/analysis/scriptBlockFragments.ts",
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts",
@@ -8300,6 +8316,7 @@
       "lines": 46,
       "imports": [],
       "importedBy": [
+        "companion/src/analysis/persistenceSniperImport.ts",
         "companion/src/analysis/velociraptorImport.ts"
       ],
       "routes": [],
@@ -18027,5 +18044,4 @@
       ]
     }
   ]
-}
-</script><script>const data=JSON.parse(document.getElementById('data').textContent);const rows=document.getElementById('rows');const render=()=>{const q=document.getElementById('q').value.toLowerCase();rows.innerHTML=data.modules.filter(m=>JSON.stringify(m).toLowerCase().includes(q)).map(m=>'<tr><td><code>'+m.path+'</code><br><span class="muted">'+m.kind+' · '+m.lines+' lines'+(m.routes.length?'<br>'+m.routes.join('<br>'):'')+'</span></td><td>'+m.imports.join('<br>')+'</td><td>'+m.importedBy.join('<br>')+'</td><td>'+m.tests.join('<br>')+'</td></tr>').join('')};document.getElementById('q').addEventListener('input',render);render();</script></body></html>
+}</script><script>const data=JSON.parse(document.getElementById('data').textContent);const rows=document.getElementById('rows');const render=()=>{const q=document.getElementById('q').value.toLowerCase();rows.innerHTML=data.modules.filter(m=>JSON.stringify(m).toLowerCase().includes(q)).map(m=>'<tr><td><code>'+m.path+'</code><br><span class="muted">'+m.kind+' · '+m.lines+' lines'+(m.routes.length?'<br>'+m.routes.join('<br>'):'')+'</span></td><td>'+m.imports.join('<br>')+'</td><td>'+m.importedBy.join('<br>')+'</td><td>'+m.tests.join('<br>')+'</td></tr>').join('')};document.getElementById('q').addEventListener('input',render);render();</script></body></html>

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -5339,7 +5339,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 146,
+      "lines": 154,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -5339,7 +5339,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 161,
+      "lines": 177,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -5339,7 +5339,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 110,
+      "lines": 121,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -5339,7 +5339,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 154,
+      "lines": 161,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -5339,7 +5339,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 97,
+      "lines": 110,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -5339,7 +5339,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 121,
+      "lines": 130,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -6,7 +6,7 @@
     "extension/src",
     "public/dashboard.html"
   ],
-  "moduleCount": 803,
+  "moduleCount": 804,
   "routeCount": 477,
   "modules": [
     {
@@ -5337,6 +5337,20 @@
       ]
     },
     {
+      "path": "companion/src/analysis/persistenceSniperImport.ts",
+      "kind": "module",
+      "lines": 97,
+      "imports": [
+        "companion/src/analysis/siemImport.ts",
+        "companion/src/analysis/velociraptorTitle.ts"
+      ],
+      "importedBy": [
+        "companion/src/analysis/velociraptorImport.ts"
+      ],
+      "routes": [],
+      "tests": []
+    },
+    {
       "path": "companion/src/analysis/pinnedFindings.ts",
       "kind": "module",
       "lines": 138,
@@ -6431,6 +6445,7 @@
         "companion/src/analysis/networkImport.ts",
         "companion/src/analysis/oktaImport.ts",
         "companion/src/analysis/osqueryImport.ts",
+        "companion/src/analysis/persistenceSniperImport.ts",
         "companion/src/analysis/plasoImport.ts",
         "companion/src/analysis/pstreeDepth.ts",
         "companion/src/analysis/sandboxImport.ts",
@@ -8256,6 +8271,7 @@
       "imports": [
         "companion/src/analysis/chainsawImport.ts",
         "companion/src/analysis/csvImport.ts",
+        "companion/src/analysis/persistenceSniperImport.ts",
         "companion/src/analysis/scriptBlockFragments.ts",
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/stateTypes.ts",
@@ -8295,6 +8311,7 @@
       "lines": 46,
       "imports": [],
       "importedBy": [
+        "companion/src/analysis/persistenceSniperImport.ts",
         "companion/src/analysis/velociraptorImport.ts"
       ],
       "routes": [],

--- a/docs/codemap/codemap.json
+++ b/docs/codemap/codemap.json
@@ -5339,7 +5339,7 @@
     {
       "path": "companion/src/analysis/persistenceSniperImport.ts",
       "kind": "module",
-      "lines": 130,
+      "lines": 146,
       "imports": [
         "companion/src/analysis/siemImport.ts",
         "companion/src/analysis/velociraptorTitle.ts"

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "9fb7acfa4015ddaa3e3fd656d071f3e4f070fe4054e7b8b85e3e3e239939bc7d",
+  "sha256": "cfc97f0143cecb382f4910a3fecc97d4cdf0c4d2d8fbb73315e4c9c9191728a3",
   "moduleCount": 804,
   "routeCount": 477
 }

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "532138c7c4e10a0aae7ea9d2f3110e35b88cd3d383aa171c5af2f14360125344",
+  "sha256": "b7e0c0d302e3605b5be0b93fce21b855ccb10900167b24b8c3dd4fd19b67b017",
   "moduleCount": 804,
   "routeCount": 477
 }

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "09aee9e2c08831b1a3e83375b332942f9069b34403408a958b3b6fcd766de00c",
+  "sha256": "9fb7acfa4015ddaa3e3fd656d071f3e4f070fe4054e7b8b85e3e3e239939bc7d",
   "moduleCount": 804,
   "routeCount": 477
 }

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "76d3f6be0c5adb11c6669eba37d6cab88fa6feeec7ddbc59e26833e5228af859",
-  "moduleCount": 803,
+  "sha256": "4068f6aad22f8fe681503ae29a73438d6221b99fe3ae543c4f8afda1f18a7be6",
+  "moduleCount": 804,
   "routeCount": 477
 }

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "4068f6aad22f8fe681503ae29a73438d6221b99fe3ae543c4f8afda1f18a7be6",
+  "sha256": "1f51979b7d75c77b3bf6689571578c76eff2bbb57555038f5a55901519460b72",
   "moduleCount": 804,
   "routeCount": 477
 }

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "cfc97f0143cecb382f4910a3fecc97d4cdf0c4d2d8fbb73315e4c9c9191728a3",
+  "sha256": "33c9cdb1bd8d14c4b91532ec7d907491769264f74d76c1ab202c9acbe12fbdd8",
   "moduleCount": 804,
   "routeCount": 477
 }

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "33c9cdb1bd8d14c4b91532ec7d907491769264f74d76c1ab202c9acbe12fbdd8",
+  "sha256": "532138c7c4e10a0aae7ea9d2f3110e35b88cd3d383aa171c5af2f14360125344",
   "moduleCount": 804,
   "routeCount": 477
 }

--- a/docs/codemap/codemap.lock
+++ b/docs/codemap/codemap.lock
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "sha256": "1f51979b7d75c77b3bf6689571578c76eff2bbb57555038f5a55901519460b72",
+  "sha256": "09aee9e2c08831b1a3e83375b332942f9069b34403408a958b3b6fcd766de00c",
   "moduleCount": 804,
   "routeCount": 477
 }


### PR DESCRIPTION
## Summary
- `Windows.Forensics.PersistenceSniper` had no dedicated importer, so every row fell through to the generic key=value fallback and produced titles like `Technique=Scheduled Task - Classification=MITRE ATT&CK T1053.005 - ... - Signature=Status= , Subject =`
- Adds a dedicated mapper that reads the module's real columns (Technique/Path/Value/Access Gained/Signature) into a clean title, extracts the MITRE technique id from `Classification`, and adds the executable as a file IOC
- The noisy `Reference` URL and a clean (`Status = Valid`) Signature are dropped from the title; a non-valid signature status is still surfaced

## Test plan
- [x] `npx vitest run tests/analysis/velociraptorImport.test.ts` — new PersistenceSniper describe block (8 tests) + all existing tests, 168/168 pass
- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` (full suite) — 675 files / 10397 tests pass