### PR TITLE
fix(analysis): grade a Windows process on what it did, not on what it is called

### DIFF
--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -462,6 +462,7 @@
     "velociraptorRelease.ts": "analysis/case",
     "velociraptorTitle.ts": "analysis/ingest",
     "wazuhImport.ts": "analysis/ingest",
+    "winProcessBaseline.ts": "analysis/ingest",
     "workLogFilter.ts": "analysis/workflow",
     "yaraImport.ts": "analysis/ingest",
     "zipArchive.ts": "analysis/ingest",

--- a/companion/src/analysis/importDetect.ts
+++ b/companion/src/analysis/importDetect.ts
@@ -19,6 +19,7 @@ import { looksLikeYara } from "./yaraImport.js";
 import { looksLikeCombinedLog } from "./combinedLogImport.js";
 import { looksLikeCiscoAsa } from "./ciscoAsaImport.js";
 import { looksLikeSyslog } from "./syslogImport.js";
+import { IMPORT_KINDS } from "./importerSpec.js";
 import type { EngineDetectContext, ExternalImporter } from "./declarativeImporter.js";
 // Newer-source detectors live in importDetectSources.ts — this file is at the 800-line limit.
 import {
@@ -30,47 +31,9 @@ import {
   hindsightCsvSig,
 } from "./importDetectSources.js";
 
-export type ImportKind =
-  | "thor"
-  | "siem"
-  | "evtxxml"
-  | "chainsaw"
-  | "hayabusa"
-  | "ecar"
-  | "velociraptor"
-  | "securityonion"
-  | "socrates"
-  | "network"
-  | "kape"
-  | "cybertriage"
-  | "m365"
-  | "okta"
-  | "gws"
-  | "hindsight"
-  | "macos"
-  | "leapp"
-  | "aws"
-  | "cloud"
-  | "k8s"
-  | "osquery"
-  | "plaso"
-  | "sandbox"
-  | "memory"
-  | "email"
-  | "auditd"
-  | "journald"
-  | "sysdig"
-  | "wazuh"
-  | "thehive"
-  | "bashhistory"
-  | "snort"
-  | "yara"
-  | "combinedlog"
-  | "asa"
-  | "syslog"
-  | "csv"
-  | "log"
-  | "unknown";
+// The kind list itself lives in importerSpec.ts, which is where a custom importer id is checked
+// against it — one array, so the union and the shadow-guard can never drift apart again.
+export type ImportKind = (typeof IMPORT_KINDS)[number];
 
 type Row = Record<string, unknown>;
 
@@ -543,7 +506,7 @@ function kapeSig(h: Set<string>): boolean {
   );
 }
 
