### PR TITLE
fix(analysis): narrowing the scope hides prior findings instead of deleting them

### DIFF
--- a/companion/src/analysis/ai/synthesis.ts
+++ b/companion/src/analysis/ai/synthesis.ts
@@ -53,7 +53,7 @@ import {
   type SynthesisInputBlocks,
   type SynthesisInputContext,
 } from "./synthesisInputs.js";
-import { foldSynthesisDelta, gradeFindings } from "./synthesisMerge.js";
+import { carryOutOfWindowFindings, foldSynthesisDelta, gradeFindings } from "./synthesisMerge.js";
 import { persistSynthesis } from "./synthesisPersist.js";
 
 /**
@@ -584,6 +584,14 @@ export async function synthesize(
     sourceTrust,
     aliasIndex,
   });
+
+  // Scope is a lens, not a shredder (#751). This run rebuilt its conclusions from an empty base over
+  // the events inside the window, so a narrowed window would otherwise DELETE the deterministic
+  // findings a wider earlier run had persisted outside it — irreversibly, since widening again gives
+  // the backfills nothing to re-derive them from. Re-attach those, untouched and with their event
+  // links, and let projectScope hide them for as long as the narrow window is set. AFTER grading, so
+  // a carried finding keeps the confidence it was stored with; a no-op when no scope is set.
+  next = carryOutOfWindowFindings(next, { prior: state, inWindowEvents: run.inWindowEvents, markers });
 
   // What this run changed vs the pre-AI findings. Findings are FINAL here — neither persistLatest
   // nor the hypothesis auto-gen below touch them — so it's computed once and reused for the

--- a/companion/src/analysis/ai/synthesisMerge.ts
+++ b/companion/src/analysis/ai/synthesisMerge.ts
@@ -1,7 +1,7 @@
 import { flagContradictedAnswers } from "../answerContradiction.js";
 import { buildAssetGraph } from "../assetGraph.js";
 import { buildEvidenceGraph } from "../evidenceGraph.js";
-import { applyFalsePositive, type FalsePositiveMarker } from "../falsePositive.js";
+import { applyFalsePositive, falsePositiveEventIds, type FalsePositiveMarker } from "../falsePositive.js";
 import {
   capIntelOnlyFindings,
   buildIntelCorroborationSteps,
@@ -42,6 +42,11 @@ import { mergeDelta, type WindowContext } from "../stateMerge.js";
  *
  * Every one of them only ever LOWERS a claim. That is the invariant worth protecting here: the
  * deterministic passes can refuse to believe the model, never the other way round.
+ *
+ * `carryOutOfWindowFindings` is the one export that is NOT part of that sequence. It runs after
+ * grading, from `synthesize`, and it neither raises nor lowers anything: it re-attaches deterministic
+ * findings a WIDER earlier run persisted outside this run's window, byte for byte, so narrowing the
+ * scope hides them instead of deleting them (#751).
  */
 
 /** Keep analyst-pinned questions across a synthesis (it replaces keyQuestions wholesale). */
@@ -175,6 +180,122 @@ function linkEventsToFindings(
       ...e,
       relatedFindingIds: eventToFindings.get(e.id) ?? [],
     })),
