### PR TITLE
feat(velociraptor): eval follow-ups — technique mapping, IOC roles, truncation visibility

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,872 of the 1,911 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,873 of the 1,912 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -375,6 +375,7 @@
     "pushPayload.ts": "analysis/notify",
     "pushTokenStore.ts": "analysis/notify",
     "queryTranslate.ts": "analysis/ai",
+    "rdpLateralDetect.ts": "analysis/ingest",
     "reconTechniques.ts": "analysis/intel",
     "redactPaths.ts": "analysis/privacy",
     "redactedExport.ts": "analysis/privacy",

--- a/companion/src/analysis/ingest/endpointImports.ts
+++ b/companion/src/analysis/ingest/endpointImports.ts
@@ -110,7 +110,9 @@ export async function importChainsaw(
       `${parsed.detections > 0 ? "Chainsaw" : "EVTX"} import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
       (parsed.detections > 0 ? `, ${parsed.detections} rule detection(s)` : "") +
       (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-      (parsed.dropped > 0 ? `, ${parsed.dropped} record(s) omitted at the event cap` : "") +
+      (parsed.groups > parsed.kept && parsed.dropped > 0
+        ? `, ${parsed.dropped} record(s) omitted at the event cap`
+        : "") +
       (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
     summary: "",
   };
@@ -165,7 +167,9 @@ export async function importHayabusa(
     timelineNote:
       `Hayabusa import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
       (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-      (parsed.dropped > 0 ? `, ${parsed.dropped} record(s) omitted at the event cap` : "") +
+      (parsed.groups > parsed.kept && parsed.dropped > 0
+        ? `, ${parsed.dropped} record(s) omitted at the event cap`
+        : "") +
       (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
     summary: "",
   };
@@ -256,7 +260,9 @@ export async function importVelociraptor(
       // must know rows were omitted rather than read the kept count as the whole picture. The cap
       // keeps the most-severe events first, so what is dropped is low-signal telemetry — raise
       // DFIR_MAX_EVENTS to keep more.
-      (parsed.dropped > 0 ? `, ${parsed.dropped} row(s) omitted at the event cap` : "") +
+      (parsed.groups > parsed.kept && parsed.dropped > 0
+        ? `, ${parsed.dropped} row(s) omitted at the event cap`
+        : "") +
       (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
     summary: "",
   };

--- a/companion/src/analysis/ingest/endpointImports.ts
+++ b/companion/src/analysis/ingest/endpointImports.ts
@@ -110,6 +110,7 @@ export async function importChainsaw(
       `${parsed.detections > 0 ? "Chainsaw" : "EVTX"} import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
       (parsed.detections > 0 ? `, ${parsed.detections} rule detection(s)` : "") +
       (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.dropped > 0 ? `, ${parsed.dropped} record(s) omitted at the event cap` : "") +
       (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
     summary: "",
   };
@@ -164,6 +165,7 @@ export async function importHayabusa(
     timelineNote:
       `Hayabusa import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} record(s)` +
       (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      (parsed.dropped > 0 ? `, ${parsed.dropped} record(s) omitted at the event cap` : "") +
       (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
     summary: "",
   };
@@ -250,6 +252,11 @@ export async function importVelociraptor(
       `Velociraptor import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s)` +
       (parsed.detections > 0 ? `, ${parsed.detections} detection(s)` : "") +
       (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
+      // Make truncation explicit: a huge MFT/USN artifact (275k+ rows) is capped, and the analyst
+      // must know rows were omitted rather than read the kept count as the whole picture. The cap
+      // keeps the most-severe events first, so what is dropped is low-signal telemetry — raise
+      // DFIR_MAX_EVENTS to keep more.
+      (parsed.dropped > 0 ? `, ${parsed.dropped} row(s) omitted at the event cap` : "") +
       (parsed.hostname ? ` (host ${parsed.hostname})` : ""),
     summary: "",
   };

--- a/companion/src/analysis/iocRiskScore.ts
+++ b/companion/src/analysis/iocRiskScore.ts
@@ -36,7 +36,16 @@ export type IocRiskTier = "critical" | "high" | "medium" | "low" | "benign";
 export interface IocRisk {
   score: IocRiskTier;
   factors: string[]; // human-readable reasons, strongest first
+  // Whether this value is a THREAT INDICATOR or merely an OBSERVATION. An import scrapes every file
+  // path and hash it sees — 5,000+ on a single collection — and presenting them all as "indicators"
+  // drowns the handful that matter. An indicator earned a signal (reputation verdict, a Medium+
+  // event, corroboration, KEV); an observation is a value that appeared in the evidence with none.
+  // Both stay searchable; only the count / panel / export should treat them differently. Set by
+  // scoreIocs (which has the IOC's enrichments); a bare scoreIoc call leaves it undefined.
+  role?: IocRole;
 }
+
+export type IocRole = "indicator" | "observation";
 
 /** The pre-derived signals scoreIoc grades. Kept explicit so the core rubric is unit-testable. */
 export interface IocRiskSignals {
@@ -150,7 +159,7 @@ export function scoreIocs(
     const kevMatch = extractCveIds(ioc.value).some(
       (cve) => ctx.kevCveIds?.has(cve) || (ctx.kevCatalog ? ctx.kevCatalog.has(cve) : false),
     );
-    out[ioc.id] = scoreIoc({
+    const risk = scoreIoc({
       verdictClass,
       distinctTools: sources[ioc.id]?.length ?? 0,
       maxSeverityRank: sevRank[ioc.id] ?? -1,
@@ -159,8 +168,39 @@ export function scoreIocs(
       whitelisted,
       suspiciousDomain: (ioc.type === "domain" || ioc.type === "url") && looksSuspiciousDomain(ioc.value),
     });
+    risk.role = iocRole(ioc, risk.score);
+    out[ioc.id] = risk;
   }
   return out;
+}
+
+/**
+ * Is this value a THREAT INDICATOR or just an OBSERVATION? An indicator earned a signal; a bare file
+ * path or hash that appeared in the evidence with no reputation verdict, no Medium+ event, and no
+ * corroboration is an observation. The risk tier already folds severity, corroboration, intel and KEV
+ * together, so tier ≥ medium is the behavioural gate; a reputation HIT on an otherwise-quiet value
+ * still counts (a low-risk hash MalwareBazaar flagged is worth surfacing).
+ */
+export function iocRole(ioc: IOC, tier: IocRiskTier): IocRole {
+  if (RISK_TIER_RANK[tier] >= RISK_TIER_RANK.medium) return "indicator";
+  const flagged = (ioc.enrichments ?? []).some(
+    (e) => e.verdict === "malicious" || e.verdict === "suspicious",
+  );
+  return flagged ? "indicator" : "observation";
+}
+
+/** Split a scored IOC set into indicator / observation counts. */
+export function summarizeIocRoles(risks: Record<string, IocRisk>): {
+  indicators: number;
+  observations: number;
+} {
+  let indicators = 0;
+  let observations = 0;
+  for (const r of Object.values(risks)) {
+    if (r.role === "indicator") indicators++;
+    else observations++;
+  }
+  return { indicators, observations };
 }
 
 /** Rank ordering for sorting / filtering (higher = riskier). */

--- a/companion/src/analysis/iocRiskScore.ts
+++ b/companion/src/analysis/iocRiskScore.ts
@@ -175,14 +175,16 @@ export function scoreIocs(
 }
 
 /**
- * Is this value a THREAT INDICATOR or just an OBSERVATION? An indicator earned a signal; a bare file
- * path or hash that appeared in the evidence with no reputation verdict, no Medium+ event, and no
- * corroboration is an observation. The risk tier already folds severity, corroboration, intel and KEV
- * together, so tier ≥ medium is the behavioural gate; a reputation HIT on an otherwise-quiet value
- * still counts (a low-risk hash MalwareBazaar flagged is worth surfacing).
+ * Is this value a THREAT INDICATOR or just an OBSERVATION? An indicator either earned a signal — a
+ * Medium+ risk tier (the tier already folds severity, corroboration, intel and KEV) or a reputation
+ * verdict — or it is a NETWORK indicator (ip / domain / url), which an analyst pivots on immediately
+ * and which enrichment reaches asynchronously, so it is surfaced even while quiet. An observation is
+ * the bulk that is neither: a scraped file path / hash / process an import records by the thousand
+ * with no signal at all. Both stay searchable; only the count / panel / export treat them differently.
  */
 export function iocRole(ioc: IOC, tier: IocRiskTier): IocRole {
   if (RISK_TIER_RANK[tier] >= RISK_TIER_RANK.medium) return "indicator";
+  if (ioc.type === "ip" || ioc.type === "domain" || ioc.type === "url") return "indicator";
   const flagged = (ioc.enrichments ?? []).some(
     (e) => e.verdict === "malicious" || e.verdict === "suspicious",
   );

--- a/companion/src/analysis/iocRiskScore.ts
+++ b/companion/src/analysis/iocRiskScore.ts
@@ -183,6 +183,10 @@ export function scoreIocs(
  * with no signal at all. Both stay searchable; only the count / panel / export treat them differently.
  */
 export function iocRole(ioc: IOC, tier: IocRiskTier): IocRole {
+  // Known-good overrides everything (the same invariant scoreIoc enforces): a whitelisted or
+  // NSRL-known value is `benign` and is never a threat indicator, even a network value or one with a
+  // stale malicious enrichment. Checked FIRST, before the network / flagged branches below.
+  if (tier === "benign") return "observation";
   if (RISK_TIER_RANK[tier] >= RISK_TIER_RANK.medium) return "indicator";
   if (ioc.type === "ip" || ioc.type === "domain" || ioc.type === "url") return "indicator";
   const flagged = (ioc.enrichments ?? []).some(

--- a/companion/src/analysis/motwDownload.ts
+++ b/companion/src/analysis/motwDownload.ts
@@ -82,5 +82,10 @@ export function gradeMotwDownload(zoneId: string, fileName: string): MotwGrade {
   const dot = name.lastIndexOf(".");
   const ext = dot >= 0 ? name.slice(dot + 1) : "";
   if (!RUNNABLE_EXT.test(ext) && !CONTAINER_EXT.test(ext)) return { severity: "Info", mitre: [], zoneLabel };
-  return { severity: "Medium", mitre: ["T1204.002"], zoneLabel };
+  // A runnable/container pulled from the ORDINARY internet zone is the drive-by / malvertising entry
+  // vector (T1189) as well as user-execution of a downloaded file (T1204.002) — the initial-access
+  // half is what tied 004 (Bing SEO poisoning) and 008 (malvertising) to their reports. Zone 4
+  // (Restricted) keeps only T1204.002; the zone number does not identify a website compromise there.
+  const mitre = zone === "3" ? ["T1189", "T1204.002"] : ["T1204.002"];
+  return { severity: "Medium", mitre, zoneLabel };
 }

--- a/companion/src/analysis/prefetchExecution.ts
+++ b/companion/src/analysis/prefetchExecution.ts
@@ -111,6 +111,13 @@ const DUAL_USE: Record<string, string[]> = {
   "psexesvc.exe": ["T1569.002"],
   "paexec.exe": ["T1569.002"],
   "at.exe": ["T1053.002"],
+  // Cloud/bulk exfil tools (T1567.002). tradecraftRules maps these from a COMMAND LINE, but on a
+  // prefetch/amcache row there is no command line — the execution name is all there is, and rclone
+  // running on a workstation at all is worth a Medium. (A renamed rclone is caught by BinaryRename.)
+  "rclone.exe": ["T1567.002"],
+  "restic.exe": ["T1567.002"],
+  "megasync.exe": ["T1567.002"],
+  "megacmd.exe": ["T1567.002"],
 };
 
 // A binary that ships INSIDE a browser and is only itself there. Both are ordinary Edge/Chromium

--- a/companion/src/analysis/rdpLateralDetect.ts
+++ b/companion/src/analysis/rdpLateralDetect.ts
@@ -1,0 +1,71 @@
+// Lateral movement (T1021.001) from the Custom.DFIR.RDPLateralMovementDetection artifact.
+//
+// That artifact records EID 4648 "explicit credential" logons — an account presenting DIFFERENT
+// credentials to reach another machine, the classic RDP/`runas`-then-pivot signature. But it also
+// captures the LOCAL boot noise Windows raises as `UMFD-0` / `DWM-*` to `localhost`, so grading every
+// row would be almost all false positives. The signal is a REMOTE target with a real initiating
+// user: that pair is what an operator moving with stolen credentials leaves, and neither half is a
+// name the local machine writes for itself. A local/boot row returns null (stays Info).
+//
+// Kept out of velociraptorImport (frozen at the size ledger); called from mapGeneric next to the
+// ransomware signal, since these rows otherwise land in the generic mapper as Info.
+
+import type { Severity } from "./stateTypes.js";
+import { getCI, str } from "./siemImport.js";
+
+type Row = Record<string, unknown>;
+
+export interface RdpLateralSignal {
+  severity: Severity;
+  mitre: string[];
+  note: string;
+}
+
+function toEid(v: unknown): number {
+  const n = Number(str(v).trim());
+  return Number.isFinite(n) ? n : 0;
+}
+
+// A target that names the local machine itself (or nothing) is not lateral movement.
+function isLocalTarget(target: string, computer: string): boolean {
+  const t = target.trim().toLowerCase();
+  if (!t) return true;
+  if (t === "localhost" || t === "127.0.0.1" || t === "::1" || t === "-") return true;
+  const c = computer.trim().toLowerCase();
+  return !!c && (t === c || t === c.split(".")[0]);
+}
+
+// A machine / service principal (ends in `$`, or a well-known non-interactive session owner) is the
+// boot-time noise, not an operator.
+function isMachineOrNoiseUser(user: string): boolean {
+  const u = user.trim().toLowerCase();
+  if (!u || u === "-") return true;
+  if (u.endsWith("$")) return true;
+  return /^(?:umfd-\d+|dwm-\d+|system|local service|network service|font driver host)$/.test(u);
+}
+
+/**
+ * Grade a Custom.DFIR.RDPLateralMovementDetection row. Returns a Medium T1021.001 signal for an
+ * explicit-credential logon to a REMOTE host by a real user, or null for local / boot rows.
+ */
+export function rdpLateralSignal(artifact: string, row: Row): RdpLateralSignal | null {
+  if (!/rdplateralmovement/i.test(artifact)) return null;
+  if (toEid(getCI(row, "EventID")) !== 4648) return null;
+
+  const target = str(getCI(row, "TargetServer"));
+  const computer = str(getCI(row, "ComputerName"));
+  if (isLocalTarget(target, computer)) return null;
+
+  const initiator = str(getCI(row, "InitiatingUser"));
+  if (isMachineOrNoiseUser(initiator)) return null;
+
+  const srcIp = str(getCI(row, "SourceIP")).trim();
+  const who = initiator || "a user";
+  return {
+    severity: "Medium",
+    mitre: ["T1021.001"],
+    note: `explicit-credential logon (EID 4648) by ${who} to remote ${target}${
+      srcIp && srcIp !== "-" ? ` from ${srcIp}` : ""
+    } — RDP lateral movement`,
+  };
+}

--- a/companion/src/analysis/rdpLateralDetect.ts
+++ b/companion/src/analysis/rdpLateralDetect.ts
@@ -52,14 +52,18 @@ export function rdpLateralSignal(artifact: string, row: Row): RdpLateralSignal |
   if (!/rdplateralmovement/i.test(artifact)) return null;
   if (toEid(getCI(row, "EventID")) !== 4648) return null;
 
-  const target = str(getCI(row, "TargetServer"));
-  const computer = str(getCI(row, "ComputerName"));
+  // The destination host. The Custom.DFIR.RDPLateralMovementDetection artifact writes `TargetServer`;
+  // a native EID 4648 record calls the same field `TargetServerName`. Read both so the detector works
+  // on the artifact AND a raw 4648 export.
+  const target = str(getCI(row, "TargetServer")) || str(getCI(row, "TargetServerName"));
+  const computer = str(getCI(row, "ComputerName")) || str(getCI(row, "Computer"));
   if (isLocalTarget(target, computer)) return null;
 
-  const initiator = str(getCI(row, "InitiatingUser"));
+  // The operator. The artifact uses `InitiatingUser`; a native 4648 uses `SubjectUserName`.
+  const initiator = str(getCI(row, "InitiatingUser")) || str(getCI(row, "SubjectUserName"));
   if (isMachineOrNoiseUser(initiator)) return null;
 
-  const srcIp = str(getCI(row, "SourceIP")).trim();
+  const srcIp = str(getCI(row, "SourceIP") ?? getCI(row, "IpAddress")).trim();
   const who = initiator || "a user";
   return {
     severity: "Medium",

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -77,6 +77,7 @@ import {
 } from "./veloDetectionNoise.js";
 import { gradeYaraHit } from "./yaraGrade.js";
 import { ransomwareSignal } from "./ransomwareDetect.js";
+import { rdpLateralSignal } from "./rdpLateralDetect.js";
 import { mapHijackLib } from "./hijackLibImport.js";
 import { decodeHitContext } from "./yaraHitContext.js";
 import { amcacheMasquerade } from "./amcacheMasquerade.js";
@@ -894,15 +895,18 @@ function mapGeneric(row: Row, artifact: string, host: string, sink: Map<string, 
     severity = "Info";
   }
 
-  // Ransomware impact (T1486): a file encrypted to a family extension, or a ransom note. A raise
-  // only, and only when not already self-scan-demoted, so it never rescues a tool-tree hit.
+  // Raises on a generic row: ransomware impact (T1486 — encrypted file / ransom note, not a
+  // self-scan hit) and RDP lateral movement (T1021.001 — an explicit-cred 4648 to a remote host).
   const genRansom = severity !== "Info" || !isDetectionToolLocation(path) ? ransomwareSignal(path) : null;
-  const ransomMitre = genRansom ? genRansom.mitre : [];
+  const rdp = rdpLateralSignal(artifact, row);
+  const ransomMitre = [...(genRansom?.mitre ?? []), ...(rdp?.mitre ?? [])];
   if (genRansom) severity = worst(severity, genRansom.severity);
+  if (rdp) severity = worst(severity, rdp.severity);
 
   // A THOR row names its own finding; the generic form would name the artifact plumbing instead.
   let description = thor?.description ?? `Velociraptor${artifact ? ` [${artifact}]` : ""}: ${base}`;
   if (genRansom) description = `${description} — ${genRansom.note} (T1486)`.slice(0, 600);
+  else if (rdp) description = `${description} — ${rdp.note} (T1021.001)`.slice(0, 600);
   description = withHostSuffix(description.slice(0, 600), host).slice(0, 600);
 
   const aggKey =
@@ -964,13 +968,10 @@ function mapUsn(row: Row, artifact: string, host: string): MappedEvent {
     600,
   );
   description = withHostSuffix(description, host).slice(0, 600);
-  // Ransomware impact hides in the USN journal: files renamed to a family extension, and the ransom
-  // note created. Grade those High + T1486 so they survive the most-severe-first cap that otherwise
-  // buries them under hundreds of thousands of Info change records. See ransomwareDetect.
+  // Ransomware impact (T1486) hides in the USN journal (encrypted-file renames + the ransom note):
+  // grade it High so it survives the most-severe-first cap, and collapse every "encrypted with .X"
+  // row on a host into ONE counted finding by the signal note. See ransomwareDetect.
   const ransom = ransomwareSignal(path);
-  // Mass encryption is ONE impact, not N: collapse every "file encrypted with .X" row on a host into
-  // a single counted High finding by the signal note (which names the extension / the note, not the
-  // file), so the timeline reads "encrypted with .trigona ×1240" instead of 1240 separate Highs.
   const aggKey = ransom
     ? `vr|ransomware|${host.toLowerCase()}|${ransom.note.toLowerCase()}`
     : `vr|usn|${host.toLowerCase()}|${reason.toLowerCase()}|${path.toLowerCase()}`
@@ -1047,8 +1048,7 @@ function mapMft(row: Row, artifact: string, host: string): MappedEvent[] {
       600,
     );
     description = withHostSuffix(description, host).slice(0, 600);
-    // A ransomware sweep touches thousands of MFT records — collapse them into one counted High per
-    // host + impact type (see mapUsn) instead of flooding the timeline with a High per encrypted file.
+    // A ransomware sweep touches thousands of MFT records — collapse per host + impact type (see mapUsn).
     const aggKey = ransom
       ? `vr|ransomware|${host.toLowerCase()}|${ransom.note.toLowerCase()}`
       : `vr|mft|${host.toLowerCase()}|${macb.toLowerCase()}|${path.toLowerCase()}`

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1650,18 +1650,17 @@ function mapRowToEvents(row: Row, ctx: VrParseCtx): { events: MappedEvent[]; det
       ms = [mapLnk(row, artifact, host)];
     } else {
       ms = [mapGeneric(row, artifact, host, rowSink)];
-      // A row from a DETECTION rule pack that matched no signature still lands in the generic
-      // key=value dump at Info — and Info never reaches the forensic timeline, so the detection the
-      // pack fired is invisible to synthesis. BinaryRename was one such artifact (it ships no
-      // `Detection` column, so rowVerdict() returns null and classify() falls through); it now has a
-      // mapper of its own, but the next pack with that shape should not be silently discarded while
-      // it waits for one. Floor the grade to Medium — the same "a named rule fired" baseline
-      // detectionSeverity() uses — and only ever raise it.
-      if (isDetectionArtifact(artifact)) {
+      // mapGeneric graded the RDP-lateral artifact authoritatively (remote 4648 → T1021, boot → Info);
+      // its name ends in "Detection" and its rows are bare 4648s, so the floor + flat-EID overlay below
+      // would re-raise the SUPPRESSED boot rows to Medium/T1078. Skip both for it. (#codex)
+      const rdpArt = /rdplateralmovement/i.test(artifact);
+      // A DETECTION rule pack row that matched no signature lands in the generic key=value dump at
+      // Info, invisible to synthesis; floor it to Medium ("a named rule fired"), only ever raising.
+      if (!rdpArt && isDetectionArtifact(artifact)) {
         for (const m of ms) if (m && m.severity === "Info") m.severity = "Medium";
       }
       // A FLAT Windows row (bare EventID, no wrapper) also lands here — see overlayFlatWindowsEid.
-      for (const m of ms) if (m) overlayFlatWindowsEid(row, m);
+      if (!rdpArt) for (const m of ms) if (m) overlayFlatWindowsEid(row, m);
     }
 
     // A 4104 script block that is generated or signed module scaffolding is detection content, not

--- a/companion/src/reports/markdown.ts
+++ b/companion/src/reports/markdown.ts
@@ -813,13 +813,13 @@ function investigation(
   } else {
     // Corroboration: tools that observed each indicator (derived from the events' sources).
     const iocSrc = deriveIocSources(state.iocs, state.forensicTimeline);
-    // Composite risk tier per indicator (#63) so the table is actionable at a glance.
-    const iocRisk = scoreIocsFromState(state);
+    const iocRisk = scoreIocsFromState(state); // composite risk (#63); role splits indicator vs observation
+    const indicators = state.iocs.filter((i) => iocRisk[i.id]?.role !== "observation");
     lines.push(
       "| ID | Type | Value | First seen | Sources | Risk |",
       "| --- | --- | --- | --- | --- | --- |",
     );
-    for (const i of state.iocs) {
+    for (const i of indicators) {
       const src = iocSrc[i.id];
       const srcCell =
         src && src.length ? `${src.join(", ")}${src.length > 1 ? ` (⊕ ${src.length})` : ""}` : "—";
@@ -829,6 +829,8 @@ function investigation(
         `| ${cellMd(i.id)} | ${cellMd(i.type)} | ${cellMd(i.value)} | ${cellMd(i.firstSeen)} | ${cellMd(srcCell)} | ${cellMd(riskCell)} |`,
       );
     }
+    const obs = state.iocs.length - indicators.length;
+    if (obs) lines.push("", `_Plus ${obs} observation(s) with no threat signal (searchable in the case)._`);
     lines.push("");
   }
 

--- a/companion/tests/analysis/evalFollowups.test.ts
+++ b/companion/tests/analysis/evalFollowups.test.ts
@@ -1,0 +1,66 @@
+// MITRE-mapping follow-ups from the Velociraptor eval: T1189 (drive-by download) and
+// T1021.001 (RDP lateral movement). T1567.002 (rclone execution) is covered in prefetchExecution.test.
+import { describe, it, expect } from "vitest";
+import { gradeMotwDownload } from "../../src/analysis/motwDownload.js";
+import { rdpLateralSignal } from "../../src/analysis/rdpLateralDetect.js";
+
+describe("gradeMotwDownload — internet download is drive-by initial access (T1189)", () => {
+  it("adds T1189 alongside T1204.002 for an internet-zone runnable", () => {
+    const g = gradeMotwDownload("3", "installer.msi");
+    expect(g.severity).toBe("Medium");
+    expect(g.mitre).toContain("T1189");
+    expect(g.mitre).toContain("T1204.002");
+  });
+
+  it("keeps only T1204.002 for the Restricted zone (4) — no website-compromise claim", () => {
+    const g = gradeMotwDownload("4", "tool.exe");
+    expect(g.mitre).toContain("T1204.002");
+    expect(g.mitre).not.toContain("T1189");
+  });
+
+  it("says nothing about a trusted-zone or non-runnable download", () => {
+    expect(gradeMotwDownload("1", "installer.msi").mitre).toEqual([]); // intranet zone
+    expect(gradeMotwDownload("3", "notes.txt").mitre).toEqual([]); // not runnable/container
+  });
+});
+
+describe("rdpLateralSignal — explicit-credential logon to a remote host (T1021.001)", () => {
+  const row = (over: Record<string, unknown> = {}) => ({
+    EventID: 4648,
+    ComputerName: "WS-01",
+    TargetServer: "DC-01",
+    InitiatingUser: "svc_backup",
+    SourceIP: "10.0.0.5",
+    ...over,
+  });
+
+  it("grades a 4648 to a remote server by a real user Medium + T1021.001", () => {
+    const s = rdpLateralSignal("Custom.DFIR.RDPLateralMovementDetection", row());
+    expect(s?.severity).toBe("Medium");
+    expect(s?.mitre).toEqual(["T1021.001"]);
+    expect(s?.note).toMatch(/DC-01/);
+  });
+
+  it("ignores the local boot noise (UMFD-0 -> localhost) that dominates the artifact", () => {
+    expect(
+      rdpLateralSignal(
+        "Custom.DFIR.RDPLateralMovementDetection",
+        row({ TargetServer: "localhost", InitiatingUser: "UMFD-0" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores a machine-account principal and a target that is the host itself", () => {
+    expect(
+      rdpLateralSignal("Custom.DFIR.RDPLateralMovementDetection", row({ InitiatingUser: "WS-01$" })),
+    ).toBeNull();
+    expect(
+      rdpLateralSignal("Custom.DFIR.RDPLateralMovementDetection", row({ TargetServer: "WS-01" })),
+    ).toBeNull();
+  });
+
+  it("only fires for that artifact, and only on EID 4648", () => {
+    expect(rdpLateralSignal("Windows.EventLogs.Evtx", row())).toBeNull();
+    expect(rdpLateralSignal("Custom.DFIR.RDPLateralMovementDetection", row({ EventID: 4624 }))).toBeNull();
+  });
+});

--- a/companion/tests/analysis/evalFollowups.test.ts
+++ b/companion/tests/analysis/evalFollowups.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect } from "vitest";
 import { gradeMotwDownload } from "../../src/analysis/motwDownload.js";
 import { rdpLateralSignal } from "../../src/analysis/rdpLateralDetect.js";
+import { parseVelociraptorJson } from "../../src/analysis/velociraptorImport.js";
 
 describe("gradeMotwDownload — internet download is drive-by initial access (T1189)", () => {
   it("adds T1189 alongside T1204.002 for an internet-zone runnable", () => {
@@ -62,5 +63,52 @@ describe("rdpLateralSignal — explicit-credential logon to a remote host (T1021
   it("only fires for that artifact, and only on EID 4648", () => {
     expect(rdpLateralSignal("Windows.EventLogs.Evtx", row())).toBeNull();
     expect(rdpLateralSignal("Custom.DFIR.RDPLateralMovementDetection", row({ EventID: 4624 }))).toBeNull();
+  });
+
+  it("reads a native 4648's TargetServerName / SubjectUserName field names too (not only the artifact aliases)", () => {
+    const native = {
+      EventID: 4648,
+      Computer: "WS-01",
+      TargetServerName: "DC-01",
+      SubjectUserName: "svc_backup",
+      IpAddress: "10.0.0.5",
+    };
+    const s = rdpLateralSignal("Custom.DFIR.RDPLateralMovementDetection", native);
+    expect(s?.mitre).toEqual(["T1021.001"]);
+  });
+});
+
+describe("RDP-lateral artifact — the suppressed boot rows are not re-raised by the overlay/floor", () => {
+  it("keeps local UMFD boot 4648 rows at Info through the full parse, and grades a remote one Medium + T1021.001", () => {
+    const rows = [
+      // local boot noise — must stay Info despite the artifact name ending in 'Detection' and the flat 4648 overlay.
+      {
+        EventID: 4648,
+        ComputerName: "WS-01",
+        TargetServer: "localhost",
+        TargetAccount: "UMFD-0",
+        InitiatingUser: "WS-01$",
+      },
+      // a real remote pivot.
+      {
+        EventID: 4648,
+        ComputerName: "WS-01",
+        TargetServer: "DC-01",
+        TargetAccount: "svc",
+        InitiatingUser: "svc_backup",
+        SourceIP: "10.0.0.9",
+      },
+    ];
+    const r = parseVelociraptorJson(JSON.stringify(rows), {
+      artifact: "Custom.DFIR.RDPLateralMovementDetection",
+      aggregate: false,
+    });
+    const remote = r.events.find((e) => (e.description || "").includes("DC-01"));
+    const boot = r.events.find(
+      (e) => (e.description || "").includes("UMFD-0") || (e.description || "").includes("localhost"),
+    );
+    expect(remote?.severity).toBe("Medium");
+    expect(remote?.mitreTechniques).toContain("T1021.001");
+    expect(boot?.severity).toBe("Info"); // NOT re-raised to Medium/T1078
   });
 });

--- a/companion/tests/analysis/iocRiskScore.test.ts
+++ b/companion/tests/analysis/iocRiskScore.test.ts
@@ -156,6 +156,12 @@ describe("iocRole — indicator vs observation (the 5,000-file-path problem)", (
     );
   });
 
+  it("a network value (ip / domain / url) is an indicator even unenriched — a pivot point", () => {
+    expect(iocRole(mk({ id: "n1", type: "ip", value: "1.2.3.4" }), "low")).toBe("indicator");
+    expect(iocRole(mk({ id: "n2", type: "domain", value: "c2.example" }), "low")).toBe("indicator");
+    expect(iocRole(mk({ id: "n3", type: "url", value: "http://c2.example/x" }), "low")).toBe("indicator");
+  });
+
   it("a hash a reputation source flagged is an indicator even at low risk", () => {
     const ioc = mk({
       id: "h1",

--- a/companion/tests/analysis/iocRiskScore.test.ts
+++ b/companion/tests/analysis/iocRiskScore.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { scoreIoc, scoreIocs, type IocRiskSignals } from "../../src/analysis/iocRiskScore.js";
+import {
+  scoreIoc,
+  scoreIocs,
+  iocRole,
+  summarizeIocRoles,
+  type IocRiskSignals,
+} from "../../src/analysis/iocRiskScore.js";
 import type { IOC, ForensicEvent } from "../../src/analysis/stateTypes.js";
 
 // Minimal signal set (nothing risky) that individual tests override.
@@ -135,5 +141,51 @@ describe("scoreIocs — batch orchestration over real IOCs/events", () => {
     });
     expect(out["i1"].score).toBe("benign"); // NSRL known-good beats the malicious verdict
     expect(out["i2"].score).toBe("benign"); // whitelisted
+  });
+});
+
+describe("iocRole — indicator vs observation (the 5,000-file-path problem)", () => {
+  const mk = (p: Partial<IOC> & { id: string; value: string; type: IOC["type"] }): IOC => ({
+    firstSeen: "",
+    ...p,
+  });
+
+  it("a bare file path with no signal is an observation", () => {
+    expect(iocRole(mk({ id: "f1", type: "file", value: "C:\\Windows\\notepad.exe" }), "low")).toBe(
+      "observation",
+    );
+  });
+
+  it("a hash a reputation source flagged is an indicator even at low risk", () => {
+    const ioc = mk({
+      id: "h1",
+      type: "hash",
+      value: "a".repeat(64),
+      enrichments: [{ source: "MalwareBazaar", verdict: "malicious", fetchedAt: "" }],
+    });
+    expect(iocRole(ioc, "low")).toBe("indicator");
+  });
+
+  it("any Medium+ risk tier is an indicator, whatever the type", () => {
+    expect(iocRole(mk({ id: "x", type: "file", value: "x" }), "medium")).toBe("indicator");
+    expect(iocRole(mk({ id: "y", type: "ip", value: "1.2.3.4" }), "high")).toBe("indicator");
+  });
+
+  it("scoreIocs stamps role, and summarizeIocRoles splits the set", () => {
+    const iocs: IOC[] = [
+      mk({ id: "obs1", type: "file", value: "C:\\Program Files\\app\\a.dll" }),
+      mk({ id: "obs2", type: "hash", value: "b".repeat(64) }),
+      mk({
+        id: "ind1",
+        type: "domain",
+        value: "evil.test",
+        enrichments: [{ source: "VT", verdict: "malicious", fetchedAt: "" }],
+      }),
+    ];
+    const risks = scoreIocs(iocs, [], { hostNames: new Set() });
+    expect(risks["obs1"].role).toBe("observation");
+    expect(risks["obs2"].role).toBe("observation");
+    expect(risks["ind1"].role).toBe("indicator");
+    expect(summarizeIocRoles(risks)).toEqual({ indicators: 1, observations: 2 });
   });
 });

--- a/companion/tests/analysis/iocRiskScore.test.ts
+++ b/companion/tests/analysis/iocRiskScore.test.ts
@@ -162,6 +162,24 @@ describe("iocRole — indicator vs observation (the 5,000-file-path problem)", (
     expect(iocRole(mk({ id: "n3", type: "url", value: "http://c2.example/x" }), "low")).toBe("indicator");
   });
 
+  it("a benign (whitelisted / NSRL known-good) value is never an indicator — even a network value or a stale verdict", () => {
+    // known-good overrides everything, so the network and flagged branches must not fire.
+    expect(iocRole(mk({ id: "b1", type: "domain", value: "safe.example.com" }), "benign")).toBe(
+      "observation",
+    );
+    expect(
+      iocRole(
+        mk({
+          id: "b2",
+          type: "hash",
+          value: "a".repeat(64),
+          enrichments: [{ source: "old", verdict: "malicious", fetchedAt: "" }],
+        }),
+        "benign",
+      ),
+    ).toBe("observation");
+  });
+
   it("a hash a reputation source flagged is an indicator even at low risk", () => {
     const ioc = mk({
       id: "h1",

--- a/companion/tests/analysis/prefetchExecution.test.ts
+++ b/companion/tests/analysis/prefetchExecution.test.ts
@@ -13,6 +13,14 @@ describe("prefetchExecution — the dual-use binaries a Prefetch entry can name"
     expect(prefetchSignal("MSBUILD.EXE")?.mitre).toContain("T1127.001");
   });
 
+  it("grades a cloud/bulk exfil tool execution Medium with T1567.002 (name alone, no command line)", () => {
+    for (const exe of ["rclone.exe", "RCLONE.EXE", "restic.exe", "megasync.exe", "megacmd.exe"]) {
+      const s = prefetchSignal(exe);
+      expect(s?.severity, exe).toBe("Medium");
+      expect(s?.mitre, exe).toContain("T1567.002");
+    }
+  });
+
   it("grades the defense-tampering and anti-forensics utilities with their own technique", () => {
     expect(prefetchSignal("WEVTUTIL.EXE")?.mitre).toEqual(["T1070.001"]);
     expect(prefetchSignal("TASKKILL.EXE")?.mitre).toEqual(["T1562.001"]);

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -3154,8 +3154,9 @@ describe("parseVelociraptorJson — BinaryRename drop time", () => {
 
 // Custom VQL artifacts SELECT the columns they want, so a Windows event arrives as a flat row: a
 // bare EventID with no System/EventData wrapper and no Channel. classify() sends it to the generic
-// key=value dump, which grades Info — and Info never reaches the forensic timeline. The benchmark's
-// explicit-credential logons (EID 4648) were invisible to synthesis for exactly this reason.
+// key=value dump, which grades Info — and Info never reaches the forensic timeline. The flat-EID
+// overlay grades it from the per-EID table instead. (The RDP-lateral artifact is the ONE exception —
+// it is graded authoritatively by rdpLateralDetect and exempt from this overlay; see evalFollowups.)
 describe("parseVelociraptorJson — flat Windows EventID rows", () => {
   function logonRow(o: Record<string, unknown> = {}): object {
     return {
@@ -3172,7 +3173,7 @@ describe("parseVelociraptorJson — flat Windows EventID rows", () => {
   }
   const parse = (o: Record<string, unknown> = {}): ReturnType<typeof parseVelociraptorJson> =>
     parseVelociraptorJson(JSON.stringify([logonRow(o)]), {
-      artifact: "Custom.DFIR.RDPLateralMovementDetection/ExplicitCredentialLogons",
+      artifact: "Custom.Windows.EventLogs.ExplicitCredentialLogons",
     });
 
   it("grades a known EventID from the Windows event table instead of Info", () => {
@@ -3577,5 +3578,26 @@ describe("parseVelociraptorJson — truncation is counted, not silent", () => {
     expect(r.kept).toBe(10);
     expect(r.total).toBe(50);
     expect(r.dropped).toBe(40);
+    // groups > kept confirms the CAP truncated (not a severity-floor/unparseable drop) — the import
+    // note only claims "omitted at the event cap" under exactly this condition.
+    expect(r.groups).toBeGreaterThan(r.kept);
+  });
+
+  it("does not overstate cap truncation when the drop is a severity floor, not the cap", () => {
+    // 5 Low rows dropped by a High floor, well under the cap → groups do NOT exceed kept, so the
+    // import note must not attribute the loss to the event cap.
+    const rows = Array.from({ length: 5 }, (_, i) => ({
+      _Source: "Windows.EventLogs.Evtx",
+      System: {
+        EventID: 4624,
+        Channel: "Security",
+        Computer: "H",
+        TimeCreated: "2026-08-26T03:00:0" + i + "Z",
+      },
+      EventData: { LogonType: "3" },
+    }));
+    const r = parseVelociraptorJson(JSON.stringify(rows), { minSeverity: "High" });
+    expect(r.kept).toBe(0);
+    expect(r.groups).not.toBeGreaterThan(r.kept); // cap was never the cause
   });
 });

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -3561,3 +3561,21 @@ describe("parseVelociraptorJson — Amcache masquerade", () => {
     expect(e.severity).toBe("Medium");
   });
 });
+
+// The per-import event cap truncates a huge MFT/USN artifact; the parse result must report how many
+// rows were omitted (not just how many were kept) so the import note can make the loss visible.
+describe("parseVelociraptorJson — truncation is counted, not silent", () => {
+  it("reports dropped rows when the event cap truncates the import", () => {
+    // 50 distinct Info telemetry rows, capped to 10 → 40 omitted.
+    const rows = Array.from({ length: 50 }, (_, i) => ({
+      _Source: "Windows.Forensics.Usn",
+      OSPath: `C:\\Users\\v\\Documents\\file${i}.txt`,
+      Reason: "DATA_EXTEND|CLOSE",
+      Usn: i,
+    }));
+    const r = parseVelociraptorJson(JSON.stringify(rows), { maxEvents: 10, aggregate: false });
+    expect(r.kept).toBe(10);
+    expect(r.total).toBe(50);
+    expect(r.dropped).toBe(40);
+  });
+});

--- a/companion/tests/dashboard/featureManifest.ts
+++ b/companion/tests/dashboard/featureManifest.ts
@@ -1287,6 +1287,7 @@ export const FEATURES: Feature[] = [
       "iocProvenanceOf",
       "iocProvenanceBadge",
       "iocRiskRankOf",
+      "iocRoleOf",
       "iocRiskBadge",
       "iocCorroBadge",
       "iocChainChip",

--- a/companion/tests/reports/markdown.test.ts
+++ b/companion/tests/reports/markdown.test.ts
@@ -525,7 +525,15 @@ describe("renderMarkdownReport", () => {
         pointer: "collect 4624 logs on targets",
       },
     );
-    state.iocs.push({ id: "i1", type: "ip", value: "10.0.0.5", firstSeen: "2026-05-20T09:00:00Z" });
+    state.iocs.push({
+      id: "i1",
+      type: "ip",
+      value: "10.0.0.5",
+      firstSeen: "2026-05-20T09:00:00Z",
+      // A verdict makes it a real INDICATOR — a bare, unenriched value is now an observation and
+      // reduced to a count, not listed in the indicators table.
+      enrichments: [{ source: "AbuseIPDB", verdict: "malicious", fetchedAt: "2026-05-20T09:00:00Z" }],
+    });
 
     const md = renderMarkdownReport(state);
     expect(md).toContain("### 4.7 Key investigative questions");
@@ -1062,5 +1070,30 @@ describe("renderMarkdownReport", () => {
       const md = renderMarkdownReport(emptyState("c1"));
       expect(md).not.toContain("### 3.5 Model performance");
     });
+  });
+});
+
+describe("renderMarkdownReport — IOC section leads with indicators (eval follow-up)", () => {
+  it("lists real indicators in the table and reduces observations to a count", () => {
+    const state = emptyState("c1");
+    state.iocs = [
+      {
+        id: "i-ind",
+        type: "domain",
+        value: "evil-c2.example",
+        firstSeen: "2026-01-01T00:00:00Z",
+        enrichments: [{ source: "VirusTotal", verdict: "malicious", fetchedAt: "2026-01-01T00:00:00Z" }],
+      },
+      {
+        id: "i-obs",
+        type: "file",
+        value: "C:\\Windows\\System32\\notepad.exe",
+        firstSeen: "2026-01-01T00:00:00Z",
+      },
+    ];
+    const md = renderMarkdownReport(state);
+    expect(md).toContain("evil-c2.example"); // the indicator is in the table
+    expect(md).not.toContain("notepad.exe"); // the observation is not listed as an indicator
+    expect(md).toMatch(/Plus 1 observation\(s\)/); // …it is a count instead
   });
 });

--- a/companion/tests/server/iocRisk.test.ts
+++ b/companion/tests/server/iocRisk.test.ts
@@ -69,6 +69,9 @@ describe("GET /cases/:id/ioc-risk", () => {
     expect(["critical", "high"]).toContain(res.body["i-bad"].score);
     expect(res.body["i-bad"].factors.length).toBeGreaterThan(0);
     expect(res.body["i-wl"].score).toBe("benign");
+    // Each risk now carries a role so the dashboard's risk filter can separate a real indicator from
+    // an ordinary observation (a scraped file path / hash with no signal).
+    expect(res.body["i-bad"].role).toBe("indicator");
   });
 
   it("404s for an unknown case", async () => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4441,7 +4441,7 @@
       const iocs = sortIocsForDisplay(dedupeIocsById(iocsRaw));
       const iocTypeHidden = typeof renderIocTypeFilter === "function" && renderIocTypeFilter(iocs);   // effective count, so the chip below cannot claim a filter that is not there
       typeof renderIocExcludeRules === "function" && renderIocExcludeRules((DfirState.lastState() && DfirState.lastState().iocExcludeRules) || []);
-      const flaggedTotal = iocs.filter(iocFlagged).length;
+      const flaggedTotal = iocs.filter(iocFlagged).length, observationTotal = typeof iocRoleOf === "function" ? iocs.filter(i => iocRoleOf(i.id) === "observation").length : 0; // observationTotal = scraped file/hash, no signal
       let visible = showFlaggedIocsOnly ? iocs.filter(iocFlagged) : iocs;
       if (DfirTimelineView.search()) visible = visible.filter(i => _iocMatchesSearch(i, DfirTimelineView.search()));
       if (DfirTimelineView.excludeTerms().length) visible = visible.filter(i => !_iocMatchesExclude(i, DfirTimelineView.excludeTerms()));
@@ -4484,7 +4484,7 @@
       if (cnt) {
         const scope = visible.length === iocs.length ? `${iocs.length} IOC${iocs.length !== 1 ? "s" : ""}` : `${visible.length} of ${iocs.length} IOCs`;
         const pageSuffix = (iocPageSize > 0 && totalFiltered > iocPageSize) ? ` — page ${iocPage + 1} of ${iocTotalPages}` : "";
-        cnt.textContent = ` (${scope}${flaggedTotal ? ` · ${flaggedTotal} flagged` : ""}${pageSuffix})`;
+        cnt.textContent = ` (${scope}${flaggedTotal ? ` · ${flaggedTotal} flagged` : ""}${observationTotal ? ` · ${observationTotal} observation${observationTotal !== 1 ? "s" : ""}` : ""}${pageSuffix})`;
       }
       if (!visible.length) {
         el.innerHTML = showFlaggedIocsOnly

--- a/public/js/dashboard-ioc-provenance.js
+++ b/public/js/dashboard-ioc-provenance.js
@@ -120,6 +120,12 @@
     const r = iocRisk[iocId];
     return r && r.score in RISK_RANK ? RISK_RANK[r.score] : -1; // -1 = not yet scored (excluded by a tier filter)
   }
+  // "indicator" (earned a signal, or a network pivot) vs "observation" (a scraped file/hash with no
+  // signal), from the server's IOC-risk scoring. null until /ioc-risk has loaded for the case.
+  function iocRoleOf(iocId) {
+    const r = iocRisk[iocId];
+    return r && r.role ? r.role : null;
+  }
   // Colored risk badge with the factors as a tooltip. Benign/low recede; medium+ signal.
   function iocRiskBadge(iocId) {
     const r = iocRisk[iocId];
@@ -474,6 +480,7 @@
   window.iocProvenanceOf = iocProvenanceOf;
   window.iocProvenanceBadge = iocProvenanceBadge;
   window.iocRiskRankOf = iocRiskRankOf;
+  window.iocRoleOf = iocRoleOf;
   window.iocRiskBadge = iocRiskBadge;
   window.iocCorroBadge = iocCorroBadge;
   window.iocChainChip = iocChainChip;


### PR DESCRIPTION
Follow-ups to #700, from the Velociraptor artifact eval. Three self-contained commits.

## 1. Map lateral movement, drive-by download, and cloud exfil
Three ATT&CK techniques the eval flagged as missed when the evidence is present:
- **T1189 (drive-by):** an internet-zone (ZoneId 3) runnable/container download now carries T1189 alongside T1204.002 — the initial-access half that ties the browser-delivered payloads to their reports.
- **T1567.002 (cloud exfil):** `rclone`/`restic`/`megasync`/`megacmd` execution recorded in Prefetch now grades Medium + T1567.002 from the name alone, where `tradecraftRules` (which needs a command line) cannot see it.
- **T1021.001 (RDP lateral):** the `Custom.DFIR.RDPLateralMovementDetection` artifact (EID 4648 explicit-credential logons) is graded by a new `rdpLateralDetect` module. Only a **remote** target by a real user fires; the local `UMFD-0 -> localhost` boot noise that dominates the artifact stays Info, so it never fabricates lateral movement.

Each detector is scoped to real evidence and returns null otherwise — true positives without inventing them.

## 2. Classify each IOC as a threat indicator or an observation
An import scrapes every file path and hash it sees — 5,000+ on one collection — and presenting them all as "IOCs" drowns the few that matter. The risk model already tiers a bare value as `low`; this names the distinction:
- `IocRisk` gains a `role` (`indicator` | `observation`), stamped by `scoreIocs`. A value is an indicator when it earned a signal (a Medium+ risk tier, or a reputation verdict); otherwise an observation.
- The role rides the existing `GET /cases/:id/ioc-risk` response (additive, no shape change), so the dashboard's risk filter can hide observations without losing them.

## 3. Make import truncation visible
A 275k-row MFT / 333k-row USN artifact is capped, and the note read "N events from M rows". The parser already computes `dropped`; the Velociraptor/Chainsaw/Hayabusa notes now append "K row(s) omitted at the event cap". The cap keeps the most-severe events first, so what's dropped is low-signal telemetry; `DFIR_MAX_EVENTS` raises the ceiling.

Deliberately **not** collapsing MFT MACB rows into one per file: a super-timeline is meant to be a complete bodyfile, and per-timestamp granularity is the point — collapsing would degrade it and blur the $SI/$FN timestomp signal.

## Verification
- `npm run typecheck` clean; 4978 analysis/server tests pass; architecture suite (incl. moduleMap comply/total) green.
- All six gates green; new modules classified in `module-map.json`; ARCHITECTURE.md comply/total updated (1,873 / 1,912).

## Still open (from the eval)
- ~~Applying the indicator/observation split in the dashboard panel and the report~~ — **now included** (commit 4): network IOCs stay visible, file/hash observations become a count in both the report and the dashboard IOC label (verified live). Remaining: none — this completes the eval follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)