### PR TITLE
Fix the two real findings from the #665-670 review sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The bundle hunt label picker stays responsive on a large fleet** — deduping the cached inventory's labels no longer slows down as the fleet grows. (closes #665)
+
 ## [0.36.0] - 2026-08-29
 
 ### Added

--- a/companion/src/analysis/stagingPaths.ts
+++ b/companion/src/analysis/stagingPaths.ts
@@ -9,12 +9,27 @@
 //
 // Pure, no I/O.
 
-// World-writable / transient locations malware commonly drops into. Kept as one alternation so the
-// two matchers below can never diverge on WHICH directories count.
+// World-writable / transient locations malware commonly drops into.
+//
+// THESE ARE LITERAL BACKSLASHES IN A WINDOWS COMMAND-LINE VALUE, not this file's own path
+// separators, so do not "fix" them to match the matcher below. `\\\\` in a TypeScript string
+// literal is `\\` in the compiled regex, which matches one backslash — the character that actually
+// appears inside "C:\ProgramData\x.dll".
 const STAGING_DIRS = "temp|tmp|appdata\\\\local\\\\temp|programdata|public|windows\\\\temp";
 
-// The same list with forward slashes allowed, for the bare-path matcher.
-const STAGING_DIRS_ANY_SEP = String.raw`temp|tmp|appdata[\\/]local[\\/]temp|programdata|public|windows[\\/]temp|perflogs|\$recycle\.bin`;
+// The same list for the bare-path matcher: either separator, plus two directories that only apply
+// there.
+//
+// DERIVED, NOT RETYPED. This was a second hand-written literal, and the two had already drifted —
+// perflogs and $Recycle.Bin were added here and never reached STAGING_DIRS, so the header comment's
+// promise that the lists could not diverge was false the moment it was written. Rewriting each `\\`
+// into `[\\/]` means a directory added above now reaches BOTH matchers by construction.
+//
+// The two extras stay bare-path-only on purpose. Teaching isStagedCommandValue about them widens
+// what persistenceSniperImport flags, which is a detection change to make deliberately with its own
+// test — not a side effect of removing a duplicated string.
+const STAGING_DIRS_ANY_SEP =
+  STAGING_DIRS.replace(/\\\\/g, String.raw`[\\/]`) + String.raw`|perflogs|\$recycle\.bin`;
 
 // Executable-ish extensions. An archive or a document in Temp is ordinary; a binary is not.
 export const STAGING_EXT =