+  };
+}
+
+/** Ids the DETERMINISTIC backfills mint. Everything else in a finding set came from the model. */
+function isDeterministicFindingId(id: string): boolean {
+  return id.startsWith("f-auto-") || id.startsWith("f-gap-") || id === "f-waves";
+}
+
+/**
+ * Every event that backs a finding — forward links and reverse links alike — that still exists and
+ * that the analyst has NOT confirmed benign.
+ *
+ * Dropping the false-positive events HERE is what makes both readers below correct at once: a
+ * finding left with no support at all is not carried, and a finding that is carried never gets a
+ * link back to an event the analyst rejected. `applyFalsePositive` cannot do this job — it matches
+ * finding titles and IOC values, and an `event` marker is deliberately not one of its cases (the raw
+ * event stays in state so un-marking restores it). Without this, an out-of-window finding backed
+ * only by rejected events would survive every narrow run and reappear the moment the window widened.
+ */
+function supportingEventIds(
+  prior: InvestigationState,
+  markers: FalsePositiveMarker[],
+): Map<string, Set<string>> {
+  const benign = falsePositiveEventIds(markers);
+  const known = new Set(
+    prior.forensicTimeline.filter((e) => !benign.has(e.id.trim().toLowerCase())).map((e) => e.id),
+  );
+  const byFinding = new Map<string, Set<string>>();
+  const add = (findingId: string, eventId: string): void => {
+    if (!known.has(eventId)) return; // a dangling id proves nothing about the window
+    const set = byFinding.get(findingId) ?? new Set<string>();
+    set.add(eventId);
+    byFinding.set(findingId, set);
+  };
+  for (const e of prior.forensicTimeline) for (const fid of e.relatedFindingIds) add(fid, e.id);
+  for (const f of prior.findings) for (const eid of f.relatedEventIds ?? []) add(f.id, eid);
+  return byFinding;
+}
+
+export interface CarryForwardInput {
+  /** The correlated pre-call snapshot: the prior findings and the event links that back them. */
+  prior: InvestigationState;
+  /** Events inside the analyst's window, BEFORE the false-positive filter. */
+  inWindowEvents: readonly ForensicEvent[];
+  markers: FalsePositiveMarker[];
+}
+
+/**
+ * Scope is a LENS, not a shredder (#751).
+ *
+ * `replaceConclusions` builds this run's findings from an EMPTY base, and the backfills only ever
+ * look at events inside the analyst's window. Together those two facts made narrowing the window
+ * DELETE every deterministic finding a wider earlier run had persisted: the rows were overwritten in
+ * SQLite, widening the window again did not bring them back, and a Critical detection the tool had
+ * already made simply vanished from the case.
+ *
+ * So, once this run's finding set is final, re-attach the deterministic findings the PRIOR state
+ * held whose supporting events all fall OUTSIDE this run's window — stored exactly as they were,
+ * with their event back-links restored. `projectScope` (and its client mirror) then drops them from
+ * every view for as long as the narrow window is set, which is the behaviour the analyst asked for,
+ * and widening the window brings them straight back.
+ *
+ * Deliberately narrow:
+ *   - MODEL findings are NOT carried. Synthesis replacing its own conclusions is the invariant this
+ *     module exists to protect; only the ids the deterministic backfills mint are preserved.
+ *   - A finding this run already produced is left alone — same id, and the run's version wins.
+ *   - A finding with ANY supporting event in the window is left alone: this run reassessed it.
+ *   - `inWindowEvents` is the PRE-false-positive set on purpose. A finding whose events the analyst
+ *     confirmed benign was excluded by that filter, not by the window, so it still goes away.
+ *   - An event the analyst confirmed benign backs nothing. It is dropped before the window test, so
+ *     a finding left with no other support is not carried and never gets a link back to it.
+ *   - What is carried still passes through the finding/IOC false-positive filter as well, so no
+ *     marker of any kind can be undone here.
+ *
+ * With no scope set every event is in-window, so nothing is ever carried and this is a no-op.
+ *
+ * Runs AFTER grading, so a carried finding keeps the confidence and severity it was stored with.
+ * Grading grounds findings against the IN-SCOPE events; it would read a deliberately out-of-window
+ * finding as ungrounded and cap it a little further on every narrow run.
+ */
+export function carryOutOfWindowFindings(
+  next: InvestigationState,
+  input: CarryForwardInput,
+): InvestigationState {
+  const { prior, inWindowEvents, markers } = input;
+  const inWindowIds = new Set(inWindowEvents.map((e) => e.id));
+  const alreadyPresent = new Set(next.findings.map((f) => f.id));
+  const backing = supportingEventIds(prior, markers);
+
+  const candidates = prior.findings.filter((f) => {
+    if (alreadyPresent.has(f.id)) return false;
+    if (!isDeterministicFindingId(f.id)) return false;
+    const events = backing.get(f.id);
+    if (!events?.size) return false; // unlinked: nothing proves it is outside the window
+    return [...events].every((id) => !inWindowIds.has(id));
+  });
+  if (candidates.length === 0) return next;
+
+  const carried = applyFalsePositive({ ...prior, findings: candidates }, markers).findings;
+  if (carried.length === 0) return next;
+
+  const relink = new Map<string, string[]>();
+  for (const f of carried) {
+    for (const eid of backing.get(f.id) ?? []) {
+      const arr = relink.get(eid) ?? [];
+      arr.push(f.id);
+      relink.set(eid, arr);
+    }
+  }
+  return {
+    ...next,
+    findings: [...next.findings, ...carried],
+    forensicTimeline: next.forensicTimeline.map((e) => {
+      const add = relink.get(e.id)?.filter((fid) => !e.relatedFindingIds.includes(fid));
+      return add?.length ? { ...e, relatedFindingIds: [...e.relatedFindingIds, ...add] } : e;
+    }),
   };
 }
 

