### PR TITLE
fix(tools): refuse an upload the chosen parser cannot read

### DIFF
--- a/companion/src/integrations/tools/toolConfig.ts
+++ b/companion/src/integrations/tools/toolConfig.ts
@@ -1,3 +1,5 @@
+import { extname } from "node:path";
+
 // Env-driven configuration for the analyst's external forensic tools. A tool is OFF until its
 // `DFIR_TOOL_<ID>_BINARY` key is set (mirrors DFIR_VELOCIRAPTOR_API_CONFIG gating loadVelociraptorConfig).
 // The Companion NEVER bundles or downloads a binary — TOOL_DEFS only links to each official repo; the
@@ -349,4 +351,28 @@ export function toolForExtension(ext: string, configured: Map<string, ToolConfig
 // banner). Null when the extension isn't a raw-tool input.
 export function suggestedToolForExtension(ext: string): ToolId | null {
   return toolPreferenceForExtension(ext)[0] ?? null;
+}
+
+// The extension of an uploaded filename. `extname` is the one definition of "extension" the rest of
+// the server already uses (analysis/dropScan.ts reads the drop folder with it), and the Import dialog
+// now matches it too (public/js/dashboard-values.js `uploadExtOf`). All three must agree, or the
+// dialog offers a tool the server then refuses.
+//
+// It answers "" for a name with no suffix — both a bare `evtx` and a stemless `.evtx`. Neither is an
+// EVTX file: the first is a file someone named after a format, the second a dotfile. Reading either
+// as an extension is how the dialog used to offer Hayabusa for a file it could not parse.
+export function uploadExtensionOf(filename: string): string {
+  return extname(String(filename ?? "")).toLowerCase();
+}
+
+// May this tool be handed this uploaded file? `declared` is the tool's claimed extensions —
+// TOOL_DEFS[id].extensions for a built-in, the analyst's list for a custom tool.
+//
+// An EMPTY list means "claims nothing in particular", not "claims nothing": YARA scans files and
+// directories on demand and declares none, and a custom tool may leave the field blank. Gating on an
+// empty list would put those tools out of reach of the upload route entirely, so it accepts anything.
+export function uploadExtensionAccepted(declared: readonly string[], filename: string): boolean {
+  if (!declared.length) return true;
+  const ext = uploadExtensionOf(filename);
+  return !!ext && declared.some((d) => d.toLowerCase() === ext);
 }

--- a/companion/src/routes/tools.ts
+++ b/companion/src/routes/tools.ts
@@ -2,7 +2,12 @@ import type { Express, Request, Response } from "express";
 import { join, basename } from "node:path";
 import { writeFile, rm, mkdir, mkdtemp } from "node:fs/promises";
 import { reloadEnvPrefix } from "../settings/envManager.js";
-import { TOOL_DEFS, type ToolId } from "../integrations/tools/toolConfig.js";
+import {
+  TOOL_DEFS,
+  uploadExtensionAccepted,
+  uploadExtensionOf,
+  type ToolId,
+} from "../integrations/tools/toolConfig.js";
 import { updateToolRules } from "../integrations/tools/runToolImport.js";
 import { resolveForensicMinSeverity } from "../analysis/forensicGate.js";
 import { logActivity } from "../analysis/activityLog.js";
@@ -35,6 +40,13 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
   // tool like SO-CRATES must work on a machine with no local forensic binaries installed.
   const transportOf = (toolId: string): "spawn" | "http" =>
     toolId in TOOL_DEFS ? TOOL_DEFS[toolId as ToolId].transport : "spawn";
+
+  // The raw extensions this tool claims. Built-ins declare them statically; a custom tool carries the
+  // analyst's list. Empty for a tool that claims none (YARA) — see uploadExtensionAccepted.
+  const extensionsOf = (toolId: string): string[] =>
+    toolId in TOOL_DEFS
+      ? TOOL_DEFS[toolId as ToolId].extensions
+      : (ctx.customTools().find((t) => t.id === toolId)?.extensions ?? []);
 
   // ── External forensic tools (#211) ────────────────────────────────────────────────────────────
   // Per-tool configured/auto-run status for the Settings → Tools tab (no secret values). Derived LIVE
@@ -159,6 +171,25 @@ export function registerToolsRoutes(app: Express, ctx: RouteContext): void {
         return res.status(400).json({ ok: false, error: (err as Error).message });
       }
     }
