### PR TITLE
fix(memory): print what the malfind key discriminates on, or the merge undoes it

### DIFF
--- a/companion/src/analysis/memoryFields.ts
+++ b/companion/src/analysis/memoryFields.ts
@@ -147,28 +147,57 @@ export function regionAddress(raw: string): string {
 }
 
 /**
- * The sentence a malfind row becomes. Arguments are in the order they read:
- * tool, plugin label, process, pid, region, protection, tag.
+ * How a malfind row NAMES the region it found: the token its aggregation key uses, and the phrase
+ * its description prints. They come from one place because they must agree.
  *
- * It lives here because the REGION is the part that matters and the part that was missing. Malfind
- * rows are undated, and correlation folds two events that share a timestamp and a description — so
- * with no address in the text, three separate RWX regions in one process collapsed into one row
- * while the import note still counted three. `region` must be an ADDRESS: the caller's aggregation
- * key falls back to CommitCharge, a page count, and rendering that as `at 0x1` would have the row
- * state a memory location that does not exist.
+ * Two layers can fold malfind rows, and only the second is visible to the analyst. The aggregator
+ * keys on this token, so the parser keeps regions apart. Correlation then unions events sharing a
+ * timestamp and a description — and malfind rows are undated — so ANY discriminator the key uses but
+ * the description does not print is undone at the case merge, silently, with the count reset to 1
+ * while the import note still reports the true number. Three regions became one row that way.
+ *
+ * So the rule is: print what you key on. An address when the source gives one; the end address, or
+ * the commit charge, when it does not — each labelled for what it is, never dressed up as an address.
+ * When the source offers nothing at all the token is empty for every row, the AGGREGATOR collapses
+ * them into one event, and its count says how many there were. That is the honest answer to evidence
+ * that genuinely cannot tell two regions apart, and it is not the same as losing them at the merge.
+ */
+export function malfindRegion(row: Row): { token: string; phrase: string } {
+  const at = (keys: string[]): string => {
+    for (const k of keys) {
+      const v = cellStr(getCI(row, k)).trim();
+      if (v && !/^(n\/?a|-|none|null)$/i.test(v)) return v;
+    }
+    return "";
+  };
+  const start = at(["Start VPN", "Start", "start"]);
+  if (start) return { token: regionAddress(start), phrase: ` at ${regionAddress(start)}` };
+  const end = at(["End VPN", "End", "end"]);
+  if (end) return { token: `end:${regionAddress(end)}`, phrase: ` ending at ${regionAddress(end)}` };
+  const charge = at(["CommitCharge", "commit_charge"]);
+  if (charge) return { token: `cc:${charge}`, phrase: ` commit charge ${charge}` };
+  return { token: "", phrase: "" };
+}
+
+/**
+ * The sentence a malfind row becomes. Arguments are in the order they read:
+ * tool, plugin label, process, pid, region phrase, protection, tag.
+ *
+ * The region phrase comes from malfindRegion, which also supplies the aggregation key's token — see
+ * there for why the two must be built together.
  */
 export function malfindDescription(
   tool: string,
   label: string,
   process: string,
   pid: string,
-  region: string,
+  regionPhrase: string,
   protection: string,
   tag: string,
 ): string {
   return (
     `${tool} ${label}: executable/injected private memory in ${process || "?"} (PID ${pid || "?"})` +
-    `${region ? ` at ${regionAddress(region)}` : ""}${protection ? ` — protection ${protection}` : ""}` +
+    `${regionPhrase}${protection ? ` — protection ${protection}` : ""}` +
     `${tag ? `, tag ${tag}` : ""}`
   ).slice(0, 600);
 }

--- a/companion/src/analysis/memoryImport.ts
+++ b/companion/src/analysis/memoryImport.ts
@@ -54,6 +54,7 @@ import {
   cellStr,
   filePathIoc,
   malfindDescription,
+  malfindRegion,
   pickTime,
   serviceImagePath,
 } from "./memoryFields.js";
