### PR TITLE
fix(auth): version unlock tokens, stop OIDC error reflection, sweep expired sessions, fix the timer-lifecycle leak

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,879 of the 1,918 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,881 of the 1,920 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **A failed OIDC sign-in no longer shows the identity provider's error text** — the login page gets one sentence and a reference; the full detail goes to the server log under that reference. (closes #674)
+- **Case unlock tokens carry a payload version** — a token signed under an older payload shape now stops verifying instead of being read under today's rules. Unlock cookies issued before this release stop working, so each password-protected case asks for its password once more. (closes #671)
+
 ### Fixed
+- **Expired team-mode sessions are swept every six hours** instead of accumulating in the auth database for the life of the deployment. (closes #676)
+- **The timer-lifecycle test suite no longer flakes** — a poll still in flight when its test ended re-armed into the next test's fake-timer queue. (closes #685)
 - **Concurrent edits to dwell windows, playbook tasks, the collection plan, the IOC whitelist, notification channels and report versions no longer overwrite each other** in team mode. (closes #682)
 - **Switching a webhook channel to another provider requires the new provider's URL** — a blank field no longer reuses the old service's endpoint. (closes #683)
 - **`"false"` disables a notification channel or event toggle** instead of enabling it; anything that is not a boolean or `"true"`/`"false"` is now a 400. (closes #684)

--- a/companion/src/analysis/casePassword.ts
+++ b/companion/src/analysis/casePassword.ts
@@ -37,7 +37,22 @@ export function sanitizeCaseMeta(meta: CaseMeta): Omit<CaseMeta, "password"> & {
 
 const TOKEN_SEPARATOR = ".";
 
+/**
+ * Payload schema version, carried inside the signed bytes.
+ *
+ * The HMAC covers the encoded payload, not the SHAPE of it. Without a version, a later change to
+ * this interface — a renamed field, a new one, a field that stops being written — would leave old
+ * tokens still verifying, because a payload from the old code can deserialize into the new one and
+ * the missing field simply reads `undefined`. The token would then be judged under semantics it was
+ * never signed for. Bumping this constant is the one-line way to make that impossible: every token
+ * issued under the old shape stops verifying the moment the shape changes, and the analyst re-enters
+ * the case password once. Costing a single re-entry is the safe side of that trade (#671).
+ */
+const UNLOCK_TOKEN_VERSION = 1;
+
 interface UnlockPayload {
+  /** Always {@link UNLOCK_TOKEN_VERSION}. Bump it whenever any other field here changes. */
+  v: number;
   caseId: string;
   salt: string;
   exp: number;
@@ -56,7 +71,13 @@ export function signUnlockToken(
   ttlMs: number,
   remember: boolean,
 ): string {
-  const payload: UnlockPayload = { caseId, salt, exp: Date.now() + ttlMs, remember };
+  const payload: UnlockPayload = {
+    v: UNLOCK_TOKEN_VERSION,
+    caseId,
+    salt,
+    exp: Date.now() + ttlMs,
+    remember,
+  };
   const payloadB64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
   const sig = createHmac("sha256", secret).update(payloadB64).digest("base64url");
   return `${payloadB64}${TOKEN_SEPARATOR}${sig}`;
@@ -85,6 +106,9 @@ function decodeVerifiedPayload(
   } catch {
     return null;
   }
+  // Version FIRST: a token from a different payload shape is rejected before any of its fields
+  // are read, so no old-shape value ever reaches a comparison written for the new shape.
+  if (payload.v !== UNLOCK_TOKEN_VERSION) return null;
   if (payload.caseId !== caseId || payload.salt !== salt) return null;
   if (typeof payload.exp !== "number" || Date.now() > payload.exp) return null;
   return payload as UnlockPayload;

--- a/companion/src/auth/authRoutes.ts
+++ b/companion/src/auth/authRoutes.ts
@@ -1,5 +1,7 @@
+import { randomBytes } from "node:crypto";
 import type { Express, Request, Response } from "express";
 import { getLoginLimiter, getLoginIpLimiter, getOidcStartLimiter } from "../http/rateLimiter.js";
+import { warnLine } from "../logging/serverLogger.js";
 import { withNonce } from "../http/securityHeaders.js";
 import { readPublicAsset } from "../serverAssets.js";
 import type { TeamAuth } from "./teamAuth.js";
@@ -15,6 +17,62 @@ function bodyObject(req: Request): Record<string, unknown> {
 
 function bodyString(body: Record<string, unknown>, key: string): string {
   return typeof body[key] === "string" ? body[key].trim() : "";
+}
+
+/**
+ * Longest provider error this server will write to its log, before the escaping below expands it.
+ * Long enough to carry a real message from an identity provider, short enough that a caller cannot
+ * push anything else out of a scrolled log by sending a megabyte of it.
+ */
+const LOGGED_DETAIL_MAX = 300;
+
+/**
+ * Control characters, matching the class analysis/motwDownload.ts already uses: C0, DEL and C1.
+ */
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+
+/**
+ * Make one line of untrusted text safe to write to a log.
+ *
+ * Moving the provider's error out of the browser and into the server log is only a fix if the log
+ * is not itself a rendering surface, and it is two of them. The log sink appends `line + "\n"`
+ * verbatim, so ONE newline inside the detail ends the entry and starts a second one the caller
+ * wrote — a forged audit line in the operator's own session log. The same line goes to the console,
+ * where an ANSI escape repaints whatever terminal is tailing it. The `?error=` on the OIDC callback
+ * is public, unauthenticated, and handed over already percent-decoded by Express, so `%0a` is all
+ * it takes.
+ *
+ * Escaped, not stripped: an operator diagnosing a real provider failure should still see that the
+ * message contained a newline, rather than read a silently reflowed version of it.
+ */
+function logSafe(detail: string): string {
+  const capped = detail.length > LOGGED_DETAIL_MAX ? `${detail.slice(0, LOGGED_DETAIL_MAX)}…` : detail;
+  return capped.replace(CONTROL_CHARS, (c) => `\\x${(c.codePointAt(0) ?? 0).toString(16).padStart(2, "0")}`);
+}
+
+/**
+ * Send a failed OIDC sign-in back to /login WITHOUT the underlying error text (#674).
+ *
+ * The three OIDC failure paths used to URL-encode the raw message straight into the redirect, and
+ * login.html prints whatever arrives in `?error=` verbatim. Two of those messages are written by
+ * the identity provider, not by us: discovery and token-exchange errors carry internal host names,
+ * endpoint paths and configuration detail, and the `?error=` the provider hands to the callback is
+ * attacker-reachable text reflected back into the page. None of it helps the person signing in —
+ * they cannot act on it — while all of it helps someone mapping a team deployment.
+ *
+ * So the browser gets one fixed sentence plus a short random REFERENCE, and the full detail goes to
+ * the server log under that same reference. The operator keeps everything they had for diagnosis;
+ * they just have to look in the log, where only they can see it.
+ *
+ * `stage` is written as a completed failure ("callback failed"), because it is the subject of the
+ * log line rather than a label appended to one. `detail` is untrusted on all three paths — two of
+ * them carry the provider's own words — so it goes through {@link logSafe} on the way out.
+ */
+function oidcFailureRedirect(res: Response, stage: string, detail: string): void {
+  const reference = randomBytes(4).toString("hex").toUpperCase();
+  warnLine(`[oidc] ${stage} (reference ${reference}): ${logSafe(detail)}`);
+  const message = `Sign-in with your identity provider failed (reference ${reference}). Ask your administrator to check the server log.`;
+  res.redirect(`/login?error=${encodeURIComponent(message)}`);
 }
 
 function setSessionCookie(res: Response, auth: TeamAuth, token: string): void {
@@ -137,7 +195,7 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
       res.setHeader("Cache-Control", "no-store");
       return res.redirect(started.authorizationUrl);
     } catch (err) {
-      return res.redirect(`/login?error=${encodeURIComponent((err as Error).message)}`);
+      return oidcFailureRedirect(res, "provider discovery failed", (err as Error).message);
     }
   });
 
@@ -147,9 +205,7 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
     res.setHeader("Cache-Control", "no-store");
     const providerError = typeof req.query.error === "string" ? req.query.error : "";
     if (providerError) {
-      return res.redirect(
-        `/login?error=${encodeURIComponent(`identity provider refused sign-in: ${providerError}`)}`,
-      );
+      return oidcFailureRedirect(res, "identity provider refused sign-in", providerError);
     }
     const state = typeof req.query.state === "string" ? req.query.state : "";
     const code = typeof req.query.code === "string" ? req.query.code : "";
@@ -176,7 +232,7 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
       auth.store.addAudit(identity, "oidc-login", identity.id, undefined, "");
       return auth.withIdentity(identity, () => res.redirect(completed.returnTo));
     } catch (err) {
-      return res.redirect(`/login?error=${encodeURIComponent((err as Error).message)}`);
+      return oidcFailureRedirect(res, "callback failed", (err as Error).message);
     }
   });
 

--- a/companion/src/auth/authStore.ts
+++ b/companion/src/auth/authStore.ts
@@ -450,6 +450,24 @@ export class AuthStore {
     return Number(result.changes);
   }
 
+  /**
+   * Drop every session whose expiry has passed. Returns how many rows went.
+   *
+   * authenticateSession already deletes an expired session, but only the one it was just handed —
+   * a session whose owner never comes back with that cookie is never looked at again, so it sits in
+   * the table for the life of the deployment. listSessions filters on expires_at, so nothing reads
+   * stale rows; they simply accumulate, and the file grows with every sign-in that is not signed
+   * out. Sweeping on a timer bounds that (#676). Row-shaped, not VACUUM: reclaiming pages is a
+   * separate, far more expensive operation, and the point here is to stop the row count climbing.
+   *
+   * `expires_at` is a UTC ISO-8601 string, which sorts lexicographically in the same order it sorts
+   * chronologically — the same comparison listSessions already makes.
+   */
+  deleteExpiredSessions(now: Date = new Date()): number {
+    const result = this.db.prepare("DELETE FROM auth_sessions WHERE expires_at<=?").run(now.toISOString());
+    return Number(result.changes);
+  }
+
   listSessions(identityId: string): SessionRecord[] {
     return this.db
       .prepare(

--- a/companion/src/composition/maintenanceTasks.ts
+++ b/companion/src/composition/maintenanceTasks.ts
@@ -1,15 +1,16 @@
 /**
- * The maintenance timers a real server run arms at startup: automatic state backup, and periodic
- * evidence re-verification. Lifted out of startServer by #416.
+ * The maintenance timers a real server run arms at startup: expired-session cleanup, automatic state
+ * backup, and periodic evidence re-verification. Lifted out of startServer by #416.
  *
  * THEY REUSE A PATTERN, NOT A CONCERN. The integrity sweep is scheduled beside the backup timer
  * rather than inside BackupManager on purpose: state backups and custody verification are unrelated,
- * and folding one into the other would only couple them. What they share is the shape — an interval,
- * `.unref()`d so it never blocks process exit, doing best-effort work that must never throw into
- * the request path.
+ * and folding one into the other would only couple them. The session sweep (#676) sits here for the
+ * same reason. What they share is the shape — an interval, `.unref()`d so it never blocks process
+ * exit, doing best-effort work that must never throw into the request path.
  *
- * Both are OPT-OUT by interval: a zero interval arms nothing, which is what createApp-only tests and
- * the scripts/* pipelines get, since they never call this.
+ * They are OPT-OUT by absence: a zero interval arms no timer, and no authStore arms no session
+ * sweep. That is what createApp-only tests and the scripts/* pipelines get, since they never call
+ * this at all.
  */
 import { join } from "node:path";
 import { stat } from "node:fs/promises";
@@ -24,6 +25,7 @@ import { seedDemoCase } from "../analysis/seedDemoCase.js";
 import { resolveUpdateMode, UPDATE_CHECK_THROTTLE_MS } from "../analysis/updateCheck.js";
 import { performUpdateCheck } from "../analysis/updateCheckRun.js";
 import type { UpdateCheckStore } from "../analysis/updateCheckStore.js";
+import type { AuthStore } from "../auth/authStore.js";
 import type { VelociraptorClient } from "../integrations/velociraptor/velociraptorApi.js";
 import type { VelociraptorClientStore } from "../analysis/velociraptorClientStore.js";
 
@@ -34,12 +36,24 @@ import type { VelociraptorClientStore } from "../analysis/velociraptorClientStor
  */
 const INITIAL_INTEGRITY_SWEEP_DELAY_MS = 60_000;
 
+/**
+ * How often to delete expired team-mode sessions (#676).
+ *
+ * Six hours, not minutes: an expired session is already unusable — listSessions filters it out and
+ * authenticateSession refuses and deletes it — so this sweep buys disk, never security, and there is
+ * nothing to race. A lapsed row therefore waits up to one interval before it goes, which even at the
+ * shortest TTL the server accepts (15 minutes) is a handful of rows per signed-in analyst.
+ */
+const SESSION_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
 export interface MaintenanceDeps {
   store: CaseStore;
   custodyStore: CustodyStore;
   notifier: Notifier;
   /** Used to deep-link an integrity alert back to the affected case. */
   dashboardBaseUrl: string;
+  /** Team mode only. Absent in solo mode, where there is no session table to sweep. */
+  authStore?: AuthStore;
 }
 
 export interface MaintenanceTasks {
@@ -53,7 +67,26 @@ export function startMaintenanceTasks({
   custodyStore,
   notifier,
   dashboardBaseUrl,
+  authStore,
 }: MaintenanceDeps): MaintenanceTasks {
+  // Expired team-mode sessions (#676). Same shape as the two timers below — an interval, .unref()'d,
+  // best-effort — and armed only in team mode. Swept once at startup too, because a restart is the
+  // one moment a deployment is certain to have accumulated lapsed sessions since the last sweep.
+  if (authStore) {
+    const sweepSessions = (): void => {
+      try {
+        const removed = authStore.deleteExpiredSessions();
+        if (removed > 0) logLine(`[auth] swept ${removed} expired session(s)`);
+      } catch (e) {
+        // A sweep failure must never reach the request path: the rows stay, nothing else breaks.
+        warnLine(`[auth] expired-session sweep failed: ${(e as Error).message}`);
+      }
+    };
+    sweepSessions();
+    const sessionTimer = setInterval(sweepSessions, SESSION_SWEEP_INTERVAL_MS);
+    sessionTimer.unref();
+  }
+
   // Automatic state backup (#180): snapshot SNAPSHOT_STATE_FILES before synthesis + on a timer.
   const backupConfig = resolveBackupConfig(process.env);
   const backupManager = new BackupManager(store, backupConfig);

--- a/companion/src/server.ts
+++ b/companion/src/server.ts
@@ -444,6 +444,7 @@ export function startServer(casesRoot: string, port = 4773, host = "127.0.0.1", 
     custodyStore,
     notifier,
     dashboardBaseUrl,
+    authStore: teamAuth?.store,
   });
 
   // Model providers, the optional Presidio gate, the OCR runner and the pipeline that binds them to

--- a/companion/tests/analysis/casePassword.test.ts
+++ b/companion/tests/analysis/casePassword.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { randomBytes } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import {
   hashCasePassword,
   verifyCasePassword,
@@ -83,6 +83,30 @@ describe("signUnlockToken / verifyUnlockToken", () => {
   it("rejects garbage input without throwing", () => {
     expect(verifyUnlockToken("not-a-token", "c1", "salt-a", secret)).toBe(false);
     expect(verifyUnlockToken("", "c1", "salt-a", secret)).toBe(false);
+  });
+
+  /**
+   * #671: the HMAC covers the ENCODED BYTES, not the payload schema.
+   *
+   * So the attack this pins is not tampering — it is a token that was legitimately signed under a
+   * DIFFERENT payload shape. The forge below builds exactly that: a real signature, made with the
+   * real secret, over a payload today's code never writes. Every field it does carry still passes
+   * the caseId/salt/expiry checks, so without the version test it unlocks the case under semantics
+   * it was never signed for. `v` is what makes the shape part of what is verified.
+   */
+  it("rejects a validly-signed token whose payload is not the current version", () => {
+    const forge = (payload: Record<string, unknown>): string => {
+      const b64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+      return `${b64}.${createHmac("sha256", secret).update(b64).digest("base64url")}`;
+    };
+    const fields = { caseId: "c1", salt: "salt-a", exp: Date.now() + 60_000, remember: true };
+
+    expect(verifyUnlockToken(forge({ ...fields, v: 1 }), "c1", "salt-a", secret)).toBe(true); // control
+    expect(verifyUnlockToken(forge(fields), "c1", "salt-a", secret)).toBe(false); // pre-version shape
+    expect(verifyUnlockToken(forge({ ...fields, v: 2 }), "c1", "salt-a", secret)).toBe(false); // newer
+    expect(verifyUnlockToken(forge({ ...fields, v: "1" }), "c1", "salt-a", secret)).toBe(false); // string
+    // The remember flag rides in the same payload, so it must be refused on the same grounds.
+    expect(isRememberedUnlockToken(forge(fields), "c1", "salt-a", secret)).toBe(false);
   });
 });
 

--- a/companion/tests/auth/expiredSessionSweep.test.ts
+++ b/companion/tests/auth/expiredSessionSweep.test.ts
@@ -1,0 +1,134 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStore } from "../../src/auth/authStore.js";
+import { loadDatabaseSync, type SqliteDatabase } from "../../src/analysis/sqliteRuntime.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { startMaintenanceTasks } from "../../src/composition/maintenanceTasks.js";
+import { CustodyStore } from "../../src/analysis/custody.js";
+import type { Notifier } from "../../src/integrations/notify/notifyDispatch.js";
+
+/**
+ * Expired team-mode sessions must not accumulate forever (#676).
+ *
+ * authenticateSession deletes an expired session, but only the one it was just handed. A session
+ * whose owner never returns with that cookie — the normal end of a shift — is never looked at
+ * again. Nothing READS it either (listSessions filters on expires_at), which is what made this
+ * invisible: the table just grows for the life of the deployment.
+ *
+ * So every assertion here counts RAW ROWS, over a second connection to the same file. Going through
+ * listSessions would hide exactly the rows under test.
+ */
+let root: string;
+let store: AuthStore;
+let cases: CaseStore;
+let probe: SqliteDatabase;
+
+const silentNotifier = { dispatch: async () => {} } as unknown as Notifier;
+
+async function freshStore(prefix: string): Promise<void> {
+  root = await mkdtemp(join(tmpdir(), prefix));
+  store = new AuthStore(join(root, "auth.sqlite"));
+  cases = new CaseStore(join(root, "cases"));
+  probe = new (loadDatabaseSync())(join(root, "auth.sqlite"));
+}
+
+const sessionRows = (): number =>
+  Number((probe.prepare("SELECT COUNT(*) AS n FROM auth_sessions").get() as { n: number }).n);
+
+/** One identity, with `live` unexpired sessions and `lapsed` already-expired ones. */
+function seedSessions(live: number, lapsed: number): string {
+  const identity = store.upsertOidcIdentity("https://idp.test", "sub-1", "Ada", "ada");
+  for (let i = 0; i < live; i++) store.createSession(identity, 60 * 60_000);
+  for (let i = 0; i < lapsed; i++) store.createSession(identity, -1_000);
+  return identity.id;
+}
+
+function maintenance(authStore?: AuthStore): void {
+  startMaintenanceTasks({
+    store: cases,
+    custodyStore: new CustodyStore(cases),
+    notifier: silentNotifier,
+    dashboardBaseUrl: "http://localhost:4773",
+    ...(authStore ? { authStore } : {}),
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  probe?.close();
+  store?.close();
+});
+
+describe("AuthStore.deleteExpiredSessions", () => {
+  beforeEach(async () => freshStore("dfir-session-sweep-"));
+
+  it("deletes lapsed sessions and keeps live ones", () => {
+    const identityId = seedSessions(2, 3);
+    expect(sessionRows()).toBe(5);
+
+    expect(store.deleteExpiredSessions()).toBe(3);
+    expect(sessionRows()).toBe(2);
+    // The two survivors are the ones a signed-in analyst is still holding.
+    expect(store.listSessions(identityId)).toHaveLength(2);
+  });
+
+  it("is a no-op when nothing has lapsed", () => {
+    seedSessions(2, 0);
+    expect(store.deleteExpiredSessions()).toBe(0);
+    expect(sessionRows()).toBe(2);
+  });
+
+  it("takes an explicit clock, so a session lapsing later is swept later", () => {
+    const identityId = seedSessions(1, 0);
+    const [live] = store.listSessions(identityId);
+
+    expect(store.deleteExpiredSessions(new Date(Date.parse(live.expiresAt) - 1))).toBe(0);
+    expect(store.deleteExpiredSessions(new Date(Date.parse(live.expiresAt) + 1))).toBe(1);
+  });
+});
+
+describe("startMaintenanceTasks arms the session sweep", () => {
+  const BACKUP_INTERVAL = "DFIR_STATE_BACKUP_INTERVAL_MS";
+  let savedBackupInterval: string | undefined;
+
+  beforeEach(async () => {
+    await freshStore("dfir-session-sweep-timer-");
+    // Disarm the backup timer: advancing six hours below would otherwise fire six rounds of
+    // unrelated case I/O, none of which this test is about.
+    savedBackupInterval = process.env[BACKUP_INTERVAL];
+    process.env[BACKUP_INTERVAL] = "0";
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (savedBackupInterval === undefined) delete process.env[BACKUP_INTERVAL];
+    else process.env[BACKUP_INTERVAL] = savedBackupInterval;
+  });
+
+  it("sweeps at startup and again on its interval", () => {
+    const identity = store.upsertOidcIdentity("https://idp.test", "sub-1", "Ada", "ada");
+    // A day, not an hour: this session has to outlive the six hours of fake time advanced below,
+    // or the sweep would be right to take it and the test would be measuring nothing.
+    store.createSession(identity, 24 * 60 * 60_000);
+    store.createSession(identity, -1_000);
+
+    maintenance(store);
+    expect(sessionRows()).toBe(1); // the startup sweep took the lapsed one
+
+    // A session that lapses while the server keeps running is taken by the next tick, not left.
+    store.createSession(identity, 60_000);
+    vi.advanceTimersByTime(60_001);
+    expect(sessionRows()).toBe(2);
+    vi.advanceTimersByTime(6 * 60 * 60 * 1000);
+    expect(sessionRows()).toBe(1);
+  });
+
+  it("leaves the table alone in solo mode, where there is no auth store to sweep", () => {
+    seedSessions(1, 1);
+    maintenance();
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    expect(sessionRows()).toBe(2);
+  });
+});

--- a/companion/tests/http/oidcErrorRedirect.test.ts
+++ b/companion/tests/http/oidcErrorRedirect.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStore } from "../../src/auth/authStore.js";
+import { TeamAuth } from "../../src/auth/teamAuth.js";
+import { OidcClient } from "../../src/auth/oidcClient.js";
+import { createApp, setServerLogger } from "../../src/server.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { resetLimiters } from "../../src/http/rateLimiter.js";
+import type { Logger } from "../../src/logging/logger.js";
+
+/**
+ * The three OIDC failure paths must not reflect provider error text into the browser (#674).
+ *
+ * login.html prints whatever lands in `?error=` straight into the page, so every one of these
+ * redirects was a rendering surface for text this server did not write: discovery and token
+ * exchange fail with the provider's own message (internal host names, endpoint paths), and the
+ * `?error=` on the callback is text an outside caller can choose. The property under test is not
+ * "the wording changed" — it is that the SECRET below never reaches the redirect, while the server
+ * log still holds it under the reference the user was shown.
+ */
+const ISSUER = "https://identity.example.test";
+// Deliberately NOT a hostname. The scanner keeps its internal-FQDN rule on to catch a genuinely
+// new one, and a fixture is not a reason to teach it to ignore a shape it exists to find. What
+// this string has to be is unmistakable in an assertion, and it is.
+const SECRET_DETAIL = "token endpoint refused client dfir-companion, issuer key rollover pending";
+
+let app: ReturnType<typeof createApp>;
+let lines: string[];
+
+/** Capture the server log so the "operator keeps the detail" half of the fix is checkable. */
+function capturingLogger(into: string[]): Logger {
+  return {
+    debug: (m) => into.push(m),
+    info: (m) => into.push(m),
+    warn: (m) => into.push(m),
+    error: (m) => into.push(m),
+    getLevel: () => "debug",
+    setLevel: () => {},
+    close: async () => {},
+  };
+}
+
+/** The reference the user is told to quote, pulled back out of the redirect they were sent. */
+function referenceFrom(location: string): string {
+  const shown = decodeURIComponent(new URL(location, "http://x").searchParams.get("error") ?? "");
+  return /reference ([0-9A-F]{8})/.exec(shown)?.[1] ?? "";
+}
+
+const failingDiscovery = (async () => {
+  throw new Error(SECRET_DETAIL);
+}) as typeof fetch;
+
+beforeEach(async () => {
+  resetLimiters();
+  lines = [];
+  setServerLogger(capturingLogger(lines));
+  const root = await mkdtemp(join(tmpdir(), "dfir-oidc-err-"));
+  const cases = new CaseStore(join(root, "cases"));
+  app = createApp(cases, {
+    teamAuth: new TeamAuth({
+      store: new AuthStore(join(root, "auth.sqlite")),
+      cookieSecure: false,
+      sessionTtlMs: 60 * 60_000,
+      oidcClient: new OidcClient(
+        {
+          issuer: ISSUER,
+          clientId: "dfir-companion",
+          redirectUri: "https://dfir.example.test/auth/oidc/callback",
+          scopes: ["openid"],
+        },
+        failingDiscovery,
+      ),
+    }),
+  });
+});
+
+afterEach(() => {
+  resetLimiters();
+});
+
+describe("OIDC failures redirect with a reference, not the provider's error text", () => {
+  it("hides a discovery failure from /auth/oidc/start", async () => {
+    const res = await request(app).get("/auth/oidc/start");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).not.toContain("rollover");
+    expect(decodeURIComponent(res.headers.location)).toContain("identity provider failed");
+
+    const reference = referenceFrom(res.headers.location);
+    expect(reference).toMatch(/^[0-9A-F]{8}$/);
+    // The operator loses nothing: the detail is in the log, under the reference the user quotes.
+    expect(lines.some((l) => l.includes(reference) && l.includes(SECRET_DETAIL))).toBe(true);
+  });
+
+  it("hides the ?error= the provider hands to the callback", async () => {
+    const reflected = "invalid_client: " + SECRET_DETAIL;
+    const res = await request(app).get(`/auth/oidc/callback?error=${encodeURIComponent(reflected)}`);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).not.toContain("rollover");
+    expect(res.headers.location).not.toContain("invalid_client");
+    expect(lines.some((l) => l.includes(referenceFrom(res.headers.location)) && l.includes(reflected))).toBe(
+      true,
+    );
+  });
+
+  it("hides a callback completion failure", async () => {
+    const res = await request(app).get("/auth/oidc/callback?state=abc&code=def");
+
+    expect(res.status).toBe(302);
+    expect(decodeURIComponent(res.headers.location)).toContain("identity provider failed");
+    expect(referenceFrom(res.headers.location)).toMatch(/^[0-9A-F]{8}$/);
+  });
+
+  /**
+   * The callback's `?error=` is public and unauthenticated, and Express hands it over already
+   * percent-decoded. Writing it straight to the log lets an outside caller put a newline in the
+   * middle of a log line and forge the rest — a fabricated audit entry in the operator's own
+   * session log — or slip ANSI escapes past a `tail -f` and repaint the terminal reading it.
+   * Moving the detail out of the browser and into the log is only a fix if the log is not itself
+   * a rendering surface.
+   */
+  it("escapes control characters and caps the length before logging the detail", async () => {
+    const forged = "boom\n2026-08-29T00:00:00.000Z INFO  [audit] admin granted\u001b[2Jcleared\u0000";
+    const res = await request(app).get(`/auth/oidc/callback?error=${encodeURIComponent(forged)}`);
+
+    expect(res.status).toBe(302);
+    const line = lines.find((l) => l.includes(referenceFrom(res.headers.location)));
+    expect(line).toBeDefined();
+    // One line, and nothing in it that a terminal or a log parser will act on.
+    expect(line).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
+    expect(line).toContain("\\x0a"); // the newline is visible, not obeyed
+    expect(line).toContain("\\x1b");
+    expect(line).toContain("\\x00");
+    expect(line).toContain("boom");
+  });
+
+  it("caps a very long provider error rather than logging all of it", async () => {
+    const huge = "A".repeat(5_000);
+    const res = await request(app).get(`/auth/oidc/callback?error=${encodeURIComponent(huge)}`);
+
+    const line = lines.find((l) => l.includes(referenceFrom(res.headers.location)));
+    expect(line).toBeDefined();
+    expect(line!.length).toBeLessThan(500);
+    expect(line).toContain("…");
+  });
+
+  it("still answers 404 when OIDC is not configured at all", async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-oidc-off-"));
+    const plain = createApp(new CaseStore(join(root, "cases")), {
+      teamAuth: new TeamAuth({
+        store: new AuthStore(join(root, "auth.sqlite")),
+        cookieSecure: false,
+        sessionTtlMs: 60 * 60_000,
+      }),
+    });
+    expect((await request(plain).get("/auth/oidc/start")).status).toBe(404);
+    expect((await request(plain).get("/auth/oidc/callback")).status).toBe(404);
+  });
+});

--- a/companion/tests/server/timerLifecycle.test.ts
+++ b/companion/tests/server/timerLifecycle.test.ts
@@ -23,6 +23,21 @@
  * FAKE TIMERS, NARROWLY. Only setTimeout/clearTimeout are faked (the pollers use nothing else).
  * Date, setInterval and setImmediate stay real, so cursor arithmetic is honest and `settle()` can
  * still yield to the real event loop for the store's file I/O — which has no timer to advance.
+ *
+ * NO POLL MAY STILL BE IN FLIGHT WHEN A TEST ENDS (#685). This is the one rule every test here has
+ * to keep, and it is not about tidiness. `vi.useFakeTimers()` replaces the GLOBAL setTimeout, so a
+ * poll chain that outlives its own test does not die with it: it keeps running on the real event
+ * loop, and when it finally re-arms, its `setTimeout` lands in the NEXT test's fake timer queue.
+ * That test then counts a timer it never armed. The symptom is a `getTimerCount()` assertion in a
+ * LATER test failing by exactly one, at whatever point the stray happened to land — a full run once
+ * reported `expected 0, received 1` at the CANCELLED assertion below while the file passed cleanly
+ * on its own, because the leak came from the test before it.
+ *
+ * Keeping the rule is mechanical: end on `tickAndRearm()`, never `tick()`, whenever the poll is
+ * still meant to be running. The re-arm is the LAST statement of every poll chain here, so a
+ * pending timer is proof the chain finished. The `afterEach` at the bottom of this block checks the
+ * rule after every test, so a future leak fails in the test that caused it instead of flaking a
+ * later one.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtemp, mkdir, writeFile, readdir } from "node:fs/promises";
@@ -35,6 +50,7 @@ import { StateStore } from "../../src/analysis/stateStore.js";
 import { VeloMonitorStore, type VeloMonitor } from "../../src/analysis/veloMonitorStore.js";
 import { VeloHuntStore, type VeloHuntJob } from "../../src/analysis/veloHuntStore.js";
 import { DropStatusStore } from "../../src/analysis/dropStatus.js";
+import { pollBudget } from "../helpers/poll.js";
 import {
   VelociraptorClient,
   type VqlRunner,
@@ -84,17 +100,22 @@ async function tick(ms: number): Promise<void> {
  * failure. Observed directly at a reduced turn count: pending timers 0 after sweep 1, still 0 after
  * advancing for sweep 2, and 1 only after ~300ms of real time.
  *
- * Waiting for `getTimerCount() > 0` is that missing guarantee, and it is exact: it consumes no fake
- * time and fires no extra sweeps, so every "polled exactly N times" assertion in this file keeps
- * its original meaning.
+ * Waiting for the pending-timer count is that missing guarantee, and it is exact: it consumes no
+ * fake time and fires no extra sweeps, so every "polled exactly N times" assertion in this file
+ * keeps its original meaning.
+ *
+ * PASS `pollers` WHEN THE TEST DRIVES MORE THAN ONE. The wait is satisfied by the count, so with
+ * two live pollers and a default of 1 the first one to re-arm releases it while the second is still
+ * mid-poll — and that second chain then runs on past the end of the test (#685).
  *
  * Deliberately NOT used by the CANCELLED/DISARMED tests: for those, zero pending timers is the
  * property under test, so waiting for one would be waiting for the bug.
  */
-const REARM_TIMEOUT_MS = 10_000;
+const REARM_TIMEOUT_MS = pollBudget(10_000);
 
 /**
- * The timeout a test must carry PER `tickAndRearm()` CALL, plus room for its own work.
+ * The timeout a test must carry PER WAIT — every `tickAndRearm()` or `tickUntil()` call — plus room
+ * for its own work.
  *
  * Derived, not written down twice. A caller that waits up to REARM_TIMEOUT_MS twice can legitimately
  * spend 2x that before doing anything wrong, and the suite's 15s default would kill it partway
@@ -102,21 +123,37 @@ const REARM_TIMEOUT_MS = 10_000;
  * the arithmetic tests/helpers/poll.ts warns about ("keep the caller's test timeout above the SUM
  * of its poll budgets"), and this patch's own reviewer caught it here. Computing it means adjusting
  * REARM_TIMEOUT_MS can never silently outgrow the timeout again.
+ *
+ * PLATFORM-SCALED, VIA pollBudget, FOR THE REASON THAT FILE GIVES. An explicit `it()` timeout
+ * REPLACES vitest.config.ts's, and that config already triples its default to 45s on Windows — so
+ * an unscaled 20s or 30s written here would be a Windows REGRESSION for every test that carries it,
+ * on tests that do real file I/O. Scaling both the inner wait and the headroom by the one shared
+ * factor keeps every ratio the same on both platforms, which is what pollBudget exists to enforce.
  */
-const rearmBudget = (calls: number) => REARM_TIMEOUT_MS * calls + 10_000;
+const rearmBudget = (calls: number) => REARM_TIMEOUT_MS * calls + pollBudget(10_000);
 
-async function tickAndRearm(ms: number): Promise<void> {
+/**
+ * Advance the fake clock once, then yield real turns until `ready()` holds.
+ *
+ * The engine under `tickAndRearm`, exposed on its own for the one test whose poller is not supposed
+ * to re-arm — a STOPPED hunt hands off and stops, so "a timer is pending" is the wrong signal there
+ * and only the outbound-work count can say the poll actually ran. `what` names the wait, so a
+ * timeout reads as a missing guarantee rather than an anonymous 10s hang.
+ */
+async function tickUntil(ms: number, ready: () => boolean, what: string): Promise<void> {
   await vi.advanceTimersByTimeAsync(ms);
   const deadline = Date.now() + REARM_TIMEOUT_MS;
   for (;;) {
     await settle(2);
-    if (vi.getTimerCount() > 0) return;
+    if (ready()) return;
     if (Date.now() >= deadline) {
-      throw new Error(
-        `timed out after ${REARM_TIMEOUT_MS}ms waiting for: the poller to re-arm its next timer`,
-      );
+      throw new Error(`timed out after ${REARM_TIMEOUT_MS}ms waiting for: ${what}`);
     }
   }
+}
+
+async function tickAndRearm(ms: number, pollers = 1): Promise<void> {
+  await tickUntil(ms, () => vi.getTimerCount() >= pollers, `all ${pollers} poller(s) to re-arm`);
 }
 
 /** A Velociraptor runner that answers everything emptily and records what it was asked. */
@@ -194,150 +231,212 @@ beforeEach(() => {
   vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 });
 
-afterEach(() => {
+/**
+ * How long the teardown guard watches for a straggling poll chain to betray itself by re-arming.
+ * Paid once per test, so it is sized against the file I/O of a single poll, not the worst case.
+ */
+const LEAK_CHECK_TURNS = 80;
+
+afterEach(async () => {
+  // Everything a test armed on purpose is already pending by now, so nothing new should appear.
+  // A timer that shows up here came from a poll chain that outlived its test — see NO POLL MAY
+  // STILL BE IN FLIGHT at the top of this file.
+  //
+  // A BACKSTOP, NOT THE FIX. It can only see a stray that surfaces inside its own window, so a
+  // slow enough chain still lands in a later test — and then this fails in THAT test rather than
+  // the one that leaked. Either way the run fails loudly and points at the right cause, which is
+  // the whole gain over a bare `expected 0, received 1` somewhere downstream. What actually keeps
+  // the queue clean is every test ending on tickAndRearm().
+  const armed = vi.getTimerCount();
+  await settle(LEAK_CHECK_TURNS);
+  const stray = vi.getTimerCount() - armed;
   vi.useRealTimers();
+  expect(
+    stray,
+    "a poll chain was still in flight and re-armed after a test finished — this test's, or an " +
+      "earlier one's. End every test on tickAndRearm() rather than tick() while its poller is " +
+      "still meant to be running, or stop the poller first.",
+  ).toBe(0);
 });
 
 describe("Velociraptor live monitors — timer lifecycle", () => {
-  it("ARMED + RE-ARMED: a started monitor keeps polling on its own interval", async () => {
-    const { store } = await freshRoot("dfir-timer-mon-");
-    const { runner, vql } = countingRunner();
-    const app = createApp(store, {
-      pipeline: offlinePipeline(store),
-      velociraptorClient: new VelociraptorClient(veloCfg, runner),
-      veloMonitorStore: new VeloMonitorStore(store),
-    });
-    await settle();
+  // rearmBudget(2): two tickAndRearm calls, so the test must survive two full waits.
+  it(
+    "ARMED + RE-ARMED: a started monitor keeps polling on its own interval",
+    { timeout: rearmBudget(2) },
+    async () => {
+      const { store } = await freshRoot("dfir-timer-mon-");
+      const { runner, vql } = countingRunner();
+      const app = createApp(store, {
+        pipeline: offlinePipeline(store),
+        velociraptorClient: new VelociraptorClient(veloCfg, runner),
+        veloMonitorStore: new VeloMonitorStore(store),
+      });
+      await settle();
 
-    const start = await request(app)
-      .post("/cases/c1/velociraptor/monitors")
-      .send({ clientId: "C.abc123", artifact: "Windows.Events.ProcessCreation", pollSeconds: 30 });
-    expect(start.status).toBe(202);
-    expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(0); // armed, not yet fired
+      const start = await request(app)
+        .post("/cases/c1/velociraptor/monitors")
+        .send({ clientId: "C.abc123", artifact: "Windows.Events.ProcessCreation", pollSeconds: 30 });
+      expect(start.status).toBe(202);
+      expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(0); // armed, not yet fired
 
-    await tick(30_000);
-    expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(1);
+      await tickAndRearm(30_000);
+      expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(1);
 
-    // The property that matters: the poll that just ran scheduled the next one. A monitor that
-    // polls exactly once and then goes quiet is the silent failure this test exists to catch.
-    await tick(30_000);
-    expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(2);
-  });
+      // The property that matters: the poll that just ran scheduled the next one. A monitor that
+      // polls exactly once and then goes quiet is the silent failure this test exists to catch.
+      await tickAndRearm(30_000);
+      expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(2);
+    },
+  );
 
-  it("CANCELLED: stopping a monitor clears its timer — no zombie polls", async () => {
-    const { store } = await freshRoot("dfir-timer-monstop-");
-    const { runner, vql } = countingRunner();
-    const app = createApp(store, {
-      pipeline: offlinePipeline(store),
-      velociraptorClient: new VelociraptorClient(veloCfg, runner),
-      veloMonitorStore: new VeloMonitorStore(store),
-    });
-    await settle();
+  // rearmBudget(1): one tickAndRearm call. The last tick must stay a plain tick — after the stop,
+  // no timer is meant to appear, and waiting for one would be waiting for the bug.
+  it(
+    "CANCELLED: stopping a monitor clears its timer — no zombie polls",
+    { timeout: rearmBudget(1) },
+    async () => {
+      const { store } = await freshRoot("dfir-timer-monstop-");
+      const { runner, vql } = countingRunner();
+      const app = createApp(store, {
+        pipeline: offlinePipeline(store),
+        velociraptorClient: new VelociraptorClient(veloCfg, runner),
+        veloMonitorStore: new VeloMonitorStore(store),
+      });
+      await settle();
 
-    // Counting PENDING TIMERS, not just outbound traffic. pollVeloMonitor re-reads the monitor and
-    // bails when it is stopped, so a leaked timer ingests nothing and is invisible to a VQL count —
-    // it just wakes the process up forever. Only the timer count can see it, and with fake timers
-    // narrowed to setTimeout the queue holds exactly this app's pending polls.
-    const idle = vi.getTimerCount();
-    await request(app)
-      .post("/cases/c1/velociraptor/monitors")
-      .send({ clientId: "C.abc123", artifact: "Windows.Events.ProcessCreation", pollSeconds: 30 });
-    expect(vi.getTimerCount()).toBe(idle + 1); // ARMED: exactly one new timer
+      // Counting PENDING TIMERS, not just outbound traffic. pollVeloMonitor re-reads the monitor and
+      // bails when it is stopped, so a leaked timer ingests nothing and is invisible to a VQL count —
+      // it just wakes the process up forever. Only the timer count can see it, and with fake timers
+      // narrowed to setTimeout the queue holds exactly this app's pending polls.
+      const idle = vi.getTimerCount();
+      await request(app)
+        .post("/cases/c1/velociraptor/monitors")
+        .send({ clientId: "C.abc123", artifact: "Windows.Events.ProcessCreation", pollSeconds: 30 });
+      expect(vi.getTimerCount()).toBe(idle + 1); // ARMED: exactly one new timer
 
-    await tick(30_000);
-    expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(1);
-    expect(vi.getTimerCount()).toBe(idle + 1); // RE-ARMED: replaced, not stacked
+      // tickAndRearm, not tick: the count below is only meaningful once this poll has finished and
+      // scheduled its successor. A plain tick can return mid-poll, and then the re-arm lands after
+      // the stop — or after the whole test — and the count is read at a moment nobody chose.
+      await tickAndRearm(30_000);
+      expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(1);
+      expect(vi.getTimerCount()).toBe(idle + 1); // RE-ARMED: replaced, not stacked
 
-    const stop = await request(app)
-      .post("/cases/c1/velociraptor/monitors/C.abc123__Windows.Events.ProcessCreation/stop")
-      .send({});
-    expect(stop.status).toBe(200);
-    expect(vi.getTimerCount()).toBe(idle); // CANCELLED: the timer is gone
+      const stop = await request(app)
+        .post("/cases/c1/velociraptor/monitors/C.abc123__Windows.Events.ProcessCreation/stop")
+        .send({});
+      expect(stop.status).toBe(200);
+      expect(vi.getTimerCount()).toBe(idle); // CANCELLED: the timer is gone
 
-    await tick(30_000 * 5);
-    expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(1);
-  });
+      await tick(30_000 * 5);
+      expect(monitorPolls(vql, "Windows.Events.ProcessCreation")).toBe(1);
+    },
+  );
 
-  it("RESUMED: a restart re-arms persisted active monitors and leaves stopped ones alone", async () => {
-    const { store } = await freshRoot("dfir-timer-monresume-");
-    const monitors = new VeloMonitorStore(store);
-    await monitors.upsert(
-      "c1",
-      monitor({ id: "C.a__Live.Artifact", clientId: "C.aaaaaa", artifact: "Live.Artifact" }),
-    );
-    await monitors.upsert(
-      "c1",
-      monitor({
-        id: "C.b__Stopped.Artifact",
-        clientId: "C.bbbbbb",
-        artifact: "Stopped.Artifact",
-        status: "stopped",
-      }),
-    );
+  // rearmBudget(1): the closing tickAndRearm below.
+  it(
+    "RESUMED: a restart re-arms persisted active monitors and leaves stopped ones alone",
+    { timeout: rearmBudget(1) },
+    async () => {
+      const { store } = await freshRoot("dfir-timer-monresume-");
+      const monitors = new VeloMonitorStore(store);
+      await monitors.upsert(
+        "c1",
+        monitor({ id: "C.a__Live.Artifact", clientId: "C.aaaaaa", artifact: "Live.Artifact" }),
+      );
+      await monitors.upsert(
+        "c1",
+        monitor({
+          id: "C.b__Stopped.Artifact",
+          clientId: "C.bbbbbb",
+          artifact: "Stopped.Artifact",
+          status: "stopped",
+        }),
+      );
 
-    const { runner, vql } = countingRunner();
-    // Constructing the app IS the restart: createApp fires resumeVeloMonitors() on the way out.
-    createApp(store, {
-      velociraptorClient: new VelociraptorClient(veloCfg, runner),
-      veloMonitorStore: monitors,
-    });
-    await settle();
+      const { runner, vql } = countingRunner();
+      // Constructing the app IS the restart: createApp fires resumeVeloMonitors() on the way out.
+      createApp(store, {
+        velociraptorClient: new VelociraptorClient(veloCfg, runner),
+        veloMonitorStore: monitors,
+      });
+      await settle();
 
-    // One armed poll, not two: a stopped monitor whose timer is armed anyway would wake up, re-read
-    // itself, and bail — costing a file read every 30s forever while looking perfectly healthy.
-    expect(vi.getTimerCount()).toBe(1);
+      // One armed poll, not two: a stopped monitor whose timer is armed anyway would wake up, re-read
+      // itself, and bail — costing a file read every 30s forever while looking perfectly healthy.
+      expect(vi.getTimerCount()).toBe(1);
 
-    await tick(30_000);
-    expect(monitorPolls(vql, "Live.Artifact")).toBe(1);
-    expect(monitorPolls(vql, "Stopped.Artifact")).toBe(0);
-  });
+      // tickAndRearm, not tick: this monitor is still meant to be running when the test ends, so
+      // the test must not walk away while its poll is mid-flight.
+      await tickAndRearm(30_000);
+      expect(monitorPolls(vql, "Live.Artifact")).toBe(1);
+      expect(monitorPolls(vql, "Stopped.Artifact")).toBe(0);
+    },
+  );
 });
 
 describe("Velociraptor hunt status polls — timer lifecycle", () => {
-  it("RESUMED + RE-ARMED: a restart re-polls running and unreachable hunts, and only those", async () => {
-    const { store } = await freshRoot("dfir-timer-hunt-");
-    const hunts = new VeloHuntStore(store);
-    await hunts.upsert("c1", huntJob("H.RUNNING1", "running"));
-    await hunts.upsert("c1", huntJob("H.UNREACH1", "unreachable"));
-    await hunts.upsert("c1", huntJob("H.IMPORTED", "imported")); // terminal — nothing left to check
+  // rearmBudget(2): two tickAndRearm calls, so the test must survive two full waits.
+  it(
+    "RESUMED + RE-ARMED: a restart re-polls running and unreachable hunts, and only those",
+    { timeout: rearmBudget(2) },
+    async () => {
+      const { store } = await freshRoot("dfir-timer-hunt-");
+      const hunts = new VeloHuntStore(store);
+      await hunts.upsert("c1", huntJob("H.RUNNING1", "running"));
+      await hunts.upsert("c1", huntJob("H.UNREACH1", "unreachable"));
+      await hunts.upsert("c1", huntJob("H.IMPORTED", "imported")); // terminal — nothing left to check
 
-    const { runner, vql } = countingRunner();
-    createApp(store, {
-      velociraptorClient: new VelociraptorClient(veloCfg, runner),
-      veloHuntStore: hunts,
-    });
-    await settle();
+      const { runner, vql } = countingRunner();
+      createApp(store, {
+        velociraptorClient: new VelociraptorClient(veloCfg, runner),
+        veloHuntStore: hunts,
+      });
+      await settle();
 
-    await tick(30_000); // DFIR_VELO_HUNT_POLL_S default
-    expect(statusPolls(vql, "H.RUNNING1")).toBe(1);
-    expect(statusPolls(vql, "H.UNREACH1")).toBe(1);
-    expect(statusPolls(vql, "H.IMPORTED")).toBe(0);
+      // Two pollers, so wait for two re-arms: stopping at the first would walk away from the other.
+      await tickAndRearm(30_000, 2); // DFIR_VELO_HUNT_POLL_S default
+      expect(statusPolls(vql, "H.RUNNING1")).toBe(1);
+      expect(statusPolls(vql, "H.UNREACH1")).toBe(1);
+      expect(statusPolls(vql, "H.IMPORTED")).toBe(0);
 
-    // Still RUNNING → reschedule. The next tick must find a timer waiting.
-    await tick(30_000);
-    expect(statusPolls(vql, "H.RUNNING1")).toBe(2);
-  });
+      // Still RUNNING → reschedule. The next tick must find a timer waiting.
+      await tickAndRearm(30_000, 2);
+      expect(statusPolls(vql, "H.RUNNING1")).toBe(2);
+    },
+  );
 
-  it("CANCELLED: a hunt Velociraptor reports STOPPED hands off to the collect and stops polling", async () => {
-    const { store } = await freshRoot("dfir-timer-huntstop-");
-    const hunts = new VeloHuntStore(store);
-    await hunts.upsert("c1", huntJob("H.DONE1", "running"));
+  // rearmBudget(1): one tickUntil wait below.
+  it(
+    "CANCELLED: a hunt Velociraptor reports STOPPED hands off to the collect and stops polling",
+    { timeout: rearmBudget(1) },
+    async () => {
+      const { store } = await freshRoot("dfir-timer-huntstop-");
+      const hunts = new VeloHuntStore(store);
+      await hunts.upsert("c1", huntJob("H.DONE1", "running"));
 
-    const { runner, vql } = countingRunner({ huntState: "STOPPED" });
-    createApp(store, {
-      velociraptorClient: new VelociraptorClient(veloCfg, runner),
-      veloHuntStore: hunts,
-    });
-    await settle();
+      const { runner, vql } = countingRunner({ huntState: "STOPPED" });
+      createApp(store, {
+        velociraptorClient: new VelociraptorClient(veloCfg, runner),
+        veloHuntStore: hunts,
+      });
+      await settle();
 
-    await tick(30_000);
-    expect(statusPolls(vql, "H.DONE1")).toBe(1);
+      // tickUntil, not tickAndRearm: this poller is supposed to STOP, so a pending timer is the
+      // wrong thing to wait for. The poll itself is still the guarantee the assertion needs.
+      await tickUntil(30_000, () => statusPolls(vql, "H.DONE1") === 1, "the STOPPED hunt to be polled");
+      expect(statusPolls(vql, "H.DONE1")).toBe(1);
 
-    // The status poller's job is over: it handed the hunt to the collect path, which owns the
-    // job from here. A poller that kept its timer would re-collect the same hunt every 30s.
-    await tick(30_000 * 5);
-    expect(statusPolls(vql, "H.DONE1")).toBe(1);
-  });
+      // The status poller's job is over: it handed the hunt to the collect path, which owns the
+      // job from here. A poller that kept its timer would re-collect the same hunt every 30s.
+      //
+      // The hand-off is fire-and-forget, so the extra settle turns are what keep it from running on
+      // past the end of the test and re-arming into the next one.
+      await tick(30_000 * 5);
+      await settle();
+      expect(statusPolls(vql, "H.DONE1")).toBe(1);
+    },
+  );
 });
 
 describe("Evidence drop-folder watcher — timer lifecycle", () => {


### PR DESCRIPTION
Four team-mode hardening fixes, rebuilt as one commit on top of `e68eb3df`.

## Case unlock tokens carry a payload version (closes #671)

The unlock token is `base64url(payload).hmac(secret, base64url(payload))`, so the HMAC covers the encoded **bytes** and says nothing about the payload's **shape**. Any later change to `UnlockPayload` — a renamed field, a new one, a field that stops being written — would leave tokens signed under the old shape verifying happily, because an old payload deserializes into the new interface and the missing field simply reads `undefined`. The token would then be judged under semantics it was never signed for.

`v: 1` is checked before any other field is read, so no old-shape value ever reaches a comparison written for the new shape. Bumping the constant is now the one-line way to invalidate every previously-issued token.

The regression test forges an old-shape payload and signs it with the real secret — a genuine signature over a payload this code never writes, which passes the caseId, salt and expiry checks and unlocked the case before this change. Confirmed it fails without the fix.

**User-visible:** unlock cookies issued before this release stop verifying, so each password-protected case asks for its password once more.

## OIDC failures stop reflecting the provider's error text (closes #674)

All three OIDC failure paths URL-encoded the raw error into a `/login?error=` redirect, and `login.html` prints whatever arrives there straight into the page. Two of those messages are not ours: discovery and token-exchange errors carry the provider's internal host names, endpoint paths and configuration detail, and the `?error=` the provider hands to the callback is text an outside caller can choose.

The browser now gets one fixed sentence plus a short random reference; the full detail goes to the server log under that same reference.

Moving untrusted text into the log is only a fix if the log is not itself a rendering surface, and it is two of them. The sink appends `line + "\n"` verbatim, so one newline in the detail ends the entry and starts a second one the caller wrote — a forged audit line in the operator's own session log — and the same line reaches a console where an ANSI escape repaints whatever terminal is tailing it. The callback's `?error=` is public, unauthenticated and handed over already percent-decoded by Express, so `%0a` is all it takes. `logSafe()` escapes C0/DEL/C1 (escapes rather than strips, so an operator still sees that the message contained a newline) and caps the detail at 300 characters.

## Expired team sessions are swept (closes #676)

`authenticateSession` already deletes an expired session, but only the one it was just handed. A session whose owner never comes back with that cookie — the normal end of a shift — is never looked at again. Nothing **reads** it either, because `listSessions` filters on `expires_at`, and that is what kept this invisible: the table simply grows for the life of the deployment, one row per sign-in that was never signed out.

`deleteExpiredSessions()` runs from `startMaintenanceTasks` beside the backup and integrity timers — same shape, an interval, `.unref()`'d, best-effort, never able to throw into the request path. Six hours, not minutes: an expired session is already unusable, so this buys disk rather than security and there is nothing to race. It also sweeps once at startup. Solo mode passes no auth store and arms nothing.

The tests count raw rows over a second connection to the same file; going through `listSessions` would hide exactly the rows under test.

## Timer-lifecycle test isolation (closes #685)

A full run failed at *"stopping a monitor clears its timer"* with `expected 0, received 1`, then passed when the file ran on its own. **The stray timer did not belong to that test.**

`vi.useFakeTimers()` replaces the **global** `setTimeout`, so a poll chain that outlives its own test does not die with it: it keeps running on the real event loop, and when it finally re-arms, that `setTimeout` lands in the **next** test's fake timer queue. The test before the CANCELLED one ended on a plain `tick()` while its second poll was still mid-flight, and the re-arm arrived after the stop had already brought the count to zero. Reproduced in isolation with a two-test file: the second sees a timer it never armed, failing with the reported failure's exact shape.

Three changes:

- Every test that leaves a live poller now ends on `tickAndRearm()`. The re-arm is the last statement of each poll chain, so a pending timer is proof the chain finished — the guarantee `tick()`'s fixed settle budget cannot give.
- `tickAndRearm` now takes the number of pollers. It was satisfied by the count, so the hunt-resume test — which drives two — released the wait on the first re-arm while the second was still polling. **A second, independent leak, found by the guard below.**
- An `afterEach` guard watches for a stray after every test, so a future leak fails loudly and names the cause instead of flaking a later assertion. Verified by re-introducing the leak. It is a backstop, not the fix: a slow enough chain still surfaces in a later test's window, and the header says so.

Ran the file 9 times consecutively — 8/8 every time.

I did not add the CI stress job #685 suggests. The leak is deterministic now rather than probabilistic, so a repeat-run job would spend CI time re-checking a property the guard already asserts on every run.

## History rewrite

This branch was four commits plus a merge of `master`. It is now one commit on top of `e68eb3df`.

A test fixture in it invented an internal FQDN (`backend-idp-07.internal.example`) to stand for the provider detail that must not reach the browser. `betterleaks` keeps its internal-hostname rule **on** precisely to catch a genuinely new one, and `betterleaks git .` scans every reachable commit — so the finding survived fixing the file. Allowlisting a fixture I can simply rename would be teaching the scanner to ignore the shape it exists to find, so the fixture is no longer a hostname at all. Rebuilding the branch removes the commit that carried it.

Nothing was lost: the merge method here is squash, so `master` was always going to receive one commit.

`master` moved during the work, and both documentation conflicts were keep-both:

- `CHANGELOG.md` — #682-684 and #709 landed in the same Unreleased list. Both sets kept, newest first.
- `ARCHITECTURE.md` — both sides moved the cross-domain comply/total pair. The figure comes from `check-boundaries.mjs --json` on the rebuilt tree: **1,881 of 1,920**, which is master's 1,879/1,918 plus this branch's two new import edges. Measured, not assumed.

## Windows timeout scaling

Worth calling out because it was nearly a regression inside a flaky-test fix. Putting explicit `{ timeout: rearmBudget(n) }` on five more tests looked harmless, but an explicit `it()` timeout **replaces** `vitest.config.ts`'s, and that config already triples its default to 45 s on Windows. An unscaled `rearmBudget(1)` of 20 s and `rearmBudget(2)` of 30 s were therefore both *tighter* than the default those tests used to get, on tests that do real file I/O — the exact trap `tests/helpers/poll.ts` documents. Both the inner wait and the headroom now come from `pollBudget()`, so every ratio holds on both platforms. `Companion test (Windows)` is green.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run check:size` | pass — none grew |
| `npm run check:imports` | pass — 0 cycles, none new |
| `npm run check:boundaries` | pass — 39 known, none new |
| `npm run eval:change-gate` | not required — prompts and models unchanged |
| `npm run check:us-map` | pass — 243/360 |
| `npm run build` | pass |
| `npm run typecheck` | pass |
| `npx vitest run` | **694 files, 10,883 tests, all passing** |
| extension typecheck / test / build / build:firefox | pass — 17 files, 329 tests |
