### PR TITLE
fix(memory): one placeholder list, because three copies of it drifted

### DIFF
--- a/companion/src/analysis/memoryFields.ts
+++ b/companion/src/analysis/memoryFields.ts
@@ -44,7 +44,7 @@ export function pickTime(row: Row, keys: string[]): string {
       }
     }
     const raw = cellStr(v).trim();
-    if (!raw || /^(n\/?a|-|0|none|null)$/i.test(raw)) continue;
+    if (!raw || raw === "0" || isPlaceholderCell(raw)) continue; // "0" is a placeholder for a TIME only
     const t = normalizeTime(raw);
     if (t) return t;
   }
@@ -76,8 +76,23 @@ export const GENERIC_TIME_KEYS = [
   "Timestamp",
 ];
 
-// The placeholders Volatility prints for a value it could not read. None of them is a path.
-const NOT_A_PATH = /^(n\/?a|-|none|null|unknown)$/i;
+/**
+ * A cell that holds no value — the spellings the memory tools print for something they could not read.
+ *
+ * ONE list, exported, because three copies of it lived in this file and drifted apart. The address
+ * path had the shortest, so `Unknown` in a Start VPN column read as a real address: the row said
+ * "at Unknown", and matching there SKIPPED the fallback to End VPN and CommitCharge — so two regions
+ * told apart only by their commit charge became one row again at the case merge, which is the exact
+ * defect that fallback exists to prevent.
+ *
+ * `0` is deliberately absent: it is a placeholder for a TIME (pickTime rejects it separately) and a
+ * legitimate value elsewhere.
+ */
+const PLACEHOLDER_CELL = /^(?:n\/?a|n\\a|-{1,2}|none|null|unknown|unavailable|\?)$/i;
+
+export function isPlaceholderCell(value: string): boolean {
+  return PLACEHOLDER_CELL.test((value ?? "").trim());
+}
 // Where an executable's name ends and its arguments begin. The lookahead is the whole point: the
 // extension must END the token, or the cut lands inside a DIRECTORY name — `C:\tools\node.js\agent.exe`
 // became `C:\tools\node.js`, a shorter path that still looks real, which is a worse indicator than
@@ -102,7 +117,7 @@ const IMAGE_EXT = /\.(exe|dll|sys|com|scr|bat|cmd|ps1|vbs|js|jse|msi|efi|drv|ocx
  */
 export function serviceImagePath(raw: string): string {
   const s = (raw ?? "").trim();
-  if (!s || NOT_A_PATH.test(s)) return "";
+  if (!s || isPlaceholderCell(s)) return "";
   const quoted = /^"([^"]+)"/.exec(s);
   let image = quoted ? quoted[1].trim() : s;
   if (!quoted) {
@@ -110,7 +125,7 @@ export function serviceImagePath(raw: string): string {
     if (ext) image = image.slice(0, ext.index + ext[0].length);
   }
   image = image.trim();
-  if (!image || NOT_A_PATH.test(image) || !/[\\/]/.test(image)) return "";
+  if (!image || isPlaceholderCell(image) || !/[\\/]/.test(image)) return "";
   return image.slice(0, 300);
 }
 