@@ -376,17 +377,15 @@ function mapMalfind(label: string, tool: string, rows: Row[], sink: Map<string, 
     const pid = pickPid(r);
     const prot = pick(r, ["Protection", "protection"]);
     const tag = pick(r, ["Tag", "tag", "VadTag", "vad_tag"]);
-    const region = pick(r, ["Start VPN", "Start", "start"]); // an ADDRESS; CommitCharge is a page count
+    const region = malfindRegion(r); // its token and its phrase must agree — see malfindRegion
     const name = proc ? baseName(proc) : "";
     if (name) addIoc(sink, "process", name);
     out.push({
       timestamp: "",
-      description: malfindDescription(tool, label, proc, pid, region, prot, tag),
+      description: malfindDescription(tool, label, proc, pid, region.phrase, prot, tag),
       severity: "High",
       mitre: ["T1055"],
-      aggKey: `mem|malfind|${name.toLowerCase()}|${pid}|${region || pick(r, ["CommitCharge"])}|${prot}`
-        .toLowerCase()
-        .slice(0, 400),
+      aggKey: `mem|malfind|${name.toLowerCase()}|${pid}|${region.token}|${prot}`.toLowerCase().slice(0, 400),
       sources: [tool],
       ...(name ? { processName: name } : {}),
     });

--- a/companion/tests/server/memoryMergeFidelity.test.ts
+++ b/companion/tests/server/memoryMergeFidelity.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp, buildRuntimePipeline } from "../../src/server.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { ImportMetaStore } from "../../src/analysis/importMeta.js";
+import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { pollFor, POLL_TIMEOUT_MS } from "../helpers/poll.js";
+
+// #776 — malfind rows must survive the CASE MERGE, not just the parser.
+//
+// Two layers can fold them and only the second one matters to the analyst. The aggregator keys on a
+// region discriminator, so the parser keeps the rows apart. Correlation then unions events sharing a
+// timestamp and a description — and malfind rows are undated — so any discriminator the aggregation
+// key uses but the DESCRIPTION does not print gets undone at the merge, silently, with the count
+// reset to 1 while the import note still reports the true number.
+//
+// Asserting on parseMemory's output cannot see this. These tests drive the real import route.
+
+async function makeApp() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-malfind-"));
+  const store = new CaseStore(root);
+  const stateStore = new StateStore(store);
+  const importMetaStore = new ImportMetaStore(store);
+  const superTimelineStore = new SuperTimelineStore(store);
+  const pipeline = buildRuntimePipeline({
+    provider: undefined,
+    synthesisProvider: undefined,
+    stateStore,
+    store,
+    imageLoader: async () => ({ base64: "AAAA", mimeType: "image/webp" }),
+  });
+  const app = createApp(store, { pipeline, stateStore, importMetaStore, superTimelineStore });
+  await request(app).post("/cases").send({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  return { app, stateStore, importMetaStore };
+}
+
+async function importRows(
+  app: Awaited<ReturnType<typeof makeApp>>["app"],
+  importMetaStore: ImportMetaStore,
+  rows: object[],
+): Promise<void> {
+  const res = await request(app)
+    .post("/cases/c1/import")
+    .send({ filename: "malfind.json", text: JSON.stringify(rows) });
+  expect(res.status).toBe(202);
+  let seen = "";
+  await pollFor(
+    () => `import-meta to record '${res.body.file}' (last saw '${seen}')`,
+    async () => {
+      seen = (await importMetaStore.load("c1")).lastImportFile || "";
+      return seen === res.body.file ? true : undefined;
+    },
+  );
+  await new Promise((r) => setTimeout(r, 300));
+}
+
+async function malfindRows(stateStore: StateStore) {
+  const state = await stateStore.load("c1");
+  return state.forensicTimeline.filter((e) => e.description.includes("malfind"));
+}
+
+describe("#776 — malfind regions survive the case merge", () => {
+  it(
+    "keeps three addressed regions in one process as three rows",
+    async () => {
+      const { app, stateStore, importMetaStore } = await makeApp();
+      await importRows(app, importMetaStore, [
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          "Start VPN": 33554432,
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+        },
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          "Start VPN": 67108864,
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+        },
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          "Start VPN": 100663296,
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+        },
+      ]);
+      expect(await malfindRows(stateStore)).toHaveLength(3);
+    },
+    POLL_TIMEOUT_MS * 2,
+  );
+
+  it(
+    "keeps regions a source reports WITHOUT an address as separate rows too",
+    async () => {
+      const { app, stateStore, importMetaStore } = await makeApp();
+      await importRows(app, importMetaStore, [
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+          CommitCharge: 1,
+        },
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+          CommitCharge: 2,
+        },
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+          CommitCharge: 3,
+        },
+      ]);
+      const rows = await malfindRows(stateStore);
+      expect(rows).toHaveLength(3);
+      expect(rows.some((e) => e.description.includes("commit charge 2"))).toBe(true);
+      expect(rows.every((e) => !/\bat 0x/.test(e.description))).toBe(true); // no address is invented
+    },
+    POLL_TIMEOUT_MS * 2,
+  );
+
+  it(
+    "reports a truthful count when the source gives nothing to tell the regions apart",
+    async () => {
+      const { app, stateStore, importMetaStore } = await makeApp();
+      const identical = { PID: 3120, Process: "evil.exe", Tag: "VadS", Protection: "PAGE_EXECUTE_READWRITE" };
+      await importRows(app, importMetaStore, [identical, { ...identical }, { ...identical }]);
+      const rows = await malfindRows(stateStore);
+      // Indistinguishable in the evidence itself, so ONE row — but it must say it stands for three.
+      expect(rows).toHaveLength(1);
+      expect(rows[0].count).toBe(3);
+    },
+    POLL_TIMEOUT_MS * 2,
+  );
+});


