### PR TITLE
fix(import): the Intact prefix sniff is a fallback, and it must match one pattern

### DIFF
--- a/companion/src/analysis/importDetect.ts
+++ b/companion/src/analysis/importDetect.ts
@@ -645,9 +645,9 @@ export function detectImportKind(filename: string, text: string): ImportKind {
     // Rekall's JSON renderer is a list of [directive, payload] statements (arrays, not objects), so
     // jsonSample finds no representative object — detect it from the root shape first.
     if (isRekallCommandList(root)) return "memory";
-    // Intact's wrapper, read from the PREFIX — a payload bigger than the file-path route's sniff sample has no complete root object to parse (#776).
-    if (looksLikeIntactPrefix(t)) return "memory";
     if (sample) return vrHint(detectJson(root, sample));
+    // Intact's wrapper by PREFIX — a fallback, so it stays BELOW every structural signature (#776).
+    if (looksLikeIntactPrefix(t)) return "memory";
     // No representative object — but a Velociraptor-named file is still Velociraptor, so route it to
     // that importer rather than rejecting the whole file. This is what saved DetectRaptor's
     // HijackLibsMFT pack (a `{HijackLibInfo:{…}}` NDJSON shape jsonSample could not sample): the auto

--- a/companion/src/analysis/intactImport.ts
+++ b/companion/src/analysis/intactImport.ts
@@ -138,11 +138,14 @@ function isIntactYaraRow(sample: unknown): boolean {
 // How much of a file's head the prefix sniff below reads. Matches the auditd sniff's window, and
 // comfortably clears the 256 KB sample the file-path import route hands the detector.
 const PREFIX_SCAN = 256_000;
-// The wrapper's two halves, matched as TEXT rather than parsed: the `plugins` container, and at
-// least one Volatility plugin id as a key mapping to an array.
-const INTACT_PLUGINS_KEY = /"plugins"\s*:\s*\{/;
-const INTACT_PLUGIN_ENTRY =
-  /"(?:volatility\d*\.plugins\.)?(?:windows|linux|mac)\.[a-z][A-Za-z0-9_.]*"\s*:\s*\[/;
+// The wrapper matched as TEXT rather than parsed: the `plugins` container IMMEDIATELY followed by a
+// Volatility plugin id mapping to an array. It is ONE contiguous pattern on purpose. As two
+// independent searches — a `plugins` object anywhere, an os-dotted key anywhere — it claimed ordinary
+// documents that merely contained both fragments in unrelated places, and a wrongly claimed file goes
+// to the memory importer, finds no Intact payload and imports ZERO events. Only whitespace may
+// separate the two halves, which covers minified and pretty-printed output alike.
+const INTACT_WRAPPER =
+  /"plugins"\s*:\s*\{\s*"(?:volatility\d*\.plugins\.)?(?:windows|linux|mac)\.[a-z][A-Za-z0-9_.]*"\s*:\s*\[/;
 
 /**
  * Recognise the payload wrapper from its PREFIX, without parsing it.
@@ -153,7 +156,12 @@ const INTACT_PLUGIN_ENTRY =
  * `jsonSample` returns nothing, and every structural signature — including isIntactMemoryFile — is
  * skipped. The route answered 400 for the exact file this importer exists to read.
  *
- * The two regexes below are deliberately narrow. A plain Volatility plugin map has no `plugins`
+ * This is a FALLBACK, and the caller must treat it as one: it runs only after the structural
+ * signatures have failed to classify the file, never ahead of them. A text sniff cannot know what a
+ * parsed document is, so letting it outrank a signature that CAN would trade a rare unreadable file
+ * for a common misread one.
+ *
+ * The pattern is deliberately narrow. A plain Volatility plugin map has no `plugins`
  * wrapper, and a Velociraptor artifact map's keys are capitalised (`Windows.KapeFiles.Targets`), so
  * neither can trip this. The JSON-Lines half needs nothing here: its first LINE is a complete object,
  * which jsonSample already samples at any file size.
@@ -161,7 +169,7 @@ const INTACT_PLUGIN_ENTRY =
 export function looksLikeIntactPrefix(text: string): boolean {
   const head = (text ?? "").trimStart().slice(0, PREFIX_SCAN);
   if (head[0] !== "{") return false;
-  return INTACT_PLUGINS_KEY.test(head) && INTACT_PLUGIN_ENTRY.test(head);
+  return INTACT_WRAPPER.test(head);
 }
 
 /**

--- a/companion/tests/analysis/intactImport.test.ts
+++ b/companion/tests/analysis/intactImport.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  looksLikeIntactPrefix,
   INTACT_PLUGIN_ROW_CAP,
   INTACT_YARA_ROW_CAP,
   isIntactMemoryFile,
@@ -150,6 +151,36 @@ describe("Intact detection", () => {
       .subarray(0, 1 << 18)
       .toString("utf8"); // exactly what POST /cases/:id/import-file reads
     expect(detectImportKind("memory_payload.json", head)).toBe("memory");
+  });
+
+  // The prefix sniff is a FALLBACK for a file too big to parse, and it must never outrank a file the
+  // structural signatures can classify properly. Two loose fragments — a `plugins` object of any
+  // shape, and an os-dotted key anywhere else in the document — used to be enough to claim a file
+  // that parses perfectly well. Claiming it routes it to the memory importer, which finds no Intact
+  // payload and emits ZERO events: the whole file is accepted and silently dropped.
+  it("leaves a parseable file alone even when it carries both fragments in unrelated places", () => {
+    const siem = JSON.stringify({
+      "@timestamp": "2026-09-01T10:00:00Z",
+      message: "sysmon agent started",
+      host: { name: "srv1" },
+      plugins: { sysmon: "enabled", winlogbeat: "enabled" },
+      "windows.eventlog": ["Security", "System"],
+    });
+    expect(detectImportKind("agent.json", siem)).toBe("siem");
+
+    const sandbox = JSON.stringify({
+      info: { id: 1 },
+      signatures: [{ name: "x" }],
+      plugins: { processing: ["static"] },
+      "linux.behaviour": [{ call: "open" }],
+    });
+    expect(detectImportKind("report.json", sandbox)).toBe("sandbox");
+  });
+
+  it("requires the plugin id to sit INSIDE the plugins object, not merely somewhere in the file", () => {
+    const split = `{"plugins":{"sysmon":"on"},"note":"windows.pslist":[]}`;
+    expect(looksLikeIntactPrefix(split)).toBe(false);
+    expect(looksLikeIntactPrefix(payload())).toBe(true);
   });
 
   it("does not claim a truncated head that is not Intact's wrapper", () => {


### PR DESCRIPTION
Part of #776. Fixes a defect in #782, found by the Codex stop-time review.

## The defect

The prefix sniff could claim a file the structural signatures read perfectly well. A wrongly claimed
file imports **nothing**: it goes to the memory importer, finds no Intact payload, and emits zero
events. The whole file is accepted and silently dropped.

Reproduced on ordinary documents before changing anything:

```
decoy         => memory     ← a SIEM record; should be siem
sandbox decoy => memory     ← a sandbox report; should be sandbox
```

## Two causes

**It searched for two fragments independently.** A `plugins` object anywhere in the head, and an
os-dotted key anywhere else. Ordinary documents carry both — a SIEM record with
`plugins: { sysmon: "enabled" }` and a `"windows.eventlog"` field, or a sandbox report with
`plugins: { processing: [...] }` and a `"linux.behaviour"` array.

It is now one contiguous pattern: the `plugins` container immediately followed by a Volatility plugin
id, whitespace only in between. That covers minified and pretty-printed output alike, and no
coincidental pairing can reach it.

**It ran before the structural signatures**, so it outranked every check that had actually parsed a
record. A text sniff cannot know what a parsed document is. It now runs last in the JSON branch,
reached only when `jsonSample` found no representative record — which is exactly the case it was
written for, and the only one it can speak to. The function's doc comment says so, so a future editor
does not move it back up.

## Verification

```
decoy         => siem
sandbox decoy => sandbox
memory_payload.json, 256 KB head => memory   (unchanged; 288861 bytes)
```

- 2 new tests, both RED before the fix.
- Real sample files re-checked end to end: 9 tables, 6 malfind hits, 256 distinct YARA hits, 356 rows
  collapsing to 256 — all unchanged.
- Full suite green: 714 files, 11,461 tests.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.
- `importDetect.ts` back to 799 lines, under the 800-line cap.

No CHANGELOG entry: #782 has not shipped, so this corrects an unreleased bullet rather than changing
released behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
