### PR TITLE
fix(velociraptor): escalate six malware families named in a detection title

### DIFF
--- a/companion/src/analysis/velociraptorImport.ts
+++ b/companion/src/analysis/velociraptorImport.ts
@@ -240,7 +240,7 @@ function rowVerdict(row: Row): Verdict | null {
 // Known malware-family / offensive-tooling keywords in a verdict title → escalate. These read
 // the tool's OWN verdict wording, not the raw artifact, so it stays "consume, don't re-detect".
 const CRIT_KEYWORDS =
-  /ransom|lockbit|\bconti\b|wannacry|black\s*cat|\balphv\b|emotet|trickbot|qakbot|\bhive\b/i;
+  /ransom|lockbit|\bconti\b|wannacry|black\s*cat|\balphv\b|emotet|trickbot|qakbot|\bhive\b|\bdragon\s*force\b|\bplaycrypt\b|\bgrixba\b|\bsystembc\b|\bbetruger\b|\bsectop\s*rat\b/i;
 const HIGH_KEYWORDS =
   /cobalt\s*strike|mimikatz|web\s*shell|webshell|lazagne|rubeus|sharphound|bloodhound|meterpreter|\bbeacon\b|reverse\s*shell|secretsdump|psexec|\bsliver\b|brute\s*ratel|nanodump|seatbelt|\blsass\b|kerberoast|dcsync|impacket/i;
 

--- a/companion/tests/analysis/velociraptorImport.test.ts
+++ b/companion/tests/analysis/velociraptorImport.test.ts
@@ -4079,3 +4079,61 @@ describe("parseVelociraptorJson — script blocks run by the collector itself", 
     expect(parseVelociraptorJson(JSON.stringify([row])).events[0].severity).toBe("High");
   });
 });
+
+// INC-2026-020 — a lab intrusion built from a published Play / RansomHub / DragonForce report — put
+// six malware-family names in the evidence verbatim, and not one of them escalated a verdict:
+// CRIT_KEYWORDS knew lockbit/conti/emotet but none of the families this campaign actually used. A
+// rule pack that names the family it matched has already done the attribution work, so the grade
+// should read it rather than fall back to the generic "a rule fired" Medium.
+//
+// "RansomHub" needed no new entry — the list's existing `ransom` alternative already covers it — so
+// it is asserted here to pin that, not because anything was added for it.
+//
+// A bare "play" is deliberately NOT in the list. The family name reads as an ordinary English word
+// ("Google Play"), and ransomwareDetect.ts already excludes `.play` from RANSOM_EXTS for exactly
+// that reason; only the unambiguous "PlayCrypt" spelling escalates.
+describe("parseVelociraptorJson — a malware-family name in a verdict title escalates to Critical", () => {
+  function detectionRow(name: string): object {
+    return {
+      Detection: { Name: name, KeywordRegex: "GT_NET\\.exe" },
+      OSPath: "C:\\Users\\Public\\Music\\GT_NET.exe",
+      SITimestamps: { LastModified0x10: "2026-08-30T15:03:17Z" },
+    };
+  }
+  const severityOf = (name: string): string =>
+    parseVelociraptorJson(JSON.stringify([detectionRow(name)])).events[0].severity;
+
+  // Each title avoids the word "ransom" so the new alternative is the ONLY reason it escalates.
+  it.each([
+    ["Grixba Malware Reconnaissance Activity 2", "grixba"],
+    ["DragonForce Encryptor Execution", "dragonforce"],
+    ["Dragon Force Affiliate Tooling", "dragonforce, spelled as two words"],
+    ["PlayCrypt Shadow Copy Deletion", "playcrypt"],
+    ["SystemBC Proxy Implant", "systembc"],
+    ["Betruger Backdoor Service Install", "betruger"],
+    ["SectopRAT Remote Access Activity", "sectoprat"],
+  ])("%s → Critical (%s)", (title) => {
+    expect(severityOf(title)).toBe("Critical");
+  });
+
+  it("RansomHub is already covered by the existing `ransom` alternative", () => {
+    expect(severityOf("RansomHub Affiliate Tooling")).toBe("Critical");
+  });
+
+  it("a bare 'play' does not escalate — the family name is an ordinary English word", () => {
+    expect(severityOf("Google Play Services Update Detected")).toBe("Medium");
+  });
+
+  // Review follow-up. The first version of these alternatives was unbounded, so a family name
+  // buried mid-word escalated an unrelated rule to Critical — "DisplayCryptographic" contains
+  // "playcrypt", and "IntersectOpRating" contains "sectop" + "rat". Each name is now \b-bounded on
+  // both sides, which also stops a longer word that merely STARTS with the family ("Dragon Forces").
+  it.each([
+    "DisplayCryptographic Provider Activity",
+    "Dragon Forces Service Activity",
+    "IntersectOpRating Service Started",
+    "Filesystembc Handle Leak",
+  ])("%s stays Medium — the family name is only an incidental substring", (title) => {
+    expect(severityOf(title)).toBe("Medium");
+  });
+});


