### PR TITLE
fix(tagger): refuse a stale rules-editor save instead of overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Case unlock tokens carry a payload version** — a token signed under an older payload shape now stops verifying instead of being read under today's rules. Unlock cookies issued before this release stop working, so each password-protected case asks for its password once more. (closes #671)
 
 ### Fixed
+- **The tagger rule editor refuses to overwrite a rule somebody else added** while it was open — it says the rules changed and to reopen the editor, instead of silently deleting their work. (follow-up to #682)
 - **Tagger rule edits no longer overwrite each other** — the shared rules file is now serialized like every other side store. (follow-up to #682)
 - **A screenshot redaction found by OCR is no longer lost when the analyst clicks at the same moment** — the value stayed unmasked in redacted exports. The one store of its class a solo analyst could trip. (follow-up to #682)
 - **Analyst decisions no longer overwrite each other in team mode** — finding triage and assignment, asset-graph renames/merges/link edits, IOC merges, dismissed lateral-movement chains, host near-duplicate dismissals and learned dismissal patterns. (follow-up to #682)

--- a/companion/src/analysis/taggerStore.ts
+++ b/companion/src/analysis/taggerStore.ts
@@ -10,6 +10,7 @@
 // error; the auto-run pipeline hook catches it and skips (a broken hand-edit must not break imports).
 
 import { readFile, access, rm, mkdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,12 +19,31 @@ import { atomicWrite } from "../storage/atomicWrite.js";
 import { StateLock } from "./stateLock.js";
 import { compileRuleset, type CompiledRuleset } from "./taggerRules.js";
 
+// Thrown when a whole-document save carries a revision that no longer matches the file on disk —
+// somebody else changed the rules while this editor was open. A distinct type so the route can
+// answer 409 (you are out of date, reload) instead of 400 (your YAML is wrong), which are very
+// different instructions to give an analyst.
+export class TaggerRulesConflictError extends Error {
+  constructor(readonly currentRevision: string) {
+    super("the rules changed since this editor was opened; reload before saving");
+    this.name = "TaggerRulesConflictError";
+  }
+}
+
+// A revision is just a digest of the active rule text. It needs to change whenever the file does and
+// be cheap to compare — not to be unguessable — so a truncated sha256 is enough.
+export function rulesRevision(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
 export type RulesSource = "env" | "user" | "default";
 
 export interface ActiveRules {
   text: string;
   source: RulesSource;
   path: string;
+  /** Digest of `text`. The editor sends it back on save so a stale submission can be rejected. */
+  revision: string;
 }
 
 // Candidate locations of the bundled default, most-likely first (mirrors countryCentroids.ts):
@@ -95,6 +115,11 @@ export class TaggerStore {
 
   /** The active rule file's raw YAML text + where it came from. Empty ruleset when none is found. */
   async readActive(): Promise<ActiveRules> {
+    const active = await this.readActiveText();
+    return { ...active, revision: rulesRevision(active.text) };
+  }
+
+  private async readActiveText(): Promise<Omit<ActiveRules, "revision">> {
     const env = this.envPath();
     if (env) return { text: await readFile(env, "utf8"), source: "env", path: env };
     if (await exists(this.userRulesPath)) {
@@ -117,15 +142,28 @@ export class TaggerStore {
    * "never a bare writeFile" invariant). Throws BEFORE writing if the YAML or ruleset is invalid,
    * so a bad edit never overwrites a working file. Returns the compiled ruleset.
    */
-  // NOTE the limit of this lock. It makes a whole-document PUT atomic with respect to the structural
-  // edits, so neither can land inside the other's critical section. It does NOT make the PUT
-  // conflict-aware: a full-document submission REPLACES the file, so an editor save that goes second
-  // still discards a rule added while the analyst was typing. That is what last-write-wins means and
-  // is unchanged from before; closing it needs the editor to send a revision the server can reject as
-  // stale, which is an API and UI change rather than a locking one. Pinned by
-  // "still lets a whole-document save replace an edit that landed first" in taggerStore.test.ts.
-  async save(yamlText: string): Promise<CompiledRuleset> {
-    return rulesLock.runExclusive(this.userRulesPath, () => this.persist(yamlText));
+  // A whole-document save REPLACES the file, so on its own it is last-write-wins: an editor
+  // submission that lands after somebody else added a rule silently deletes that rule. The lock
+  // alone could never fix that — it makes the two writes atomic with respect to each other, which is
+  // a different problem. `expectedRevision` is what fixes it: the editor sends back the revision it
+  // loaded, and a mismatch is refused rather than applied.
+  //
+  // The comparison happens INSIDE the lock, which is the whole point. Checking outside would leave
+  // exactly the race it is meant to close — read the current revision, another writer lands, then
+  // overwrite anyway.
+  //
+  // Omitting `expectedRevision` keeps the old last-write-wins behaviour. That is deliberate: a
+  // script or curl caller with the full ruleset in hand is stating intent, and the dashboard editor
+  // (the client that can actually be stale) always sends one.
+  async save(yamlText: string, expectedRevision?: string): Promise<CompiledRuleset & { revision: string }> {
+    return rulesLock.runExclusive(this.userRulesPath, async () => {
+      if (expectedRevision !== undefined) {
+        const current = rulesRevision((await this.readActiveText()).text);
+        if (current !== expectedRevision) throw new TaggerRulesConflictError(current);
+      }
+      const compiled = await this.persist(yamlText);
+      return { ...compiled, revision: rulesRevision(yamlText) };
+    });
   }
 
   // The unlocked body of save(). StateLock is NOT reentrant — a runExclusive nested inside another

--- a/companion/src/routes/tagger.ts
+++ b/companion/src/routes/tagger.ts
@@ -2,7 +2,7 @@ import type { Express, Request, Response } from "express";
 import { logActivity } from "../analysis/activityLog.js";
 import type { ForensicEvent } from "../analysis/stateTypes.js";
 import { runTagger, selectScopedEvents } from "../analysis/tagger.js";
-import { compileText } from "../analysis/taggerStore.js";
+import { compileText, TaggerRulesConflictError } from "../analysis/taggerStore.js";
 import { runAndApplyTagger, readTaggerSettings, TAGGER_AUTHOR_PREFIX } from "../analysis/taggerRun.js";
 import { sendPipelineError } from "./presidioApproval.js";
 import type { RouteContext } from "./context.js";
@@ -57,30 +57,39 @@ export function registerTaggerRoutes(app: Express, ctx: RouteContext): void {
       } catch (err) {
         error = (err as Error).message; // a hand-edited file can be invalid; report it, still return the text
       }
-      return res
-        .status(200)
-        .json({
-          text: active.text,
-          source: active.source,
-          ruleCount: ruleSummary.length,
-          rules: ruleSummary,
-          error,
-        });
+      return res.status(200).json({
+        text: active.text,
+        source: active.source,
+        // The editor sends this back on save; a mismatch means somebody else edited the rules in
+        // the meantime and the submission is refused instead of overwriting them.
+        revision: active.revision,
+        ruleCount: ruleSummary.length,
+        rules: ruleSummary,
+        error,
+      });
     } catch (err) {
       return res.status(500).json({ error: (err as Error).message });
     }
   });
 
   // Validate + persist edited rule YAML. An invalid ruleset is rejected (400) BEFORE the file is
-  // written, so a bad edit never clobbers a working ruleset.
+  // written, so a bad edit never clobbers a working ruleset. A `revision` from GET /tagger/rules is
+  // refused with 409 when the file has changed since — a whole-document save would otherwise delete
+  // a rule somebody added while this editor was open. 409 and 400 are deliberately different: one
+  // says "reload, you are out of date", the other "your YAML is wrong".
   app.put("/tagger/rules", async (req: Request, res: Response) => {
     if (!options.taggerStore) return res.status(501).json({ error: "tagger not configured" });
     const text = typeof req.body?.text === "string" ? req.body.text : "";
+    const revision = typeof req.body?.revision === "string" ? req.body.revision : undefined;
     try {
-      const compiled = await options.taggerStore.save(text);
+      const compiled = await options.taggerStore.save(text, revision);
       logLine(`[tagger] rules updated — ${compiled.rules.length} rule(s)`);
-      return res.status(200).json({ ruleCount: compiled.rules.length });
+      return res.status(200).json({ ruleCount: compiled.rules.length, revision: compiled.revision });
     } catch (err) {
+      if (err instanceof TaggerRulesConflictError) {
+        logLine("[tagger] rules save refused — the editor was out of date");
+        return res.status(409).json({ error: err.message, revision: err.currentRevision });
+      }
       return res.status(400).json({ error: (err as Error).message });
     }
   });

--- a/companion/tests/analysis/taggerStore.test.ts
+++ b/companion/tests/analysis/taggerStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, writeFile, rm, readFile, access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { TaggerStore, compileText } from "../../src/analysis/taggerStore.js";
+import { TaggerStore, TaggerRulesConflictError, compileText } from "../../src/analysis/taggerStore.js";
 
 const VALID = `svc:
   any:
@@ -248,17 +248,63 @@ describe("TaggerStore concurrency (follow-up to #682)", () => {
     expect(ids).toContain("from-add");
   });
 
-  // The other ordering, asserted rather than avoided. A whole-document PUT REPLACES the file, so an
-  // editor submission that went second discards a structural edit that landed while the analyst was
-  // typing. The lock does not change that and was never going to: it makes the two writes atomic
-  // with respect to each other, and last-write-wins is what a full-document PUT means. Closing this
-  // needs the editor to submit a revision the server can reject as stale, which is an API and UI
-  // change, not a locking one. Pinned here so the limitation is visible instead of implied.
-  it("still lets a whole-document save replace an edit that landed first (last-write-wins)", async () => {
+  // The other ordering. A whole-document save REPLACES the file, so on its own it still discards a
+  // structural edit that landed first — the lock makes the two writes atomic with respect to each
+  // other, which is a different problem. A caller that sends no revision is opting into that.
+  it("lets a revision-less save replace an edit that landed first (last-write-wins)", async () => {
     const store = new TaggerStore(userPath, [defaultPath]);
     await Promise.all([store.addRuleYaml(rule("from-add")), store.save(rule("from-editor"))]);
     const ids = (await store.load()).rules.map((r) => r.id);
     expect(ids).toEqual(["from-editor"]);
+  });
+
+  // …and the fix for it. The editor sends back the revision it loaded, so the same submission is
+  // REFUSED rather than applied, and the rule the other analyst added survives.
+  it("refuses a save whose revision went stale, keeping the other analyst's rule", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    const opened = (await store.readActive()).revision; // what the editor loaded
+
+    await store.addRuleYaml(rule("from-add")); // somebody else edits while the box is open
+
+    await expect(store.save(rule("from-editor"), opened)).rejects.toBeInstanceOf(TaggerRulesConflictError);
+    const ids = (await store.load()).rules.map((r) => r.id);
+    expect(ids).toContain("from-add"); // not deleted
+    expect(ids).not.toContain("from-editor"); // not applied
+  });
+
+  it("accepts a save whose revision is current, and hands back the new one", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    const opened = (await store.readActive()).revision;
+    const saved = await store.save(rule("from-editor"), opened);
+    expect(saved.revision).toBe((await store.readActive()).revision);
+    expect((await store.load()).rules.map((r) => r.id)).toEqual(["from-editor"]);
+    // The returned revision is immediately reusable, so a second save needs no reload.
+    await expect(store.save(rule("again"), saved.revision)).resolves.toBeDefined();
+  });
+
+  // The comparison has to happen INSIDE the lock. Outside it, this is the exact race it exists to
+  // close: read the current revision, another writer lands, overwrite anyway.
+  it("compares the revision inside the lock, not before it", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    const opened = (await store.readActive()).revision;
+    const [addResult, saveResult] = await Promise.allSettled([
+      store.addRuleYaml(rule("from-add")),
+      store.save(rule("from-editor"), opened),
+    ]);
+    expect(addResult.status).toBe("fulfilled");
+    // The add went first and moved the revision on, so the save must be refused — even though it
+    // was issued before the add completed.
+    expect(saveResult.status).toBe("rejected");
+    expect((await store.load()).rules.map((r) => r.id)).toContain("from-add");
+  });
+
+  it("reports the current revision on the conflict, so a client can resync without a second call", async () => {
+    const store = new TaggerStore(userPath, [defaultPath]);
+    const opened = (await store.readActive()).revision;
+    await store.addRuleYaml(rule("from-add"));
+    await expect(store.save(rule("from-editor"), opened)).rejects.toMatchObject({
+      currentRevision: (await store.readActive()).revision,
+    });
   });
 
   it("still de-collides ids raced against each other", async () => {

--- a/companion/tests/server/taggerRoutes.test.ts
+++ b/companion/tests/server/taggerRoutes.test.ts
@@ -90,6 +90,15 @@ describe("GET /tagger/rules", () => {
     expect(res.body.rules[0]).toMatchObject({ id: "svc", severity: "High", view: "Service Installs" });
     expect(res.body.text).toContain("svc:");
   });
+
+  it("hands out a revision for the editor to send back", async () => {
+    const res = await request(app()).get("/tagger/rules");
+    expect(typeof res.body.revision).toBe("string");
+    expect(res.body.revision).not.toBe("");
+    // Stable while the file is unchanged — otherwise every save would look stale.
+    const again = await request(app()).get("/tagger/rules");
+    expect(again.body.revision).toBe(res.body.revision);
+  });
 });
 
 describe("PUT /tagger/rules", () => {
@@ -112,6 +121,66 @@ describe("PUT /tagger/rules", () => {
     const get = await request(app()).get("/tagger/rules");
     expect(get.body.source).toBe("user");
     expect(get.body.rules[0].id).toBe("logon");
+  });
+
+  // The wire contract the dashboard editor depends on. Two analysts, one rules file: one opens the
+  // editor, the other adds a rule, the first submits. Without this the submission REPLACES the file
+  // and the added rule is gone with no error shown to anyone.
+  describe("a stale editor submission", () => {
+    const RULE = "logon:\n  any:\n    - { field: message, contains: 'logged on' }\n  tags: ['logon']\n";
+    const ADDED = "extra:\n  any:\n    - { field: message, contains: 'extra' }\n  tags: ['extra']\n";
+
+    it("is refused with 409, and the other analyst's rule survives", async () => {
+      const opened = (await request(app()).get("/tagger/rules")).body.revision;
+      expect((await request(app()).post("/tagger/rules/add").send({ ruleYaml: ADDED })).status).toBe(200);
+
+      const put = await request(app()).put("/tagger/rules").send({ text: RULE, revision: opened });
+      expect(put.status).toBe(409);
+      expect(put.body.error).toMatch(/reload/i);
+
+      const get = await request(app()).get("/tagger/rules");
+      expect(get.body.rules.map((r: { id: string }) => r.id)).toContain("extra");
+    });
+
+    it("reports the current revision, so the client can resync from the 409 itself", async () => {
+      const opened = (await request(app()).get("/tagger/rules")).body.revision;
+      await request(app()).post("/tagger/rules/add").send({ ruleYaml: ADDED });
+      const put = await request(app()).put("/tagger/rules").send({ text: RULE, revision: opened });
+      const current = (await request(app()).get("/tagger/rules")).body.revision;
+      expect(put.body.revision).toBe(current);
+    });
+
+    it("succeeds once the editor resends with the current revision", async () => {
+      const opened = (await request(app()).get("/tagger/rules")).body.revision;
+      await request(app()).post("/tagger/rules/add").send({ ruleYaml: ADDED });
+      expect((await request(app()).put("/tagger/rules").send({ text: RULE, revision: opened })).status).toBe(
+        409,
+      );
+      const fresh = (await request(app()).get("/tagger/rules")).body.revision;
+      const retry = await request(app()).put("/tagger/rules").send({ text: RULE, revision: fresh });
+      expect(retry.status).toBe(200);
+      expect(retry.body.revision).toBe((await request(app()).get("/tagger/rules")).body.revision);
+    });
+
+    // 409 and 400 are different instructions to an analyst: one says reload, the other says fix
+    // your YAML. A stale revision must not be reported as a syntax problem.
+    it("is a 409, not the 400 an invalid ruleset gets", async () => {
+      const opened = (await request(app()).get("/tagger/rules")).body.revision;
+      await request(app()).post("/tagger/rules/add").send({ ruleYaml: ADDED });
+      const stale = await request(app()).put("/tagger/rules").send({ text: RULE, revision: opened });
+      const invalid = await request(app())
+        .put("/tagger/rules")
+        .send({ text: "bad:\n  any:\n    - { field: nope, contains: x }\n  tags: ['t']\n" });
+      expect(stale.status).toBe(409);
+      expect(invalid.status).toBe(400);
+    });
+
+    // A caller that sends no revision keeps the old behaviour, so scripts and curl are unaffected.
+    it("does not apply to a caller that sends no revision", async () => {
+      await request(app()).post("/tagger/rules/add").send({ ruleYaml: ADDED });
+      const put = await request(app()).put("/tagger/rules").send({ text: RULE });
+      expect(put.status).toBe(200);
+    });
   });
 });
 
@@ -259,11 +328,9 @@ describe("POST /tagger/rules/add", () => {
 
 describe("DELETE /tagger/rules/:ruleId", () => {
   it("removes a rule (200) and 404s for an unknown id", async () => {
-    await request(app())
-      .post("/tagger/rules/add")
-      .send({
-        ruleYaml: "logon:\n  any:\n    - { field: message, contains: 'logged on' }\n  tags: ['logon']\n",
-      });
+    await request(app()).post("/tagger/rules/add").send({
+      ruleYaml: "logon:\n  any:\n    - { field: message, contains: 'logged on' }\n  tags: ['logon']\n",
+    });
     const del = await request(app()).delete("/tagger/rules/svc");
     expect(del.status).toBe(200);
     expect(del.body.ruleCount).toBe(1);

--- a/public/js/dashboard-tagger.js
+++ b/public/js/dashboard-tagger.js
@@ -221,6 +221,13 @@ async function clearTaggerTags() {
   } catch (e) { msg.style.color = "var(--badge-danger-text)"; msg.textContent = "Clear failed: " + e.message; }
 }
 
+// The revision of the text currently sitting in the editor box. Sent back on save so the server can
+// refuse a submission that would delete a rule somebody else added while this editor was open. Set
+// ONLY when the box is filled from the server — never after a structural add/remove/reset, because
+// the box still holds the pre-edit text at that point and silently freshening this would hand back
+// exactly the overwrite it exists to prevent. The 409 is the safety net for that case.
+let taggerRulesRevision = "";
+
 async function toggleTaggerRules() {
   const pane = document.getElementById("taggerRulesPane");
   if (!pane.hidden) { pane.hidden = true; return; }
@@ -231,6 +238,7 @@ async function toggleTaggerRules() {
     const r = await fetch(`/tagger/rules`);
     const d = await r.json();
     document.getElementById("taggerRulesText").value = d.text || "";
+    taggerRulesRevision = d.revision || "";
     document.getElementById("taggerRulesSource").textContent =
       (d.source || "default") + (d.error ? ` (current file invalid: ${d.error})` : ` — ${d.ruleCount} rule(s)`);
   } catch (e) { msg.style.color = "var(--badge-danger-text)"; msg.textContent = "Failed to load rules: " + e.message; }
@@ -243,9 +251,21 @@ async function saveTaggerRules() {
   msg.style.color = "var(--text-muted)";
   msg.textContent = "Saving…";
   try {
-    const r = await fetch(`/tagger/rules`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ text }) });
+    const r = await fetch(`/tagger/rules`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text, revision: taggerRulesRevision }),
+    });
     const d = await r.json();
+    if (r.status === 409) {
+      // Somebody else changed the rules while this box was open. Saving would delete their change,
+      // so say what happened and what to do rather than reporting a generic rejection.
+      msg.style.color = "var(--badge-danger-text)";
+      msg.textContent = "Not saved — the rules changed since you opened the editor. Close and reopen it to pick up the current rules, then reapply your edit.";
+      return;
+    }
     if (!r.ok) { msg.style.color = "var(--badge-danger-text)"; msg.textContent = "Rejected: " + (d.error || r.status); return; }
+    taggerRulesRevision = d.revision || "";
     msg.style.color = "#6bcB77";
     msg.textContent = `Saved — ${d.ruleCount} rule(s). Run tagger to apply.`;
     document.getElementById("taggerRulesSource").textContent = `user — ${d.ruleCount} rule(s)`;


### PR DESCRIPTION
#714 serialized writes to the shared tagger rules file and wrote down what that did **not** fix. A stop-time review called it, correctly, the primary team-mode scenario still open. This closes it.

Follow-up to #682.

## The scenario

Two analysts, one global rules file. One opens the rule editor. The other adds a rule. The first submits.

A whole-document save **replaces** the file, so the second analyst's rule was silently deleted — no error, to either of them. The lock added in #714 could never have fixed this: it makes two writes atomic with respect to each other, which is a different problem entirely. Closing it needs the editor to prove it is up to date.

## What changed

`GET /tagger/rules` now returns a **revision** of the active rule text. The editor sends it back on save, and `PUT` answers **409** when it no longer matches.

`409` and `400` are deliberately different answers. One tells the analyst to reload; the other says their YAML is wrong. Reporting a stale editor as a syntax error would send someone looking in entirely the wrong place, so a test pins that the two stay distinct.

**The comparison runs inside the lock.** Outside it, this is exactly the race it exists to close — read the current revision, another writer lands, overwrite anyway. A test drives that ordering directly rather than trusting the placement.

## Two deliberate limits

**Omitting the revision keeps last-write-wins.** A script or curl caller holding the full ruleset is stating intent; only the dashboard editor can genuinely be stale, and it always sends one. Covered by a test so the escape hatch is intentional rather than incidental.

**The editor does not silently refresh its revision after an add, remove or reset.** Its box still holds the pre-edit text at that moment, so freshening the revision would hand back the exact overwrite this prevents. The 409 is the safety net, and the message says what happened and what to do:

> Not saved — the rules changed since you opened the editor. Close and reopen it to pick up the current rules, then reapply your edit.

That does mean an analyst who adds a rule via the suggest pane while the editor is open will see a 409 from their own action. That is correct: their editor genuinely does not contain the new rule, and saving it would delete it.

## Verification

Seven tests fail against the pre-fix code — three at the store, four at the route. Confirmed by reverting both sources with `git show HEAD:` and re-running.

Coverage spans the store (stale refused, current accepted, revision returned is immediately reusable, comparison inside the lock, conflict reports the current revision) and the wire (409 with the other analyst's rule intact, resync from the 409 body, retry succeeds, 409 stays distinct from 400, no-revision callers unaffected).

## Gates

`lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`, `eval:change-gate`, `check:us-map`, `build`, `typecheck` — all green. Companion: **695 files, 10,953 tests, 0 failures**. Extension: typecheck, tests, Chrome and Firefox builds green. Dashboard module suite: 38 files, 2,290 tests — the editor change adds no new declared function, so the namespace contract is untouched.

No cross-domain boundary drift, so `ARCHITECTURE.md` is unchanged.
