### PR TITLE
fix(security): send X-Content-Type-Options on every response, not just geo tiles

### DIFF
--- a/companion/src/http/securityHeaders.ts
+++ b/companion/src/http/securityHeaders.ts
@@ -85,12 +85,22 @@ export function withNonce(html: string, nonce: string): string {
  * stamp the matching value into the document. Per-response is the point: a nonce reused across
  * requests is worth no more than `'unsafe-inline'`, because an attacker who can read one page can
  * embed that value in the payload they inject into the next.
+ *
+ * `X-Content-Type-Options: nosniff` rides along (#728). It was previously set on ONE route, the
+ * geo-tile proxy, on the grounds that those bytes came from another server. Evidence has a better
+ * claim: `GET /cases/:id/evidence/:file` serves imported artifact content — hostile by assumption
+ * here — and answers an unrecognized suffix with `application/octet-stream`, which a sniffing
+ * browser is otherwise free to re-read as a document. The CSP above is what actually denies such a
+ * document its payload, so this is a second lock on a locked door; it is global rather than
+ * per-route for the same reason `caseLockGate` is, namely that a per-route opt-in leaves every new
+ * route one forgotten line away from shipping without it.
  */
 export function createSecurityHeaders(): RequestHandler {
   return function securityHeaders(_req: Request, res: Response, next: NextFunction): void {
     const nonce = randomBytes(16).toString("base64");
     res.locals.cspNonce = nonce;
     res.setHeader("Content-Security-Policy", cspWithNonce(nonce));
+    res.setHeader("X-Content-Type-Options", "nosniff");
     next();
   };
 }

--- a/companion/tests/http/securityHeaders.test.ts
+++ b/companion/tests/http/securityHeaders.test.ts
@@ -68,6 +68,37 @@ describe("createSecurityHeaders — CSP on every response", () => {
   });
 });
 
+/**
+ * X-Content-Type-Options (#728).
+ *
+ * Until this landed the header was set on exactly ONE route — the geo-tile proxy — because those
+ * bytes came from another server. Evidence deserves it more: GET /cases/:id/evidence/:file serves
+ * imported artifact content, which this project treats as adversary-controlled, and hands unknown
+ * suffixes back as application/octet-stream.
+ *
+ * The CSP is what actually blocks a payload today (no 'unsafe-inline', script-src pinned to 'self'),
+ * so this is a second lock on a locked door. It belongs in the global middleware for the same reason
+ * caseLockGate is mounted globally: a per-route opt-in leaves every new route one forgotten line
+ * away from shipping without it.
+ */
+describe("createSecurityHeaders — X-Content-Type-Options on every response", () => {
+  it("stops a browser second-guessing the type of a served document", async () => {
+    const res = await request(withHeaders()).get("/dashboard");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("sets it on API responses too", async () => {
+    const res = await request(withHeaders()).get("/cases/abc");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  // The value is the whole contract: any other token and browsers ignore the header entirely.
+  it("sends exactly the token browsers honour, not a variant", async () => {
+    const res = await request(withHeaders()).get("/nonce-echo");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+});
+
 describe("withNonce — stamping the served HTML", () => {
   it("replaces every placeholder occurrence, not just the first", () => {
     const html =

--- a/companion/tests/server.test.ts
+++ b/companion/tests/server.test.ts
@@ -620,6 +620,13 @@ describe("server analysis wiring", () => {
     expect(csv.headers["content-type"]).toContain("text/plain");
     expect(csv.text).toContain("a,b");
 
+    // Evidence is imported artifact content, so it is hostile by assumption, and an unknown suffix
+    // comes back as application/octet-stream. nosniff denies the browser the chance to decide it is
+    // really HTML. Asserted on the REAL app, not just the middleware in isolation, because that is
+    // the claim worth holding: the header reaches the route that serves the hostile bytes (#728).
+    expect(shot.headers["x-content-type-options"]).toBe("nosniff");
+    expect(csv.headers["x-content-type-options"]).toBe("nosniff");
+
     expect((await request(evApp).get("/cases/c1/evidence/missing.png")).status).toBe(404);
     expect((await request(evApp).get("/cases/c1/evidence/bad@name.png")).status).toBe(400); // bad charset
     expect((await request(evApp).get("/cases/c1/evidence/a..b.png")).status).toBe(400); // traversal guard


### PR DESCRIPTION
## What changes

One line in the middleware that already stamps the CSP on every response:

```ts
res.setHeader("X-Content-Type-Options", "nosniff");
```

Nothing an analyst sees changes. Evidence still opens the same way.

## Why

The header was set on exactly one route — the geo-tile proxy — on the grounds that those bytes came from another server. Evidence has a better claim to it.

`GET /cases/:id/evidence/:file` serves imported artifact content, which this project treats as adversary-controlled, and answers an unrecognized suffix with `application/octet-stream`. A sniffing browser is otherwise free to re-read that as a document. Analyst-supplied `.csv`/`.log`/`.txt` evidence goes out as `text/plain` and carries the same exposure.

## This is not a live vulnerability

Stating it plainly so it is triaged for what it is. The CSP already denies such a document its payload:

- `script-src 'self' 'nonce-<per-response>'` with no `unsafe-inline`, so injected inline script has no nonce.
- `'self'` means an attacker cannot host a script file either.
- `object-src 'none'`, `base-uri 'none'`, `form-action 'none'`.

A second lock on a locked door. Worth having because a CSP is one refactor away from being loosened and the header costs nothing.

## Two decisions worth reviewing

**Global, not per-route.** Same reasoning as `caseLockGate` being mounted globally: a per-route opt-in leaves every new route one forgotten line away from shipping without it.

**The geo-tile route keeps its own call.** It now sets the same value twice, which is a no-op. Removing it would be scope creep into an unrelated route, and its local comment still explains why proxied bytes wanted the header in the first place. Happy to drop it if you would rather not carry the duplicate.

## Tests

Three unit tests on the middleware — document response, API response, and that the value is exactly `nosniff`, since any other token makes browsers ignore the header entirely.

The one that matters is on the **real app**, folded into the existing evidence-route test rather than the middleware in isolation. That is the claim worth holding: the header actually reaches the route serving the hostile bytes, not just a fixture that mounts the middleware by hand.

Written test-first; all four failed for the right reason before the change.

## Gates

`lint` · `format:check` · `check:size` · `check:imports` · `check:boundaries` · `eval:change-gate` · `check:us-map` · `build` · `typecheck` — all green.

Companion suite: **11122 passed, 703 files**, no flakes this run. Extension: typecheck, test, build, build:firefox all green.

Closes #728.