+    // Refuse a file this parser does not claim, BEFORE anything touches disk (#673). These extensions
+    // already decide which tools the Import dialog offers for a file (dashboard-values.js
+    // `toolsForExt`), so until now the server was trusting a rule only the client enforced — a direct
+    // API caller could hand a .txt to Hayabusa and get a parser crash instead of an answer. Refusing
+    // first also means no evidence is preserved for a run that was never going to work.
+    //
+    // SPAWN ONLY, deliberately: the http branch above has already returned. SO-CRATES claims a long
+    // list but exists to YARA-scan whatever it is given, including the extensionless, hash-named
+    // samples its own toolConfig comment calls out — an extension gate there would reject its job.
+    const declared = extensionsOf(toolId);
+    if (!uploadExtensionAccepted(declared, filename)) {
+      const got = uploadExtensionOf(filename) || "no extension";
+      return res.status(400).json({
+        error:
+          `${toolId} does not accept "${basename(filename)}" (${got}) — it runs on ${declared.join(", ")}. ` +
+          `Choose a tool that claims this file type, or import the file directly.`,
+      });
+    }
+
     // Stage into a FRESH per-upload dir under the file's ORIGINAL basename (no collisions, so no need to
     // mangle the name) — folder-root tools (Velociraptor --ROOT) detect the EVTX channel from the filename.
     const toolWork = join(store.caseDir(caseId), ".toolwork");

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -180,6 +180,7 @@ export interface ValuesApi {
   ticketLabel(target: string | undefined): string;
   veloTimeScopeBody(form: ElementLike): { preset?: string; start?: string; end?: string } | undefined;
   veloTimeScopeIncomplete(form: ElementLike): boolean;
+  uploadExtOf(name: string): string;
   toolForExt(ext: string, status: unknown): string | null;
   suggestToolForExt(ext: string, status: unknown): string | null;
   toolsForExt(ext: string, status: unknown): Array<{ id: string }>;

--- a/companion/tests/dashboard/dashboardModules.test.ts
+++ b/companion/tests/dashboard/dashboardModules.test.ts
@@ -152,10 +152,11 @@ describe("every moved function still resolves at its call sites", () => {
     (name) => name !== "esc" && name !== "escAttr",
   );
 
-  // 99 at the extraction; 102 since the prose split (proseParagraphs / proseSentences / proseHtml)
-  // was added to the text and fragment helpers. The number is a vacuity guard, not a budget.
-  it("moved 102 functions, so the check below is not vacuous", () => {
-    expect(MOVED.length).toBe(102);
+  // 99 at the extraction; 102 after the prose split (proseParagraphs / proseSentences / proseHtml)
+  // joined the text and fragment helpers; 103 since uploadExtOf gave the two import entry points one
+  // shared reading of a filename's extension (#673). The number is a vacuity guard, not a budget.
+  it("moved 103 functions, so the check below is not vacuous", () => {
+    expect(MOVED.length).toBe(103);
   });
 
   it("provides every one of them as a global once the tagged scripts have run", async () => {

--- a/companion/tests/dashboard/dashboardValues.test.ts
+++ b/companion/tests/dashboard/dashboardValues.test.ts
@@ -46,6 +46,28 @@ describe("ticketLabel", () => {
 
 // Three lookups over the same tool list with three different jobs: what IS configured for this
 // extension, what COULD be, and all of them.
+describe("uploadExtOf", () => {
+  // The dialog's answer decides which tools it OFFERS, and the server's extension gate then decides
+  // whether to accept the upload (#673). They read the same name, so they must read it the same way:
+  // this mirrors integrations/tools/toolConfig.ts `uploadExtensionOf`, which is node's extname.
+  it.each([
+    ["Security.evtx", ".evtx"],
+    ["Security.EVTX", ".evtx"],
+    ["x.tar.gz", ".gz"],
+    ["a.", "."],
+    ["evtx", ""], // named after a format, but has no suffix
+    [".evtx", ""], // a stemless dotfile, not an EVTX file
+    ["a3f9c2e1", ""],
+    ["", ""],
+  ])("%j -> %j", (name, expected) => expect(v.uploadExtOf(name)).toBe(expected));
+
+  it("no longer offers a tool for a suffix-less name", () => {
+    const status = { tools: [{ id: "hayabusa", configured: true, extensions: [".evtx"] }] };
+    expect(v.toolsForExt(v.uploadExtOf("evtx"), status)).toEqual([]);
+    expect(v.toolsForExt(v.uploadExtOf("Security.evtx"), status).map((t) => t.id)).toEqual(["hayabusa"]);
+  });
+});
+
 describe("toolForExt / suggestToolForExt / toolsForExt", () => {
   const status = {
     tools: [

--- a/companion/tests/integrations/toolRunner.test.ts
+++ b/companion/tests/integrations/toolRunner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { extname, join } from "node:path";
 import {
   tokenizeArgs,
   substituteArgs,
@@ -18,6 +18,8 @@ import {
   toolForExtension,
   toolPreferenceForExtension,
   suggestedToolForExtension,
+  uploadExtensionAccepted,
+  uploadExtensionOf,
   TOOL_DEFS,
   type ToolId,
 } from "../../src/integrations/tools/toolConfig.js";
@@ -454,5 +456,46 @@ describe("spawnToolRunner output decoding", () => {
       maxOutputBytes: 200,
     });
     expect(r.stdout).toBe(text);
+  });
+});
+
+describe("uploadExtensionAccepted (#673)", () => {
+  it("accepts a claimed extension, case-insensitively", () => {
+    expect(uploadExtensionAccepted([".evtx", ".evt"], "Security.evtx")).toBe(true);
+    expect(uploadExtensionAccepted([".evtx", ".evt"], "Security.EVTX")).toBe(true);
+    expect(uploadExtensionAccepted([".pcap", ".pcapng"], "capture.PcapNg")).toBe(true);
+  });
+
+  it("refuses an unclaimed extension and a bare name", () => {
+    expect(uploadExtensionAccepted([".evtx", ".evt"], "notes.txt")).toBe(false);
+    expect(uploadExtensionAccepted([".evtx", ".evt"], "a3f9c2e1")).toBe(false);
+    expect(uploadExtensionAccepted([".evtx"], "Security.evtx.bak")).toBe(false); // last suffix wins
+  });
+
+  // A name with no suffix has no extension, and that is BOTH a bare `evtx` and a stemless `.evtx`.
+  // Reading either as ".evtx" is the mismatch #673's first cut shipped: the Import dialog did read
+  // them that way, offered Hayabusa, and the server then answered 400 on the upload it had invited.
+  it("treats a suffix-less name as having no extension, both shapes", () => {
+    expect(uploadExtensionOf("evtx")).toBe("");
+    expect(uploadExtensionOf(".evtx")).toBe("");
+    expect(uploadExtensionAccepted([".evtx"], "evtx")).toBe(false);
+    expect(uploadExtensionAccepted([".evtx"], ".evtx")).toBe(false);
+  });
+
+  // extname is what analysis/dropScan.ts already reads the drop folder with, so the upload route and
+  // the drop route cannot disagree about what a file is.
+  it("reads an extension exactly as node:path extname does", () => {
+    for (const name of ["evtx", ".evtx", "Security.evtx", "a.", "x.tar.gz", "a3f9c2e1"]) {
+      expect(uploadExtensionOf(name)).toBe(extname(name).toLowerCase());
+    }
+  });
+
+  // YARA declares no extensions ("scans files/dirs on demand"), and so may a custom tool. An empty
+  // list is "claims nothing in particular", not "claims nothing" — gating on it would make those
+  // tools unreachable through the upload route entirely.
+  it("accepts anything when the tool declares no extensions", () => {
+    expect(TOOL_DEFS.yara.extensions).toEqual([]);
+    expect(uploadExtensionAccepted([], "a3f9c2e1")).toBe(true);
+    expect(uploadExtensionAccepted([], "notes.txt")).toBe(true);
   });
 });

--- a/companion/tests/server/toolRunProvenance.test.ts
+++ b/companion/tests/server/toolRunProvenance.test.ts
@@ -164,3 +164,48 @@ describe("a case-relative tool run (#688)", () => {
     expect(log).not.toContain("| original ");
   });
 });
+
+/**
+ * The upload path never checked the uploaded filename against the extensions the tool declares
+ * (#673). Those extensions already decide which tools the Import dialog OFFERS for a file
+ * (public/js/dashboard-values.js `toolsForExt`), so the server was trusting a rule only the client
+ * enforced: a direct API caller could hand a .txt to Hayabusa and get a parser crash instead of an
+ * answer. The check refuses first, so nothing is written and no evidence is preserved for a run
+ * that was never going to work.
+ */
+describe("refusing an upload the tool does not claim (#673)", () => {
+  it("refuses a file whose extension the tool does not declare, and preserves nothing", async () => {
+    const { app, store } = await harness();
+    const r = await request(app)
+      .post("/cases/c1/tools/hayabusa/run-upload")
+      .send({ filename: "notes.txt", dataBase64: Buffer.from("hello").toString("base64") });
+
+    expect(r.status).toBe(400);
+    expect(r.body.error).toContain(".txt");
+    expect(r.body.error).toContain(".evtx"); // says what it DOES accept
+
+    // The refusal comes before persistRawEvidence, so the case is untouched.
+    const importsDir = join(store.caseDir("c1"), "imports");
+    const stored = await readdir(importsDir).catch(() => [] as string[]);
+    expect(stored).toEqual([]);
+  });
+
+  it("refuses a file with no extension at all", async () => {
+    const { app } = await harness();
+    const r = await request(app)
+      .post("/cases/c1/tools/hayabusa/run-upload")
+      .send({ filename: "a3f9c2e1", dataBase64: RAW_EVTX.toString("base64") });
+
+    expect(r.status).toBe(400);
+    expect(r.body.error).toContain("hayabusa");
+  });
+
+  it("still accepts a file the tool does claim", async () => {
+    const { app } = await harness();
+    const r = await request(app)
+      .post("/cases/c1/tools/hayabusa/run-upload")
+      .send({ filename: "Security.EVTX", dataBase64: RAW_EVTX.toString("base64") });
+
+    expect(r.status).toBe(200); // and case-insensitively
+  });
+});

--- a/public/js/dashboard-import-changes.js
+++ b/public/js/dashboard-import-changes.js
@@ -152,7 +152,7 @@
       .then((r) => (r.ok ? r.json() : null))
       .then((status) => {
         const items = rawFiles.map((f, i) => {
-          const ext = "." + (f.name.split(".").pop() || "").toLowerCase();
+          const ext = uploadExtOf(f.name);
           return {
             idx: i,
             file: f,

--- a/public/js/dashboard-unified-import.js
+++ b/public/js/dashboard-unified-import.js
@@ -46,7 +46,7 @@
       // text import path. #211
       const rawExtSet = await fetchRawToolExts();
       const isRawTool = (f) =>
-        rawExtSet.has("." + (f.name.split(".").pop() || "").toLowerCase());
+        rawExtSet.has(uploadExtOf(f.name));
       const images = files.filter(isImage);
       const rawTool = files.filter((f) => !isImage(f) && isRawTool(f));
       const data = files.filter((f) => !isImage(f) && !isRawTool(f));

--- a/public/js/dashboard-values.js
+++ b/public/js/dashboard-values.js
@@ -58,6 +58,17 @@ function veloTimeScopeIncomplete(form) {
   return form.querySelector(".velo-timescope").value === "custom" && !form.querySelector(".velo-ts-start").value;
 }
 
+// The extension of a picked file, matching the server's `extname` exactly (see
+// integrations/tools/toolConfig.js `uploadExtensionOf`). "" when the name has no suffix: a bare
+// `evtx` is a file someone named after a format, and `.evtx` is a stemless dotfile — neither is an
+// EVTX file. The old `"." + name.split(".").pop()` read both as `.evtx` and offered Hayabusa for a
+// file the server then refused with a 400 (#673).
+function uploadExtOf(name) {
+  const s = String(name || "");
+  const dot = s.lastIndexOf(".");
+  return dot > 0 ? s.slice(dot).toLowerCase() : "";
+}
+
 // Resolve which CONFIGURED tool handles a file extension (server preference order), from /tools/status.
 function toolForExt(ext, status) {
   const t = (status && status.tools || []).find((x) => x.configured && (x.extensions || []).includes(ext));
@@ -216,6 +227,7 @@ window.DfirValues = {
   _workflowInitials,
   pbLocalStats,
   ticketLabel,
+  uploadExtOf,
   toolForExt,
   suggestToolForExt,
   toolsForExt,


### PR DESCRIPTION
## What an analyst sees

Pick a raw file in the Import dialog, choose a tool to run on it, and the server now refuses the file if that tool does not handle its file type:

```
hayabusa does not accept "notes.txt" (.txt) — it runs on .evtx, .evt.
Choose a tool that claims this file type, or import the file directly.
```

Before, the upload went through and the parser crashed on it, which read as a broken tool rather than a wrong file.

The dialog and the server also now agree on what a file's type is. A file named `evtx` with no dot has no type to either of them, so the dialog stops offering a parser it cannot run.

## Why

The upload route never checked the uploaded filename against the extensions the tool declares. Those extensions already decide which tools the Import dialog **offers** for a file, so the server was trusting a rule only the client enforced — a direct API caller could hand a `.txt` to Hayabusa.

The check refuses **before anything touches disk**, so no evidence is preserved for a run that was never going to work.

**Spawn tools only.** SO-CRATES claims a long extension list but exists to scan whatever it is given, including the extensionless hash-named samples its own config comment calls out. An extension gate there would reject its job.

## The second half of the bug

Reading the extension was itself inconsistent:

| Name | Import dialog (before) | Server | Drop-folder scanner |
|---|---|---|---|
| `Security.evtx` | `.evtx` | `.evtx` | `.evtx` |
| `evtx` | `.evtx` | `""` | `""` |
| `.evtx` | `.evtx` | `""` | `""` |

The dialog's `"." + name.split(".").pop()` read a bare `evtx` as an EVTX file and offered Hayabusa; the server would then have answered 400 on the upload the dialog had just invited. Both sides now use `extname` semantics, which the drop-folder scanner already used, so the three paths cannot disagree about what a file is.

A shared `uploadExtOf` helper gives the two import entry points one reading of a filename. That took the moved-function ledger in `dashboardModules.test.ts` from 102 to 103 — a documented vacuity guard, not a budget.

## Tests

- Unit: claimed / unclaimed / bare name / last-suffix-wins; empty declared list accepts anything (YARA declares none); both suffix-less shapes rejected.
- Parity: a table of edge cases run through **both** the helper and `node:path` `extname`, asserting equality. The contract is agreement, so the oracle is the other implementation rather than hand-written expectations.
- Route: `.txt` returns 400 and `imports/` stays empty; no extension returns 400; `Security.EVTX` still returns 200.
- Dashboard: an `uploadExtOf` table, plus one confirming a suffix-less name now offers no tool.

## Scope

Part of #673. The rest of that issue is stale, and I have posted the claim-by-claim detail there:

- Filename sanitization, staging containment and both-path cleanup all landed with #688.
- The tool runner never executes the staged file — it passes the path as one argv element to the analyst's own binary, with no shell, and nothing sets an execute bit.
- Magic-byte validation is deliberately **not** added: this endpoint exists to hand raw, often-malformed evidence to a forensic parser, and gating on content would reject the carved and truncated artifacts analysts need to parse.

One item from that issue remains open and is not in this PR: `X-Content-Type-Options: nosniff` is set only on geo tiles, not on the evidence-serving route. CSP already blocks the payload, so it is defence in depth and belongs in its own issue.

## Gates

`lint` · `format:check` · `check:size` · `check:imports` · `check:boundaries` · `eval:change-gate` · `check:us-map` · `build` · `typecheck` — all green. Companion suite: 11096 passed. Extension: typecheck, test, build, build:firefox all green.

One flake seen and cleared: `siemImport.test.ts`'s ReDoS wall-clock ratio failed under full-suite contention (`expected 10 to be less than 8`) and passes isolated. That file is untouched by this branch.
