### PR TITLE
feat(dashboard): hide the Related Cases panel by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Related Cases** — a new dashboard panel and two routes (`GET /cases/:id/related`, `GET /global/iocs?q=`) that surface the other investigations sharing an indicator with this one. Ranked so a flagged hash outweighs a private address; scoped to the cases your account may already read. (closes #679)
+- **Related Cases** — a new dashboard panel and two routes (`GET /cases/:id/related`, `GET /global/iocs?q=`) that surface the other investigations sharing an indicator with this one. Ranked so a flagged hash outweighs a private address; scoped to the cases your account may already read. Off by default — turn it on in Settings → Dashboard sections. (closes #679)
 - **Chainsaw runs on raw `.evtx` from inside the Companion** — a sixth built-in tool alongside Hayabusa and the Velociraptor CLI (binary, Sigma rule directory and mapping file in Settings → Tools). The importer already existed; only the runner was missing. (#688)
 - **A parser run is now recorded in the chain of custody** — the tool output's custody entry states the parser's version, the exact arguments, the rule-set hash, the exit code, a stderr tail and the output hash, instead of a bare "companion". (#688)
 - **A raw file uploaded to a parser is kept byte-for-byte** as evidence beside the parser's output, and it survives a failed parse. It used to be deleted once parsed. (#688)

--- a/companion/tests/dashboard/relatedCasesPanel.test.ts
+++ b/companion/tests/dashboard/relatedCasesPanel.test.ts
@@ -106,7 +106,16 @@ describe("related cases panel reachability", () => {
   });
 
   it("registers the section so Settings can show and order it", () => {
-    expect(markup).toContain('{ id: "sec-related-cases", label: "Related Cases" }');
+    expect(markup).toContain('{ id: "sec-related-cases", label: "Related Cases", defaultHidden: true }');
+  });
+
+  // Off by default, not removed. A shared indicator across one estate is usually ordinary, so the
+  // panel does not earn a slot on every analyst's page unasked — but the routes, the data gate and
+  // the Settings checkbox all stay, and an explicit tick still wins (see SECTION_DEFS lookup in
+  // applySectionsVis).
+  it("is hidden by default until the analyst turns it on", () => {
+    const def = markup.match(/\{ id: "sec-related-cases",[^}]*\}/);
+    expect(def?.[0]).toContain("defaultHidden: true");
   });
 
   it("is loaded on case connect", () => {

--- a/mkdocs-docs/reference/dashboard.md
+++ b/mkdocs-docs/reference/dashboard.md
@@ -424,7 +424,11 @@ phishing case and in today's ransomware case — and every other panel stops at 
 Each row names the case, links straight to it, and lists what the two have in common. Fully
 deterministic; no AI, no network.
 
-The panel stays hidden until this case actually overlaps with another one you may read. It
+**The panel is off by default.** Turn it on in Settings → Dashboard sections. Across one estate a
+shared indicator is usually ordinary, so the panel earns its place only in the investigations where
+you go looking for a cross-case link.
+
+Once on, it stays hidden until this case actually overlaps with another one you may read. It
 refreshes when you connect to a case, and again whenever an import settles — so a newly imported
 domain that another case already holds surfaces the link straight away.
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -3875,7 +3875,7 @@
       { id: "sec-beacons",      label: "Beacon Candidates" },
       { id: "sec-anomalies",    label: "Timeline Anomalies" },
       { id: "sec-geomap",       label: "GeoIP Map" },
-      { id: "sec-iocs",         label: "IOCs" }, { id: "sec-related-cases", label: "Related Cases" },
+      { id: "sec-iocs",         label: "IOCs" }, { id: "sec-related-cases", label: "Related Cases", defaultHidden: true },
       { id: "sec-exposure",     label: "Customer Exposure" },
       { id: "sec-questions",    label: "Key Investigative Questions" },
       { id: "sec-uncertainties", label: "Uncertainty Ledger" },


### PR DESCRIPTION
Related Cases now ships off. Across one estate a shared indicator is usually ordinary — one DNS resolver, one proxy, one patch server — and a panel titled "Related Cases" invites the analyst to read an overlap as a link.

Nothing is removed. The routes, the ranking, the panel's own data gate and the Settings checkbox are untouched, and an explicit tick in **Settings → Dashboard sections** still wins over the default — the same mechanism Recommended Next Steps already uses.

The manual and the `[Unreleased]` changelog entry now say it is off by default.

Relates to #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)