### PR TITLE
fix(analysis): grade a privileged group add by its SID, not only its English name

### DIFF
--- a/companion/src/analysis/siemImport.ts
+++ b/companion/src/analysis/siemImport.ts
@@ -351,6 +351,35 @@ export interface WinEventDef {
 const PRIVILEGED_GROUP =
   /\b(?:domain admins|enterprise admins|schema admins|administrators|account operators|server operators|backup operators|print operators|dnsadmins|group policy creator owners|domain controllers|enterprise key admins|key admins)\b/i;
 
+// The name above is English. AD localises built-in group display names at domain creation, so the
+// same add reads "Admins du domaine" on a French domain and "Domänen-Admins" on a German one, and
+// the regex misses the one event class where a miss costs a High — and with it the deterministic
+// finding backfill that a High guarantees. A group's SID does not localise, so it is checked
+// ALONGSIDE the name, never instead of it: DnsAdmins is created by the DNS Server role with a
+// variable domain RID, so it has no well-known SID and is only ever reachable by name.
+// Builtin groups (S-1-5-32-<rid>): Administrators, Account/Server/Backup/Print Operators. 545
+// (Users) and the rest are deliberately absent — they are where routine provisioning lands.
+const BUILTIN_PRIVILEGED_RIDS = new Set([544, 548, 549, 550, 551]);
+// Domain-relative (S-1-5-21-<3 domain ids>-<rid>): Enterprise Read-only Domain Controllers 498,
+// Domain Admins 512, Domain Controllers 516, Schema Admins 518, Enterprise Admins 519, Group Policy
+// Creator Owners 520, Read-only Domain Controllers 521, Cloneable Domain Controllers 522, Key
+// Admins 526, Enterprise Key Admins 527. Domain Users 513 is NOT privilege.
+// 498 and 522 are here because the name check already grades them — both end in "Domain
+// Controllers", which PRIVILEGED_GROUP matches — so leaving them out would make the SID path grade
+// a localised domain STRICTLY worse than an English one, which is the whole bug this fixes.
+const DOMAIN_PRIVILEGED_RIDS = new Set([498, 512, 516, 518, 519, 520, 521, 522, 526, 527]);
+const BUILTIN_SID_RE = /^S-1-5-32-(\d{1,10})$/i;
+// Same shape as TEXT_SID_RE below: exactly three domain sub-authorities, then the RID.
+const DOMAIN_SID_RE = /^S-1-5-21-(?:\d{1,10}-){3}(\d{1,10})$/i;
+
+function isPrivilegedGroupSid(sid: string): boolean {
+  const trimmed = sid.trim();
+  const builtin = BUILTIN_SID_RE.exec(trimmed);
+  if (builtin) return BUILTIN_PRIVILEGED_RIDS.has(Number(builtin[1]));
+  const domain = DOMAIN_SID_RE.exec(trimmed);
+  return domain ? DOMAIN_PRIVILEGED_RIDS.has(Number(domain[1])) : false;
+}
+
 // Security + System channel events keyed by Event ID. Exported so a CONDENSED summary artifact
 // (one that reports an EID without the parsed record) reads its label and base grade from the same
 // table as a parsed event, instead of growing a second, drifting copy of the same knowledge.
@@ -949,10 +978,13 @@ export function mapWindows(
     if (payload && (isSuspiciousCmd(payload, payload) || tradecraftSignal("", payload)))
       severity = worst(severity, "High");
     // A group add is High when the GROUP is privileged — see PRIVILEGED_GROUP. 4728/4732/4756 name
-    // the group in TargetUserName and the member in MemberName, not the other way round.
+    // the group in TargetUserName and the member in MemberName, not the other way round. The name
+    // is localised and the SID is not, so either identifying the group is enough — see
+    // isPrivilegedGroupSid for why neither check subsumes the other.
     if (
       (eid === 4728 || eid === 4732 || eid === 4756) &&
-      PRIVILEGED_GROUP.test(str(getCI(ed, "TargetUserName")))
+      (PRIVILEGED_GROUP.test(str(getCI(ed, "TargetUserName"))) ||
+        isPrivilegedGroupSid(str(getCI(ed, "TargetSid"))))
     )
       severity = worst(severity, "High");
   }

--- a/companion/tests/analysis/siemImport.test.ts
+++ b/companion/tests/analysis/siemImport.test.ts
@@ -1453,6 +1453,95 @@ describe("persistence and account events — High is earned, not assumed", () =>
     expect(sev(win(4728, { TargetUserName: "Domain Admins", MemberName: "CN=jsmith" }))).toBe("High");
     expect(sev(win(4732, { TargetUserName: "Administrators", MemberName: "CN=jsmith" }))).toBe("High");
   });
