### PR TITLE
feat(import): read Intact's trimmed VolWeb memory and YARA output (closes #776)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,952 of the 1,991 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,954 of the 1,993 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Intact (trimmed VolWeb) import** — `memory_payload.json` and `yarascan_results.jsonl` are read deterministically instead of going to AI log triage; the two overlapping YARA sets dedupe on (offset, rule), memory-resident hits grade Low, a dense many-rule address cluster grades Info, and Intact's per-table row caps are disclosed. (closes #776)
 - **Related Cases** — a new dashboard panel and two routes (`GET /cases/:id/related`, `GET /global/iocs?q=`) that surface the other investigations sharing an indicator with this one. Ranked so a flagged hash outweighs a private address; scoped to the cases your account may already read. Off by default — set `DFIR_CROSS_CASE=on` to enable the routes, then turn the panel on in Settings → Dashboard sections. (closes #679)
 - **Chainsaw runs on raw `.evtx` from inside the Companion** — a sixth built-in tool alongside Hayabusa and the Velociraptor CLI (binary, Sigma rule directory and mapping file in Settings → Tools). The importer already existed; only the runner was missing. (#688)
 - **A parser run is now recorded in the chain of custody** — the tool output's custody entry states the parser's version, the exact arguments, the rule-set hash, the exit code, a stderr tail and the output hash, instead of a bare "companion". (#688)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ All importers are **deterministic (no AI call)**, read the artifact's own timest
 | **Plaso** | `psort` CSV (dynamic + l2tcsv) | — (Info events) |
 | **Sandbox reports** | CAPEv2 `report.json`, Falcon Sandbox summary | Sample verdict + behavioural signatures |
 | **Memory forensics** | Volatility 3 (`-r json`) + Rekall: pslist/pstree, netscan, malfind, cmdline, svcscan | malfind injected code → High (T1055); listings → Info/Low evidence |
+| **Intact (trimmed VolWeb)** | `memory_payload.json` plugin tables + `yarascan_results.jsonl` | Same plugin mapping; memory YARA hits → Low, a dense many-rule cluster → Info; row caps disclosed |
 | **TheHive** | Case / alert JSON export, observable list (TheHive 5) | TheHive severity 1–4; MITRE from ATT&CK-tagged tags |
 | **Email** | `.eml` (RFC 2822), best-effort `.msg` | SPF/DKIM/DMARC fail → sender spoof heuristics (T1566 Phishing) |
 | **Shell history** | `.bash_history` / `.zsh_history` (bash `HISTTIMEFORMAT` `#epoch` + zsh extended history) | Info by default; conservative bump on tradecraft (reverse shell, download-and-exec, cred access, log/history tampering, lateral SSH) |

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -310,6 +310,7 @@
     "iocWhitelist.ts": "analysis/findings",
     "iocWhitelistStore.ts": "analysis/findings",
     "iocsDiff.ts": "analysis/findings",
+    "intactImport.ts": "analysis/ingest",
     "irisImport.ts": "analysis/ingest",
     "jobLedgerStore.ts": "analysis/case",
     "jobLedgerWorker.ts": "analysis/case",

--- a/companion/src/analysis/importDetect.ts
+++ b/companion/src/analysis/importDetect.ts
@@ -8,6 +8,7 @@
 
 import { isObject, getCI, getPath, str, parseConcatenatedJson } from "./siemImport.js";
 import { isRekallCommandList, looksLikeVolatilityText, looksLikeMemprocfsFindevil } from "./memoryImport.js";
+import { isIntactMemoryFile } from "./intactImport.js";
 import { parseCsv } from "./csvImport.js";
 import { looksLikeJournald } from "./journaldImport.js";
 import { looksLikeSysdig } from "./sysdigImport.js";
@@ -393,6 +394,9 @@ function looksLikeTheHive(s: Row, root: unknown): boolean {
 }
 
 function detectJson(root: unknown, sample: Row): ImportKind {
+  // Intact (trimmed VolWeb) — FIRST: its `{plugins:{…},yara:[…]}` wrapper would fall through to the
+  // event-shaped SIEM catch-all, and its YARA rows carry no field any other signature claims (#776).
+  if (isIntactMemoryFile(root, sample)) return "memory";
   if (isVolatilityMap(root)) return "memory";
   if (isSandbox(sample)) return "sandbox";
   if (isAws(sample)) return "aws";

--- a/companion/src/analysis/ingest/platformImports.ts
+++ b/companion/src/analysis/ingest/platformImports.ts
@@ -2,7 +2,7 @@ import { type ExternalImporter } from "../declarativeImporter.js";
 import { parseEmail, type EmailImportOptions } from "../emailImport.js";
 import { parseEvtxXmlProgress } from "../evtxXmlImport.js";
 import { parseIrisCase, type IrisCaseData, type IrisImportOptions } from "../irisImport.js";
-import { parseMemory, type MemoryImportOptions } from "../memoryImport.js";
+import { intactTruncationNote, parseMemoryOrIntact, type MemoryImportOptions } from "../intactImport.js";
 import { deltaSchema } from "../responseSchema.js";
 import { parseSandboxReport, type SandboxImportOptions } from "../sandboxImport.js";
 import { applySeverityFloor } from "../severityFloor.js";
@@ -193,7 +193,7 @@ export async function importMemory(
     onProgress?: (done: number, total: number) => void;
   },
 ): Promise<InvestigationState> {
-  const parsedRaw = parseMemory(text, { ...opts.memory, filename: opts.label });
+  const parsedRaw = parseMemoryOrIntact(text, { ...opts.memory, filename: opts.label });
   const parsed = { ...parsedRaw, events: applySeverityFloor(parsedRaw.events, opts.minSeverity) };
   if (parsed.events.length === 0 && parsed.iocs.length === 0)
     return noteEmptyImport(ctx, caseId, opts, "Memory", parsed.total);
@@ -203,9 +203,12 @@ export async function importMemory(
     findings: [],
     iocs: parsed.iocs.map((c, i) => ({ id: `${opts.idPrefix}i${i + 1}`, type: c.type, value: c.value })),
     mitreTechniques: [],
+    // A parser may mint its OWN id: the Intact adapter derives one from the (Offset, Rule) a YARA hit
+    // matched at, so the same hit arriving in both of Intact's files lands on ONE timeline row
+    // instead of being double-counted (#776). Everyone else leaves it empty and gets numbered here.
     forensicEvents: parsed.events.map((e, i) => ({
       ...e,
-      id: `${opts.idPrefix}e${i + 1}`,
+      id: e.id || `${opts.idPrefix}e${i + 1}`,
       sources: e.sources?.length ? e.sources : [tool],
     })),
     threadsOpened: [],
@@ -214,8 +217,10 @@ export async function importMemory(
       `Memory import (${parsed.format}): ${parsed.kept} event(s) from ${parsed.total} row(s) across ${parsed.tables} plugin(s)` +
       (parsed.injected > 0 ? `, ${parsed.injected} injected-code hit(s)` : "") +
       (parsed.connections > 0 ? `, ${parsed.connections} connection(s)` : "") +
+      (parsed.yaraHits ? `, ${parsed.yaraHits} YARA hit(s)` : "") +
       (parsed.groups > parsed.kept ? `, ${parsed.groups - parsed.kept} group(s) over the cap` : "") +
-      `, ${parsed.iocs.length} IOC(s)`,
+      `, ${parsed.iocs.length} IOC(s)` +
+      (parsed.truncated?.length ? ` — ${intactTruncationNote(parsed.truncated)}` : ""),
     summary: "",
   };
   const delta = deltaSchema.parse(raw);

--- a/companion/src/analysis/intactImport.ts
+++ b/companion/src/analysis/intactImport.ts
@@ -1,0 +1,428 @@
+// Deterministic importer for Intact output — the trimmed VolWeb memory + YARA pair (#776).
+//
+// Intact is a separate program: it runs VolWeb over a RAM image, then COMBINES and TRIMS the result
+// into two files. What reaches the Companion is therefore not raw Volatility output, and the row
+// caps below are Intact's, not Volatility's:
+//
+//   memory_payload.json    { "plugins": { "<fully.qualified.Class>": [rows], … }, "yara": [ … ] }
+//   yarascan_results.jsonl one JSON object per line: { Offset, Rule, Component, Value }
+//
+// Both files used to sniff as "log" — the generic AI fallback — so a 289 KB memory export went into
+// a model prompt instead of the deterministic path, and forcing them through the right importer
+// still parsed ZERO rows. Three separate blockers, none of them a near miss:
+//
+//   1. `isVolatilityPluginMap` requires every top-level value to be an array; `plugins` is an object.
+//   2. The plugin keys are fully qualified (`volatility3.plugins.windows.pstree.PsTree`), and
+//      `VOL_PLUGIN_KEY` is anchored at `^(windows|linux|mac)\.`.
+//   3. The YARA importer parses YARA's TEXT CLI output, whose header line carries a file PATH.
+//      These rows carry an ADDRESS instead — there is no path anywhere in them.
+//
+// This module is a thin ADAPTER, not a second memory importer. It unwraps the container, rewrites
+// the plugin keys into the `os.module` form the existing classifier expects, and hands the result
+// straight to `parseMemory` — the column-fingerprint classifier and every per-category mapper
+// (process tree with parent→child links, malfind → T1055, svcscan, dlllist, …) then do the work
+// unchanged. Only the YARA half is new, because memory-resident YARA hits are graded differently
+// from file-based ones. See yaraImport.ts for the file-based path.
+
+import { boundedAggKey } from "./aggKey.js";
+import { stampSourceArtifactHash } from "./canonicalEvent.js";
+import { parseMemory, type MemoryImportOptions, type MemoryParseResult } from "./memoryImport.js";
+import {
+  aggregateEvents,
+  isObject,
+  maxEventsDefault,
+  oneLine,
+  type MappedEvent,
+  type SiemEvent,
+} from "./siemImport.js";
+import { SEVERITY_RANK, type Severity } from "./stateTypes.js";
+import { YARA_SOURCE } from "./yaraImport.js";
+import { createHash } from "node:crypto";
+
+type Row = Record<string, unknown>;
+
+// Re-exported so a caller can take the memory-import entry point and its options from ONE module:
+// this adapter is what routes and the ingest layer call, not parseMemory directly.
+export type { MemoryImportOptions };
+
+/** Tool tag added to every event this adapter produces, so the trimming is attributable. */
+export const INTACT_SOURCE = "Intact";
+
+/**
+ * Intact's per-table row caps.
+ *
+ * They are properties of INTACT, not of Volatility and not of this importer, and nothing in either
+ * file records them — so they are recorded here. A table that comes back holding exactly the cap
+ * was almost certainly cut short, and a truncated read looks exactly like a clean one: absence in a
+ * capped table proves nothing. Reporting at-or-above the cap over-reports a caveat rather than
+ * hiding one, which is the safe direction. Raise these if Intact's trimming changes.
+ */
+export const INTACT_PLUGIN_ROW_CAP = 250;
+/** Applies to the `yara` array INSIDE memory_payload.json, not to the standalone JSON-Lines file. */
+export const INTACT_YARA_ROW_CAP = 100;
+
+/**
+ * The rule-file guard: a window of address space, and the number of DISTINCT rules inside it that
+ * marks the window as a YARA rule set matching itself rather than a set of independent detections.
+ *
+ * On the sample this was built from, 22 hits landed within 14.6 KiB of one another while tripping
+ * nine different webshell rules — on a Windows image with no web server, with the matched values
+ * being the rule strings themselves. That is a rule file resident in RAM. Eight distinct rules in
+ * 64 KiB is deliberately conservative: it demoted 22 of 256 hits on that sample and left every
+ * scattered hit alone.
+ */
+export const INTACT_RULE_CLUSTER_WINDOW = 64 * 1024;
+export const INTACT_RULE_CLUSTER_RULES = 8;
+
+/** A plugin table (or the YARA array) that came back holding Intact's cap. */
+export interface IntactTruncatedTable {
+  name: string;
+  rows: number;
+}
+
+export interface IntactParseResult extends MemoryParseResult {
+  /** Tables whose read hit Intact's row cap — findings beyond it were never exported. */
+  truncated: IntactTruncatedTable[];
+  /** Distinct (Offset, Rule) YARA hits kept. */
+  yaraHits: number;
+}
+
+// ───────────────────────────── shape recognition ─────────────────────────────
+
+const VOL_MODULE_KEY = /^(windows|linux|mac)\.[a-z]/;
+// The four columns Intact's YARA rows carry. A row with any OTHER key is some other NDJSON feed.
+const YARA_ROW_KEYS = new Set(["offset", "rule", "component", "value"]);
+
+/**
+ * Reduce a fully qualified Volatility 3 plugin id to the `os.module` form the memory importer's
+ * classifier and label logic expect: `volatility3.plugins.windows.pstree.PsTree` → `windows.pstree`.
+ *
+ * The LEAF module wins over the namespace, so a nested plugin
+ * (`…windows.registry.userassist.UserAssist`) becomes `windows.userassist` rather than
+ * `windows.registry` — the label the analyst reads names the plugin that produced the rows.
+ * An already-plain key is returned untouched.
+ */
+export function normalizeVolatilityPluginKey(key: string): string {
+  const parts = key.replace(/^volatility\d*\.plugins\./i, "").split(".");
+  // Drop the trailing class name (`PsTree`, `CmdLine`) — Volatility classes are capitalised.
+  if (parts.length > 1 && /^[A-Z]/.test(parts[parts.length - 1])) parts.pop();
+  if (parts.length < 2) return parts.join(".");
+  return `${parts[0]}.${parts[parts.length - 1]}`;
+}
+
+// The short, analyst-facing table name: the module half of a normalized key.
+function tableLabel(key: string): string {
+  const normalized = normalizeVolatilityPluginKey(key);
+  return normalized.split(".").pop() || normalized;
+}
+
+function isIntactPayload(root: unknown): boolean {
+  if (!isObject(root)) return false;
+  const plugins = root.plugins;
+  if (!isObject(plugins)) return false;
+  const entries = Object.entries(plugins);
+  return (
+    entries.length > 0 &&
+    entries.every(([, v]) => Array.isArray(v)) &&
+    entries.some(([k]) => VOL_MODULE_KEY.test(normalizeVolatilityPluginKey(k)))
+  );
+}
+
+function isIntactYaraRow(sample: unknown): boolean {
+  if (!isObject(sample)) return false;
+  const keys = Object.keys(sample);
+  if (!keys.length || !keys.every((k) => YARA_ROW_KEYS.has(k.toLowerCase()))) return false;
+  return typeof sample.Offset === "number" && typeof sample.Rule === "string" && !!sample.Rule.trim();
+}
+
+/**
+ * Is this an Intact file? Consulted by the unified import detector on the SAME representative record
+ * every other signature sees, and checked FIRST: the payload wrapper would otherwise fall through to
+ * the generic event-shaped catch-all, and the YARA rows carry no field any other importer claims.
+ */
+export function isIntactMemoryFile(root: unknown, sample: Row | null): boolean {
+  return isIntactPayload(root) || isIntactYaraRow(sample);
+}
+
+// ───────────────────────────── container parsing ─────────────────────────────
+
+interface IntactInput {
+  plugins: [string, Row[]][];
+  yara: Row[];
+  format: string;
+}
+
+// Read the two Intact shapes out of raw text. Returns null for anything else, so the caller falls
+// back to the ordinary memory importer.
+function readIntact(text: string): IntactInput | null {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return null;
+
+  if (trimmed[0] === "{" || trimmed[0] === "[") {
+    try {
+      const root: unknown = JSON.parse(trimmed);
+      if (isIntactPayload(root)) {
+        const obj = root as Row;
+        const plugins = Object.entries(obj.plugins as Record<string, unknown[]>).map(
+          ([k, v]) => [k, v.filter(isObject)] as [string, Row[]],
+        );
+        const yara = Array.isArray(obj.yara) ? obj.yara.filter(isObject) : [];
+        return { plugins, yara, format: "intact-volweb" };
+      }
+      // A bare array of YARA rows — the inner set exported on its own.
+      if (Array.isArray(root) && isIntactYaraRow(root.find(isObject))) {
+        return { plugins: [], yara: root.filter(isObject), format: "intact-yara" };
+      }
+      return null;
+    } catch {
+      /* fall through to JSON Lines */
+    }
+  }
+
+  // JSON Lines: one YARA hit per line.
+  const rows: Row[] = [];
+  for (const line of trimmed.split(/\r\n|\r|\n/)) {
+    const l = line.trim();
+    if (!l || l[0] !== "{") continue;
+    try {
+      const o: unknown = JSON.parse(l);
+      if (isObject(o)) rows.push(o);
+    } catch {
+      /* skip an unparseable line rather than the whole file */
+    }
+  }
+  if (!rows.length || !isIntactYaraRow(rows[0])) return null;
+  return { plugins: [], yara: rows, format: "intact-yara" };
+}
+
+// ───────────────────────────── YARA hits in memory ─────────────────────────────
+
+interface YaraHit {
+  offset: number;
+  rule: string;
+  components: string[];
+  value: string;
+}
+
+// Collapse the raw rows on (Offset, Rule). Two rows differing only in `Component` are two STRING
+// matches of one rule at one address — one hit, not two.
+function dedupeYaraRows(rows: readonly Row[]): YaraHit[] {
+  const byPair = new Map<string, YaraHit>();
+  for (const r of rows) {
+    if (!isIntactYaraRow(r)) continue;
+    const offset = r.Offset as number;
+    const rule = (r.Rule as string).trim();
+    const key = `${offset}|${rule.toLowerCase()}`;
+    const component = typeof r.Component === "string" ? r.Component.trim() : "";
+    const value = typeof r.Value === "string" ? r.Value.trim() : "";
+    const existing = byPair.get(key);
+    if (existing) {
+      if (component && !existing.components.includes(component)) existing.components.push(component);
+      if (!existing.value && value) existing.value = value;
+      continue;
+    }
+    byPair.set(key, { offset, rule, components: component ? [component] : [], value });
+  }
+  return [...byPair.values()].sort((a, b) => a.offset - b.offset || a.rule.localeCompare(b.rule));
+}
+
+/**
+ * Mark the hits that sit inside a dense many-rule window.
+ *
+ * `hits` must be sorted by offset. A window is dense when INTACT_RULE_CLUSTER_RULES or more DISTINCT
+ * rules fall within INTACT_RULE_CLUSTER_WINDOW bytes of one another — the signature of a rule file
+ * matching itself. Many hits of ONE rule in a small span is the opposite case (one region a single
+ * signature covers) and is deliberately left alone.
+ */
+function ruleFileClusters(hits: readonly YaraHit[]): Set<number> {
+  const marked = new Set<number>();
+  const rulesInWindow = new Map<string, number>(); // rule -> hits currently inside [i, j)
+  let j = 0; // first hit PAST the window opened at i — monotonic, so this is one linear pass
+  let markedUpTo = 0; // high-water mark, so an overlapping window never re-marks the same hits
+  for (let i = 0; i < hits.length; i++) {
+    while (j < hits.length && hits[j].offset - hits[i].offset <= INTACT_RULE_CLUSTER_WINDOW) {
+      const rule = hits[j].rule.toLowerCase();
+      rulesInWindow.set(rule, (rulesInWindow.get(rule) ?? 0) + 1);
+      j++;
+    }
+    if (rulesInWindow.size >= INTACT_RULE_CLUSTER_RULES) {
+      for (let k = Math.max(i, markedUpTo); k < j; k++) marked.add(k);
+      markedUpTo = Math.max(markedUpTo, j);
+    }
+    const leaving = hits[i].rule.toLowerCase();
+    const left = (rulesInWindow.get(leaving) ?? 0) - 1;
+    if (left > 0) rulesInWindow.set(leaving, left);
+    else rulesInWindow.delete(leaving);
+  }
+  return marked;
+}
+
+// The aggregation key IS the (Offset, Rule) identity, so it is also what the stable event id is
+// minted from — see intactYaraEventId.
+function yaraAggKey(hit: YaraHit): string {
+  return boundedAggKey(`intact-yara|${hit.rule.toLowerCase()}|${hit.offset.toString(16)}`);
+}
+
+/**
+ * A CONTENT-derived event id, so one (Offset, Rule) is one timeline row no matter which file it
+ * arrived in.
+ *
+ * The `yara` array inside memory_payload.json is a strict subset of yarascan_results.jsonl, stripped
+ * of Component and Value — so an analyst importing both files, which is the obvious thing to do,
+ * would otherwise double-count every hit they share. Forensic events dedupe by id at the state
+ * merge, and every other importer numbers its events from a per-import prefix, so a stable id is
+ * what makes the two imports converge. The richer file wins on description simply by being merged
+ * last, exactly as a re-import of any artifact does.
+ */
+function intactYaraEventId(aggKey: string): string {
+  return `iy${createHash("sha256").update(aggKey).digest("hex").slice(0, 16)}`;
+}
+
+/**
+ * Map deduped hits to events.
+ *
+ * Memory-resident YARA hits default to LOW, one tier below the file-based importer's Medium. That
+ * importer's reasoning — a match is a real detection against a NAMED FILE — does not survive the
+ * move to RAM: there is no file, the matched values are frequently the rule strings themselves, and
+ * on the sample this was built from 183 of 263 hits were Linux/Unix or web-server rules firing on a
+ * Windows image with no web server. Low keeps them in the forensic timeline (Info would hide them
+ * from synthesis entirely, which is the wrong answer for a genuine hit) while keeping ~84 unearned
+ * rule names out of the suspicious tier. No IOCs are minted at all: a rule name matched at an
+ * address names no file and no hash.
+ */
+function mapYaraHits(hits: readonly YaraHit[]): MappedEvent[] {
+  const clustered = ruleFileClusters(hits);
+  return hits.map((hit, i) => {
+    const severity: Severity = clustered.has(i) ? "Info" : "Low";
+    const where = `0x${hit.offset.toString(16)}`;
+    const components = hit.components.length ? ` [${hit.components.slice(0, 8).join(", ")}]` : "";
+    const value = hit.value ? ` — ${oneLine(hit.value).slice(0, 120)}` : "";
+    const note = clustered.has(i)
+      ? " (many distinct rules within one small span — a YARA rule set resident in memory, not independent detections)"
+      : "";
+    return {
+      timestamp: "", // a memory scan has no event time — mergeDelta stamps it at import time
+      description: `Intact YARA (memory): ${hit.rule} matched at ${where}${components}${value}${note}`.slice(
+        0,
+        600,
+      ),
+      severity,
+      mitre: [], // a rule NAME is not a technique; the file-based path reads T#### from rule meta, which Intact strips
+      aggKey: yaraAggKey(hit),
+      sources: [YARA_SOURCE, INTACT_SOURCE],
+    };
+  });
+}
+
+// ───────────────────────────── the importer ─────────────────────────────
+
+// Most-severe first, then noisiest, then earliest — the same order eventAggregate applies, so the
+// two halves interleave the way a single aggregated pass would.
+function bySeverityThenCount(a: SiemEvent, b: SiemEvent): number {
+  return (
+    SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity] ||
+    (b.count ?? 1) - (a.count ?? 1) ||
+    (a.timestamp || "~").localeCompare(b.timestamp || "~")
+  );
+}
+
+/**
+ * Parse Intact output. Returns null when the text is not Intact's, so callers can fall through to
+ * the ordinary memory importer.
+ */
+export function parseIntact(text: string, opts: MemoryImportOptions = {}): IntactParseResult | null {
+  const input = readIntact(text);
+  if (!input) return null;
+
+  const truncated: IntactTruncatedTable[] = [];
+
+  // The plugin half: rewrite the keys and hand the whole map to the existing memory importer, which
+  // classifies each table by its columns and maps it. Nothing about those mappers is Intact-specific.
+  const pluginMap: Record<string, Row[]> = {};
+  for (const [key, rows] of input.plugins) {
+    pluginMap[normalizeVolatilityPluginKey(key)] = rows;
+    if (rows.length >= INTACT_PLUGIN_ROW_CAP) truncated.push({ name: tableLabel(key), rows: rows.length });
+  }
+  const plugins: MemoryParseResult = input.plugins.length
+    ? parseMemory(JSON.stringify(pluginMap), opts)
+    : {
+        events: [],
+        iocs: [],
+        total: 0,
+        kept: 0,
+        dropped: 0,
+        groups: 0,
+        tables: 0,
+        injected: 0,
+        processes: 0,
+        connections: 0,
+        format: "empty",
+        tool: "",
+      };
+
+  // The YARA half. Only the array INSIDE the payload is capped — yarascan_results.jsonl carries the
+  // full set (263 hits on the sample, against the inner copy's 100), so it is never reported as cut.
+  if (input.format === "intact-volweb" && input.yara.length >= INTACT_YARA_ROW_CAP)
+    truncated.push({ name: "yara", rows: input.yara.length });
+  const hits = dedupeYaraRows(input.yara);
+  const { events: yaraEvents, groups: yaraGroups } = aggregateEvents(mapYaraHits(hits), {
+    aggregate: opts.aggregate,
+    minSeverity: opts.minSeverity,
+    maxEvents: opts.maxEvents ?? maxEventsDefault(),
+  });
+
+  // Tag the whole import as Intact's, and give each YARA row the stable id that makes the two files
+  // converge on one timeline row per (Offset, Rule).
+  const tagged: SiemEvent[] = [
+    ...plugins.events.map((e) => ({ ...e, sources: [...new Set([...(e.sources ?? []), INTACT_SOURCE])] })),
+    ...yaraEvents.map((e) => ({ ...e, id: intactYaraEventId(e.aggKey ?? "") })),
+  ];
+  // Cap the COMBINED list, not each half: two independent caps would let one import emit twice the
+  // configured maximum. Re-stamp against the ORIGINAL text — the plugin half was parsed from a
+  // rewritten copy, and the artifact hash must point at the file the analyst actually stored.
+  const events = stampSourceArtifactHash(
+    tagged.sort(bySeverityThenCount).slice(0, opts.maxEvents ?? maxEventsDefault()),
+    text,
+  );
+
+  const total = plugins.total + input.yara.length;
+  const represented = events.reduce((n, e) => n + (e.count ?? 1), 0);
+  return {
+    events,
+    iocs: plugins.iocs,
+    total,
+    kept: events.length,
+    dropped: Math.max(0, total - represented),
+    groups: plugins.groups + yaraGroups,
+    tables: plugins.tables,
+    injected: plugins.injected,
+    processes: plugins.processes,
+    connections: plugins.connections,
+    format: input.format,
+    tool: plugins.tool || "Volatility",
+    truncated,
+    yaraHits: hits.length,
+  };
+}
+
+/** The Intact adapter in front of the ordinary memory importer. Pure. */
+export function parseMemoryOrIntact(
+  text: string,
+  opts: MemoryImportOptions = {},
+): MemoryParseResult & Partial<Pick<IntactParseResult, "truncated" | "yaraHits">> {
+  return parseIntact(text, opts) ?? parseMemory(text, opts);
+}
+
+/**
+ * The operator-facing disclosure for a truncated read — the same failure mode, and the same wording
+ * shape, as a Velociraptor artifact that hit its collection row cap (see collectWarnings). A failed
+ * import is loud; a truncated one looks exactly like a clean success, so absence has to be named.
+ */
+export function intactTruncationNote(truncated: readonly IntactTruncatedTable[]): string {
+  if (!truncated.length) return "";
+  return (
+    `${truncated.length} table(s) hit Intact's row cap — ` +
+    `${truncated.map((t) => `${t.name} (${t.rows})`).join("; ")}. Rows BEYOND the cap were never ` +
+    `exported, so absence in these tables is not evidence of absence.`
+  );
+}

--- a/companion/src/routes/import.ts
+++ b/companion/src/routes/import.ts
@@ -18,7 +18,7 @@ import { parseCloudTrail, type AwsImportOptions } from "../analysis/awsImport.js
 import { parseCloudActivity, type CloudActivityImportOptions } from "../analysis/cloudActivityImport.js";
 import { parsePlasoCsv, type PlasoImportOptions } from "../analysis/plasoImport.js";
 import { parseSandboxReport, type SandboxImportOptions } from "../analysis/sandboxImport.js";
-import { parseMemory, type MemoryImportOptions } from "../analysis/memoryImport.js";
+import { parseMemoryOrIntact, type MemoryImportOptions } from "../analysis/intactImport.js";
 import { parseEmail, type EmailImportOptions } from "../analysis/emailImport.js";
 import { parseTheHive } from "../analysis/theHiveImport.js";
 import { parseAuditdLog, type AuditdImportOptions } from "../analysis/auditdImport.js";
@@ -2482,7 +2482,7 @@ export function registerImportRoutes(app: Express, ctx: RouteContext): void {
     };
 
     try {
-      const preview = parseMemory(text, memoryOpts);
+      const preview = parseMemoryOrIntact(text, memoryOpts);
       if (preview.format === "empty" && preview.kept === 0)
         return res.status(400).json({
           error:

--- a/companion/tests/analysis/intactImport.test.ts
+++ b/companion/tests/analysis/intactImport.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from "vitest";
+import {
+  INTACT_PLUGIN_ROW_CAP,
+  INTACT_YARA_ROW_CAP,
+  isIntactMemoryFile,
+  normalizeVolatilityPluginKey,
+  parseIntact,
+  parseMemoryOrIntact,
+} from "../../src/analysis/intactImport.js";
+import { detectImportKind } from "../../src/analysis/importDetect.js";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+//
+// Shapes taken from real Intact output (a VolWeb run trimmed into two files). Plugin keys are the
+// FULLY QUALIFIED Volatility 3 class ids Intact emits, the plugin rows carry no `__children`
+// (Intact flattens the TreeGrid away), and the YARA rows are `{Offset, Rule, Component, Value}`.
+
+function psTreeRows(): object[] {
+  return [
+    {
+      Cmd: "wininit.exe",
+      PID: 684,
+      PPID: 588,
+      Path: "C:\\WINDOWS\\system32\\wininit.exe",
+      Threads: 1,
+      "Offset(V)": 213901691167040,
+      CreateTime: "2026-08-30T15:00:34+00:00",
+      ImageFileName: "wininit.exe",
+    },
+    {
+      Cmd: "services.exe",
+      PID: 832,
+      PPID: 684,
+      Path: "C:\\WINDOWS\\system32\\services.exe",
+      Threads: 8,
+      "Offset(V)": 213901691334784,
+      CreateTime: "2026-08-30T15:00:35+00:00",
+      ImageFileName: "services.exe",
+    },
+    {
+      Cmd: "svchost.exe -k netsvcs",
+      PID: 1944,
+      PPID: 832,
+      Path: "C:\\WINDOWS\\system32\\svchost.exe",
+      Threads: 12,
+      "Offset(V)": 213901691444608,
+      CreateTime: "2026-08-30T15:00:37+00:00",
+      ImageFileName: "svchost.exe",
+    },
+  ];
+}
+
+// Two benign RWX regions from the real sample: Defender's scanning emulator, and an interactive
+// PowerShell console with the .NET JIT loaded.
+function malfindRows(): object[] {
+  return [
+    {
+      PID: 10884,
+      Tag: "VadS",
+      Process: "powershell.exe",
+      "Start VPN": 2178332819456,
+      Protection: "PAGE_EXECUTE_READWRITE",
+      PrivateMemory: 1,
+    },
+    {
+      PID: 10268,
+      Tag: "VadS",
+      Process: "MsMpEng.exe",
+      "Start VPN": 2178563471360,
+      Protection: "PAGE_EXECUTE_READWRITE",
+      PrivateMemory: 1,
+    },
+  ];
+}
+
+function svcRows(n: number): object[] {
+  return Array.from({ length: n }, (_, i) => ({
+    Dll: "-",
+    PID: 2008,
+    Name: `Service${i}`,
+    Order: i,
+    Start: "SERVICE_AUTO_START",
+    State: "SERVICE_RUNNING",
+    Binary: `C:\\Windows\\System32\\svc${i}.exe`,
+    Offset: 2411206176288 + i,
+    Display: `Service ${i}`,
+  }));
+}
+
+function yaraRow(offset: number, rule: string, component = "$s0", value = "b'x'"): object {
+  return { Offset: offset, Rule: rule, Component: component, Value: value };
+}
+
+// Hits far enough apart that the rule-file cluster guard never fires.
+function scatteredYara(): { Offset: number; Rule: string; Component: string; Value: string }[] {
+  return [
+    { Offset: 0x1000_0000, Rule: "Cobalt_Strike_Beacon", Component: "$s1", Value: "b'beacon.dll'" },
+    { Offset: 0x2000_0000, Rule: "Mimikatz_Memory", Component: "$s2", Value: "b'sekurlsa'" },
+  ];
+}
+
+function payload(extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    plugins: {
+      "volatility3.plugins.windows.pstree.PsTree": psTreeRows(),
+      "volatility3.plugins.windows.malfind.Malfind": malfindRows(),
+      "volatility3.plugins.windows.svcscan.SvcScan": svcRows(3),
+      "volatility3.plugins.windows.registry.userassist.UserAssist": [
+        { Name: "N/A", Path: "ntuser.dat\\Software\\Microsoft\\Windows", Type: "Key" },
+      ],
+      ...(extra.plugins as object | undefined),
+    },
+    yara: extra.yara ?? scatteredYara().map((r) => ({ Offset: r.Offset, Rule: r.Rule })),
+  });
+}
+
+function jsonl(rows: object[]): string {
+  return rows.map((r) => JSON.stringify(r)).join("\n");
+}
+
+// ── detection ─────────────────────────────────────────────────────────────────
+
+describe("Intact detection", () => {
+  it("routes the wrapped memory payload to the memory importer, not the AI log fallback", () => {
+    expect(detectImportKind("memory_payload.json", payload())).toBe("memory");
+  });
+
+  it("routes the YARA JSON-Lines file to the memory importer, not the AI log fallback", () => {
+    expect(detectImportKind("yarascan_results.jsonl", jsonl(scatteredYara()))).toBe("memory");
+  });
+
+  it("claims neither a plain Volatility plugin map nor an unrelated NDJSON record", () => {
+    expect(isIntactMemoryFile({ "windows.pslist.PsList": [] }, null)).toBe(false);
+    expect(isIntactMemoryFile({ Offset: 1, Rule: "R", Extra: 2 }, { Offset: 1, Rule: "R", Extra: 2 })).toBe(
+      false,
+    );
+  });
+});
+
+// ── plugin-key normalisation ──────────────────────────────────────────────────
+
+describe("normalizeVolatilityPluginKey", () => {
+  it("reduces a fully qualified class id to the os.module form the classifier expects", () => {
+    expect(normalizeVolatilityPluginKey("volatility3.plugins.windows.pstree.PsTree")).toBe("windows.pstree");
+    expect(normalizeVolatilityPluginKey("volatility3.plugins.windows.malfind.Malfind")).toBe(
+      "windows.malfind",
+    );
+  });
+
+  it("keeps the leaf module of a nested plugin namespace", () => {
+    expect(normalizeVolatilityPluginKey("volatility3.plugins.windows.registry.userassist.UserAssist")).toBe(
+      "windows.userassist",
+    );
+  });
+
+  it("leaves an already-plain key alone", () => {
+    expect(normalizeVolatilityPluginKey("windows.pslist")).toBe("windows.pslist");
+  });
+});
+
+// ── plugin tables ─────────────────────────────────────────────────────────────
+
+describe("Intact plugin tables", () => {
+  it("parses every plugin in the wrapper into its own table", () => {
+    const r = parseIntact(payload(), {});
+    expect(r).not.toBeNull();
+    expect(r!.tables).toBe(4);
+    expect(r!.format).toBe("intact-volweb");
+  });
+
+  it("keeps the process tree's parent to child links", () => {
+    const r = parseIntact(payload(), {})!;
+    const svchost = r.events.find((e) => /pstree.*svchost\.exe/.test(e.description));
+    expect(svchost?.parentName).toBe("services.exe");
+    expect(svchost?.description).toContain("PPID 832");
+  });
+
+  it("tags malfind rows for process injection", () => {
+    const r = parseIntact(payload(), {})!;
+    const malfind = r.events.filter((e) => e.mitreTechniques.includes("T1055"));
+    expect(malfind).toHaveLength(2);
+    expect(r.injected).toBe(2);
+  });
+
+  it("surfaces a benign RWX region without asserting an injection happened", () => {
+    const r = parseIntact(payload(), {})!;
+    const defender = r.events.find((e) => /MsMpEng\.exe/.test(e.description))!;
+    expect(defender.description).toContain("executable/injected private memory");
+    expect(defender.description).toContain("PAGE_EXECUTE_READWRITE");
+    expect(defender.description).not.toMatch(/\binjected code\b|\bconfirmed\b/i);
+  });
+
+  it("marks every event as coming from Intact", () => {
+    const r = parseIntact(payload(), {})!;
+    expect(r.events.every((e) => e.sources?.includes("Intact"))).toBe(true);
+  });
+});
+
+// ── YARA rows ─────────────────────────────────────────────────────────────────
+
+describe("Intact YARA rows", () => {
+  it("parses the JSON-Lines file on its own", () => {
+    const r = parseIntact(jsonl(scatteredYara()), {})!;
+    expect(r.format).toBe("intact-yara");
+    expect(r.yaraHits).toBe(2);
+    expect(r.events).toHaveLength(2);
+  });
+
+  it("grades a memory-resident hit Low, below the file-based YARA default", () => {
+    const r = parseIntact(jsonl(scatteredYara()), {})!;
+    expect(r.events.map((e) => e.severity)).toEqual(["Low", "Low"]);
+  });
+
+  it("carries the matched string component and value into the description", () => {
+    const r = parseIntact(jsonl(scatteredYara()), {})!;
+    const beacon = r.events.find((e) => e.description.includes("Cobalt_Strike_Beacon"))!;
+    expect(beacon.description).toContain("$s1");
+    expect(beacon.description).toContain("beacon.dll");
+    expect(beacon.description).toContain("0x10000000");
+  });
+
+  it("mints no IOCs — a rule name matched in RAM names no file and no hash", () => {
+    const r = parseIntact(jsonl(scatteredYara()), {})!;
+    expect(r.iocs).toEqual([]);
+  });
+
+  it("collapses two string matches of one rule at one offset into a single hit", () => {
+    const rows = [
+      yaraRow(0x1000_0000, "WinX_Shell_html", "$s0", "b'WinX Shell'"),
+      yaraRow(0x1000_0000, "WinX_Shell_html", "$s1", "b'Created by greenwood'"),
+    ];
+    const r = parseIntact(jsonl(rows), {})!;
+    expect(r.yaraHits).toBe(1);
+    expect(r.events).toHaveLength(1);
+  });
+});
+
+// ── the two YARA sets overlap ─────────────────────────────────────────────────
+
+describe("Intact YARA dedupe across the two files", () => {
+  it("mints the same event id for one (Offset, Rule) whichever file it came from", () => {
+    const shared = scatteredYara();
+    const fromPayload = parseIntact(
+      payload({ yara: shared.map((r) => ({ Offset: r.Offset, Rule: r.Rule })) }),
+      {},
+    )!;
+    const fromJsonl = parseIntact(jsonl(shared), {})!;
+    const idsA = fromPayload.events.filter((e) => e.id).map((e) => e.id);
+    const idsB = fromJsonl.events.map((e) => e.id);
+    expect(idsA.length).toBe(2);
+    expect(new Set(idsA)).toEqual(new Set(idsB));
+  });
+
+  it("gives two different (Offset, Rule) pairs two different ids", () => {
+    const r = parseIntact(jsonl(scatteredYara()), {})!;
+    expect(new Set(r.events.map((e) => e.id)).size).toBe(2);
+  });
+
+  it("leaves the plugin events without a stable id, so the import prefix still numbers them", () => {
+    const r = parseIntact(payload({ yara: [] }), {})!;
+    expect(r.events.every((e) => e.id === "")).toBe(true);
+  });
+});
+
+// ── the rule-file cluster guard ───────────────────────────────────────────────
+
+describe("Intact YARA rule-file cluster guard", () => {
+  // A YARA rule set resident in RAM matches ITSELF: many distinct rules inside a few kilobytes.
+  function ruleFileCluster(): object[] {
+    const base = 0x980c_a715_6462;
+    return Array.from({ length: 10 }, (_, i) => yaraRow(base + i * 1400, `WebShell_Rule_${i}`, "$s0"));
+  }
+
+  it("demotes a dense many-rule cluster to Info", () => {
+    const r = parseIntact(jsonl(ruleFileCluster()), {})!;
+    expect(r.events.every((e) => e.severity === "Info")).toBe(true);
+    expect(r.events[0].description).toContain("rule set resident in memory");
+  });
+
+  it("leaves hits scattered across the address space at Low", () => {
+    const spread = Array.from({ length: 10 }, (_, i) => yaraRow(0x1000_0000 + i * 0x100_0000, `Rule_${i}`));
+    const r = parseIntact(jsonl(spread), {})!;
+    expect(r.events.every((e) => e.severity === "Low")).toBe(true);
+  });
+
+  it("leaves many hits of ONE rule in a small span alone — that is one region, not a rule file", () => {
+    const same = Array.from({ length: 10 }, (_, i) => yaraRow(0x1000_0000 + i * 64, "Cobalt_Strike_Beacon"));
+    const r = parseIntact(jsonl(same), {})!;
+    expect(r.events.every((e) => e.severity === "Low")).toBe(true);
+  });
+});
+
+// ── truncation disclosure ─────────────────────────────────────────────────────
+
+describe("Intact row caps", () => {
+  it("names every table that hit Intact's row cap", () => {
+    const r = parseIntact(
+      payload({
+        plugins: { "volatility3.plugins.windows.svcscan.SvcScan": svcRows(INTACT_PLUGIN_ROW_CAP) },
+        yara: Array.from({ length: INTACT_YARA_ROW_CAP }, (_, i) => ({
+          Offset: 0x1000_0000 + i * 0x10_0000,
+          Rule: `Rule_${i}`,
+        })),
+      }),
+      {},
+    )!;
+    expect(r.truncated.map((t) => t.name)).toEqual(["svcscan", "yara"]);
+    expect(r.truncated.map((t) => t.rows)).toEqual([INTACT_PLUGIN_ROW_CAP, INTACT_YARA_ROW_CAP]);
+  });
+
+  it("reports nothing when no table reached the cap", () => {
+    expect(parseIntact(payload(), {})!.truncated).toEqual([]);
+  });
+
+  it("never calls the standalone JSON-Lines file truncated — it carries the full set", () => {
+    const many = Array.from({ length: INTACT_YARA_ROW_CAP * 2 }, (_, i) =>
+      yaraRow(0x1000_0000 + i * 0x10_0000, `Rule_${i}`),
+    );
+    expect(parseIntact(jsonl(many), {})!.truncated).toEqual([]);
+  });
+});
+
+// ── dispatch ──────────────────────────────────────────────────────────────────
+
+describe("parseMemoryOrIntact", () => {
+  it("hands an Intact payload to the Intact path", () => {
+    expect(parseMemoryOrIntact(payload(), {}).format).toBe("intact-volweb");
+  });
+
+  it("leaves a plain Volatility plugin map on the existing path", () => {
+    const plain = JSON.stringify({ "windows.pslist.PsList": psTreeRows() });
+    expect(parseMemoryOrIntact(plain, {}).format).toBe("volatility-map");
+  });
+
+  it("returns null from parseIntact for output that is not Intact's", () => {
+    expect(parseIntact(JSON.stringify({ "windows.pslist.PsList": psTreeRows() }), {})).toBeNull();
+    expect(parseIntact("not json at all", {})).toBeNull();
+  });
+});

--- a/companion/tests/server/intactImportEndToEnd.test.ts
+++ b/companion/tests/server/intactImportEndToEnd.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import type { Express } from "express";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, buildRuntimePipeline } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ImportMetaStore } from "../../src/analysis/importMeta.js";
+import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
+
+// #776 — the two Intact files overlap, and importing both is the obvious thing an analyst does.
+//
+// The `yara` array inside memory_payload.json is a strict SUBSET of yarascan_results.jsonl, stripped
+// of Component and Value. Nothing else in the merge would catch that: forensic events dedupe by ID,
+// every other importer numbers its events from a per-import sequence, and correlation's exact
+// timestamp+description step cannot help either — the JSON-Lines copy of a hit carries the matched
+// string and the payload's copy does not, so the two descriptions differ by construction.
+//
+// What absorbs the overlap is the Intact adapter minting a CONTENT-derived id from (Offset, Rule).
+// This test drives the real HTTP import route for both files and counts the result, so it fails if
+// that id stops being stable, if platformImports goes back to overwriting a parser-supplied id, or
+// if detection stops routing either file to the memory importer.
+
+const SHARED = [
+  { Offset: 0x1000_0000, Rule: "Cobalt_Strike_Beacon" },
+  { Offset: 0x2000_0000, Rule: "Mimikatz_Memory" },
+];
+
+const PAYLOAD = JSON.stringify({
+  plugins: {
+    "volatility3.plugins.windows.pstree.PsTree": [
+      {
+        Cmd: "services.exe",
+        PID: 832,
+        PPID: 684,
+        Path: "C:\\WINDOWS\\system32\\services.exe",
+        "Offset(V)": 213901691334784,
+        CreateTime: "2026-08-30T15:00:35+00:00",
+        ImageFileName: "services.exe",
+      },
+    ],
+  },
+  yara: SHARED,
+});
+
+// The full set: the two hits the payload also carries, plus one it does not — with the matched
+// string and value the payload's copy was stripped of.
+const YARA_JSONL = [
+  { ...SHARED[0], Component: "$s1", Value: "b'beacon.dll'" },
+  { ...SHARED[1], Component: "$s2", Value: "b'sekurlsa'" },
+  { Offset: 0x3000_0000, Rule: "Webshell_Generic", Component: "$s0", Value: "b'eval(' " },
+]
+  .map((r) => JSON.stringify(r))
+  .join("\n");
+
+const FILE_PAYLOAD = { filename: "memory_payload.json", text: PAYLOAD };
+const FILE_YARA = { filename: "yarascan_results.jsonl", text: YARA_JSONL };
+
+async function makeApp() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-intact-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const superTimelineStore = new SuperTimelineStore(store);
+  const importMetaStore = new ImportMetaStore(store);
+  // No-AI pipeline: the Intact import is fully deterministic, so no model call is needed.
+  const pipeline = buildRuntimePipeline({
+    provider: undefined,
+    synthesisProvider: undefined,
+    stateStore,
+    store,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+  const app = createApp(store, { pipeline, stateStore, importMetaStore, superTimelineStore });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, stateStore, importMetaStore };
+}
+
+// Wait for ONE import cycle, identified by the stored filename the 202 returned. import-meta is
+// written after the importer's events have merged into the forensic timeline (see
+// importReimportIdempotence.test.ts for why the audit log is not usable as the signal).
+async function settle(importMetaStore: ImportMetaStore, storedFile: string): Promise<void> {
+  let seen = "(nothing)";
+  await pollFor(
+    () => `import-meta to record the '${storedFile}' import cycle (last saw '${seen}')`,
+    async () => {
+      seen = (await importMetaStore.load("c1")).lastImportFile || "(nothing)";
+      return seen === storedFile ? true : undefined;
+    },
+  );
+  await new Promise((r) => setTimeout(r, 300));
+}
+
+async function startImport(app: Express, file: { filename: string; text: string }): Promise<string> {
+  const res = await request(app).post("/cases/c1/import").send(file);
+  expect(res.status).toBe(202);
+  expect(res.body.kind).toBe("memory"); // not "log" — the AI fallback both files used to land in
+  return res.body.file as string;
+}
+
+async function yaraRows(stateStore: StateStore): Promise<string[]> {
+  const state = await stateStore.load("c1");
+  return state.forensicTimeline
+    .filter((e) => e.description.startsWith("Intact YARA (memory):"))
+    .map((e) => e.description);
+}
+
+describe("#776 — importing both Intact files", () => {
+  it(
+    "keeps one timeline row per (offset, rule) instead of double-counting the shared hits",
+    async () => {
+      const { app, stateStore, importMetaStore } = await makeApp();
+
+      await settle(importMetaStore, await startImport(app, FILE_PAYLOAD));
+      const afterPayload = await yaraRows(stateStore);
+      expect(afterPayload).toHaveLength(2);
+
+      await settle(importMetaStore, await startImport(app, FILE_YARA));
+      const afterBoth = await yaraRows(stateStore);
+
+      // 2 + 3 rows arrived; 2 of them are the same two hits. Three distinct hits remain.
+      expect(afterBoth).toHaveLength(3);
+      // The richer file merged last, so a shared hit now carries the matched string it was missing.
+      expect(afterBoth.find((d) => d.includes("Cobalt_Strike_Beacon"))).toContain("beacon.dll");
+    },
+    POLL_TIMEOUT_MS * 3,
+  );
+});

--- a/mkdocs-docs/reference/importing.md
+++ b/mkdocs-docs/reference/importing.md
@@ -26,7 +26,7 @@ Before importing, you can set a **minimum severity** filter. Events below the fl
 | **EDR / SIEM** | Velociraptor native JSON/JSONL/artifact-map, Velociraptor **upload-only artifacts** (e.g. THOR) — paste the GUI's "Uploaded Files" tab URL to import just the uploaded report, skipping rows entirely; also reads `.csv`/`.txt`/`.log`/`.jsonl` uploads, not just `.json`, SIEM/EDR JSON (Elastic, Splunk, Kibana, winlogbeat), Wazuh JSON, THOR Nextron JSONL, ECAR (EDR Common Activity Record) NDJSON |
 | **Network** | Suricata eve.json, Zeek JSON (combined or per-stream conn/dns/http/ssl/x509/files), Security Onion events |
 | **Firewall / IDS / web logs** | Cisco ASA syslog (Built/Teardown/Deny), Snort/Suricata `alert_fast` IDS alerts, Apache/Nginx/Squid combined access logs, plain syslog (RFC 5424 / RFC 3164, Linux/Unix hosts) |
-| **Memory forensics** | Volatility 3 JSON + default text output, Rekall JSON, MemProcFS timeline CSV, MemProcFS findevil |
+| **Memory forensics** | Volatility 3 JSON + default text output, Rekall JSON, MemProcFS timeline CSV, MemProcFS findevil, Intact (trimmed VolWeb) `memory_payload.json` + `yarascan_results.jsonl` |
 | **Cloud IR** | AWS CloudTrail JSON, M365 Unified Audit Log, Entra ID sign-in/audit logs, GCP Cloud Audit Logs, Azure Activity Log |
 | **Identity provider** | Okta System Log, Google Workspace admin/login audit — severity comes from the event type, not the vendor's own operational grade, so IdP account-takeover tradecraft (MFA/2SV disabled, admin role granted, API token minted, OAuth grant consented, session impersonated, Workspace mail monitor added) grades above Info |
 | **Browser artifacts** | Hindsight JSON or CSV — Chrome/Edge/Brave history, downloads and interpretations. Every row is Info: browser artifacts are evidence, not verdicts, so they land in the super-timeline |
@@ -48,6 +48,27 @@ All of the above except CSV/log/DFIR-IRIS are **fully deterministic — no AI ca
 Deterministic imports also retain a [versioned canonical event envelope](canonical-events.md) with
 structured identities and field-level provenance. This lets graphs and cross-source correlation use
 the source facts rather than parsing the displayed description back into data.
+
+### Intact (trimmed VolWeb output)
+
+Intact runs VolWeb over a RAM image, then combines and trims the result into two files. Drop either
+or both on the **Import** button — both are recognised as memory imports:
+
+- `memory_payload.json` — the Volatility 3 plugin tables (process tree, cmdline, malfind, svcscan,
+  dlllist, mutantscan, userassist, …) plus a stripped copy of the YARA hits.
+- `yarascan_results.jsonl` — one YARA hit per line, with the matched string and value.
+
+Three things are specific to Intact:
+
+- **The two YARA sets overlap.** The copy inside `memory_payload.json` is a subset of the JSON-Lines
+  file. Importing both is the obvious thing to do, so a hit is keyed on the address and the rule name
+  and lands on ONE timeline row either way — it is never counted twice.
+- **Memory YARA hits grade Low**, one tier below a file-based YARA match. A match in RAM names no
+  file, and a rule set loaded into memory matches its own strings. When many DIFFERENT rules fire
+  inside a few kilobytes of one another, that is a rule file rather than a set of detections, and
+  those rows drop to Info with the reason shown in the row.
+- **Intact caps its tables.** A table that came back holding the cap is named in the import note:
+  rows beyond it were never exported, so absence in that table is not evidence of absence.
 
 ## Evidence Drop Folder (Auto-Import Inbox)
 


### PR DESCRIPTION
Closes #776.

Intact runs VolWeb over a RAM image, then combines and trims the result into two files. Both sniffed
as `"log"` — the generic AI fallback — so a 289 KB memory export went into a model prompt, and
forcing either through the memory importer still parsed **zero** rows.

## What the analyst gets

Drop `memory_payload.json` or `yarascan_results.jsonl` (or both) on the **Import** button. Both are
now recognised as memory imports and parsed deterministically — no AI call.

On the real sample the payload yields 9 plugin tables, 1,304 rows, 6 malfind hits, 378 process rows
and 261 IOCs, and the JSON-Lines file yields 256 distinct YARA hits.

## What is new, and why

**The plugin half reuses everything.** `intactImport.ts` is a thin adapter: it unwraps the `plugins`
container and rewrites the fully qualified keys
(`volatility3.plugins.windows.pstree.PsTree` → `windows.pstree`) into the form the existing
classifier expects, then hands the map to `parseMemory`. The process tree with its parent links,
malfind → T1055, svcscan, dlllist and the rest all work unchanged.

**Memory YARA hits grade Low**, one tier below a file-based match. The file-based importer's
reasoning — a match is a real detection against a named file — does not survive the move to RAM.
On the sample, 183 of 263 hits were Linux/Unix or web-server rules firing on a Windows image with no
web server, and the matched values were the rule strings themselves. Low keeps a genuine hit visible
to synthesis; Info would hide it.

**A dense many-rule cluster drops to Info.** When eight or more *distinct* rules fire within 64 KiB,
that is a rule set resident in memory matching itself, not a set of independent detections. The row
says so. It demoted 22 of 256 hits on the sample and left every scattered hit alone. Many hits of
*one* rule in a small span are deliberately untouched — that is one region, not a rule file.

**No IOCs from a memory YARA hit.** A rule name matched at an address names no file and no hash.

**The two YARA sets dedupe.** The `yara` array inside `memory_payload.json` is a strict subset of the
JSON-Lines file, stripped of `Component` and `Value`, so importing both — the obvious thing to do —
would have double-counted 100 hits. A hit now gets a content-derived event id from (offset, rule) and
lands on one timeline row whichever file it arrived in. `importMemory` keeps a parser-supplied id;
every other importer leaves it empty and is numbered from the import prefix exactly as before.

**Intact's row caps are disclosed.** Three plugins came back holding exactly 250 rows and the inner
YARA array exactly 100. Those are caps, so absence in those tables proves nothing. The import note
names them, the way a cut-short Velociraptor artifact is reported. The standalone JSON-Lines file is
never called truncated — it carries the full set.

## Verification

- 29 new unit tests + 1 HTTP end-to-end test that imports both files into a real case and counts the
  result. That test fails with 5 rows instead of 3 if the stable-id seam is removed — checked.
- Full suite green: 714 files, 11,450 tests.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.
- `ARCHITECTURE.md`'s cross-domain counter re-derived **after** merging master, not by adding deltas.

## Known limit

Intact trims `PsTree` to 9 rows whose parents live in the other process tables, so those 9 rows carry
their PPID but no resolved parent *name*. Across the import as a whole 301 of 312 process rows do
resolve one. Reconstructing the trimmed-away parents would mean fabricating tree structure Intact
never exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
