### PR TITLE
fix(import): recognise a large Intact payload from a server path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **One Windows record read by two parsers is one timeline row** — a Hayabusa run and a Chainsaw run over the same EVTX now merge on the record's own identity (channel + EventRecordID + host) and carry both tools as sources, instead of doubling the timeline. Two detections from the *same* parser on one record stay distinct. (#688)
 
 ### Fixed
+- **A large Intact payload imports from a server path** — `POST /cases/:id/import-file` sniffs a bounded 256 KB head, and a real `memory_payload.json` is bigger than that, so the sample held no complete JSON document, every structural signature was skipped and the route answered 400. The wrapper is now recognised from its prefix. (#776)
 - **A one-hit Intact YARA scan is no longer dropped** — a `yarascan_results.jsonl` holding exactly one row is a complete JSON object, not JSON Lines, so it fell through to the plain memory importer and produced nothing. (#776)
 - **The matched YARA string survives either import order** — importing the stripped copy inside `memory_payload.json` after the full JSON-Lines file used to wipe the matched string off the row. It now rides in the event's detail field, which a later import can only add to. (#776)
 

--- a/companion/src/analysis/importDetect.ts
+++ b/companion/src/analysis/importDetect.ts
@@ -8,7 +8,7 @@
 
 import { isObject, getCI, getPath, str, parseConcatenatedJson } from "./siemImport.js";
 import { isRekallCommandList, looksLikeVolatilityText, looksLikeMemprocfsFindevil } from "./memoryImport.js";
-import { isIntactMemoryFile } from "./intactImport.js";
+import { isIntactMemoryFile, looksLikeIntactPrefix } from "./intactImport.js";
 import { parseCsv } from "./csvImport.js";
 import { looksLikeJournald } from "./journaldImport.js";
 import { looksLikeSysdig } from "./sysdigImport.js";
@@ -645,6 +645,8 @@ export function detectImportKind(filename: string, text: string): ImportKind {
     // Rekall's JSON renderer is a list of [directive, payload] statements (arrays, not objects), so
     // jsonSample finds no representative object — detect it from the root shape first.
     if (isRekallCommandList(root)) return "memory";
+    // Intact's wrapper, read from the PREFIX — a payload bigger than the file-path route's sniff sample has no complete root object to parse (#776).
+    if (looksLikeIntactPrefix(t)) return "memory";
     if (sample) return vrHint(detectJson(root, sample));
     // No representative object — but a Velociraptor-named file is still Velociraptor, so route it to
     // that importer rather than rejecting the whole file. This is what saved DetectRaptor's

--- a/companion/src/analysis/intactImport.ts
+++ b/companion/src/analysis/intactImport.ts
@@ -135,6 +135,35 @@ function isIntactYaraRow(sample: unknown): boolean {
   return typeof sample.Offset === "number" && typeof sample.Rule === "string" && !!sample.Rule.trim();
 }
 
+// How much of a file's head the prefix sniff below reads. Matches the auditd sniff's window, and
+// comfortably clears the 256 KB sample the file-path import route hands the detector.
+const PREFIX_SCAN = 256_000;
+// The wrapper's two halves, matched as TEXT rather than parsed: the `plugins` container, and at
+// least one Volatility plugin id as a key mapping to an array.
+const INTACT_PLUGINS_KEY = /"plugins"\s*:\s*\{/;
+const INTACT_PLUGIN_ENTRY =
+  /"(?:volatility\d*\.plugins\.)?(?:windows|linux|mac)\.[a-z][A-Za-z0-9_.]*"\s*:\s*\[/;
+
+/**
+ * Recognise the payload wrapper from its PREFIX, without parsing it.
+ *
+ * `POST /cases/:id/import-file` sniffs a bounded 256 KB head of the file and never the whole thing —
+ * a Plaso super-timeline cannot be held as one string at all, so a sample-based sniff is the only way
+ * to classify one. A real memory_payload.json is 289 KB, so that sample holds no complete root object,
+ * `jsonSample` returns nothing, and every structural signature — including isIntactMemoryFile — is
+ * skipped. The route answered 400 for the exact file this importer exists to read.
+ *
+ * The two regexes below are deliberately narrow. A plain Volatility plugin map has no `plugins`
+ * wrapper, and a Velociraptor artifact map's keys are capitalised (`Windows.KapeFiles.Targets`), so
+ * neither can trip this. The JSON-Lines half needs nothing here: its first LINE is a complete object,
+ * which jsonSample already samples at any file size.
+ */
+export function looksLikeIntactPrefix(text: string): boolean {
+  const head = (text ?? "").trimStart().slice(0, PREFIX_SCAN);
+  if (head[0] !== "{") return false;
+  return INTACT_PLUGINS_KEY.test(head) && INTACT_PLUGIN_ENTRY.test(head);
+}
+
 /**
  * Is this an Intact file? Consulted by the unified import detector on the SAME representative record
  * every other signature sees, and checked FIRST: the payload wrapper would otherwise fall through to

--- a/companion/tests/analysis/intactImport.test.ts
+++ b/companion/tests/analysis/intactImport.test.ts
@@ -129,6 +129,36 @@ describe("Intact detection", () => {
     expect(detectImportKind("yarascan_results.jsonl", jsonl(scatteredYara()))).toBe("memory");
   });
 
+  // POST /cases/:id/import-file sniffs a bounded 256 KB HEAD of the file, never the whole thing —
+  // a Plaso super-timeline cannot even be held as one string. A real memory_payload.json is 289 KB,
+  // so the sample holds no complete root object, jsonSample returns nothing, and every structural
+  // signature is skipped. The route answered 400 for the very file this importer was written for.
+  it("recognises the wrapper from a truncated head, which is all the file-path route sniffs", () => {
+    const head = payload().slice(0, 120);
+    expect(() => JSON.parse(head)).toThrow(); // no complete root object to parse
+    expect(detectImportKind("memory_payload.json", head)).toBe("memory");
+  });
+
+  // The same case at the route's real bound, so this keeps pinning production behaviour if the
+  // 120-character slice above ever stops being representative.
+  it("recognises a payload larger than the route's own 256 KB sniff sample", () => {
+    const big = payload({
+      plugins: { "volatility3.plugins.windows.svcscan.SvcScan": svcRows(INTACT_PLUGIN_ROW_CAP * 8) },
+    });
+    expect(big.length).toBeGreaterThan(1 << 18);
+    const head = Buffer.from(big, "utf8")
+      .subarray(0, 1 << 18)
+      .toString("utf8"); // exactly what POST /cases/:id/import-file reads
+    expect(detectImportKind("memory_payload.json", head)).toBe("memory");
+  });
+
+  it("does not claim a truncated head that is not Intact's wrapper", () => {
+    const plain = JSON.stringify({ "windows.pslist.PsList": psTreeRows() }).slice(0, 120);
+    expect(detectImportKind("whatever.json", plain)).not.toBe("memory");
+    const wrapped = JSON.stringify({ plugins: { "Windows.KapeFiles.Targets": [{ a: 1 }] } }).slice(0, 60);
+    expect(detectImportKind("velo.json", wrapped)).not.toBe("memory");
+  });
+
   it("claims neither a plain Volatility plugin map nor an unrelated NDJSON record", () => {
     expect(isIntactMemoryFile({ "windows.pslist.PsList": [] }, null)).toBe(false);
     expect(isIntactMemoryFile({ Offset: 1, Rule: "R", Extra: 2 }, { Offset: 1, Rule: "R", Extra: 2 })).toBe(


### PR DESCRIPTION
Part of #776 — the remaining actionable P2 from the Codex review of the merged commit.

## The bug

`POST /cases/:id/import-file` sniffs a bounded **256 KB head** of the file, never the whole thing —
a Plaso super-timeline cannot be held as one string at all, so a sample-based sniff is the only way
to classify one.

A real `memory_payload.json` is **289 KB**. Its sample therefore holds no complete JSON document,
`jsonSample` returns no representative record, and every structural signature is skipped — including
the Intact one. The route answered HTTP 400 for the exact file this importer was written to read.

Verified against the real sample file before changing anything:

```
file bytes: 288861  sample cap: 262144
full text  => memory
256KB head => unknown        ← the bug
```

and after:

```
256KB head => memory
```

## The fix

The wrapper is recognised from its **prefix**, as text, without parsing: the `plugins` container plus
at least one lowercase Volatility plugin id mapping to an array. Both are required, which is what
keeps it off a plain Volatility plugin map (no wrapper) and a Velociraptor artifact map (capitalised
keys) — there are tests for both.

The JSON-Lines half needs nothing here: its first *line* is a complete object, which `jsonSample`
already samples at any file size.

Detection was the whole bug. The route reads the full file once the kind is known, so nothing
downstream changed.

## Scope note

The drop folder is unaffected. Its 8 KB head read classifies binary-versus-text only; it reads the
whole file before detection.

## Verification

- 3 new tests. Two fail without the fix — checked by removing the one-line hook and re-running.
  One of them slices a payload at the route's own `1 << 18` bound rather than an arbitrary prefix,
  so it keeps pinning production behaviour.
- Full suite green: 714 files, 11,459 tests.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.
- `importDetect.ts` lands at 799 lines, under the 800-line cap for unledgered files.

## The other P2 is not actionable

The review also asked for `docs/codemap/{codemap.json,codemap.html,codemap.lock}` to be regenerated.
That requirement comes from `AGENTS.md`, and **no generator exists anywhere in this repo** — it was
filed as #706 and closed as not-planned. The `tests` field in particular is not reproducible from
source, and a wrong code map is worse than a stale one: it reports a module as uncovered when it is
not. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
