### PR TITLE
fix(analysis): a demotion may lower a grade, but never delete evidence (#720, #722)

### DIFF
--- a/companion/src/analysis/hijackLibImport.ts
+++ b/companion/src/analysis/hijackLibImport.ts
@@ -21,6 +21,7 @@ import {
 import { withHostSuffix } from "./velociraptorTitle.js";
 import { pickTime } from "./veloRowTime.js";
 import { isDetectionContentPath } from "./veloDetectionNoise.js";
+import { boundedAggKey } from "./aggKey.js";
 import type { Severity } from "./stateTypes.js";
 
 type Row = Record<string, unknown>;
@@ -73,7 +74,11 @@ export function mapHijackLib(
     description,
     severity,
     mitre,
-    aggKey: `vr|hijacklib|${host.toLowerCase()}|${dll.toLowerCase()}|${path.toLowerCase()}`.slice(0, 400),
+    // Host and DLL lead, the unbounded path trails, and boundedAggKey closes the key. A plain
+    // .slice(0, 400) collapsed two DLLs under one deep directory into a single row — and the
+    // aggregator does not merely miscount a collision, it overwrites the survivor's path and hash.
+    // A hijackable-DLL scan walks the whole disk, so a deep path is its normal input (#722).
+    aggKey: boundedAggKey(`vr|hijacklib|${host.toLowerCase()}|${dll.toLowerCase()}|${path.toLowerCase()}`),
     sources: ["Velociraptor"],
     ...(sha && /^[a-f0-9]{64}$/.test(sha) ? { sha256: sha } : {}),
     ...(path ? { path } : {}),

--- a/companion/src/analysis/veloDetectionNoise.ts
+++ b/companion/src/analysis/veloDetectionNoise.ts
@@ -65,8 +65,10 @@ export function isDetectionContentPath(value: string): boolean {
 // so a real payload dropped in an odd place is never lost. This one is broader on purpose, for a
 // different caller: a YARA/THOR SCAN that walks the collector's own working tree, its unpacked
 // sample corpus, the collector binary itself, or a cached copy of a simulation repo, and reports
-// them as host findings. Every marker is a location the tooling creates or the analyst supplies —
-// never a name an intruder picks on the victim host — and the only effect is to drop a hit to Info.
+// them as host findings. The markers are NOT equally trustworthy, so they do not carry equal weight:
+// only the collector's install tree is a location an intruder cannot supply, and only that one lets
+// a caller drop an IOC. A corpus directory name is a name anyone can create, so it drops the hit to
+// Info and stops there — see isCollectorOwnedLocation, and #720 for what the flat list cost.
 //
 //   [/\]Velociraptor[/\]  the collector's own install / unpacked-tool tree
 //                          (`C:\Program Files\Velociraptor\…`, incl. `\Tools\tmp*\chainsaw\…`)
@@ -79,13 +81,43 @@ export function isDetectionContentPath(value: string): boolean {
 // component, is attacker-controllable — a real payload dropped in `C:\Users\x\sigma\evil.dll` would
 // be hidden from the forensic view. So we require the collector ROOT context (`\Velociraptor\`,
 // which the real THOR row carries as `image_file: C:\Program Files\Velociraptor\Velociraptor.exe`),
-// the published sample-corpus name, or the named repo — never a component that can appear anywhere.
-const DETECTION_TOOL_LOCATION = /[/\\]Velociraptor[/\\]|EVTX-ATTACK|Digital-Forensic-Artifacts/i;
+// or the published corpus name as a WHOLE path component — never a substring that can appear
+// anywhere. Anchoring is not proof: a corpus name IS choosable, which is why it may not delete.
+
+// The collector's own tree. This is the one marker here the attacker cannot supply, so it is also
+// the only one that lets a caller DROP an indicator rather than merely lower a grade.
+const COLLECTOR_INSTALL_ROOT = /[/\\]Velociraptor[/\\]/i;
+
+// The two published corpus names, each as a WHOLE path component. They were bare substrings until
+// #720, which let `EVTX-ATTACK` match `C:\Users\public\EVTX-ATTACKER-kit\evil.exe` — a path any
+// intruder can create, and one that suppressed the finding. The trailing class admits the forms a
+// real download takes (a directory, the GitHub zip's `-master` suffix, an archive extension)
+// without admitting a longer word. Anchoring narrows the accident; it cannot stop a deliberately
+// named folder, which is why a corpus match now grades DOWN without deleting evidence — see
+// isCollectorOwnedLocation and mapYara.
+const SAMPLE_CORPUS_DIR = /[/\\](?:EVTX-ATTACK-SAMPLES|Digital-Forensic-Artifacts)(?:[-_./\\]|$)/i;
+
+const DETECTION_TOOL_LOCATION = new RegExp(
+  `${COLLECTOR_INSTALL_ROOT.source}|${SAMPLE_CORPUS_DIR.source}`,
+  "i",
+);
 
 export function isDetectionToolLocation(value: string): boolean {
   const v = (value || "").trim();
   if (!v) return false;
   return DETECTION_TOOL_LOCATION.test(v);
+}
+
+/**
+ * The subset of isDetectionToolLocation that is NOT a name an intruder can pick: the collector's own
+ * install tree. A hit here is not host evidence at all, so the caller may drop its IOCs. A hit in a
+ * sample-corpus directory only LOOKS like tooling — the directory name is attacker-choosable — so it
+ * leaves the timeline (Info) but keeps its indicators. See mapYara (#720).
+ */
+export function isCollectorOwnedLocation(value: string): boolean {
+  const v = (value || "").trim();
+  if (!v) return false;
+  return COLLECTOR_INSTALL_ROOT.test(v);
 }
 
 // A volatile memory-backed container: the page/hibernation/swap files, a crash or process memory

--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -549,11 +549,11 @@ function mapYara(row: Row, artifact: string, host: string, sink: Map<string, Sie
   // named malware on a real path → High). See yaraGrade.ts.
   const grade = gradeYaraHit(ruleName, path, procName);
 
-  // The matched file is a real IOC only when it is a real dropped file — never the collector's own
-  // tooling, a rule-content file, or a volatile container (a page-file hit names no file to block).
-  if (path && !isDetectionContentPath(path) && grade.reason !== "self-scan" && !grade.volatile)
+  // A real IOC unless it is the collector's OWN tooling, rule content, or a volatile container. Keyed
+  // on toolOwned, not the grade — a corpus folder is attacker-choosable, so it must not delete (#720).
+  if (path && !isDetectionContentPath(path) && !grade.toolOwned && !grade.volatile)
     addIoc(sink, "file", path);
-  if (procName && grade.reason !== "self-scan") addIoc(sink, "process", baseName(procName));
+  if (procName && !grade.toolOwned) addIoc(sink, "process", baseName(procName));
 
   const mitre = mitreFromText(flatStr(getCI(row, "Meta")), flatStr(getCI(row, "Tags")), ruleName);
 

--- a/companion/src/analysis/yaraGrade.ts
+++ b/companion/src/analysis/yaraGrade.ts
@@ -26,13 +26,21 @@
 
 import type { Severity } from "./stateTypes.js";
 import { boundedAggKey } from "./aggKey.js";
-import { isDetectionToolLocation, isVolatileContainer } from "./veloDetectionNoise.js";
+import {
+  isCollectorOwnedLocation,
+  isDetectionToolLocation,
+  isVolatileContainer,
+} from "./veloDetectionNoise.js";
 
 export interface YaraGrade {
   severity: Severity;
   /** true when the hit was inside a volatile memory container (pagefile / hiberfil / *.dmp). The
    *  caller aggregates these into one row per host so they never crowd the timeline. */
   volatile: boolean;
+  /** true when the self-scan match was the COLLECTOR'S OWN tree — the one demotion signal an intruder
+   *  cannot supply. A sample-corpus directory is a name anyone can create, so it earns the Info grade
+   *  but not this flag: only a tool-owned hit may have its IOCs dropped by the caller (#720). */
+  toolOwned: boolean;
   /** short machine tag for the demotion reason, appended to the description so the analyst sees WHY. */
   reason: "" | "self-scan" | "volatile-container" | "heuristic-trusted" | "heuristic";
 }
@@ -68,13 +76,14 @@ export function gradeYaraHit(ruleName: string, path: string, procName: string): 
   // 1. The detector found its own tooling, rule tree, sample corpus, or a cached simulation repo —
   //    or the matched "process" is the Velociraptor collector itself. Not host evidence.
   if (isDetectionToolLocation(where) || isDetectionToolLocation(proc)) {
-    return { severity: "Info", volatile: false, reason: "self-scan" };
+    const owned = isCollectorOwnedLocation(where) || isCollectorOwnedLocation(proc);
+    return { severity: "Info", volatile: false, toolOwned: owned, reason: "self-scan" };
   }
 
   // 2. A string inside a volatile memory container. It may mean the malware ran once, so it is kept
   //    (Low, and aggregated), but it is never proof on its own and never headlines the timeline.
   if (isVolatileContainer(where)) {
-    return { severity: "Low", volatile: true, reason: "volatile-container" };
+    return { severity: "Low", volatile: true, toolOwned: false, reason: "volatile-container" };
   }
 
   // 3. A broad heuristic / anomaly / test rule.
@@ -83,14 +92,14 @@ export function gradeYaraHit(ruleName: string, path: string, procName: string): 
     // Info: a System32/WinSxS path IS attacker-influenceable (a masqueraded DLL, a BYOVD driver), so
     // the hit stays in the forensic timeline for review — it just leaves the suspicious (Medium+) tier.
     if (TRUSTED_OS_LOCATION.test(where)) {
-      return { severity: "Low", volatile: false, reason: "heuristic-trusted" };
+      return { severity: "Low", volatile: false, toolOwned: false, reason: "heuristic-trusted" };
     }
     // …anywhere else is an anomaly worth a look, not a confirmed verdict.
-    return { severity: "Medium", volatile: false, reason: "heuristic" };
+    return { severity: "Medium", volatile: false, toolOwned: false, reason: "heuristic" };
   }
 
   // 4. A named-malware rule on a normal path — the case mapYara was built for. Unchanged.
-  return { severity: "High", volatile: false, reason: "" };
+  return { severity: "High", volatile: false, toolOwned: false, reason: "" };
 }
 
 // The aggregation key for a graded hit. The HOST LEADS. It used to trail, and a deep scanned path

--- a/companion/tests/analysis/evalFixes.test.ts
+++ b/companion/tests/analysis/evalFixes.test.ts
@@ -5,6 +5,7 @@ import { detectImportKind } from "../../src/analysis/importDetect.js";
 import { extractDomains } from "../../src/analysis/textDomains.js";
 import { scrapeText } from "../../src/analysis/veloTextIocs.js";
 import { parseVelociraptorJson } from "../../src/analysis/velociraptorImport.js";
+import { mapHijackLib } from "../../src/analysis/hijackLibImport.js";
 import type { SiemIoc } from "../../src/analysis/siemImport.js";
 
 describe("import routing — eval fixes", () => {
@@ -82,6 +83,25 @@ describe("HijackLibsMFT — DLL side-load (T1574) mapping", () => {
       JSON.stringify([hijackRow("C:\\Program Files\\Vendor\\log4net.dll", "\\\\Program Files\\\\Vendor")]),
     );
     expect(r.events[0].severity).toBe("Low");
+  });
+
+  // A hijackable-DLL scan walks the whole disk, so a deep path is its NORMAL input. The key used to
+  // be truncated with a plain .slice(0, 400): two DLLs under one deep directory collapsed to one
+  // key, and applyEventIdentity then overwrote the survivor's path and hash — deleting a row's
+  // evidence rather than miscounting it (#722). boundedAggKey digests the full key instead.
+  it("keeps the same DLL at two deep paths as two aggregation keys", () => {
+    const deepDir = `C:\\${"nested\\".repeat(70)}`;
+    const key = (leaf: string) =>
+      mapHijackLib(
+        { HijackLibInfo: { DllName: "log4net.dll" }, OSPath: `${deepDir}${leaf}\\log4net.dll` },
+        "DetectRaptor.Windows.Detection.HijackLibsMFT",
+        "HOST01",
+        new Map<string, SiemIoc>(),
+      ).aggKey;
+    const a = key("appOne");
+    const b = key("appTwo");
+    expect(a).not.toBe(b);
+    expect(a.length).toBeLessThanOrEqual(400);
   });
 });
 

--- a/companion/tests/analysis/veloDetectionNoise.test.ts
+++ b/companion/tests/analysis/veloDetectionNoise.test.ts
@@ -1,0 +1,70 @@
+// The demotion markers in veloDetectionNoise must only fire on signals an attacker cannot choose,
+// and a demotion must never delete an indicator. Both halves are #720.
+import { describe, it, expect } from "vitest";
+import { isDetectionToolLocation, isCollectorOwnedLocation } from "../../src/analysis/veloDetectionNoise.js";
+import { parseVelociraptorJson } from "../../src/analysis/velociraptorImport.js";
+
+describe("isDetectionToolLocation — corpus markers are full path components", () => {
+  it.each([
+    ["the collector install root", "C:\\Program Files\\Velociraptor\\Velociraptor.exe"],
+    ["the corpus unpacked under the tool tree", "C:\\Program Files\\Velociraptor\\Tools\\tmp1\\x.evtx"],
+    ["a corpus the analyst downloaded", "C:\\Users\\a\\Downloads\\EVTX-ATTACK-SAMPLES\\Lateral\\x.evtx"],
+    ["the GitHub zip's -master suffix", "C:\\Users\\a\\EVTX-ATTACK-SAMPLES-master\\x.evtx"],
+    ["the simulation repo", "C:\\Users\\a\\Digital-Forensic-Artifacts\\collect.ps1"],
+    ["forward slashes", "/opt/Digital-Forensic-Artifacts/collect.sh"],
+  ])("matches %s", (_label, path) => {
+    expect(isDetectionToolLocation(path)).toBe(true);
+  });
+
+  // The bare `EVTX-ATTACK` substring matched any of these. Each is a name an intruder picks, and a
+  // match here suppresses the finding — so each must miss.
+  it.each([
+    ["a longer word starting with the marker", "C:\\Users\\public\\EVTX-ATTACKER-kit\\evil.exe"],
+    ["the marker mid-token, with no leading separator", "C:\\Temp\\my-EVTX-ATTACK-notes.exe"],
+    ["the marker as a filename stem", "C:\\Users\\v\\EVTX-ATTACK.dll"],
+    ["a truncated corpus name", "C:\\Users\\v\\EVTX-ATTACK-SAMP\\evil.exe"],
+    ["the repo name as a longer token", "C:\\Users\\v\\Digital-Forensic-ArtifactsX\\evil.exe"],
+  ])("does not match %s", (_label, path) => {
+    expect(isDetectionToolLocation(path)).toBe(false);
+  });
+});
+
+describe("isCollectorOwnedLocation — only the collector's own tree", () => {
+  it("matches the install root", () => {
+    expect(isCollectorOwnedLocation("C:\\Program Files\\Velociraptor\\Tools\\tmp1\\x.evtx")).toBe(true);
+  });
+
+  // A corpus directory is a name the attacker can supply, so it grades but never owns.
+  it("does not match a sample-corpus directory", () => {
+    expect(isCollectorOwnedLocation("C:\\Users\\a\\EVTX-ATTACK-SAMPLES\\x.evtx")).toBe(false);
+    expect(isCollectorOwnedLocation("C:\\Users\\a\\Digital-Forensic-Artifacts\\x.ps1")).toBe(false);
+  });
+});
+
+// A demotion may lower a grade. It may not delete the evidence, because the corpus markers are
+// attacker-choosable: a payload under a planted EVTX-ATTACK-SAMPLES folder must still leave an IOC.
+describe("mapYara self-scan — grades down without deleting indicators", () => {
+  const yaraRow = (osPath: string) => ({
+    _Source: "Windows.Detection.Yara.Glob",
+    Rule: "DITEKSHEN_MALWARE_Win_Asyncrat",
+    OSPath: osPath,
+    Exe: "C:\\Users\\v\\loader.exe",
+  });
+
+  it("keeps the file and process IOCs for a hit under a sample-corpus folder", () => {
+    const path = "C:\\Users\\public\\EVTX-ATTACK-SAMPLES\\evil.exe";
+    const r = parseVelociraptorJson(JSON.stringify([yaraRow(path)]));
+    expect(r.events[0].severity).toBe("Info");
+    expect(r.iocs.some((i) => i.type === "file" && i.value === path)).toBe(true);
+    expect(r.iocs.some((i) => i.type === "process" && i.value === "loader.exe")).toBe(true);
+  });
+
+  // The collector's own tree is not host evidence at all, so it keeps suppressing.
+  it("still suppresses both IOCs for a hit inside the collector's own tree", () => {
+    const path = "C:\\Program Files\\Velociraptor\\Tools\\tmp1\\rules\\x.exe";
+    const r = parseVelociraptorJson(JSON.stringify([yaraRow(path)]));
+    expect(r.events[0].severity).toBe("Info");
+    expect(r.iocs.some((i) => i.type === "file" && i.value === path)).toBe(false);
+    expect(r.iocs.some((i) => i.type === "process")).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes two ways an aggregation or demotion decision deleted a row's evidence instead of merely ranking it.

## #720 — attacker-choosable demotion markers

`veloDetectionNoise` states its own design rule in a CAUTION comment: every marker must be a signal the **attacker cannot choose**. `\Velociraptor\` honored it. The two corpus markers were bare substrings:

```ts
/[/\\]Velociraptor[/\\]|EVTX-ATTACK|Digital-Forensic-Artifacts/i
```

So `C:\Users\public\EVTX-ATTACKER-kit\evil.exe` matched — a path any intruder can create. The cost is not just a grade. In `mapYara`, a self-scan match dropped the hit to Info **and** suppressed its `file` and `process` IOCs. Six call sites consume this predicate, and the repo is public, so the marker list is readable by the people it would filter.

Two changes:

1. **Anchor the corpus names** as whole path components. A longer word no longer matches; a real download still does, including the GitHub zip's `-master` suffix.

2. **Separate the two tiers.** Anchoring narrows the accident but cannot stop a deliberately named folder. `isCollectorOwnedLocation` matches only the collector's own install tree — the one marker here an intruder cannot supply — and `YaraGrade` carries it as `toolOwned`. `mapYara` now drops IOCs on `toolOwned` rather than on the grade. A hit under a planted corpus folder still leaves the timeline at Info; it keeps its indicators.

The `mapYara` edit is net-zero lines, so `velociraptorImport.ts` stays at 1868 against its ledger cap of 1869.

## #722 — truncated aggregation key

`hijackLibImport` still used the plain `.slice(0, 400)` that `aggKey.ts` deprecated in #670. A hijackable-DLL scan walks the whole disk, so a deep path is its normal input, and a collision does not miscount — `applyEventIdentity` overwrites the survivor's path and hash. Now wrapped in `boundedAggKey`, matching every other migrated site.

## Verification

- New `tests/analysis/veloDetectionNoise.test.ts`: 6 paths that must still match, 5 attacker-shaped paths that must not, and both IOC-retention cases.
- New case in `evalFixes.test.ts`: the same DLL at two deep paths sharing a 400-character prefix yields two keys.
- Full suite: **705 files, 11200 tests, all pass.**
- `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` all pass.

## Not included

`DETECTION_CONTENT_LOCATION` (same file, line 42) still carries a bare `EVTX-ATTACK` substring and also suppresses a `file` IOC, but only for `.yml`/`.yaml`/`.evtx`/`.etl` paths. Different predicate, narrower blast radius, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