### PR DESCRIPTION
Part of #776. Fixes a defect left by #789, found by the Codex stop-time review.

## The defect

A malfind row from a source with no `Start VPN` still lost its siblings. Three RWX regions in one
process, told apart only by `CommitCharge`:

```
parser says:            3 events
after the case merge:   1 row, count=1
import note still says: "3 injected-code hit(s)"
```

## Why it survived two rounds of fixing

Two layers fold these rows, and only the second reaches the analyst.

The **aggregator** keys on a region discriminator, so the parser kept all three. **Correlation** then
unions events sharing a timestamp and a description — and malfind rows are undated — so any
discriminator the key uses but the description never prints is undone at the case merge, silently,
with the count reset.

#789 made the description address-only, to stop a page count being rendered as `at 0x1`. That was
right, and it left the key discriminating on something invisible. That is the shape of this bug.

Both of my earlier tests asserted on `parseMemory`'s output — which was correct both times. The new
tests drive the real import route, which is the only layer that can see this.

## The rule

The token and the phrase now come from one function, so they cannot disagree:

| source offers | key token | description prints |
|---|---|---|
| `Start VPN` | `0x1fb2ec10000` | ` at 0x1fb2ec10000` |
| `End VPN` only | `end:0x1fb2ec29fff` | ` ending at 0x1fb2ec29fff` |
| `CommitCharge` only | `cc:7` | ` commit charge 7` |
| nothing | `` | `` |

Each is labelled for what it is; none is dressed up as an address. `N/A` in an address field falls
through to the next candidate.

When the source offers nothing, the token is empty for every row, the **aggregator** collapses them
into one event, and its `count` says how many there were. That is the honest answer for evidence that
genuinely cannot tell two regions apart — and it is not the same as losing them at the merge. There
is a test for it.

## Verification

- 3 new route-level tests; the CommitCharge one is RED before this change
  (`expected [ … ] to have a length of 3 but got 1`).
- Real export unchanged: 6 malfind events, 6 distinct descriptions, 190 file IOCs with 0 malformed,
  9 of 9 UserAssist rows dated.
- Full suite green: 720 files, 11,678 tests, no unhandled errors.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.
- `memoryImport.ts` is 1539 lines against a 1541 ledger.

No CHANGELOG entry: #788 and #789 have not shipped, so this corrects unreleased work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
