### PR TITLE
A deep path no longer merges a renamed binary across hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A renamed binary found on two machines is two findings again** — a deep path used to push the host out of the aggregation key, merging the hosts and discarding one machine's path and hash. (closes #670)
 - **The bundle hunt label picker stays responsive on a large fleet** — deduping the cached inventory's labels no longer slows down as the fleet grows. (closes #665)
 
 ## [0.36.0] - 2026-08-29

--- a/companion/src/analysis/binaryRenameImport.ts
+++ b/companion/src/analysis/binaryRenameImport.ts
@@ -12,6 +12,8 @@
 //
 // Kept as its own module rather than inlined into velociraptorImport.ts, which is frozen at its
 // current size by the file-size ledger (#384) — see check-file-size.mjs.
+import { createHash } from "node:crypto";
+
 import {
   str,
   getCI,
@@ -178,11 +180,30 @@ function describeRename(f: RenameFacts): string {
 // persistenceSniperImport, where it collapses volatile GUIDs in task paths — folded svchost1.exe and
 // svchost2.exe together on top of that. A renamed binary is evidence of a specific file at a specific
 // place; nothing about it is volatile enough to normalise away.
+//
+// THE CAP MUST NOT COST A DISCRIMINATOR, which is why the host leads and the path trails. Two rows
+// sharing a key do not merely merge a count: aggregation keeps ONE row and applyEventIdentity
+// overwrites its path, hash and description with whichever row landed last, so a collision DELETES
+// one binary's evidence rather than miscounting it.
+//
+// The host used to sit LAST, so it was the first field truncation threw away — and a deep path
+// reaches 400 characters on its own. A renamed binary found at the same path on two machines came
+// back as one finding on one machine, which is the cross-host merge #659 fixed for Windows events
+// arriving again by a different route. Host first puts every short discriminator inside the bound
+// by construction.
+//
+// The path is then the only field that can realistically exhaust what is left, and when it does the
+// tail carries a digest of the FULL key, so two deep paths sharing a 400-character prefix stay two
+// rows. A key short enough to fit is untouched, so nothing that already aggregates correctly starts
+// aggregating differently.
+const AGG_KEY_MAX = 400;
+const AGG_KEY_DIGEST = 16; // 64 bits of hex — collision-free at any case's row count
+
 function renameAggKey(f: RenameFacts, host: string): string {
-  return `vr-rename|${leafName(f.onDisk)}|${leafName(f.original)}|${f.path.toLowerCase()}|${host.toLowerCase()}`.slice(
-    0,
-    400,
-  );
+  const key = `vr-rename|${host.toLowerCase()}|${leafName(f.onDisk)}|${leafName(f.original)}|${f.path.toLowerCase()}`;
+  if (key.length <= AGG_KEY_MAX) return key;
+  const digest = createHash("sha256").update(key).digest("hex").slice(0, AGG_KEY_DIGEST);
+  return `${key.slice(0, AGG_KEY_MAX - AGG_KEY_DIGEST - 1)}#${digest}`;
 }
 
 // A masquerading binary is a COPY of the tool it impersonates. A copy carries the SOURCE file's

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -3013,6 +3013,37 @@ describe("parseVelociraptorJson — BinaryRename edge cases", () => {
     expect(r.events).toHaveLength(2);
   });
 
+  // The aggregation key is length-capped, and the cap used to cost a discriminator. Two rows sharing
+  // a key do not merely merge a count — applyEventIdentity overwrites the survivor's path, hash and
+  // description with whichever row landed last, so a collision DELETES one binary's evidence.
+  //
+  // A deep path is enough to reach the cap on its own, and the host used to sit LAST in the key, so
+  // it was the first thing truncation threw away. That is the cross-host merge #659 fixed for
+  // Windows events, arriving again by a different route: one renamed binary found on two machines,
+  // reported as one machine.
+  const DEEP = "C:\\" + "deep\\".repeat(80);
+
+  it("keeps the same deep path on two hosts as two events", () => {
+    const r = parseVelociraptorJson(
+      JSON.stringify([
+        row({ Fqdn: "HOST-A", OSPath: DEEP + "java.exe" }),
+        row({ Fqdn: "HOST-B", OSPath: DEEP + "java.exe", Hash: { SHA256: "c".repeat(64) } }),
+      ]),
+    );
+    expect(r.events).toHaveLength(2);
+    expect(r.events.map((e) => e.asset).sort()).toEqual(["HOST-A", "HOST-B"]);
+  });
+
+  it("keeps two deep paths that share a long prefix as two events", () => {
+    const r = parseVelociraptorJson(
+      JSON.stringify([
+        row({ OSPath: DEEP + "alpha\\java.exe" }),
+        row({ OSPath: DEEP + "bravo\\java.exe", Hash: { SHA256: "c".repeat(64) } }),
+      ]),
+    );
+    expect(r.events).toHaveLength(2);
+  });
+
   it("grades a renamed system utility in System32 High, not Medium", () => {
     // A legitimate cmd.exe in System32 is NAMED cmd.exe. A renamed one there needs admin rights to
     // place and is the classic blend-in location, so a vendor-root allowance must not cover it.


### PR DESCRIPTION
#670 was filed as "the 400-character truncation is undocumented" and asked for a comment. Verifying it found a live bug of the same class as #659.

## What was wrong

`renameAggKey` built its grouping key as **name pair → path → host**, then capped it at 400 characters. The host sat last, so it was the first thing truncation threw away — and a deep path reaches 400 on its own.

The result an analyst would have seen: **the same renamed binary found at the same path on two machines reported as one finding on one machine.** That is exactly what #659 fixed for Windows events, arriving again by a different route.

It is worse than a wrong count. When two rows share a key, aggregation keeps one row and overwrites its path, hash and description with whichever row landed last. The second machine's evidence was deleted, not summarised.

A second, milder case: two different deep paths on one host that share a 400-character prefix also collapsed into one row.

## What changed

The host now leads the key, which puts every short discriminator inside the cap by construction. The path trails, and when it exhausts the remaining budget the tail carries a 64-bit digest of the full key — so two deep paths sharing a long prefix stay two rows.

A key short enough to fit is untouched, so nothing that already aggregates correctly starts aggregating differently. The key is stripped before an event is stored, so **no existing case data re-aggregates** — this changes what future imports produce, not what is already on disk.

The 400 ceiling is now explained in the code, which is what #670 originally asked for.

## Tests

Two new cases in the BinaryRename edge-cases block — the same block where this mapper's earlier aggregation defects were pinned. Both fail against the previous key:

- the same deep path on two hosts must stay two events, with both assets intact
- two deep paths sharing a long prefix must stay two events

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass
- `prettier --check` — pass
- `npm test` — 691 files, 10788 tests, 10787 passed

The one failure is `anonymize.test.ts > scans a log full of key headers in linear time`, a timing-ratio benchmark that fails under machine load (`expected 9.574 to be less than 8`). It passes in isolation in 337ms against 1770ms under load, and does not touch aggregation keys.

## Related, not fixed here

`yaraImport.ts` builds its key as `yara|<rule>|<file>` with **no host field at all**, so the same rule hitting the same path on two machines may collapse the same way. Out of scope for this PR and worth its own investigation.

closes #670