### PR TITLE
fix(tools): fail closed on a signal kill, and derive the run identity once per import (#719, #721)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,913 of the 1,952 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,917 of the 1,956 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/src/composition/dropFolder.ts
+++ b/companion/src/composition/dropFolder.ts
@@ -34,6 +34,7 @@ import type { AiControl } from "../analysis/aiControl.js";
 import type { CaptureMetadata } from "../types.js";
 import type { ToolConfig } from "../integrations/tools/toolConfig.js";
 import { suggestedToolForExtension } from "../integrations/tools/toolConfig.js";
+import { createToolRunCache, type ToolRunCache } from "../integrations/tools/toolProvenance.js";
 import { ingestCapture } from "../ingest/captureIngest.js";
 import {
   selectReadyFiles,
@@ -97,8 +98,7 @@ export interface DropFolderDeps {
     caseId: string,
     toolId: string,
     fullPath: string,
-    name: string,
-    dropRelpath?: string,
+    opts: { name: string; dropRelpath?: string; cache?: ToolRunCache },
   ) => Promise<boolean>;
   // A dropped image joins the SAME capture + vision path as POST /captures.
   indexCaptureText: (metadata: CaptureMetadata) => void;
@@ -287,6 +287,10 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
     caseId: string,
     dropDir: string,
     file: DropFileStat,
+    // One memo per SWEEP, so a folder of 40 EVTX hashes the Sigma tree once rather than 40 times
+    // (#721). It never outlives the sweep, so the custody record it feeds says "the rules as they
+    // stood when this sweep began" — a boundary an analyst can state.
+    cache: ToolRunCache,
   ): Promise<{ ok: boolean; reason?: string; pending?: PendingRawInput; submitted?: string }> {
     const full = join(dropDir, file.relpath);
     const name = basename(file.relpath);
@@ -339,7 +343,11 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
             },
           };
         }
-        const async_ = await runDropToolAndIngest(caseId, toolId, full, name, file.relpath);
+        const async_ = await runDropToolAndIngest(caseId, toolId, full, {
+          name,
+          dropRelpath: file.relpath,
+          cache,
+        });
         // An HTTP tool has only been HANDED the file here; its verdicts land later (or the analysis
         // fails), so the sweep logs SUBMITTED and the job appends the outcome when it resolves.
         return async_
@@ -403,6 +411,7 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
       });
       if (job) await job.ready;
 
+      const runCache = createToolRunCache();
       const imported: string[] = [];
       // Handed to an asynchronous tool this sweep — logged SUBMITTED, with the outcome appended by the
       // job itself when the analysis resolves.
