### PR TITLE
fix(tagger): serialize edits to the shared rules file

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,901 of the 1,940 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,902 of the 1,941 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Case unlock tokens carry a payload version** — a token signed under an older payload shape now stops verifying instead of being read under today's rules. Unlock cookies issued before this release stop working, so each password-protected case asks for its password once more. (closes #671)
 
 ### Fixed
+- **Tagger rule edits no longer overwrite each other** — the shared rules file is now serialized like every other side store. (follow-up to #682)
 - **A screenshot redaction found by OCR is no longer lost when the analyst clicks at the same moment** — the value stayed unmasked in redacted exports. The one store of its class a solo analyst could trip. (follow-up to #682)
 - **Analyst decisions no longer overwrite each other in team mode** — finding triage and assignment, asset-graph renames/merges/link edits, IOC merges, dismissed lateral-movement chains, host near-duplicate dismissals and learned dismissal patterns. (follow-up to #682)
 - **A bulk dismissal writes the learned-pattern ledger once instead of once per finding.** (follow-up to #682)

--- a/companion/src/analysis/taggerStore.ts
+++ b/companion/src/analysis/taggerStore.ts
@@ -15,6 +15,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { atomicWrite } from "../storage/atomicWrite.js";
+import { StateLock } from "./stateLock.js";
 import { compileRuleset, type CompiledRuleset } from "./taggerRules.js";
 
 export type RulesSource = "env" | "user" | "default";
@@ -59,6 +60,10 @@ function uniqueKey(base: string, taken: ReadonlySet<string>): string {
     if (!taken.has(candidate)) return candidate;
   }
 }
+
+// Keyed by the rules file path rather than a case id: this store is GLOBAL, and the path is what is
+// actually being contended for.
+const rulesLock = new StateLock();
 
 export class TaggerStore {
   /**
@@ -113,6 +118,13 @@ export class TaggerStore {
    * so a bad edit never overwrites a working file. Returns the compiled ruleset.
    */
   async save(yamlText: string): Promise<CompiledRuleset> {
+    return rulesLock.runExclusive(this.userRulesPath, () => this.persist(yamlText));
+  }
+
+  // The unlocked body of save(). StateLock is NOT reentrant — a runExclusive nested inside another
+  // on the same key waits on a tail that is waiting on it — so the structural edits below, which
+  // already hold the lock, must persist through here rather than calling save().
+  private async persist(yamlText: string): Promise<CompiledRuleset> {
     const compiled = compileText(yamlText); // throws on invalid — nothing is written
     await mkdir(dirname(this.userRulesPath), { recursive: true }); // atomicWrite won't create parents
     await atomicWrite(this.userRulesPath, yamlText);
@@ -138,9 +150,16 @@ export class TaggerStore {
     }
   }
 
-  // addRuleYaml/removeRule/resetToDefault do an UNLOCKED read-modify-write on the shared rules file,
-  // matching the existing PUT /tagger/rules behavior — concurrent edits could interleave and one may
-  // clobber the other. Acceptable for a single-analyst local tool; not wired to a lock deliberately.
+  // Every write to the rules file — the three structural edits below AND the whole-document save()
+  // the rules editor PUTs — runs under one lock (follow-up to #682).
+  //
+  // This was deliberately unlocked, on the reasoning that a single-analyst local tool did not need
+  // it. Team mode is what changed that: the rules file is GLOBAL, shared by everyone on the
+  // deployment, so two analysts editing rules is now ordinary rather than impossible. The cost of
+  // losing one is also worse here than a lost row. A rule that silently never landed does not
+  // announce itself, and the tagger only grades evidence AT IMPORT — so nothing re-runs over what
+  // is already in the case, and the gap looks like "that rule does not match" rather than "that
+  // rule was never saved".
 
   /**
    * Merge one rule (a single-entry YAML map of id → rule) into the active ruleset. Validates the new
@@ -157,33 +176,39 @@ export class TaggerStore {
     if (entries.length !== 1) throw new Error(`expected exactly one rule, got ${entries.length}`);
     const [rawId, rule] = entries[0];
     compileRuleset({ [rawId]: rule }); // throws on an invalid rule BEFORE we touch the file
-    const map = await this.loadRawMap();
-    const id = uniqueKey(rawId, new Set(Object.keys(map)));
-    const compiled = await this.save(stringifyYaml({ ...map, [id]: rule }));
-    return { id, ruleCount: compiled.rules.length };
+    return rulesLock.runExclusive(this.userRulesPath, async () => {
+      const map = await this.loadRawMap();
+      const id = uniqueKey(rawId, new Set(Object.keys(map)));
+      const compiled = await this.persist(stringifyYaml({ ...map, [id]: rule }));
+      return { id, ruleCount: compiled.rules.length };
+    });
   }
 
   /** Remove one rule by id. Returns removed=false (and the unchanged count) when the id is absent. */
   async removeRule(id: string): Promise<{ removed: boolean; ruleCount: number }> {
     this.assertEditable();
-    const map = await this.loadRawMap();
-    if (!Object.hasOwn(map, id)) {
-      const current = await this.load();
-      return { removed: false, ruleCount: current.rules.length };
-    }
-    const { [id]: _removed, ...next } = map;
-    // An empty map serializes to "{}"; persist "" instead so the store reads back an empty ruleset.
-    const text = Object.keys(next).length ? stringifyYaml(next) : "";
-    const compiled = await this.save(text);
-    return { removed: true, ruleCount: compiled.rules.length };
+    return rulesLock.runExclusive(this.userRulesPath, async () => {
+      const map = await this.loadRawMap();
+      if (!Object.hasOwn(map, id)) {
+        const current = await this.load();
+        return { removed: false, ruleCount: current.rules.length };
+      }
+      const { [id]: _removed, ...next } = map;
+      // An empty map serializes to "{}"; persist "" instead so the store reads back an empty ruleset.
+      const text = Object.keys(next).length ? stringifyYaml(next) : "";
+      const compiled = await this.persist(text);
+      return { removed: true, ruleCount: compiled.rules.length };
+    });
   }
 
   /** Delete the user rule file so the active ruleset falls back to the bundled default. No-op if absent. */
   async resetToDefault(): Promise<{ ruleCount: number }> {
     this.assertEditable();
-    await rm(this.userRulesPath, { force: true });
-    const compiled = await this.load();
-    return { ruleCount: compiled.rules.length };
+    return rulesLock.runExclusive(this.userRulesPath, async () => {
+      await rm(this.userRulesPath, { force: true });
+      const compiled = await this.load();
+      return { ruleCount: compiled.rules.length };
+    });
   }
 }
 

--- a/companion/src/analysis/taggerStore.ts
+++ b/companion/src/analysis/taggerStore.ts
@@ -117,6 +117,13 @@ export class TaggerStore {
    * "never a bare writeFile" invariant). Throws BEFORE writing if the YAML or ruleset is invalid,
    * so a bad edit never overwrites a working file. Returns the compiled ruleset.
    */
+  // NOTE the limit of this lock. It makes a whole-document PUT atomic with respect to the structural
+  // edits, so neither can land inside the other's critical section. It does NOT make the PUT
+  // conflict-aware: a full-document submission REPLACES the file, so an editor save that goes second
+  // still discards a rule added while the analyst was typing. That is what last-write-wins means and
+  // is unchanged from before; closing it needs the editor to send a revision the server can reject as
+  // stale, which is an API and UI change rather than a locking one. Pinned by
+  // "still lets a whole-document save replace an edit that landed first" in taggerStore.test.ts.
   async save(yamlText: string): Promise<CompiledRuleset> {
     return rulesLock.runExclusive(this.userRulesPath, () => this.persist(yamlText));
   }

--- a/companion/tests/analysis/taggerStore.test.ts
+++ b/companion/tests/analysis/taggerStore.test.ts
@@ -192,3 +192,76 @@ describe("TaggerStore edits (add/remove/reset)", () => {
     await expect(store.resetToDefault()).rejects.toThrow(/operator override/i);
   });
 });
+
+// The rules file is GLOBAL and shared by every analyst on a team-mode deployment. Its methods
+// load-modify-write the whole YAML document, so two edits arriving together keep only one — a rule
+// the analyst watched get added is simply absent, and (per tagger semantics) nothing re-grades the
+// evidence it was written for. The store used to say the missing lock was a deliberate choice for a
+// single-analyst tool; team mode is what changed that.
+describe("TaggerStore concurrency (follow-up to #682)", () => {
+  let userPath: string;
+  let defaultPath: string;
+  let dir: string;
+
+  const rule = (id: string) =>
+    `${id}:\n  any:\n    - { field: message, contains: ['${id}'] }\n  tags: ['${id}']\n`;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "dfir-tagger-race-"));
+    userPath = join(dir, "user-tags.yaml");
+    defaultPath = join(dir, "default-tags.yaml");
+    await writeFile(defaultPath, VALID, "utf8");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("keeps every rule when many are added at once", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    await Promise.all(Array.from({ length: 12 }, (_, i) => store.addRuleYaml(rule(`r${i}`))));
+    const ids = (await store.load()).rules.map((r) => r.id);
+    // The bundled default's own rule rides along, so 12 added + 1 default.
+    expect(ids).toHaveLength(13);
+    expect(new Set(ids).size).toBe(13);
+  });
+
+  it("does not lose a concurrent add while another rule is removed", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    await store.addRuleYaml(rule("doomed"));
+    await Promise.all([store.removeRule("doomed"), store.addRuleYaml(rule("kept"))]);
+    const ids = (await store.load()).rules.map((r) => r.id);
+    expect(ids).toContain("kept");
+    expect(ids).not.toContain("doomed");
+  });
+
+  // A whole-document PUT from the rules editor must not land inside another edit's critical
+  // section, so save() takes the same lock. save() is called from the route directly, and the
+  // three structural edits call an unlocked persist underneath — StateLock is not reentrant, so
+  // nesting the two would deadlock rather than serialize.
+  it("serializes a whole-document save against a structural add", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    await Promise.all([store.save(rule("from-editor")), store.addRuleYaml(rule("from-add"))]);
+    const ids = (await store.load()).rules.map((r) => r.id);
+    // Whichever order wins, the file must be one coherent document — never a torn mix.
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids).toContain("from-add");
+  });
+
+  it("still de-collides ids raced against each other", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    const results = await Promise.all(Array.from({ length: 5 }, () => store.addRuleYaml(rule("dupe"))));
+    // Every add gets its own id; none silently overwrites another.
+    expect(new Set(results.map((r) => r.id)).size).toBe(5);
+    expect((await store.load()).rules.filter((r) => r.id.startsWith("dupe"))).toHaveLength(5);
+  });
+
+  it("does not let a reset race an add into a half-reset file", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    await store.addRuleYaml(rule("before-reset"));
+    await Promise.all([store.resetToDefault(), store.addRuleYaml(rule("after-reset"))]);
+    // Either ordering is legitimate; the file must parse and reflect one of them cleanly.
+    const ids = (await store.load()).rules.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/companion/tests/analysis/taggerStore.test.ts
+++ b/companion/tests/analysis/taggerStore.test.ts
@@ -238,14 +238,27 @@ describe("TaggerStore concurrency (follow-up to #682)", () => {
   // A whole-document PUT from the rules editor must not land inside another edit's critical
   // section, so save() takes the same lock. save() is called from the route directly, and the
   // three structural edits call an unlocked persist underneath — StateLock is not reentrant, so
-  // nesting the two would deadlock rather than serialize.
-  it("serializes a whole-document save against a structural add", async () => {
+  // nesting the two would deadlock rather than serialize. The lock is FIFO by call order, so both
+  // orderings below are deterministic rather than racy.
+  it("lets a structural add merge onto a save that went first", async () => {
     const store = new TaggerStore(userPath, [defaultPath]);
     await Promise.all([store.save(rule("from-editor")), store.addRuleYaml(rule("from-add"))]);
     const ids = (await store.load()).rules.map((r) => r.id);
-    // Whichever order wins, the file must be one coherent document — never a torn mix.
-    expect(ids.length).toBeGreaterThan(0);
+    expect(ids).toContain("from-editor");
     expect(ids).toContain("from-add");
+  });
+
+  // The other ordering, asserted rather than avoided. A whole-document PUT REPLACES the file, so an
+  // editor submission that went second discards a structural edit that landed while the analyst was
+  // typing. The lock does not change that and was never going to: it makes the two writes atomic
+  // with respect to each other, and last-write-wins is what a full-document PUT means. Closing this
+  // needs the editor to submit a revision the server can reject as stale, which is an API and UI
+  // change, not a locking one. Pinned here so the limitation is visible instead of implied.
+  it("still lets a whole-document save replace an edit that landed first (last-write-wins)", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    await Promise.all([store.addRuleYaml(rule("from-add")), store.save(rule("from-editor"))]);
+    const ids = (await store.load()).rules.map((r) => r.id);
+    expect(ids).toEqual(["from-editor"]);
   });
 
   it("still de-collides ids raced against each other", async () => {


### PR DESCRIPTION
The last item from the #682 sweep, and the one deliberately left behind in #712 because the code said the omission was on purpose:

> `addRuleYaml/removeRule/resetToDefault` do an UNLOCKED read-modify-write on the shared rules file … Acceptable for a single-analyst local tool; not wired to a lock deliberately.

Team mode is what expired that reasoning. The rules file is **global** — shared by everyone on a deployment — so two analysts editing rules went from impossible to ordinary. Reversing a written-down decision belongs to its author, so #712 flagged it and stopped; this PR closes it at the maintainer's request.

Follow-up to #682.

## Why losing a write here is worse than losing a row

A rule that silently never landed does not announce itself. The tagger grades evidence **only at import**, so nothing re-runs over what is already in the case. The gap reads as *"that rule doesn't match"* rather than *"that rule was never saved"* — the harder of the two to notice, and the one that costs an analyst a day chasing a detection that was never there.

## The part that needed care

`save()` takes the lock too, so the rules editor's whole-document PUT cannot land inside a structural edit's critical section. That required splitting an unlocked `persist()` out from under it: **`StateLock` is not reentrant**, so `addRuleYaml` holding the lock and then calling a locked `save()` would have deadlocked rather than serialized. The tests exercise that path directly — a deadlock hangs them rather than failing an assertion.

## What this does NOT fix, now pinned in a test

A review caught that my first save-vs-add test asserted an outcome that only holds for one ordering, while its comment claimed "whichever order wins". `StateLock` is FIFO by call order, so `save()` went first and the assertion passed — but reverse the two calls and only the editor's document survives. Nothing said so.

Both orderings are now asserted explicitly, and the second one pins the limitation instead of hiding it:

- `save()` first → the structural add merges onto it, both survive.
- `addRuleYaml` first → the editor's full-document PUT **replaces** the file and the added rule is gone.

That is what last-write-wins means for a whole-document submission, it is unchanged from before this PR, and the lock was never going to change it. Closing it needs the editor to send a revision the server can reject as stale — an API and UI change, not a locking one. The same note now sits above `save()` so the source states what the lock does and does not buy.

## Verification

Three tests fail against the unlocked store — bulk adds, add-racing-removal, and id de-collision under a race. Two more cover the save/add orderings, and one covers reset.

## Gates

`lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`, `eval:change-gate`, `check:us-map`, `build`, `typecheck` — all green. Companion: **695 files, 10,943 tests, 0 failures**. Extension: typecheck, 329 tests, Chrome and Firefox builds green.

`ARCHITECTURE.md`'s cross-domain comply/total pair moves to 1,902 / 1,941.

## The sweep is now closed

Seven files still do a read-modify-write, and none is a defect: `hostScopeStore` and `operationalMetrics` already serialize with their own promise chains, `falsePositive.load` is a one-time idempotent migration, and the four `*Control.set` methods write a single setting where last-write-wins is the intent and a lost write costs one re-click.
