### PR TITLE
fix(import): scope the Intact prefix sniff to the one input it can answer

### DIFF
--- a/companion/src/analysis/intactImport.ts
+++ b/companion/src/analysis/intactImport.ts
@@ -124,7 +124,12 @@ function isIntactPayload(root: unknown): boolean {
   return (
     entries.length > 0 &&
     entries.every(([, v]) => Array.isArray(v)) &&
-    entries.some(([k]) => VOL_MODULE_KEY.test(normalizeVolatilityPluginKey(k)))
+    // A Volatility-keyed entry holding ROW OBJECTS. The row check is the part that separates this
+    // from an ordinary config whose `plugins` map is keyed by platform — `{"windows.eventlog":
+    // ["Security"]}` clears every other condition here, and claiming it imports zero events.
+    entries.some(
+      ([k, v]) => VOL_MODULE_KEY.test(normalizeVolatilityPluginKey(k)) && (v as unknown[]).some(isObject),
+    )
   );
 }
 
@@ -145,7 +150,7 @@ const PREFIX_SCAN = 256_000;
 // to the memory importer, finds no Intact payload and imports ZERO events. Only whitespace may
 // separate the two halves, which covers minified and pretty-printed output alike.
 const INTACT_WRAPPER =
-  /"plugins"\s*:\s*\{\s*"(?:volatility\d*\.plugins\.)?(?:windows|linux|mac)\.[a-z][A-Za-z0-9_.]*"\s*:\s*\[/;
+  /^\{\s*"plugins"\s*:\s*\{\s*"(?:volatility\d*\.plugins\.)?(?:windows|linux|mac)\.[a-z][A-Za-z0-9_.]*"\s*:\s*\[/;
 
 /**
  * Recognise the payload wrapper from its PREFIX, without parsing it.
@@ -156,29 +161,39 @@ const INTACT_WRAPPER =
  * `jsonSample` returns nothing, and every structural signature — including isIntactMemoryFile — is
  * skipped. The route answered 400 for the exact file this importer exists to read.
  *
- * WHERE THIS RUNS, AND WHY. It sits ABOVE the structural signatures in the JSON branch, and both
- * halves of that decision were learned the hard way — moving it either way breaks a real file.
+ * WHAT THIS IS ALLOWED TO ANSWER. Exactly one input: a document CUT SHORT before its root object
+ * closed. Two conditions enforce that, and the scope — not the call order — is what makes it safe.
  *
- * Below them it misses valid payloads. Truncation does not always leave jsonSample empty: cut a
- * row-per-line serialisation mid-file and it finds one complete ROW on a line. A `{Name, Offset}`
- * mutantscan row matches no Volatility column fingerprint, so the structural path returns the SIEM
- * catch-all and a check placed after it never runs.
+ * It must match at the START of the document, not anywhere inside it. As a substring hunt over the
+ * head it claimed ordinary files that merely mention a plugin map: a SIEM agent-config event whose
+ * `plugins` are keyed by platform, an NDJSON stream with one such record in it. A wrongly claimed
+ * file goes to the memory importer, finds no Intact payload and imports ZERO events.
  *
- * Above them it is only safe because the PATTERN is exact, never because of the position. It matched
- * two fragments INDEPENDENTLY once — a `plugins` object anywhere, an os-dotted key anywhere — and
- * claimed ordinary SIEM and sandbox documents that carried both in unrelated places. A wrongly
- * claimed file imports ZERO events, so that is the expensive direction. Keep the pattern contiguous
- * and the position stays earned; loosen it and this has to move.
+ * And the document must NOT parse. If it parses, the structural signatures read a real record and
+ * answer correctly — a complete Intact payload included, via isIntactMemoryFile — so a text guess
+ * has nothing to add and everything to break.
  *
- * The pattern is deliberately narrow. A plain Volatility plugin map has no `plugins`
+ * Under those two conditions the call order stops mattering for safety, and it is placed ahead of the
+ * structural signatures for a reason of its own: truncation does not always leave jsonSample empty.
+ * Cut a row-per-line serialisation mid-file and it finds one complete ROW on a line; a
+ * `{Name, Offset}` mutantscan row matches no Volatility column fingerprint, so the structural path
+ * returns the SIEM catch-all and a check placed after it never runs.
+ *
+ * What is left is a truncated document whose first bytes are the wrapper's, which is Intact's own
+ * shape. The pattern is otherwise deliberately narrow. A plain Volatility plugin map has no `plugins`
  * wrapper, and a Velociraptor artifact map's keys are capitalised (`Windows.KapeFiles.Targets`), so
  * neither can trip this. The JSON-Lines half needs nothing here: its first LINE is a complete object,
  * which jsonSample already samples at any file size.
  */
 export function looksLikeIntactPrefix(text: string): boolean {
-  const head = (text ?? "").trimStart().slice(0, PREFIX_SCAN);
-  if (head[0] !== "{") return false;
-  return INTACT_WRAPPER.test(head);
+  if (!INTACT_WRAPPER.test((text ?? "").trimStart().slice(0, PREFIX_SCAN))) return false;
+  // Cheap regex first, parse second: only a document already shaped like the wrapper pays for this.
+  try {
+    JSON.parse(text);
+    return false; // it parses — the structural signatures have the real answer, including for Intact
+  } catch {
+    return true; // cut short before its root object closed: the one input this sniff speaks for
+  }
 }
 
 /**

--- a/companion/tests/analysis/intactImport.test.ts
+++ b/companion/tests/analysis/intactImport.test.ts
@@ -177,10 +177,13 @@ describe("Intact detection", () => {
     expect(detectImportKind("report.json", sandbox)).toBe("sandbox");
   });
 
-  it("requires the plugin id to sit INSIDE the plugins object, not merely somewhere in the file", () => {
+  it("requires the plugin id to open the document, not merely appear somewhere in it", () => {
     const split = `{"plugins":{"sysmon":"on"},"note":"windows.pslist":[]}`;
     expect(looksLikeIntactPrefix(split)).toBe(false);
-    expect(looksLikeIntactPrefix(payload())).toBe(true);
+    // Cut short: the one input the sniff answers for.
+    expect(looksLikeIntactPrefix(payload().slice(0, 120))).toBe(true);
+    // Complete: the structural signatures read the real record, so the sniff stands down.
+    expect(looksLikeIntactPrefix(payload())).toBe(false);
   });
 
   // The two constraints this sniff has to satisfy AT ONCE, so neither can be traded for the other.
@@ -206,6 +209,38 @@ describe("Intact detection", () => {
       '{\n "plugins": {\n  "volatility3.plugins.windows.mutantscan.MutantScan": [\n' +
       rows.map((r) => `   ${JSON.stringify(r)}`).join(",\n");
     expect(detectImportKind("memory_payload.json", cut(perRow))).toBe("memory");
+  });
+
+  // The sniff speaks for ONE input: a document cut short before its root object closed. It has no
+  // standing on a document that parses — the structural signatures read the real record there, and
+  // they classify a COMPLETE Intact payload correctly on their own. Treating it as a substring hunt
+  // over 256 KB instead claimed ordinary files that merely mention a plugin map.
+  it("leaves a parseable document alone even when it opens with the wrapper's own shape", () => {
+    const agent = JSON.stringify({
+      "@timestamp": "2026-09-01T10:00:00Z",
+      message: "agent configuration loaded",
+      plugins: { "windows.eventlog": ["Security", "System"], "linux.audit": ["auditd"] },
+    });
+    expect(detectImportKind("agent.json", agent)).toBe("siem");
+
+    // Even with the plugin map FIRST, which is the wrapper's own opening.
+    const pluginsFirst = JSON.stringify({
+      plugins: { "windows.eventlog": ["Security"] },
+      "@timestamp": "2026-09-01T10:00:00Z",
+      message: "agent configuration loaded",
+    });
+    expect(detectImportKind("agent.json", pluginsFirst)).toBe("siem");
+  });
+
+  it("leaves an NDJSON stream alone when one record happens to carry a plugin map", () => {
+    const stream = [
+      { "@timestamp": "2026-09-01T10:00:00Z", message: "boot", host: { name: "srv1" } },
+      { "@timestamp": "2026-09-01T10:00:01Z", message: "cfg", plugins: { "windows.eventlog": ["Security"] } },
+      { "@timestamp": "2026-09-01T10:00:02Z", message: "login", host: { name: "srv1" } },
+    ]
+      .map((r) => JSON.stringify(r))
+      .join("\n");
+    expect(detectImportKind("events.jsonl", stream)).toBe("siem");
   });
 
   it("does not claim a truncated head that is not Intact's wrapper", () => {


### PR DESCRIPTION
Part of #776. Fixes a defect in #784, found by the Codex stop-time review. Third and final correction
to the prefix sniff — this time on the axis that actually mattered.

## The defect

The sniff was a substring hunt over 256 KB of head, so it claimed ordinary files that merely mention
a plugin map:

```
agent config      => memory   (should be siem)
ndjson with a hit => memory   (should be siem)
```

A SIEM agent-config event whose `plugins` are keyed by platform, and an NDJSON stream with one such
record anywhere in it. Both go to the memory importer, find no Intact payload, and import **zero
events**.

## What three rounds of review were really pointing at

#783 said the check was too early; #784 said it was too late. The position was never the variable.
The sniff answers exactly one question — *is this a document cut short before its root object
closed?* — and it now says so in two conditions:

- it must match at the **start** of the document, not anywhere inside it;
- the document must **not parse**, because a document that parses is answered correctly by the
  structural signatures, a complete Intact payload included.

Under those conditions the call order stops mattering for safety, so it stays where #784 put it —
ahead of the structural signatures, for a reason of its own: truncation does not always leave
`jsonSample` empty, and a row-per-line truncation yields a mutantscan row that no Volatility
fingerprint recognises.

`isIntactPayload` was loose in the same way and is tightened with it: a Volatility-keyed entry must
hold **row objects**. `{"plugins":{"windows.eventlog":["Security"]}}` cleared every other condition,
which is how a parseable agent config reached the importer even with the sniff standing down.

## Verified together, since no single position passes them all

```
decoy (SIEM record)        => siem       (#783)
decoy (sandbox report)     => sandbox    (#783)
agent config               => siem       (new)
ndjson with a hit          => siem       (new)
minified,       truncated  => memory     (#784)
pretty 2-space, truncated  => memory     (#784)
row-per-line,   truncated  => memory     (#784)
memory_payload.json, 256 KB head => memory
```

Real sample files unchanged end to end: 9 tables, 1,404 rows, 6 malfind hits, 378 process rows,
261 IOCs, 256 distinct YARA hits, 356 rows collapsing to 256.

## Test run

- 2 new tests, both RED before the fix. One existing test's expectation was corrected: a *complete*
  payload must now return false from the sniff, because the structural path owns that case.
- Full suite: 11,463 of 11,464 passed. The one failure is
  `siemImport.test.ts > costs LINEAR time in the input, not quadratic` — a wall-clock ratio assertion
  (`10.45` against a limit of `8`) that flakes under suite contention. It passes in isolation in
  1.07 s, and this branch does not touch `siemImport.ts`.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.

No CHANGELOG entry: #782–#784 have not shipped, so this corrects unreleased work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
