### PR TITLE
feat(net): bound HTTP response reads across providers, enrichment, and integrations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,917 of the 1,956 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,940 of the 1,979 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/src/enrichment/abuseipdb.ts
+++ b/companion/src/enrichment/abuseipdb.ts
@@ -7,6 +7,7 @@ import {
   type IocKind,
   type Verdict,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface AbuseIpdbOptions {
   apiKey: string;
@@ -42,7 +43,7 @@ export class AbuseIpdbProvider implements EnrichmentProvider {
       throw new RateLimitError("AbuseIPDB rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`AbuseIPDB HTTP ${res.status}`);
 
-    const json = (await res.json()) as {
+    const json = await readBoundedJson<{
       data?: {
         abuseConfidenceScore?: number;
         totalReports?: number;
@@ -50,7 +51,7 @@ export class AbuseIpdbProvider implements EnrichmentProvider {
         isp?: string;
         domain?: string;
       };
-    };
+    }>(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "AbuseIPDB" });
     const d = json.data;
     if (!d) return null;
     const score = d.abuseConfidenceScore ?? 0;

--- a/companion/src/enrichment/crowdstrike.ts
+++ b/companion/src/enrichment/crowdstrike.ts
@@ -7,6 +7,7 @@ import {
   type IocKind,
   type Verdict,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface CrowdStrikeOptions {
   clientId: string;
@@ -121,7 +122,10 @@ export class CrowdStrikeProvider implements EnrichmentProvider {
       );
     }
     if (!res.ok) throw new Error(`CrowdStrike token HTTP ${res.status}`);
-    const json = (await res.json()) as { access_token?: string; expires_in?: number };
+    const json = await readBoundedJson<{ access_token?: string; expires_in?: number }>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "CrowdStrike",
+    });
     if (!json.access_token) throw new CsAuthError("CrowdStrike token response missing access_token");
     this.token = json.access_token;
     this.tokenExpiresAt = Date.now() + Math.max(0, (json.expires_in ?? 1799) - 60) * 1000; // 60s safety margin
@@ -143,7 +147,10 @@ export class CrowdStrikeProvider implements EnrichmentProvider {
       throw new RateLimitError("CrowdStrike rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (res.status === 404) return {};
     if (!res.ok) throw new Error(`CrowdStrike HTTP ${res.status}`);
-    return (await res.json()) as Record<string, unknown>;
+    return readBoundedJson<Record<string, unknown>>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "CrowdStrike",
+    });
   }
 
   // Falcon Intelligence Indicators — adversary-attributed IOC intel.

--- a/companion/src/enrichment/geoip.ts
+++ b/companion/src/enrichment/geoip.ts
@@ -6,6 +6,7 @@ import {
   type FetchFn,
   type IocKind,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 // Geo-IP lookup for an IP IOC — "what country (and city / ASN / hosting org) did this address
 // come from?". Answers the analyst's first question about any external IP. Pure geo/network
@@ -122,7 +123,10 @@ export class GeoIpProvider implements EnrichmentProvider {
       throw new RateLimitError("GeoIP rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`GeoIP HTTP ${res.status}`);
 
-    const json = (await res.json()) as GeoResponse;
+    const json = await readBoundedJson<GeoResponse>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "GeoIP",
+    });
     // Reserved / private / invalid IPs come back as a non-success body (HTTP 200) → miss.
     if (json.success === false || json.status === "fail" || json.error) return null;
 

--- a/companion/src/enrichment/hashlookup.ts
+++ b/companion/src/enrichment/hashlookup.ts
@@ -7,6 +7,7 @@ import {
   type IocKind,
   type Verdict,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 // CIRCL hashlookup (https://www.circl.lu/services/hashlookup/) — a large, free, keyless
 // KNOWN-FILE database (NSRL-derived corpus + Linux distro packages + more). For DFIR this is
@@ -86,7 +87,10 @@ export class HashlookupProvider implements EnrichmentProvider {
       throw new RateLimitError("Hashlookup rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`Hashlookup HTTP ${res.status}`);
 
-    const json = (await res.json()) as Record<string, unknown>;
+    const json = await readBoundedJson<Record<string, unknown>>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: this.name,
+    });
     if (!json || typeof json !== "object" || Array.isArray(json)) return null;
 
     const fileName = typeof json.FileName === "string" ? json.FileName.trim() : "";

--- a/companion/src/enrichment/huntingch.ts
+++ b/companion/src/enrichment/huntingch.ts
@@ -1,4 +1,5 @@
 import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface HuntingChOptions {
   apiKey: string; // unified abuse.ch Auth-Key (one key from https://auth.abuse.ch/)
@@ -46,7 +47,10 @@ class AbuseCtx {
     });
     if (res.status === 401 || res.status === 403) throw new AbuseAuthError(`${platform} auth ${res.status}`);
     if (!res.ok) throw new Error(`${platform} HTTP ${res.status}`);
-    return (await res.json()) as Record<string, unknown>;
+    return readBoundedJson<Record<string, unknown>>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: platform,
+    });
   }
 }
 

--- a/companion/src/enrichment/misp.ts
+++ b/companion/src/enrichment/misp.ts
@@ -4,6 +4,7 @@ import {
   mispPingStatusMessage,
   mispTransportMessage,
 } from "../integrations/misp/mispConnectivity.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface MispOptions {
   baseUrl: string; // your MISP instance, e.g. https://misp.example.org
@@ -90,7 +91,9 @@ export class MispProvider implements EnrichmentProvider {
     if (res.status === 401 || res.status === 403) throw new Error("MISP auth failed (check DFIR_MISP_KEY)");
     if (!res.ok) throw new Error(`MISP HTTP ${res.status}`);
 
-    const json = (await res.json()) as { response?: { Attribute?: MispAttribute[] } };
+    const json = await readBoundedJson<{
+      response?: { Attribute?: MispAttribute[] };
+    }>(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "MISP" });
     const attrs = json.response?.Attribute ?? [];
     if (attrs.length === 0) return null; // not present on this instance
 

--- a/companion/src/enrichment/opencti.ts
+++ b/companion/src/enrichment/opencti.ts
@@ -1,4 +1,5 @@
 import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind, Verdict } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface OpenCtiOptions {
   baseUrl: string; // your OpenCTI instance, e.g. https://opencti.example.org
@@ -90,7 +91,10 @@ export class OpenCtiProvider implements EnrichmentProvider {
     if (res.status === 401 || res.status === 403)
       throw new Error("OpenCTI auth failed (check DFIR_OPENCTI_KEY)");
     if (!res.ok) throw new Error(`OpenCTI HTTP ${res.status}`);
-    const json = (await res.json()) as GraphQlResponse<T>;
+    const json = await readBoundedJson<GraphQlResponse<T>>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "OpenCTI",
+    });
     if (json.errors && json.errors.length > 0) {
       throw new Error(`OpenCTI GraphQL error: ${json.errors[0]?.message ?? "unknown"}`);
     }

