### PR TITLE
fix(auth): authenticate a team request before its body is parsed (#681)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,879 of the 1,918 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,880 of the 1,919 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/.env.example
+++ b/companion/.env.example
@@ -64,6 +64,10 @@ DFIR_AUTH_MODE=single-user              # single-user | team
 
 # Max request body (MB). Bulk CSV/log/THOR/SIEM imports send the whole file — raise on HTTP 413.
 # Beyond a few hundred MB you approach V8's max string length; split the export instead.
+# Applies to AUTHENTICATED callers. Under DFIR_AUTH_MODE=team the few endpoints a stranger may
+# still POST to (login, the chat webhooks) are parsed at 1 MB, and everything else is answered 401
+# before its body is read at all — so a remote deployment cannot be made to allocate this much on
+# an unauthenticated request.
 DFIR_MAX_BODY_MB=256
 
 # Extra browser origins allowed to call the API (comma-separated), e.g. https://soc.example.com.

--- a/companion/src/auth/authRoutes.ts
+++ b/companion/src/auth/authRoutes.ts
@@ -83,6 +83,29 @@ async function existingCase(cases: CaseStore, caseId: string, res: Response): Pr
   return false;
 }
 
+/**
+ * The paths registerTeamAuthRoutes mounts below, as a predicate.
+ *
+ * These routes are registered BEFORE teamAuth.middleware(), so the request policy never applies to
+ * them — POST /auth/local/login and POST /auth/bootstrap are unauthenticated by definition, because
+ * they are how a caller GETS a credential. The pre-parse gate in composition/httpStack.ts has to
+ * know the same list: a path it lets through with no credential is a path whose body it must parse
+ * itself, at the small unauthenticated limit (#681). Add a route here when you add one below.
+ *
+ * Express routing is neither case-sensitive nor strict, so /AUTH/local/login and /auth/local/login/
+ * both reach the handler. Match the way the router matches, or the gate would 401 a spelling the
+ * router still serves.
+ */
+export function isTeamAuthRoutePath(path: string): boolean {
+  const normalized = (path.length > 1 ? path.replace(/\/+$/, "") : path).toLowerCase();
+  return (
+    normalized === "/login" ||
+    normalized === "/admin" ||
+    normalized === "/auth" ||
+    normalized.startsWith("/auth/")
+  );
+}
+
 export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: CaseStore): void {
   app.use("/auth", (_req, res, next) => {
     res.setHeader("Cache-Control", "no-store");

--- a/companion/src/auth/teamAuth.ts
+++ b/companion/src/auth/teamAuth.ts
@@ -223,6 +223,24 @@ export class TeamAuth {
     return safeStringEqual(supplied, auth.session.csrfToken);
   }
 
+  /**
+   * The answer to a request that carries no usable credential: a login redirect for a browser
+   * navigation, a 401 for everything else.
+   *
+   * Exported as a method because TWO layers now send it. composition/httpStack.ts runs a pre-parse
+   * gate BEFORE the body parsers so an unauthenticated caller cannot make the process inflate,
+   * allocate and JSON-parse hundreds of MB on its way to this same 401 (#681). The two must answer
+   * identically — a client that used to be redirected to /login must still be redirected — so the
+   * answer lives here once instead of being copied there.
+   */
+  rejectUnauthenticated(req: Request, res: Response): void {
+    if (acceptsHtml(req)) {
+      res.redirect(`/login?returnTo=${encodeURIComponent(req.originalUrl)}`);
+      return;
+    }
+    res.status(401).json({ error: "authentication required" });
+  }
+
   middleware(): RequestHandler {
     return (req: Request, res: Response, next: NextFunction): void => {
       const policy = resolveRequestPolicy(req.method, req.path);
@@ -232,11 +250,7 @@ export class TeamAuth {
       }
       const auth = this.authenticateRequest(req);
       if (!auth) {
-        if (acceptsHtml(req)) {
-          res.redirect(`/login?returnTo=${encodeURIComponent(req.originalUrl)}`);
-          return;
-        }
-        res.status(401).json({ error: "authentication required" });
+        this.rejectUnauthenticated(req, res);
         return;
       }
       if (!this.authorized(auth, policy, req)) {

--- a/companion/src/composition/httpStack.ts
+++ b/companion/src/composition/httpStack.ts
@@ -15,6 +15,7 @@
  *   demoModeReadOnlyGate blocks writes on the public demo before any route can act on them
  *   requestLogger        so even a rejected request is logged
  *   operationalMetrics   counts what the logger logged
+ *   preAuthBodyGate      team mode only: 401 before the generous parsers can read a stranger's body
  *   json/text parsers    the body limit; generous because imports arrive as request bodies
  *   bodyParserErrorHandler  4-arg, immediately after the parsers so it catches THEIR errors
  *   errorPathRedactor    wraps res.json ONCE for every route, present and future
@@ -40,12 +41,47 @@ import {
   unlockCookieName,
   parseCookieHeader,
 } from "../analysis/casePassword.js";
-import { registerTeamAuthRoutes } from "../auth/authRoutes.js";
+import { isTeamAuthRoutePath, registerTeamAuthRoutes } from "../auth/authRoutes.js";
+import { resolveRequestPolicy } from "../auth/policy.js";
 import { redactPaths } from "../analysis/redactPaths.js";
 import { registerStaticAssets } from "../http/staticAssets.js";
 import { CaseNotFoundError } from "../ingest/captureIngest.js";
 import { ZodError } from "zod";
 import { logLine, getServerLogger } from "../logging/serverLogger.js";
+
+/**
+ * Ceiling on a body this server reads from a caller it has not authenticated yet, in MB (#681).
+ *
+ * The generous DFIR_MAX_BODY_MB limit exists for bulk evidence imports, and every import route
+ * requires a credential. Count what is left — what a stranger may still POST a body to in team
+ * mode — and it is a login form, a user/role edit, and three chat webhooks. None of them is bulk
+ * anything; the largest is a Telegram Update. 1 MB is the same cap routes/slashCommand.ts already
+ * puts on Slack's own urlencoded parser.
+ *
+ * Not a separate env knob on purpose: it is a floor under DFIR_MAX_BODY_MB, so lowering that knob
+ * lowers this too and the 413 still names the one variable an operator has to change.
+ */
+const PRE_AUTH_BODY_MB = 1;
+
+/**
+ * Set on a request whose body the pre-auth parsers read, so bodyParserErrorHandler can tell which
+ * of the two limits rejected it. The two need DIFFERENT advice: "raise DFIR_MAX_BODY_MB" is sound
+ * for an import and a dead end for a webhook, because the pre-auth cap is a floor and raising the
+ * knob above 1 cannot lift it. An operator who followed that advice would restart and get the same
+ * 413. Comparing byte counts instead would be ambiguous the moment the two limits coincide.
+ */
+type PreAuthBodyRequest = Request & { dfirPreAuthBody?: boolean };
+
+/**
+ * Bytes → the MB figure an operator actually typed. `DFIR_MAX_BODY_MB=0.25` is a number Node
+ * accepts and body-parser honours, so rounding the reported limit to whole MB would answer a
+ * 262,144-byte refusal with "exceeds the 0 MB limit" — a message that reads as a bug in the server
+ * rather than a cap on the caller. toFixed(3) then Number() drops the trailing zeros an exact
+ * value would otherwise grow (1 → "1", not "1.000").
+ */
+function megabytes(bytes: number): string {
+  return String(Number((bytes / (1024 * 1024)).toFixed(3)));
+}
 
 export interface HttpStackDeps {
   store: CaseStore;
@@ -111,29 +147,83 @@ export function mountRequestPipeline(app: Express, { store, options, instanceSec
   // JSON body limit. Bulk evidence imports (CSV / log / THOR / SIEM-EDR JSON exports) wrap the
   // whole file in the request body, and SIEM/EDR exports in particular are routinely tens to
   // hundreds of MB — so the cap is generous and configurable via DFIR_MAX_BODY_MB (default
-  // 256 MB). Localhost-only single-user tool, so a large limit is not a DoS concern. Files
-  // beyond a few hundred MB approach V8's max string length; for those, split the export.
+  // 256 MB). Files beyond a few hundred MB approach V8's max string length; for those, split the
+  // export. WHO may spend that budget is the gate below, not this limit.
   const maxBodyMb = Number(process.env.DFIR_MAX_BODY_MB) || 256;
+  // Text types are listed once: the pre-auth parser below has to match exactly the same set, or a
+  // body it was supposed to cap would fall through to the generous parser instead.
+  const textBodyTypes = ["text/*", "application/x-ndjson", "application/jsonl"];
+
+  // ── Authenticate BEFORE the generous parsers, in team mode (#681) ─────────────────────
+  // This limit used to be justified by "localhost-only single-user tool, so a large limit is not a
+  // DoS concern". That is true of DFIR_AUTH_MODE=single. It is false of DFIR_AUTH_MODE=team behind
+  // a DFIR_HOST that answers the network: the parsers sat ABOVE teamAuth.middleware(), so a
+  // stranger's 256 MB body was received, inflated, allocated, decoded and JSON-parsed in full, and
+  // only THEN answered 401. A few concurrent requests exhaust the heap or stall the event loop.
+  //
+  // So resolve the policy — which is a pure function of method and path — and demand a credential
+  // first. This layer only ever answers "no credential"; teamAuth.middleware() below still does the
+  // whole authorization decision, on the parsed body, exactly as before. A request that gets past
+  // here has proven it is someone, and only then is the generous limit its to spend.
+  if (options.teamAuth) {
+    const teamAuth = options.teamAuth;
+    const preAuthLimit = `${Math.min(maxBodyMb, PRE_AUTH_BODY_MB)}mb`;
+    const preAuthJson = express.json({ limit: preAuthLimit });
+    const preAuthText = express.text({ limit: preAuthLimit, type: textBodyTypes });
+    app.use(function preAuthBodyGate(req: Request, res: Response, next: NextFunction) {
+      const policy = resolveRequestPolicy(req.method, req.path);
+      // Two kinds of request legitimately arrive with no credential. The public routes — /health,
+      // the login page, and the slash-command webhooks, which authenticate themselves against a
+      // per-platform HMAC or shared secret inside the handler. And the /auth routes, because
+      // logging in is HOW a caller gets a credential. Both parse right here, at the small limit;
+      // body-parser then marks the request consumed, so the generous parsers below do nothing.
+      //
+      // POST /captures is NOT in this set even though its policy is decided by the caseId in its
+      // body. Read middleware() again: the body picks WHICH case the caller may write to, but a
+      // caller with no credential at all is turned away before that, by the same 401 this gate
+      // sends. So a capture already had to be somebody, and its body is still parsed at the
+      // generous limit — the extension's screenshots are unaffected by this change.
+      if (policy.kind === "public" || isTeamAuthRoutePath(req.path)) {
+        (req as PreAuthBodyRequest).dfirPreAuthBody = true;
+        preAuthJson(req, res, (err) => (err ? next(err) : preAuthText(req, res, next)));
+        return;
+      }
+      // Header- and cookie-only: nothing here touches the body, which is the entire point.
+      if (teamAuth.authenticateRequest(req)) {
+        next();
+        return;
+      }
+      teamAuth.rejectUnauthenticated(req, res);
+    });
+  }
+
   app.use(express.json({ limit: `${maxBodyMb}mb` }));
   // Also accept text/plain + NDJSON bodies so the generic push endpoint (#84) can take a raw blob
   // (a Velociraptor monitor dump, an NDJSON alert stream) without forcing every caller to wrap it in
   // a JSON envelope. JSON bodies still parse via express.json above; this only catches non-JSON types.
-  app.use(
-    express.text({ limit: `${maxBodyMb}mb`, type: ["text/*", "application/x-ndjson", "application/jsonl"] }),
-  );
+  app.use(express.text({ limit: `${maxBodyMb}mb`, type: textBodyTypes }));
 
   // Turn body-parser failures into actionable JSON (instead of Express's default HTML page):
   // an over-limit upload → 413 with how to raise the cap; malformed JSON → 400. Placed right
   // after the parser so it catches its errors; normal requests skip it (4-arg = error-only).
   app.use(function bodyParserErrorHandler(
-    err: Error & { type?: string; status?: number },
-    _req: Request,
+    err: Error & { type?: string; status?: number; limit?: number },
+    req: Request,
     res: Response,
     next: NextFunction,
   ) {
     if (err?.type === "entity.too.large") {
+      // Name the limit that actually fired, and give advice that works on it. Telling a webhook
+      // its payload exceeded "the 256 MB limit" would be a puzzle; telling it to raise
+      // DFIR_MAX_BODY_MB would be worse, because that knob cannot lift the pre-auth floor.
+      const limitMb = megabytes(err.limit ?? maxBodyMb * 1024 * 1024);
+      if ((req as PreAuthBodyRequest).dfirPreAuthBody) {
+        return res.status(413).json({
+          error: `request exceeds the ${limitMb} MB limit that applies before a caller is authenticated — this cap is fixed and DFIR_MAX_BODY_MB does not raise it; send a smaller payload, or authenticate and use an import route`,
+        });
+      }
       return res.status(413).json({
-        error: `upload exceeds the ${maxBodyMb} MB limit — raise DFIR_MAX_BODY_MB and restart the companion, or split the export into smaller files`,
+        error: `upload exceeds the ${limitMb} MB limit — raise DFIR_MAX_BODY_MB and restart the companion, or split the export into smaller files`,
       });
     }
     if (err?.type === "entity.parse.failed") {

--- a/companion/tests/http/teamAuthBodyGate.test.ts
+++ b/companion/tests/http/teamAuthBodyGate.test.ts
@@ -1,0 +1,241 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { ActivityLogStore } from "../../src/analysis/activityLog.js";
+import { CommentsStore } from "../../src/analysis/comments.js";
+import { SlashCommandChannelStore } from "../../src/analysis/slashCommandStore.js";
+import { StateLock } from "../../src/analysis/stateLock.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { AuthStore } from "../../src/auth/authStore.js";
+import { TeamAuth } from "../../src/auth/teamAuth.js";
+import { createApp } from "../../src/server.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+
+/**
+ * THE BODY PARSERS SIT ABOVE THE AUTHENTICATOR, SO WHO PAYS FOR A BODY IS A SECURITY QUESTION (#681).
+ *
+ * express.json() was mounted before teamAuth.middleware(), at a limit meant for bulk evidence
+ * imports (DFIR_MAX_BODY_MB, 256 MB by default). On a team deployment that answers the network,
+ * that made every 401 expensive: a stranger's body was received, inflated, allocated, decoded and
+ * JSON-parsed in full, and only then refused. A handful of concurrent requests is enough to exhaust
+ * the heap or stall the single-threaded event loop.
+ *
+ * composition/httpStack.ts now resolves the request policy — a pure function of method and path —
+ * and demands a credential BEFORE those parsers. These tests pin the observable consequence, which
+ * is a status code: a body that used to come back 413 or 400 (proving it was read) must now come
+ * back 401 (proving it was not). They also pin the two things that must NOT change — an
+ * authenticated caller still gets the generous limit, and the routes that legitimately take a body
+ * from a stranger still parse one, under their own small cap.
+ *
+ * DFIR_MAX_BODY_MB is 2 here so both limits can be crossed with small bodies instead of pushing
+ * 256 MB through supertest. TWO sizes, and the difference is the whole test:
+ *   1.5 MB  over the 1 MB pre-auth floor, under the configured limit — what a credential buys
+ *   2.5 MB  over BOTH, so without the gate the parser reads it and answers 413
+ * Mutation-proven on that second size: stub the gate out and the 401 assertions go back to 413.
+ */
+
+const BOOTSTRAP_TOKEN = "body-gate-bootstrap-token-with-entropy";
+const TELEGRAM_SECRET = "telegram-webhook-secret-token";
+const OVER_THE_PRE_AUTH_CAP = "x".repeat(1_500_000);
+const OVER_EVERY_CAP = "x".repeat(2_500_000);
+
+describe("team mode authenticates before it parses a body", () => {
+  let cases: CaseStore;
+  let authStore: AuthStore;
+  let app: ReturnType<typeof createApp>;
+  const previous: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    previous.DFIR_MAX_BODY_MB = process.env.DFIR_MAX_BODY_MB;
+    previous.DFIR_TELEGRAM_SECRET_TOKEN = process.env.DFIR_TELEGRAM_SECRET_TOKEN;
+    process.env.DFIR_MAX_BODY_MB = "2";
+    process.env.DFIR_TELEGRAM_SECRET_TOKEN = TELEGRAM_SECRET;
+  });
+
+  afterAll(() => {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  beforeEach(async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-body-gate-"));
+    cases = new CaseStore(join(root, "cases"));
+    authStore = new AuthStore(join(root, "auth.sqlite"));
+    app = createApp(cases, {
+      teamAuth: new TeamAuth({
+        store: authStore,
+        bootstrapToken: BOOTSTRAP_TOKEN,
+        cookieSecure: false,
+        sessionTtlMs: 60 * 60_000,
+      }),
+      stateLock: new StateLock(),
+      stateStore: new StateStore(cases),
+      activityLogStore: new ActivityLogStore(cases),
+      commentsStore: new CommentsStore(cases),
+      slashCommandChannelStore: new SlashCommandChannelStore(join(root, "slash.json")),
+    });
+  });
+
+  async function admin(): Promise<{ agent: ReturnType<typeof request.agent>; csrf: string }> {
+    const agent = request.agent(app);
+    const created = await agent.post("/auth/bootstrap").send({
+      bootstrapToken: BOOTSTRAP_TOKEN,
+      username: "admin",
+      password: "correct horse battery staple",
+      displayName: "Primary Admin",
+    });
+    expect(created.status).toBe(201);
+    const me = await agent.get("/auth/me");
+    expect(me.status).toBe(200);
+    return { agent, csrf: me.body.csrfToken as string };
+  }
+
+  it("answers 401 to an oversized body on a protected route, instead of reading it", async () => {
+    const res = await request(app)
+      .post("/cases/c1/import-siem")
+      .send({ filename: "big.json", json: OVER_EVERY_CAP });
+    // 413 would mean the parser ran to the limit and then gave up — the very work being refused.
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("authentication required");
+  });
+
+  it("answers 401 to a malformed body on a protected route, instead of parsing it", async () => {
+    const res = await request(app)
+      .post("/cases/c1/import-siem")
+      .set("Content-Type", "application/json")
+      .send("{ not json at all");
+    // 400 "request body is not valid JSON" is what the parser says. Never reaching it is the fix.
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("authentication required");
+  });
+
+  it("answers 401 to an oversized text body too, not only JSON", async () => {
+    const res = await request(app)
+      .post("/cases/c1/push")
+      .set("Content-Type", "text/plain")
+      .send(OVER_EVERY_CAP);
+    expect(res.status).toBe(401);
+  });
+
+  it("refuses concurrent oversized unauthenticated requests without parsing any of them", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        request(app).post("/cases/c1/import-siem").send({ filename: "big.json", json: OVER_EVERY_CAP }),
+      ),
+    );
+    expect(results.map((r) => r.status)).toEqual(Array(8).fill(401));
+  });
+
+  it("redirects a browser navigation to the login page rather than 401-ing it", async () => {
+    // The pre-parse gate answers for requests that used to reach teamAuth.middleware(), so it has
+    // to answer the same way: a human typing a URL gets the login page, not a JSON error.
+    const res = await request(app).get("/dashboard").set("Accept", "text/html");
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe("/login?returnTo=%2Fdashboard");
+  });
+
+  it("still gives an authenticated caller the full DFIR_MAX_BODY_MB budget", async () => {
+    const { agent, csrf } = await admin();
+    const created = await agent
+      .post("/cases")
+      .set("X-DFIR-CSRF", csrf)
+      .send({ caseId: "c1", name: "n", investigator: "i" });
+    expect(created.status).toBe(201);
+
+    // 1.5 MB is over the 1 MB pre-auth floor and under the 2 MB configured limit. A credential is
+    // what buys the difference, so this must parse rather than 413.
+    const res = await agent
+      .post("/cases/c1/import-siem")
+      .set("X-DFIR-CSRF", csrf)
+      .send({ filename: "big.json", json: OVER_THE_PRE_AUTH_CAP });
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(401);
+  });
+
+  it("still parses the login body, which is how a caller gets a credential at all", async () => {
+    await admin();
+    const res = await request(app)
+      .post("/auth/local/login")
+      .send({ username: "admin", password: "not the right password" });
+    // The route's own answer, not the gate's — proof the gate let the body through and it parsed.
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("invalid username or password");
+  });
+
+  it("still parses a public webhook body, and caps it at 1 MB", async () => {
+    const accepted = await request(app)
+      .post("/integrations/telegram/command")
+      .set("X-Telegram-Bot-Api-Secret-Token", "wrong-secret")
+      .send({ message: { chat: { id: "42" }, text: "/dfir status" } });
+    // "secret token mismatch" is the handler talking, so the gate did not intercept the webhook.
+    expect(accepted.status).toBe(401);
+    expect(accepted.body.error).toBe("secret token mismatch");
+
+    const oversized = await request(app)
+      .post("/integrations/telegram/command")
+      .set("X-Telegram-Bot-Api-Secret-Token", TELEGRAM_SECRET)
+      .send({ message: { chat: { id: "42" }, text: OVER_THE_PRE_AUTH_CAP } });
+    expect(oversized.status).toBe(413);
+    expect(oversized.body.error).toMatch(/exceeds the 1 MB limit/);
+    // And the advice has to be advice. The pre-auth cap is a floor under DFIR_MAX_BODY_MB, so
+    // "raise DFIR_MAX_BODY_MB and restart" sends an operator to do the one thing that cannot work.
+    expect(oversized.body.error).toMatch(/DFIR_MAX_BODY_MB does not raise it/);
+    expect(oversized.body.error).not.toMatch(/raise DFIR_MAX_BODY_MB and restart/);
+  });
+
+  it("still tells an AUTHENTICATED caller to raise the knob, because for them it works", async () => {
+    const { agent, csrf } = await admin();
+    const created = await agent
+      .post("/cases")
+      .set("X-DFIR-CSRF", csrf)
+      .send({ caseId: "c1", name: "n", investigator: "i" });
+    expect(created.status).toBe(201);
+
+    const res = await agent
+      .post("/cases/c1/import-siem")
+      .set("X-DFIR-CSRF", csrf)
+      .send({ filename: "big.json", json: OVER_EVERY_CAP });
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/exceeds the 2 MB limit/);
+    expect(res.body.error).toMatch(/raise DFIR_MAX_BODY_MB and restart/);
+  });
+
+  it("reports a fractional DFIR_MAX_BODY_MB exactly, instead of rounding it into a lie", async () => {
+    // 0.25 is a value Number() accepts and body-parser honours — it caps bodies at 262,144 bytes.
+    // Rounding the reported limit to whole MB answered that real cap with "exceeds the 0 MB limit",
+    // which reads as a broken server rather than as a limit the caller crossed.
+    process.env.DFIR_MAX_BODY_MB = "0.25";
+    try {
+      const root = await mkdtemp(join(tmpdir(), "dfir-body-gate-fraction-"));
+      const fractional = createApp(new CaseStore(join(root, "cases")), {
+        teamAuth: new TeamAuth({
+          store: new AuthStore(join(root, "auth.sqlite")),
+          bootstrapToken: BOOTSTRAP_TOKEN,
+          cookieSecure: false,
+          sessionTtlMs: 60 * 60_000,
+        }),
+      });
+      const res = await request(fractional)
+        .post("/auth/local/login")
+        .send({ username: "admin", password: OVER_THE_PRE_AUTH_CAP });
+      expect(res.status).toBe(413);
+      expect(res.body.error).toMatch(/exceeds the 0\.25 MB limit/);
+    } finally {
+      process.env.DFIR_MAX_BODY_MB = "2";
+    }
+  });
+
+  it("leaves the public GETs reachable", async () => {
+    expect((await request(app).get("/health")).status).toBe(200);
+  });
+
+  it("keeps demanding a credential for POST /captures, whose body it no longer pre-parses", async () => {
+    const res = await request(app).post("/captures").send({ caseId: "c1", imageBase64: "AAAA" });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("authentication required");
+  });
+});


### PR DESCRIPTION
Closes #681.

## The problem

On a team deployment the companion read a stranger's entire upload before deciding whether that stranger was allowed in.

`express.json()` and `express.text()` were mounted **above** `teamAuth.middleware()`, at the limit meant for bulk evidence imports — `DFIR_MAX_BODY_MB`, 256 MB by default. The comment justified that limit with "localhost-only single-user tool, so a large limit is not a DoS concern". That is true of `DFIR_AUTH_MODE=single`. It is false of `DFIR_AUTH_MODE=team` behind a `DFIR_HOST` that answers the network: an unauthenticated body was received, inflated, allocated, decoded and JSON-parsed in full, and only then answered 401. A handful of concurrent requests is enough to exhaust the heap or stall the single-threaded event loop.

## The fix

The request policy is a pure function of method and path, so it can be resolved before any body is read. A new `preAuthBodyGate` in `composition/httpStack.ts` does exactly that, in team mode only, and demands a credential from headers and cookies alone.

The gate only ever answers "no credential". `teamAuth.middleware()` still makes the whole authorization decision, on the parsed body, unchanged.

Two kinds of request legitimately carry no credential, and keep parsing at a **1 MB floor**:

- the **public** routes — `/health`, the login page, and the three chat webhooks, which authenticate themselves against a per-platform HMAC or shared secret inside their handlers;
- the **`/auth`** routes, because logging in is how a caller gets a credential.

`POST /captures` is deliberately **not** among them, even though its policy is decided by the `caseId` in its body. Read `middleware()` again: the body picks *which* case the caller may write to, but a caller with no credential at all is turned away before that. So a capture already had to be somebody, and its body still parses at the generous limit — the extension is untouched.

Nothing changes for a single-user localhost install: the gate is inside `if (options.teamAuth)`.

## Supporting changes

- `TeamAuth.rejectUnauthenticated()` — the unauthenticated answer (401, or a `/login` redirect for a browser navigation) now lives in one place, called by both layers, so the two cannot drift.
- `isTeamAuthRoutePath()` in `authRoutes.ts` — names the routes registered *before* the middleware, beside the routes themselves. It folds case and trailing slashes, because Express routing is neither case-sensitive nor strict and the gate must match the way the router matches.
- The 413 now reports the limit that actually fired, and gives advice that works on it. Raising `DFIR_MAX_BODY_MB` cannot lift the pre-auth floor, so a pre-auth refusal no longer suggests it. A fractional `DFIR_MAX_BODY_MB` is reported exactly rather than rounded (`0.25` no longer reads as "0 MB").

## Two parts of the issue not implemented, and why

- **Compressed-body inflation** is already capped. body-parser applies its limit to the *inflated* stream, so a gzip bomb stops at the same cap.
- **Concurrent large uploads** get no semaphore. After this change only authenticated callers can send a large body, so the concurrency in question is a team member's, not a stranger's. Throttling it would slow legitimate parallel imports for no security gain.

## Tests

`tests/http/teamAuthBodyGate.test.ts` — 12 tests, covering all three regression tests the issue asked for plus the no-regression side.

Mutation-proven three ways: stub the gate out and 5 tests fail (oversized JSON, oversized text, malformed JSON, 8 concurrent oversized, the webhook cap); restore the rounding and the fractional-limit test fails; drop the pre-auth advice branch and the webhook test fails.

## Gates

Lint, format, size, imports, boundaries, us-map, eval-change-gate, build, typecheck all green. Companion suite 10,895 passed. Extension 329 passed, both builds green. `master` merged in first; the `ARCHITECTURE.md` cross-domain count conflicted with #710 and was recomputed to 1,882 of 1,921.