+
+  // AD localises built-in group names at domain creation, so TargetUserName on a French or German
+  // domain is never the English string PRIVILEGED_GROUP looks for — and a group add is the one
+  // event where a miss costs a High, and with it the deterministic finding backfill. TargetSid does
+  // not localise.
+  it("grades a localized privileged group add High from the group SID", () => {
+    expect(
+      sev(
+        win(4728, {
+          TargetUserName: "Admins du domaine",
+          TargetSid: "S-1-5-21-1004336348-1177238915-682003330-512",
+          MemberName: "CN=jsmith",
+        }),
+      ),
+    ).toBe("High");
+    expect(
+      sev(
+        win(4732, {
+          TargetUserName: "Administratoren",
+          TargetSid: "S-1-5-32-544",
+          MemberName: "CN=jsmith",
+        }),
+      ),
+    ).toBe("High");
+  });
+
+  // The SID check must not widen the net: Domain Users (-513) and Builtin\Users (-545) are where
+  // every routine account provisioning lands, so matching them would turn day-to-day user admin
+  // into a case full of High findings.
+  it("leaves a localized NON-privileged group add at Medium", () => {
+    expect(
+      sev(
+        win(4728, {
+          TargetUserName: "Utilisateurs du domaine",
+          TargetSid: "S-1-5-21-1004336348-1177238915-682003330-513",
+          MemberName: "CN=jsmith",
+        }),
+      ),
+    ).toBe("Medium");
+    expect(
+      sev(
+        win(4732, {
+          TargetUserName: "Benutzer",
+          TargetSid: "S-1-5-32-545",
+          MemberName: "CN=jsmith",
+        }),
+      ),
+    ).toBe("Medium");
+  });
+
+  // The two DC groups whose English names already earn High through the "domain controllers" name
+  // match, so the SID list has to cover them too or localisation quietly downgrades them: Enterprise
+  // Read-only Domain Controllers (498, universal -> 4756) and Cloneable Domain Controllers (522,
+  // global -> 4728).
+  it("grades the localized domain-controller groups High from the group SID", () => {
+    expect(
+      sev(
+        win(4756, {
+          TargetUserName: "Contrôleurs de domaine en lecture seule d'entreprise",
+          TargetSid: "S-1-5-21-1004336348-1177238915-682003330-498",
+          MemberName: "CN=RODC01",
+        }),
+      ),
+    ).toBe("High");
+    expect(
+      sev(
+        win(4728, {
+          TargetUserName: "Klonbare Domänencontroller",
+          TargetSid: "S-1-5-21-1004336348-1177238915-682003330-522",
+          MemberName: "CN=DC02",
+        }),
+      ),
+    ).toBe("High");
+  });
+
+  // DnsAdmins is created by the DNS Server role with a variable domain RID, not a well-known one,
+  // so the SID says nothing and only the name identifies it. Replacing the name check with SIDs
+  // would silently drop a known escalation path — hence both, not either.
+  it("keeps the name check for a privileged group that has no well-known SID", () => {
+    expect(
+      sev(
+        win(4732, {
+          TargetUserName: "DnsAdmins",
+          TargetSid: "S-1-5-21-1004336348-1177238915-682003330-1101",
+          MemberName: "CN=jsmith",
+        }),
+      ),
+    ).toBe("High");
+  });
 });
 
 // Defender was the only security product on the benign-actor lists, so on a CrowdStrike or


### PR DESCRIPTION
## What an analyst sees differently

When someone is added to a powerful Windows group — Domain Admins, the local
Administrators group, the domain controller groups — the Companion grades that
event **High**, and High is what guarantees it becomes a finding in the case.

Until now it recognised those groups only by their **English** names. Windows
translates them. On a French domain the same group is "Admins du domaine"; on a
German one, "Domänen-Admins". So on any non-English domain, the single event
that says an attacker just granted themselves the domain was graded Medium and
produced no finding at all.

The Companion now also reads the group's **SID**, which Windows never translates.
Analysts working non-English estates will start seeing these promotions where
they previously saw nothing. Nothing changes for English domains.

## How

`PRIVILEGED_GROUP` still runs. `TargetSid` is checked alongside it — either one
identifying the group is enough. Alongside, not instead, for two reasons:

- **DnsAdmins has no well-known SID.** The DNS Server role creates it with a
  variable domain RID, so only the name identifies it. SID-only matching would
  have silently dropped a known escalation path.
- **Not every source carries the SID.** Summarised exports may have the group
  name and no `TargetSid`. `str()` returns `""` for a missing field, so those
  fall through to the name check with no new branch.

The RID sets are deliberately narrow:

- Builtin `S-1-5-32-`: 544, 548, 549, 550, 551.
- Domain-relative `S-1-5-21-<3 ids>-`: 498, 512, 516, 518, 519, 520, 521, 522,
  526, 527.
- **Domain Users (513) and Builtin\Users (545) are excluded.** They are where
  routine account provisioning lands; matching them would fill a case with
  meaningless High findings.
- **498 and 522 are included** because their English names already earn High
  through the existing `domain controllers` name match. Omitting them would have
  left a localized domain graded strictly worse than an English one — the exact
  bug this fixes.

No new plumbing: `event_data` is already passed through wholesale, so
`TargetSid` was available and simply unread.

## Tests

Four new cases in `siemImport.test.ts`, written before the fix:

- Localized privileged group add graded High from the SID (the driving test —
  failed first with `expected 'Medium' to be 'High'`).
- Localized domain-controller groups (498, 522) graded High from the SID.
- Localized non-privileged group (513, 545) stays Medium.
- `DnsAdmins` still graded High by name despite a non-well-known SID.

## Gates

`vitest run` 706/706 files, 11249/11249 tests · `build` · `typecheck` · `lint` ·
`format:check` · `check:size` · `check:imports` · `check:boundaries` ·
`eval:change-gate` · `check:us-map` · extension typecheck/test/build/build:firefox
— all exit 0.

Closes #718

Reviewed alongside #717, which needed no change.