--- a/companion/src/enrichment/rdap.ts
+++ b/companion/src/enrichment/rdap.ts
@@ -6,6 +6,7 @@ import {
   type FetchFn,
   type IocKind,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 // WHOIS-equivalent registration lookup for an IP IOC, over RDAP (the modern, JSON-over-HTTPS
 // replacement for port-43 WHOIS). Resolves which network block owns the address: net name,
@@ -108,7 +109,10 @@ export class RdapProvider implements EnrichmentProvider {
       throw new RateLimitError("RDAP/WHOIS rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`RDAP/WHOIS HTTP ${res.status}`);
 
-    const json = (await res.json()) as RdapIpResponse;
+    const json = await readBoundedJson<RdapIpResponse>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "RDAP/WHOIS",
+    });
     const netname = json.name ?? json.handle;
     const range = cidrRange(json);
     const country = json.country;

--- a/companion/src/enrichment/rockyraccoon.ts
+++ b/companion/src/enrichment/rockyraccoon.ts
@@ -7,6 +7,7 @@ import {
   type IocKind,
   type Verdict,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface RockyRaccoonOptions {
   apiKey: string; // et_live_… (Authorization: Bearer)
@@ -85,7 +86,10 @@ export class RockyRaccoonProvider implements EnrichmentProvider {
       );
     if (!res.ok) throw new Error(`RockyRaccoon HTTP ${res.status}`);
 
-    const p = (await res.json()) as ProcessProfile;
+    const p = await readBoundedJson<ProcessProfile>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "RockyRaccoon",
+    });
     const cls = p.classification ?? {};
     const risk = (cls.risk_level ?? "").toLowerCase();
     // A process PROFILE describes the process TYPE, not whether this instance is evil:
@@ -136,11 +140,11 @@ export class RockyRaccoonProvider implements EnrichmentProvider {
       );
     if (!res.ok) throw new Error(`RockyRaccoon HTTP ${res.status}`);
 
-    const j = (await res.json()) as {
+    const j = await readBoundedJson<{
       observed?: boolean;
       percentage?: number;
       common_parents?: Array<{ parent?: string; percentage?: number }>;
-    };
+    }>(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "RockyRaccoon" });
     if (j.observed) {
       return {
         observed: true,

--- a/companion/src/enrichment/shodan.ts
+++ b/companion/src/enrichment/shodan.ts
@@ -6,6 +6,7 @@ import {
   type FetchFn,
   type IocKind,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 // Shodan host lookup for an IP IOC — "what is hosted on this address?". Surfaces the web
 // properties / services Shodan has seen: hostnames + domains, open ports, the running
@@ -68,7 +69,10 @@ export class ShodanProvider implements EnrichmentProvider {
       throw new RateLimitError("Shodan rate limit", parseRetryAfterMs(res.headers.get("retry-after")));
     if (!res.ok) throw new Error(`Shodan HTTP ${res.status}`);
 
-    const h = (await res.json()) as ShodanHost;
+    const h = await readBoundedJson<ShodanHost>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "Shodan",
+    });
     const hostnames = uniq([...(h.hostnames ?? []), ...(h.domains ?? [])]);
     const ports = (h.ports ?? []).filter((p) => Number.isFinite(p));
     const vulns = uniq(h.vulns ?? []);

--- a/companion/src/enrichment/virustotal.ts
+++ b/companion/src/enrichment/virustotal.ts
@@ -7,6 +7,7 @@ import {
   type IocKind,
   type Verdict,
 } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface VirusTotalOptions {
   apiKey: string;
@@ -81,7 +82,13 @@ export class VirusTotalProvider implements EnrichmentProvider {
       );
     if (!res.ok) throw new Error(`VirusTotal HTTP ${res.status}`);
 
-    const json = (await res.json()) as { data?: { id?: string; attributes?: Record<string, unknown> } };
+    const json = await readBoundedJson<{ data?: { id?: string; attributes?: Record<string, unknown> } }>(
+      res,
+      {
+        maxBytes: RESPONSE_SIZE_LIMITS.json,
+        context: "VirusTotal",
+      },
+    );
     const attrs = json.data?.attributes ?? {};
     const stats = (attrs.last_analysis_stats as VtStats) ?? {};
     const { verdict, detections, total } = verdictFromStats(stats);

--- a/companion/src/enrichment/yeti.ts
+++ b/companion/src/enrichment/yeti.ts
@@ -1,4 +1,5 @@
 import type { EnrichmentProvider, EnrichmentResult, FetchFn, IocKind, Verdict } from "./provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 export interface YetiOptions {
   baseUrl: string; // your YETI instance, e.g. https://yeti.example.org
@@ -76,7 +77,12 @@ export class YetiProvider implements EnrichmentProvider {
     });
     if (res.status === 401 || res.status === 403) throw new Error("YETI auth failed (check DFIR_YETI_KEY)");
     if (!res.ok) throw new Error(`YETI auth HTTP ${res.status}`);
-    const token = ((await res.json()) as { access_token?: string }).access_token;
+    const token = (
+      await readBoundedJson<{ access_token?: string }>(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.json,
+        context: "YETI",
+      })
+    ).access_token;
     if (!token) throw new Error("YETI auth returned no access_token");
     this.token = token;
     return token;
@@ -100,7 +106,10 @@ export class YetiProvider implements EnrichmentProvider {
     if (res.status === 403) throw new Error("YETI access denied");
     if (!res.ok) throw new Error(`YETI HTTP ${res.status}`);
 
-    const json = (await res.json()) as { observables?: YetiObservable[]; total?: number };
+    const json = await readBoundedJson<{ observables?: YetiObservable[]; total?: number }>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "YETI",
+    });
     const obs = json.observables ?? [];
     if (obs.length === 0) return null; // not tracked in YETI
 

--- a/companion/src/integrations/clickup/clickupClient.ts
+++ b/companion/src/integrations/clickup/clickupClient.ts
@@ -7,6 +7,7 @@
 // orchestrator (clickupPush.ts) is unit-testable with no network.
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS, rethrowIfTooLarge } from "../../providers/boundedResponse.js";
 
 const CLICKUP_BASE = "https://api.clickup.com/api/v2";
 
@@ -77,7 +78,10 @@ export class ClickUpClient {
     }
 
     if (!res.ok) {
-      const env = (await res.json().catch(() => ({}))) as ClickUpErrorEnvelope;
+      const env = (await readBoundedJson(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.json,
+        context: "ClickUp",
+      }).catch(() => ({}))) as ClickUpErrorEnvelope;
       const detail = env.err ? `: ${env.err}` : "";
       if (res.status === 401)
         throw new ClickUpApiError(`ClickUp auth failed (check DFIR_CLICKUP_TOKEN)${detail}`, 401, "auth");
@@ -94,7 +98,10 @@ export class ClickUpClient {
         throw new ClickUpApiError(`ClickUp rejected the request${detail}`, 400, "validation");
       throw new ClickUpApiError(`ClickUp HTTP ${res.status} on ${path}${detail}`, res.status, "http");
     }
-    return (await res.json().catch(() => ({}))) as T;
+    return (await readBoundedJson(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "ClickUp",
+    }).catch((err) => rethrowIfTooLarge(err, {}))) as T;
   }
 
   // Auth check — the authorized user.

--- a/companion/src/integrations/customerExposureProviders.ts
+++ b/companion/src/integrations/customerExposureProviders.ts
@@ -5,6 +5,7 @@ import type {
 } from "../analysis/customerExposure.js";
 import type { FetchFn } from "../enrichment/provider.js";
 import { LeakCheckClient, type LeakCheckRecord } from "./leakcheck/leakcheckClient.js";
+import { readBoundedJson, readBoundedText, RESPONSE_SIZE_LIMITS } from "../providers/boundedResponse.js";
 
 function asArray(v: unknown): unknown[] {
   return Array.isArray(v) ? v : [];
@@ -117,7 +118,7 @@ export class HaveIBeenPwnedExposureProvider implements CustomerExposureProvider 
       throw new Error("HIBP auth failed or domain is not verified for this account");
     if (res.status === 429) throw new Error("HIBP rate limit");
     if (!res.ok) throw new Error(`HIBP HTTP ${res.status}`);
-    return res.json();
+    return readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "HIBP" });
   }
 
   async lookupEmail(email: string): Promise<CustomerExposureResult[]> {
@@ -193,7 +194,10 @@ export class DeHashedExposureProvider implements CustomerExposureProvider {
       signal: AbortSignal.timeout(this.timeoutMs),
     });
     if (res.status === 401 || res.status === 403) {
-      const body = await res.text().catch(() => "");
+      const body = await readBoundedText(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.text,
+        context: "DeHashed",
+      }).catch(() => "");
       throw new Error(
         `DeHashed auth failed (${res.status})${body ? `: ${body.slice(0, 200)}` : ""} — check DFIR_DEHASHED_KEY (v2 API key, sent as the DeHashed-Api-Key header)`,
       );