@@ -124,7 +139,7 @@ export function serviceImagePath(raw: string): string {
  */
 export function filePathIoc(raw: string): string {
   const s = (raw ?? "").trim();
-  if (!s || NOT_A_PATH.test(s) || !/[\\/]/.test(s)) return "";
+  if (!s || isPlaceholderCell(s) || !/[\\/]/.test(s)) return "";
   return s.slice(0, 300);
 }
 
@@ -166,7 +181,7 @@ export function malfindRegion(row: Row): { token: string; phrase: string } {
   const at = (keys: string[]): string => {
     for (const k of keys) {
       const v = cellStr(getCI(row, k)).trim();
-      if (v && !/^(n\/?a|-|none|null)$/i.test(v)) return v;
+      if (v && !isPlaceholderCell(v)) return v;
     }
     return "";
   };

--- a/companion/tests/analysis/memoryFields.test.ts
+++ b/companion/tests/analysis/memoryFields.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { filePathIoc, regionAddress, serviceImagePath } from "../../src/analysis/memoryFields.js";
+import {
+  filePathIoc,
+  isPlaceholderCell,
+  malfindRegion,
+  pickTime,
+  regionAddress,
+  serviceImagePath,
+} from "../../src/analysis/memoryFields.js";
 
 describe("serviceImagePath", () => {
   it("unwraps a quoted ImagePath and drops the arguments after it", () => {
@@ -77,5 +84,44 @@ describe("regionAddress", () => {
 
   it("stays exact past 2^53, where a double would round", () => {
     expect(regionAddress("18446744073709551615")).toBe("0xffffffffffffffff");
+  });
+});
+
+// Three copies of the placeholder list lived in this file and drifted apart. The shortest one was
+// the address path, so `Unknown` in a Start VPN column read as a real address: the row said
+// "at Unknown", and — worse — matching there SKIPPED the fallback to End VPN and CommitCharge, so
+// two regions told apart only by their commit charge became one row again at the case merge.
+describe("isPlaceholderCell", () => {
+  it("covers every spelling the memory tools print for an absent value", () => {
+    for (const v of ["N/A", "n/a", "n\\a", "-", "--", "none", "NULL", "Unknown", "unavailable", "?", "  -  "])
+      expect(isPlaceholderCell(v), v).toBe(true);
+  });
+
+  it("does not touch a real value", () => {
+    for (const v of ["0x2000000", "2178332819456", "C:\\Windows", "VadS", "0"])
+      expect(isPlaceholderCell(v), v).toBe(false);
+  });
+
+  it("is the SAME list every reader uses, so the copies cannot drift apart again", () => {
+    expect(malfindRegion({ "Start VPN": "Unknown", CommitCharge: 4 }).token).toBe("cc:4");
+    expect(filePathIoc("Unknown")).toBe("");
+    expect(serviceImagePath("Unknown")).toBe("");
+    expect(pickTime({ CreateTime: "Unknown" }, ["CreateTime"])).toBe("");
+    expect(pickTime({ CreateTime: "0" }, ["CreateTime"])).toBe(""); // pickTime's own extra rule survives
+  });
+});
+
+describe("malfindRegion", () => {
+  it("falls through a placeholder address to whatever the row can still tell apart", () => {
+    for (const junk of ["Unknown", "--", "N/A", "none"]) {
+      const a = malfindRegion({ "Start VPN": junk, CommitCharge: 1 });
+      const b = malfindRegion({ "Start VPN": junk, CommitCharge: 2 });
+      expect(a.token, junk).not.toBe(b.token);
+      expect(a.phrase, junk).toBe(" commit charge 1");
+    }
+  });
+
+  it("never prints a placeholder as a location", () => {
+    for (const junk of ["Unknown", "--", "N/A"]) expect(malfindRegion({ "Start VPN": junk }).phrase).toBe("");
   });
 });

--- a/companion/tests/server/memoryMergeFidelity.test.ts
+++ b/companion/tests/server/memoryMergeFidelity.test.ts
@@ -131,6 +131,45 @@ describe("#776 — malfind regions survive the case merge", () => {
     POLL_TIMEOUT_MS * 2,
   );
 
+  // `Unknown` in the address column used to satisfy the address branch, which both printed it as a
+  // location and skipped the fallback — so these three collapsed back to one row.
+  it(
+    "does not let a placeholder address stand in for a real one",
+    async () => {
+      const { app, stateStore, importMetaStore } = await makeApp();
+      await importRows(app, importMetaStore, [
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          "Start VPN": "Unknown",
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+          CommitCharge: 1,
+        },
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          "Start VPN": "Unknown",
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+          CommitCharge: 2,
+        },
+        {
+          PID: 3120,
+          Process: "evil.exe",
+          "Start VPN": "Unknown",
+          Tag: "VadS",
+          Protection: "PAGE_EXECUTE_READWRITE",
+          CommitCharge: 3,
+        },
+      ]);
+      const rows = await malfindRows(stateStore);
+      expect(rows).toHaveLength(3);
+      expect(rows.every((e) => !/Unknown/.test(e.description))).toBe(true);
+    },
+    POLL_TIMEOUT_MS * 2,
+  );
+
   it(
     "reports a truthful count when the source gives nothing to tell the regions apart",
     async () => {


### PR DESCRIPTION
Part of #776. Fixes a defect left by #790, found by the Codex stop-time review.

## The defect

`Unknown` in a `Start VPN` column read as a real memory address:

```
{"Start VPN":"Unknown","CommitCharge":1}  ->  token "Unknown", phrase " at Unknown"
{"Start VPN":"Unknown","CommitCharge":2}  ->  token "Unknown", phrase " at Unknown"
{"Start VPN":"--","CommitCharge":5}       ->  token "--",      phrase " at --"
```

Two harms. The row states a location that is a placeholder. And matching there **skipped the
fallback** to `End VPN` and `CommitCharge`, so two regions told apart only by their commit charge
became one row again at the case merge — the exact defect the fallback added in #790 exists to
prevent, reached through a different spelling.

## The cause

Three copies of the placeholder list lived in one file, each different:

| reader | list |
|---|---|
| `pickTime` | `n/a` `-` `0` `none` `null` |
| `NOT_A_PATH` | `n/a` `-` `none` `null` `unknown` |
| `malfindRegion` | `n/a` `-` `none` `null` |

The address path had the shortest one. I wrote that third copy in #790 rather than reusing the
existing one, which is what let `unknown` through.

## The fix

One exported predicate every reader calls, covering the union plus `--`, `n\a`, `unavailable` and
`?`. A test asserts all four readers agree on `Unknown`, so the copies cannot drift apart again.

`0` deliberately stays out of the shared list and remains `pickTime`'s own rule: it is a placeholder
for a *time* and a legitimate value elsewhere. That is asserted too.

## Verification

- 5 new unit tests and 1 route-level test. The route test fails without the fix
  (`expected [ … ] to have a length of 3 but got 1`) — checked by restoring the old regex.
- Real export unchanged: 6 malfind events / 6 distinct, 190 file IOCs with 0 malformed, 9 of 9
  UserAssist rows dated, 9 tables / 1404 rows / 245 IOCs.
- `build`, `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check` all pass.
- Full suite: 11,594 passed, **0 failed**, exit 0. One file
  (`dashboardFeatureLifecycle.test.ts`, 310 tests) was cut short by a
  `[vitest-worker]: Timeout calling "onTaskUpdate"` RPC timeout on a loaded box; it passes in
  isolation in 45 s and this branch does not touch the dashboard.

### A note on the test that found its own fixture bug

The route test's first draft dropped the `Tag` column, so the file sniffed as SIEM rather than memory
and the assertion reported zero rows instead of one. The fixture now carries it. Worth recording
because the failure mode was mine, not the product's.

No CHANGELOG entry: #788–#790 have not shipped, so this corrects unreleased work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
