### PR TITLE
feat(velociraptor): move the webshell and MFT scans into Best Practice - Big Hogs

### DIFF
--- a/companion/src/analysis/artifactBundleStore.ts
+++ b/companion/src/analysis/artifactBundleStore.ts
@@ -110,7 +110,6 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
       "Windows.EventLogs.Chainsaw",
       "Windows.EventLogs.CondensedAccountUsage",
       "DetectRaptor.Generic.Detection.BrowserExtensions",
-      "DetectRaptor.Generic.Detection.YaraWebshell",
       "DetectRaptor.Linux.Detection.YaraProcessLinux",
       "DetectRaptor.Macos.Detection.YaraProcessMacos",
       "DetectRaptor.Windows.Detection.Amcache",
@@ -124,7 +123,6 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
       "DetectRaptor.Windows.Detection.LolDriversMalicious",
       "DetectRaptor.Windows.Detection.LolDriversVulnerable",
       "DetectRaptor.Windows.Detection.LolRMM",
-      "DetectRaptor.Windows.Detection.MFT",
       "DetectRaptor.Windows.Detection.NamedPipes",
       "DetectRaptor.Windows.Detection.Powershell.ISEAutoSave",
       "DetectRaptor.Windows.Detection.Powershell.PSReadline",
@@ -171,11 +169,17 @@ export const BUILT_IN_BUNDLES: readonly ArtifactBundle[] = [
   {
     id: "best-practice-big-hogs",
     name: "Best Practice - Big Hogs",
-    description: "Slow full-disk/file scans split out of Best Practice (YaraFile, THOR ZIP)",
+    description:
+      "Slow full-disk/file scans split out of Best Practice (YaraFile, YaraWebshell, MFT, THOR ZIP)",
     builtIn: true,
-    artifacts: ["DetectRaptor.Generic.Detection.YaraFile", "Generic.Scanner.ThorZIP"],
+    artifacts: [
+      "DetectRaptor.Generic.Detection.YaraFile",
+      "DetectRaptor.Generic.Detection.YaraWebshell",
+      "DetectRaptor.Windows.Detection.MFT",
+      "Generic.Scanner.ThorZIP",
+    ],
     defaultWaitMinutes: 60, // these scan the whole disk — the 10-min Best Practice default collects too early
-    timeoutSeconds: 6000, // matches the other bundles' default, well past the 600s Velociraptor default
+    timeoutSeconds: 7200, // longer than the other bundles' 6000s — these four walk the whole disk
     // Drop known-noisy rows at the source: YaraFile pagefile hits.
     filters: {
       "DetectRaptor.Generic.Detection.YaraFile": "NOT OSPath =~ 'pagefile'",

--- a/companion/tests/analysis/artifactBundleStore.test.ts
+++ b/companion/tests/analysis/artifactBundleStore.test.ts
@@ -264,18 +264,22 @@ describe("ArtifactBundleStore", () => {
     expect(bigHogs?.filters?.["DetectRaptor.Generic.Detection.YaraFile"]).toContain("pagefile");
   });
 
-  it("ships Best Practice - Big Hogs with the slow artifacts and the shared bundle timeout", async () => {
+  it("ships Best Practice - Big Hogs with the slow artifacts and its own longer timeout", async () => {
     const bigHogs = await store.get("best-practice-big-hogs");
     expect(bigHogs).not.toBeNull();
     expect(bigHogs?.builtIn).toBe(true);
     expect(bigHogs?.artifacts).toEqual([
       "DetectRaptor.Generic.Detection.YaraFile",
+      "DetectRaptor.Generic.Detection.YaraWebshell",
+      "DetectRaptor.Windows.Detection.MFT",
       "Generic.Scanner.ThorZIP",
     ]);
-    expect(bigHogs?.timeoutSeconds).toBe(6000);
+    expect(bigHogs?.timeoutSeconds).toBe(7200);
     const bp = await store.get("best-practice");
     expect(bp?.artifacts).not.toContain("DetectRaptor.Generic.Detection.YaraFile");
     expect(bp?.artifacts).not.toContain("Generic.Scanner.ThorZIP");
+    expect(bp?.artifacts).not.toContain("DetectRaptor.Generic.Detection.YaraWebshell");
+    expect(bp?.artifacts).not.toContain("DetectRaptor.Windows.Detection.MFT");
   });
 
   it("sanitizes params — drops nested objects and coerces values to strings", async () => {

--- a/mkdocs-docs/reference/integrations.md
+++ b/mkdocs-docs/reference/integrations.md
@@ -35,7 +35,7 @@ Run fleet hunts, collect artifacts, and stream live monitoring events into cases
 
 ### Triage Bundles
 
-Settings → Velociraptor. Four bundles ship built-in — **Best Practice** (the quick-wins detection sweep), **Best Practice - Big Hogs** (the DetectRaptor YARA file scan and THOR, split out because both walk the whole disk and run far longer than the rest of Best Practice; same 6000s default timeout as the other bundles), **Super-Timeline Triage** (raw host artifacts; results go to the super-timeline only), and **Linux Triage**. Every bundle is editable in place, and **Reset to default** restores a built-in. You can also create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results. See [Step 3a of the walkthrough](../walkthrough.md) for the run procedure.
+Settings → Velociraptor. Four bundles ship built-in — **Best Practice** (the quick-wins detection sweep), **Best Practice - Big Hogs** (the DetectRaptor YARA file and webshell scans, the DetectRaptor MFT keyword scan, and THOR, split out because they all walk the whole disk and run far longer than the rest of Best Practice; 7200s default timeout, longer than the other bundles' 6000s), **Super-Timeline Triage** (raw host artifacts; results go to the super-timeline only), and **Linux Triage**. Every bundle is editable in place, and **Reset to default** restores a built-in. You can also create and save custom bundles. Run a bundle from the Settings tab — it launches a fleet hunt and auto-imports results. See [Step 3a of the walkthrough](../walkthrough.md) for the run procedure.
 
 #### Third-party tools
 

--- a/mkdocs-docs/walkthrough.md
+++ b/mkdocs-docs/walkthrough.md
@@ -43,13 +43,13 @@ Open **Settings → Velociraptor**. Four bundles ship built-in:
 | Bundle | What it collects | Where results land |
 |--------|------------------|--------------------|
 | **Best Practice** | The quick-wins detection sweep — DetectRaptor rules, Hayabusa, Chainsaw, condensed account usage, process and network state, persistence, scheduled tasks | Forensic timeline (the AI sees them) |
-| **Best Practice - Big Hogs** *(optional)* | The two slow full-disk/file scans split out of Best Practice — the DetectRaptor YARA file scan and THOR. Same 6000s default timeout as the other bundles | Forensic timeline (the AI sees them) |
+| **Best Practice - Big Hogs** *(optional)* | The slow full-disk/file scans split out of Best Practice — the DetectRaptor YARA file and webshell scans, the DetectRaptor MFT keyword scan, and THOR. 7200s default timeout — longer than the other bundles' 6000s | Forensic timeline (the AI sees them) |
 | **Super-Timeline Triage** *(optional)* | Raw host artifacts — MFT, USN journal, prefetch, amcache, shellbags, SRUM, jump lists, registry, event logs | **Super-timeline only** |
 | **Linux Triage** | Linux host triage — users, persistence, network, packages, detection artifacts | Forensic timeline |
 
 **Run Best Practice on every case.** It is the fastest path from "a case exists" to "the dashboard has findings".
 
-**Best Practice - Big Hogs is optional.** The YARA file scan and THOR both walk the whole disk, so they run far longer than the rest of Best Practice. Run this bundle separately when you have time for a deeper sweep, rather than holding up the quick-wins pass.
+**Best Practice - Big Hogs is optional.** The YARA scans, the MFT keyword scan, and THOR all walk the whole disk, so they run far longer than the rest of Best Practice. Run this bundle separately when you have time for a deeper sweep, rather than holding up the quick-wins pass.
 
 **Super-Timeline Triage is optional.** Its artifacts hold hundreds of thousands of rows, so its results go to the super-timeline and never to the forensic timeline — they would drown synthesis. Run it when you need file-level or execution-level detail, then promote the rows that matter up from the [Super-Timeline panel](reference/dashboard.md). Skip it on a first pass.
 


### PR DESCRIPTION
Two DetectRaptor detections move out of **Best Practice** and into **Best Practice - Big Hogs**:

- `DetectRaptor.Generic.Detection.YaraWebshell`
- `DetectRaptor.Windows.Detection.MFT`

Both walk the whole disk, which is the exact shape Big Hogs was split out for in #654. Leaving them in the quick-wins sweep held up every other artifact in it.

Big Hogs now carries four full-disk scans:

```
DetectRaptor.Generic.Detection.YaraFile
DetectRaptor.Generic.Detection.YaraWebshell
DetectRaptor.Windows.Detection.MFT
Generic.Scanner.ThorZIP
```

Its per-collection timeout goes from 6000s to 7200s. The old value was picked in #658 to match the other bundles rather than to fit the bundle's own workload, and that workload just doubled.

### What an analyst sees

Best Practice finishes sooner. Webshell and MFT keyword hits now arrive with the separate Big Hogs run, which already waits an hour before collecting instead of ten minutes — the right wait for a scan of this length.

The change affects **new hunts only**. A bundle already customized on disk keeps its saved override; **Reset to default** picks up the new list.

### Also updated

- `mkdocs-docs/walkthrough.md` and `mkdocs-docs/reference/integrations.md` — both described Big Hogs as "the two slow scans" with a "same 6000s timeout as the other bundles". Both statements are now wrong on two counts.
- The Big Hogs test pinned the exact artifact list and the timeout, so both needed updating. Added two `not.toContain` assertions so Best Practice is checked for the departure of the moved artifacts, matching how the existing YaraFile/ThorZIP pair is checked.

### Verification

All gates run locally against the merge with `origin/master`: lint, format:check, check:size, check:imports, check:boundaries, eval:change-gate, check:us-map, build, typecheck, full `vitest run`, plus the extension typecheck, tests and both builds.