@@ -201,7 +205,10 @@ export class DeHashedExposureProvider implements CustomerExposureProvider {
     if (res.status === 429) throw new Error("DeHashed rate limit");
     if (res.status === 404) return [];
     if (!res.ok) throw new Error(`DeHashed HTTP ${res.status}`);
-    const json = (await res.json()) as Record<string, unknown>;
+    const json = await readBoundedJson<Record<string, unknown>>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "DeHashed",
+    });
     const rows = asArray(json.entries ?? json.data ?? json.results).filter(isObject);
     return rows.map((row) => {
       const data = unique(
@@ -281,7 +288,10 @@ export class ShodanExposureProvider implements CustomerExposureProvider {
       throw new Error("Shodan auth failed (check DFIR_SHODAN_KEY)");
     if (res.status === 429) throw new Error("Shodan rate limit / out of query credits");
     if (!res.ok) throw new Error(`Shodan HTTP ${res.status}`);
-    const json = (await res.json()) as { matches?: unknown };
+    const json = await readBoundedJson<{ matches?: unknown }>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "Shodan",
+    });
     return asArray(json.matches)
       .filter(isObject)
       .slice(0, this.maxMatches)

--- a/companion/src/integrations/iris/irisClient.ts
+++ b/companion/src/integrations/iris/irisClient.ts
@@ -9,6 +9,7 @@
 // supplied for a self-hosted IRIS with an internal-CA / self-signed cert.
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS, rethrowIfTooLarge } from "../../providers/boundedResponse.js";
 
 export interface IrisClientOptions {
   baseUrl: string; // e.g. https://iris.example.org
@@ -117,7 +118,9 @@ export class IrisClient {
     if (res.status === 404) throw new IrisApiError(`IRIS endpoint not found: ${path}`, 404, "notfound");
     if (!res.ok) throw new IrisApiError(`IRIS HTTP ${res.status} on ${path}`, res.status, "http");
 
-    const json = (await res.json().catch(() => ({}))) as Envelope<T>;
+    const json = (await readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "IRIS" }).catch(
+      (err) => rethrowIfTooLarge(err, {}),
+    )) as Envelope<T>;
     if (json.status && json.status !== "success") {
       throw new IrisApiError(`IRIS error on ${path}: ${json.message ?? "unknown"}`, res.status, "api");
     }

--- a/companion/src/integrations/jira/jiraClient.ts
+++ b/companion/src/integrations/jira/jiraClient.ts
@@ -4,6 +4,7 @@
 // integration pattern).
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS, rethrowIfTooLarge } from "../../providers/boundedResponse.js";
 
 export interface JiraClientOptions {
   baseUrl: string; // e.g. https://your-domain.atlassian.net
@@ -90,7 +91,9 @@ export class JiraClient {
     }
 
     if (!res.ok) {
-      const env = (await res.json().catch(() => ({}))) as JiraErrorEnvelope;
+      const env = (await readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "Jira" }).catch(
+        () => ({}),
+      )) as JiraErrorEnvelope;
       const detail = env.errorMessages?.join("; ") || Object.values(env.errors || {}).join("; ");
       const suffix = detail ? `: ${detail}` : "";
       if (res.status === 401)
@@ -105,7 +108,9 @@ export class JiraClient {
       if (res.status === 400) throw new JiraApiError(`Jira rejected the request${suffix}`, 400, "validation");
       throw new JiraApiError(`Jira HTTP ${res.status} on ${path}${suffix}`, res.status, "http");
     }
-    return (await res.json().catch(() => ({}))) as T;
+    return (await readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "Jira" }).catch(
+      (err) => rethrowIfTooLarge(err, {}),
+    )) as T;
   }
 
   async me(): Promise<{ id?: string; displayName?: string }> {

--- a/companion/src/integrations/leakcheck/leakcheckClient.ts
+++ b/companion/src/integrations/leakcheck/leakcheckClient.ts
@@ -8,6 +8,7 @@
 // orchestration and transforms can be unit-tested with no network.
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../../providers/boundedResponse.js";
 
 export type LeakCheckType = "auto" | "email" | "domain" | "username" | "phone" | "hash" | "keyword";
 
@@ -86,7 +87,10 @@ export class LeakCheckClient {
     // ambiguous on their own (e.g. a 403 is "Active plan required" OR "Limit reached", never a
     // per-query-type thing), so the reason must come from `error`, not a guessed message.
     if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      const body = await readBoundedJson<{ error?: string }>(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.json,
+        context: "LeakCheck",
+      }).catch((): { error?: string } => ({}));
       const reason = body.error ? ` — ${body.error}` : "";
       if (res.status === 401)
         throw new LeakCheckError(`LeakCheck 401 (auth)${reason} — check DFIR_LEAKCHECK_KEY`, 401, "auth");
@@ -113,7 +117,10 @@ export class LeakCheckClient {
       throw new LeakCheckError(`LeakCheck HTTP ${res.status}${reason}`, res.status, "http");
     }
 
-    const json = (await res.json()) as Partial<LeakCheckResult>;
+    const json = await readBoundedJson<Partial<LeakCheckResult>>(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "LeakCheck",
+    });
     // A genuine "no breaches" answer is success:true / found:0; success:false is an API-level error.
     if (json.success === false)
       throw new LeakCheckError(`LeakCheck: ${json.error ?? "query failed"}`, 200, "api");

--- a/companion/src/integrations/misp/mispPushClient.ts
+++ b/companion/src/integrations/misp/mispPushClient.ts
@@ -5,6 +5,7 @@
 // so the orchestrator can be unit-tested with no network.
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../../providers/boundedResponse.js";
 import {
   MISP_PING_PATH,
   mispCauseCode,
@@ -105,7 +106,11 @@ function saveFailureReason(data: unknown): string {
 // MISP's own explanation for a rejected request, when the body carries one.
 async function readErrorDetail(res: Response): Promise<string> {
   try {
-    const body = (await res.json()) as { errors?: unknown; message?: unknown; name?: unknown };
+    const body = await readBoundedJson<{
+      errors?: unknown;
+      message?: unknown;
+      name?: unknown;
+    }>(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "MISP" });
     return (
       flattenMispErrors(body.errors) ||
       (typeof body.message === "string" && body.message.trim()) ||
@@ -173,7 +178,7 @@ export class MispPushClient implements MispPushClientLike {
       );
     }
     if (!res.ok) throw new MispApiError(`MISP HTTP ${res.status} on ${path}`, res.status);
-    const data = (await res.json()) as T;
+    const data = await readBoundedJson<T>(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "MISP" });
     // MISP reports several write failures as HTTP 200 with the error IN THE BODY —
     // `{"saved":false,"errors":"Invalid Tag."}` is the common one. Treating that as success made
     // every addTag silently no-op while still being counted, which left the idempotency tag off the

--- a/companion/src/integrations/notify/webhookSender.ts
+++ b/companion/src/integrations/notify/webhookSender.ts
@@ -1,4 +1,5 @@
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedText, RESPONSE_SIZE_LIMITS } from "../../providers/boundedResponse.js";
 
 // POST a JSON payload to a Slack/Teams incoming webhook. Injectable `fetchFn` (tests pass a mock —
 // no real network), bounded by a timeout. Slack replies "ok" / Teams replies "1" on success; we
@@ -8,6 +9,17 @@ export interface WebhookResult {
   ok: boolean;
   status: number;
   error?: string;
+}
+
+// Best-effort host for the bounded-read context (e.g. an error message reading "webhook
+// (hooks.slack.com) response too large"). Never throws — an unparsable url falls back to a
+// generic label rather than blowing up the already-in-progress error handling.
+function safeHost(url: string): string {
+  try {
+    return `webhook (${new URL(url).host})`;
+  } catch {
+    return "webhook";
+  }
 }
 
 export async function postWebhook(
@@ -29,7 +41,10 @@ export async function postWebhook(
   }
 
   if (!res.ok) {
-    const body = await res.text().catch(() => "");
+    const body = await readBoundedText(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.text,
+      context: safeHost(url),
+    }).catch(() => "");
     const detail = body ? `: ${body.slice(0, 200)}` : "";
     return { ok: false, status: res.status, error: `webhook HTTP ${res.status}${detail}` };
   }

--- a/companion/src/integrations/notion/notionClient.ts
+++ b/companion/src/integrations/notion/notionClient.ts
@@ -11,6 +11,7 @@
 // own notes/screenshots — see notionPush.ts.
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS, rethrowIfTooLarge } from "../../providers/boundedResponse.js";
 import type { NotionBlock } from "./notionBlocks.js";
 
 // Notion's API version is pinned — Notion is explicit that the header selects the request/
