### PR TITLE
fix(import): the Intact prefix sniff runs ahead of the structural checks again

### DIFF
--- a/companion/src/analysis/importDetect.ts
+++ b/companion/src/analysis/importDetect.ts
@@ -645,9 +645,9 @@ export function detectImportKind(filename: string, text: string): ImportKind {
     // Rekall's JSON renderer is a list of [directive, payload] statements (arrays, not objects), so
     // jsonSample finds no representative object — detect it from the root shape first.
     if (isRekallCommandList(root)) return "memory";
-    if (sample) return vrHint(detectJson(root, sample));
-    // Intact's wrapper by PREFIX — a fallback, so it stays BELOW every structural signature (#776).
+    // Intact's wrapper by PREFIX — ABOVE the structural checks, which a truncated payload defeats; its pattern is exact enough to claim nothing else (#776).
     if (looksLikeIntactPrefix(t)) return "memory";
+    if (sample) return vrHint(detectJson(root, sample));
     // No representative object — but a Velociraptor-named file is still Velociraptor, so route it to
     // that importer rather than rejecting the whole file. This is what saved DetectRaptor's
     // HijackLibsMFT pack (a `{HijackLibInfo:{…}}` NDJSON shape jsonSample could not sample): the auto

--- a/companion/src/analysis/intactImport.ts
+++ b/companion/src/analysis/intactImport.ts
@@ -156,10 +156,19 @@ const INTACT_WRAPPER =
  * `jsonSample` returns nothing, and every structural signature — including isIntactMemoryFile — is
  * skipped. The route answered 400 for the exact file this importer exists to read.
  *
- * This is a FALLBACK, and the caller must treat it as one: it runs only after the structural
- * signatures have failed to classify the file, never ahead of them. A text sniff cannot know what a
- * parsed document is, so letting it outrank a signature that CAN would trade a rare unreadable file
- * for a common misread one.
+ * WHERE THIS RUNS, AND WHY. It sits ABOVE the structural signatures in the JSON branch, and both
+ * halves of that decision were learned the hard way — moving it either way breaks a real file.
+ *
+ * Below them it misses valid payloads. Truncation does not always leave jsonSample empty: cut a
+ * row-per-line serialisation mid-file and it finds one complete ROW on a line. A `{Name, Offset}`
+ * mutantscan row matches no Volatility column fingerprint, so the structural path returns the SIEM
+ * catch-all and a check placed after it never runs.
+ *
+ * Above them it is only safe because the PATTERN is exact, never because of the position. It matched
+ * two fragments INDEPENDENTLY once — a `plugins` object anywhere, an os-dotted key anywhere — and
+ * claimed ordinary SIEM and sandbox documents that carried both in unrelated places. A wrongly
+ * claimed file imports ZERO events, so that is the expensive direction. Keep the pattern contiguous
+ * and the position stays earned; loosen it and this has to move.
  *
  * The pattern is deliberately narrow. A plain Volatility plugin map has no `plugins`
  * wrapper, and a Velociraptor artifact map's keys are capitalised (`Windows.KapeFiles.Targets`), so

--- a/companion/tests/analysis/intactImport.test.ts
+++ b/companion/tests/analysis/intactImport.test.ts
@@ -183,6 +183,31 @@ describe("Intact detection", () => {
     expect(looksLikeIntactPrefix(payload())).toBe(true);
   });
 
+  // The two constraints this sniff has to satisfy AT ONCE, so neither can be traded for the other.
+  //
+  // A truncated payload can still yield a sample: cut a row-per-line serialisation mid-file and
+  // jsonSample finds one complete row on a line. A `{Name, Offset}` mutantscan row matches no
+  // Volatility column fingerprint, so the structural path lands on the SIEM catch-all — and a sniff
+  // placed BELOW that path never gets to correct it. Hence the sniff runs ahead of the structural
+  // checks. What makes that safe is the PATTERN, not the position: it matches `plugins` immediately
+  // followed by a Volatility plugin id, which nothing but Intact's wrapper has.
+  it("claims a truncated payload whichever way it was serialised", () => {
+    const rows = Array.from({ length: 4000 }, (_, i) => ({ Name: `Mutant_${i}`, Offset: 60559664 + i }));
+    const body = { plugins: { "volatility3.plugins.windows.mutantscan.MutantScan": rows } };
+    const cut = (text: string): string =>
+      Buffer.from(text, "utf8")
+        .subarray(0, 1 << 18)
+        .toString("utf8");
+
+    expect(detectImportKind("memory_payload.json", cut(JSON.stringify(body)))).toBe("memory");
+    expect(detectImportKind("memory_payload.json", cut(JSON.stringify(body, null, 2)))).toBe("memory");
+    // Row-per-line: jsonSample DOES find a sample here, and it is not a recognisable Volatility row.
+    const perRow =
+      '{\n "plugins": {\n  "volatility3.plugins.windows.mutantscan.MutantScan": [\n' +
+      rows.map((r) => `   ${JSON.stringify(r)}`).join(",\n");
+    expect(detectImportKind("memory_payload.json", cut(perRow))).toBe("memory");
+  });
+
   it("does not claim a truncated head that is not Intact's wrapper", () => {
     const plain = JSON.stringify({ "windows.pslist.PsList": psTreeRows() }).slice(0, 120);
     expect(detectImportKind("whatever.json", plain)).not.toBe("memory");


### PR DESCRIPTION
Part of #776. Fixes a defect in #783, found by the Codex stop-time review.

## What #783 got wrong

#783 moved the prefix sniff below the structural signatures, reasoning that a text sniff must never
outrank a check that parsed a real record. True in general, wrong here: **truncation does not always
leave `jsonSample` empty.**

Cut a row-per-line serialisation of `memory_payload.json` at the import-file route's 256 KB bound and
`jsonSample` finds one complete *row* on a line. A `{Name, Offset}` mutantscan row matches no
Volatility column fingerprint, so the structural path lands on the SIEM catch-all — and a sniff placed
after it never gets to correct that.

Measured before changing anything:

```
minified,     truncated => memory
pretty 2-space, truncated => memory
row-per-line, truncated => siem      ← a valid Intact payload, misrouted
```

## The fix

The sniff runs ahead of the structural checks again. What makes that safe is the **pattern**, not the
position — and the pattern is the part #783 actually fixed: one contiguous match of `plugins`
immediately followed by a Volatility plugin id.

The defect #783 was written for was two *independent* fragment searches claiming ordinary documents
that carried both fragments in unrelated places. Those documents still classify correctly here, and
their tests now sit beside the truncation test, so neither constraint can be traded for the other:

```
decoy (SIEM record)        => siem
decoy (sandbox report)     => sandbox
all three truncations      => memory
memory_payload.json (289 KB), 256 KB head => memory
```

Both directions of the trade-off are written on `looksLikeIntactPrefix`, naming the file each one
breaks, so the next reader does not rediscover them by shipping a regression.

## Verification

- 1 new test covering all three serialisations; RED before the fix (`expected 'siem' to be 'memory'`).
- The #783 decoy tests still pass unchanged — that pairing is the actual regression guard.
- Real sample files re-checked end to end; unchanged.
- Full suite green: 714 files, 11,462 tests.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.
- `importDetect.ts` stays at 799 lines, under the 800-line cap.

No CHANGELOG entry: neither #782 nor #783 has shipped, so this corrects unreleased work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
