### PR TITLE
fix(security): warn when an imported .dfircase used the weaker v1 encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **One Windows record read by two parsers is one timeline row** — a Hayabusa run and a Chainsaw run over the same EVTX now merge on the record's own identity (channel + EventRecordID + host) and carry both tools as sources, instead of doubling the timeline. Two detections from the *same* parser on one record stay distinct. (#688)
 
 ### Security
+- **Importing an old `.dfircase` archive now warns that its encryption is weaker** — files exported by v0.31.0–v0.33.0 used scrypt `N=2^14`; v0.34.0 onward use `N=2^17`. The import reports the archive's format version and tells the analyst to re-export. v1 archives stay readable — nothing is refused or re-keyed. (closes #672)
 - **The EVTX parsers fail closed** — a non-zero exit from Hayabusa, Chainsaw or the Velociraptor CLI rejects the run instead of importing a partial parse, and Chainsaw refuses to start when its Sigma rule directory is missing or empty rather than reporting a false all-clear. (#688)
 - **A failed OIDC sign-in no longer shows the identity provider's error text** — the login page gets one sentence and a reference; the full detail goes to the server log under that reference. (closes #674)
 - **Case unlock tokens carry a payload version** — a token signed under an older payload shape now stops verifying instead of being read under today's rules. Unlock cookies issued before this release stop working, so each password-protected case asks for its password once more. (closes #671)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,34 @@ own auth/reverse proxy.
 Please report security issues privately via a **GitHub security advisory**
 (repo → Security → *Report a vulnerability*) rather than a public issue.
 
+## Encrypted case archives (`.dfircase`)
+
+An exported `.dfircase` file is AES-256-GCM encrypted under a key derived from your password
+with scrypt. The 8-byte magic at the front of the file is a **format version**, and the version
+selects the scrypt cost:
+
+| Version | Magic | scrypt `N` | Written by |
+| --- | --- | --- | --- |
+| v1 | `DFIRCZ01` | 2^14 (16,384) | v0.31.0 – v0.33.0 |
+| v2 | `DFIRCZ02` | 2^17 (131,072) | v0.34.0 onward |
+
+**v1 is weaker than it should be.** `N=2^14` is Node's `scryptSync` default. It is too low for a
+file an attacker holds with unlimited offline attempts, which is exactly the situation a
+`.dfircase` file is in. v2 raises it to OWASP's recommendation for sensitive data at rest.
+
+**If you hold a `.dfircase` file exported by v0.31.0, v0.32.0 or v0.33.0, re-export it.** Import
+it into a current build and export the case again — the new file is v2. Importing a v1 archive
+now prints a warning saying exactly this.
+
+Nothing refuses to open a v1 archive. It stays readable, so an archive that the
+delete-with-archive flow left as a case's only remaining copy is never stranded. This also means
+re-exporting is the only thing that upgrades a file you already hold; no build will silently
+re-key it.
+
+The parameters of an existing version are never changed. Raising the cost always means adding a
+new version, because re-keying an existing one would make every archive already written under it
+unopenable while reporting itself as a wrong password.
+
 ## Known dependency advisories (tracked, deferred)
 
 `npm audit` in `companion/` currently reports **5 advisories (4 moderate, 1 critical)**. They

--- a/companion/src/analysis/caseEncryption.ts
+++ b/companion/src/analysis/caseEncryption.ts
@@ -40,11 +40,33 @@ const SCRYPT_V2 = { N: 1 << 17, r: 8, p: 1, maxmem: 256 * 1024 * 1024 } as const
 
 type ScryptParams = typeof SCRYPT_V1 | typeof SCRYPT_V2;
 
-const FORMATS: ReadonlyArray<{ magic: Buffer; scrypt: ScryptParams }> = [
-  { magic: Buffer.from("DFIRCZ01", "utf8"), scrypt: SCRYPT_V1 },
-  { magic: Buffer.from("DFIRCZ02", "utf8"), scrypt: SCRYPT_V2 },
+const FORMATS: ReadonlyArray<{ version: number; magic: Buffer; scrypt: ScryptParams }> = [
+  { version: 1, magic: Buffer.from("DFIRCZ01", "utf8"), scrypt: SCRYPT_V1 },
+  { version: 2, magic: Buffer.from("DFIRCZ02", "utf8"), scrypt: SCRYPT_V2 },
 ];
 const CURRENT_FORMAT = FORMATS[FORMATS.length - 1];
+
+/** The container version {@link encryptBuffer} writes. A version is only ever ADDED to raise the
+ * KDF cost (see the rule above), so a container whose version is BELOW this one was written under
+ * weaker parameters. That is what makes `version < CURRENT_FORMAT_VERSION` a sound weakness test,
+ * and it keeps working when a v3 arrives without any caller remembering to update a hardcoded 2. */
+export const CURRENT_FORMAT_VERSION = CURRENT_FORMAT.version;
+
+function findFormat(container: Buffer): (typeof FORMATS)[number] | undefined {
+  if (container.length < HEADER_LEN) return undefined;
+  return FORMATS.find((f) => container.subarray(0, MAGIC_LEN).equals(f.magic));
+}
+
+/** The container version of `container`, or undefined if it isn't a .dfircase archive this build
+ * reads (garbage, truncated, or written by a NEWER build).
+ *
+ * Reads the magic only — no password, no derivation — so it is cheap. That is exactly why the
+ * import route reports it only AFTER a successful decrypt (#672): an endpoint that answered this
+ * question without a password would let an unauthenticated caller sort a pile of archives by which
+ * ones are cheapest to crack offline. */
+export function readFormatVersion(container: Buffer): number | undefined {
+  return findFormat(container)?.version;
+}
 
 function deriveKey(password: string, salt: Buffer, params: ScryptParams): Buffer {
   return scryptSync(password, salt, KEY_LEN, params);
@@ -67,10 +89,7 @@ export function encryptBuffer(data: Buffer, password: string): Buffer {
  * isn't a .dfircase container (including one written by a NEWER build — an unknown version is
  * reported as such rather than as a wrong password). */
 export function decryptBuffer(container: Buffer, password: string): Buffer {
-  const format =
-    container.length >= HEADER_LEN
-      ? FORMATS.find((f) => container.subarray(0, MAGIC_LEN).equals(f.magic))
-      : undefined;
+  const format = findFormat(container);
   if (!format) throw new DecryptionError("not a valid .dfircase archive");
   let offset = MAGIC_LEN;
   const salt = container.subarray(offset, offset + SALT_LEN);

--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -15,7 +15,7 @@ import { isValidCaseId, type CaseStore } from "../storage/caseStore.js";
 import { isTransientCasePath } from "./caseTransientPaths.js";
 import type { CaseMeta } from "../types.js";
 import { createZip, readZip, type ZipEntry } from "./zipArchive.js";
-import { encryptBuffer, decryptBuffer } from "./caseEncryption.js";
+import { encryptBuffer, decryptBuffer, readFormatVersion, CURRENT_FORMAT_VERSION } from "./caseEncryption.js";
 import { getAppVersion } from "../version.js";
 import { caseSqliteWorker } from "./caseSqliteWorker.js";
 import { INVESTIGATION_DB_FILENAME } from "./stateStore.js";
@@ -476,6 +476,12 @@ export interface ImportEncryptedCaseOptions {
 export interface ImportEncryptedCaseResult {
   meta: CaseMeta;
   counts: CaseImportCounts;
+  /** The container version the archive was written in, and the version this build writes. An
+   * archive below the current version was encrypted under a weaker KDF (#672) — the caller shows
+   * that to the analyst so they can re-export and upgrade it. Nothing here re-keys the archive:
+   * v1 stays readable forever, by the rule in caseEncryption.ts. */
+  formatVersion: number;
+  currentFormatVersion: number;
 }
 
 /**
@@ -492,6 +498,10 @@ export async function importEncryptedCase(
   password: string,
   options: ImportEncryptedCaseOptions = {},
 ): Promise<ImportEncryptedCaseResult> {
+  // Read the version BEFORE decrypting so it comes from the same bytes the derivation used, then
+  // let decryptBuffer be the thing that rejects an unknown/short container. readFormatVersion
+  // cannot return undefined past that call — decryptBuffer would already have thrown.
+  const formatVersion = readFormatVersion(fileBuffer);
   const zip = decryptBuffer(fileBuffer, password);
   const archiveEntries = readZip(zip);
   const manifestCounts = countsFromManifest(
@@ -609,7 +619,13 @@ export async function importEncryptedCase(
 
   const meta = await store.getCaseMeta(targetCaseId);
   if (!meta) throw new Error("import failed: case.json missing after write");
-  return { meta, counts };
+  return {
+    meta,
+    counts,
+    // Non-null: decryptBuffer above already threw on any container this build cannot read.
+    formatVersion: formatVersion!,
+    currentFormatVersion: CURRENT_FORMAT_VERSION,
+  };
 }
 
 /**

--- a/companion/src/routes/encryptedImport.ts
+++ b/companion/src/routes/encryptedImport.ts
@@ -60,17 +60,28 @@ export function registerEncryptedImportRoutes(app: Express, ctx: RouteContext): 
         return res.status(429).json({ error: "too many import attempts, try again later" });
       }
       const fileBuffer = Buffer.from(data, "base64");
-      const { meta, counts } = await importEncryptedCase(store, fileBuffer, password, {
-        targetCaseId:
-          typeof targetCaseId === "string" && targetCaseId.trim() ? targetCaseId.trim() : undefined,
-      });
+      const { meta, counts, formatVersion, currentFormatVersion } = await importEncryptedCase(
+        store,
+        fileBuffer,
+        password,
+        {
+          targetCaseId:
+            typeof targetCaseId === "string" && targetCaseId.trim() ? targetCaseId.trim() : undefined,
+        },
+      );
       options.teamAuth?.grantCreator(req, meta.caseId);
       // An archived case.json is written back byte-for-byte on import (see
       // caseExportArchive.ts), so an exported case that had a case-lock password carries
       // its salt+hash into the archive. Sanitize before responding — never let it reach
       // the client, same as every other route that serializes a CaseMeta.
       limiter.clear(limiterKey);
-      return res.status(201).json({ ...sanitizeCaseMeta(meta), counts });
+      // Both versions ride in the response so the dashboard can say "this archive used an older,
+      // weaker key derivation" without hardcoding which version is current — a client that
+      // hardcoded "warn below 2" would silently stop warning about v2 the day a v3 lands (#672).
+      // This is safe to return only because it is the SUCCESS path: the caller has already proven
+      // it holds the password. Never answer "what version is this archive?" before a decrypt, or
+      // an unauthenticated caller could sort a pile of archives by which are cheapest to crack.
+      return res.status(201).json({ ...sanitizeCaseMeta(meta), counts, formatVersion, currentFormatVersion });
     } catch (err) {
       // A conflict means the archive DID open — a real analyst re-importing, not an attacker
       // burning CPU. Deliberately not counted as a failure; the per-request budget above is what

--- a/companion/tests/analysis/caseEncryption.test.ts
+++ b/companion/tests/analysis/caseEncryption.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { encryptBuffer, decryptBuffer, DecryptionError } from "../../src/analysis/caseEncryption.js";
+import {
+  encryptBuffer,
+  decryptBuffer,
+  readFormatVersion,
+  CURRENT_FORMAT_VERSION,
+  DecryptionError,
+} from "../../src/analysis/caseEncryption.js";
 
 describe("encryptBuffer / decryptBuffer", () => {
   it("round-trips arbitrary bytes", () => {
@@ -76,5 +82,45 @@ describe("container versioning", () => {
     const fromTheFuture = encryptBuffer(Buffer.from("written by a later build"), "pw12345678");
     Buffer.from("DFIRCZ99", "utf8").copy(fromTheFuture, 0);
     expect(() => decryptBuffer(fromTheFuture, "pw12345678")).toThrow(/not a valid \.dfircase archive/);
+  });
+  // readFormatVersion is what lets the import flow TELL the analyst the archive was written under
+  // the weaker v1 derivation (#672). It reads the magic only — no password, no derivation — so it
+  // must stay on the post-decryption path in the route; an endpoint that reported the version
+  // before decrypting would let an unauthenticated caller sort a pile of archives by which ones
+  // are cheapest to crack.
+  it("reports version 1 for a v1 archive", () => {
+    expect(readFormatVersion(Buffer.from(V1_CONTAINER_HEX, "hex"))).toBe(1);
+  });
+
+  it("reports version 2 for a freshly written archive", () => {
+    expect(readFormatVersion(encryptBuffer(Buffer.from("fresh export"), "pw12345678"))).toBe(2);
+  });
+
+  it("CURRENT_FORMAT_VERSION is the version encryptBuffer actually writes", () => {
+    const container = encryptBuffer(Buffer.from("fresh export"), "pw12345678");
+    expect(readFormatVersion(container)).toBe(CURRENT_FORMAT_VERSION);
+  });
+
+  // A version older than the current one is always the weaker one: the module's rule is that an
+  // existing version's parameters never change, so the ONLY way the cost is ever raised is by
+  // adding a version. That makes "version < CURRENT_FORMAT_VERSION" a sound weakness test, and it
+  // keeps working when a v3 arrives without anyone remembering to update the caller.
+  it("orders versions so an older one is the weaker one", () => {
+    expect(readFormatVersion(Buffer.from(V1_CONTAINER_HEX, "hex"))!).toBeLessThan(CURRENT_FORMAT_VERSION);
+  });
+
+  it("returns undefined for a buffer that isn't a .dfircase container", () => {
+    expect(readFormatVersion(Buffer.from("not a dfircase file"))).toBeUndefined();
+  });
+
+  it("returns undefined for a container written by a newer build", () => {
+    const fromTheFuture = encryptBuffer(Buffer.from("written by a later build"), "pw12345678");
+    Buffer.from("DFIRCZ99", "utf8").copy(fromTheFuture, 0);
+    expect(readFormatVersion(fromTheFuture)).toBeUndefined();
+  });
+
+  it("returns undefined for a truncated container", () => {
+    const container = encryptBuffer(Buffer.from("secret data"), "correct-password");
+    expect(readFormatVersion(container.subarray(0, 10))).toBeUndefined();
   });
 });

--- a/companion/tests/analysis/caseExportArchive.test.ts
+++ b/companion/tests/analysis/caseExportArchive.test.ts
@@ -14,7 +14,7 @@ import {
 import { createZip, readZip } from "../../src/analysis/zipArchive.js";
 import { encryptBuffer, decryptBuffer, DecryptionError } from "../../src/analysis/caseEncryption.js";
 import { atomicWrite } from "../../src/storage/atomicWrite.js";
-import { createHash } from "node:crypto";
+import { createHash, scryptSync, createCipheriv, randomBytes } from "node:crypto";
 import { StateStore, INVESTIGATION_DB_FILENAME } from "../../src/analysis/stateStore.js";
 import { StateLock } from "../../src/analysis/stateLock.js";
 import { caseSqliteWorker } from "../../src/analysis/caseSqliteWorker.js";
@@ -222,6 +222,20 @@ describe("exportEncryptedCase — symlink/hardlink rejection (#247)", () => {
     expect(archive.length).toBeGreaterThan(0);
   });
 });
+
+// Re-wrap a decrypted archive in the v1 container the 0.31.0–0.33.0 writer produced. Nothing in
+// production writes v1 any more (#268), so a test that needs one has to build it, and the scrypt
+// parameters are spelled out here on purpose: they are an INDEPENDENT statement of what v1 is, so
+// this breaks loudly if v1's parameters are ever changed in the module (which would make every
+// archive already in an analyst's evidence store unopenable — see caseEncryption.ts).
+function encryptAsV1(plain: Buffer, password: string): Buffer {
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = scryptSync(password, salt, 32, { N: 1 << 14, r: 8, p: 1, maxmem: 32 * 1024 * 1024 });
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plain), cipher.final()]);
+  return Buffer.concat([Buffer.from("DFIRCZ01", "utf8"), salt, iv, cipher.getAuthTag(), ciphertext]);
+}
 
 describe("importEncryptedCase", () => {
   it("imports under a target id, preserving evidence bytes exactly", async () => {
@@ -529,6 +543,35 @@ describe("importEncryptedCase", () => {
       /duplicate entry path/,
     );
     expect(await store.caseExists("INC-DUP")).toBe(false);
+  });
+
+  // #672: the import result carries the container version so the caller can tell the analyst the
+  // archive was written under the weaker v1 derivation. Nothing re-keys the archive — v1 stays
+  // readable forever — the analyst is simply told, so they can re-export and get v2.
+  it("reports the container format version of the archive it opened", async () => {
+    const store = await harness();
+    await seedCase(store, "INC-1");
+    const archive = await exportEncryptedCase(store, "INC-1", PASSWORD);
+
+    const { formatVersion } = await importEncryptedCase(store, archive, PASSWORD, {
+      targetCaseId: "INC-2",
+    });
+    expect(formatVersion).toBe(2);
+  });
+
+  it("reports version 1 for an archive written by the pre-#268 writer", async () => {
+    const store = await harness();
+    await seedCase(store, "INC-1");
+    const v1Archive = encryptAsV1(
+      decryptBuffer(await exportEncryptedCase(store, "INC-1", PASSWORD), PASSWORD),
+      PASSWORD,
+    );
+
+    const { meta, formatVersion } = await importEncryptedCase(store, v1Archive, PASSWORD, {
+      targetCaseId: "INC-2",
+    });
+    expect(formatVersion).toBe(1);
+    expect(meta.caseId).toBe("INC-2"); // still imports — the weaker version is read-only, not refused
   });
 });
 

--- a/companion/tests/dashboard/dashboardImportCase.test.ts
+++ b/companion/tests/dashboard/dashboardImportCase.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { loadDashboardModule } from "../helpers/dashboardModule.js";
+import type { DashboardGlobals } from "../helpers/dashboardModule.js";
+
+// #672. An analyst importing a .dfircase written by 0.31.0-0.33.0 used to get no signal that the
+// archive was encrypted under the weaker v1 key derivation. The import response now carries both
+// the archive's version and the version this build writes, and this function turns that pair into
+// the sentence the analyst reads.
+//
+// It is a pure function on purpose. The rest of the module is DOM wiring that only exists after
+// initImportCase() has run against fifteen elements; the DECISION — warn or stay quiet — is the
+// part worth pinning, and pinning it needs no DOM at all.
+interface ImportCaseApi {
+  encryptionUpgradeNotice(formatVersion: unknown, currentFormatVersion: unknown): string;
+}
+
+const { encryptionUpgradeNotice } = loadDashboardModule<ImportCaseApi>("dashboard-import-case.js");
+
+describe("encryptionUpgradeNotice", () => {
+  it("warns when the archive is older than the version this build writes", () => {
+    const notice = encryptionUpgradeNotice(1, 2);
+    expect(notice).toMatch(/weaker key derivation/i);
+    // It must say what to DO, not only what is wrong — re-exporting is the only thing that
+    // upgrades a file the analyst already holds.
+    expect(notice).toMatch(/export the case again/i);
+  });
+
+  it("says nothing when the archive is already current", () => {
+    expect(encryptionUpgradeNotice(2, 2)).toBe("");
+  });
+
+  // A version ABOVE the current one cannot reach here — the server refuses to decrypt a container
+  // written by a newer build — but if it ever did, "your encryption is weak" would be exactly
+  // backwards. Staying silent is the only safe answer for a comparison this function cannot make.
+  it("says nothing when the archive is newer than this build writes", () => {
+    expect(encryptionUpgradeNotice(3, 2)).toBe("");
+  });
+
+  // Absent fields mean an older companion answered, not a weak archive. Guessing "weak" from a
+  // missing field would put a security warning on every import from such a server.
+  it("says nothing when either version is missing", () => {
+    expect(encryptionUpgradeNotice(undefined, 2)).toBe("");
+    expect(encryptionUpgradeNotice(1, undefined)).toBe("");
+    expect(encryptionUpgradeNotice(undefined, undefined)).toBe("");
+  });
+
+  it("says nothing when either version is not a number", () => {
+    expect(encryptionUpgradeNotice("1", 2)).toBe("");
+    expect(encryptionUpgradeNotice(null, 2)).toBe("");
+  });
+});
+
+// The warning has to SURVIVE, not merely be written. The first version of this feature appended it
+// to the shared #status element and then called connect(), whose WebSocket onopen handler in
+// js/dashboard-case-connect.js overwrites #status with "connected (live)" milliseconds later — so
+// the sentence the whole change exists to deliver flashed and vanished, and every unit test still
+// passed because they only checked the string.
+//
+// These drive the real click handler against a stub document, which is the only level at which
+// "does the analyst actually end up looking at it" can be asked.
+
+interface StubEl {
+  id: string;
+  textContent: string;
+  value: string;
+  disabled: boolean;
+  hidden: boolean;
+  files: unknown[];
+  classes: Set<string>;
+  classList: { add(c: string): void; remove(c: string): void; contains(c: string): boolean };
+  onclick: ((e?: unknown) => unknown) | null;
+  onchange: ((e?: unknown) => unknown) | null;
+  addEventListener(type: string, fn: (e?: unknown) => unknown): void;
+  focus(): void;
+  click(): void;
+}
+
+function stubEl(id: string): StubEl {
+  const classes = new Set<string>();
+  return {
+    id,
+    textContent: "",
+    value: "",
+    disabled: false,
+    hidden: false,
+    files: [],
+    classes,
+    classList: {
+      add: (c) => void classes.add(c),
+      remove: (c) => void classes.delete(c),
+      contains: (c) => classes.has(c),
+    },
+    onclick: null,
+    onchange: null,
+    addEventListener: () => {},
+    focus: () => {},
+    click: () => {},
+  };
+}
+
+const EL_IDS = [
+  "importCaseOverlay",
+  "importCaseBtn",
+  "importCaseCancel",
+  "importCaseEncrypted",
+  "importCaseIris",
+  "importCaseHint",
+  "encryptedImportFile",
+  "importPasswordOverlay",
+  "ipFilename",
+  "ipPassword",
+  "ipMsg",
+  "ipImport",
+  "ipCancel",
+  "status",
+  "caseId",
+];
+
+/** Run one full import through the real handler and hand back the DOM it left behind. */
+async function runImport(responseBody: Record<string, unknown>) {
+  const els = new Map(EL_IDS.map((id) => [id, stubEl(id)]));
+  let connected = 0;
+  const globals: DashboardGlobals = {
+    document: { getElementById: (id: string) => els.get(id) ?? null },
+    fetch: async () => ({ status: 201, json: async () => responseBody }),
+    arrayBufferToBase64: () => "AAAA",
+    loadCaseList: () => {},
+    connect: () => {
+      connected++;
+      // What js/dashboard-case-connect.js really does on ws.onopen. If the warning lives in
+      // #status, this is the line that destroys it.
+      els.get("status")!.textContent = "connected (live)";
+    },
+    openIrisImportModal: () => {},
+  };
+
+  const mod = loadDashboardModule<{ initImportCase(): void }>("dashboard-import-case.js", [], globals);
+  mod.initImportCase();
+
+  // Pick a file, then press Import — the two steps the analyst takes.
+  els.get("encryptedImportFile")!.onchange!({
+    target: {
+      files: [{ name: "case.dfircase", size: 1024, arrayBuffer: async () => new ArrayBuffer(8) }],
+      value: "",
+    },
+  });
+  els.get("ipPassword")!.value = "correct horse battery staple"; // the handler refuses an empty one
+  await els.get("ipImport")!.onclick!();
+
+  return { els, connected };
+}
+
+describe("a weak-encryption warning survives the import that raised it", () => {
+  it("keeps the warning where the automatic reconnect cannot overwrite it", async () => {
+    const { els, connected } = await runImport({
+      caseId: "INC-2",
+      counts: {},
+      formatVersion: 1,
+      currentFormatVersion: 2,
+    });
+
+    expect(connected).toBe(1); // the case really did load
+    expect(els.get("status")!.textContent).toBe("connected (live)"); // and really did clobber #status
+    expect(els.get("ipMsg")!.textContent).toMatch(/weaker key derivation/i);
+    expect(els.get("importPasswordOverlay")!.classList.contains("open")).toBe(true);
+  });
+
+  it("closes the modal as before when the archive is already current", async () => {
+    const { els } = await runImport({
+      caseId: "INC-2",
+      counts: {},
+      formatVersion: 2,
+      currentFormatVersion: 2,
+    });
+
+    expect(els.get("importPasswordOverlay")!.classList.contains("open")).toBe(false);
+    expect(els.get("ipMsg")!.textContent).toBe("");
+  });
+
+  // The Import button must not invite a second run against the file that was just consumed —
+  // pressing it would report "no file selected" into ipMsg and wipe the warning off the screen.
+  it("leaves only a way out once the warning is showing", async () => {
+    const { els } = await runImport({
+      caseId: "INC-2",
+      counts: {},
+      formatVersion: 1,
+      currentFormatVersion: 2,
+    });
+
+    expect(els.get("ipImport")!.hidden).toBe(true);
+    expect(els.get("ipCancel")!.disabled).toBe(false);
+    // "Cancel" would read as "undo the import", which is not on offer — the case is already on
+    // disk and the archive is already open. The only thing left to do is close the warning.
+    expect(els.get("ipCancel")!.textContent).toBe("Close");
+  });
+});

--- a/companion/tests/dashboard/featureManifest.ts
+++ b/companion/tests/dashboard/featureManifest.ts
@@ -603,7 +603,11 @@ export const FEATURES: Feature[] = [
     // nothing here can safely sit in the module body.
     file: "dashboard-import-case.js",
     initializer: "initImportCase",
-    publish: ["initImportCase"],
+    // encryptionUpgradeNotice is published even though the inline script never calls it: it is the
+    // one function here that touches no DOM, so it is the one that can be tested without standing
+    // up fifteen elements (#672). Keeping it inside the closure would make the decision it encodes
+    // — warn about a weak archive, or stay quiet — reachable only through the whole import flow.
+    publish: ["initImportCase", "encryptionUpgradeNotice"],
     private: [],
   },
   {

--- a/companion/tests/server/encryptedCaseRoutes.test.ts
+++ b/companion/tests/server/encryptedCaseRoutes.test.ts
@@ -9,7 +9,8 @@ import { createApp } from "../../src/server.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { CommentsStore } from "../../src/analysis/comments.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
-import { encryptBuffer } from "../../src/analysis/caseEncryption.js";
+import { encryptBuffer, decryptBuffer } from "../../src/analysis/caseEncryption.js";
+import { scryptSync, createCipheriv, randomBytes } from "node:crypto";
 
 const PASSWORD = "correct horse battery staple";
 
@@ -170,6 +171,46 @@ describe("POST /cases/import/encrypted", () => {
     // evidence bytes travelled too — this is the whole point of replacing the JSON snapshot
     const evidence = await request(app).get("/cases/INC-2/evidence/shot.webp");
     expect(evidence.status).toBe(200);
+  });
+
+  // #672: an analyst importing a .dfircase written by 0.31.0-0.33.0 gets no signal that it was
+  // encrypted under the weaker v1 derivation. Both versions ride in the 201 body so the dashboard
+  // can compare them; the client never hardcodes "warn below 2", which would silently stop warning
+  // about v2 the day a v3 lands.
+  it("reports the archive's format version and the current one on a successful import", async () => {
+    const { app, stateStore, store } = await harness();
+    await seedCase(app, stateStore, store);
+    const data = await exportArchive(app, "INC-1");
+
+    const imp = await request(app)
+      .post("/cases/import/encrypted")
+      .send({ data, password: PASSWORD, targetCaseId: "INC-2" });
+    expect(imp.status).toBe(201);
+    expect(imp.body.formatVersion).toBe(2);
+    expect(imp.body.currentFormatVersion).toBe(2);
+  });
+
+  it("reports formatVersion 1 below currentFormatVersion for a pre-#268 archive", async () => {
+    const { app, stateStore, store } = await harness();
+    await seedCase(app, stateStore, store);
+    const plain = decryptBuffer(Buffer.from(await exportArchive(app, "INC-1"), "base64"), PASSWORD);
+
+    // Re-wrap in the v1 container 0.31.0 wrote. Nothing in production writes v1 any more, so a
+    // test that needs one has to build it; the parameters are spelled out as an independent
+    // statement of what v1 is.
+    const salt = randomBytes(16);
+    const iv = randomBytes(12);
+    const key = scryptSync(PASSWORD, salt, 32, { N: 1 << 14, r: 8, p: 1, maxmem: 32 * 1024 * 1024 });
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    const ciphertext = Buffer.concat([cipher.update(plain), cipher.final()]);
+    const v1 = Buffer.concat([Buffer.from("DFIRCZ01", "utf8"), salt, iv, cipher.getAuthTag(), ciphertext]);
+
+    const imp = await request(app)
+      .post("/cases/import/encrypted")
+      .send({ data: v1.toString("base64"), password: PASSWORD, targetCaseId: "INC-2" });
+    expect(imp.status).toBe(201); // v1 stays readable — the analyst is warned, not refused
+    expect(imp.body.formatVersion).toBe(1);
+    expect(imp.body.formatVersion).toBeLessThan(imp.body.currentFormatVersion);
   });
 
   it("imports under the archive's own id when no target is given", async () => {

--- a/mkdocs-docs/reference/cases.md
+++ b/mkdocs-docs/reference/cases.md
@@ -93,5 +93,7 @@ delete an already-archived case's live folder out from under its archive.
 
 **Import archive:** toolbar → **Import case → Encrypted case archive (.dfircase)**. Restores as a new case. If the Case ID already exists you get a conflict warning.
 
+**If the archive was exported by v0.31.0–v0.33.0**, the import warns you that it used an older, weaker key derivation. Export the case again afterwards to upgrade the file to the current encryption. See [SECURITY.md](https://github.com/hasamba/DFIR-Companion/blob/master/SECURITY.md) for the detail.
+
 !!! info "What's in the archive"
     Everything under the case directory travels with the export — screenshots, raw imported artifact files, and all analyst decisions. The AI configuration (keys) is never included — keys live in `.env` and never enter the case directory. The recipient's copy inherits settings like external-enrichment opt-in as they were on the exporting machine, since the archive is a verbatim copy.

--- a/public/js/dashboard-import-case.js
+++ b/public/js/dashboard-import-case.js
@@ -13,6 +13,31 @@
 // The two guard stanzas that earlier extractions left in this range — for the search/scope wiring
 // and for enrichment — did NOT come with it.
 (function () {
+  // The one thing in this file that is NOT DOM wiring, and so the one thing that lives in the
+  // module body rather than inside the initializer: it reads no element, so the reason the rest of
+  // the file has to wait does not apply to it.
+  //
+  // #672. A .dfircase written by 0.31.0-0.33.0 used the weaker v1 key derivation (scrypt N=2^14),
+  // and importing one used to say nothing about that. The import response now carries the
+  // archive's container version alongside the version this build writes, and this turns that pair
+  // into the sentence the analyst reads.
+  //
+  // It compares the two NUMBERS the server sent rather than testing `formatVersion < 2`. A
+  // hardcoded 2 would silently stop warning about v2 archives the day a v3 lands — the failure
+  // would be a warning that no longer appears, which nothing notices.
+  //
+  // Silence is the answer for every case it cannot judge: equal versions, an archive somehow
+  // NEWER than this build (where "your encryption is weak" would be backwards), and either field
+  // absent or non-numeric, which means an older companion answered rather than a weak archive.
+  function encryptionUpgradeNotice(formatVersion, currentFormatVersion) {
+    if (typeof formatVersion !== "number" || typeof currentFormatVersion !== "number") return "";
+    if (!(formatVersion < currentFormatVersion)) return "";
+    return (
+      "Imported, but this archive was encrypted with an older, weaker key derivation. " +
+      "Export the case again to upgrade the encryption."
+    );
+  }
+
   function initImportCase() {
     const importCaseOverlay = document.getElementById("importCaseOverlay");
     function closeImportCaseModal() {
@@ -44,6 +69,9 @@
       document.getElementById("ipFilename").textContent = file.name;
       document.getElementById("ipPassword").value = "";
       document.getElementById("ipMsg").textContent = "";
+      // Undo what a warning from the PREVIOUS import left behind (below).
+      document.getElementById("ipImport").hidden = false;
+      document.getElementById("ipCancel").textContent = "Cancel";
       document.getElementById("importPasswordOverlay").classList.add("open");
       document.getElementById("ipPassword").focus();
     };
@@ -118,10 +146,26 @@
         const body = await res.json().catch(() => ({}));
         if (res.status === 201) {
           const c = body.counts || {};
-          document
-            .getElementById("importPasswordOverlay")
-            .classList.remove("open");
           _pendingImportFile = null;
+          // WHERE the warning goes is the whole point, and #status is the one place it cannot go.
+          // connect() below opens a WebSocket whose onopen handler in js/dashboard-case-connect.js
+          // writes "connected (live)" into #status a few milliseconds later, so a security warning
+          // parked there flashes and is gone — possibly without ever painting. The same is true of
+          // showToast, which writes #status too and then fades itself after six seconds.
+          //
+          // So the modal the analyst is already looking at stays OPEN and carries the sentence,
+          // and the only control left is the one that closes it. Nothing else on the page writes
+          // to ipMsg, and dismissing it is a deliberate act rather than a race with the socket.
+          const upgrade = encryptionUpgradeNotice(body.formatVersion, body.currentFormatVersion);
+          if (upgrade) {
+            msg.textContent = upgrade;
+            document.getElementById("ipImport").hidden = true;
+            // The import already happened and cannot be undone, so "Cancel" would be a lie.
+            cancelBtn.textContent = "Close";
+          } else {
+            msg.textContent = "";
+            document.getElementById("importPasswordOverlay").classList.remove("open");
+          }
           status.textContent = `imported case ${body.caseId} (${c.forensicEvents || 0} events, ${c.findings || 0} findings, ${c.iocs || 0} IOCs)`;
           document.getElementById("caseId").value = body.caseId;
           loadCaseList();
@@ -144,5 +188,6 @@
     };
   }
 
+  window.encryptionUpgradeNotice = encryptionUpgradeNotice;
   window.initImportCase = initImportCase;
 })();


### PR DESCRIPTION
## What an analyst sees

Import a `.dfircase` file that was exported by v0.31.0, v0.32.0 or v0.33.0, and the import
window now stays open with one sentence:

> Imported, but this archive was encrypted with an older, weaker key derivation. Export the
> case again to upgrade the encryption.

The case imports normally. The only control left is **Close**. Import a file from v0.34.0 or
later and nothing changes — the window closes as it always did.

## Why

Those three releases derived the archive key with scrypt `N=2^14`, Node's default. That is too
low for a file an attacker holds with unlimited offline attempts, which is exactly the position
a `.dfircase` file is in. v0.34.0 raised the writer to `N=2^17`, OWASP's figure for sensitive
data at rest — but a file already sitting in an evidence store stays at the old strength, and
nothing said so.

## What this does not do

- **Nothing is refused.** A v1 archive still opens. The delete-with-encrypted-archive flow can
  leave an archive as a case's only remaining copy, and that copy must never become unreadable.
- **Nothing is re-keyed.** Exporting the case again is the only thing that upgrades a file, and
  that stays the analyst's decision.
- The parameters of an existing container version are never changed. Raising the cost always
  means adding a version.

## Two details worth reviewing

**Where the warning lives.** It is in the import modal, not the status line. `connect()` runs
immediately after a successful import, and its WebSocket `onopen` handler overwrites the status
line with "connected (live)" a few milliseconds later — a warning parked there could vanish
before it ever painted. `showToast` writes the status line too and fades itself after six
seconds. The modal is the only surface nothing else writes to.

**How the comparison is made.** The import response carries both the archive's container
version and the version this build writes, and the dashboard compares the two numbers. Testing
`formatVersion < 2` would silently stop warning about v2 archives the day a v3 lands, and a
warning that quietly stops appearing is a failure nobody notices.

## Tests

16 new, each written before the code and watched fail first:

- 7 on `readFormatVersion`, including that v1 sorts below the current version.
- 4 across the archive and route layers, importing a real v1 container rebuilt in the test
  (nothing writes v1 any more, so a test that needs one has to build it).
- 5 on the warning text, covering equal, newer, missing and non-numeric versions.
- 3 driving the real click handler against a stub document. These assert both that the status
  line *does* get overwritten and that the warning survives it, so the bug cannot come back
  quietly.

Full suite green: 702 files, 11,099 tests. Extension: 329 tests, both builds.

## Documentation

`SECURITY.md` gains a `.dfircase` section with the version table and the affected release
range, so someone holding an old archive can learn about it without importing it. The published
manual (`mkdocs-docs/reference/cases.md`) points at it from the import instructions.

closes #672