@@ -134,7 +135,10 @@ export class NotionClient {
     }
 
     if (!res.ok) {
-      const env = (await res.json().catch(() => ({}))) as NotionErrorEnvelope;
+      const env = (await readBoundedJson(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.json,
+        context: "Notion",
+      }).catch(() => ({}))) as NotionErrorEnvelope;
       const detail = env.message ? `: ${env.message}` : "";
       if (res.status === 401)
         throw new NotionApiError(`Notion auth failed (check DFIR_NOTION_TOKEN)${detail}`, 401, "auth");
@@ -155,7 +159,10 @@ export class NotionClient {
         throw new NotionApiError(`Notion rejected the request${detail}`, 400, "validation");
       throw new NotionApiError(`Notion HTTP ${res.status} on ${path}${detail}`, res.status, "http");
     }
-    return (await res.json().catch(() => ({}))) as T;
+    return (await readBoundedJson(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "Notion",
+    }).catch((err) => rethrowIfTooLarge(err, {}))) as T;
   }
 
   // ---- connectivity --------------------------------------------------------

--- a/companion/src/integrations/servicenow/servicenowClient.ts
+++ b/companion/src/integrations/servicenow/servicenowClient.ts
@@ -2,6 +2,7 @@
 // password. Creates incidents by default; the table name can be overridden via options.
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS, rethrowIfTooLarge } from "../../providers/boundedResponse.js";
 
 export interface ServiceNowClientOptions {
   baseUrl: string; // e.g. https://instance.service-now.com
@@ -93,7 +94,10 @@ export class ServiceNowClient {
     }
 
     if (!res.ok) {
-      const env = (await res.json().catch(() => ({}))) as ServiceNowErrorEnvelope;
+      const env = (await readBoundedJson(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.json,
+        context: "ServiceNow",
+      }).catch(() => ({}))) as ServiceNowErrorEnvelope;
       const detail = env.error?.message || env.error?.detail;
       const suffix = detail ? `: ${detail}` : "";
       if (res.status === 401)
@@ -112,7 +116,10 @@ export class ServiceNowClient {
         throw new ServiceNowApiError(`ServiceNow rejected the request${suffix}`, 400, "validation");
       throw new ServiceNowApiError(`ServiceNow HTTP ${res.status} on ${path}${suffix}`, res.status, "http");
     }
-    return (await res.json().catch(() => ({}))) as T;
+    return (await readBoundedJson(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "ServiceNow",
+    }).catch((err) => rethrowIfTooLarge(err, {}))) as T;
   }
 
   async me(): Promise<{ userId?: string; userName?: string }> {

--- a/companion/src/integrations/socrates/socratesApi.ts
+++ b/companion/src/integrations/socrates/socratesApi.ts
@@ -10,6 +10,7 @@
 
 import { createHash } from "node:crypto";
 import type { FetchFn } from "../../enrichment/provider.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS } from "../../providers/boundedResponse.js";
 
 export interface SocratesStatus {
   status: "ready" | "processing" | "error";
@@ -49,7 +50,7 @@ export function md5Buffer(data: Buffer): string {
 async function getJson(url: string, fetchFn: FetchFn): Promise<unknown> {
   const res = await fetchFn(url, { method: "GET" });
   if (!res.ok) throw new Error(`SO-CRATES GET ${new URL(url).pathname} failed: HTTP ${res.status}`);
-  return res.json();
+  return readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "SO-CRATES" });
 }
 
 async function postJson(url: string, body: unknown, fetchFn: FetchFn): Promise<unknown> {
@@ -59,7 +60,7 @@ async function postJson(url: string, body: unknown, fetchFn: FetchFn): Promise<u
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`SO-CRATES POST ${new URL(url).pathname} failed: HTTP ${res.status}`);
-  return res.json();
+  return readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "SO-CRATES" });
 }
 
 /**
@@ -93,11 +94,17 @@ export async function uploadBuffer(
   form.append("file", new Blob([new Uint8Array(data)]), filename);
   const res = await fetchFn(`${trimBase(baseUrl)}/api/upload`, { method: "POST", body: form });
   if (!res.ok) {
-    const detail = await res.json().catch(() => ({}));
+    const detail = await readBoundedJson(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: "SO-CRATES",
+    }).catch(() => ({}));
     const msg = (detail as { error?: string }).error ?? `HTTP ${res.status}`;
     throw new Error(`SO-CRATES upload of "${filename}" failed: ${msg}`);
   }
-  return (await res.json()) as SocratesUploadResult;
+  return readBoundedJson<SocratesUploadResult>(res, {
+    maxBytes: RESPONSE_SIZE_LIMITS.json,
+    context: "SO-CRATES",
+  });
 }
 
 /** Poll whether analysis has finished. */

--- a/companion/src/integrations/timesketch/timesketchClient.ts
+++ b/companion/src/integrations/timesketch/timesketchClient.ts
@@ -10,6 +10,12 @@
 // https://github.com/google/timesketch/tree/master/api_client/python
 
 import type { FetchFn } from "../../enrichment/provider.js";