--- a/companion/tests/analysis/stagingPaths.test.ts
+++ b/companion/tests/analysis/stagingPaths.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { isStagedCommandValue, isStagedPath, isVendorRootPath } from "../../src/analysis/stagingPaths.js";
+
+// companion/src/analysis/stagingPaths.ts — the one definition of "this file sits somewhere a
+// legitimately-installed binary does not".
+//
+// THE POINT OF THIS FILE IS THAT THE TWO MATCHERS CANNOT DISAGREE. Three copies of the staging-path
+// idea had drifted apart before they were merged here, and then the merged version drifted again:
+// the bare-path list was a second hand-typed literal, so perflogs and $Recycle.Bin were added to it
+// and never reached the command-value matcher, while the file's own header comment promised the two
+// could not diverge. The list is now derived rather than retyped, and the first block below is what
+// holds that: every shared directory has to be recognised by BOTH matchers, so a directory added to
+// one and not the other fails here instead of shipping as a silent detection gap.
+const SHARED_DIRS: readonly { dir: string; command: string; bare: string }[] = [
+  { dir: "temp", command: String.raw`C:\Temp\x.exe`, bare: String.raw`C:\Temp\x.exe` },
+  { dir: "tmp", command: String.raw`C:\tmp\x.exe`, bare: String.raw`C:\tmp\x.exe` },
+  {
+    dir: "appdata\\local\\temp",
+    command: String.raw`C:\Users\bob\AppData\Local\Temp\x.exe`,
+    bare: String.raw`C:\Users\bob\AppData\Local\Temp\x.exe`,
+  },
+  {
+    dir: "programdata",
+    command: String.raw`C:\ProgramData\x.exe`,
+    bare: String.raw`C:\ProgramData\x.exe`,
+  },
+  {
+    dir: "public",
+    command: String.raw`C:\Users\Public\x.exe`,
+    bare: String.raw`C:\Users\Public\x.exe`,
+  },
+  {
+    dir: "windows\\temp",
+    command: String.raw`C:\Windows\Temp\x.exe`,
+    bare: String.raw`C:\Windows\Temp\x.exe`,
+  },
+];
+
+describe("staging directories are shared by both matchers", () => {
+  for (const { dir, command, bare } of SHARED_DIRS) {
+    it(`${dir} is staging for a command value and for a bare path`, () => {
+      expect(isStagedCommandValue(command)).toBe(true);
+      expect(isStagedPath(bare)).toBe(true);
+    });
+  }
+
+  // Forward slashes are the reason the bare-path list is a separate expression at all. A file-stat
+  // artifact hands over whichever separator the collector used.
+  it("accepts either separator on a bare path", () => {
+    expect(isStagedPath("C:/Users/bob/AppData/Local/Temp/x.exe")).toBe(true);
+    expect(isStagedPath(String.raw`\\host\share\ProgramData\x.exe`)).toBe(true);
+  });
+
+  // These two are deliberately bare-path-only. Teaching the command-value matcher about them widens
+  // what persistenceSniperImport flags, which is a detection change and needs its own test — this
+  // one only pins where the asymmetry currently sits, so a future change to it is a decision rather
+  // than an accident.
+  it("keeps perflogs and $Recycle.Bin on the bare-path side only", () => {
+    expect(isStagedPath(String.raw`C:\PerfLogs\x.exe`)).toBe(true);
+    expect(isStagedPath(String.raw`C:\$Recycle.Bin\S-1-5-21\x.exe`)).toBe(true);
+    expect(isStagedCommandValue(String.raw`C:\PerfLogs\x.exe`)).toBe(false);
+  });
+
+  // User-writable locations a dropped binary often sits in, which a command-line value would rarely
+  // name. Bare-path side only, like the two above.
+  it("treats a user's Downloads/Desktop/Documents as staging for a bare path", () => {
+    expect(isStagedPath(String.raw`C:\Users\bob\Downloads\x.exe`)).toBe(true);
+    expect(isStagedPath(String.raw`C:\Users\bob\Desktop\x.exe`)).toBe(true);
+    expect(isStagedPath(String.raw`C:\Users\bob\Documents\x.exe`)).toBe(true);
+  });
+});
+
+describe("isStagedCommandValue only claims the row's OWN target", () => {
+  // "msiexec.exe /i C:\Windows\Temp\update.msi" runs msiexec, not the staged .msi. Flagging it was a
+  // real false positive, so only a LEADING path or a QUOTED one anywhere counts.
+  it("ignores an unquoted staged path sitting in an argument list", () => {
+    expect(isStagedCommandValue(String.raw`msiexec.exe /i C:\Windows\Temp\update.msi`)).toBe(false);
+  });
+
+  it("claims a quoted staged path anywhere in the value", () => {
+    expect(isStagedCommandValue(String.raw`rundll32.exe "C:\ProgramData\x.dll",stow`)).toBe(true);
+  });
+
+  // The file has to sit DIRECTLY in the staging directory. A deep vendor path below one must not
+  // match — Defender's Platform\<ver>\MpCmdRun.exe was the case that made this rule.
+  it("does not match a file nested below the staging directory", () => {
+    expect(isStagedCommandValue(String.raw`C:\ProgramData\Vendor\Platform\1.2\MpCmdRun.exe`)).toBe(false);
+  });
+
+  // A bare \b matched an extension PREFIX inside a multi-dot filename: readme.hta.txt is a .txt
+  // file, not an .hta.
+  it("does not treat a multi-dot filename as its middle extension", () => {
+    expect(isStagedCommandValue(String.raw`C:\Windows\Temp\readme.hta.txt`)).toBe(false);
+  });
+
+  // An allow-list of terminators silently dropped cmd.exe operators, so the guard rejects only what
+  // is actually wrong: another dot, or a continuing word character.
+  it("still matches when a cmd.exe operator follows the extension", () => {
+    expect(isStagedCommandValue(String.raw`C:\Windows\Temp\evil.exe&calc.exe`)).toBe(true);
+  });
+});
+
+describe("isVendorRootPath", () => {
+  it("recognises the OS and Program Files install roots", () => {
+    expect(isVendorRootPath(String.raw`C:\Program Files\Vendor\app.exe`)).toBe(true);
+    expect(isVendorRootPath(String.raw`C:\Program Files (x86)\Vendor\app.exe`)).toBe(true);
+    expect(isVendorRootPath(String.raw`C:\Windows\System32\svchost.exe`)).toBe(true);
+  });
+
+  // NOT the inverse of staging. C:\Tools is neither, and callers must treat that middle as neutral
+  // rather than as evidence either way.
+  it("leaves the ambiguous middle as neither staged nor vendor-owned", () => {
+    const p = String.raw`C:\Tools\app.exe`;
+    expect(isVendorRootPath(p)).toBe(false);
+    expect(isStagedPath(p)).toBe(false);
+  });
+});