-function detectCsv(text: string): ImportKind {
+function detectCsv(text: string, filename: string): ImportKind {
   const { headers, rows } = parseCsv(text);
   if (headers.length === 0) return "unknown";
   const h = new Set(headers.map((x) => x.trim().toLowerCase()));
@@ -560,6 +523,18 @@ function detectCsv(text: string): ImportKind {
   if (velociraptorElasticCsvSig(h)) return "velociraptor";
   // A comma-delimited table with data rows → the generic (AI) CSV importer.
   if (headers.length >= 2 && rows.length > 0) return "csv";
+  // One column is still a table — but ONLY when the file says so on three counts at once. This is
+  // the last fallback before `log`, so every unrecognized text file lands here, and a comma-less
+  // log line parses as a one-column row: depth alone would have claimed stack traces and plain
+  // application logs as CSV, then eaten their first line as a header. So require the .csv/.tsv
+  // extension the author chose, the depth a real export has, AND values that look like values —
+  // whitespace-free single tokens, which is the IOC-list shape this exists for (a header plus a
+  // run of hashes, IPs or domains) and which no prose or log line survives.
+  if (headers.length === 1 && rows.length >= 10 && /\.(?:csv|tsv)$/i.test(filename)) {
+    const token = (v: string): boolean => v !== "" && !/\s/.test(v);
+    // 50 rows is enough to tell a value list from a log; scanning all of a 500k-line file is not.
+    if (token(headers[0]) && rows.slice(0, 50).every((r) => r.length === 1 && token(r[0]))) return "csv";
+  }
   return "log";
 }
 
@@ -622,8 +597,12 @@ function looksLikeVelociraptorFile(filename: string): boolean {
 // `ausearch` format. The `type=… msg=audit(secs.millis:serial)` shape is unique to auditd, so one
 // matching line anywhere in the head is enough to claim it ahead of the generic log fallback.
 const RE_AUDITD = /(?:^|\n)\s*type=\w+\s+msg=audit\(\d+\.\d+:\d+\)/;
+// 8 KB was not enough: a real audit.log opens with a boot banner and a run of SYSCALL-less noise,
+// and a file whose first `type=… msg=audit(…)` sat past that window sniffed as a plain log and went
+// to AI line-triage. 256 KB clears any realistic preamble while still being a cheap slice — the
+// regex is anchored per line, so a bigger window costs a scan, not a backtrack.
 function isAuditd(text: string): boolean {
-  return RE_AUDITD.test(text.slice(0, 8000));
+  return RE_AUDITD.test(text.slice(0, 256_000));
 }
 
 // ───────────────────────────── top-level ─────────────────────────────
@@ -715,7 +694,7 @@ export function detectImportKind(filename: string, text: string): ImportKind {
   if (looksLikeYara(t)) return "yara";
 
   // Tabular (CSV / EZ / Plaso / Hayabusa-csv / M365-csv) vs a line-oriented log.
-  const csvKind = detectCsv(t);
+  const csvKind = detectCsv(t, filename);
   if (csvKind !== "unknown" && csvKind !== "log") return csvKind;
   // No CSV signature and no comma-table → treat as a generic log (AI line triage).
   return "log";

--- a/companion/src/analysis/importerSpec.ts
+++ b/companion/src/analysis/importerSpec.ts
@@ -4,8 +4,14 @@
 import { z } from "zod";
 import { checkRegexSafety } from "./regexSafety.js";
 
-// The built-in ImportKind values a custom id must NOT shadow (kept in sync with importDetect.ts).
-export const BUILTIN_KINDS: ReadonlySet<string> = new Set([
+// Every kind the detector can return. This array is the single source of truth: importDetect.ts
+// derives its `ImportKind` union from it, and BUILTIN_KINDS below is built from it, so the list
+// that DEFINES a kind and the list that FORBIDS a custom importer from shadowing it cannot differ.
+// They were two hand-maintained copies and they drifted: okta, gws, hindsight, macos, leapp and
+// yara were detector kinds absent from BUILTIN_KINDS, so a custom spec could claim one of those ids
+// and displace the built-in importer for every file that detected as it — silently, because the
+// shadow check passed. Add a kind HERE and both halves move together.
+export const IMPORT_KINDS = [
   "thor",
   "siem",
   "evtxxml",
@@ -19,6 +25,11 @@ export const BUILTIN_KINDS: ReadonlySet<string> = new Set([
   "kape",
   "cybertriage",
   "m365",
+  "okta",
+  "gws",
+  "hindsight",
+  "macos",
+  "leapp",
   "aws",
   "cloud",
   "k8s",
@@ -34,13 +45,17 @@ export const BUILTIN_KINDS: ReadonlySet<string> = new Set([
   "thehive",
   "bashhistory",
   "snort",
+  "yara",
   "combinedlog",
   "asa",
   "syslog",
   "csv",
   "log",
   "unknown",
-]);
+] as const;
+
+// The built-in kinds a custom importer id must NOT shadow — every kind, by construction.
+export const BUILTIN_KINDS: ReadonlySet<string> = new Set(IMPORT_KINDS);
 
 const severityEnum = z.enum(["Critical", "High", "Medium", "Low", "Info"]);
 const transformEnum = z.enum(["trim", "lowercase", "basename", "cleanIp", "defang", "refang"]);

--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -33,6 +33,14 @@ import { toUtcIso } from "./timeUtc.js";
 import { reconTechniques } from "./reconTechniques.js";
 import { tradecraftSignal } from "./tradecraftRules.js";
 import { secretSpillSignal } from "./secretSpillRules.js";
+import {
+  LOLBINS,
+  NOISY_LOLBINS,
+  SUSP_PATH,
+  BENIGN_THREAD_SOURCES,
+  BENIGN_LSASS_ACCESSORS,
+  isTrustedSystemImage,
+} from "./winProcessBaseline.js";
 import { extractDomains, TEXT_DOMAIN_SKIP_RE, TEXT_FILE_EXT_RE, hasPlausibleTld } from "./textDomains.js";
 
 // Re-exported for the sibling importers, which already source their shared helpers
@@ -431,108 +439,11 @@ const SYSMON_EVENTS: Record<number, WinEventDef> = {
   26: { label: "File delete logged", severity: "Low", mitre: ["T1070.004"] },
 };
 
-// LOLBins whose appearance as the image (Sysmon 1 / 4688) bumps a benign process-create.
-const LOLBINS = new Set([
-  "powershell.exe",
-  "pwsh.exe",
-  "cmd.exe",
-  "wscript.exe",
-  "cscript.exe",
-  "mshta.exe",
-  "rundll32.exe",
-  "regsvr32.exe",
-  "wmic.exe",
-  "certutil.exe",
-  "bitsadmin.exe",
-  "msiexec.exe",
-  "installutil.exe",
-  "regasm.exe",
-  "regsvcs.exe",
-  "msbuild.exe",
-  "cmstp.exe",
-  "schtasks.exe",
-  "at.exe",
-  "sc.exe",
-  "net.exe",
-  "net1.exe",
-  "psexec.exe",
-  "psexesvc.exe",
-  "vssadmin.exe",
-  "bcdedit.exe",
-  "wevtutil.exe",
-  "reg.exe",
-  "curl.exe",
-  "ftp.exe",
-  "hh.exe",
-  "odbcconf.exe",
-]);
-// Core OS processes that legitimately call CreateRemoteThread (Sysmon EID 8) during normal
-// session/process setup — csrss/wininit/services injecting is routine, so we downgrade those
-// from the default High (they stay in the timeline; synthesis/legit-marking can still act).
-// Core OS processes that legitimately CreateRemoteThread as routine session/service setup, PLUS
-// Windows Defender / Defender-for-Endpoint, which inject monitoring threads into user processes as
-// part of behavioral scanning — a benign EID 8 source, not injection tradecraft. Also the desktop/
-// shell brokers that routinely inject as part of ordinary UI plumbing: Windows Search indexing its
-// own protocol host, dllhost.exe (COM Surrogate) loading shell-extension/COM objects, and the UWP
-// app-model brokers taskhostw/RuntimeBroker — all fire constantly on a stock, uncompromised desktop
-// and otherwise drown real injection signal in noise (see the fairhaven-rdp-takeover benchmark,
-// where this exact pairing on unrelated hosts got escalated into a fabricated finding).
-const BENIGN_THREAD_SOURCES = new Set([
-  "csrss.exe",
-  "wininit.exe",
-  "services.exe",
-  "smss.exe",
-  "svchost.exe",
-  "wmiprvse.exe",
-  "lsm.exe",
-  "winlogon.exe",
-  "msmpeng.exe",
-  "mpdefendercoreservice.exe",
-  "mssense.exe",
-  "sensendr.exe",
-  "mpcmdrun.exe", // Defender / MDE
-  "searchindexer.exe",
-  "searchprotocolhost.exe",
-  "dllhost.exe",
-  "taskhostw.exe",
-  "runtimebroker.exe", // shell/UI brokers
-]);
-// Windows-native processes that access LSASS constantly as part of normal operation (#198). A
-// Sysmon EID 10 ProcessAccess to lsass.exe from one of these is NOT credential dumping — Defender /
-// Defender-for-Endpoint scan it on every boot, and core OS processes open it routinely. Keyed on the
-// SourceImage basename; still graded High when the source runs from a SUSPICIOUS path (a masqueraded
-// "svchost.exe" in \Temp\ is not benign), and a non-listed accessor (e.g. a renamed dumper) stays High.
-const BENIGN_LSASS_ACCESSORS = new Set([
-  "msmpeng.exe",
-  "mpdefendercoreservice.exe",
-  "mssense.exe",
-  "sensendr.exe",
-  "mpcmdrun.exe", // Defender / MDE
-  "svchost.exe",
-  "services.exe",
-  "csrss.exe",
-  "wininit.exe",
-  "lsass.exe",
-  "wmiprvse.exe",
-  "smss.exe",
-  "lsm.exe",
-]);
 // Command-line markers strongly associated with attacker tradecraft → stronger bump.
 const STRONG_CMD =
   /mimikatz|sekurlsa|lsadump|invoke-mimikatz|-dumpcr|comsvcs\.dll.*minidump|vssadmin\s+delete|wbadmin\s+delete|wevtutil\s+cl\b|fsutil\s+usn\s+deletejournal|lsass[^\n]{0,40}\.dmp|\.dmp[^\n]{0,40}lsass|(?:-p|--pid|--process)\s+lsass|nanodump|dumpert|handlekatz|procdump[^\n]*lsass|reg\s+save\s+[^\n]*\\sam\b|ntds\.dit|ntdsutil[^\n]*ifm/i;
 const SUSP_CMD =
   /-enc\b|-e\s+[A-Za-z0-9+/]{20,}|encodedcommand|frombase64string|-nop\b|-noni\b|-noprofile|-w\s*hidden|-windowstyle\s+hidden|iex\b|invoke-expression|downloadstring|downloadfile|net\.webclient|-bypass|certutil.*-urlcache|bitsadmin.*\/transfer|\/add\b|reg\s+add.*\\run|mysqldump|pg_dump|mongodump|(?:curl|wget)\b[^\n]*(?:--data-binary|--upload-file|\s-T\b|\s-F\b|--form|-d\s+@)/i;
-// Execution from a user-writable / staging directory is itself a weak masquerade/tradecraft signal
-// (#199) — a non-system binary launched from Temp / AppData / Downloads / Public / ProgramData, or
-// /tmp,/dev/shm,/var/tmp on *nix. Tested against the IMAGE path (not the whole command) to avoid
-// matching a path that merely appears as an argument. ProgramData recurs across the DFIR Report and
-// Huntress corpora as ransomware/dropper staging ground (msidxsvc.exe, locker.exe, sc-created
-// payloads, renamed PowerShell) — same Medium-bump tier as the other user-writable paths, not High.
-// EXCEPTION: `\ProgramData\Microsoft\Windows Defender\` is Defender's own legitimate install path
-// (MsMpEng.exe et al. really live there), so it's carved out — otherwise every benign Defender
-// EID 8/10 event would trip the masquerade override in BENIGN_THREAD_SOURCES/BENIGN_LSASS_ACCESSORS.
-const SUSP_PATH =
-  /\\(?:appdata|temp|downloads)\\|\\users\\public\\|\\programdata\\(?!microsoft\\windows defender\\)|(?:^|[\s"])\/(?:tmp|var\/tmp|dev\/shm)\//i;
 
 // Channel → short tool label for the description and source tag.
 function channelLabel(channel: string): string {
@@ -759,14 +670,18 @@ function winAccounts(ed: Row): string[] {
 }
 
 // Grade a process image + command line for attacker tradecraft: "strong" (mimikatz / lsadump /
-// log-clearing), "weak" (a LOLBin or an encoded / hidden / download command), or null. Exported so
-// the memory-forensics importer can bump a Volatility `cmdline` row the same way.
+// log-clearing), "weak" (an encoded / hidden / download command, a user-writable image path, or an
+// UNCOMMON LOLBin image), or null. Exported so the memory-forensics importer can bump a Volatility
+// `cmdline` row the same way.
 export function isSuspiciousCmd(image: string, cmd: string): "strong" | "weak" | null {
   const blob = `${image} ${cmd}`;
   if (STRONG_CMD.test(blob)) return "strong";
-  if (LOLBINS.has(baseName(image).toLowerCase()) || SUSP_CMD.test(blob) || SUSP_PATH.test(image))
-    return "weak";
-  return null;
+  if (SUSP_CMD.test(blob) || SUSP_PATH.test(image)) return "weak";
+  // A LOLBin IMAGE on its own grades only when the binary is not itself an everyday one: cmd.exe and
+  // powershell.exe spawn continuously on a healthy endpoint, so the name proves nothing without a
+  // command-line or path signal to go with it, and grading it Medium buried the rare real one.
+  const base = baseName(image).toLowerCase();
+  return LOLBINS.has(base) && !NOISY_LOLBINS.has(base) ? "weak" : null;
 }
 
 export interface MappedEvent {
@@ -962,7 +877,7 @@ export function mapWindows(
   }
   if (def.kind === "procaccess" && /lsass\.exe$/i.test(str(getCI(ed, "TargetImage")))) {
     const srcImg = str(getCI(ed, "SourceImage"));
-    const benign = BENIGN_LSASS_ACCESSORS.has(baseName(srcImg).toLowerCase()) && !SUSP_PATH.test(srcImg);
+    const benign = BENIGN_LSASS_ACCESSORS.has(baseName(srcImg).toLowerCase()) && isTrustedSystemImage(srcImg);
     if (benign) {
       // Routine OS / Defender LSASS access — keep as Low evidence, NOT a credential-dump finding (#198).
       severity = "Low";
@@ -977,7 +892,7 @@ export function mapWindows(
   // masqueraded svchost.exe in \Temp\) is NOT benign and keeps High + T1055.
   if (isSysmon && eid === 8) {
     const srcImg = str(getCI(ed, "SourceImage"));
-    if (BENIGN_THREAD_SOURCES.has(baseName(srcImg).toLowerCase()) && !SUSP_PATH.test(srcImg)) {
+    if (BENIGN_THREAD_SOURCES.has(baseName(srcImg).toLowerCase()) && isTrustedSystemImage(srcImg)) {
       severity = "Low";
       const i = mitre.indexOf("T1055");
       if (i >= 0) mitre.splice(i, 1);

--- a/companion/src/analysis/winProcessBaseline.ts
+++ b/companion/src/analysis/winProcessBaseline.ts
@@ -1,0 +1,153 @@
+// What a normal Windows host looks like — the baseline the SIEM/Sysmon grader measures against.
+//
+// Everything here answers "is this ordinary?", which is a different question from "is this attacker
+// tradecraft?" (STRONG_CMD / SUSP_CMD / tradecraftRules.ts, which stay beside the grader). Keeping
+// the two apart matters because they fail in opposite directions: a gap in the tradecraft lists
+// costs a detection, a gap HERE costs signal-to-noise across every event the importer emits.
+
+// LOLBins — the binaries attackers reach for because they are already on the box. Appearing as
+// the image (Sysmon 1 / 4688) bumps a process-create, EXCEPT for the everyday ones listed in
+// NOISY_LOLBINS below, which need a command-line or path signal to go with the name.
+export const LOLBINS = new Set([
+  "powershell.exe",
+  "pwsh.exe",
+  "cmd.exe",
+  "wscript.exe",
+  "cscript.exe",
+  "mshta.exe",
+  "rundll32.exe",
+  "regsvr32.exe",
+  "wmic.exe",
+  "certutil.exe",
+  "bitsadmin.exe",
+  "msiexec.exe",
+  "installutil.exe",
+  "regasm.exe",
+  "regsvcs.exe",
+  "msbuild.exe",
+  "cmstp.exe",
+  "schtasks.exe",
+  "at.exe",
+  "sc.exe",
+  "net.exe",
+  "net1.exe",
+  "psexec.exe",
+  "psexesvc.exe",
+  "vssadmin.exe",
+  "bcdedit.exe",
+  "wevtutil.exe",
+  "reg.exe",
+  "curl.exe",
+  "ftp.exe",
+  "hh.exe",
+  "odbcconf.exe",
+]);
+// The LOLBins above that are ALSO ordinary. Each of these runs constantly on a stock managed
+// endpoint — every installer shells out to cmd.exe, every logon script calls net.exe, Intune/SCCM
+// live in powershell.exe, the shell itself is a rundll32.exe caller — so the image name alone
+// carries no information. Grading them Medium on the name put thousands of benign process
+// creations above the forensic gate's Low floor, which is how the genuinely rare malicious row
+// (an encoded command out of \Temp\) ends up indistinguishable from a printer driver loading.
+//
+// They are NOT removed from LOLBINS: paired with a command-line or path signal they still grade,
+// and they still carry their ATT&CK context. They simply stop being a verdict on their own.
+// The rest of LOLBINS keeps the standalone bump, because mshta.exe / certutil.exe / bitsadmin.exe /
+// installutil.exe appearing at all on an endpoint IS the anomaly.
+export const NOISY_LOLBINS = new Set([
+  "cmd.exe",
+  "powershell.exe",
+  "pwsh.exe",
+  "msiexec.exe",
+  "rundll32.exe",
+  "net.exe",
+  "net1.exe",
+  "sc.exe",
+  "reg.exe",
+  "schtasks.exe",
+  "wmic.exe",
+  "curl.exe",
+]);
+
+// Core OS processes that legitimately CreateRemoteThread as routine session/service setup, PLUS
+// Windows Defender / Defender-for-Endpoint, which inject monitoring threads into user processes as
+// part of behavioral scanning — a benign EID 8 source, not injection tradecraft. Also the desktop/
+// shell brokers that routinely inject as part of ordinary UI plumbing: Windows Search indexing its
+// own protocol host, dllhost.exe (COM Surrogate) loading shell-extension/COM objects, and the UWP
+// app-model brokers taskhostw/RuntimeBroker — all fire constantly on a stock, uncompromised desktop
+// and otherwise drown real injection signal in noise (see the fairhaven-rdp-takeover benchmark,
+// where this exact pairing on unrelated hosts got escalated into a fabricated finding).
+export const BENIGN_THREAD_SOURCES = new Set([
+  "csrss.exe",
+  "wininit.exe",
+  "services.exe",
+  "smss.exe",
+  "svchost.exe",
+  "wmiprvse.exe",
+  "lsm.exe",
+  "winlogon.exe",
+  "msmpeng.exe",
+  "mpdefendercoreservice.exe",
+  "mssense.exe",
+  "sensendr.exe",
+  "mpcmdrun.exe", // Defender / MDE
+  "searchindexer.exe",
+  "searchprotocolhost.exe",
+  "dllhost.exe",
+  "taskhostw.exe",
+  "runtimebroker.exe", // shell/UI brokers
+]); // Windows-native processes that access LSASS constantly as part of normal operation (#198). A
+// Sysmon EID 10 ProcessAccess to lsass.exe from one of these is NOT credential dumping — Defender /
+// Defender-for-Endpoint scan it on every boot, and core OS processes open it routinely. Keyed on the
+// SourceImage basename; still graded High when the source runs from a SUSPICIOUS path (a masqueraded
+// "svchost.exe" in \Temp\ is not benign), and a non-listed accessor (e.g. a renamed dumper) stays High.
+export const BENIGN_LSASS_ACCESSORS = new Set([
+  "msmpeng.exe",
+  "mpdefendercoreservice.exe",
+  "mssense.exe",
+  "sensendr.exe",
+  "mpcmdrun.exe", // Defender / MDE
+  "svchost.exe",
+  "services.exe",
+  "csrss.exe",
+  "wininit.exe",
+  "lsass.exe",
+  "wmiprvse.exe",
+  "smss.exe",
+  "lsm.exe",
+]); // Execution from a user-writable / staging directory is itself a weak masquerade/tradecraft signal
+// (#199) — a non-system binary launched from Temp / AppData / Downloads / Public / ProgramData, or
+// /tmp,/dev/shm,/var/tmp on *nix. Tested against the IMAGE path (not the whole command) to avoid
+// matching a path that merely appears as an argument. ProgramData recurs across the DFIR Report and
+// Huntress corpora as ransomware/dropper staging ground (msidxsvc.exe, locker.exe, sc-created
+// payloads, renamed PowerShell) — same Medium-bump tier as the other user-writable paths, not High.
+// EXCEPTION: `\ProgramData\Microsoft\Windows Defender\` is Defender's own legitimate install path
+// (MsMpEng.exe et al. really live there), so it's carved out — otherwise every benign Defender
+// EID 8/10 event would trip the masquerade override in BENIGN_THREAD_SOURCES/BENIGN_LSASS_ACCESSORS.
+export const SUSP_PATH =
+  /\\(?:appdata|temp|downloads)\\|\\users\\public\\|\\programdata\\(?!microsoft\\windows defender\\)|(?:^|[\s"])\/(?:tmp|var\/tmp|dev\/shm)\//i;
+
+// Where a trusted Windows binary actually lives. The benign sets above are keyed on the image
+// BASENAME, and a basename is the one thing an attacker controls for free: dropping a DLL-hijack
+// payload named svchost.exe into a directory SUSP_PATH does not cover (C:\Windows\, a subdirectory
+// of an installed product) inherited the full benign downgrade. Checking that the path is a system
+// path turns that denylist into an allowlist — the name must match AND the binary must live where
+// that name belongs.
+const SYSTEM_IMAGE_PATH =
+  /\\windows\\(?:system32|syswow64|winsxs)\\|\\program files(?: \(x86\))?\\|\\programdata\\microsoft\\windows defender\\/i;
+
+// True when `image` may be trusted on the strength of its name. A path that is present must be a
+// system path; a path that is ABSENT keeps the old name-based trust, because plenty of SIEM
+// normalizations forward only the basename and tightening that case would regrade every Defender
+// LSASS access on those feeds as credential dumping (#198) — a much worse trade than the
+// masquerade this closes.
+export function isTrustedSystemImage(image: string): boolean {
+  const p = image.trim();
+  if (!p || !/[\\/]/.test(p)) return true; // nothing to judge / no path to check
+  // Plenty of SIEMs normalize `C:\Windows\System32\svchost.exe` to `C:/Windows/System32/svchost.exe`.
+  // Both path regexes are written with backslashes, so on those feeds every benign Defender and
+  // core-OS event would have failed the allowlist and been regraded as credential dumping or
+  // injection. Fold the separator before either test — that also closes the mirror-image hole,
+  // where a masquerade at `C:/Users/Public/` slipped past SUSP_PATH for the very same reason.
+  const win = p.replace(/\//g, "\\");
+  return !SUSP_PATH.test(win) && SYSTEM_IMAGE_PATH.test(win);
+}

--- a/companion/tests/analysis/evtxXmlImport.test.ts
+++ b/companion/tests/analysis/evtxXmlImport.test.ts
@@ -158,11 +158,24 @@ describe("parseEvtxXml — reuses the SIEM Windows mapping", () => {
   });
 
   it("honors the severity floor", () => {
+    // The sample's own process-create is `cmd.exe /c echo` — benign, and Low. The LOLBin NAME on
+    // its own no longer bumps it (see NOISY_LOLBINS), so the floor needs an event that genuinely
+    // earns Medium before it has anything to keep. An encoded, hidden-window PowerShell does.
+    const graded = SAMPLE.replace(
+      "cmd.exe /c echo a &amp; echo b &lt;nul&gt;",
+      "powershell.exe -nop -w hidden -enc SQBFAFgAIAA=",
+    );
+    const r = parseEvtxXml(graded, { minSeverity: "Medium" });
+    expect(r.events.every((e) => !/Successful logon/i.test(e.description))).toBe(true); // 4624 is Low
+    expect(r.events.some((e) => /Process create/i.test(e.description))).toBe(true); // graded Medium
+  });
+
+  it("leaves an ordinary cmd.exe process-create below that same floor", () => {
+    // The other half of the change: an everyday LOLBin running an everyday command is telemetry.
+    // It used to clear a Medium floor on the strength of its name alone.
     const r = parseEvtxXml(SAMPLE, { minSeverity: "Medium" });
-    // 4624 (Low) drops; the Sysmon process-create survives because cmd.exe is a LOLBin and the
-    // shared mapWindows bumps it to Medium.
-    expect(r.events.every((e) => !/Successful logon/i.test(e.description))).toBe(true);
-    expect(r.events.some((e) => /Process create/i.test(e.description))).toBe(true);
+    expect(r.events).toHaveLength(0);
+    expect(parseEvtxXml(SAMPLE).events.some((e) => /Process create/i.test(e.description))).toBe(true);
   });
 
   it("yields and honors cancellation during the expensive record-mapping phase", async () => {

--- a/companion/tests/analysis/importDetect.test.ts
+++ b/companion/tests/analysis/importDetect.test.ts
@@ -626,6 +626,32 @@ describe("detectImportKind — CSV formats", () => {
   it("csv: a generic comma table → AI CSV importer", () => {
     expect(detectImportKind("data.csv", "colA,colB,colC\n1,2,3\n4,5,6")).toBe("csv");
   });
+
+  it("routes a single-column CSV with real depth to the CSV importer, not line-triage", () => {
+    // The common shape is an IOC list: one header plus a run of hashes. As `log` it went to AI
+    // line-triage and lost the header that says what the values ARE.
+    const hashes = ["sha256", ...Array.from({ length: 12 }, (_, i) => `${i}`.repeat(64))].join("\n");
+    expect(detectImportKind("iocs.csv", hashes)).toBe("csv");
+  });
+
+  it("does NOT claim a deep comma-less LOG as a single-column CSV", () => {
+    // detectCsv is the last fallback, so every unrecognized text file reaches it and a comma-less
+    // line parses as a one-column row. Depth alone claimed these and ate the first line as a header.
+    const stack = Array.from(
+      { length: 14 },
+      (_, i) => `    at frame${i} (/srv/app/lib/mod${i}.js:${i}:3)`,
+    ).join("\n");
+    expect(detectImportKind("crash.txt", stack)).toBe("log");
+    const tokens = Array.from({ length: 14 }, (_, i) => `worker-${i}-started`).join("\n");
+    expect(detectImportKind("worker.log", tokens)).toBe("log"); // whitespace-free, but not a .csv
+    const prose = ["Event", ...Array.from({ length: 14 }, (_, i) => `the worker restarted at ${i}:00`)];
+    expect(detectImportKind("notes.csv", prose.join("\n"))).toBe("log"); // .csv, but values are prose
+  });
+
+  it("leaves a shallow single-column file as 'log'", () => {
+    // The row floor is what keeps a scrap of prose out — an accidental single column has no depth.
+    expect(detectImportKind("note.csv", "Subject\nthe host was rebuilt on Tuesday")).toBe("log");
+  });
 });
 
 describe("detectImportKind — email", () => {
@@ -716,6 +742,19 @@ describe("detectImportKind — Linux evidence sources (#62)", () => {
       ),
     ).toBe("sysdig");
   });
+  it("auditd: the first record sits past the old 8 KB sniff window", () => {
+    // A real audit.log opens with a boot banner and a run of records the regex does not match; a
+    // file whose first `type=… msg=audit(…)` landed past 8 KB sniffed as a plain log and went to
+    // AI line-triage instead of the auditd importer.
+    const preamble = Array.from(
+      { length: 400 },
+      (_, i) => `node=host.example kernel: [${i}.000000] systemd: Starting user session ${i}`,
+    ).join("\n");
+    expect(preamble.length).toBeGreaterThan(8000);
+    const log = `${preamble}\ntype=SYSCALL msg=audit(1490451217.272:270): arch=c000003e syscall=59 comm="cat"`;
+    expect(detectImportKind("audit.log", log)).toBe("auditd");
+  });
+
   it("not auditd: a plain syslog with no audit records stays 'log'", () => {
     expect(detectImportKind("auth.log", "Jan  1 00:00:01 host sshd[1]: Failed password for root")).toBe(
       "log",

--- a/companion/tests/analysis/importerSpec.test.ts
+++ b/companion/tests/analysis/importerSpec.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseImporterSpec, EXAMPLE_IMPORTER_SPEC } from "../../src/analysis/importerSpec.js";
+import {
+  parseImporterSpec,
+  EXAMPLE_IMPORTER_SPEC,
+  IMPORT_KINDS,
+  BUILTIN_KINDS,
+} from "../../src/analysis/importerSpec.js";
+import { detectImportKind } from "../../src/analysis/importDetect.js";
 
 describe("parseImporterSpec", () => {
   it("accepts the bundled worked example", () => {
@@ -25,5 +31,29 @@ describe("parseImporterSpec", () => {
 
   it("rejects unknown top-level keys (strict)", () => {
     expect(parseImporterSpec({ ...EXAMPLE_IMPORTER_SPEC, bogus: 1 }).ok).toBe(false);
+  });
+
+  // BUILTIN_KINDS and the ImportKind union were two hand-maintained copies of one list, and they
+  // drifted: six detector kinds were missing from the guard, so a custom spec could claim one of
+  // those ids and displace the built-in importer for every file that detected as it — silently,
+  // because the collision check passed. They are one array now; this pins that.
+  it("forbids EVERY detector kind as a custom id, including the six that had drifted", () => {
+    for (const kind of ["okta", "gws", "hindsight", "macos", "leapp", "yara"]) {
+      const r = parseImporterSpec({ ...EXAMPLE_IMPORTER_SPEC, id: kind });
+      expect(r.ok, `custom id "${kind}" must not shadow the built-in kind`).toBe(false);
+      if (!r.ok) expect(r.errors.some((e) => e.path === "id")).toBe(true);
+    }
+    for (const kind of IMPORT_KINDS) expect(BUILTIN_KINDS.has(kind)).toBe(true);
+  });
+
+  it("keeps every kind the detector can actually return inside the guard", () => {
+    // Detection is the other half of the contract: a kind reachable from detectImportKind but
+    // absent from BUILTIN_KINDS is exactly the hole the drift left open.
+    const reached = [
+      detectImportKind("hashes.csv", ["sha256", ...Array.from({ length: 12 }, (_, i) => `${i}`)].join("\n")),
+      detectImportKind("audit.log", "type=SYSCALL msg=audit(1490451217.272:270): arch=c000003e"),
+      detectImportKind("data.csv", "colA,colB\n1,2"),
+    ];
+    for (const kind of reached) expect(BUILTIN_KINDS.has(kind)).toBe(true);
   });
 });

--- a/companion/tests/analysis/siemImport.test.ts
+++ b/companion/tests/analysis/siemImport.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { isTrustedSystemImage } from "../../src/analysis/winProcessBaseline.js";
 import {
   parseSiemExport,
   extractRecords,
@@ -401,6 +402,58 @@ describe("parseSiemExport — Windows Event Log mapping", () => {
     expect(r.events[0].mitreTechniques).toContain("T1003.001");
   });
 
+  it("flags a system NAME running from a non-system path, even one SUSP_PATH does not list", () => {
+    // C:\Windows\ is neither System32 nor a staging directory, so the name alone used to carry the
+    // whole downgrade — the classic DLL-hijack / side-loading drop.
+    const hijack = {
+      "@timestamp": "2024-03-18T10:03:00Z",
+      log_name: "Microsoft-Windows-Sysmon/Operational",
+      computer_name: "WS1",
+      event_id: 10,
+      event_data: {
+        SourceImage: "C:\\Windows\\svchost.exe",
+        TargetImage: "C:\\Windows\\System32\\lsass.exe",
+        GrantedAccess: "0x1410",
+      },
+    };
+    const r = parseSiemExport(elastic(hijack));
+    expect(r.events[0].severity).toBe("High");
+    expect(r.events[0].mitreTechniques).toContain("T1003.001");
+  });
+
+  it("still downgrades a benign accessor whose feed normalized the path separator", () => {
+    const slashes = {
+      "@timestamp": "2024-03-18T10:05:00Z",
+      log_name: "Microsoft-Windows-Sysmon/Operational",
+      computer_name: "WS1",
+      event_id: 10,
+      event_data: {
+        SourceImage: "C:/Windows/System32/svchost.exe",
+        TargetImage: "C:/Windows/System32/lsass.exe",
+        GrantedAccess: "0x1010",
+      },
+    };
+    const r = parseSiemExport(elastic(slashes));
+    expect(r.events[0].severity).toBe("Low");
+    expect(r.events[0].mitreTechniques).not.toContain("T1003.001");
+  });
+
+  it("still downgrades a benign accessor a feed reported by basename only", () => {
+    const bare = {
+      "@timestamp": "2024-03-18T10:04:00Z",
+      log_name: "Microsoft-Windows-Sysmon/Operational",
+      computer_name: "WS1",
+      event_id: 10,
+      event_data: {
+        SourceImage: "MsMpEng.exe",
+        TargetImage: "C:\\Windows\\System32\\lsass.exe",
+        GrantedAccess: "0x1010",
+      },
+    };
+    const r = parseSiemExport(elastic(bare));
+    expect(r.events[0].severity).toBe("Low");
+  });
+
   it("grades a renamed LSASS dumper (by argument) as High — #199", () => {
     const dump = {
       "@timestamp": "2024-03-18T15:24:38Z",
@@ -580,6 +633,83 @@ describe("isSuspiciousCmd — #199 tradecraft grading", () => {
   it("null: benign system binary running a benign command", () => {
     expect(isSuspiciousCmd("C:\\Windows\\System32\\whoami.exe", "whoami /all")).toBe(null);
     expect(isSuspiciousCmd("/usr/bin/id", "id")).toBe(null);
+  });
+
+  // An EVERYDAY LOLBin name is not a verdict. cmd.exe and powershell.exe run continuously on a
+  // healthy managed endpoint, so grading them Medium on the image alone put thousands of benign
+  // process creations above the forensic gate and buried the rare real one.
+  it("null: an everyday LOLBin with an ordinary command line", () => {
+    expect(isSuspiciousCmd("C:\\Windows\\System32\\cmd.exe", "cmd.exe /c dir C:\\Reports")).toBe(null);
+    expect(
+      isSuspiciousCmd(
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "powershell.exe -File C:\\Scripts\\Inventory.ps1",
+      ),
+    ).toBe(null);
+    expect(isSuspiciousCmd("C:\\Windows\\System32\\net.exe", "net use Z: \\\\fs01\\share")).toBe(null);
+    expect(isSuspiciousCmd("C:\\Windows\\System32\\msiexec.exe", "msiexec.exe /i app.msi /qn")).toBe(null);
+  });
+
+  it("weak: the SAME everyday LOLBin once the command line carries a signal", () => {
+    expect(isSuspiciousCmd("C:\\Windows\\System32\\cmd.exe", "cmd.exe /c powershell -enc SQBFAFgA")).toBe(
+      "weak",
+    );
+    expect(isSuspiciousCmd("C:\\Windows\\Temp\\cmd.exe", "cmd.exe /c dir")).toBe("weak");
+  });
+
+  it("weak: an UNCOMMON LOLBin still grades on the image alone", () => {
+    expect(isSuspiciousCmd("C:\\Windows\\System32\\mshta.exe", "mshta.exe https://x.example/a.hta")).toBe(
+      "weak",
+    );
+    expect(isSuspiciousCmd("C:\\Windows\\System32\\certutil.exe", "certutil.exe -decode a.txt b.exe")).toBe(
+      "weak",
+    );
+    expect(isSuspiciousCmd("C:\\Windows\\System32\\installutil.exe", "installutil.exe /u x.dll")).toBe(
+      "weak",
+    );
+  });
+});
+
+// The benign-source sets are keyed on the image BASENAME, which is the one thing an attacker gets
+// for free. SUSP_PATH alone could not close that: it lists the STAGING directories, so a payload
+// named svchost.exe dropped somewhere it does not cover inherited the full downgrade.
+describe("isTrustedSystemImage — name-based trust needs the matching path (#198 follow-up)", () => {
+  it("trusts a system path", () => {
+    expect(isTrustedSystemImage("C:\\Windows\\System32\\svchost.exe")).toBe(true);
+    expect(isTrustedSystemImage("C:\\Windows\\System32\\wbem\\WmiPrvSE.exe")).toBe(true);
+    expect(isTrustedSystemImage("C:\\Windows\\SysWOW64\\svchost.exe")).toBe(true);
+    expect(
+      isTrustedSystemImage("C:\\Program Files\\Windows Defender Advanced Threat Protection\\MsSense.exe"),
+    ).toBe(true);
+    expect(
+      isTrustedSystemImage("C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\4.18\\MsMpEng.exe"),
+    ).toBe(true);
+  });
+
+  it("does NOT trust a system NAME sitting outside a system path", () => {
+    expect(isTrustedSystemImage("C:\\Windows\\svchost.exe")).toBe(false); // the DLL-hijack drop
+    expect(isTrustedSystemImage("C:\\Users\\Public\\svchost.exe")).toBe(false);
+    expect(isTrustedSystemImage("D:\\Apps\\vendor\\csrss.exe")).toBe(false);
+  });
+
+  it("reads a forward-slash path as the same path — many SIEMs normalize the separator", () => {
+    // Both path regexes are written with backslashes. Without folding the separator first, every
+    // benign Defender / core-OS event on a normalizing feed failed the allowlist and was regraded.
+    expect(isTrustedSystemImage("C:/Windows/System32/svchost.exe")).toBe(true);
+    expect(isTrustedSystemImage("C:/ProgramData/Microsoft/Windows Defender/Platform/4.18/MsMpEng.exe")).toBe(
+      true,
+    );
+    // The mirror-image hole closes with it: a masquerade under C:/Users/Public/ used to slip past
+    // SUSP_PATH for exactly the same reason.
+    expect(isTrustedSystemImage("C:/Users/Public/svchost.exe")).toBe(false);
+    expect(isTrustedSystemImage("C:/Windows/svchost.exe")).toBe(false);
+  });
+
+  it("keeps name-based trust when the feed forwarded no path at all", () => {
+    // Tightening this case would regrade every Defender LSASS access on a basename-only feed as
+    // credential dumping — a worse trade than the masquerade the allowlist closes.
+    expect(isTrustedSystemImage("svchost.exe")).toBe(true);
+    expect(isTrustedSystemImage("")).toBe(true);
   });
 });
 


### PR DESCRIPTION
Five fixes to the SIEM/EVTX import path, all from one review of how an event reaches a severity.

## What changed

**1. A LOLBin name alone is no longer a verdict.** `isSuspiciousCmd` bumped a process-create to Medium on the image basename. `cmd.exe`, `powershell.exe`, `rundll32.exe`, `msiexec.exe`, `net.exe`, `sc.exe`, `reg.exe`, `schtasks.exe` and friends run continuously on a managed endpoint, so thousands of benign 4688 / Sysmon 1 rows cleared the forensic gate's Low floor and buried the rare real one. Those twelve now need a command-line or path signal to grade. The uncommon LOLBins — `mshta.exe`, `certutil.exe`, `bitsadmin.exe`, `installutil.exe`, … — keep the standalone bump, because their presence at all is the anomaly.

**2. A trusted name now needs the matching path.** The Sysmon 8/10 benign-source downgrade tested `!SUSP_PATH`, a denylist of staging directories. A DLL-hijack payload named `svchost.exe` dropped in `C:\Windows\` matched no staging directory and inherited the whole downgrade. `isTrustedSystemImage` turns that into an allowlist: System32 / SysWOW64 / WinSxS / Program Files / Defender's own directory. Two deliberate carve-outs — an image a feed reported by **basename only** keeps name-based trust (tightening it would regrade every Defender LSASS access on path-stripping feeds as credential dumping), and a path normalized to **forward slashes** is folded and read as the same path. The fold also closes a pre-existing hole where a masquerade at `C:/Users/Public/` slipped past `SUSP_PATH`.

**3. `BUILTIN_KINDS` had drifted from `ImportKind`.** They were two hand-maintained copies of one list. `okta`, `gws`, `hindsight`, `macos`, `leapp` and `yara` were detector kinds absent from the guard, so a custom importer spec could claim one of those ids and silently displace the built-in importer for every file that detected as it. `IMPORT_KINDS` is now the single array: the union derives from it and the guard is built from it, so the two cannot differ again.

**4. auditd detection sniffed only the first 8 KB.** A real `audit.log` opens with a boot banner, so a file whose first `type=… msg=audit(…)` sat past that window went to AI line-triage as a plain log. Now 256 KB.

**5. A single-column CSV with real depth reaches the CSV importer.** The common shape is an IOC list — one header plus a run of hashes, IPs or domains — which went to line-triage as `log` and lost the header that says what the values are. `detectCsv` is the last fallback, so the rule is deliberately narrow: the `.csv`/`.tsv` extension the author chose, ≥10 rows, **and** whitespace-free single-token values. Depth alone would have claimed stack traces and plain application logs.

## Structure

The noise-suppression constants move out of `siemImport.ts` into a new `analysis/winProcessBaseline.ts`. "Is this ordinary?" is a different question from "is this tradecraft?", and the two fail in opposite directions: a gap in the tradecraft lists costs a detection, a gap in the baseline costs signal-to-noise across every event the importer emits. `siemImport.ts` shrinks 1771 → 1687.

## Verification

- **9 new tests.** Each behavioral one was confirmed to fail against the pre-change code and pass after.
- One existing test changed on purpose: `evtxXmlImport`'s severity-floor test passed *because* of the LOLBin false positive removed in (1) — its own comment said so. Its subject is restored with an input that genuinely earns Medium, and a companion test pins the new behaviour.
- Full suite green: 10561 tests. `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all clean.