+import {
+  readBoundedJson,
+  readBoundedText,
+  RESPONSE_SIZE_LIMITS,
+  rethrowIfTooLarge,
+} from "../../providers/boundedResponse.js";
 import { tlsTrustHint } from "../tlsTrustHint.js";
 
 export interface TimesketchClientOptions {
@@ -162,7 +168,10 @@ export class TimesketchClient {
 
   private async errorFor(res: Response, what: string): Promise<TimesketchApiError> {
     let detail = `HTTP ${res.status}`;
-    const text = await res.text().catch(() => "");
+    const text = await readBoundedText(res, {
+      maxBytes: RESPONSE_SIZE_LIMITS.text,
+      context: "Timesketch",
+    }).catch(() => "");
     const m = text.match(/"message"\s*:\s*"([^"]+)"/);
     if (m) detail = m[1];
     const kind = res.status === 401 || res.status === 403 ? "auth" : res.status === 404 ? "notfound" : "http";
@@ -178,7 +187,11 @@ export class TimesketchClient {
     const loginUrl = `${this.base}/login/?local_auth=1`;
 
     const page = await this.send("GET", loginUrl, { sendCsrf: false });
-    this.csrf = scrapeCsrfToken(await page.text().catch(() => ""));
+    this.csrf = scrapeCsrfToken(
+      await readBoundedText(page, { maxBytes: RESPONSE_SIZE_LIMITS.text, context: "Timesketch" }).catch(
+        () => "",
+      ),
+    );
     if (!this.csrf) {
       throw new TimesketchApiError(
         "Timesketch login: no CSRF token on the login page (check DFIR_TIMESKETCH_URL and that local auth is enabled)",
@@ -223,7 +236,11 @@ export class TimesketchClient {
     for (let page = 1; page <= 50; page += 1) {
       const res = await this.send("GET", `${this.apiRoot}/sketches/?per_page=100&page=${page}`);
       if (!res.ok) throw await this.errorFor(res, "list sketches");
-      const rows = objectList(await res.json().catch(() => ({})));
+      const rows = objectList(
+        await readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "Timesketch" }).catch(
+          (err) => rethrowIfTooLarge(err, {}),
+        ),
+      );
       const hit = rows.find(
         (r) =>
           String(r.name ?? "")
@@ -239,7 +256,11 @@ export class TimesketchClient {
   async createSketch(name: string, description: string): Promise<TimesketchSketchRef> {
     const res = await this.send("POST", `${this.apiRoot}/sketches/`, { json: { name, description } });
     if (!res.ok) throw await this.errorFor(res, "create sketch");
-    const obj = firstObject(await res.json().catch(() => ({})));
+    const obj = firstObject(
+      await readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "Timesketch" }).catch(
+        (err) => rethrowIfTooLarge(err, {}),
+      ),
+    );
     const id = Number(obj?.id);
     if (!Number.isFinite(id))
       throw new TimesketchApiError("Timesketch create sketch: no sketch id in response", res.status, "http");
@@ -252,7 +273,11 @@ export class TimesketchClient {
   async listTimelines(sketchId: number): Promise<TimesketchTimelineRef[]> {
     const res = await this.send("GET", `${this.apiRoot}/sketches/${sketchId}/`);
     if (!res.ok) throw await this.errorFor(res, "get sketch");
-    const sketch = firstObject(await res.json().catch(() => ({})));
+    const sketch = firstObject(
+      await readBoundedJson(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "Timesketch" }).catch(
+        (err) => rethrowIfTooLarge(err, {}),
+      ),
+    );
     const timelines = Array.isArray(sketch?.timelines)
       ? (sketch.timelines as Array<Record<string, unknown>>)
       : [];

--- a/companion/src/providers/anthropic.ts
+++ b/companion/src/providers/anthropic.ts
@@ -9,6 +9,12 @@ import {
   requestSignal,
 } from "./provider.js";
 import { validateBaseUrl } from "./urlValidation.js";
+import {
+  readBoundedJson,
+  readBoundedText,
+  RESPONSE_SIZE_LIMITS,
+  ResponseTooLargeError,
+} from "./boundedResponse.js";
 
 type FetchFn = typeof fetch;
 
@@ -95,10 +101,13 @@ export class AnthropicProvider implements AIProvider {
     if (!res.ok) {
       // 529 = Anthropic overloaded — treat as rate limit so the caller can retry/wait
       const kind = res.status === 529 ? "rate_limit" : httpErrorKind(res.status);
-      const body = await res.text().catch(() => "");
+      const body = await readBoundedText(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.text,
+        context: "Anthropic",
+      }).catch(() => "");
       throw new ProviderError(httpErrorMessage("Anthropic", res.status, body), kind);
     }
-    const json = (await res.json()) as {
+    type AnthropicMessageResponse = {
       content?: { type: string; text?: string }[];
       usage?: {
         input_tokens?: number;
@@ -107,6 +116,16 @@ export class AnthropicProvider implements AIProvider {
         cache_read_input_tokens?: number;
       };
     };
+    let json: AnthropicMessageResponse;
+    try {
+      json = await readBoundedJson<AnthropicMessageResponse>(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.json,
+        context: "Anthropic",
+      });
+    } catch (err) {
+      const kind = err instanceof ResponseTooLargeError ? "transport" : "other";
+      throw new ProviderError(`Anthropic response error: ${(err as Error).message}`, kind);
+    }
     const text = json.content?.find((b) => b.type === "text")?.text;
     if (!text) throw new ProviderError("Anthropic returned no content", "other");
     const u = json.usage;

--- a/companion/src/providers/boundedResponse.ts
+++ b/companion/src/providers/boundedResponse.ts
@@ -1,0 +1,152 @@
+// Bounded reading of a fetch Response body (issue #686).
+//
+// PROBLEM. Every provider/enrichment/integration call site reads a whole response into memory
+// with res.json() / res.text() / res.arrayBuffer() before looking at it. A per-request timeout
+// bounds how LONG that takes, but not how much memory it costs — a compromised, misconfigured, or
+// just unexpectedly verbose upstream can hand back gigabytes and the process holds all of it before
+// anything gets a chance to reject it.
+//
+// FIX. Read the body through a byte-counted stream instead of the convenience methods, and stop as
+// soon as either signal says "too big":
+//   - the DECLARED Content-Length, checked before a single byte is read (cheap, catches the honest
+//     case immediately);
+//   - the ACTUAL bytes streamed, checked as they arrive (catches a missing/false Content-Length or
+//     a chunked body that grows past what it claimed — the declared header is never trustworthy on
+//     its own).
+// Either path throws ResponseTooLargeError and cancels the underlying reader so the connection is
+// torn down rather than drained to completion.
+//
+// REDACTION. The thrown error never includes response content — only the limit and an optional
+// caller-supplied label (provider name / endpoint). A response that overflows the cap is, by
+// definition, one the caller decided not to trust; quoting a slice of it back into a log or error
+// message would just relocate the same problem one level up.
+//
+// SCOPE. This closes the memory-exhaustion half of #686. Redirect-chain SSRF revalidation (the
+// other half the issue asks for) is a distinct, separately-reviewable change — see the issue for
+// tracking — and is deliberately NOT attempted here so this module stays about response size.
+
+export class ResponseTooLargeError extends Error {
+  readonly limitBytes: number;
+  readonly context?: string;
+  constructor(limitBytes: number, context?: string) {
+    super(
+      `response exceeded the ${limitBytes}-byte limit` +
+        (context ? ` (${context})` : "") +
+        " — body discarded",
+    );
+    this.name = "ResponseTooLargeError";
+    this.limitBytes = limitBytes;
+    this.context = context;
+  }
+}
+
+export interface BoundedReadOptions {
+  /** Hard cap in bytes. Both the declared Content-Length and the actual stream are checked against it. */
+  maxBytes: number;
+  /** Short label (provider/endpoint name) folded into the error message. Never response content. */
+  context?: string;
+}
+
+// Common caps so call sites don't each invent a number. A call site with a genuine reason to expect
+// a larger body (e.g. a bulk export) should pass its own maxBytes rather than reuse `binary` as a
+// default-for-everything escape hatch.
+export const RESPONSE_SIZE_LIMITS = {
+  /** Typical threat-intel / chat-completions JSON reply. */
+  json: 10 * 1024 * 1024,
+  /** Plain-text or small structured (CSV/log) replies. */
+  text: 5 * 1024 * 1024,
+  /** File-shaped downloads (report exports, attachments, artifacts). */
+  binary: 50 * 1024 * 1024,
+} as const;
+
+/**
+ * Reads a Response body into a Buffer, enforcing `maxBytes` against both the declared
+ * Content-Length (rejected before any read) and the actual byte count as it streams in.
+ * Throws ResponseTooLargeError on either overflow; the reader is cancelled so the underlying
+ * connection is torn down instead of drained to completion.
+ */
+export async function readBoundedBuffer(res: Response, opts: BoundedReadOptions): Promise<Buffer> {
+  const { maxBytes, context } = opts;
+
+  const declared = res.headers.get("content-length");
+  if (declared !== null) {
+    const declaredBytes = Number(declared);
+    if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
+      // Reject before reading a byte, but still cancel the body — otherwise the connection and
+      // its unread bytes stay alive until the caller's timeout (or GC) tears it down, defeating
+      // the whole point of rejecting early.
+      await res.body?.cancel("response exceeded byte limit").catch(() => {});
+      throw new ResponseTooLargeError(maxBytes, context);
+    }
+  }
+
+  if (!res.body) return Buffer.alloc(0); // no body (e.g. 204, HEAD, or already consumed)
+
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel("response exceeded byte limit").catch(() => {});
+        throw new ResponseTooLargeError(maxBytes, context);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c.buffer, c.byteOffset, c.byteLength)));
+}
+
+/**
+ * Bounded equivalent of `res.text()`. Strips a leading UTF-8 BOM, same as the WHATWG "UTF-8
+ * decode" the native `Response.text()`/`.json()` apply — `Buffer#toString("utf8")` does NOT do
+ * this on its own, so without it a BOM-emitting self-hosted server (some do) would parse fine
+ * through the native path and fail through this one.
+ */
+export async function readBoundedText(res: Response, opts: BoundedReadOptions): Promise<string> {
+  const buf = await readBoundedBuffer(res, opts);
+  const text = buf.toString("utf8");
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+/**
+ * Bounded equivalent of `res.json()`. A JSON.parse failure throws a plain Error that names the
+ * context and body length only — NOT the parser's own message. Modern V8 quotes a snippet of the
+ * offending text in that message (e.g. `Unexpected token 'S', "SECRET-PAY"... is not valid
+ * JSON`), which would leak response content straight back out through this "redacted" helper.
+ */
+export async function readBoundedJson<T = unknown>(res: Response, opts: BoundedReadOptions): Promise<T> {
+  const text = await readBoundedText(res, opts);
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    const label = opts.context ? ` from ${opts.context}` : "";
+    throw new Error(`invalid JSON${label} (${Buffer.byteLength(text, "utf8")} bytes) — body redacted`);
+  }
+}
+
+/**
+ * For a call site that falls back to a default value when a successful response's body doesn't
+ * parse the way it expects — use this in that fallback so a genuine `ResponseTooLargeError`
+ * doesn't get silently treated the same as "empty/malformed body". Swallowing that distinction
+ * turns "the response was too big to trust" into "the response was empty", which for something
+ * like a sketch/issue LOOKUP reads as not-found and can drive the caller to create a duplicate.
+ *
+ *   .catch((err) => rethrowIfTooLarge(err, {}))
+ */
+export function rethrowIfTooLarge<T>(err: unknown, fallback: T): T {
+  if (err instanceof ResponseTooLargeError) throw err;
+  return fallback;
+}
+
+/** Bounded equivalent of `res.arrayBuffer()`. */
+export async function readBoundedArrayBuffer(res: Response, opts: BoundedReadOptions): Promise<ArrayBuffer> {
+  const buf = await readBoundedBuffer(res, opts);
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}

--- a/companion/src/providers/gemini.ts
+++ b/companion/src/providers/gemini.ts
@@ -8,6 +8,7 @@ import {
   requestSignal,
 } from "./provider.js";
 import { validateBaseUrl } from "./urlValidation.js";
+import { readBoundedJson, readBoundedText, RESPONSE_SIZE_LIMITS } from "./boundedResponse.js";
 
 type FetchFn = typeof fetch;
 
@@ -65,17 +66,20 @@ export class GeminiProvider implements AIProvider {
       throw new ProviderError(msg, "transport");
     }
     if (!res.ok) {
-      const body = await res.text().catch(() => "");
+      const body = await readBoundedText(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.text,
+        context: "Gemini",
+      }).catch(() => "");
       throw new ProviderError(httpErrorMessage("Gemini", res.status, body), httpErrorKind(res.status));
     }
-    const json = (await res.json()) as {
+    const json = await readBoundedJson<{
       candidates?: { content?: { parts?: { text?: string }[] } }[];
       usageMetadata?: {
         promptTokenCount?: number;
         candidatesTokenCount?: number;
         cachedContentTokenCount?: number;
       };
-    };
+    }>(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: "Gemini" });
     const text = json.candidates?.[0]?.content?.parts?.[0]?.text;
     if (!text) throw new ProviderError("Gemini returned no content", "other");
     // Google's Generative Language response includes usageMetadata (promptTokenCount,

--- a/companion/src/providers/modelCatalog.ts
+++ b/companion/src/providers/modelCatalog.ts
@@ -3,6 +3,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { type CodexRunner, defaultCodexRunner } from "./codexRunner.js";
 import { validateBaseUrl } from "./urlValidation.js";
+import { readBoundedJson, RESPONSE_SIZE_LIMITS, ResponseTooLargeError } from "./boundedResponse.js";
 
 type FetchFn = typeof fetch;
 
@@ -139,8 +140,12 @@ async function fetchJson(
   }
   if (!response.ok) throw requestError(response.status);
   try {
-    return await response.json();
-  } catch {
+    return await readBoundedJson(response, {
+      maxBytes: RESPONSE_SIZE_LIMITS.json,
+      context: `${opts.provider} model list`,
+    });
+  } catch (err) {
+    if (err instanceof ResponseTooLargeError) throw new ModelCatalogError(err.message, "upstream");
     throw new ModelCatalogError("Provider model list returned invalid JSON.", "upstream");
   }
 }

--- a/companion/src/providers/openai.ts
+++ b/companion/src/providers/openai.ts
@@ -9,6 +9,7 @@ import {
   requestSignal,
 } from "./provider.js";
 import { validateBaseUrl } from "./urlValidation.js";
+import { readBoundedJson, readBoundedText, RESPONSE_SIZE_LIMITS } from "./boundedResponse.js";
 
 type FetchFn = typeof fetch;
 
@@ -135,13 +136,16 @@ export class OpenAIProvider implements AIProvider {
       throw new ProviderError(msg, "transport");
     }
     if (!res.ok) {
-      const body = await res.text().catch(() => "");
+      const body = await readBoundedText(res, {
+        maxBytes: RESPONSE_SIZE_LIMITS.text,
+        context: this.label,
+      }).catch(() => "");
       throw new ProviderError(httpErrorMessage(this.label, res.status, body), httpErrorKind(res.status));
     }
-    const json = (await res.json()) as {
+    const json = await readBoundedJson<{
       choices?: { message?: { content?: string } }[];
       usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number };
-    };
+    }>(res, { maxBytes: RESPONSE_SIZE_LIMITS.json, context: this.label });
     const text = json.choices?.[0]?.message?.content;
     if (!text) throw new ProviderError(`${this.label} returned no content`, "other");
     const u = json.usage;

