### PR TITLE
fix(import): a one-hit Intact scan imports, and the matched string survives either order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A raw file uploaded to a parser is kept byte-for-byte** as evidence beside the parser's output, and it survives a failed parse. It used to be deleted once parsed. (#688)
 - **One Windows record read by two parsers is one timeline row** — a Hayabusa run and a Chainsaw run over the same EVTX now merge on the record's own identity (channel + EventRecordID + host) and carry both tools as sources, instead of doubling the timeline. Two detections from the *same* parser on one record stay distinct. (#688)
 
+### Fixed
+- **A one-hit Intact YARA scan is no longer dropped** — a `yarascan_results.jsonl` holding exactly one row is a complete JSON object, not JSON Lines, so it fell through to the plain memory importer and produced nothing. (#776)
+- **The matched YARA string survives either import order** — importing the stripped copy inside `memory_payload.json` after the full JSON-Lines file used to wipe the matched string off the row. It now rides in the event's detail field, which a later import can only add to. (#776)
+
 ### Security
 - **A coding-agent run can no longer grow its output buffer without end** — the Claude Code and Codex CLI runners retained every byte of stdout and stderr until the child exited, so a looping agent run over evidence it does not control could exhaust the Node heap. Both streams are now bounded by default: stdout keeps its tail, where the result event is, and stderr keeps both ends, because one reader slices the error message off the front while the kind it is classified as — and so whether the call is retried — can turn on a line printed last. A caller that needs the whole stream asks for it explicitly. (closes #762, closes #763)
 - **A hostile "NSRL export" can no longer suppress evidence** — the table name read out of the analyst-selected RDS SQLite file was interpolated into the hash lookup without escaping its quotes, so a crafted name made every hash look known-good and silently auto-marked every hashed event and IOC in the case a false positive. Identifiers are now escaped. (closes #761)

--- a/companion/src/analysis/intactImport.ts
+++ b/companion/src/analysis/intactImport.ts
@@ -173,6 +173,9 @@ function readIntact(text: string): IntactInput | null {
       if (Array.isArray(root) && isIntactYaraRow(root.find(isObject))) {
         return { plugins: [], yara: root.filter(isObject), format: "intact-yara" };
       }
+      // A JSON-Lines file holding exactly ONE hit is a complete JSON object, so it never reaches the
+      // line loop below. Missing this case dropped the only detection a one-hit scan found.
+      if (isIntactYaraRow(root)) return { plugins: [], yara: [root as Row], format: "intact-yara" };
       return null;
     } catch {
       /* fall through to JSON Lines */
@@ -200,9 +203,15 @@ function readIntact(text: string): IntactInput | null {
 interface YaraHit {
   offset: number;
   rule: string;
-  components: string[];
-  value: string;
+  /** Every string match of this rule at this address — `Component` is what differs between them. */
+  matches: { component: string; value: string }[];
 }
+
+// How many of a hit's string matches are worth carrying, and how long a matched value may be. Both
+// bound a hostile input: `Value` is attacker-influenced memory content, and a rule with hundreds of
+// strings could otherwise make one row unbounded.
+const MAX_MATCHES = 8;
+const MAX_VALUE = 300;
 
 // Collapse the raw rows on (Offset, Rule). Two rows differing only in `Component` are two STRING
 // matches of one rule at one address — one hit, not two.
@@ -214,14 +223,21 @@ function dedupeYaraRows(rows: readonly Row[]): YaraHit[] {
     const rule = (r.Rule as string).trim();
     const key = `${offset}|${rule.toLowerCase()}`;
     const component = typeof r.Component === "string" ? r.Component.trim() : "";
-    const value = typeof r.Value === "string" ? r.Value.trim() : "";
+    const value = typeof r.Value === "string" ? oneLine(r.Value).slice(0, MAX_VALUE) : "";
+    const match = component || value ? [{ component, value }] : [];
     const existing = byPair.get(key);
     if (existing) {
-      if (component && !existing.components.includes(component)) existing.components.push(component);
-      if (!existing.value && value) existing.value = value;
+      // Keep each string match, not just the first: two rows sharing an address and a rule are two
+      // DIFFERENT strings of that rule, and which one matched is the analyst's whole read on the hit.
+      for (const m of match)
+        if (
+          existing.matches.length < MAX_MATCHES &&
+          !existing.matches.some((x) => x.component === m.component && x.value === m.value)
+        )
+          existing.matches.push(m);
       continue;
     }
-    byPair.set(key, { offset, rule, components: component ? [component] : [], value });
+    byPair.set(key, { offset, rule, matches: match });
   }
   return [...byPair.values()].sort((a, b) => a.offset - b.offset || a.rule.localeCompare(b.rule));
 }
@@ -257,6 +273,13 @@ function ruleFileClusters(hits: readonly YaraHit[]): Set<number> {
   return marked;
 }
 
+// The matched strings, rendered once and used for BOTH the description and `message`, so the two can
+// never disagree about what the rule actually hit.
+function matchDetail(hit: YaraHit): string {
+  const parts = hit.matches.map((m) => [m.component, m.value].filter(Boolean).join(" ")).filter(Boolean);
+  return parts.length ? `[${parts.join(" | ")}]` : "";
+}
+
 // The aggregation key IS the (Offset, Rule) identity, so it is also what the stable event id is
 // minted from — see intactYaraEventId.
 function yaraAggKey(hit: YaraHit): string {
@@ -271,8 +294,20 @@ function yaraAggKey(hit: YaraHit): string {
  * of Component and Value — so an analyst importing both files, which is the obvious thing to do,
  * would otherwise double-count every hit they share. Forensic events dedupe by id at the state
  * merge, and every other importer numbers its events from a per-import prefix, so a stable id is
- * what makes the two imports converge. The richer file wins on description simply by being merged
- * last, exactly as a re-import of any artifact does.
+ * what makes the two imports converge.
+ *
+ * WHAT THIS KEY DOES NOT SCOPE: the memory capture. Two Intact runs imported into one case whose
+ * images share a rule at the same virtual address land on ONE row. That cannot be fixed by adding a
+ * capture identity to the key, because the two files share NOTHING that identifies their capture —
+ * no image name, no host, no run id — and the payload's hit set is a strict SUBSET of the JSON-Lines
+ * set, so no fingerprint over the hits is stable across the pair either. Reconciling the pair and
+ * separating two captures are the same key, pulling opposite ways.
+ *
+ * What is done instead is to make the collision HARMLESS. Both rows describe the same rule at the
+ * same address, so the text is identical; `sources` unions at the merge, and the matched strings ride
+ * in `message`, which the merge only ever SETS. Nothing is deleted. Under ASLR two images sharing a
+ * 64-bit virtual address for one rule is already remote; two snapshots of the SAME host sharing one
+ * is plausible, and folding those into one row is the right reading of them anyway.
  */
 function intactYaraEventId(aggKey: string): string {
   return `iy${createHash("sha256").update(aggKey).digest("hex").slice(0, 16)}`;
@@ -295,21 +330,27 @@ function mapYaraHits(hits: readonly YaraHit[]): MappedEvent[] {
   return hits.map((hit, i) => {
     const severity: Severity = clustered.has(i) ? "Info" : "Low";
     const where = `0x${hit.offset.toString(16)}`;
-    const components = hit.components.length ? ` [${hit.components.slice(0, 8).join(", ")}]` : "";
-    const value = hit.value ? ` — ${oneLine(hit.value).slice(0, 120)}` : "";
+    const detail = matchDetail(hit);
     const note = clustered.has(i)
       ? " (many distinct rules within one small span — a YARA rule set resident in memory, not independent detections)"
       : "";
     return {
       timestamp: "", // a memory scan has no event time — mergeDelta stamps it at import time
-      description: `Intact YARA (memory): ${hit.rule} matched at ${where}${components}${value}${note}`.slice(
-        0,
-        600,
-      ),
+      description:
+        `Intact YARA (memory): ${hit.rule} matched at ${where}${detail ? ` ${detail}` : ""}${note}`.slice(
+          0,
+          600,
+        ),
       severity,
       mitre: [], // a rule NAME is not a technique; the file-based path reads T#### from rule meta, which Intact strips
       aggKey: yaraAggKey(hit),
       sources: [YARA_SOURCE, INTACT_SOURCE],
+      // The DURABLE copy of the matched strings. `description` is overwritten unconditionally at the
+      // state merge, so the stripped copy of a hit inside memory_payload.json would delete the detail
+      // from the row if the analyst imported that file second. `message` is only ever SET by an event
+      // that has one, so the detail survives whichever file lands last. It is also what the event
+      // details panel renders, so nothing here is hidden from the analyst.
+      ...(detail ? { message: detail } : {}),
     };
   });
 }

--- a/companion/tests/analysis/intactImport.test.ts
+++ b/companion/tests/analysis/intactImport.test.ts
@@ -224,6 +224,23 @@ describe("Intact YARA rows", () => {
     expect(r.iocs).toEqual([]);
   });
 
+  // A file holding exactly ONE hit is a complete JSON object, not JSON Lines — it parsed as an
+  // object, matched neither the payload wrapper nor an array, and fell through to the ordinary
+  // memory importer, which produced nothing. A one-hit scan is exactly the case that matters most.
+  it("reads a file holding exactly one hit", () => {
+    const r = parseIntact(jsonl([yaraRow(0x1000_0000, "Cobalt_Strike_Beacon", "$s1", "b'beacon.dll'")]), {})!;
+    expect(r).not.toBeNull();
+    expect(r.format).toBe("intact-yara");
+    expect(r.yaraHits).toBe(1);
+    expect(r.events[0].description).toContain("Cobalt_Strike_Beacon");
+  });
+
+  it("still routes that one-hit file through the dispatcher, not the plain memory importer", () => {
+    const one = jsonl([yaraRow(0x1000_0000, "Cobalt_Strike_Beacon")]);
+    expect(detectImportKind("yarascan_results.jsonl", one)).toBe("memory");
+    expect(parseMemoryOrIntact(one, {}).events).toHaveLength(1);
+  });
+
   it("collapses two string matches of one rule at one offset into a single hit", () => {
     const rows = [
       yaraRow(0x1000_0000, "WinX_Shell_html", "$s0", "b'WinX Shell'"),
@@ -249,6 +266,34 @@ describe("Intact YARA dedupe across the two files", () => {
     const idsB = fromJsonl.events.map((e) => e.id);
     expect(idsA.length).toBe(2);
     expect(new Set(idsA)).toEqual(new Set(idsB));
+  });
+
+  // mergeDelta overwrites `description` unconditionally but only sets `message` when the incoming
+  // event HAS one. The matched string therefore has to live in `message` as well, or importing the
+  // stripped payload after the full JSON-Lines file would delete the detail from the case.
+  it("carries the matched detail in `message`, which a later sparse import cannot clear", () => {
+    const rich = parseIntact(jsonl(scatteredYara()), {})!;
+    const beacon = rich.events.find((e) => e.description.includes("Cobalt_Strike_Beacon"))!;
+    expect(beacon.message).toContain("$s1");
+    expect(beacon.message).toContain("beacon.dll");
+
+    const sparse = parseIntact(
+      payload({ yara: scatteredYara().map((r) => ({ Offset: r.Offset, Rule: r.Rule })) }),
+      {},
+    )!;
+    const sparseBeacon = sparse.events.find((e) => e.description.includes("Cobalt_Strike_Beacon"))!;
+    expect(sparseBeacon.id).toBe(beacon.id); // same row…
+    expect(sparseBeacon.message).toBeUndefined(); // …and it carries nothing that could overwrite it
+  });
+
+  it("keeps every string match of one hit in `message`, untruncated", () => {
+    const rows = [
+      yaraRow(0x1000_0000, "WinX_Shell_html", "$s0", "b'WinX Shell'"),
+      yaraRow(0x1000_0000, "WinX_Shell_html", "$s1", "b'Created by greenwood from n57'"),
+    ];
+    const r = parseIntact(jsonl(rows), {})!;
+    expect(r.events[0].message).toContain("WinX Shell");
+    expect(r.events[0].message).toContain("Created by greenwood from n57");
   });
 
   it("gives two different (Offset, Rule) pairs two different ids", () => {

--- a/companion/tests/server/intactImportEndToEnd.test.ts
+++ b/companion/tests/server/intactImportEndToEnd.test.ts
@@ -107,6 +107,13 @@ async function yaraRows(stateStore: StateStore): Promise<string[]> {
     .map((e) => e.description);
 }
 
+// The matched strings as the analyst sees them in the event's details panel.
+async function yaraDetail(stateStore: StateStore, rule: string): Promise<string> {
+  const state = await stateStore.load("c1");
+  const row = state.forensicTimeline.find((e) => e.description.includes(rule));
+  return `${row?.description ?? ""} ${row?.message ?? ""}`;
+}
+
 describe("#776 — importing both Intact files", () => {
   it(
     "keeps one timeline row per (offset, rule) instead of double-counting the shared hits",
@@ -124,6 +131,41 @@ describe("#776 — importing both Intact files", () => {
       expect(afterBoth).toHaveLength(3);
       // The richer file merged last, so a shared hit now carries the matched string it was missing.
       expect(afterBoth.find((d) => d.includes("Cobalt_Strike_Beacon"))).toContain("beacon.dll");
+    },
+    POLL_TIMEOUT_MS * 3,
+  );
+
+  // The reverse order is the one that used to lose evidence: mergeDelta overwrites `description`
+  // unconditionally, so the stripped copy inside memory_payload.json wiped the matched string off a
+  // row the JSON-Lines file had already filled in. The detail rides in `message`, which the merge
+  // only ever sets, so it now survives either order.
+  it(
+    "keeps the matched string when the stripped payload is imported second",
+    async () => {
+      const { app, stateStore, importMetaStore } = await makeApp();
+
+      await settle(importMetaStore, await startImport(app, FILE_YARA));
+      expect(await yaraDetail(stateStore, "Cobalt_Strike_Beacon")).toContain("beacon.dll");
+
+      await settle(importMetaStore, await startImport(app, FILE_PAYLOAD));
+      expect(await yaraRows(stateStore)).toHaveLength(3);
+      expect(await yaraDetail(stateStore, "Cobalt_Strike_Beacon")).toContain("beacon.dll");
+    },
+    POLL_TIMEOUT_MS * 3,
+  );
+
+  // A scan that found ONE thing is a complete JSON object, not JSON Lines. It parsed as an object,
+  // matched no Intact shape, fell through to the ordinary memory importer and produced nothing.
+  it(
+    "imports a scan that found exactly one hit",
+    async () => {
+      const { app, stateStore, importMetaStore } = await makeApp();
+      const single = {
+        filename: "yarascan_results.jsonl",
+        text: JSON.stringify({ ...SHARED[0], Component: "$s1", Value: "b'beacon.dll'" }),
+      };
+      await settle(importMetaStore, await startImport(app, single));
+      expect(await yaraRows(stateStore)).toHaveLength(1);
     },
     POLL_TIMEOUT_MS * 3,
   );


### PR DESCRIPTION
Part of #776 — two ways the Intact importer lost YARA evidence, both found by a Codex review of the
merged commit.

## A scan that found exactly one thing imported nothing

A `yarascan_results.jsonl` holding one row is a complete JSON object, not JSON Lines. It parsed as an
object, matched neither the payload wrapper nor an array, and `parseIntact` returned `null` — so the
dispatcher fell through to the ordinary memory importer, which produced nothing. Detection still
routed the file to `"memory"`, so the analyst saw an accepted import and an empty case.

That is the case where losing the hit costs most.

## The matched string depended on import order

`mergeDelta` overwrites `description` unconditionally, but only *sets* `message` when the incoming
event has one. So importing the stripped copy inside `memory_payload.json` **after** the full
JSON-Lines file wiped `[$s1 b'beacon.dll']` off a row that already carried it.

The detail now rides in `message` as well — which is what the event details panel renders — so it
survives whichever file lands last. Two rows sharing an address and a rule are also kept as two
string matches rather than the first one only: which string matched is the analyst's whole read on a
memory hit.

## The third review point, and why the key does not change

The review also flagged that the stable event id does not scope the memory capture, so two Intact
runs in one case sharing a rule at the same virtual address land on one row.

That cannot be fixed by adding a capture identity to the key. The two files share **nothing** that
identifies their capture — no image name, no host, no run id — and the payload's hit set is a strict
*subset* of the JSON-Lines set, so no fingerprint over the hits is stable across the pair either.
Reconciling the pair and separating two captures are the same key pulling opposite ways.

The collision is made harmless instead: both rows describe the same rule at the same address, so the
text is identical; `sources` unions at the merge; and the matched strings now ride in a field the
merge only ever sets, so nothing is deleted. Under ASLR two images sharing a 64-bit virtual address
for one rule is already remote, and two snapshots of the *same* host sharing one is plausible —
folding those into one row is the right reading of them anyway. The reasoning is written on
`intactYaraEventId` so the next reader does not have to re-derive it.

## Verification

- 4 new unit tests and 2 new HTTP end-to-end tests. Each was confirmed RED first — the reverse-order
  test fails with `expected 'Intact YARA (memory): Cobalt_Strike_B…' to contain 'beacon.dll'` when
  the `message` field is removed.
- Re-checked against the real Intact sample files: unchanged at 9 tables, 256 distinct hits, 100
  shared with the payload, 356 rows collapsing to 256.
- Full suite green: 714 files, 11,456 tests.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