--- a/public/js/dashboard-velo-labels.js
+++ b/public/js/dashboard-velo-labels.js
@@ -19,15 +19,24 @@
 // CASE IS SIGNIFICANT. Velociraptor label matching is case-sensitive, so DMZ and dmz are two
 // different filters and both stay offerable; they sort next to each other (lowercased key, raw
 // string as the tiebreak) so it is visible that there are two rather than looking like a duplicate.
+//
+// The dedup uses a Set, not `out.includes()`. Nothing caps the cached inventory — it is the whole
+// enrolled fleet — so the scan runs once per client label, and a linear re-scan of the distinct set
+// on each one is the picker stalling the toolbar on a large deployment. The array is still what
+// gets returned, because the order below is the product.
 function veloFleetLabels(clients) {
-  const seen = [];
+  const seen = new Set();
+  const out = [];
   for (const c of clients || []) {
     for (const raw of (c && c.labels) || []) {
       const label = String(raw == null ? "" : raw).trim();
-      if (label && !seen.includes(label)) seen.push(label);
+      if (label && !seen.has(label)) {
+        seen.add(label);
+        out.push(label);
+      }
     }
   }
-  return seen.sort((a, b) => {
+  return out.sort((a, b) => {
     const la = a.toLowerCase(),
       lb = b.toLowerCase();
     if (la !== lb) return la < lb ? -1 : 1;


### PR DESCRIPTION
Six auto-filed `[Code Review]` issues (#665-670) were reviewed against the code. Three were wrong and are closed with reasons; this PR takes the two that were real. #670 stays open pending a decision.

## What changed for an analyst

**The bundle-run label picker stays responsive on a large fleet.** Building the include/exclude label list re-scanned everything it had already collected, once per client label. On a big enrolled fleet that showed up as the toolbar stalling while the picker drew. It now scales with the fleet instead of with the square of it. Nothing about the list changes — same labels, same case-sensitive order. (closes #665)

**A staging-directory added in one place now reaches both detections.** No analyst-visible change today, but a real gap was closing behind the scenes — see below. (closes #667)

## The #667 finding

#667 asked only for a clarifying comment about backslash escaping. Verifying it surfaced the actual defect.

`stagingPaths.ts` claimed in its header that its directory list was "kept as one alternation so the two matchers below can never diverge". It was not one alternation — it was two hand-typed literals, and they had already diverged. `perflogs` and `$Recycle.Bin` had been added to the bare-path matcher and never reached the command-value one. Adding a staging directory updated half the detection and looked like it had updated all of it.

The bare-path list is now derived from the shared one. The derived string is byte-identical to the literal it replaces, so **no detection behaviour changes** in this PR. The two extras stay bare-path-only deliberately — extending them to command values would widen what `persistenceSniperImport` flags, which is a detection change that deserves its own issue and test.

The escaping asymmetry that made the duplication look intentional is now documented, which is what #667 originally asked for.

## Tests

The file had no coverage at all. The new suite pins the no-divergence invariant — every shared directory has to be recognised by both matchers — so a future drift fails in CI instead of shipping as a silent detection gap. It also locks the false-positive cases the file's comments describe: an unquoted staged path sitting in an argument list, a deep vendor path below a staging directory, and `readme.hta.txt` not counting as an `.hta`.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass
- `prettier --check` — pass
- `npm test` — 691 files, 10786 tests, 0 failures

closes #665
closes #667