--- a/companion/tests/enrichment/geoip.test.ts
+++ b/companion/tests/enrichment/geoip.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import { GeoIpProvider } from "../../src/enrichment/geoip.js";
 
 function mockFetch(body: unknown) {
-  return async () => ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+  return async () =>
+    new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
 }
 
 describe("GeoIpProvider coordinates (#133)", () => {

--- a/companion/tests/integrations/iris.test.ts
+++ b/companion/tests/integrations/iris.test.ts
@@ -583,11 +583,10 @@ import { IrisClient } from "../../src/integrations/iris/irisClient.js";
 function fakeFetch(payload: unknown, urls: string[]): typeof fetch {
   return (async (url: string) => {
     urls.push(String(url));
-    return {
+    return new Response(JSON.stringify({ status: "success", data: payload }), {
       status: 200,
-      ok: true,
-      json: async () => ({ status: "success", data: payload }),
-    } as Response;
+      headers: { "content-type": "application/json" },
+    });
   }) as unknown as typeof fetch;
 }
 

--- a/companion/tests/integrations/jiraClient.test.ts
+++ b/companion/tests/integrations/jiraClient.test.ts
@@ -27,11 +27,10 @@ function mockFetch(responses: Array<{ status?: number; json?: unknown }>): {
       body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
     });
     const status = next.status ?? 200;
-    return {
-      ok: status >= 200 && status < 300,
+    return new Response(status === 204 ? null : JSON.stringify(next.json ?? {}), {
       status,
-      json: async () => next.json ?? {},
-    } as unknown as Response;
+      headers: { "content-type": "application/json" },
+    });
   };
   return { fetchFn, calls };
 }

--- a/companion/tests/integrations/mispPushClient.test.ts
+++ b/companion/tests/integrations/mispPushClient.test.ts
@@ -24,11 +24,10 @@ function stubFetch(handler: (call: Call) => { status?: number; json: unknown }) 
     };
     calls.push(call);
     const { status = 200, json } = handler(call);
-    return {
-      ok: status >= 200 && status < 300,
+    return new Response(JSON.stringify(json), {
       status,
-      json: async () => json,
-    } as Response;
+      headers: { "content-type": "application/json" },
+    });
   }) as unknown as typeof fetch;
   return { fetchFn, calls };
 }
