### PR TITLE
feat(cross-case): gate the estate-wide pivot off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Related Cases** — a new dashboard panel and two routes (`GET /cases/:id/related`, `GET /global/iocs?q=`) that surface the other investigations sharing an indicator with this one. Ranked so a flagged hash outweighs a private address; scoped to the cases your account may already read. Off by default — turn it on in Settings → Dashboard sections. (closes #679)
+- **Related Cases** — a new dashboard panel and two routes (`GET /cases/:id/related`, `GET /global/iocs?q=`) that surface the other investigations sharing an indicator with this one. Ranked so a flagged hash outweighs a private address; scoped to the cases your account may already read. Off by default — set `DFIR_CROSS_CASE=on` to enable the routes, then turn the panel on in Settings → Dashboard sections. (closes #679)
 - **Chainsaw runs on raw `.evtx` from inside the Companion** — a sixth built-in tool alongside Hayabusa and the Velociraptor CLI (binary, Sigma rule directory and mapping file in Settings → Tools). The importer already existed; only the runner was missing. (#688)
 - **A parser run is now recorded in the chain of custody** — the tool output's custody entry states the parser's version, the exact arguments, the rule-set hash, the exit code, a stderr tail and the output hash, instead of a bare "companion". (#688)
 - **A raw file uploaded to a parser is kept byte-for-byte** as evidence beside the parser's output, and it survives a failed parse. It used to be deleted once parsed. (#688)
 - **One Windows record read by two parsers is one timeline row** — a Hayabusa run and a Chainsaw run over the same EVTX now merge on the record's own identity (channel + EventRecordID + host) and carry both tools as sources, instead of doubling the timeline. Two detections from the *same* parser on one record stay distinct. (#688)
 
 ### Security
+- **The cross-case pivot is off unless a deployment asks for it** — `GET /cases/:id/related` and `GET /global/iocs` now answer 404 until `DFIR_CROSS_CASE=on`. The routes decide whether one case may name another, and every answered request pinned a trimmed copy of each readable case's indicators in memory for the process lifetime, with no eviction when a case was deleted. (closes #723)
 - **Importing an old `.dfircase` archive now warns that its encryption is weaker** — files exported by v0.31.0–v0.33.0 used scrypt `N=2^14`; v0.34.0 onward use `N=2^17`. The import reports the archive's format version and tells the analyst to re-export. v1 archives stay readable — nothing is refused or re-keyed. (closes #672)
 - **The EVTX parsers fail closed** — a non-zero exit from Hayabusa, Chainsaw or the Velociraptor CLI rejects the run instead of importing a partial parse, and Chainsaw refuses to start when its Sigma rule directory is missing or empty rather than reporting a false all-clear. (#688)
 - **A failed OIDC sign-in no longer shows the identity provider's error text** — the login page gets one sentence and a reference; the full detail goes to the server log under that reference. (closes #674)

--- a/companion/src/routes/crossCase.ts
+++ b/companion/src/routes/crossCase.ts
@@ -109,6 +109,27 @@ function parseTypes(raw: unknown): IocType[] | null | undefined {
 
 export function registerCrossCaseRoutes(app: Express, ctx: RouteContext): void {
   const { store, options } = ctx;
+
+  // OFF unless asked for (#723). Across one estate a shared indicator is usually ordinary
+  // infrastructure — one resolver, one proxy, one patch server — and reading that overlap as a link
+  // between investigations is the mistake the feature invites; #730 already hid the panel that
+  // surfaced it. The ROUTES stayed live, though, and every answered request pins a slimmed copy of
+  // each visible case's IOCs in memory for the life of the process, with nothing evicting a case
+  // that has since been deleted. Off by default, that index is never built and nothing is pinned.
+  //
+  // Read ONCE at registration rather than per request: this is a deployment decision, and a value
+  // that could change mid-session would let two requests in one sitting disagree about whether the
+  // estate is searchable. Deliberately NOT on the Settings writable allowlist — envManager keeps
+  // security toggles out of the dashboard's reach, and this one decides whether a case may name
+  // other cases.
+  const enabled = (process.env.DFIR_CROSS_CASE ?? "off").trim().toLowerCase() === "on";
+
+  /** Refuse with the reason, so an operator meeting a 404 is not left guessing which. */
+  function disabled(res: Response): Response {
+    return res
+      .status(404)
+      .json({ error: "cross-case pivot is disabled — set DFIR_CROSS_CASE=on to enable it" });
+  }
   const snapshots = new Map<string, CachedSnapshot>();
   let indexCache: { key: string; index: CrossCaseIndex } | null = null;
 
@@ -197,6 +218,7 @@ export function registerCrossCaseRoutes(app: Express, ctx: RouteContext): void {
   // gated exactly like GET /cases (auth/policy.ts resolves it to the "case-list" bucket): any
   // session, and a service token holding "read" — which sees only its own case.
   app.get("/global/iocs", async (req: Request, res: Response) => {
+    if (!enabled) return disabled(res);
     const stateStore = options.stateStore;
     if (!stateStore) return res.status(501).json({ error: "state store not configured" });
     const q = typeof req.query.q === "string" ? req.query.q : "";
@@ -222,6 +244,7 @@ export function registerCrossCaseRoutes(app: Express, ctx: RouteContext): void {
   // the standard case-read policy plus the case-lock gate; every OTHER case in the answer went
   // through visibleCases() above.
   app.get("/cases/:id/related", async (req: Request, res: Response) => {
+    if (!enabled) return disabled(res);
     const stateStore = options.stateStore;
     if (!stateStore) return res.status(501).json({ error: "state store not configured" });
     const caseId = req.params.id;

--- a/companion/tests/server/crossCaseRoutes.test.ts
+++ b/companion/tests/server/crossCaseRoutes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -17,6 +17,10 @@ import type { IOC } from "../../src/analysis/stateTypes.js";
 // case-lock gate nor the per-case team policy covers those.
 
 const BOOTSTRAP_TOKEN = "test-bootstrap-token-with-enough-entropy";
+
+afterEach(() => {
+  delete process.env.DFIR_CROSS_CASE;
+});
 
 function ioc(id: string, type: IOC["type"], value: string, flagged = false): IOC {
   return {
@@ -45,6 +49,7 @@ describe("cross-case pivot — single-user mode", () => {
   let stateStore: StateStore;
 
   beforeEach(async () => {
+    process.env.DFIR_CROSS_CASE = "on"; // the pivot is off by default (#723)
     const root = await mkdtemp(join(tmpdir(), "dfir-crosscase-"));
     store = new CaseStore(root);
     stateStore = new StateStore(store);
@@ -146,6 +151,7 @@ describe("cross-case pivot — a password-protected case stays out", () => {
   let app: ReturnType<typeof createApp>;
 
   beforeEach(async () => {
+    process.env.DFIR_CROSS_CASE = "on"; // the pivot is off by default (#723)
     const root = await mkdtemp(join(tmpdir(), "dfir-crosscase-pw-"));
     const store = new CaseStore(root);
     const stateStore = new StateStore(store);
@@ -192,6 +198,7 @@ describe("cross-case pivot — team mode respects case roles", () => {
   }
 
   beforeEach(async () => {
+    process.env.DFIR_CROSS_CASE = "on"; // the pivot is off by default (#723)
     const root = await mkdtemp(join(tmpdir(), "dfir-crosscase-team-"));
     const store = new CaseStore(join(root, "cases"));
     const stateStore = new StateStore(store);
@@ -252,5 +259,61 @@ describe("cross-case pivot — team mode respects case roles", () => {
   it("shows a global administrator both cases", async () => {
     const res = await admin.agent.get("/cases/c1/related");
     expect(res.body.related.map((r: { caseId: string }) => r.caseId)).toEqual(["c2"]);
+  });
+});
+
+// The pivot names cases OTHER than the one the analyst is looking at, and each answered request
+// pins a slimmed copy of every visible case's IOCs for the life of the process. It stays off until
+// a deployment asks for it (#723).
+describe("cross-case pivot — off by default", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(async () => {
+    delete process.env.DFIR_CROSS_CASE;
+    const root = await mkdtemp(join(tmpdir(), "dfir-crosscase-off-"));
+    const store = new CaseStore(root);
+    const stateStore = new StateStore(store);
+    await seed(store, stateStore, "c1", [ioc("i1", "domain", "evil.com")]);
+    await seed(store, stateStore, "c2", [ioc("i9", "domain", "evil.com")]);
+    app = createApp(store, { stateStore });
+  });
+
+  it("refuses the estate-wide search, and says why", async () => {
+    const res = await request(app).get("/global/iocs?q=evil.com");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/DFIR_CROSS_CASE/);
+  });
+
+  it("refuses the related-cases lookup for a case that really exists", async () => {
+    // Not a 404 about a missing case — c1 is there. The 404 is the feature being off.
+    const res = await request(app).get("/cases/c1/related");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/DFIR_CROSS_CASE/);
+  });
+
+  it.each([["off"], [""], ["  "], ["true"], ["1"], ["yes"]])(
+    'stays off for DFIR_CROSS_CASE=%j — only an explicit "on" enables it',
+    async (value) => {
+      process.env.DFIR_CROSS_CASE = value;
+      const root = await mkdtemp(join(tmpdir(), "dfir-crosscase-val-"));
+      const store = new CaseStore(root);
+      const stateStore = new StateStore(store);
+      await seed(store, stateStore, "c1", [ioc("i1", "domain", "evil.com")]);
+      const scoped = createApp(store, { stateStore });
+      expect((await request(scoped).get("/global/iocs?q=evil.com")).status).toBe(404);
+    },
+  );
+
+  it("enables on an explicit ON, whatever the case and spacing", async () => {
+    process.env.DFIR_CROSS_CASE = "  ON  ";
+    const root = await mkdtemp(join(tmpdir(), "dfir-crosscase-on-"));
+    const store = new CaseStore(root);
+    const stateStore = new StateStore(store);
+    await seed(store, stateStore, "c1", [ioc("i1", "domain", "evil.com")]);
+    await seed(store, stateStore, "c2", [ioc("i9", "domain", "evil.com")]);
+    const scoped = createApp(store, { stateStore });
+    const res = await request(scoped).get("/global/iocs?q=evil.com");
+    expect(res.status).toBe(200);
+    expect(res.body.entries[0].caseIds).toEqual(["c1", "c2"]);
   });
 });

--- a/mkdocs-docs/reference/dashboard.md
+++ b/mkdocs-docs/reference/dashboard.md
@@ -424,9 +424,18 @@ phishing case and in today's ransomware case — and every other panel stops at 
 Each row names the case, links straight to it, and lists what the two have in common. Fully
 deterministic; no AI, no network.
 
-**The panel is off by default.** Turn it on in Settings → Dashboard sections. Across one estate a
-shared indicator is usually ordinary, so the panel earns its place only in the investigations where
-you go looking for a cross-case link.
+**The whole feature is off by default, server-side.** Set `DFIR_CROSS_CASE=on` in the environment
+and restart; until then both routes answer 404 and say so. It is an environment setting rather than
+a Settings checkbox on purpose — it decides whether one case may name another, so it stays out of
+the dashboard's reach, like every other setting that governs what an account can see.
+
+Across one estate a shared indicator is usually ordinary, so the feature earns its place only where
+you actually go looking for a cross-case link. Leaving it off also costs nothing to run: each
+answered request holds a trimmed copy of every readable case's indicators in memory for as long as
+the server is up, and off means that index is never built.
+
+**The panel is off by default too**, separately, and stays so even once the routes are enabled —
+turn it on in Settings → Dashboard sections.
 
 Once on, it stays hidden until this case actually overlaps with another one you may read. It
 refreshes when you connect to a case, and again whenever an import settles — so a newly imported
@@ -448,7 +457,7 @@ cases you hold a role on — a reader on case A learns nothing about case B. A p
 contributes nothing until you have unlocked it in the same browser session, whichever case you are
 looking at.
 
-Two routes back it, scoped the same way:
+Two routes back it, scoped the same way (both 404 while `DFIR_CROSS_CASE` is unset):
 
 - `GET /cases/<id>/related` — the panel's own data.
 - `GET /global/iocs?q=<value>` — search one indicator across every case you may read. Optional


### PR DESCRIPTION
`GET /cases/:id/related` and `GET /global/iocs` now answer 404 unless `DFIR_CROSS_CASE=on`. The 404 names the variable, so an operator is not left guessing which 404 they hit.

## Why a gate rather than a fix

[#730](https://github.com/hasamba/DFIR-Companion/pull/730) hid the Related Cases *panel* by default. The **routes** stayed live, and that is where the two problems are:

- **They decide whether one case may name another.** Across one estate a shared indicator is usually ordinary infrastructure — one resolver, one proxy, one patch server — and reading that overlap as a link between investigations is the mistake the feature invites.
- **Each answered request pinned memory.** A slimmed copy of every visible case's IOCs was held for the process lifetime, with nothing evicting a case that had since been deleted ([#723](https://github.com/hasamba/DFIR-Companion/issues/723)). Off, `indexFor` never runs, so that leak has no surface rather than a smaller one — which is why #723 is closed as not planned rather than fixed.

## Choices worth review

- **Environment-only, not a Settings checkbox.** `envManager.ts` keeps toggles that govern what an account may see off the dashboard-writable allowlist, and this is one of those — a Settings checkbox would let any dashboard user re-enable estate-wide search. Happy to add the allowlist entry plus a checkbox if that trade is preferred.
- **Read once at registration**, not per request, so two requests in one session cannot disagree about whether the estate is searchable.
- **No UI change needed.** `dashboard-related-cases.js` already returns early on a non-ok response, and its own comment calls an empty, closed panel the honest failure mode.

## Verification

26 tests in `crossCaseRoutes.test.ts`. The 17 existing ones now set the flag explicitly, with an `afterEach` deleting it so a leaked `on` cannot mask the gate. Nine new ones cover: the default 404 on both routes, the 404 naming `DFIR_CROSS_CASE`, that the related-cases 404 is the feature being off rather than a missing case, that only a literal `on` enables it (`true`, `1`, `yes`, `""` all stay off), and that `"  ON  "` works.

`typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` all pass. Boundary pair unchanged, so `ARCHITECTURE.md` needs no edit.

Docs: `dashboard.md` explains both gates and why this one is not a checkbox. `CHANGELOG.md` gains a Security entry, and I corrected the existing #679 Added entry, which said "off by default" while meaning only the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