--- a/companion/tests/analysis/synthesizeCharacterisation.test.ts
+++ b/companion/tests/analysis/synthesizeCharacterisation.test.ts
@@ -12,6 +12,7 @@ import { IncidentTypeStore } from "../../src/analysis/incidentTypeStore.js";
 import { MockProvider } from "../../src/providers/provider.js";
 import type { AnalyzeRequest, AnalyzeResult } from "../../src/providers/provider.js";
 import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { projectScope } from "../../src/analysis/scopeProject.js";
 import { emptyState, type ForensicEvent, type InvestigationState } from "../../src/analysis/stateTypes.js";
 
 /**
@@ -348,6 +349,236 @@ describe("synthesize — the delta merge", () => {
     await pipeline.synthesize("c1"); // a real run still happens
     expect(analyze).toHaveBeenCalledTimes(2);
     expect((await stateStore.load("c1")).findings).toHaveLength(1);
+  });
+});
+
+describe("synthesize — narrowing the scope (#751)", () => {
+  // A wider run's deterministic findings used to be DELETED by a narrower one: the run rebuilds its
+  // findings from an empty base, the backfills only see in-window events, and StateStore.save
+  // overwrites the rows. Widening the window again did not bring them back. Scope has to be a lens.
+  const NARROW = { start: "2026-01-01T00:00:00.000Z", end: "2026-12-31T00:00:00.000Z" };
+
+  // Two Critical events far apart in time, neither covered by the model, so the backfill mints one
+  // f-auto finding per event. The 2024 one is what the narrow window later excludes.
+  async function seedTwoBackfilledFindings(): Promise<void> {
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("old", "2024-06-01T00:00:00.000Z", "ransomware note dropped", "Critical"),
+      event("in", "2026-06-01T00:00:00.000Z", "shadow copies deleted", "Critical"),
+    );
+    await stateStore.save(seeded);
+  }
+
+  it("keeps the deterministic findings the new window excludes, and hides them by projection", async () => {
+    await seedTwoBackfilledFindings();
+    const scopeStore = new ScopeStore(caseStore);
+    const { provider } = spyProvider(delta({ findings: [] }));
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      scopeStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    const wide = await pipeline.synthesize("c1");
+    expect(wide.findings.map((f) => f.id).sort()).toEqual(["f-auto-in", "f-auto-old"]);
+
+    await scopeStore.save("c1", NARROW);
+    const narrow = await pipeline.synthesize("c1"); // the scope change re-arms the skip hash
+
+    // Still PERSISTED — the whole point. f-auto-in is re-derived from the window, f-auto-old carried.
+    expect(narrow.findings.map((f) => f.id).sort()).toEqual(["f-auto-in", "f-auto-old"]);
+    // …and its back-link is restored, which is what lets the projection recognise it as out of window.
+    expect(narrow.forensicTimeline.find((e) => e.id === "old")!.relatedFindingIds).toEqual(["f-auto-old"]);
+
+    // HIDDEN, not deleted: every view runs the projection, and widening the window brings it back.
+    expect(projectScope(narrow, NARROW).findings.map((f) => f.id)).toEqual(["f-auto-in"]);
+    expect(
+      projectScope(narrow, { start: null, end: null })
+        .findings.map((f) => f.id)
+        .sort(),
+    ).toEqual(["f-auto-in", "f-auto-old"]);
+  });
+
+  it("still replaces a MODEL finding the new window no longer supports", async () => {
+    // The carry-forward is for the deterministic backfills only. Synthesis replacing its own
+    // conclusions wholesale is the invariant the fold exists to protect, so a model finding backed
+    // only by out-of-window events must still go.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("old", "2024-06-01T00:00:00.000Z", "ancient event", "Medium", {
+        relatedFindingIds: ["f-model"],
+      }),
+      event("in", "2026-06-01T00:00:00.000Z", "in-window event"),
+    );
+    seeded.findings.push({
+      id: "f-model",
+      severity: "High",
+      title: "a previous run's conclusion",
+      description: "",
+      relatedIocs: [],
+      mitreTechniques: [],
+      sourceScreenshots: [],
+      firstSeen: "",
+      lastUpdated: "",
+      status: "open",
+      relatedEventIds: ["old"],
+    });
+    await stateStore.save(seeded);
+
+    const scopeStore = new ScopeStore(caseStore);
+    await scopeStore.save("c1", NARROW);
+    const { provider } = spyProvider(delta());
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      scopeStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    const state = await pipeline.synthesize("c1");
+    expect(state.findings.map((f) => f.id)).toEqual(["f1"]); // f-model dropped, this run's finding stands
+  });
+
+  it("does not bring back a finding whose events the analyst confirmed benign", async () => {
+    // The false-positive filter excludes events too, and its exclusions must stay exclusions. The
+    // carry-forward tests the PRE-false-positive in-window set for exactly this reason.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("fp", "2026-06-01T00:00:00.000Z", "ransomware note dropped", "Critical"),
+      event("keep", "2026-06-02T00:00:00.000Z", "the real lead"),
+    );
+    await stateStore.save(seeded);
+
+    const falsePositiveStore = new FalsePositiveStore(caseStore);
+    const { provider } = spyProvider(delta({ findings: [] }));
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      falsePositiveStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    expect((await pipeline.synthesize("c1")).findings.map((f) => f.id)).toEqual(["f-auto-fp"]);
+
+    await falsePositiveStore.save("c1", [
+      {
+        id: markerId("event", "fp"),
+        kind: "event",
+        ref: "fp",
+        reason: "known-good-tool",
+        note: "",
+        markedAt: "2026-06-03T00:00:00.000Z",
+        markedBy: "analyst",
+      },
+    ]);
+
+    expect((await pipeline.synthesize("c1")).findings).toEqual([]);
+  });
+
+  it("does not carry a finding backed only by events the analyst confirmed benign", async () => {
+    // The false-positive EVENT marker is the case applyFalsePositive does not cover: it matches
+    // finding titles and IOC values, never event ids. Without dropping benign events from the
+    // backing set, an out-of-window finding built entirely on rejected events would survive every
+    // narrow run and reappear the moment the analyst widened the window again.
+    await seedTwoBackfilledFindings();
+    const scopeStore = new ScopeStore(caseStore);
+    const falsePositiveStore = new FalsePositiveStore(caseStore);
+    const { provider } = spyProvider(delta({ findings: [] }));
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      scopeStore,
+      falsePositiveStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    expect((await pipeline.synthesize("c1")).findings.map((f) => f.id).sort()).toEqual([
+      "f-auto-in",
+      "f-auto-old",
+    ]);
+
+    // Reject the 2024 event AND narrow past it, so the window can no longer do the rejecting.
+    await falsePositiveStore.save("c1", [
+      {
+        id: markerId("event", "old"),
+        kind: "event",
+        ref: "old",
+        reason: "known-good-tool",
+        note: "",
+        markedAt: "2026-07-01T00:00:00.000Z",
+        markedBy: "analyst",
+      },
+    ]);
+    await scopeStore.save("c1", NARROW);
+
+    const state = await pipeline.synthesize("c1");
+    expect(state.findings.map((f) => f.id)).toEqual(["f-auto-in"]);
+    expect(state.forensicTimeline.find((e) => e.id === "old")!.relatedFindingIds).toEqual([]);
+  });
+
+  it("carries an out-of-window finding on its remaining support when only SOME of it is benign", async () => {
+    // Same shortTitle, so the backfill groups both events under one finding. Rejecting one event is
+    // not rejecting the finding — the other still backs it, and the link to the rejected event goes.
+    const seeded = emptyState("c1");
+    seeded.forensicTimeline.push(
+      event("old1", "2024-06-01T00:00:00.000Z", "ransomware note dropped", "Critical"),
+      event("old2", "2024-06-02T00:00:00.000Z", "ransomware note dropped", "Critical"),
+      event("in", "2026-06-01T00:00:00.000Z", "the real lead"),
+    );
+    await stateStore.save(seeded);
+
+    const scopeStore = new ScopeStore(caseStore);
+    const falsePositiveStore = new FalsePositiveStore(caseStore);
+    const { provider } = spyProvider(delta({ findings: [] }));
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      scopeStore,
+      falsePositiveStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    expect((await pipeline.synthesize("c1")).findings.map((f) => f.id)).toEqual(["f-auto-old1"]);
+
+    await falsePositiveStore.save("c1", [
+      {
+        id: markerId("event", "old2"),
+        kind: "event",
+        ref: "old2",
+        reason: "known-good-tool",
+        note: "",
+        markedAt: "2026-07-01T00:00:00.000Z",
+        markedBy: "analyst",
+      },
+    ]);
+    await scopeStore.save("c1", NARROW);
+
+    const state = await pipeline.synthesize("c1");
+    expect(state.findings.map((f) => f.id)).toEqual(["f-auto-old1"]);
+    expect(state.forensicTimeline.find((e) => e.id === "old1")!.relatedFindingIds).toEqual(["f-auto-old1"]);
+    expect(state.forensicTimeline.find((e) => e.id === "old2")!.relatedFindingIds).toEqual([]);
+  });
+
+  it("changes nothing when no scope is set", async () => {
+    // With no window every event is in-window, so no prior finding can qualify as out of it. A
+    // re-synthesis that drops a stale deterministic finding must keep dropping it.
+    await seedTwoBackfilledFindings();
+    const { provider } = spyProvider(delta({ findings: [] }));
+    const pipeline = new AnalysisPipeline({
+      provider,
+      stateStore,
+      imageLoader: async () => ({ base64: "A", mimeType: "image/webp" }),
+    });
+
+    await pipeline.synthesize("c1");
+    // Remove the event behind f-auto-old; the finding it backed has to go with it.
+    const live = await stateStore.load("c1");
+    live.forensicTimeline = live.forensicTimeline.filter((e) => e.id !== "old");
+    await stateStore.save(live);
+
+    const state = await pipeline.synthesize("c1", { force: true });
+    expect(state.findings.map((f) => f.id)).toEqual(["f-auto-in"]);
   });
 });
 


### PR DESCRIPTION
Closes #751.

## The bug

Narrowing a case's investigation scope **permanently deleted** the deterministic `f-auto-*`
findings a previous wider run had created. They were not hidden and not recoverable by
widening the scope again — the rows were overwritten in SQLite.

Two facts combined to cause it. `replaceConclusions` builds this run's findings from an
EMPTY base, and the backfills only ever look at events inside the analyst's window. A
finding whose supporting events fell outside the new window could therefore be neither
carried nor re-derived.

On INC-2026-020 that cost twelve auto-findings, including `f-auto-1e10` and `f-auto-1e11`,
across one scope change.

## The fix

`carryOutOfWindowFindings` re-attaches those findings after grading, stored exactly as they
were and with their event back-links restored. `projectScope` and its client mirror already
drop a finding backed only by out-of-window events, so they disappear from every view for as
long as the narrow window is set — and widening the window brings them straight back.

Scope becomes a lens rather than a shredder. Nothing changes about which events get analysed.

### Deliberately narrow

- **Model findings are not carried.** Synthesis replacing its own conclusions is the
  invariant the fold exists to protect. Only `f-auto-*`, `f-gap-*` and `f-waves` are
  preserved — the ids the deterministic backfills mint.
- A finding this run produced wins on an id collision.
- A finding with **any** supporting event in the window is left alone: this run reassessed it.
- Events the analyst confirmed benign back nothing. They are dropped before the window test,
  so a finding left with no other support is still deleted, and a carried finding never gets
  a link back to a rejected event. `applyFalsePositive` cannot do this job — it matches
  finding titles and IOC values, and `kind: "event"` markers never reach it.
- **With no scope set every event is in-window, so nothing is ever carried and this is a
  strict no-op.**

It runs after grading on purpose. Grading grounds findings against the in-scope events, so it
would read a deliberately out-of-window finding as ungrounded and cap its confidence a little
further on every narrow run.

## Rejected directions

- **Widening `eligibleIds` to the whole timeline** — rejected in the issue, and rightly: it
  defeats the purpose of scope, dragging back the IT noise and pre-attack activity the
  analyst deliberately excluded.
- **Mechanism 4 (the lost-update guard omits findings)** — real, but not the cause. The lost
  rows were in the pre-call snapshot, so carrying `latest`-only findings recovers none of
  them, and adding findings to `mergeConcurrentAdditions` would let an older run's conclusions
  accumulate on top of a newer one's.
- **Mechanism 5 (the SQLite writer overwrites by ordinal)** — the storage layer doing what
  `StateStore.save` asked it to.

## Tests

Six in `synthesizeCharacterisation.test.ts`, under `synthesize — narrowing the scope (#751)`:

| Test | Pins |
|---|---|
| keeps the deterministic findings the new window excludes, and hides them by projection | the regression itself, plus the restored back-link and both projection directions |
| still replaces a MODEL finding the new window no longer supports | the replace-conclusions invariant |
| does not bring back a finding whose events the analyst confirmed benign | the pre-FP window set |
| changes nothing when no scope is set | the no-op property |
| does not carry a finding backed only by events the analyst confirmed benign | the event-marker gap |
| carries an out-of-window finding on its remaining support when only SOME of it is benign | partial rejection |

Each was verified to fail with its guard removed.

The existing characterization tests at `tests/analysis/pipeline.test.ts:1241` and `:1321`
still pass unchanged — the finding they assert is dropped is a model finding with no event
links, so neither carry-forward condition applies to it.

## Checks

- `vitest run` — 706 files, 11318 tests, green. One timeout in `caseExportArchive.test.ts`
  under parallel load; it passes in isolation in 4.4s against a 17.1s timed-out run, and
  passed in an earlier full run. Unrelated to this change.
- `typecheck`, `lint`, `format:check` — clean.
- `check:size`, `check:imports`, `check:boundaries` — none new.
