### PR TITLE
fix: finish the unlocked side-store sweep #682 started

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,879 of the 1,918 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,880 of the 1,919 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,886 of the 1,925 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,896 of the 1,935 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,896 of the 1,935 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,898 of the 1,937 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,898 of the 1,937 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,900 of the 1,939 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,900 of the 1,939 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,901 of the 1,940 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,880 of the 1,919 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,886 of the 1,925 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **A screenshot redaction found by OCR is no longer lost when the analyst clicks at the same moment** — the value stayed unmasked in redacted exports. The one store of its class a solo analyst could trip. (follow-up to #682)
+- **Analyst decisions no longer overwrite each other in team mode** — finding triage and assignment, asset-graph renames/merges/link edits, IOC merges, dismissed lateral-movement chains, host near-duplicate dismissals and learned dismissal patterns. (follow-up to #682)
+- **A bulk dismissal writes the learned-pattern ledger once instead of once per finding.** (follow-up to #682)
 - **Concurrent edits to dwell windows, playbook tasks, the collection plan, the IOC whitelist, notification channels and report versions no longer overwrite each other** in team mode. (closes #682)
 - **Switching a webhook channel to another provider requires the new provider's URL** — a blank field no longer reuses the old service's endpoint. (closes #683)
 - **`"false"` disables a notification channel or event toggle** instead of enabling it; anything that is not a boolean or `"true"`/`"false"` is now a 400. (closes #684)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A screenshot redaction found by OCR is no longer lost when the analyst clicks at the same moment** — the value stayed unmasked in redacted exports. The one store of its class a solo analyst could trip. (follow-up to #682)
 - **Concurrent edits to dwell windows, playbook tasks, the collection plan, the IOC whitelist, notification channels and report versions no longer overwrite each other** in team mode. (closes #682)
 - **Switching a webhook channel to another provider requires the new provider's URL** — a blank field no longer reuses the old service's endpoint. (closes #683)
 - **`"false"` disables a notification channel or event toggle** instead of enabling it; anything that is not a boolean or `"true"`/`"false"` is now a 400. (closes #684)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A screenshot redaction found by OCR is no longer lost when the analyst clicks at the same moment** — the value stayed unmasked in redacted exports. The one store of its class a solo analyst could trip. (follow-up to #682)
 - **Analyst decisions no longer overwrite each other in team mode** — finding triage and assignment, asset-graph renames/merges/link edits, IOC merges, dismissed lateral-movement chains, host near-duplicate dismissals and learned dismissal patterns. (follow-up to #682)
 - **A bulk dismissal writes the learned-pattern ledger once instead of once per finding.** (follow-up to #682)
+- **Overlapping Jira/ServiceNow/ClickUp/Notion exports no longer drop ticket references** — a lost reference made the next export open a duplicate ticket. (follow-up to #682)
+- **Velociraptor hunts and monitors, SO-CRATES jobs, MCP servers, custom tools and chat bindings survive concurrent edits.** (follow-up to #682)
 - **Concurrent edits to dwell windows, playbook tasks, the collection plan, the IOC whitelist, notification channels and report versions no longer overwrite each other** in team mode. (closes #682)
 - **Switching a webhook channel to another provider requires the new provider's URL** — a blank field no longer reuses the old service's endpoint. (closes #683)
 - **`"false"` disables a notification channel or event toggle** instead of enabling it; anything that is not a boolean or `"true"`/`"false"` is now a 400. (closes #684)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A bulk dismissal writes the learned-pattern ledger once instead of once per finding.** (follow-up to #682)
 - **Overlapping Jira/ServiceNow/ClickUp/Notion exports no longer drop ticket references** — a lost reference made the next export open a duplicate ticket. (follow-up to #682)
 - **Velociraptor hunts and monitors, SO-CRATES jobs, MCP servers, custom tools and chat bindings survive concurrent edits.** (follow-up to #682)
+- **A second-look sweep result is no longer erased by a concurrent synthesis** — the lost stamp dropped second-look leads from the report. (follow-up to #682)
 - **Concurrent edits to dwell windows, playbook tasks, the collection plan, the IOC whitelist, notification channels and report versions no longer overwrite each other** in team mode. (closes #682)
 - **Switching a webhook channel to another provider requires the new provider's URL** — a blank field no longer reuses the old service's endpoint. (closes #683)
 - **`"false"` disables a notification channel or event toggle** instead of enabling it; anything that is not a boolean or `"true"`/`"false"` is now a 400. (closes #684)

--- a/companion/src/analysis/anonDiscovered.ts
+++ b/companion/src/analysis/anonDiscovered.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import { sanitizeCustomEntities } from "./anonEntities.js";
 import type { CustomEntity } from "./anonymize.js";
 
@@ -18,6 +19,24 @@ export interface AnonDiscovered {
 }
 
 const MAX_DISCOVERED = 2000;
+
+// Serializes a case's load->modify->save section on anon-discovered.json. atomicWrite stops a TORN
+// file, not a LOST one, and losing a write here is not a lost click — it is an unredacted value in
+// an exported screenshot.
+//
+// MODULE-level, and that is the whole point. This file has two writers that are not the same
+// object: the OCR pass writes through the store built in composition/aiProviders.ts, and the
+// analyst's suppress/unsuppress clicks write through the one built in routes/anonymization.ts. A
+// per-instance lock would leave the actual race completely unguarded.
+//
+// It is also the one store of its class a SOLO analyst can trip. Everywhere else this bug needs two
+// people or two tabs; here a background pass is the second writer, so one investigator on one
+// laptop is enough. The dangerous direction is losing the OCR write: the entity never enters
+// `discovered`, so it is never tokenized, and the real value ships in the redacted export.
+//
+// Keyed by case id, so a busy case never blocks another, and private to this file, so it can never
+// deadlock against the pipeline's investigation-state lock.
+const discoveredLock = new StateLock();
 
 export function emptyDiscovered(): AnonDiscovered {
   return { discovered: [], suppressed: [] };
@@ -88,26 +107,34 @@ export class DiscoveredEntitiesStore {
     }
   }
 
-  async save(caseId: string, data: AnonDiscovered): Promise<void> {
+  // PRIVATE, so the lock above cannot be walked around: a caller holding this store could otherwise
+  // load, mutate and save outside the critical section and reintroduce the exact race.
+  private async save(caseId: string, data: AnonDiscovered): Promise<void> {
     await atomicWrite(this.path(caseId), JSON.stringify(sanitizeDiscovered(data), null, 2));
   }
 
-  async addDiscovered(caseId: string, entities: CustomEntity[]): Promise<AnonDiscovered> {
+  addDiscovered(caseId: string, entities: CustomEntity[]): Promise<AnonDiscovered> {
     if (entities.length === 0) return this.load(caseId);
-    const next = mergeDiscovered(await this.load(caseId), entities);
-    await this.save(caseId, next);
-    return next;
+    return discoveredLock.runExclusive(caseId, async () => {
+      const next = mergeDiscovered(await this.load(caseId), entities);
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
-  async suppress(caseId: string, value: string): Promise<AnonDiscovered> {
-    const next = suppressValue(await this.load(caseId), value);
-    await this.save(caseId, next);
-    return next;
+  suppress(caseId: string, value: string): Promise<AnonDiscovered> {
+    return discoveredLock.runExclusive(caseId, async () => {
+      const next = suppressValue(await this.load(caseId), value);
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
-  async unsuppress(caseId: string, value: string): Promise<AnonDiscovered> {
-    const next = unsuppressValue(await this.load(caseId), value);
-    await this.save(caseId, next);
-    return next;
+  unsuppress(caseId: string, value: string): Promise<AnonDiscovered> {
+    return discoveredLock.runExclusive(caseId, async () => {
+      const next = unsuppressValue(await this.load(caseId), value);
+      await this.save(caseId, next);
+      return next;
+    });
   }
 }

--- a/companion/src/analysis/assetOverrides.ts
+++ b/companion/src/analysis/assetOverrides.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import type { AssetType, AssetGraph, GraphAsset, GraphIoc, AssetGraphEdge } from "./assetGraph.js";
 import { SEVERITY_RANK, worstSeverity } from "./stateTypes.js";
 
@@ -162,6 +163,13 @@ export function applyAssetOverrides(graph: AssetGraph, overrides: AssetOverrides
   return { assets, iocs, edges };
 }
 
+// Serializes a case's load->modify->save section on asset-overrides.json (follow-up to #682). Every
+// method here rewrites the WHOLE override document — renames, manual assets, suppressions, link
+// edits and merges all live in one object — so two analysts tidying two different corners of the
+// asset graph at the same time discard each other's work wholesale, not just the field they touched.
+// MODULE-level: the app builds this store twice (runtimeStores.ts and aiProviders.ts).
+const assetOverridesLock = new StateLock();
+
 export class AssetOverridesStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -178,20 +186,27 @@ export class AssetOverridesStore {
     }
   }
 
+  // Every mutation runs through here, so no method can forget the lock.
+  private mutate<T>(caseId: string, fn: () => Promise<T>): Promise<T> {
+    return assetOverridesLock.runExclusive(caseId, fn);
+  }
+
   private async save(caseId: string, overrides: AssetOverrides): Promise<void> {
     await atomicWrite(this.path(caseId), JSON.stringify(overrides, null, 2));
   }
 
   // Set (or clear) a display-name override for an asset. An empty name clears the rename.
-  async rename(caseId: string, assetId: string, name: string): Promise<AssetOverrides> {
-    const ov = await this.load(caseId);
-    const trimmed = name.trim();
-    const renames = { ...ov.renames };
-    if (trimmed) renames[assetId] = trimmed;
-    else delete renames[assetId];
-    const next = { ...ov, renames };
-    await this.save(caseId, next);
-    return next;
+  rename(caseId: string, assetId: string, name: string): Promise<AssetOverrides> {
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      const trimmed = name.trim();
+      const renames = { ...ov.renames };
+      if (trimmed) renames[assetId] = trimmed;
+      else delete renames[assetId];
+      const next = { ...ov, renames };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
   // Add a manually created asset. Returns the created asset + updated overrides.
@@ -202,72 +217,85 @@ export class AssetOverridesStore {
   ): Promise<{ overrides: AssetOverrides; asset: ManualAsset }> {
     const name = input.name.trim();
     if (!name) throw new Error("name is required");
-    const ov = await this.load(caseId);
-    const asset: ManualAsset = { id: `manual:${randomUUID()}`, name, type: input.type };
-    const next = { ...ov, added: [...ov.added, asset] };
-    await this.save(caseId, next);
-    return { overrides: next, asset };
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      const asset: ManualAsset = { id: `manual:${randomUUID()}`, name, type: input.type };
+      const next = { ...ov, added: [...ov.added, asset] };
+      await this.save(caseId, next);
+      return { overrides: next, asset };
+    });
   }
 
   // Remove an asset: deletes from `added` if manual (also pruning any now-orphaned rename entry
   // for it — a deleted manual asset's id can never come back, so the rename would sit dead in
   // storage forever otherwise); pushes to `removed` if auto-derived (its rename is kept — an
   // auto-derived id can reappear on a later synthesis, and the analyst's rename should still apply).
-  async removeAsset(caseId: string, assetId: string): Promise<AssetOverrides> {
-    const ov = await this.load(caseId);
-    if (assetId.startsWith("manual:")) {
-      const renames = { ...ov.renames };
-      delete renames[assetId];
-      const next = { ...ov, added: ov.added.filter((a) => a.id !== assetId), renames };
+  removeAsset(caseId: string, assetId: string): Promise<AssetOverrides> {
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      if (assetId.startsWith("manual:")) {
+        const renames = { ...ov.renames };
+        delete renames[assetId];
+        const next = { ...ov, added: ov.added.filter((a) => a.id !== assetId), renames };
+        await this.save(caseId, next);
+        return next;
+      }
+      const next = { ...ov, removed: [...new Set([...ov.removed, assetId])] };
       await this.save(caseId, next);
       return next;
-    }
-    const next = { ...ov, removed: [...new Set([...ov.removed, assetId])] };
-    await this.save(caseId, next);
-    return next;
+    });
   }
 
   // Restore a suppressed auto-derived asset (remove it from the `removed` list).
-  async restoreAsset(caseId: string, assetId: string): Promise<AssetOverrides> {
-    const ov = await this.load(caseId);
-    const next = { ...ov, removed: ov.removed.filter((id) => id !== assetId) };
-    await this.save(caseId, next);
-    return next;
+  restoreAsset(caseId: string, assetId: string): Promise<AssetOverrides> {
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      const next = { ...ov, removed: ov.removed.filter((id) => id !== assetId) };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
   // Add a manual link between an asset and an IoC. Idempotent; also un-suppresses the pair.
-  async addLink(caseId: string, asset: string, ioc: string): Promise<AssetOverrides> {
-    const ov = await this.load(caseId);
-    const alreadyAdded = ov.addedLinks.some((l) => l.asset === asset && l.ioc === ioc);
-    const addedLinks = alreadyAdded ? ov.addedLinks : [...ov.addedLinks, { asset, ioc }];
-    const removedLinks = ov.removedLinks.filter((l) => !(l.asset === asset && l.ioc === ioc));
-    const next = { ...ov, addedLinks, removedLinks };
-    await this.save(caseId, next);
-    return next;
+  addLink(caseId: string, asset: string, ioc: string): Promise<AssetOverrides> {
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      const alreadyAdded = ov.addedLinks.some((l) => l.asset === asset && l.ioc === ioc);
+      const addedLinks = alreadyAdded ? ov.addedLinks : [...ov.addedLinks, { asset, ioc }];
+      const removedLinks = ov.removedLinks.filter((l) => !(l.asset === asset && l.ioc === ioc));
+      const next = { ...ov, addedLinks, removedLinks };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
   // Suppress (or delete) a link. If it was a manual addition, removes from addedLinks;
   // otherwise adds to removedLinks so the auto-derived edge is hidden. Idempotent.
-  async removeLink(caseId: string, asset: string, ioc: string): Promise<AssetOverrides> {
-    const ov = await this.load(caseId);
-    const wasManual = ov.addedLinks.some((l) => l.asset === asset && l.ioc === ioc);
-    const addedLinks = ov.addedLinks.filter((l) => !(l.asset === asset && l.ioc === ioc));
-    const alreadyRemoved = ov.removedLinks.some((l) => l.asset === asset && l.ioc === ioc);
-    const removedLinks = wasManual || alreadyRemoved ? ov.removedLinks : [...ov.removedLinks, { asset, ioc }];
-    const next = { ...ov, addedLinks, removedLinks };
-    await this.save(caseId, next);
-    return next;
+  removeLink(caseId: string, asset: string, ioc: string): Promise<AssetOverrides> {
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      const wasManual = ov.addedLinks.some((l) => l.asset === asset && l.ioc === ioc);
+      const addedLinks = ov.addedLinks.filter((l) => !(l.asset === asset && l.ioc === ioc));
+      const alreadyRemoved = ov.removedLinks.some((l) => l.asset === asset && l.ioc === ioc);
+      const removedLinks =
+        wasManual || alreadyRemoved ? ov.removedLinks : [...ov.removedLinks, { asset, ioc }];
+      const next = { ...ov, addedLinks, removedLinks };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
   // Restore a suppressed auto-derived link (remove it from removedLinks).
-  async restoreLink(caseId: string, asset: string, ioc: string): Promise<AssetOverrides> {
-    const ov = await this.load(caseId);
-    const next = {
-      ...ov,
-      removedLinks: ov.removedLinks.filter((l) => !(l.asset === asset && l.ioc === ioc)),
-    };
-    await this.save(caseId, next);
-    return next;
+  restoreLink(caseId: string, asset: string, ioc: string): Promise<AssetOverrides> {
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      const next = {
+        ...ov,
+        removedLinks: ov.removedLinks.filter((l) => !(l.asset === asset && l.ioc === ioc)),
+      };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
   // Merge a duplicate asset onto a canonical one (#82): folds its IOC/finding/event links onto
@@ -276,20 +304,24 @@ export class AssetOverridesStore {
   // undefined, so the store refuses rather than silently corrupting it.
   async mergeAsset(caseId: string, fromId: string, intoId: string): Promise<AssetOverrides> {
     if (fromId === intoId) throw new Error("cannot merge an asset into itself");
-    const ov = await this.load(caseId);
-    if (resolveCanonical(intoId, ov.merges) === fromId) throw new Error("merge would create a cycle");
-    const next = { ...ov, merges: { ...ov.merges, [fromId]: intoId } };
-    await this.save(caseId, next);
-    return next;
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      if (resolveCanonical(intoId, ov.merges) === fromId) throw new Error("merge would create a cycle");
+      const next = { ...ov, merges: { ...ov.merges, [fromId]: intoId } };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
   // Un-merge: remove a duplicate id from the merge map so it reappears as its own node.
-  async unmergeAsset(caseId: string, fromId: string): Promise<AssetOverrides> {
-    const ov = await this.load(caseId);
-    const merges = { ...ov.merges };
-    delete merges[fromId];
-    const next = { ...ov, merges };
-    await this.save(caseId, next);
-    return next;
+  unmergeAsset(caseId: string, fromId: string): Promise<AssetOverrides> {
+    return this.mutate(caseId, async () => {
+      const ov = await this.load(caseId);
+      const merges = { ...ov.merges };
+      delete merges[fromId];
+      const next = { ...ov, merges };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 }

--- a/companion/src/analysis/findingWorkflow.ts
+++ b/companion/src/analysis/findingWorkflow.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 
 // Analyst assignment + workflow status for findings (#87). A finding carries an AI-set tri-state
 // `status` (open/confirmed/dismissed, `stateTypes.ts`) but no HUMAN owner and no analyst-editable
@@ -42,6 +43,13 @@ export interface FindingWorkflowPatch {
   updatedBy?: string;
 }
 
+// Serializes a case's load->modify->save section on finding-workflow.json (follow-up to #682). The
+// whole file is rewritten on every patch, so a lead assigning one finding while an analyst sets the
+// status of another discards whichever save landed first — and the triage board then shows a
+// finding as unowned that somebody has already taken. Two routes reach this (routes/findings.ts and
+// routes/cockpit.ts), which is exactly the traffic that collides. Keyed by case id.
+const workflowLock = new StateLock();
+
 export class FindingWorkflowStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -73,7 +81,14 @@ export class FindingWorkflowStore {
   ): Promise<FindingWorkflow | null> {
     const id = String(findingId ?? "").trim();
     if (!id) throw new Error("findingId is required");
+    return workflowLock.runExclusive(caseId, () => this.applyPatch(caseId, id, patch));
+  }
 
+  private async applyPatch(
+    caseId: string,
+    id: string,
+    patch: FindingWorkflowPatch,
+  ): Promise<FindingWorkflow | null> {
     const records = await this.load(caseId);
     const existing = records.find((r) => r.findingId === id);
 

--- a/companion/src/analysis/hostDuplicateDismissals.ts
+++ b/companion/src/analysis/hostDuplicateDismissals.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import { canonicalHostName } from "./hostAlias.js";
 
 // Pairs the analyst has judged to be genuinely DIFFERENT machines, so the merge gate stops asking
@@ -31,6 +32,13 @@ export function dismissalKey(canonical: string, other: string): string {
   return `${canonicalHostName(canonical)}|${canonicalHostName(other)}`;
 }
 
+// Serializes a case's load->modify->save section on host-duplicate-dismissals.json (follow-up to
+// #682). Losing one of these re-arms the merge gate on a pair an analyst already judged to be two
+// genuinely different machines, and the gate blocks synthesis — so the lost write does not merely
+// forget a decision, it stalls the case until somebody makes the same call again. MODULE-level: the
+// app builds this store twice (runtimeStores.ts and aiProviders.ts).
+const hostDuplicateLock = new StateLock();
+
 export class HostDuplicateDismissalStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -49,17 +57,19 @@ export class HostDuplicateDismissalStore {
 
   // Idempotent: re-dismissing a pair keeps the FIRST decision, so the recorded timestamp and
   // analyst stay the ones who actually made the call.
-  async append(caseId: string, d: HostDuplicateDismissal): Promise<HostDuplicateDismissal[]> {
-    const existing = await this.load(caseId);
-    const normalized: HostDuplicateDismissal = {
-      ...d,
-      canonical: canonicalHostName(d.canonical),
-      other: canonicalHostName(d.other),
-    };
-    const key = dismissalKey(normalized.canonical, normalized.other);
-    if (existing.some((e) => dismissalKey(e.canonical, e.other) === key)) return existing;
-    const next = [...existing, normalized];
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return next;
+  append(caseId: string, d: HostDuplicateDismissal): Promise<HostDuplicateDismissal[]> {
+    return hostDuplicateLock.runExclusive(caseId, async () => {
+      const existing = await this.load(caseId);
+      const normalized: HostDuplicateDismissal = {
+        ...d,
+        canonical: canonicalHostName(d.canonical),
+        other: canonicalHostName(d.other),
+      };
+      const key = dismissalKey(normalized.canonical, normalized.other);
+      if (existing.some((e) => dismissalKey(e.canonical, e.other) === key)) return existing;
+      const next = [...existing, normalized];
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return next;
+    });
   }
 }

--- a/companion/src/analysis/iocAlias.ts
+++ b/companion/src/analysis/iocAlias.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 
 // Per-case IOC alias map (#82): duplicate IOC value (lowercased) -> canonical IOC id it was
 // merged into. Kept in `state/ioc-aliases.json`, NOT in InvestigationState, so re-synthesis never
@@ -22,6 +23,14 @@ export type IocAliasMap = z.infer<typeof iocAliasSchema>;
 export function emptyIocAliasMap(): IocAliasMap {
   return { aliases: {} };
 }
+
+// Serializes a case's load->modify->save section on ioc-aliases.json (follow-up to #682). Two
+// merges confirmed at the same moment both read the same map and the second save drops the first —
+// the un-merged duplicate then reappears as its own IOC on the next synthesis, which is the exact
+// outcome the alias map exists to prevent. MODULE-level: the app builds this store twice (the
+// routes' copy in runtimeStores.ts, synthesis's in aiProviders.ts). Only the routes' copy writes
+// today, but that is an invariant nothing enforces — anonDiscovered.ts is where it stopped holding.
+const aliasLock = new StateLock();
 
 export class IocAliasStore {
   constructor(private readonly cases: CaseStore) {}
@@ -45,20 +54,24 @@ export class IocAliasStore {
 
   // Record that `value` (the merged-away duplicate's value) should route onto `intoId` going
   // forward. Idempotent.
-  async add(caseId: string, value: string, intoId: string): Promise<IocAliasMap> {
-    const map = await this.load(caseId);
-    const next = { aliases: { ...map.aliases, [value.trim().toLowerCase()]: intoId } };
-    await this.save(caseId, next);
-    return next;
+  add(caseId: string, value: string, intoId: string): Promise<IocAliasMap> {
+    return aliasLock.runExclusive(caseId, async () => {
+      const map = await this.load(caseId);
+      const next = { aliases: { ...map.aliases, [value.trim().toLowerCase()]: intoId } };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 
   // Un-merge: stop auto-routing this value onto its former canonical IOC.
-  async remove(caseId: string, value: string): Promise<IocAliasMap> {
-    const map = await this.load(caseId);
-    const aliases = { ...map.aliases };
-    delete aliases[value.trim().toLowerCase()];
-    const next = { aliases };
-    await this.save(caseId, next);
-    return next;
+  remove(caseId: string, value: string): Promise<IocAliasMap> {
+    return aliasLock.runExclusive(caseId, async () => {
+      const map = await this.load(caseId);
+      const aliases = { ...map.aliases };
+      delete aliases[value.trim().toLowerCase()];
+      const next = { aliases };
+      await this.save(caseId, next);
+      return next;
+    });
   }
 }

--- a/companion/src/analysis/lateralPathDismiss.ts
+++ b/companion/src/analysis/lateralPathDismiss.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import type { CaseStore } from "../storage/caseStore.js";
 import type { LateralPath } from "./evidenceGraph.js";
 
@@ -87,6 +88,12 @@ export function buildDismissal(
 }
 
 // Per-case persistence, mirroring FalsePositiveStore: one JSON file in the case's state dir.
+// Serializes a case's load->modify->save section on lateral-path-dismissals.json (follow-up to
+// #682). Two analysts ruling out two different lateral-movement chains at the same moment both read
+// the same list and the second save discards the first — the dismissed chain returns to the graph
+// and the record shows nobody ruled it out. Keyed by case id, private to this file.
+const lateralDismissLock = new StateLock();
+
 export class LateralPathDismissStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -117,17 +124,21 @@ export class LateralPathDismissStore {
   async add(caseId: string, hostIds: readonly string[], note: string): Promise<LateralPathDismissal | null> {
     const record = buildDismissal(hostIds, note);
     if (!record) return null;
-    const existing = await this.load(caseId);
-    await this.save(caseId, [...existing.filter((d) => lateralPathKey(d.hostIds) !== record.key), record]);
-    return record;
+    return lateralDismissLock.runExclusive(caseId, async () => {
+      const existing = await this.load(caseId);
+      await this.save(caseId, [...existing.filter((d) => lateralPathKey(d.hostIds) !== record.key), record]);
+      return record;
+    });
   }
 
   // Restore a route by its key. Returns true when something was actually removed.
-  async remove(caseId: string, key: string): Promise<boolean> {
-    const existing = await this.load(caseId);
-    const remaining = existing.filter((d) => lateralPathKey(d.hostIds) !== key.trim().toLowerCase());
-    if (remaining.length === existing.length) return false;
-    await this.save(caseId, remaining);
-    return true;
+  remove(caseId: string, key: string): Promise<boolean> {
+    return lateralDismissLock.runExclusive(caseId, async () => {
+      const existing = await this.load(caseId);
+      const remaining = existing.filter((d) => lateralPathKey(d.hostIds) !== key.trim().toLowerCase());
+      if (remaining.length === existing.length) return false;
+      await this.save(caseId, remaining);
+      return true;
+    });
   }
 }

--- a/companion/src/analysis/learnedPatternStore.ts
+++ b/companion/src/analysis/learnedPatternStore.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import type { CaseStore } from "../storage/caseStore.js";
 import { mergeLearnedPattern, type LearnedPattern, type LearnedPatternInput } from "./learnedPatterns.js";
 
@@ -8,6 +9,14 @@ import { mergeLearnedPattern, type LearnedPattern, type LearnedPatternInput } fr
 // A stateless wrapper over CaseStore (mirrors FalsePositiveStore) so a fresh instance reads/writes the same
 // file. record() is the single mutation: it distils one reasoned dismissal through the pure merge core and
 // persists only when something changed.
+// Serializes a case's load->modify->save section on learned-patterns.json (follow-up to #682). A
+// bulk dismissal calls record() once per finding, so a single analyst action is already a burst of
+// read-modify-writes against one file; a second request landing inside that burst loses whatever it
+// overlapped. What is lost is not a row but a REASON, and later synthesis is what consumes it — so
+// the case silently stops learning from a dismissal the analyst did explain. MODULE-level: the app
+// builds this store twice (runtimeStores.ts and aiProviders.ts).
+const learnedPatternLock = new StateLock();
+
 export class LearnedPatternStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -30,14 +39,36 @@ export class LearnedPatternStore {
 
   // Record one reasoned dismissal. Returns the updated ledger (persisted only when it actually changed —
   // an opaque/too-short signature is a no-op). `now` is injectable for deterministic tests.
-  async record(
+  record(
     caseId: string,
     input: LearnedPatternInput,
     now: string = new Date().toISOString(),
   ): Promise<LearnedPattern[]> {
-    const existing = await this.load(caseId);
-    const { patterns, changed } = mergeLearnedPattern(existing, input, now);
-    if (changed) await this.save(caseId, patterns);
-    return patterns;
+    return this.recordMany(caseId, [input], now);
+  }
+
+  // Record a whole batch in ONE load->merge->save. Dismissing forty findings used to call record()
+  // forty times, so a single analyst action re-read and rewrote the entire ledger forty times over —
+  // work that grows with the case, for one click. Folding the batch in memory makes it one write,
+  // and it also means a bulk dismissal takes the lock once instead of contending with itself.
+  // Persists only when the batch actually changed something (an opaque or too-short signature is a
+  // no-op, exactly as it is for a single record).
+  recordMany(
+    caseId: string,
+    inputs: readonly LearnedPatternInput[],
+    now: string = new Date().toISOString(),
+  ): Promise<LearnedPattern[]> {
+    if (inputs.length === 0) return this.load(caseId);
+    return learnedPatternLock.runExclusive(caseId, async () => {
+      let patterns: LearnedPattern[] = await this.load(caseId);
+      let changed = false;
+      for (const input of inputs) {
+        const merged = mergeLearnedPattern(patterns, input, now);
+        patterns = merged.patterns;
+        changed = changed || merged.changed;
+      }
+      if (changed) await this.save(caseId, patterns);
+      return patterns;
+    });
   }
 }

--- a/companion/src/analysis/nsrlStore.ts
+++ b/companion/src/analysis/nsrlStore.ts
@@ -2,6 +2,7 @@ import { readFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import { normalizeHash, parseNsrlText } from "./nsrl.js";
 
 // Persists the NSRL known-good hash set (issue #63). GLOBAL — shared across cases, like the IOC
@@ -12,6 +13,12 @@ import { normalizeHash, parseNsrlText } from "./nsrl.js";
 //
 // The in-memory Set is cached after first load and invalidated on every mutation, so the per-import
 // auto-apply sweep doesn't re-read (and re-parse) the file each time.
+// Serializes the load->union->persist section on the known-good hash set (follow-up to #682). Two
+// RDS imports running together keep only one, so hashes the operator believes are suppressed are
+// not — the failure direction is extra noise rather than a missed detection, but it is silent.
+// GLOBAL store, keyed by the file path.
+const nsrlLock = new StateLock();
+
 export class NsrlStore {
   private cache: Set<string> | null = null;
 
@@ -50,18 +57,20 @@ export class NsrlStore {
 
   // Union new hashes into the set. Normalizes + dedups; only valid hashes are kept. Returns how many
   // were NEW and the resulting total. No-op write when nothing new (keeps re-imports cheap).
-  async addMany(hashes: readonly string[]): Promise<{ added: number; total: number }> {
-    const set = new Set(await this.load());
-    let added = 0;
-    for (const h of hashes) {
-      const n = normalizeHash(h);
-      if (n && !set.has(n)) {
-        set.add(n);
-        added++;
+  addMany(hashes: readonly string[]): Promise<{ added: number; total: number }> {
+    return nsrlLock.runExclusive(this.file, async () => {
+      const set = new Set(await this.load());
+      let added = 0;
+      for (const h of hashes) {
+        const n = normalizeHash(h);
+        if (n && !set.has(n)) {
+          set.add(n);
+          added++;
+        }
       }
-    }
-    if (added > 0) await this.persist(set);
-    return { added, total: set.size };
+      if (added > 0) await this.persist(set);
+      return { added, total: set.size };
+    });
   }
 
   // Wipe the set (e.g. to swap in a different RDS release).

--- a/companion/src/analysis/slashCommandStore.ts
+++ b/companion/src/analysis/slashCommandStore.ts
@@ -2,6 +2,7 @@ import { readFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { z } from "zod";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 
 // Per-channel case binding store for the war-room slash-command bot (#235). A channel can bind
 // to a default case (`/dfir bind <caseId>`) so subsequent commands omit the caseId. Stored in a
@@ -18,6 +19,12 @@ const bindingSchema = z.object({
 const bindingsFileSchema = z.record(z.string(), bindingSchema).catch({});
 
 export type ChannelBindingMap = Record<string, { caseId: string; boundAt: string }>;
+
+// Serializes the loadAll->modify->write section on the chat-binding file (follow-up to #682). The
+// bindings are one JSON object, so two chats bound at the same moment lose one — and the war-room
+// bot then answers that chat about the wrong case, or about no case at all. GLOBAL store, so the
+// lock is keyed by the file path.
+const slashCommandLock = new StateLock();
 
 export class SlashCommandChannelStore {
   constructor(private readonly file: string) {}
@@ -44,24 +51,28 @@ export class SlashCommandChannelStore {
     await atomicWrite(this.file, JSON.stringify(map, null, 2));
   }
 
-  async bind(
+  bind(
     key: string,
     caseId: string,
     at: string = new Date().toISOString(),
   ): Promise<{ caseId: string; boundAt: string }> {
-    const all = await this.loadAll();
-    const next = { ...all, [key]: { caseId, boundAt: at } };
-    await this.write(next);
-    return next[key];
+    return slashCommandLock.runExclusive(this.file, async () => {
+      const all = await this.loadAll();
+      const next = { ...all, [key]: { caseId, boundAt: at } };
+      await this.write(next);
+      return next[key];
+    });
   }
 
-  async unbind(key: string): Promise<boolean> {
-    const all = await this.loadAll();
-    if (!(key in all)) return false;
-    const next = { ...all };
-    delete next[key];
-    await this.write(next);
-    return true;
+  unbind(key: string): Promise<boolean> {
+    return slashCommandLock.runExclusive(this.file, async () => {
+      const all = await this.loadAll();
+      if (!(key in all)) return false;
+      const next = { ...all };
+      delete next[key];
+      await this.write(next);
+      return true;
+    });
   }
 }
 

--- a/companion/src/analysis/synthMeta.ts
+++ b/companion/src/analysis/synthMeta.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import type { FindingsDiff } from "./findingsDiff.js";
 
 // Lightweight per-case record of the LAST synthesis run: when it actually ran (the AI call, not a
@@ -209,6 +210,16 @@ export function modelPerfLabel(m: ModelPerfSnapshot): string | null {
   return parts.length ? parts.join(" ") : null;
 }
 
+// Serializes every write to a case's synth-meta (follow-up to #682). record() REPLACES the document
+// while recordSecondLook/recordSecondOpinionPerf load-merge-save onto it, and those two are ordered
+// by comment ("called AFTER the sweep... so it merges onto the latest record() write") rather than
+// by anything enforcing it. A record() landing between a merge method's load and its save is
+// silently undone. That is not just a stale timestamp: reportWriter.ts reads secondLook.leads and
+// coverage straight out of this file, so a lost merge drops second-look leads from the REPORT.
+// MODULE-level: the app builds this store twice (runtimeStores.ts and aiProviders.ts), and the two
+// paths that collide here are exactly synthesis and an on-demand route.
+const synthMetaLock = new StateLock();
+
 export class SynthMetaStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -227,34 +238,40 @@ export class SynthMetaStore {
 
   // Record a completed synthesis run: stamp the time, store the findings diff, and
   // optionally store performance metrics (duration, event/IOC counts).
-  async record(
+  record(
     caseId: string,
     diff: FindingsDiff,
     at: string = new Date().toISOString(),
     perf?: SynthPerfMetrics,
   ): Promise<SynthMeta> {
-    const meta: SynthMeta = { lastSynthesizedAt: at, lastDiff: diff, ...perf };
-    await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
-    return meta;
+    return synthMetaLock.runExclusive(caseId, async () => {
+      const meta: SynthMeta = { lastSynthesizedAt: at, lastDiff: diff, ...perf };
+      await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
+      return meta;
+    });
   }
 
   // Stamp the second-look sweep result onto the CURRENT synth-meta (#11). Called AFTER the sweep and its
   // (optional) re-synthesis, so it merges onto the latest record() write instead of being clobbered by
   // it. Load-merge-save so the rest of the meta (time/diff/perf) is preserved. `null` clears it.
-  async recordSecondLook(caseId: string, secondLook: SecondLookMeta | null): Promise<SynthMeta> {
-    const cur = await this.load(caseId);
-    const meta: SynthMeta = { ...cur, secondLook };
-    await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
-    return meta;
+  recordSecondLook(caseId: string, secondLook: SecondLookMeta | null): Promise<SynthMeta> {
+    return synthMetaLock.runExclusive(caseId, async () => {
+      const cur = await this.load(caseId);
+      const meta: SynthMeta = { ...cur, secondLook };
+      await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
+      return meta;
+    });
   }
 
   // Stamp a second-opinion agreement snapshot onto the CURRENT synth-meta (#74). Same load-merge-save
   // shape as recordSecondLook: secondOpinion() runs on demand (not as part of every synthesize() call),
   // so this must merge onto whatever the last record() wrote rather than replace it. `null` clears it.
-  async recordSecondOpinionPerf(caseId: string, perf: SecondOpinionPerf | null): Promise<SynthMeta> {
-    const cur = await this.load(caseId);
-    const meta: SynthMeta = { ...cur, secondOpinionPerf: perf };
-    await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
-    return meta;
+  recordSecondOpinionPerf(caseId: string, perf: SecondOpinionPerf | null): Promise<SynthMeta> {
+    return synthMetaLock.runExclusive(caseId, async () => {
+      const cur = await this.load(caseId);
+      const meta: SynthMeta = { ...cur, secondOpinionPerf: perf };
+      await atomicWrite(this.path(caseId), JSON.stringify(meta, null, 2));
+      return meta;
+    });
   }
 }

--- a/companion/src/analysis/veloHuntStore.ts
+++ b/companion/src/analysis/veloHuntStore.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import type { Severity } from "./stateTypes.js";
 import type { HuntTarget, SkippedArtifact } from "../integrations/velociraptor/velociraptorApi.js";
 
@@ -127,6 +128,11 @@ export function superOnlyHunt(job: VeloHuntJob, bundleFlag: boolean | undefined)
 // Cap retained jobs per case (newest first) so the side file stays small — old terminal jobs drop off.
 const MAX_JOBS = 12;
 
+// Serializes a case's list->modify->save section on the hunt-job file (follow-up to #682). Two
+// hunts launched together both read the same list and the second save drops the first, so a hunt
+// that IS running on the fleet has no record here — the analyst cannot see or collect it.
+const veloHuntLock = new StateLock();
+
 export class VeloHuntStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -154,11 +160,13 @@ export class VeloHuntStore {
   }
 
   // Add a new job (prepended) or update an existing one IN PLACE (matched by huntId), capping history.
-  async upsert(caseId: string, job: VeloHuntJob): Promise<VeloHuntJob> {
-    const jobs = await this.list(caseId);
-    const idx = jobs.findIndex((j) => j.huntId === job.huntId);
-    const next = idx >= 0 ? jobs.map((j, i) => (i === idx ? job : j)) : [job, ...jobs].slice(0, MAX_JOBS);
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return job;
+  upsert(caseId: string, job: VeloHuntJob): Promise<VeloHuntJob> {
+    return veloHuntLock.runExclusive(caseId, async () => {
+      const jobs = await this.list(caseId);
+      const idx = jobs.findIndex((j) => j.huntId === job.huntId);
+      const next = idx >= 0 ? jobs.map((j, i) => (i === idx ? job : j)) : [job, ...jobs].slice(0, MAX_JOBS);
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return job;
+    });
   }
 }

--- a/companion/src/analysis/veloMonitorStore.ts
+++ b/companion/src/analysis/veloMonitorStore.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CaseStore } from "../storage/caseStore.js";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import type { Severity } from "./stateTypes.js";
 
 // Per-case record of live Velociraptor CLIENT_EVENT monitors (#84). Each monitor watches one client
@@ -40,6 +41,10 @@ export function monitorId(clientId: string, artifact: string): string {
   return `${clientId}__${artifact}`;
 }
 
+// Serializes a case's list->modify->save section on the monitor file (follow-up to #682). A lost
+// upsert leaves a monitor armed on the server with no local record, so nothing can later stop it.
+const veloMonitorLock = new StateLock();
+
 export class VeloMonitorStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -65,22 +70,26 @@ export class VeloMonitorStore {
   }
 
   // Add a new monitor (appended) or update an existing one in place (matched by id), capping history.
-  async upsert(caseId: string, monitor: VeloMonitor): Promise<VeloMonitor> {
-    const monitors = await this.list(caseId);
-    const idx = monitors.findIndex((m) => m.id === monitor.id);
-    const next =
-      idx >= 0
-        ? monitors.map((m, i) => (i === idx ? monitor : m))
-        : [...monitors, monitor].slice(-MAX_MONITORS);
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return monitor;
+  upsert(caseId: string, monitor: VeloMonitor): Promise<VeloMonitor> {
+    return veloMonitorLock.runExclusive(caseId, async () => {
+      const monitors = await this.list(caseId);
+      const idx = monitors.findIndex((m) => m.id === monitor.id);
+      const next =
+        idx >= 0
+          ? monitors.map((m, i) => (i === idx ? monitor : m))
+          : [...monitors, monitor].slice(-MAX_MONITORS);
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return monitor;
+    });
   }
 
-  async remove(caseId: string, id: string): Promise<void> {
-    const monitors = await this.list(caseId);
-    const next = monitors.filter((m) => m.id !== id);
-    if (next.length !== monitors.length) {
-      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    }
+  remove(caseId: string, id: string): Promise<void> {
+    return veloMonitorLock.runExclusive(caseId, async () => {
+      const monitors = await this.list(caseId);
+      const next = monitors.filter((m) => m.id !== id);
+      if (next.length !== monitors.length) {
+        await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      }
+    });
   }
 }

--- a/companion/src/integrations/clickup/clickupExportStore.ts
+++ b/companion/src/integrations/clickup/clickupExportStore.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../../storage/caseStore.js";
 import { atomicWrite } from "../../storage/atomicWrite.js";
+import { StateLock } from "../../analysis/stateLock.js";
 
 // Per-case memory of the LAST ClickUp export: the target list and the map from each playbook task
 // id → the ClickUp task id we created for it. On re-export this lets us UPDATE the existing ClickUp
@@ -21,6 +22,13 @@ export type ClickUpExport = z.infer<typeof clickupExportSchema>;
 
 const EMPTY: ClickUpExport = { listId: "", taskIds: {}, lastTaskUrl: "", lastExportedAt: "" };
 
+// Serializes a case's load->merge->save section on the export pointer file (follow-up to #682). The
+// ticket references live in one map, so two exports of the same case running together drop one
+// side's refs — and because a missing ref is how this store says "no ticket exists yet", the NEXT
+// export opens a DUPLICATE ticket in somebody else's queue. That is the rare one in this class with
+// a consequence outside the tool.
+const clickupExportLock = new StateLock();
+
 export class ClickUpExportStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -38,10 +46,16 @@ export class ClickUpExportStore {
   }
 
   // Persist the latest export pointer (merged over whatever was there before).
-  async record(caseId: string, patch: Partial<ClickUpExport>): Promise<ClickUpExport> {
-    const prev = await this.load(caseId);
-    const next: ClickUpExport = { ...prev, ...patch, taskIds: { ...prev.taskIds, ...(patch.taskIds ?? {}) } };
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return next;
+  record(caseId: string, patch: Partial<ClickUpExport>): Promise<ClickUpExport> {
+    return clickupExportLock.runExclusive(caseId, async () => {
+      const prev = await this.load(caseId);
+      const next: ClickUpExport = {
+        ...prev,
+        ...patch,
+        taskIds: { ...prev.taskIds, ...(patch.taskIds ?? {}) },
+      };
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return next;
+    });
   }
 }

--- a/companion/src/integrations/jira/jiraExportStore.ts
+++ b/companion/src/integrations/jira/jiraExportStore.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../../storage/caseStore.js";
 import { atomicWrite } from "../../storage/atomicWrite.js";
+import { StateLock } from "../../analysis/stateLock.js";
 import type { JiraIssueRef } from "./jiraClient.js";
 
 // Per-case memory of the finding → Jira issue keys we created. On re-export this lets us update
@@ -18,6 +19,13 @@ const jiraExportSchema = z.object({
 export type JiraExport = z.infer<typeof jiraExportSchema>;
 
 const EMPTY: JiraExport = { issueRefs: {}, lastExportedAt: "" };
+
+// Serializes a case's load->merge->save section on the export pointer file (follow-up to #682). The
+// ticket references live in one map, so two exports of the same case running together drop one
+// side's refs — and because a missing ref is how this store says "no ticket exists yet", the NEXT
+// export opens a DUPLICATE ticket in somebody else's queue. That is the rare one in this class with
+// a consequence outside the tool.
+const jiraExportLock = new StateLock();
 
 export class JiraExportStore {
   constructor(private readonly cases: CaseStore) {}
@@ -35,14 +43,16 @@ export class JiraExportStore {
     }
   }
 
-  async record(caseId: string, refs: Record<string, JiraIssueRef>, now?: string): Promise<JiraExport> {
-    const prev = await this.load(caseId);
-    const next: JiraExport = {
-      issueRefs: { ...prev.issueRefs, ...refs },
-      lastExportedAt: now ?? new Date().toISOString(),
-    };
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return next;
+  record(caseId: string, refs: Record<string, JiraIssueRef>, now?: string): Promise<JiraExport> {
+    return jiraExportLock.runExclusive(caseId, async () => {
+      const prev = await this.load(caseId);
+      const next: JiraExport = {
+        issueRefs: { ...prev.issueRefs, ...refs },
+        lastExportedAt: now ?? new Date().toISOString(),
+      };
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return next;
+    });
   }
 
   // Alias matching the structural store interface used by jiraPush.ts.

--- a/companion/src/integrations/mcp/mcpServerStore.ts
+++ b/companion/src/integrations/mcp/mcpServerStore.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { dirname, basename } from "node:path";
 import { z } from "zod";
 import { atomicWrite } from "../../storage/atomicWrite.js";
+import { StateLock } from "../../analysis/stateLock.js";
 
 // POLICY for the MCP servers Claude Code is configured with (#296).
 //
@@ -173,6 +174,11 @@ function fromInput(input: McpServerInput, id: string): McpServer {
   };
 }
 
+// Serializes the load->modify->save section on the server list (follow-up to #682). The list is one
+// JSON array, so adding a server while another is being removed drops one of the two edits — and a
+// server the operator believes is configured simply is not. GLOBAL store, keyed by the file path.
+const mcpServerLock = new StateLock();
+
 export class McpServerStore {
   constructor(private readonly file: string) {}
 
@@ -212,43 +218,49 @@ export class McpServerStore {
     const deliveryError = validateDelivery(server.delivery);
     if (deliveryError) throw new Error(deliveryError);
 
-    const list = await this.load();
-    const next = list.some((s) => s.id === id)
-      ? list.map((s) => (s.id === id ? server : s))
-      : [...list, server];
-    await this.save(next);
-    return server;
+    return mcpServerLock.runExclusive(this.file, async () => {
+      const list = await this.load();
+      const next = list.some((s) => s.id === id)
+        ? list.map((s) => (s.id === id ? server : s))
+        : [...list, server];
+      await this.save(next);
+      return server;
+    });
   }
 
   async update(id: string, patch: Partial<McpServerInput>): Promise<McpServer | null> {
-    const list = await this.load();
-    const cur = list.find((s) => s.id === id);
-    if (!cur) return null;
-    const merged = fromInput(
-      {
+    return mcpServerLock.runExclusive(this.file, async () => {
+      const list = await this.load();
+      const cur = list.find((s) => s.id === id);
+      if (!cur) return null;
+      const merged = fromInput(
+        {
+          id,
+          label: patch.label ?? cur.label,
+          enabled: patch.enabled ?? cur.enabled,
+          allowedTools: patch.allowedTools ?? cur.allowedTools,
+          allowedCommands: patch.allowedCommands ?? cur.allowedCommands,
+          agentEnabled: patch.agentEnabled ?? cur.agentEnabled,
+          timeoutMs: patch.timeoutMs ?? cur.timeoutMs,
+          // Merged field-wise so changing one delivery setting does not reset the rest to defaults.
+          delivery: { ...cur.delivery, ...(patch.delivery ?? {}) },
+        },
         id,
-        label: patch.label ?? cur.label,
-        enabled: patch.enabled ?? cur.enabled,
-        allowedTools: patch.allowedTools ?? cur.allowedTools,
-        allowedCommands: patch.allowedCommands ?? cur.allowedCommands,
-        agentEnabled: patch.agentEnabled ?? cur.agentEnabled,
-        timeoutMs: patch.timeoutMs ?? cur.timeoutMs,
-        // Merged field-wise so changing one delivery setting does not reset the rest to defaults.
-        delivery: { ...cur.delivery, ...(patch.delivery ?? {}) },
-      },
-      id,
-    );
-    const deliveryError = validateDelivery(merged.delivery);
-    if (deliveryError) throw new Error(deliveryError);
-    await this.save(list.map((s) => (s.id === id ? merged : s)));
-    return merged;
+      );
+      const deliveryError = validateDelivery(merged.delivery);
+      if (deliveryError) throw new Error(deliveryError);
+      await this.save(list.map((s) => (s.id === id ? merged : s)));
+      return merged;
+    });
   }
 
   async remove(id: string): Promise<boolean> {
-    const list = await this.load();
-    const next = list.filter((s) => s.id !== id);
-    if (next.length === list.length) return false;
-    await this.save(next);
-    return true;
+    return mcpServerLock.runExclusive(this.file, async () => {
+      const list = await this.load();
+      const next = list.filter((s) => s.id !== id);
+      if (next.length === list.length) return false;
+      await this.save(next);
+      return true;
+    });
   }
 }

--- a/companion/src/integrations/notion/notionExportStore.ts
+++ b/companion/src/integrations/notion/notionExportStore.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../../storage/caseStore.js";
 import { atomicWrite } from "../../storage/atomicWrite.js";
+import { StateLock } from "../../analysis/stateLock.js";
 
 // Per-case memory of the LAST Notion export: which page we wrote to and the id of the single
 // managed container block we own on it. Unlike IRIS/Timesketch (which we can find-by-name on
@@ -35,6 +36,13 @@ const EMPTY: NotionExport = {
   lastMode: "",
 };
 
+// Serializes a case's load->merge->save section on the export pointer file (follow-up to #682). The
+// ticket references live in one map, so two exports of the same case running together drop one
+// side's refs — and because a missing ref is how this store says "no ticket exists yet", the NEXT
+// export opens a DUPLICATE ticket in somebody else's queue. That is the rare one in this class with
+// a consequence outside the tool.
+const notionExportLock = new StateLock();
+
 export class NotionExportStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -52,10 +60,12 @@ export class NotionExportStore {
   }
 
   // Persist the latest export pointer (merged over whatever was there before).
-  async record(caseId: string, patch: Partial<NotionExport>): Promise<NotionExport> {
-    const prev = await this.load(caseId);
-    const next: NotionExport = { ...prev, ...patch };
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return next;
+  record(caseId: string, patch: Partial<NotionExport>): Promise<NotionExport> {
+    return notionExportLock.runExclusive(caseId, async () => {
+      const prev = await this.load(caseId);
+      const next: NotionExport = { ...prev, ...patch };
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return next;
+    });
   }
 }

--- a/companion/src/integrations/servicenow/servicenowExportStore.ts
+++ b/companion/src/integrations/servicenow/servicenowExportStore.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import type { CaseStore } from "../../storage/caseStore.js";
 import { atomicWrite } from "../../storage/atomicWrite.js";
+import { StateLock } from "../../analysis/stateLock.js";
 import type { ServiceNowIncidentRef } from "./servicenowClient.js";
 
 // Per-case memory of finding → ServiceNow incident numbers. Stored in `state/servicenow-export.json`.
@@ -17,6 +18,13 @@ const servicenowExportSchema = z.object({
 export type ServiceNowExport = z.infer<typeof servicenowExportSchema>;
 
 const EMPTY: ServiceNowExport = { incidentRefs: {}, lastExportedAt: "" };
+
+// Serializes a case's load->merge->save section on the export pointer file (follow-up to #682). The
+// ticket references live in one map, so two exports of the same case running together drop one
+// side's refs — and because a missing ref is how this store says "no ticket exists yet", the NEXT
+// export opens a DUPLICATE ticket in somebody else's queue. That is the rare one in this class with
+// a consequence outside the tool.
+const servicenowExportLock = new StateLock();
 
 export class ServiceNowExportStore {
   constructor(private readonly cases: CaseStore) {}
@@ -34,18 +42,20 @@ export class ServiceNowExportStore {
     }
   }
 
-  async record(
+  record(
     caseId: string,
     refs: Record<string, ServiceNowIncidentRef>,
     now?: string,
   ): Promise<ServiceNowExport> {
-    const prev = await this.load(caseId);
-    const next: ServiceNowExport = {
-      incidentRefs: { ...prev.incidentRefs, ...refs },
-      lastExportedAt: now ?? new Date().toISOString(),
-    };
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return next;
+    return servicenowExportLock.runExclusive(caseId, async () => {
+      const prev = await this.load(caseId);
+      const next: ServiceNowExport = {
+        incidentRefs: { ...prev.incidentRefs, ...refs },
+        lastExportedAt: now ?? new Date().toISOString(),
+      };
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return next;
+    });
   }
 
   // Alias matching the structural store interface used by servicenowPush.ts.

--- a/companion/src/integrations/socrates/socratesJobStore.ts
+++ b/companion/src/integrations/socrates/socratesJobStore.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { CaseStore } from "../../storage/caseStore.js";
 import { atomicWrite } from "../../storage/atomicWrite.js";
+import { StateLock } from "../../analysis/stateLock.js";
 
 // Per-case record of SO-CRATES analyses. Persisted to a side file (state/socrates-jobs.json) so a
 // server restart does not strand an in-flight analysis — the dashboard still shows it and the
@@ -25,6 +26,10 @@ export interface SocratesJob {
 
 const MAX_JOBS = 25;
 
+// Serializes a case's list->modify->save section on the job file (follow-up to #682). A lost upsert
+// leaves a submitted job with no local record, so its result is never collected.
+const socratesJobLock = new StateLock();
+
 export class SocratesJobStore {
   constructor(private readonly cases: CaseStore) {}
 
@@ -47,11 +52,13 @@ export class SocratesJobStore {
   }
 
   /** Add a job (prepended) or update an existing one in place, matched by jobId. */
-  async upsert(caseId: string, job: SocratesJob): Promise<SocratesJob> {
-    const jobs = await this.list(caseId);
-    const idx = jobs.findIndex((j) => j.jobId === job.jobId);
-    const next = idx >= 0 ? jobs.map((j, i) => (i === idx ? job : j)) : [job, ...jobs].slice(0, MAX_JOBS);
-    await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
-    return job;
+  upsert(caseId: string, job: SocratesJob): Promise<SocratesJob> {
+    return socratesJobLock.runExclusive(caseId, async () => {
+      const jobs = await this.list(caseId);
+      const idx = jobs.findIndex((j) => j.jobId === job.jobId);
+      const next = idx >= 0 ? jobs.map((j, i) => (i === idx ? job : j)) : [job, ...jobs].slice(0, MAX_JOBS);
+      await atomicWrite(this.path(caseId), JSON.stringify(next, null, 2));
+      return job;
+    });
   }
 }

--- a/companion/src/integrations/tools/customToolStore.ts
+++ b/companion/src/integrations/tools/customToolStore.ts
@@ -4,6 +4,7 @@ import { dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { atomicWrite } from "../../storage/atomicWrite.js";
+import { StateLock } from "../../analysis/stateLock.js";
 import type { ToolConfig } from "./toolConfig.js";
 
 // User-defined external tools (#211) — the extensible counterpart to the built-in Hayabusa/Velociraptor
@@ -110,6 +111,11 @@ function fromInput(input: CustomToolInput, id: string): CustomTool {
   };
 }
 
+// Serializes the load->modify->save section on the tool list (follow-up to #682). Same shape as
+// McpServerStore: one JSON array, so two edits at once keep only the later one and a registered
+// tool quietly is not. GLOBAL store, keyed by the file path.
+const customToolLock = new StateLock();
+
 export class CustomToolStore {
   constructor(private readonly file: string) {}
 
@@ -145,38 +151,46 @@ export class CustomToolStore {
     if (!binary) throw new Error("a binary path is required");
     const id = slugifyToolName(name);
     const tool = fromInput(input, id);
-    const list = await this.load();
-    const next = list.some((t) => t.id === id) ? list.map((t) => (t.id === id ? tool : t)) : [...list, tool];
-    await this.save(next);
-    return tool;
+    return customToolLock.runExclusive(this.file, async () => {
+      const list = await this.load();
+      const next = list.some((t) => t.id === id)
+        ? list.map((t) => (t.id === id ? tool : t))
+        : [...list, tool];
+      await this.save(next);
+      return tool;
+    });
   }
 
   async update(id: string, patch: Partial<CustomToolInput>): Promise<CustomTool | null> {
-    const list = await this.load();
-    const cur = list.find((t) => t.id === id);
-    if (!cur) return null;
-    const merged = fromInput(
-      {
-        name: patch.name ?? cur.name,
-        binary: patch.binary ?? cur.binary,
-        runArgs: patch.runArgs ?? cur.runArgs,
-        updateCommand: patch.updateCommand ?? cur.updateCommand,
-        extensions: patch.extensions ?? cur.extensions,
-        autoRun: patch.autoRun ?? cur.autoRun,
-        timeoutMs: patch.timeoutMs ?? cur.timeoutMs,
-        maxOutputBytes: patch.maxOutputBytes ?? cur.maxOutputBytes,
-      },
-      id,
-    ); // keep the same id (name change does not re-slug an existing tool)
-    await this.save(list.map((t) => (t.id === id ? merged : t)));
-    return merged;
+    return customToolLock.runExclusive(this.file, async () => {
+      const list = await this.load();
+      const cur = list.find((t) => t.id === id);
+      if (!cur) return null;
+      const merged = fromInput(
+        {
+          name: patch.name ?? cur.name,
+          binary: patch.binary ?? cur.binary,
+          runArgs: patch.runArgs ?? cur.runArgs,
+          updateCommand: patch.updateCommand ?? cur.updateCommand,
+          extensions: patch.extensions ?? cur.extensions,
+          autoRun: patch.autoRun ?? cur.autoRun,
+          timeoutMs: patch.timeoutMs ?? cur.timeoutMs,
+          maxOutputBytes: patch.maxOutputBytes ?? cur.maxOutputBytes,
+        },
+        id,
+      ); // keep the same id (name change does not re-slug an existing tool)
+      await this.save(list.map((t) => (t.id === id ? merged : t)));
+      return merged;
+    });
   }
 
   async remove(id: string): Promise<boolean> {
-    const list = await this.load();
-    const next = list.filter((t) => t.id !== id);
-    if (next.length === list.length) return false;
-    await this.save(next);
-    return true;
+    return customToolLock.runExclusive(this.file, async () => {
+      const list = await this.load();
+      const next = list.filter((t) => t.id !== id);
+      if (next.length === list.length) return false;
+      await this.save(next);
+      return true;
+    });
   }
 }

--- a/companion/src/routes/findings.ts
+++ b/companion/src/routes/findings.ts
@@ -201,7 +201,7 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
       .filter((i) => i.text.trim().length > 0);
     if (!inputs.length) return;
     try {
-      for (const input of inputs) await options.learnedPatternStore.record(caseId, input);
+      await options.learnedPatternStore.recordMany(caseId, inputs);
       options.onLearnedPatterns?.(caseId);
     } catch (err) {
       console.warn(`[DFIR] learned-pattern record failed for case ${caseId}: ${(err as Error).message}`);
@@ -731,11 +731,9 @@ export function registerFindingsRoutes(app: Express, ctx: RouteContext): void {
       } else if ((FINDING_WORKFLOW_STATUSES as readonly string[]).includes(String(raw))) {
         patch.status = String(raw) as FindingWorkflowStatus;
       } else {
-        return res
-          .status(400)
-          .json({
-            error: `status must be one of ${FINDING_WORKFLOW_STATUSES.join(", ")} (or empty to clear)`,
-          });
+        return res.status(400).json({
+          error: `status must be one of ${FINDING_WORKFLOW_STATUSES.join(", ")} (or empty to clear)`,
+        });
       }
     }
     if (typeof req.body?.updatedBy === "string") patch.updatedBy = req.body.updatedBy;

--- a/companion/tests/analysis/anonDiscovered.test.ts
+++ b/companion/tests/analysis/anonDiscovered.test.ts
@@ -92,3 +92,102 @@ describe("DiscoveredEntitiesStore", () => {
     expect((await store.load("c1")).suppressed).toEqual([]);
   });
 });
+
+// The redaction list has TWO writers that are not the same object: the OCR pass writes through the
+// store built in composition/aiProviders.ts, and the analyst's suppress/unsuppress clicks write
+// through the one built in routes/anonymization.ts. Both load-modify-write the whole file, so a
+// click landing on a snapshot taken before the OCR pass saved discards what OCR just found — and a
+// value that should be masked goes out UNMASKED in an exported screenshot. This is the one store in
+// this class a SOLO analyst can trip: it needs no second person, only a background pass. That also
+// makes a per-instance lock useless here; the lock has to be shared by every instance.
+describe("DiscoveredEntitiesStore concurrency (follow-up to #682)", () => {
+  let cases: CaseStore;
+  const CASE = "c1";
+  const CONCURRENT = 20;
+
+  beforeEach(async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-disc-race-"));
+    cases = new CaseStore(root);
+    await cases.createCase({ caseId: CASE, name: "n", investigator: "i", aiProvider: null });
+  });
+
+  it("keeps every discovery when many OCR batches land at once", async () => {
+    const store = new DiscoveredEntitiesStore(cases);
+    await Promise.all(
+      Array.from({ length: CONCURRENT }, (_, i) =>
+        store.addDiscovered(CASE, [{ value: `HOST-${i}`, category: "HOST" }]),
+      ),
+    );
+    const stored = await store.load(CASE);
+    expect(stored.discovered).toHaveLength(CONCURRENT);
+    expect(new Set(stored.discovered.map((e) => e.value)).size).toBe(CONCURRENT);
+  });
+
+  it("keeps every suppression when the analyst vetoes many values at once", async () => {
+    const store = new DiscoveredEntitiesStore(cases);
+    await store.addDiscovered(
+      CASE,
+      Array.from({ length: CONCURRENT }, (_, i) => ({ value: `NOISE-${i}`, category: "HOST" as const })),
+    );
+    await Promise.all(Array.from({ length: CONCURRENT }, (_, i) => store.suppress(CASE, `NOISE-${i}`)));
+    const stored = await store.load(CASE);
+    expect(stored.suppressed).toHaveLength(CONCURRENT);
+    expect(stored.discovered).toHaveLength(0);
+  });
+
+  // The bug exactly as it reaches a real investigation: the OCR pass and the analyst hold SEPARATE
+  // store objects over the same case. Losing the OCR write is the dangerous direction — the entity
+  // is never tokenized again, so the real value appears in an exported screenshot.
+  it("does not drop an OCR discovery when an analyst suppression lands at the same moment", async () => {
+    const ocrPass = new DiscoveredEntitiesStore(cases); // composition/aiProviders.ts
+    const analyst = new DiscoveredEntitiesStore(cases); // routes/anonymization.ts
+    await analyst.addDiscovered(CASE, [{ value: "FALSE-POSITIVE", category: "HOST" }]);
+
+    await Promise.all([
+      ocrPass.addDiscovered(CASE, [{ value: "REAL-PII", category: "USER" }]),
+      analyst.suppress(CASE, "FALSE-POSITIVE"),
+    ]);
+
+    const stored = await analyst.load(CASE);
+    expect(stored.discovered.map((e) => e.value)).toEqual(["REAL-PII"]);
+    expect(stored.suppressed).toEqual(["false-positive"]);
+  });
+
+  it("serializes a burst across two instances over the same case", async () => {
+    const ocrPass = new DiscoveredEntitiesStore(cases);
+    const analyst = new DiscoveredEntitiesStore(cases);
+    await Promise.all([
+      ...Array.from({ length: 10 }, (_, i) =>
+        ocrPass.addDiscovered(CASE, [{ value: `ocr-${i}`, category: "HOST" }]),
+      ),
+      ...Array.from({ length: 10 }, (_, i) =>
+        analyst.addDiscovered(CASE, [{ value: `manual-${i}`, category: "HOST" }]),
+      ),
+    ]);
+    expect((await analyst.load(CASE)).discovered).toHaveLength(20);
+  });
+
+  it("keeps a suppression and an un-suppression of different values from erasing each other", async () => {
+    const store = new DiscoveredEntitiesStore(cases);
+    await store.addDiscovered(CASE, [{ value: "KEEP-VETO", category: "HOST" }]);
+    await store.suppress(CASE, "LIFT-ME");
+    await Promise.all([store.suppress(CASE, "KEEP-VETO"), store.unsuppress(CASE, "LIFT-ME")]);
+    const stored = await store.load(CASE);
+    expect(stored.suppressed).toEqual(["keep-veto"]);
+  });
+
+  it("keeps two cases independent while both are written concurrently", async () => {
+    await cases.createCase({ caseId: "c2", name: "n", investigator: "i", aiProvider: null });
+    const store = new DiscoveredEntitiesStore(cases);
+    await Promise.all([
+      ...Array.from({ length: 6 }, (_, i) =>
+        store.addDiscovered(CASE, [{ value: `c1-${i}`, category: "HOST" }]),
+      ),
+      ...Array.from({ length: 6 }, (_, i) =>
+        store.addDiscovered("c2", [{ value: `c2-${i}`, category: "HOST" }]),
+      ),
+    ]);
+    expect((await store.load(CASE)).discovered).toHaveLength(6);
+    expect((await store.load("c2")).discovered).toHaveLength(6);
+  });
+});

--- a/companion/tests/analysis/sideStoreConcurrency.test.ts
+++ b/companion/tests/analysis/sideStoreConcurrency.test.ts
@@ -15,7 +15,9 @@ import { HostDuplicateDismissalStore } from "../../src/analysis/hostDuplicateDis
 import { IocAliasStore } from "../../src/analysis/iocAlias.js";
 import { LateralPathDismissStore } from "../../src/analysis/lateralPathDismiss.js";
 import { LearnedPatternStore } from "../../src/analysis/learnedPatternStore.js";
+import { NsrlStore } from "../../src/analysis/nsrlStore.js";
 import { SlashCommandChannelStore } from "../../src/analysis/slashCommandStore.js";
+import { SynthMetaStore } from "../../src/analysis/synthMeta.js";
 import { VeloHuntStore } from "../../src/analysis/veloHuntStore.js";
 import { VeloMonitorStore } from "../../src/analysis/veloMonitorStore.js";
 import { ClickUpExportStore } from "../../src/integrations/clickup/clickupExportStore.js";
@@ -653,6 +655,78 @@ describe("side store concurrency (#682)", () => {
         store.bind("slack:KEPT", "case-new", "2026-08-29T00:00:00.000Z"),
       ]);
       expect(Object.keys(await store.loadAll())).toEqual(["slack:KEPT"]);
+    });
+  });
+
+  describe("SynthMetaStore", () => {
+    const diff = { added: [], removed: [], changed: [] } as never;
+
+    // The two stamp methods each load-merge-save the whole document, so run together the second
+    // save drops the first one's field. reportWriter.ts reads secondLook.leads straight out of this
+    // file, so the lost stamp takes second-look leads out of the REPORT — not just the dashboard.
+    it("keeps both stamps when they are written at the same moment", async () => {
+      const store = new SynthMetaStore(cases);
+      await store.record(CASE, diff, "2026-08-29T00:00:00.000Z");
+      await Promise.all([
+        store.recordSecondLook(CASE, {
+          at: "2026-08-29T00:00:00.000Z",
+          summary: "sweep",
+          promoted: 3,
+          requests: 5,
+          matched: 4,
+          leads: ["missed persistence"],
+        }),
+        store.recordSecondOpinionPerf(CASE, {
+          modelA: "a",
+          modelB: "b",
+          agreementCount: 8,
+          deltaCount: 2,
+          agreementRate: 0.8,
+          at: "2026-08-29T00:00:00.000Z",
+        }),
+      ]);
+      const meta = await store.load(CASE);
+      expect(meta.secondLook?.leads).toHaveLength(1);
+      expect(meta.secondOpinionPerf?.agreementCount).toBe(8);
+    });
+
+    // Synthesis holds one instance (aiProviders.ts) and the on-demand routes another
+    // (runtimeStores.ts) — the two paths that actually collide here.
+    it("serializes two store instances over the same case", async () => {
+      const routes = new SynthMetaStore(cases);
+      const synthesis = new SynthMetaStore(cases);
+      await routes.record(CASE, diff, "2026-08-29T00:00:00.000Z");
+      await Promise.all([
+        routes.recordSecondLook(CASE, {
+          at: "2026-08-29T00:00:00.000Z",
+          summary: "sweep",
+          promoted: 1,
+          requests: 2,
+          matched: 1,
+          leads: ["from routes"],
+        }),
+        synthesis.recordSecondOpinionPerf(CASE, {
+          modelA: "a",
+          modelB: "b",
+          agreementCount: 91,
+          deltaCount: 9,
+          agreementRate: 0.91,
+          at: "2026-08-29T00:00:00.000Z",
+        }),
+      ]);
+      const meta = await routes.load(CASE);
+      expect(meta.secondLook?.leads).toHaveLength(1);
+      expect(meta.secondOpinionPerf?.agreementCount).toBe(91);
+    });
+  });
+
+  describe("NsrlStore", () => {
+    it("keeps every hash when several imports land at once", async () => {
+      const store = new NsrlStore(join(root, "nsrl", "hashes.txt"));
+      const batch = (n: number) =>
+        Array.from({ length: 5 }, (_, i) => `${n}${i}`.padStart(32, "a").slice(0, 32));
+      await Promise.all(Array.from({ length: 6 }, (_, n) => store.addMany(batch(n))));
+      expect(await store.load()).toHaveLength(30);
     });
   });
 

--- a/companion/tests/analysis/sideStoreConcurrency.test.ts
+++ b/companion/tests/analysis/sideStoreConcurrency.test.ts
@@ -9,6 +9,12 @@ import { IocWhitelistStore } from "../../src/analysis/iocWhitelistStore.js";
 import { NotificationConfigStore } from "../../src/analysis/notificationStore.js";
 import { PlaybookStore } from "../../src/analysis/playbookStore.js";
 import { parseChannelInput } from "../../src/analysis/notifications.js";
+import { AssetOverridesStore } from "../../src/analysis/assetOverrides.js";
+import { FindingWorkflowStore } from "../../src/analysis/findingWorkflow.js";
+import { HostDuplicateDismissalStore } from "../../src/analysis/hostDuplicateDismissals.js";
+import { IocAliasStore } from "../../src/analysis/iocAlias.js";
+import { LateralPathDismissStore } from "../../src/analysis/lateralPathDismiss.js";
+import { LearnedPatternStore } from "../../src/analysis/learnedPatternStore.js";
 import { ReportVersionStore } from "../../src/reports/reportVersionStore.js";
 import { emptyReportMeta } from "../../src/reports/reportMeta.js";
 
@@ -211,6 +217,270 @@ describe("side store concurrency (#682)", () => {
       const doomed = await store.add(draft("doomed"));
       await Promise.all([store.remove(doomed.id), store.add(draft("kept"))]);
       expect((await store.load()).map((c) => c.name)).toEqual(["kept"]);
+    });
+  });
+
+  // ── The decision stores (follow-up to #682) ────────────────────────────────────────────────────
+  // These hold ANALYST DECISIONS, which is what makes losing one worse than losing a row. A missing
+  // comment is noticed; a missing dismissal or triage assignment leaves the case file reading as
+  // though nobody ever made the call. Four of them are built TWICE by the app (runtimeStores.ts for
+  // the routes, aiProviders.ts for synthesis), so their locks are module-level — a per-instance lock
+  // guards an object, and what needs guarding is a file.
+
+  describe("FindingWorkflowStore", () => {
+    it("keeps every triage decision when many findings are patched at once", async () => {
+      const store = new FindingWorkflowStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) =>
+          store.patch(CASE, `f${i}`, { assignee: `analyst-${i}`, status: "in_progress" }),
+        ),
+      );
+      const stored = await store.load(CASE);
+      expect(stored).toHaveLength(CONCURRENT);
+      expect(new Set(stored.map((r) => r.assignee)).size).toBe(CONCURRENT);
+    });
+
+    // routes/findings.ts and routes/cockpit.ts both patch this file — a lead assigning an owner
+    // while an analyst sets a status is the traffic that collides.
+    it("keeps an assignment and a status change to two findings from erasing each other", async () => {
+      const store = new FindingWorkflowStore(cases);
+      await store.patch(CASE, "f1", { assignee: "alice" });
+      await Promise.all([
+        store.patch(CASE, "f1", { status: "in_review" }),
+        store.patch(CASE, "f2", { assignee: "bob" }),
+      ]);
+      const stored = await store.load(CASE);
+      expect(stored).toHaveLength(2);
+      expect(stored.find((r) => r.findingId === "f1")?.assignee).toBe("alice");
+      expect(stored.find((r) => r.findingId === "f1")?.status).toBe("in_review");
+      expect(stored.find((r) => r.findingId === "f2")?.assignee).toBe("bob");
+    });
+
+    it("does not lose a concurrent patch while another record is cleared", async () => {
+      const store = new FindingWorkflowStore(cases);
+      await store.patch(CASE, "gone", { assignee: "alice" });
+      await Promise.all([
+        store.patch(CASE, "gone", { assignee: "", status: null }),
+        store.patch(CASE, "kept", { assignee: "bob" }),
+      ]);
+      expect((await store.load(CASE)).map((r) => r.findingId)).toEqual(["kept"]);
+    });
+  });
+
+  describe("AssetOverridesStore", () => {
+    it("keeps every rename when many land at once", async () => {
+      const store = new AssetOverridesStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) => store.rename(CASE, `asset-${i}`, `Renamed ${i}`)),
+      );
+      expect(Object.keys((await store.load(CASE)).renames)).toHaveLength(CONCURRENT);
+    });
+
+    // The whole override document is rewritten on every edit, so edits to unrelated corners of the
+    // graph destroy each other wholesale — not just the field they touched.
+    it("keeps a rename, a merge, a link edit and a removal made at the same moment", async () => {
+      const store = new AssetOverridesStore(cases);
+      await Promise.all([
+        store.rename(CASE, "host-a", "DC01"),
+        store.mergeAsset(CASE, "host-dup", "host-a"),
+        store.addLink(CASE, "host-a", "ioc-1"),
+        store.removeAsset(CASE, "host-noise"),
+      ]);
+      const ov = await store.load(CASE);
+      expect(ov.renames["host-a"]).toBe("DC01");
+      expect(ov.merges["host-dup"]).toBe("host-a");
+      expect(ov.addedLinks).toContainEqual({ asset: "host-a", ioc: "ioc-1" });
+      expect(ov.removed).toContain("host-noise");
+    });
+
+    it("keeps every manually added asset when many are created at once", async () => {
+      const store = new AssetOverridesStore(cases);
+      const made = await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) =>
+          store.addAsset(CASE, { name: `Manual ${i}`, type: "host" }),
+        ),
+      );
+      expect((await store.load(CASE)).added).toHaveLength(CONCURRENT);
+      expect(new Set(made.map((m) => m.asset.id)).size).toBe(CONCURRENT);
+    });
+
+    // The cycle check reads the merge map, so it has to run INSIDE the lock or a concurrent merge
+    // can slip a cycle past it.
+    it("still refuses a self-merge and a cycle under concurrent traffic", async () => {
+      const store = new AssetOverridesStore(cases);
+      await expect(store.mergeAsset(CASE, "a", "a")).rejects.toThrow(/into itself/);
+      await store.mergeAsset(CASE, "a", "b");
+      await expect(store.mergeAsset(CASE, "b", "a")).rejects.toThrow(/cycle/);
+      expect((await store.load(CASE)).merges).toEqual({ a: "b" });
+    });
+
+    it("serializes two store instances over the same case", async () => {
+      const routes = new AssetOverridesStore(cases);
+      const synthesis = new AssetOverridesStore(cases);
+      await Promise.all([
+        ...Array.from({ length: 10 }, (_, i) => routes.rename(CASE, `r${i}`, `R${i}`)),
+        ...Array.from({ length: 10 }, (_, i) => synthesis.rename(CASE, `s${i}`, `S${i}`)),
+      ]);
+      expect(Object.keys((await routes.load(CASE)).renames)).toHaveLength(20);
+    });
+  });
+
+  describe("IocAliasStore", () => {
+    it("keeps every alias when many merges are confirmed at once", async () => {
+      const store = new IocAliasStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) => store.add(CASE, `dupe-${i}.example`, `ioc-${i}`)),
+      );
+      expect(Object.keys((await store.load(CASE)).aliases)).toHaveLength(CONCURRENT);
+    });
+
+    // A lost alias is not just a lost row: the un-merged duplicate reappears as its own IOC on the
+    // next synthesis, which is the exact outcome the alias map exists to prevent.
+    it("does not lose a concurrent merge while another is un-merged", async () => {
+      const store = new IocAliasStore(cases);
+      await store.add(CASE, "old.example", "ioc-old");
+      await Promise.all([store.remove(CASE, "old.example"), store.add(CASE, "new.example", "ioc-new")]);
+      expect((await store.load(CASE)).aliases).toEqual({ "new.example": "ioc-new" });
+    });
+  });
+
+  describe("LateralPathDismissStore", () => {
+    it("keeps every dismissed chain when many are ruled out at once", async () => {
+      const store = new LateralPathDismissStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) =>
+          store.add(CASE, [`host-${i}`, `host-${i}-b`], `benign ${i}`),
+        ),
+      );
+      expect(await store.load(CASE)).toHaveLength(CONCURRENT);
+    });
+
+    it("does not lose a concurrent dismissal while another chain is restored", async () => {
+      const store = new LateralPathDismissStore(cases);
+      const gone = await store.add(CASE, ["a", "b"], "restore me");
+      await Promise.all([store.remove(CASE, gone!.key), store.add(CASE, ["c", "d"], "keep me")]);
+      const stored = await store.load(CASE);
+      expect(stored).toHaveLength(1);
+      expect(stored[0].note).toBe("keep me");
+    });
+  });
+
+  describe("HostDuplicateDismissalStore", () => {
+    // Losing one of these re-arms the merge gate, and the gate BLOCKS synthesis — so the lost write
+    // does not just forget a decision, it stalls the case.
+    it("keeps every dismissed pair when many are judged at once", async () => {
+      const store = new HostDuplicateDismissalStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) =>
+          store.append(CASE, {
+            canonical: `host-${i}.corp.example`,
+            other: `host-${i}`,
+            dismissedAt: "2026-08-29T00:00:00.000Z",
+            dismissedBy: `analyst-${i}`,
+          }),
+        ),
+      );
+      expect(await store.load(CASE)).toHaveLength(CONCURRENT);
+    });
+
+    it("stays idempotent when the same pair is dismissed twice at once", async () => {
+      const store = new HostDuplicateDismissalStore(cases);
+      const pair = {
+        canonical: "dc01.corp.example",
+        other: "dc01",
+        dismissedAt: "2026-08-29T00:00:00.000Z",
+        dismissedBy: "alice",
+      };
+      await Promise.all([store.append(CASE, pair), store.append(CASE, { ...pair, dismissedBy: "bob" })]);
+      const stored = await store.load(CASE);
+      expect(stored).toHaveLength(1);
+      // First decision wins — the recorded analyst must stay whoever actually made the call.
+      expect(stored[0].dismissedBy).toBe("alice");
+    });
+
+    it("serializes two store instances over the same case", async () => {
+      const routes = new HostDuplicateDismissalStore(cases);
+      const gate = new HostDuplicateDismissalStore(cases);
+      await Promise.all([
+        ...Array.from({ length: 10 }, (_, i) =>
+          routes.append(CASE, {
+            canonical: `r${i}.corp.example`,
+            other: `r${i}`,
+            dismissedAt: "2026-08-29T00:00:00.000Z",
+            dismissedBy: "a",
+          }),
+        ),
+        ...Array.from({ length: 10 }, (_, i) =>
+          gate.append(CASE, {
+            canonical: `g${i}.corp.example`,
+            other: `g${i}`,
+            dismissedAt: "2026-08-29T00:00:00.000Z",
+            dismissedBy: "b",
+          }),
+        ),
+      ]);
+      expect(await routes.load(CASE)).toHaveLength(20);
+    });
+  });
+
+  describe("LearnedPatternStore", () => {
+    // routes/findings.ts records a BULK dismissal one finding at a time, so a single analyst action
+    // is already a burst against this file.
+    it("keeps every reasoned dismissal when a bulk dismissal is recorded at once", async () => {
+      const store = new LearnedPatternStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) =>
+          store.record(CASE, { text: `benign scheduled task ${i}`, reason: "known-good-tool" }),
+        ),
+      );
+      expect(await store.load(CASE)).toHaveLength(CONCURRENT);
+    });
+
+    // A bulk dismissal is ONE analyst click. Folding it into a single load->merge->save keeps the
+    // work flat instead of re-reading and rewriting the whole ledger once per dismissed finding.
+    it("records a whole batch in one write", async () => {
+      const store = new LearnedPatternStore(cases);
+      const inputs = Array.from({ length: CONCURRENT }, (_, i) => ({
+        text: `benign maintenance script ${i}`,
+        reason: "known-good-tool" as const,
+      }));
+      expect(await store.recordMany(CASE, inputs)).toHaveLength(CONCURRENT);
+      expect(await store.load(CASE)).toHaveLength(CONCURRENT);
+    });
+
+    it("leaves the ledger untouched for an empty batch", async () => {
+      const store = new LearnedPatternStore(cases);
+      await store.record(CASE, { text: "already here", reason: "duplicate" });
+      expect(await store.recordMany(CASE, [])).toHaveLength(1);
+    });
+
+    it("keeps concurrent batches from overwriting each other", async () => {
+      const store = new LearnedPatternStore(cases);
+      await Promise.all([
+        store.recordMany(CASE, [
+          { text: "first batch alpha", reason: "known-good-tool" },
+          { text: "first batch bravo", reason: "known-good-tool" },
+        ]),
+        store.recordMany(CASE, [
+          { text: "second batch charlie", reason: "authorized-test" },
+          { text: "second batch delta", reason: "authorized-test" },
+        ]),
+      ]);
+      expect(await store.load(CASE)).toHaveLength(4);
+    });
+
+    it("serializes two store instances over the same case", async () => {
+      const routes = new LearnedPatternStore(cases);
+      const synthesis = new LearnedPatternStore(cases);
+      await Promise.all([
+        ...Array.from({ length: 8 }, (_, i) =>
+          routes.record(CASE, { text: `routes pattern ${i}`, reason: "detection-misfire" }),
+        ),
+        ...Array.from({ length: 8 }, (_, i) =>
+          synthesis.record(CASE, { text: `synthesis pattern ${i}`, reason: "authorized-test" }),
+        ),
+      ]);
+      expect(await routes.load(CASE)).toHaveLength(16);
     });
   });
 

--- a/companion/tests/analysis/sideStoreConcurrency.test.ts
+++ b/companion/tests/analysis/sideStoreConcurrency.test.ts
@@ -15,6 +15,16 @@ import { HostDuplicateDismissalStore } from "../../src/analysis/hostDuplicateDis
 import { IocAliasStore } from "../../src/analysis/iocAlias.js";
 import { LateralPathDismissStore } from "../../src/analysis/lateralPathDismiss.js";
 import { LearnedPatternStore } from "../../src/analysis/learnedPatternStore.js";
+import { SlashCommandChannelStore } from "../../src/analysis/slashCommandStore.js";
+import { VeloHuntStore } from "../../src/analysis/veloHuntStore.js";
+import { VeloMonitorStore } from "../../src/analysis/veloMonitorStore.js";
+import { ClickUpExportStore } from "../../src/integrations/clickup/clickupExportStore.js";
+import { JiraExportStore } from "../../src/integrations/jira/jiraExportStore.js";
+import { NotionExportStore } from "../../src/integrations/notion/notionExportStore.js";
+import { McpServerStore } from "../../src/integrations/mcp/mcpServerStore.js";
+import { ServiceNowExportStore } from "../../src/integrations/servicenow/servicenowExportStore.js";
+import { SocratesJobStore } from "../../src/integrations/socrates/socratesJobStore.js";
+import { CustomToolStore } from "../../src/integrations/tools/customToolStore.js";
 import { ReportVersionStore } from "../../src/reports/reportVersionStore.js";
 import { emptyReportMeta } from "../../src/reports/reportMeta.js";
 
@@ -481,6 +491,168 @@ describe("side store concurrency (#682)", () => {
         ),
       ]);
       expect(await routes.load(CASE)).toHaveLength(16);
+    });
+  });
+
+  // ── Integration + config stores (follow-up to #682) ────────────────────────────────────────────
+  // Lower stakes than the decision stores — nothing here is evidence — but two of them reach outside
+  // the tool, which is worth more than the tidiness of the file they live in.
+
+  describe("export pointer stores", () => {
+    // A missing ticket ref is how these stores say "no ticket exists yet", so losing one does not
+    // just forget a pointer — the next export opens a DUPLICATE ticket in somebody else's queue.
+    it("keeps every Jira issue ref when exports overlap", async () => {
+      const store = new JiraExportStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) =>
+          store.record(CASE, { [`f${i}`]: { id: `${i}`, key: `SOC-${i}` } }),
+        ),
+      );
+      expect(Object.keys((await store.load(CASE)).issueRefs)).toHaveLength(CONCURRENT);
+    });
+
+    it("keeps every ServiceNow incident ref when exports overlap", async () => {
+      const store = new ServiceNowExportStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) =>
+          store.record(CASE, { [`f${i}`]: { id: `sys-${i}`, number: `INC${i}` } }),
+        ),
+      );
+      expect(Object.keys((await store.load(CASE)).incidentRefs)).toHaveLength(CONCURRENT);
+    });
+
+    it("keeps every ClickUp task id when exports overlap", async () => {
+      const store = new ClickUpExportStore(cases);
+      await Promise.all(
+        Array.from({ length: CONCURRENT }, (_, i) => store.record(CASE, { taskIds: { [`f${i}`]: `t${i}` } })),
+      );
+      expect(Object.keys((await store.load(CASE)).taskIds)).toHaveLength(CONCURRENT);
+    });
+
+    it("does not lose a Notion field written beside another", async () => {
+      const store = new NotionExportStore(cases);
+      await Promise.all([
+        store.record(CASE, { pageId: "page-1" }),
+        store.record(CASE, { lastBlocksAppended: 42 }),
+      ]);
+      const stored = await store.load(CASE);
+      expect(stored.pageId).toBe("page-1");
+      expect(stored.lastBlocksAppended).toBe(42);
+    });
+  });
+
+  describe("VeloHuntStore / VeloMonitorStore / SocratesJobStore", () => {
+    const hunt = (i: number) => ({
+      bundleId: `b${i}`,
+      bundleName: `Bundle ${i}`,
+      artifacts: ["Windows.KapeFiles.Targets"],
+      huntId: `H.${i}`,
+      launchedAt: "2026-08-29T00:00:00.000Z",
+      waitMinutes: 10,
+      collectAt: "2026-08-29T00:10:00.000Z",
+      status: "running" as const,
+    });
+
+    // A lost hunt record leaves a hunt RUNNING on the fleet that the analyst can neither see nor
+    // collect.
+    it("keeps every hunt when several are launched at once", async () => {
+      const store = new VeloHuntStore(cases);
+      await Promise.all(Array.from({ length: 12 }, (_, i) => store.upsert(CASE, hunt(i))));
+      expect(await store.list(CASE)).toHaveLength(12);
+    });
+
+    it("updates a hunt in place rather than duplicating it", async () => {
+      const store = new VeloHuntStore(cases);
+      await store.upsert(CASE, hunt(1));
+      await Promise.all([
+        store.upsert(CASE, { ...hunt(1), status: "imported" }),
+        store.upsert(CASE, hunt(2)),
+      ]);
+      const jobs = await store.list(CASE);
+      expect(jobs).toHaveLength(2);
+      expect(jobs.find((j) => j.huntId === "H.1")?.status).toBe("imported");
+    });
+
+    it("keeps every monitor, and a concurrent removal only removes its own", async () => {
+      const store = new VeloMonitorStore(cases);
+      const monitor = (i: number) => ({
+        id: `C.${i}__Windows.Events.ProcessCreation`,
+        clientId: `C.${i}`,
+        artifact: "Windows.Events.ProcessCreation",
+        pollSeconds: 60,
+        cursor: 0,
+        status: "active" as const,
+        createdAt: "2026-08-29T00:00:00.000Z",
+      });
+      await Promise.all(Array.from({ length: 10 }, (_, i) => store.upsert(CASE, monitor(i))));
+      expect(await store.list(CASE)).toHaveLength(10);
+      await Promise.all([store.remove(CASE, monitor(0).id), store.upsert(CASE, monitor(10))]);
+      const left = await store.list(CASE);
+      expect(left).toHaveLength(10);
+      expect(left.some((m) => m.id === monitor(0).id)).toBe(false);
+      expect(left.some((m) => m.id === monitor(10).id)).toBe(true);
+    });
+
+    it("keeps every SO-CRATES job when several are submitted at once", async () => {
+      const store = new SocratesJobStore(cases);
+      await Promise.all(
+        Array.from({ length: 12 }, (_, i) =>
+          store.upsert(CASE, {
+            jobId: `j${i}`,
+            md5: `${i}`.padStart(32, "0"),
+            sourceName: `sample-${i}.exe`,
+            status: "processing" as const,
+            startedAt: "2026-08-29T00:00:00.000Z",
+          }),
+        ),
+      );
+      expect(await store.list(CASE)).toHaveLength(12);
+    });
+  });
+
+  describe("global config stores", () => {
+    it("keeps every MCP server when many are added at once", async () => {
+      const store = new McpServerStore(join(root, "mcp", "servers.json"));
+      await Promise.all(
+        Array.from({ length: 12 }, (_, i) => store.add({ id: `server-${i}`, label: `Server ${i}` })),
+      );
+      expect(await store.load()).toHaveLength(12);
+    });
+
+    it("does not lose an MCP add while another server is removed", async () => {
+      const store = new McpServerStore(join(root, "mcp", "servers.json"));
+      await store.add({ id: "doomed", label: "Doomed" });
+      await Promise.all([store.remove("doomed"), store.add({ id: "kept", label: "Kept" })]);
+      expect((await store.load()).map((s) => s.id)).toEqual(["kept"]);
+    });
+
+    it("keeps every custom tool when many are added at once", async () => {
+      const store = new CustomToolStore(join(root, "tools", "tools.json"));
+      await Promise.all(
+        Array.from({ length: 12 }, (_, i) => store.add({ name: `Tool ${i}`, binary: `/usr/bin/tool${i}` })),
+      );
+      expect(await store.load()).toHaveLength(12);
+    });
+
+    // A lost binding makes the war-room bot answer a chat about the wrong case, or about none.
+    it("keeps every chat binding when many are bound at once", async () => {
+      const store = new SlashCommandChannelStore(join(root, "notifications", "bindings.json"));
+      await Promise.all(
+        Array.from({ length: 12 }, (_, i) =>
+          store.bind(`slack:C${i}`, `case-${i}`, "2026-08-29T00:00:00.000Z"),
+        ),
+      );
+      expect(Object.keys(await store.loadAll())).toHaveLength(12);
+    });
+
+    it("does not lose a binding while another is unbound", async () => {
+      const store = new SlashCommandChannelStore(join(root, "notifications", "bindings.json"));
+      await store.bind("slack:GONE", "case-old", "2026-08-29T00:00:00.000Z");
+      await Promise.all([
+        store.unbind("slack:GONE"),
+        store.bind("slack:KEPT", "case-new", "2026-08-29T00:00:00.000Z"),
+      ]);
+      expect(Object.keys(await store.loadAll())).toEqual(["slack:KEPT"]);
     });
   });
 


### PR DESCRIPTION
The rest of the concurrency class #682 opened. That issue said "examples include" and listed six stores; this finishes the sweep it started.

Follow-up to #682.

## What the triage actually found

70 files write JSON without a lock. Only **27** have the lost-update shape — read the whole document, change it, write it back. The rest replace a document outright, where the last writer winning is the intent.

| Outcome | Count |
|---|---|
| Fixed here | 20 |
| Already serialized by their own promise chain | 2 |
| Not a bug | 5 |
| Left deliberately | 1 |

`hostScopeStore` and `operationalMetrics` already have hand-rolled per-case queues doing exactly what `StateLock` does — both were false positives in my first pass, found by reading them rather than trusting the scan. `falsePositive.load` is a one-time idempotent migration. The four `*Control.set` methods write a single setting where last-write-wins is the point. `taggerStore` carries a comment calling its unlocked read-modify-write a considered choice for a single-analyst tool; the premise has arguably expired now that team mode is the point of #682, but reversing a written-down decision belongs to its author, not to a drive-by in this PR.

## The two that mattered most, and neither was obvious

**`anon-discovered.json` — the only one a solo analyst can trip.** Everywhere else this defect needs two people or two tabs. Here the second writer is a background pass: the OCR pass writes through the store built in `composition/aiProviders.ts`, the analyst's suppress/unsuppress clicks through the one in `routes/anonymization.ts`. An analyst click landing on a snapshot read before the OCR pass saved discards what OCR just found — that entity never enters `discovered`, is never tokenized, and the real value ships **unmasked in a redacted export**.

That also proves why every lock here is module-level. A per-instance lock guards an object; what needs guarding is a file.

**`synth-meta.json` — I nearly filed this as cosmetic.** `record()` replaces the document while `recordSecondLook` and `recordSecondOpinionPerf` load-merge-save onto it, ordered by a comment rather than by anything enforcing it. It is not just a stale timestamp: `reportWriter.ts` reads `secondLook.leads` and `coverage` straight out of the file, so a lost stamp drops second-look leads from the **report**.

## Everything fixed

**Analyst decisions** — losing one of these leaves the case file reading as though nobody ever made the call:

| File | What was lost |
|---|---|
| `finding-workflow.json` | Triage status and assignee |
| `asset-overrides.json` | Renames, merges, link edits, suppressions |
| `ioc-aliases.json` | Two IOCs judged to be one thing |
| `lateral-path-dismissals.json` | Movement chains ruled out |
| `host-duplicate-dismissals.json` | "These really are two machines" |
| `learned-patterns.json` | Reasoned dismissals that feed synthesis |
| `anon-discovered.json` | The screenshot redaction list |
| `synth-meta.json` | Second-look and second-opinion stamps |

Two are worse than a lost row. A lost host-duplicate dismissal re-arms the merge gate, and that gate **blocks synthesis** — so it stalls the case until somebody makes the same call again. A lost IOC alias makes the un-merged duplicate reappear as its own IOC on the next synthesis, precisely what the alias map exists to prevent.

**Reaching outside the tool** — the four export pointer files (Jira, ServiceNow, ClickUp, Notion) hold the finding → ticket map. A missing reference is how those stores say "no ticket exists yet", so losing one does not merely forget a pointer: the next export opens a **duplicate ticket in somebody else's queue**. The bulk push loop is sequential, so one export cannot race itself; two overlapping exports of the same case can.

**Work in flight and operator config** — Velociraptor hunts and monitors, SO-CRATES jobs, MCP servers, custom tools, chat bindings, the NSRL hash set. A lost hunt record leaves a hunt running on the fleet that nobody can see or collect. A lost monitor leaves one armed on the server that nothing can stop. A lost chat binding makes the war-room bot answer about the wrong case.

## Also fixed

`LearnedPatternStore.recordMany`. Dismissing forty findings is one analyst click, but it called `record()` forty times — re-reading and rewriting the whole ledger per finding, work that grows with the case. Now one load, one merge, one save, taking the lock once instead of contending with itself.

## Two mistakes worth recording

**Dropping `async` changed a contract.** Methods that validate *before* taking the lock were rewritten to return the lock's promise directly, which turned a rejected promise into a **synchronous throw**. The new asset-merge cycle test caught it. Those methods are `async` again on purpose, with a comment saying why, and the same rule was applied to every later batch.

**My first `synth-meta` tests pinned nothing.** They asserted `expect(...).not.toBeNull()` on a field that comes back `undefined` when it is lost — and `expect(undefined).not.toBeNull()` passes. They went green against the unlocked store. I only noticed because I ran them against reverted sources and the expected failures did not arrive. They now assert on stored content.

## Verification

Every batch was checked the same way: revert the sources with `git show HEAD:`, confirm the new tests fail, restore. **16, 13 and 3 failures** across the three batches, plus 6 for `anonDiscovered`. The handful that pass either way are guard tests, not race tests, and are marked as such.

`tests/analysis/sideStoreConcurrency.test.ts` now covers bulk concurrent writes, mixed add/update/remove traffic, per-case independence, two-instance serialization, and idempotency under a race, for every store touched.

## Gates

`lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`, `eval:change-gate`, `check:us-map`, `build`, `typecheck` — all green against the merge result. Companion: **694 files, 10,925 tests, 0 failures**. Extension: typecheck, 329 tests, Chrome and Firefox builds green.

`ARCHITECTURE.md`'s cross-domain comply/total pair is recomputed to 1,900 / 1,939 — the merge brought master's two new edges alongside this branch's nineteen, and neither side's number described the union.