### PR DESCRIPTION
## What

Adds six malware-family names to `CRIT_KEYWORDS` in `velociraptorImport.ts`, so a detection whose **rule title** already names the family it matched grades Critical instead of the generic "a rule fired" Medium.

```
|\bdragon\s*force\b|\bplaycrypt\b|\bgrixba\b|\bsystembc\b|\bbetruger\b|\bsectop\s*rat\b
```

## Why

The list knew lockbit/conti/emotet but none of the families in the INC-2026-020 corpus. A rule pack that names the malware it matched has already done the attribution work; the grade should read it rather than discard it.

## Decisions worth reviewing

**RansomHub needed no entry.** The list's existing `ransom` alternative already covers it. A test pins that, so nobody adds a redundant token later.

**A bare `play` is deliberately absent.** The family name reads as an ordinary English word ("Google Play"). `ransomwareDetect.ts` already excludes `.play` from `RANSOM_EXTS` after it produced a false T1486, so this follows a precedent the codebase set. Only the unambiguous `PlayCrypt` spelling escalates.

**Every name is `\b`-bounded on both sides.** The first version was unbounded and review caught real collisions — `DisplayCryptographic` contains `playcrypt`, `IntersectOpRating` contains `sectop`+`rat`. The trailing boundary also rejects a longer word that merely starts with the family (`Dragon Forces`). Four such titles are regression tests.

## Known limitation — this does not reach Sigma rows

`mapSigma` (`velociraptorImport.ts:594`) grades from `SIGMA_LEVEL[level]` and returns `sev ?? "Medium"` without ever calling `detectionSeverity`, so a Sigma rule carrying its own level never consults the keyword lists.

Verified by running the real parser over the real 17MB INC-2026-020 import: the two `Grixba Malware Reconnaissance Activity 2` rows still grade **High**, not Critical, because the Hayabusa row carries `"Level": "high"`.

Reaching them would mean letting a family name raise a severity the rule stated explicitly. That contradicts a tested invariant (`tests/analysis/velociraptorImport.test.ts:178` — an explicit `Detection.Criticality` wins over a keyword) and is deliberately left alone here.

## Context

Found while reviewing #747. That issue's other half — a deterministic scanner over raw evidence text — was **rejected** and the issue closed not-planned: in the corpus, five of the six gang names appear only inside the simulation's own header comment naming its source report. A detector tuned to that text would score perfectly on the eval and find nothing in a real case.

#751 tracks the separate finding that narrowing a case's scope permanently deletes previously-created findings.

## Tests

13 new tests in `tests/analysis/velociraptorImport.test.ts`: 7 positive (one per new alternative, each title avoiding the word "ransom" so the new token is the only thing that can escalate it), 1 pinning the RansomHub-via-`ransom` path, 5 negative (bare `play` plus the four substring collisions).

Local: 322 passing in that file, 356 with `evalFixes.test.ts`, `npm run typecheck` clean, file-size ledger unchanged (the edit adds no lines to a file already at its cap), prettier and eslint clean. `origin/master` merged in before push.