@@ -255,13 +254,10 @@ describe("MispPushClient ping diagnostics (issue #179)", () => {
   it("diagnoses a 200 that isn't MISP JSON — the URL points at some other web app", async () => {
     // A reverse proxy or an unrelated app on that port answers 200 with an HTML page; parsing it
     // used to escape as a raw "Unexpected token '<'" with no hint that the URL was the problem.
-    const fetchFn = (async () => ({
-      ok: true,
-      status: 200,
-      json: async () => {
-        throw new SyntaxError(`Unexpected token '<', "<!DOCTYPE "... is not valid JSON`);
-      },
-    })) as unknown as typeof fetch;
+    const fetchFn = (async () =>
+      new Response("<!DOCTYPE html><html><body>not MISP</body></html>", {
+        status: 200,
+      })) as unknown as typeof fetch;
     const msg = await client(fetchFn)
       .ping()
       .catch((e: Error) => e.message);

--- a/companion/tests/integrations/socratesApi.test.ts
+++ b/companion/tests/integrations/socratesApi.test.ts
@@ -14,10 +14,16 @@ function mockFetch(routes: Array<[string, unknown]>, seen: string[] = []) {
     seen.push(url);
     for (const [needle, body] of routes) {
       if (url.includes(needle)) {
-        return { ok: true, status: 200, json: async () => body } as unknown as Response;
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
       }
     }
-    return { ok: false, status: 404, json: async () => ({ error: "not found" }) } as unknown as Response;
+    return new Response(JSON.stringify({ error: "not found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
   }) as unknown as typeof fetch;
 }
 
@@ -95,7 +101,10 @@ describe("fetchVerdicts", () => {
       seen.push(url);
       let body: unknown = [];
       if (url.includes("type=alert")) body = alertCall++ === 0 ? full : [{ event_type: "alert", n: 1000 }];
-      return { ok: true, status: 200, json: async () => body } as unknown as Response;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }) as unknown as typeof fetch;
 
     const res = await fetchVerdicts("http://localhost:8000", "e".repeat(32), f);

--- a/companion/tests/integrations/timesketch.test.ts
+++ b/companion/tests/integrations/timesketch.test.ts
@@ -12,6 +12,7 @@ import {
   describeFetchError,
   TimesketchClient,
 } from "../../src/integrations/timesketch/timesketchClient.js";
+import { ResponseTooLargeError, RESPONSE_SIZE_LIMITS } from "../../src/providers/boundedResponse.js";
 import {
   pushCaseToTimesketch,
   pushSuperTimelineToTimesketch,
@@ -203,6 +204,26 @@ describe("TimesketchClient network failure", () => {
     expect(err?.message).toContain("DFIR_TIMESKETCH_CA");
     expect(err?.message).toContain("DFIR_TIMESKETCH_INSECURE=1");
     expect(err?.message).toContain("DFIR_TLS_ALLOW_INSECURE_EXTERNAL=true");
+  });
+});
+
+describe("TimesketchClient bounded response (issue #686)", () => {
+  // Regression: readBoundedJson().catch(() => ({})) originally caught EVERY rejection, including
+  // ResponseTooLargeError — so an oversized-but-VALID sketches list silently looked like "no
+  // sketches on this page", findSketchByName returned null, and the push flow went on to create a
+  // duplicate sketch instead of reusing the existing one. It must now propagate.
+  it("findSketchByName propagates ResponseTooLargeError instead of treating an oversized page as empty", async () => {
+    const client = new TimesketchClient({
+      baseUrl: "https://timesketch.example.org",
+      username: "u",
+      password: "p",
+      fetchFn: async () =>
+        new Response("irrelevant — rejected on the declared Content-Length before this is read", {
+          status: 200,
+          headers: { "content-length": String(RESPONSE_SIZE_LIMITS.json + 1) },
+        }),
+    });
+    await expect(client.findSketchByName("existing-case-sketch")).rejects.toThrow(ResponseTooLargeError);
   });
 });
 

--- a/companion/tests/providers/boundedResponse.test.ts
+++ b/companion/tests/providers/boundedResponse.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  readBoundedBuffer,
+  readBoundedText,
+  readBoundedJson,
+  readBoundedArrayBuffer,
+  ResponseTooLargeError,
+  RESPONSE_SIZE_LIMITS,
+  rethrowIfTooLarge,
+} from "../../src/providers/boundedResponse.js";
+
+// A Response whose body streams `chunks` one at a time, regardless of what Content-Length (if any)
+// claims — this is what lets the tests exercise "declared size lies" independently of "actual size
+// exceeds the cap".
+function streamedResponse(chunks: string[], headers: Record<string, string> = {}): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(new TextEncoder().encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(stream, { headers });
+}
+
+// Same shape, but also exposes a spy on the underlying stream's `cancel` — for asserting a
+// rejected body is actually torn down, not just refused.
+function streamedResponseWithCancelSpy(
+  chunks: string[],
+  headers: Record<string, string> = {},
+): { res: Response; cancel: ReturnType<typeof vi.fn> } {
+  const cancel = vi.fn();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(new TextEncoder().encode(chunk));
+      controller.close();
+    },
+    cancel,
+  });
+  return { res: new Response(stream, { headers }), cancel };
+}
+
+describe("readBoundedBuffer", () => {
+  it("reads a normal body under the cap", async () => {
+    const res = streamedResponse(["hello ", "world"]);
+    const buf = await readBoundedBuffer(res, { maxBytes: 1024 });
+    expect(buf.toString("utf8")).toBe("hello world");
+  });
+
+  it("rejects up front on an honest but oversized Content-Length, without reading the body", async () => {
+    const res = streamedResponse(["x".repeat(100)], { "content-length": "100" });
+    await expect(readBoundedBuffer(res, { maxBytes: 10 })).rejects.toThrow(ResponseTooLargeError);
+  });
+
+  it("rejects a body that exceeds the cap with NO Content-Length header (chunked transfer)", async () => {
+    const res = streamedResponse(["a".repeat(50), "b".repeat(50)]); // no content-length at all
+    await expect(readBoundedBuffer(res, { maxBytes: 60 })).rejects.toThrow(ResponseTooLargeError);
+  });
+
+  it("rejects a body whose actual bytes exceed a FALSE (too-low) Content-Length", async () => {
+    // Content-Length under-declares — the streamed check must still catch the real size.
+    const res = streamedResponse(["x".repeat(200)], { "content-length": "5" });
+    await expect(readBoundedBuffer(res, { maxBytes: 5 })).rejects.toThrow(ResponseTooLargeError);
+  });
+
+  it("accepts a body exactly at the cap", async () => {
+    const res = streamedResponse(["x".repeat(10)]);
+    const buf = await readBoundedBuffer(res, { maxBytes: 10 });
+    expect(buf.byteLength).toBe(10);
+  });
+
+  it("stops reading as soon as the running total crosses the cap, not just at the final chunk", async () => {
+    const res = streamedResponse(["a".repeat(5), "b".repeat(5), "c".repeat(5)]);
+    await expect(readBoundedBuffer(res, { maxBytes: 8 })).rejects.toThrow(ResponseTooLargeError);
+  });
+
+  it("names the limit and context in the error, never response content", async () => {
+    const res = streamedResponse(["SECRET-PAYLOAD-DATA".repeat(10)]);
+    try {
+      await readBoundedBuffer(res, { maxBytes: 5, context: "TestProvider" });
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResponseTooLargeError);
+      const e = err as ResponseTooLargeError;
+      expect(e.limitBytes).toBe(5);
+      expect(e.context).toBe("TestProvider");
+      expect(e.message).not.toContain("SECRET-PAYLOAD-DATA");
+      expect(e.message).toContain("TestProvider");
+    }
+  });
+
+  it("returns an empty buffer for a body-less response (e.g. 204)", async () => {
+    const res = new Response(null, { status: 204 });
+    const buf = await readBoundedBuffer(res, { maxBytes: 10 });
+    expect(buf.byteLength).toBe(0);
+  });
+
+  it("cancels the body stream when rejecting on a declared Content-Length, instead of leaving it dangling", async () => {
+    const { res, cancel } = streamedResponseWithCancelSpy(["x".repeat(100)], { "content-length": "100" });
+    await expect(readBoundedBuffer(res, { maxBytes: 10 })).rejects.toThrow(ResponseTooLargeError);
+    expect(cancel).toHaveBeenCalled();
+  });
+});
+
+describe("readBoundedText / readBoundedJson / readBoundedArrayBuffer", () => {
+  it("readBoundedText decodes utf8", async () => {
+    const res = streamedResponse(["héllo"]);
+    expect(await readBoundedText(res, { maxBytes: 1024 })).toBe("héllo");
+  });
+
+  it("readBoundedJson parses a normal payload", async () => {
+    const res = streamedResponse([JSON.stringify({ a: 1, b: [2, 3] })]);
+    expect(await readBoundedJson<{ a: number; b: number[] }>(res, { maxBytes: 1024 })).toEqual({
+      a: 1,
+      b: [2, 3],
+    });
+  });
+
+  it("readBoundedJson throws on malformed JSON near the cap without leaking the body", async () => {
+    const res = streamedResponse(['{"a": 1, "b": '.padEnd(30, "x")]); // truncated/invalid, ~cap-sized
+    await expect(readBoundedJson(res, { maxBytes: 100, context: "TestProvider" })).rejects.toThrow(
+      /invalid JSON.*TestProvider/,
+    );
+  });
+
+  it("readBoundedJson still enforces the size cap before attempting to parse", async () => {
+    const res = streamedResponse([JSON.stringify({ a: "x".repeat(100) })]);
+    await expect(readBoundedJson(res, { maxBytes: 10 })).rejects.toThrow(ResponseTooLargeError);
+  });
+
+  it("readBoundedJson never leaks a snippet of the malformed body via the parser's own error message", async () => {
+    // Modern V8 quotes a slice of the offending text in SyntaxError.message (e.g. `Unexpected
+    // token 'S', "SECRET-TO"... is not valid JSON`) — the helper must not pass that through.
+    const res = streamedResponse(["SECRET-TOKEN-VALUE-not-json"]);
+    try {
+      await readBoundedJson(res, { maxBytes: 1024, context: "TestProvider" });
+      expect.unreachable();
+    } catch (err) {
+      expect((err as Error).message).not.toContain("SECRET-TOKEN-VALUE");
+      expect((err as Error).message).toContain("TestProvider");
+    }
+  });
+
+  it("readBoundedText strips a leading UTF-8 BOM, matching native Response.text()", async () => {
+    const res = streamedResponse(["﻿hello"]);
+    expect(await readBoundedText(res, { maxBytes: 1024 })).toBe("hello");
+  });
+
+  it("readBoundedJson parses a BOM-prefixed JSON body (some self-hosted servers emit one)", async () => {
+    const res = streamedResponse(["﻿" + JSON.stringify({ ok: true })]);
+    expect(await readBoundedJson(res, { maxBytes: 1024 })).toEqual({ ok: true });
+  });
+
+  it("readBoundedArrayBuffer returns the right byte length", async () => {
+    const res = streamedResponse(["abcdef"]);
+    const ab = await readBoundedArrayBuffer(res, { maxBytes: 1024 });
+    expect(ab.byteLength).toBe(6);
+    expect(Buffer.from(ab).toString("utf8")).toBe("abcdef");
+  });
+
+  it("readBoundedArrayBuffer rejects over the cap", async () => {
+    const res = streamedResponse(["x".repeat(20)]);
+    await expect(readBoundedArrayBuffer(res, { maxBytes: 10 })).rejects.toThrow(ResponseTooLargeError);
+  });
+});
+
+describe("RESPONSE_SIZE_LIMITS", () => {
+  it("orders json <= text is NOT assumed; binary is the largest of the three presets", () => {
+    expect(RESPONSE_SIZE_LIMITS.binary).toBeGreaterThan(RESPONSE_SIZE_LIMITS.json);
+    expect(RESPONSE_SIZE_LIMITS.binary).toBeGreaterThan(RESPONSE_SIZE_LIMITS.text);
+  });
+});
+
+describe("rethrowIfTooLarge", () => {
+  it("rethrows a ResponseTooLargeError instead of swallowing it into the fallback", () => {
+    const err = new ResponseTooLargeError(10, "TestProvider");
+    expect(() => rethrowIfTooLarge(err, { fallback: true })).toThrow(ResponseTooLargeError);
+  });
+
+  it("returns the fallback for any other error (the original .catch(() => fallback) behavior)", () => {
+    expect(rethrowIfTooLarge(new SyntaxError("bad json"), { fallback: true })).toEqual({ fallback: true });
+    expect(rethrowIfTooLarge("not even an Error", [])).toEqual([]);
+  });
+
+  it("end-to-end: a success-path .catch(() => ({})) pattern must not turn an oversized body into an empty result", async () => {
+    const res = streamedResponse(["x".repeat(50)]);
+    const readAsFallback = () =>
+      readBoundedJson<Record<string, unknown>>(res, { maxBytes: 5, context: "TestProvider" }).catch((err) =>
+        rethrowIfTooLarge(err, {}),
+      );
+    await expect(readAsFallback()).rejects.toThrow(ResponseTooLargeError);
+  });
+});

