### PR TITLE
refactor(analysis): drop yearClampAdjustments, which no caller ever grew

### DIFF
--- a/companion/src/analysis/timeYearClamp.ts
+++ b/companion/src/analysis/timeYearClamp.ts
@@ -133,32 +133,6 @@ export function clampOutlierYears(
   });
 }
 
-/** One year-clamp adjustment, aggregated for display: "N events moved from 2025 to 2026". */
-export interface YearClampAdjustment {
-  from: number;
-  to: number;
-  count: number;
-}
-
-/**
- * What the clamp changed on this timeline, read back off the events themselves. The UI signal #739
- * asks for — an analyst must be able to see that a displayed time is machine-adjusted rather than
- * recorded. Pure; returns [] for a timeline the clamp never touched.
- */
-export function yearClampAdjustments(events: readonly ForensicEvent[]): YearClampAdjustment[] {
-  const byPair = new Map<string, YearClampAdjustment>();
-  for (const e of events) {
-    const from = yearOf(e.yearClampedFrom);
-    const to = yearOf(e.timestamp);
-    if (from === null || to === null || from === to) continue;
-    const key = `${from}>${to}`;
-    const hit = byPair.get(key);
-    if (hit) hit.count++;
-    else byPair.set(key, { from, to, count: 1 });
-  }
-  return [...byPair.values()].sort((a, b) => b.count - a.count || a.from - b.from);
-}
-
 // Best-guess year for a NEW year-less import (Cisco ASA / Snort / syslog), to use as the parser's
 // `assumeYear` instead of blindly stamping the current calendar year.
 //

--- a/companion/tests/analysis/timeYearClamp.test.ts
+++ b/companion/tests/analysis/timeYearClamp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clampOutlierYears, pickImportYear, yearClampAdjustments } from "../../src/analysis/timeYearClamp.js";
+import { clampOutlierYears, pickImportYear } from "../../src/analysis/timeYearClamp.js";
 import type { ForensicEvent } from "../../src/analysis/stateTypes.js";
 
 function ev(id: string, timestamp: string, extra: Partial<ForensicEvent> = {}): ForensicEvent {
@@ -133,25 +133,6 @@ describe("clampOutlierYears", () => {
     const again = clampOutlierYears([...once.filter((e) => e.id === "old"), ...body(2025, 30)]);
     expect(again.find((e) => e.id === "old")!.timestamp).toBe("2025-05-14T12:01:13.000Z");
     expect(again.find((e) => e.id === "old")!.yearClampedFrom).toBe("2023-05-14T12:01:13Z");
-  });
-});
-
-describe("yearClampAdjustments", () => {
-  it("aggregates the rewrites by year pair, most frequent first", () => {
-    const out = clampOutlierYears([
-      guessed("a", "2023-05-14T12:00:00Z"),
-      guessed("b", "2023-05-14T13:00:00Z"),
-      guessed("c", "2022-05-14T13:00:00Z"),
-      ...body(2024, 30),
-    ]);
-    expect(yearClampAdjustments(out)).toEqual([
-      { from: 2023, to: 2024, count: 2 },
-      { from: 2022, to: 2024, count: 1 },
-    ]);
-  });
-
-  it("reports nothing for a timeline the clamp never touched", () => {
-    expect(yearClampAdjustments(body(2024, 30))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #759.

## What was wrong

`yearClampAdjustments()` in `companion/src/analysis/timeYearClamp.ts` was written as "the UI signal #739 asks for", and the wiring never happened. Nothing in `src/` called it. Its only consumer was its own unit test.

## Why deleting is the right half to keep

The aggregation is not missing. The dashboard's diagnostics panel already builds the same by-year-pair counts inline, in JS, from each event's `yearClampedFrom` (`public/js/dashboard-diagnostics.js`). The analyst-facing signal #739 asked for is on screen, and always was.

So what existed here was a second copy of one aggregation in a second language — agreeing with the first today, answerable to nothing tomorrow. That is the shape that drifted into #744.

The alternative the issue offers is to serve the adjustments from the API and have the panel consume them. That is another route, a client change and a migration, to replace a working panel with an identical one.

## What goes

- `yearClampAdjustments()` — no production caller.
- `YearClampAdjustment` — described that function's return value, no other user.
- Its two unit tests.

`yearOf()` stays: three other places in the same file use it. Nothing an analyst sees changes.

## Tests

Full suite green: **722/722 files, 11,715/11,715 tests**, plus `build`, `typecheck`, `lint`, `format:check` and the four ratchets (`check:size`, `check:imports`, `check:boundaries`, `check:us-map`).

Every file reported this run — no `onTaskUpdate` worker timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