@@ -415,7 +424,7 @@ export function createDropFolder(deps: DropFolderDeps): DropFolder {
         await Promise.all(
           batch.map(async (file) => {
             try {
-              const res = await processDropFile(caseId, dropDir, file);
+              const res = await processDropFile(caseId, dropDir, file, runCache);
               if (res.pending) {
                 // Raw input awaiting a tool: keep it in place (don't move, keep tracked) so the banner's
                 // "Run <tool>" can act on it and a later config/auto-run picks it up next sweep.

--- a/companion/src/composition/externalTools.ts
+++ b/companion/src/composition/externalTools.ts
@@ -34,6 +34,7 @@ import {
   type ToolConfig,
 } from "../integrations/tools/toolConfig.js";
 import { runToolAgainstFile, resolveContainedPath } from "../integrations/tools/runToolImport.js";
+import type { ToolRunCache } from "../integrations/tools/toolProvenance.js";
 import { describeToolRun } from "../integrations/tools/toolProvenance.js";
 import { customToolToConfig, type CustomTool } from "../integrations/tools/customToolStore.js";
 import { RAW_TOOL_EXTS } from "../analysis/dropScan.js";
@@ -90,14 +91,17 @@ export interface ExternalTools {
     caseId: string,
     toolId: string,
     fullPath: string,
-    name: string,
-    dropRelpath?: string,
+    opts: { name: string; dropRelpath?: string; cache?: ToolRunCache },
   ): Promise<boolean>;
   runToolAndIngest(
     caseId: string,
     toolId: string,
     targetPath: string,
-    opts?: { undoLabel?: string; preserveOriginal?: { bytes: Buffer; originalName: string } },
+    opts?: {
+      undoLabel?: string;
+      preserveOriginal?: { bytes: Buffer; originalName: string };
+      cache?: ToolRunCache;
+    },
   ): Promise<{ storedName: string; addedEvents: number; addedIocs: number; analyzed: boolean }>;
   startSocratesAnalysis(
     caseId: string,
@@ -184,16 +188,16 @@ export function createExternalTools(deps: ExternalToolsDeps): ExternalTools {
     caseId: string,
     toolId: string,
     fullPath: string,
-    name: string,
-    dropRelpath?: string,
+    opts: { name: string; dropRelpath?: string; cache?: ToolRunCache },
   ): Promise<boolean> {
+    const { name, dropRelpath, cache } = opts;
     const cfg = liveToolConfigs().get(toolId);
     if (!cfg) throw new Error(`tool "${toolId}" is not configured`);
     if (cfg.transport === "http") {
       await startSocratesAnalysis(caseId, { data: await readFile(fullPath), filename: name, dropRelpath });
       return true;
     }
-    const r = await runToolAndIngest(caseId, toolId, fullPath);
+    const r = await runToolAndIngest(caseId, toolId, fullPath, { cache });
     if (!r.analyzed)
       throw new Error(`${toolId} ran but AI is off — output saved as evidence but not analyzed`);
     return false;
@@ -208,7 +212,11 @@ export function createExternalTools(deps: ExternalToolsDeps): ExternalTools {
     caseId: string,
     toolId: string,
     targetPath: string,
-    opts: { undoLabel?: string; preserveOriginal?: { bytes: Buffer; originalName: string } } = {},
+    opts: {
+      undoLabel?: string;
+      preserveOriginal?: { bytes: Buffer; originalName: string };
+      cache?: ToolRunCache;
+    } = {},
   ): Promise<{ storedName: string; addedEvents: number; addedIocs: number; analyzed: boolean }> {
     const cfg = liveToolConfigs().get(toolId);
     if (!cfg) throw new Error(`tool "${toolId}" is not configured`);
@@ -247,6 +255,7 @@ export function createExternalTools(deps: ExternalToolsDeps): ExternalTools {
       runner: options.toolRunner,
       targetPath: contained,
       workDir: join(caseDir, ".toolwork"),
+      cache: opts.cache,
     });
     const outName = `${basename(contained)}.${toolId}.out`;
     // Custom tools declare no fixed importer — detect the kind from the tool's output.

--- a/companion/src/integrations/tools/runToolImport.ts
+++ b/companion/src/integrations/tools/runToolImport.ts
@@ -2,7 +2,13 @@ import { mkdtemp, mkdir, readFile, rm, copyFile } from "node:fs/promises";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import type { ToolConfig } from "./toolConfig.js";
 import { substituteArgs, tokenizeArgs, stripAnsi, cleanToolOutput, type ToolRunner } from "./toolRunner.js";
-import { hashOutputText, hashRuleset, probeToolVersion, type ToolRunProvenance } from "./toolProvenance.js";
+import {
+  hashOutputText,
+  hashRuleset,
+  probeToolVersion,
+  type ToolRunCache,
+  type ToolRunProvenance,
+} from "./toolProvenance.js";
 
 // Orchestrates "run the analyst's tool against a raw file on disk → hand its TEXT output to the existing
 // importer". Pure of any server/HTTP concern; the ToolRunner is injected so tests never spawn. Security
@@ -42,6 +48,8 @@ export async function runToolAgainstFile(opts: {
   workDir: string; // e.g. cases/<id>/.toolwork
   rulesPath?: string; // overrides cfg.rulesPath when provided
   definitions?: string; // overrides cfg.definitions when provided
+  // Per-import-job memo for the ruleset hash + version probe. Omit for a one-off run (#721).
+  cache?: ToolRunCache;
 }): Promise<RunToolResult> {
   const { cfg, runner, targetPath, workDir } = opts;
   const rules = (opts.rulesPath ?? cfg.rulesPath ?? "").trim();
@@ -61,7 +69,7 @@ export async function runToolAgainstFile(opts: {
   // BEFORE the tool is spawned so a fail-closed parser refuses to run at all rather than reporting a
   // confident "no detections" over rules it never loaded — which is indistinguishable, in the output,
   // from a genuinely clean log.
-  const ruleset = rules ? await hashRuleset(rules) : null;
+  const ruleset = rules ? await hashRuleset(rules, opts.cache) : null;
   if (cfg.requireRuleset && !ruleset) {
     throw new Error(
       `${cfg.id}: the rule set at "${rules}" could not be identified — the path must exist and hold at least one readable rule file. ` +
@@ -116,7 +124,7 @@ export async function runToolAgainstFile(opts: {
 
     // Best effort, and deliberately before the run so a version probe that hangs is bounded by its
     // own short timeout rather than eating into the parse. A blank version never fails the run.
-    const version = await probeToolVersion(cfg, runner);
+    const version = await probeToolVersion(cfg, runner, opts.cache);
 
     const res = await runner(cfg.binary, argv, {
       timeoutMs: cfg.timeoutMs,
@@ -132,7 +140,13 @@ export async function runToolAgainstFile(opts: {
     // A SIGNAL kill counts too, and is the likeliest way a parser dies on real evidence: the OOM
     // killer takes it out partway through a large EVTX, or it segfaults on a malformed chunk. Both
     // leave a plausible-looking partial output file behind.
-    if (cfg.failOnNonZeroExit && (res.code !== 0 || res.signal)) {
+    //
+    // The two halves are gated SEPARATELY (#719). Only the exit CODE is tool-specific — the flag is
+    // unset for YARA and Snort because they exit non-zero to mean "matches found". A signal is not a
+    // return value: no tool uses one to report matches, so a killed process is a partial parse for
+    // EVERY tool, flag or no flag. Riding both halves on the flag meant a YARA scan the OOM killer
+    // took out imported its half-written stdout as a completed scan.
+    if (res.signal || (cfg.failOnNonZeroExit && res.code !== 0)) {
       const detail = cleanToolOutput(res.stderr, 4);
       const how = res.signal ? `was killed by ${res.signal}` : `exited with code ${res.code}`;
       throw new Error(

--- a/companion/src/integrations/tools/toolProvenance.ts
+++ b/companion/src/integrations/tools/toolProvenance.ts
@@ -47,6 +47,39 @@ export interface ToolRunProvenance {
   ruleset: RulesetIdentity | null;
 }
 
+/**
+ * Per-import-job memo for the two derivations every run repeats identically (#721).
+ *
+ * hashRuleset walks and SHA-256s the entire rules tree, and probeToolVersion spawns the binary —
+ * both on EVERY runToolAgainstFile call. A folder import runs the tool once per evidence file, and a
+ * real Velociraptor collection is 20-60 EVTX files, so one import re-derived the same identity 20-60
+ * times over a rules directory that is a git checkout of ~10k Sigma files.
+ *
+ * Scoped to ONE import job, deliberately never global. The ruleset hash is a custody claim about
+ * which rules produced these verdicts, so a cached value needs a boundary an analyst can state out
+ * loud; per job it reads "the rules as they stood when this import began". A global cache with a
+ * time-based expiry has no such sentence. Keying a global cache on the rules DIRECTORY's mtime would
+ * be worse than useless — editing a rule file's content does not touch its parent directory's mtime,
+ * so the identity would go stale silently, and a custody record that names the wrong rules is worse
+ * than one that cost a few seconds to recompute.
+ *
+ * PROMISES are memoized rather than settled values: a drop sweep processes several files
+ * concurrently, so caching only on completion would let every file in the first batch start its own
+ * walk before any of them finished.
+ *
+ * A null identity is cached like any other result. It means the path did not resolve, which for a
+ * requireRuleset tool is a refuse-to-run — the safe direction, and re-deriving it can be as
+ * expensive as the success case (an oversized tree is only known to be oversized after the walk).
+ */
+export interface ToolRunCache {
+  ruleset: Map<string, Promise<RulesetIdentity | null>>;
+  version: Map<string, Promise<string>>;
+}
+
+export function createToolRunCache(): ToolRunCache {
+  return { ruleset: new Map(), version: new Map() };
+}
+
 // A rule set is a git checkout of a few thousand small YAML files. These caps exist so a mistyped
 // path pointing at a home directory (or a checkout with its .git intact) cannot turn one tool run
 // into an unbounded disk walk. Exceeding either means "this is not a rule set" — the identity comes
@@ -77,9 +110,17 @@ async function hashOneFile(path: string): Promise<string> {
  * in, and it changes when a rule is added, removed, edited OR renamed. Two analysts on the same
  * Sigma commit get the same hash on Windows and on Linux (the separator is normalized to "/").
  */
-export async function hashRuleset(path: string): Promise<RulesetIdentity | null> {
+export async function hashRuleset(path: string, cache?: ToolRunCache): Promise<RulesetIdentity | null> {
   const target = path.trim();
   if (!target) return null;
+  const hit = cache?.ruleset.get(target);
+  if (hit) return hit;
+  const pending = hashRulesetUncached(target);
+  cache?.ruleset.set(target, pending);
+  return pending;
+}
+
+async function hashRulesetUncached(target: string): Promise<RulesetIdentity | null> {
   let info;
   try {
     info = await stat(target);
@@ -150,8 +191,23 @@ const VERSION_MAX_BYTES = 64 * 1024;
  * saying nothing, so a failed probe records nothing. Every tool the Companion ships a definition for
  * exits 0 on its version flag; a custom tool that does not simply has a blank version.
  */
-export async function probeToolVersion(cfg: ToolConfig, runner: ToolRunner): Promise<string> {
+export async function probeToolVersion(
+  cfg: ToolConfig,
+  runner: ToolRunner,
+  cache?: ToolRunCache,
+): Promise<string> {
   if (!cfg.binary) return "";
+  // Path + flags is enough of a key at job scope: a binary is not swapped mid-import. A GLOBAL cache
+  // would have to add the binary's mtime and size to stay honest across an upgrade (#721).
+  const key = `${cfg.binary} ${(cfg.versionArgs ?? ["--version"]).join(" ")}`;
+  const hit = cache?.version.get(key);
+  if (hit) return hit;
+  const pending = probeToolVersionUncached(cfg, runner);
+  cache?.version.set(key, pending);
+  return pending;
+}
+
+async function probeToolVersionUncached(cfg: ToolConfig, runner: ToolRunner): Promise<string> {
   try {
     const res = await runner(cfg.binary, cfg.versionArgs ?? ["--version"], {
       timeoutMs: VERSION_TIMEOUT_MS,

--- a/companion/src/routes/context.ts
+++ b/companion/src/routes/context.ts
@@ -14,6 +14,7 @@ import type { NsrlDb } from "../analysis/nsrlDb.js";
 import type { ImporterFailure, AiError, ImporterRunStat } from "../analysis/diagnostics.js";
 import type { Severity, InvestigationState } from "../analysis/stateTypes.js";
 import type { ToolConfig } from "../integrations/tools/toolConfig.js";
+import type { ToolRunCache } from "../integrations/tools/toolProvenance.js";
 import type { CustomTool } from "../integrations/tools/customToolStore.js";
 import type { SocratesJobStore } from "../integrations/socrates/socratesJobStore.js";
 import type { VeloMonitor } from "../analysis/veloMonitorStore.js";
@@ -159,8 +160,8 @@ export interface RouteContext {
     caseId: string,
     toolId: string,
     fullPath: string,
-    name: string,
-    dropRelpath?: string,
+    // `cache` is a per-import-job memo so a batch hashes the rule set once, not once per file (#721).
+    opts: { name: string; dropRelpath?: string; cache?: ToolRunCache },
   ): Promise<boolean>;
   // Import machinery shared between routes/import.ts and the createApp import seams that stay
   // (the Velociraptor bundle collector reuses dispatchImport/demoteForensicForCase/resynthesize,

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -39,6 +39,7 @@ import {
   suggestedToolForExtension,
   type ToolConfig,
 } from "../integrations/tools/toolConfig.js";
+import { createToolRunCache } from "../integrations/tools/toolProvenance.js";
 import { summarizeUndoStack, applyUndo, applyRedo } from "../analysis/importUndo.js";
 import type { Severity, InvestigationState } from "../analysis/stateTypes.js";
 import type { PendingRawInput } from "../analysis/dropStatus.js";
@@ -165,6 +166,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         skipped = 0;
       const stillPending: PendingRawInput[] = [];
       const resolvedEntries: DropLogEntry[] = [];
+      const runCache = createToolRunCache();
       for (const p of pending) {
         const toolId = resolveToolForExt(p.ext, configured);
         if (!toolId) {
@@ -175,13 +177,11 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
         try {
           // Dispatch by transport: a spawn tool runs and imports inline; SO-CRATES hands off to its
           // background poller and the verdicts land when the analysis finishes.
-          const async_ = await ctx.runDropToolAndIngest(
-            caseId,
-            toolId,
-            join(dropDir, p.relpath),
-            basename(p.relpath),
-            p.relpath,
-          );
+          const async_ = await ctx.runDropToolAndIngest(caseId, toolId, join(dropDir, p.relpath), {
+            name: basename(p.relpath),
+            dropRelpath: p.relpath,
+            cache: runCache,
+          });
           await moveDropFile(dropDir, p.relpath, true).catch(() => {
             /* best-effort */
           });

--- a/companion/tests/integrations/toolProvenance.test.ts
+++ b/companion/tests/integrations/toolProvenance.test.ts
@@ -7,6 +7,7 @@ import {
   probeToolVersion,
   describeToolRun,
   hashOutputText,
+  createToolRunCache,
 } from "../../src/integrations/tools/toolProvenance.js";
 import { loadToolConfig, TOOL_DEFS } from "../../src/integrations/tools/toolConfig.js";
 import { runToolAgainstFile } from "../../src/integrations/tools/runToolImport.js";
@@ -334,5 +335,85 @@ describe("runToolAgainstFile records what the run was (#688)", () => {
     expect(res.provenance.version).toBe("");
     expect(res.provenance.ruleset).toBeNull();
     expect(res.importKind).toBe("hayabusa");
+  });
+});
+
+// #721. hashRuleset walks and SHA-256s the whole rules tree and probeToolVersion spawns the binary,
+// both on EVERY run. A folder import runs the tool once per evidence file — 20-60 for a real
+// collection — so one import re-derived the same identity that many times.
+describe("ToolRunCache — one derivation per import job (#721)", () => {
+  it("hashes a rules tree once per cache, and re-derives without one", async () => {
+    const dir = await ruleDir({ "a.yml": "one", "b.yml": "two" });
+    const cache = createToolRunCache();
+    const first = (await hashRuleset(dir, cache))!;
+
+    // Change the CONTENT of a rule. The parent directory's mtime is untouched by this, which is
+    // exactly why a global cache must not key on it.
+    await writeFile(join(dir, "a.yml"), "one-edited", "utf8");
+
+    expect((await hashRuleset(dir, cache))!.sha256).toBe(first.sha256); // cached for this job
+    expect((await hashRuleset(dir))!.sha256).not.toBe(first.sha256); // uncached sees the edit
+  });
+
+  it("shares ONE walk between concurrent callers (memoizes the promise, not the result)", async () => {
+    const dir = await ruleDir({ "a.yml": "one" });
+    const cache = createToolRunCache();
+    const [x, y] = await Promise.all([hashRuleset(dir, cache), hashRuleset(dir, cache)]);
+    expect(x!.sha256).toBe(y!.sha256);
+    expect(cache.ruleset.size).toBe(1);
+  });
+
+  it("keeps caches independent, so a later job re-derives", async () => {
+    const dir = await ruleDir({ "a.yml": "one" });
+    const first = (await hashRuleset(dir, createToolRunCache()))!;
+    await writeFile(join(dir, "a.yml"), "changed", "utf8");
+    expect((await hashRuleset(dir, createToolRunCache()))!.sha256).not.toBe(first.sha256);
+  });
+
+  it("spawns the version probe once per cache", async () => {
+    const cfg = loadToolConfig("hayabusa", { DFIR_TOOL_HAYABUSA_BINARY: "hayabusa" })!;
+    let probes = 0;
+    const runner: ToolRunner = async () => {
+      probes++;
+      return { stdout: "hayabusa 3.2.0", stderr: "", code: 0 };
+    };
+    const cache = createToolRunCache();
+    expect(await probeToolVersion(cfg, runner, cache)).toBe("hayabusa 3.2.0");
+    expect(await probeToolVersion(cfg, runner, cache)).toBe("hayabusa 3.2.0");
+    expect(probes).toBe(1);
+    await probeToolVersion(cfg, runner); // no cache → probes again
+    expect(probes).toBe(2);
+  });
+
+  it("runToolAgainstFile threads the cache, so a 3-file batch derives once", async () => {
+    const caseDir = await mkdtemp(join(tmpdir(), "case-"));
+    const rules = await ruleDir({ "a.yar": "rule A {condition: true}" });
+    const cfg = loadToolConfig("yara", {
+      DFIR_TOOL_YARA_BINARY: "yara",
+      DFIR_TOOL_YARA_RULES: rules,
+    })!;
+    let probes = 0;
+    const runner: ToolRunner = async (_binary, args) => {
+      if (args.includes("--version")) {
+        probes++;
+        return { stdout: "YARA 4.5.0", stderr: "", code: 0 };
+      }
+      return { stdout: "EvilRule /x/a.bin", stderr: "", code: 0 };
+    };
+    const cache = createToolRunCache();
+    for (const name of ["a.bin", "b.bin", "c.bin"]) {
+      await writeFile(join(caseDir, name), "sample");
+      const res = await runToolAgainstFile({
+        cfg,
+        runner,
+        targetPath: join(caseDir, name),
+        workDir: join(caseDir, ".toolwork"),
+        cache,
+      });
+      expect(res.provenance.ruleset?.sha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(res.provenance.version).toBe("YARA 4.5.0");
+    }
+    expect(probes).toBe(1);
+    expect(cache.ruleset.size).toBe(1);
   });
 });

--- a/companion/tests/integrations/toolRunner.test.ts
+++ b/companion/tests/integrations/toolRunner.test.ts
@@ -313,6 +313,69 @@ describe("runToolAgainstFile", () => {
     ).rejects.toThrow(/rules file is required/i);
   });
 
+  // #719. failOnNonZeroExit is unset for YARA and Snort because a non-zero EXIT CODE means "matches
+  // found" for them. The signal half of the check rode on the same flag, so a YARA scan killed by the
+  // OOM killer imported its half-written stdout as a completed scan — the exact "silently partial
+  // view of the evidence" the fail-closed design refuses. No tool signals "matches found".
+  it("refuses a signal-killed run even for a tool whose exit code is not fail-closed", async () => {
+    const caseDir = await mkdtemp(join(tmpdir(), "case-"));
+    await writeFile(join(caseDir, "a.bin"), "sample");
+    const cfg = loadToolConfig("yara", { DFIR_TOOL_YARA_BINARY: "yara", DFIR_TOOL_YARA_RULES: "/r.yar" })!;
+    expect(cfg.failOnNonZeroExit).toBeFalsy();
+    const runner: ToolRunner = async (_binary, args) => {
+      if (args.includes("--version")) return { stdout: "YARA 4.5.0", stderr: "", code: 0 };
+      // The OOM killer takes the scan out partway through; plausible-looking partial stdout remains.
+      return { stdout: "EvilRule /x/a.bin", stderr: "", code: -1, signal: "SIGKILL" };
+    };
+    await expect(
+      runToolAgainstFile({
+        cfg,
+        runner,
+        targetPath: join(caseDir, "a.bin"),
+        workDir: join(caseDir, ".toolwork"),
+      }),
+    ).rejects.toThrow(/killed by SIGKILL.*refusing to import a partial parse/i);
+  });
+
+  // The other half of the flag's purpose must survive: a non-zero exit with output is a NORMAL YARA
+  // run, and splitting the condition must not start rejecting it.
+  it("still imports a non-zero exit from a tool that uses it to mean 'matches found'", async () => {
+    const caseDir = await mkdtemp(join(tmpdir(), "case-"));
+    await writeFile(join(caseDir, "a.bin"), "sample");
+    const cfg = loadToolConfig("yara", { DFIR_TOOL_YARA_BINARY: "yara", DFIR_TOOL_YARA_RULES: "/r.yar" })!;
+    const runner: ToolRunner = async (_binary, args) =>
+      args.includes("--version")
+        ? { stdout: "YARA 4.5.0", stderr: "", code: 0 }
+        : { stdout: "EvilRule /x/a.bin", stderr: "", code: 1, signal: null };
+    const res = await runToolAgainstFile({
+      cfg,
+      runner,
+      targetPath: join(caseDir, "a.bin"),
+      workDir: join(caseDir, ".toolwork"),
+    });
+    expect(res.outputText).toBe("EvilRule /x/a.bin");
+    expect(res.provenance.exitCode).toBe(1);
+  });
+
+  it("still refuses a signal-killed run for a fail-closed tool", async () => {
+    const caseDir = await mkdtemp(join(tmpdir(), "case-"));
+    await writeFile(join(caseDir, "a.evtx"), "binary-evtx");
+    const cfg = loadToolConfig("hayabusa", { DFIR_TOOL_HAYABUSA_BINARY: "hayabusa" })!;
+    expect(cfg.failOnNonZeroExit).toBe(true);
+    const runner: ToolRunner = async (_binary, args) =>
+      args.includes("--version")
+        ? { stdout: "hayabusa 3.2.0", stderr: "", code: 0 }
+        : { stdout: "", stderr: "", code: -1, signal: "SIGSEGV" };
+    await expect(
+      runToolAgainstFile({
+        cfg,
+        runner,
+        targetPath: join(caseDir, "a.evtx"),
+        workDir: join(caseDir, ".toolwork"),
+      }),
+    ).rejects.toThrow(/killed by SIGSEGV/i);
+  });
+
   it("throws with stderr detail when the tool produces no output", async () => {
     const caseDir = await mkdtemp(join(tmpdir(), "case-"));
     await writeFile(join(caseDir, "a.bin"), "x");


### PR DESCRIPTION
Two issues in the external-tool run path, both in `runToolImport.ts`.

## #719 — a signal kill imported a partial parse

The fail-closed check gated **both** halves on one flag:

```ts
if (cfg.failOnNonZeroExit && (res.code !== 0 || res.signal))
```

`failOnNonZeroExit` is deliberately unset for YARA and Snort, because they exit non-zero to mean *matches found*. That skipped the `res.signal` half for them as well. A YARA scan killed by the OOM killer, or segfaulting on a malformed chunk, left plausible-looking partial stdout — and the run imported it as a completed scan. That is exactly the "silently partial view of the evidence" the #688 design refuses; it just did not refuse it for these two tools.

Only the exit **code** is tool-specific. No tool uses a signal to report matches, so the halves are now gated apart:

```ts
if (res.signal || (cfg.failOnNonZeroExit && res.code !== 0))
```

## #721 — every run re-derived the same identity

`hashRuleset` walks and SHA-256s the entire rules tree, and `probeToolVersion` spawns the binary — both on **every** `runToolAgainstFile` call. A rules directory is a git checkout of ~10k Sigma files, and a folder import runs the tool once per evidence file (20–60 for a real Velociraptor collection), so one import repeated both 20–60 times.

New `ToolRunCache`, created at the two batch boundaries — the drop-folder sweep and the Run-pending route — and threaded down to `runToolAgainstFile`. Three deliberate choices:

- **Job-scoped, never global.** The ruleset hash is a custody claim about which rules produced the verdicts, so a cached value needs a boundary an analyst can state out loud: "the rules as they stood when this import began."
- **Nothing keys on the rules directory's mtime.** Editing a rule file's content does not touch its parent directory's mtime, so that key would go stale silently — and a custody record naming the wrong rules is worse than one that cost a few seconds.
- **Promises are memoized, not settled values.** The sweep processes four files concurrently; caching on completion would let the whole first batch start its own walk.

## Signature change

`runDropToolAndIngest` moves from six positional parameters (two of them trailing optionals) to `(caseId, toolId, fullPath, opts)`. This was forced by the size ledger: `routes/import.ts` sits at 3202 lines against a cap of 3203, and the wiring needed three. The shorter call site pays for the addition, so the file ends at its original **3202 lines — no growth**. It is also the better shape.

## Verification

- `toolRunner.test.ts`: a SIGKILL'd YARA run is refused; a non-zero YARA exit **with** output still imports (the flag's original purpose); a SIGSEGV on a fail-closed tool still refuses.
- `toolProvenance.test.ts`: a rules tree is hashed once per cache and re-derived without one, including after a content edit the parent mtime does not reflect; concurrent callers share one walk; separate caches re-derive; the version probe spawns once per cache; a 3-file batch through `runToolAgainstFile` probes once.
- Full suite: **11,208 tests, 703 of 705 files clean.** One file, `dashboardFeatureLifecycle.test.ts`, hit a vitest worker RPC timeout under load; it passes 310/310 in isolation and is untouched by this diff.
- `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