--- a/companion/tests/providers/gemini.test.ts
+++ b/companion/tests/providers/gemini.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { GeminiProvider } from "../../src/providers/gemini.js";
 import { ProviderError, type AnalyzeResult } from "../../src/providers/provider.js";
+import { jsonResponse } from "../helpers/fetchMock.js";
 
 describe("GeminiProvider — base URL validation (#246)", () => {
   // validateBaseUrl() has its own unit tests (urlValidation.test.ts); these confirm it's actually
@@ -40,12 +41,7 @@ describe("GeminiProvider — API key placement (#516)", () => {
       fetchFn: async (input: RequestInfo | URL, init?: RequestInit) => {
         seenUrl = String(input);
         seenHeaders = (init?.headers ?? {}) as Record<string, string>;
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }] }),
-          text: async () => "",
-        } as unknown as Response;
+        return jsonResponse({ candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }] });
       },
     });
     await provider.analyze({ systemPrompt: "s", userPrompt: "x", images: [] });
@@ -58,19 +54,14 @@ describe("GeminiProvider — API key placement (#516)", () => {
 
 describe("GeminiProvider — usageMetadata parsing (#3)", () => {
   it("reports input/output/cacheRead tokens from usageMetadata so the AI cost card is not always 0/0", async () => {
-    const fakeResponse = {
-      ok: true,
-      status: 200,
-      json: async () => ({
-        candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }],
-        usageMetadata: { promptTokenCount: 42, candidatesTokenCount: 7, cachedContentTokenCount: 3 },
-      }),
-      text: async () => "",
-    };
     const provider = new GeminiProvider({
       apiKey: "k",
       model: "gemini-2.5-pro",
-      fetchFn: async () => fakeResponse as unknown as Response,
+      fetchFn: async () =>
+        jsonResponse({
+          candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }],
+          usageMetadata: { promptTokenCount: 42, candidatesTokenCount: 7, cachedContentTokenCount: 3 },
+        }),
     });
     const result: AnalyzeResult = await provider.analyze({ systemPrompt: "s", userPrompt: "x", images: [] });
     expect(result.usage).toBeDefined();
@@ -82,16 +73,11 @@ describe("GeminiProvider — usageMetadata parsing (#3)", () => {
   });
 
   it("omits usage when usageMetadata is absent (no regression)", async () => {
-    const fakeResponse = {
-      ok: true,
-      status: 200,
-      json: async () => ({ candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }] }),
-      text: async () => "",
-    };
     const provider = new GeminiProvider({
       apiKey: "k",
       model: "gemini-2.5-pro",
-      fetchFn: async () => fakeResponse as unknown as Response,
+      fetchFn: async () =>
+        jsonResponse({ candidates: [{ content: { parts: [{ text: '{"findings":[]}' }] } }] }),
     });
     const result = await provider.analyze({ systemPrompt: "s", userPrompt: "x", images: [] });
     expect(result.usage).toBeUndefined();


### PR DESCRIPTION
## Summary

- Adds `companion/src/providers/boundedResponse.ts`, a shared bounded reader for `fetch`
  responses: rejects an oversized declared `Content-Length` before reading anything,
  aborts mid-stream if the actual bytes cross the cap (covers a missing/false
  `Content-Length` and chunked transfer), strips a leading UTF-8 BOM to match native
  `fetch` behavior, and never echoes response content back through its own error
  messages.
- Migrates all 51 real call sites across AI providers (`providers/`), threat-intel
  enrichment (`enrichment/`), and third-party integrations (`integrations/`) from raw
  `res.json()` / `res.text()` / `res.arrayBuffer()` to the bounded reader, preserving
  existing status-code branching and error handling.
- Adds `rethrowIfTooLarge()` and applies it at 8 success-path call sites (Jira, ClickUp,
  Notion, IRIS, ServiceNow, and 3 in Timesketch) that previously swallowed a
  `ResponseTooLargeError` into an empty-result fallback — which could read as "not found"
  and drive a caller (e.g. Timesketch's sketch lookup) to create a duplicate remote
  object.

## Why

A per-request timeout bounds how long an outside call takes, but not how much memory it
costs. A compromised, misconfigured, or just unexpectedly verbose upstream could hand
back an unbounded reply, and the Companion would try to hold all of it in memory before
checking anything.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run check:size`
- [x] `npm run check:imports`
- [x] `npm run check:boundaries`
- [x] `npm run eval:change-gate`
- [x] `npm run check:us-map`
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npx vitest run` (companion, 706 files / 11245 tests)
- [x] `extension`: typecheck, `npm test` (329 tests), `build`, `build:firefox`

Closes #686
