### PR TITLE
fix(analysis): a superseded synthesis must stop, and the jobs chip must not lie

### DIFF
--- a/companion/src/analysis/ai/synthesis.ts
+++ b/companion/src/analysis/ai/synthesis.ts
@@ -471,6 +471,33 @@ async function resolveHostsOrThrow(
 }
 
 /**
+ * Stop here if this run has been superseded or cancelled.
+ *
+ * THE SIGNAL IS NOT THE PROVIDER'S ALONE. `exclusive: true` on the synthesis job means a newer kick
+ * aborts this run's signal, drops its row and frees the case's single concurrency slot so the newer
+ * run can start — see JobManager.dropForExclusiveRegistration. That only works if this run then
+ * stops. Handing `signal` to the model call is not enough: a provider that finishes the call anyway
+ * (the claude-code provider completed a six-minute call after its signal was aborted) used to carry
+ * on into the fold, the PERSIST — over the newer run's work — the run record and the second-look
+ * sweep, which is another full synthesis of its own. Two top-level runs then held the whole case
+ * state at once, state loads went from 0.6 s to 140 s, and neither reached its terminal `ai_status`,
+ * which is what left the header pill stuck on "AI: synthesizing…" with no job left to explain it.
+ *
+ * Called at the stage boundaries rather than inside the steps: a step that has begun should finish
+ * or throw on its own, and the boundaries are where nothing is half-written.
+ *
+ * Throws an `AbortError`, which is what both callers already classify a cancellation by (see
+ * captureAnalysis.settleSynthesisRejection and routes/analystGate.ts) — so a superseded run reports
+ * "cancelled", never "synthesis failed".
+ */
+function throwIfSuperseded(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  const err = new Error("synthesis superseded by a newer run");
+  err.name = "AbortError";
+  throw err;
+}
+
+/**
  * ABOVE 50 LINES ON PURPOSE (#453). Everything here is a single named step and a hand-off of its
  * result to the next one: load, prepare, decide-to-run, prompt, call, fold, finalize, persist,
  * record, notify, sweep. Each step's DETAIL lives in its own function or module; what is left is the
@@ -498,6 +525,7 @@ export async function synthesize(
   const observationsBlock = opts.observationsBlock ?? "";
   const synthProvider = opts.provider ?? ctx.opts.synthesisProvider ?? ctx.requireProvider("synthesis");
   ctx.warnOnPromptDrift(); // once per process: a stale synthesis-prompt override silently drops shipped capabilities
+  throwIfSuperseded(opts.signal); // a run superseded before it started spends no state load and no prompt
   const loaded = await ctx.opts.stateStore.load(caseId);
   if (loaded.forensicTimeline.length === 0) return loaded;
   const aliasIndex = await resolveHostsOrThrow(ctx, caseId, loaded);
@@ -521,8 +549,14 @@ export async function synthesize(
   });
 
   const synthStart = Date.now();
+  throwIfSuperseded(opts.signal); // building the prompt takes seconds on a large case
   const call = await callSynthesisModel(ctx, caseId, state, synthProvider, prompt.userPrompt, opts);
   const { delta } = call;
+
+  // THE ONE THAT MATTERS. Everything below writes: the fold grades findings, persistSynthesis saves
+  // the case, and recordSynthesisOutcome appends a run to the manifest chain. A superseded run that
+  // gets past here overwrites the run that replaced it.
+  throwIfSuperseded(opts.signal);
 
   const {
     next: folded,
@@ -609,7 +643,11 @@ async function sweepSecondLook(
     aliasIndex: HostAliasIndex;
   },
 ): Promise<InvestigationState | null> {
-  if (opts.skipSecondLook || !ctx.opts.superTimelineStore) return null;
+  // Superseded AFTER the write, so this run's conclusions stand and are returned — but the sweep
+  // itself is an unbounded super-timeline query plus a second full synthesis, and the run that
+  // replaced this one is already doing that work. Skip it rather than throw: nothing is half-written
+  // here, and a throw would only be swallowed by the catch below as a "sweep failed" warning.
+  if (opts.skipSecondLook || opts.signal?.aborted || !ctx.opts.superTimelineStore) return null;
   try {
     const outcome = await runSecondLook(ctx, caseId, {
       // The sweep treats anything not in `promptEvents` as a candidate to re-discover; events

--- a/companion/src/composition/captureAnalysis.ts
+++ b/companion/src/composition/captureAnalysis.ts
@@ -115,7 +115,12 @@ export function createCaptureAnalysis(deps: CaptureAnalysisDeps): CaptureAnalysi
       if (held) await options.jobManager?.cancel(job.jobId);
       else await options.jobManager?.fail(job.jobId, err); // no-op if already cancelled
     }
-    if (!held && errorPhase) recordAiError(caseId, errorPhase, err);
+    // A SUPERSEDE IS NOT AN AI ERROR EITHER, for the same reason a gate is not. The registry
+    // REMOVES a superseded row rather than marking it cancelled — it is a queue entry that was
+    // replaced, not a result — and synthesize() now stops such a run at its next stage boundary
+    // (analysis/ai/synthesis.ts). Recording that abort here lit the dashboard's AI-error badge over
+    // a case whose synthesis was proceeding normally in the run that replaced it.
+    if (!held && !aborted && errorPhase) recordAiError(caseId, errorPhase, err);
     if (held) {
       // Reported even when a newer run is queued, unlike the supersede guard below: superseding
       // changes nothing about a gate. The newer run reads the same case and stops at the same

--- a/companion/tests/analysis/synthesizeAbort.test.ts
+++ b/companion/tests/analysis/synthesizeAbort.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { SynthMetaStore } from "../../src/analysis/synthMeta.js";
+import type { AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+/**
+ * A SUPERSEDED SYNTHESIS MUST STOP, NOT FINISH.
+ *
+ * `exclusive: true` on the synthesis job means the newest "the case changed, re-derive it" kick
+ * subsumes every older one: JobManager.dropForExclusiveRegistration aborts the old job's signal,
+ * removes its row, and frees the case's single concurrency slot so the new run can start.
+ *
+ * That only works if the old run actually stops. It did not. `synthesize` handed `signal` to the
+ * model call and never looked at it again, so a run whose provider does not abort mid-call — the
+ * claude-code provider completed a 6-minute call after its signal was aborted — went on to fold the
+ * delta, PERSIST it over the newer run's work, record an analysis run, and start the second-look
+ * sweep, which is itself another full synthesis. Two top-level runs then held the whole case state
+ * at once: state loads went from 0.6 s to 140 s, RSS from 451 MB to 986 MB, and neither run reached
+ * its terminal `ai_status` — which is what left the header pill reading "AI: synthesizing…" with no
+ * job left to explain it.
+ *
+ * So the contract is: once the signal is aborted, nothing downstream of the model call runs.
+ */
+
+let caseStore: CaseStore;
+let stateStore: StateStore;
+
+function event(id: string, timestamp: string, description: string): ForensicEvent {
+  return {
+    id,
+    timestamp,
+    description,
+    severity: "Medium",
+    mitreTechniques: [],
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+  };
+}
+
+function delta(): string {
+  return JSON.stringify({
+    findings: [
+      {
+        id: "f1",
+        severity: "High",
+        title: "synth finding",
+        description: "d",
+        relatedIocs: [],
+        mitreTechniques: [],
+        status: "open",
+        relatedEventIds: [],
+      },
+    ],
+    iocs: [],
+    mitreTechniques: [],
+    attackerPath: "p",
+    summary: "s",
+    forensicEvents: [],
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote: "",
+  });
+}
+
+/**
+ * A provider that IGNORES the abort signal and answers normally — the real failure mode. A provider
+ * that rejects on abort would make this test pass without any check in `synthesize`.
+ */
+function deafProvider(rawText: string, during?: () => void) {
+  return {
+    name: "deaf",
+    model: "deaf-model",
+    analyze: async (_req: AnalyzeRequest): Promise<AnalyzeResult> => {
+      during?.();
+      return { rawText };
+    },
+  };
+}
+
+beforeEach(async () => {
+  const root = await mkdtemp(join(tmpdir(), "dfir-synth-abort-"));
+  caseStore = new CaseStore(root);
+  await caseStore.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: "mock" });
+  stateStore = new StateStore(caseStore);
+});
+
+describe("synthesize — a superseded run stops at the next stage boundary", () => {
+  it("does not persist the delta when the signal aborts while the model is answering", async () => {
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(event("e1", "2026-01-04T00:00:00.000Z", "the real lead"));
+    await stateStore.save(seeded);
+    const synthMetaStore = new SynthMetaStore(caseStore);
+
+    // Superseded mid-call, exactly as dropForExclusiveRegistration does it.
+    const controller = new AbortController();
+    const pipeline = new AnalysisPipeline({
+      provider: deafProvider(delta(), () => controller.abort()),
+      stateStore,
+      synthMetaStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await expect(pipeline.synthesize("c1", { signal: controller.signal })).rejects.toThrow();
+
+    // The newer run owns the case now; this one must have written nothing.
+    const after = await stateStore.load("c1");
+    expect(after.findings).toHaveLength(0);
+    expect(after.lastSummary).not.toBe("s");
+    expect((await synthMetaStore.load("c1")).lastSynthesizedAt).toBe(""); // the store's "never ran"
+  });
+
+  it("does not call the model at all when the signal is already aborted", async () => {
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(event("e1", "2026-01-04T00:00:00.000Z", "the real lead"));
+    await stateStore.save(seeded);
+
+    let calls = 0;
+    const controller = new AbortController();
+    controller.abort();
+    const pipeline = new AnalysisPipeline({
+      provider: {
+        name: "deaf",
+        model: "deaf-model",
+        analyze: async (): Promise<AnalyzeResult> => {
+          calls += 1;
+          return { rawText: delta() };
+        },
+      },
+      stateStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await expect(pipeline.synthesize("c1", { signal: controller.signal })).rejects.toThrow();
+    expect(calls).toBe(0); // a superseded run must not spend a prompt either
+  });
+});

--- a/companion/tests/composition/supersededSynthesisIsNotAnError.test.ts
+++ b/companion/tests/composition/supersededSynthesisIsNotAnError.test.ts
@@ -1,0 +1,105 @@
+// A superseded synthesis is a replaced queue entry, not a failed run.
+//
+// The registry already says so — dropForExclusiveRegistration REMOVES the row rather than marking
+// it cancelled, "because a superseded job is a queue entry that was replaced, not a result". The
+// live-synthesis path did not: settleSynthesisRejection recorded every non-gate rejection against
+// the AI-error ledger, so an aborted run wrote "synthesis superseded by a newer run" there and lit
+// the dashboard's AI-error badge over a case whose synthesis was proceeding normally in the run
+// that replaced it.
+//
+// It only became reachable once synthesize() started honouring its abort signal at the stage
+// boundaries (see analysis/ai/synthesis.ts) — before that a superseded run quietly ran to
+// completion, which is the bug that fix exists to end.
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { JobManager } from "../../src/analysis/jobManager.js";
+import { createCaptureAnalysis } from "../../src/composition/captureAnalysis.js";
+import type { AppOptions } from "../../src/composition/appOptions.js";
+import type { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import type { AiControl } from "../../src/analysis/aiControl.js";
+import { pollFor } from "../helpers/poll.js";
+import { countRegistrations } from "../helpers/jobRegistrations.js";
+
+const CASE_ID = "case-superseded-synth";
+
+function abortError(): Error {
+  const err = new Error("synthesis superseded by a newer run");
+  err.name = "AbortError";
+  return err;
+}
+
+async function harness() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-superseded-"));
+  const store = new CaseStore(root);
+  const jobManager = new JobManager({ perCaseConcurrency: 1 });
+  const kicks = countRegistrations(jobManager, "synthesis");
+
+  // Stands in for the fixed synthesize(): it rejects at its next stage boundary once the run has
+  // been superseded, and otherwise waits to be released.
+  const started: string[] = [];
+  const pipeline = {
+    hasSynthesisProvider: () => true,
+    synthesize: (caseId: string, opts: { signal?: AbortSignal } = {}) => {
+      started.push(caseId);
+      return new Promise((resolve, reject) => {
+        if (opts.signal) opts.signal.addEventListener("abort", () => reject(abortError()));
+        releases.push(() => resolve({}));
+      });
+    },
+  } as unknown as AnalysisPipeline;
+  const releases: (() => void)[] = [];
+
+  const statuses: { status: string; detail?: string }[] = [];
+  const aiErrors: { phase: string; err: unknown }[] = [];
+  const options = {
+    pipeline,
+    jobManager,
+    autoSynthesize: true,
+    autoSynthesizeDebounceMs: 1,
+    onAiStatus: (_caseId: string, s: { status: string; detail?: string }) => statuses.push(s),
+  } as unknown as AppOptions;
+
+  const analysis = createCaptureAnalysis({
+    store,
+    options,
+    hasAiProvider: () => true,
+    getControl: async () => ({ enabled: true }) as AiControl,
+    setControl: async () => ({ enabled: true }) as AiControl,
+    recordAiError: (_caseId: string, phase: string, err: unknown) => aiErrors.push({ phase, err }),
+    autoEnrichIfEnabled: () => {},
+    dispatchNotify: () => {},
+  });
+
+  return { analysis, jobManager, kicks, started, statuses, aiErrors, releases };
+}
+
+describe("a live synthesis superseded by a newer kick", () => {
+  it("is not written to the AI-error ledger and does not paint the pill red", async () => {
+    const { analysis, kicks, started, statuses, aiErrors, releases } = await harness();
+
+    analysis.scheduleSynthesis(CASE_ID); // the debounced live run
+    await kicks.waitFor(1);
+    await pollFor("the live synthesis to reach the pipeline", async () =>
+      started.length === 1 ? true : undefined,
+    );
+
+    analysis.resynthesizeInBackground(CASE_ID); // the newer kick supersedes it
+    await kicks.waitFor(2);
+
+    // The superseded run's rejection has to settle before anything can be asserted about it.
+    await pollFor("the superseded run to settle", async () =>
+      statuses.some((s) => s.status === "analyzing" && s.detail?.includes("re-synthesizing"))
+        ? true
+        : undefined,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(aiErrors).toEqual([]); // a supersede is not an AI failure
+    expect(statuses.map((s) => s.status)).not.toContain("error");
+
+    releases.forEach((release) => release()); // let the surviving run finish so nothing dangles
+  });
+});

--- a/companion/tests/dashboard/jobsBadgeFetchFailure.test.ts
+++ b/companion/tests/dashboard/jobsBadgeFetchFailure.test.ts
@@ -1,0 +1,112 @@
+// A failed /api/jobs must not be drawn as "no jobs".
+//
+// Reported alongside a header pill stuck on "AI: synthesizing…": "no jobs chip at all". The jobs
+// badge is the one surface that would have named the run the pill was claiming — and it had hidden
+// itself. loadJobs mapped any non-ok response to `{ jobs: [] }`, so a 401 from an expired session,
+// a 500, or a request the server dropped while it was overloaded emptied the cache and rendered the
+// case as idle. That is the opposite of the truth: the badge is hidden exactly when the analyst
+// most needs it, and there is then no Cancel button for the run that is still going.
+//
+// refreshAiState already gets this right ("a failed correction must not invent a state" — see
+// js/dashboard-ai-status.js). This pins the same rule for the badge: on a failed read, keep the
+// last known answer.
+import { describe, it, expect } from "vitest";
+import { loadDashboardModule } from "../helpers/dashboardModule.js";
+
+interface JobsApi {
+  loadJobs: () => Promise<void>;
+  runningJob: (kind: string) => unknown;
+}
+
+const RUNNING = [{ id: "synth-1", kind: "synthesis", status: "running", cancellable: true }];
+
+const PRELOAD = ["dashboard-escape.js", "dashboard-values.js", "dashboard-fragments.js"];
+
+/** The page, plus a fetch whose answer the test swaps between calls. */
+function harness(answers: { ok: boolean; jobs?: unknown[] }[]) {
+  const menu = {
+    innerHTML: "",
+    style: { display: "none" },
+    querySelectorAll: () => [] as unknown[],
+  };
+  const badge = { textContent: "", style: { display: "" }, addEventListener: () => {} };
+  const caseIdInput = { value: "INC-1" };
+  const elements: Record<string, unknown> = {
+    caseId: caseIdInput,
+    jobsBadge: badge,
+    jobsMenu: menu,
+    status: { textContent: "" },
+  };
+  let call = 0;
+  const globals = {
+    document: {
+      getElementById: (id: string) => elements[id] ?? null,
+      addEventListener: () => {},
+    },
+    fetch: () => {
+      const answer = answers[Math.min(call++, answers.length - 1)];
+      return Promise.resolve({
+        ok: answer.ok,
+        status: answer.ok ? 200 : 401,
+        json: () => Promise.resolve({ jobs: answer.jobs ?? [] }),
+      });
+    },
+    deepPassBusy: () => false,
+    deepPassJob: () => null,
+    applyDeepPassGate: () => {},
+    loadCockpit: () => Promise.resolve(),
+  };
+  return {
+    badge,
+    menu,
+    caseIdInput,
+    api: loadDashboardModule<JobsApi>("dashboard-jobs.js", PRELOAD, globals),
+  };
+}
+
+describe("the background-jobs badge", () => {
+  it("keeps the last known jobs when the read fails, instead of reporting none", async () => {
+    const { api, badge } = harness([
+      { ok: true, jobs: RUNNING },
+      { ok: false }, // the session expired, or the server dropped it under load
+    ]);
+
+    await api.loadJobs();
+    expect(badge.textContent).toBe("⚙ 1 job");
+    expect(badge.style.display).toBe("");
+
+    await api.loadJobs();
+    expect(badge.textContent).toBe("⚙ 1 job"); // still the truth we last had, not "no jobs"
+    expect(badge.style.display).toBe("");
+  });
+
+  it("still hides itself when the server genuinely answers with no jobs", async () => {
+    const { api, badge } = harness([
+      { ok: true, jobs: RUNNING },
+      { ok: true, jobs: [] },
+    ]);
+
+    await api.loadJobs();
+    await api.loadJobs();
+
+    expect(badge.style.display).toBe("none");
+  });
+
+  // "Keep the last known answer" is only true for the case that answer describes. The cache is one
+  // module-level array, so keeping it across a case switch would draw case A's running jobs under
+  // case B — and every Cancel button in that popover POSTs A's job id, killing work in a case the
+  // analyst is no longer even looking at.
+  it("does not carry one case's jobs over to the next when the new case's read fails", async () => {
+    const { api, badge, menu, caseIdInput } = harness([{ ok: true, jobs: RUNNING }, { ok: false }]);
+
+    await api.loadJobs();
+    expect(badge.textContent).toBe("⚙ 1 job");
+
+    caseIdInput.value = "INC-2"; // the analyst switches case; INC-2's jobs never load
+    await api.loadJobs();
+
+    expect(badge.style.display).toBe("none");
+    expect(menu.innerHTML).not.toContain("synth-1");
+    expect(api.runningJob("synthesis")).toBeUndefined(); // and the deep-pass lock agrees
+  });
+});

--- a/public/js/dashboard-jobs.js
+++ b/public/js/dashboard-jobs.js
@@ -17,6 +17,12 @@
   // clicking it opens a popover to view recent jobs and cancel a long/stuck one. Fed by GET
   // /api/jobs and refreshed on the job_changed WS event.
   let _jobsCache = [];
+  // WHICH CASE _jobsCache DESCRIBES. A job id only means anything inside its own case, and every
+  // Cancel button in the popover POSTs one — so a cache drawn under the wrong case offers to kill
+  // work in a case the analyst has already left. Nothing needed this while a failed read emptied
+  // the cache; now that a failed read KEEPS it (see loadJobs), the cache outlives a case switch and
+  // has to say whose it is.
+  let _jobsCacheCaseId = "";
   let _jobsMenuShape = "";
   let _jobsLoadPromise = null;
   let _jobsLoadCaseId = "";
@@ -33,19 +39,40 @@
     const el = document.getElementById("caseId");
     return el && typeof el.value === "string" ? el.value.trim() : "";
   }
+  // The cache, but only when it belongs to the case on screen. THE ONE READ EVERY CONSUMER USES —
+  // the badge, the popover, the deep-pass lock and runningJob() — because a stale-case answer is
+  // wrong for all four in the same way, and one of them can cancel the wrong job.
+  function jobsForCurrentCase() {
+    return _jobsCacheCaseId && _jobsCacheCaseId === jobsCaseId() ? _jobsCache : [];
+  }
   function loadJobs() {
     const cid = jobsCaseId();
     if (!cid) return Promise.resolve();
     if (_jobsLoadPromise && _jobsLoadCaseId === cid) return _jobsLoadPromise;
     _jobsLoadCaseId = cid;
+    // THROW, don't substitute an empty list. A non-ok answer — an expired session's 401, a 500, a
+    // request the server dropped while it was overloaded — used to be mapped to `{ jobs: [] }`,
+    // which emptied the cache and hid the badge: the case was drawn as idle at the exact moment the
+    // analyst needed to see (and cancel) the run the header pill was claiming. Reported as "the AI
+    // chip still shows running, no jobs chip at all". A failed read means we learned nothing, so
+    // fall through to the catch and keep the last known answer — the same rule refreshAiState
+    // follows in js/dashboard-ai-status.js. Only a real answer may empty the badge.
+    //
+    // "The last known answer" is scoped to the case it was read for. jobsForCurrentCase() enforces
+    // that on every read; the render in the catch is what repaints a badge still showing the case
+    // the analyst just left.
     const request = fetch(`/api/jobs?caseId=${encodeURIComponent(cid)}`)
-      .then((r) => (r.ok ? r.json() : { jobs: [] }))
+      .then((r) => {
+        if (!r.ok) throw new Error("jobs HTTP " + r.status);
+        return r.json();
+      })
       .then((d) => {
         if (cid !== jobsCaseId()) return;
         _jobsCache = Array.isArray(d.jobs) ? d.jobs : [];
+        _jobsCacheCaseId = cid;
         renderJobs();
       })
-      .catch(() => {})
+      .catch(() => renderJobs())
       .finally(() => {
         if (_jobsLoadPromise === request) {
           _jobsLoadPromise = null;
@@ -102,10 +129,11 @@
     const badge = document.getElementById("jobsBadge");
     const menu = document.getElementById("jobsMenu");
     if (!badge || !menu) return;
-    const running = _jobsCache.filter(
+    const cached = jobsForCurrentCase();
+    const running = cached.filter(
       (j) => j.status === "running" || j.status === "queued",
     );
-    const attention = _jobsCache.filter(
+    const attention = cached.filter(
       (j) =>
         j.resumable &&
         (j.status === "interrupted" ||
@@ -119,13 +147,13 @@
     } else if (attention.length) {
       badge.style.display = "";
       badgeText = `⚠ ${attention.length} job${attention.length > 1 ? "s" : ""} need attention`;
-    } else if (menuOpen && _jobsCache.length) {
+    } else if (menuOpen && cached.length) {
       badge.style.display = "";
       badgeText = "⚙ jobs";
     } // keep it clickable while the popover is open so it can't vanish under the cursor
     else {
       badge.style.display = "none";
-      if (menuOpen && !_jobsCache.length) menu.style.display = "none";
+      if (menuOpen && !cached.length) menu.style.display = "none";
     }
     if (badgeText && badge.textContent !== badgeText)
       badge.textContent = badgeText;
@@ -134,11 +162,11 @@
     // work the badge was counting off the end — "⚙ 3 jobs" over a list with no queued row in it.
     // Order is preserved (newest first): this only chooses WHICH rows fit, never reorders them.
     const shown = new Set(running.concat(attention).map((j) => j.id));
-    for (const j of _jobsCache) {
+    for (const j of cached) {
       if (shown.size >= JOBS_MENU_ROWS) break;
       shown.add(j.id);
     }
-    const views = _jobsCache.filter((j) => shown.has(j.id)).map(jobMenuView);
+    const views = cached.filter((j) => shown.has(j.id)).map(jobMenuView);
     const shape = JSON.stringify(
       views.map((v) => [v.job.id, v.cancel, v.resume]),
     );
@@ -189,7 +217,7 @@
   // Nothing server-side prevents that, so the buttons lock each other out here.
   function applyHeavyAiJobLock() {
     const dp = deepPassBusy();
-    const synth = _jobsCache.some(
+    const synth = jobsForCurrentCase().some(
       (j) =>
         j.kind === "synthesis" &&
         (j.status === "running" || j.status === "queued"),
@@ -277,7 +305,7 @@
 
   // What dashboard-deep-pass.js asks: the running/queued job of a kind, if any.
   function runningJob(kind) {
-    return _jobsCache.find(
+    return jobsForCurrentCase().find(
       (j) =>
         j.kind === kind && (j.status === "running" || j.status === "queued"),
     );


### PR DESCRIPTION
## What the analyst saw

The header chip sat on **"AI: synthesizing…"** long after the server console had reported the
synthesis model call done — and there was no background-jobs chip to explain it, or to cancel it.

## What was actually happening

Two full syntheses were running on the same case at once. Taken from the reporting case's own files:

| Run | Model call | Wrote its conclusions |
|---|---|---|
| 9 | 15:28:45 → 15:34:49 | 15:36:26 |
| 10 | 15:29:39 → 15:36:37 | 15:38:33 |

The job ledger held only **one** synthesis row, still `running`, never updated after 15:29:12. The
metrics file showed the cost: case reads climbed from 0.6 s to 140 s and memory went from 451 MB to
986 MB over the same period.

`exclusive: true` on the synthesis job is supposed to prevent this. A newer kick aborts the older
run's signal, drops its row, and frees the case's single concurrency slot so the newer run can
start. But `synthesize()` handed the abort signal to the model call and never looked at it again.
A provider that finishes its call anyway — the claude-code provider completed a six-minute call
after its signal was aborted — carried the superseded run on into the delta fold, the **persist,
over the newer run's work**, the run record, and the second-look sweep, which is another full
synthesis of its own. Neither run reached its terminal status, which is what stranded the chip.

## The three changes

1. **A superseded synthesis now stops.** `synthesize()` checks its abort signal at the stage
   boundaries: before the state load, before the model call, **before the fold / persist / record**,
   and before the second-look sweep. The one before the persist is what ends the lost update.

2. **A supersede is reported as a cancellation, not a failure.** It no longer writes to the
   AI-error ledger. Without this, change 1 would have traded a stuck chip for a red AI-error badge
   over a case whose synthesis was proceeding normally in the run that replaced it.

3. **The jobs chip no longer draws a failed read as "no jobs".** `loadJobs()` mapped any non-ok
   `/api/jobs` response to an empty list, so an expired session or a request dropped under load
   hid the badge — removing the one surface that would have named the running job and offered
   Cancel. It keeps the last known answer now, **scoped to the case that answer describes**: one
   module-level cache drawn under the wrong case would have offered Cancel buttons that POST
   another case's job ids. Every consumer — the badge, the popover, the deep-pass lock and
   `runningJob()` — reads through the case-scoped accessor.

## Tests

Three new specs, each of which failed before its fix:

- `synthesizeAbort.test.ts` — a run aborted while a deaf provider is answering persists nothing,
  and an already-aborted run never reaches the model at all.
- `supersededSynthesisIsNotAnError.test.ts` — a superseded live synthesis writes no AI error and
  never paints the pill red.
- `jobsBadgeFetchFailure.test.ts` — a failed read keeps the badge; a real empty answer still clears
  it; a case switch with a failed read does not carry the previous case's jobs over.

## Gates

Companion lint, format:check, check:size, check:imports, check:boundaries, eval:change-gate,
check:us-map, build, typecheck, and the full suite (685 files / 10673 tests) all green. Extension
typecheck, tests (329), and both builds green.

## Not covered here

The header pill still has no periodic re-derive — it corrects itself only on case connect,
WebSocket open, a terminal event, and gate resolution. With these fixes a stalled run is far less
likely, but a dropped WebSocket message can still strand it until the socket reconnects. Worth a
follow-up if it shows up again.
