### PR TITLE
fix(velociraptor): give Best Practice - Big Hogs the shared 6000s timeout

### DIFF
--- a/companion/src/analysis/artifactBundleStore.ts
+++ b/companion/src/analysis/artifactBundleStore.ts
@@ -174,7 +174,7 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
     builtIn: true,
     artifacts: ["DetectRaptor.Generic.Detection.YaraFile", "Generic.Scanner.ThorZIP"],
     defaultWaitMinutes: 60, // these scan the whole disk — the 10-min Best Practice default collects too early
-    timeoutSeconds: 3600, // 1 hour default, well past the 600s Velociraptor default
+    timeoutSeconds: 6000, // matches the other bundles' default, well past the 600s Velociraptor default
     // Drop known-noisy rows at the source: YaraFile pagefile hits.
     filters: {
       "DetectRaptor.Generic.Detection.YaraFile": "NOT OSPath =~ 'pagefile'",

--- a/companion/tests/analysis/artifactBundleStore.test.ts
+++ b/companion/tests/analysis/artifactBundleStore.test.ts
@@ -259,7 +259,7 @@ describe("ArtifactBundleStore", () => {
     expect(bigHogs?.filters?.["DetectRaptor.Generic.Detection.YaraFile"]).toContain("pagefile");
   });
 
-  it("ships Best Practice - Big Hogs with the slow artifacts and a 1-hour timeout", async () => {
+  it("ships Best Practice - Big Hogs with the slow artifacts and the shared bundle timeout", async () => {
     const bigHogs = await store.get("best-practice-big-hogs");
     expect(bigHogs).not.toBeNull();
     expect(bigHogs?.builtIn).toBe(true);
@@ -267,7 +267,7 @@ describe("ArtifactBundleStore", () => {
       "DetectRaptor.Generic.Detection.YaraFile",
       "Generic.Scanner.ThorZIP",
     ]);
-    expect(bigHogs?.timeoutSeconds).toBe(3600);
+    expect(bigHogs?.timeoutSeconds).toBe(6000);
     const bp = await store.get("best-practice");
     expect(bp?.artifacts).not.toContain("DetectRaptor.Generic.Detection.YaraFile");
     expect(bp?.artifacts).not.toContain("Generic.Scanner.ThorZIP");

--- a/mkdocs-docs/reference/integrations.md
+++ b/mkdocs-docs/reference/integrations.md
@@ -35,7 +35,7 @@ Run fleet hunts, collect artifacts, and stream live monitoring events into cases
 
 ### Triage Bundles
 
-Settings → Velociraptor. Four bundles ship built-in — **Best Practice** (the quick-wins detection sweep), **Best Practice - Big Hogs** (the DetectRaptor YARA file scan and THOR, split out because both walk the whole disk and run far longer than the rest of Best Practice; 1-hour default timeout), **Super-Timeline Triage** (raw host artifacts; results go to the super-timeline only), and **Linux Triage**. Every bundle is editable in place, and **Reset to default** restores a built-in. You can also create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results. See [Step 3a of the walkthrough](../walkthrough.md) for the run procedure.
+Settings → Velociraptor. Four bundles ship built-in — **Best Practice** (the quick-wins detection sweep), **Best Practice - Big Hogs** (the DetectRaptor YARA file scan and THOR, split out because both walk the whole disk and run far longer than the rest of Best Practice; same 6000s default timeout as the other bundles), **Super-Timeline Triage** (raw host artifacts; results go to the super-timeline only), and **Linux Triage**. Every bundle is editable in place, and **Reset to default** restores a built-in. You can also create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results. See [Step 3a of the walkthrough](../walkthrough.md) for the run procedure.
 
 #### Third-party tools
 

--- a/mkdocs-docs/walkthrough.md
+++ b/mkdocs-docs/walkthrough.md
@@ -43,7 +43,7 @@ Open **Settings → Velociraptor**. Four bundles ship built-in:
 | Bundle | What it collects | Where results land |
 |--------|------------------|--------------------|
 | **Best Practice** | The quick-wins detection sweep — DetectRaptor rules, Hayabusa, Chainsaw, condensed account usage, process and network state, persistence, scheduled tasks | Forensic timeline (the AI sees them) |
-| **Best Practice - Big Hogs** *(optional)* | The two slow full-disk/file scans split out of Best Practice — the DetectRaptor YARA file scan and THOR. 1-hour default timeout | Forensic timeline (the AI sees them) |
+| **Best Practice - Big Hogs** *(optional)* | The two slow full-disk/file scans split out of Best Practice — the DetectRaptor YARA file scan and THOR. Same 6000s default timeout as the other bundles | Forensic timeline (the AI sees them) |
 | **Super-Timeline Triage** *(optional)* | Raw host artifacts — MFT, USN journal, prefetch, amcache, shellbags, SRUM, jump lists, registry, event logs | **Super-timeline only** |
 | **Linux Triage** | Linux host triage — users, persistence, network, packages, detection artifacts | Forensic timeline |
 


### PR DESCRIPTION
## Summary
- Best Practice - Big Hogs shipped with `timeoutSeconds: 3600` while Best Practice, Super-Timeline Triage, and Linux Triage all use 6000. Aligned it to match.
- Updated the test that pinned the old 3600 value, and the two docs mentions of the old "1-hour default timeout" wording.

## Test plan
- [x] `npx vitest run tests/analysis/artifactBundleStore.test.ts` — 27 passed
- [x] `npm run typecheck`
- [x] `npm run lint`