### PR TITLE
fix(hunt): three Sigma → VQL refusal gaps — an anchor bomb, an empty selection, and a rooted contains/endswith path (closes #805, #806, #807)

### DIFF
--- a/companion/src/analysis/sigmaCondition.ts
+++ b/companion/src/analysis/sigmaCondition.ts
@@ -38,7 +38,12 @@ function tokenize(text: string): Token[] {
 
 /** Sigma's `*` / `?` selection-name wildcards, anchored, against the names the rule defines. */
 function resolvePattern(pattern: string, names: readonly string[]): string[] {
-  if (pattern.toLowerCase() === "them") return [...names];
+  if (pattern.toLowerCase() === "them") {
+    // With no selections `them` would resolve to nothing and compile to `WHERE ()` (#806).
+    if (names.length === 0)
+      throw new ConditionRefusal("'them' refers to every selection, but the rule defines none");
+    return [...names];
+  }
   if (!/[*?]/.test(pattern)) {
     if (!names.includes(pattern))
       throw new ConditionRefusal(`selection '${pattern}' is not defined under detection`);

--- a/companion/src/analysis/sigmaRule.ts
+++ b/companion/src/analysis/sigmaRule.ts
@@ -86,11 +86,31 @@ function readDocument(text: string, out: Refusals): Plain | null {
     );
     return null;
   }
+  if (hasCycle(value)) {
+    // `sel: &a [*a]` converts without an error into a value that refers to itself; every walk
+    // after this point (countValues, readFieldMap) would recurse without end.
+    out.add(
+      "yaml",
+      "the YAML refers to itself through an anchor (a cyclic alias); paste a plain Sigma rule without anchors or aliases",
+    );
+    return null;
+  }
   if (!isPlain(value)) {
     out.add("yaml", "the rule must be a YAML map with title, logsource and detection keys");
     return null;
   }
   return value;
+}
+
+/** True when a converted YAML value contains itself. The trail is per path, so a value reached twice by two different aliases is fine. */
+function hasCycle(value: unknown, trail = new Set<object>()): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (trail.has(value)) return true;
+  trail.add(value);
+  const children = Array.isArray(value) ? value : Object.values(value);
+  const cyclic = children.some((c) => hasCycle(c, trail));
+  trail.delete(value);
+  return cyclic;
 }
 
 // ── Metadata ──────────────────────────────────────────────────────────────────────────────────
@@ -276,12 +296,14 @@ function readSelection(name: string, raw: unknown, out: Refusals): SigmaSelectio
     return null;
   }
   if (raw.every(isPlain)) {
-    const empty = raw.findIndex((m) => Object.keys(m).length === 0);
-    if (empty >= 0) {
-      out.add(`${path}[${empty}]`, NO_FIELDS.replace("this selection", "this entry of the selection list"));
+    // Every entry is read even after an empty one, so the refusal list stays complete.
+    const alternatives = raw.map((m, i) => {
+      if (Object.keys(m).length > 0) return readFieldMap(path, m, out);
+      out.add(`${path}[${i}]`, NO_FIELDS.replace("this selection", "this entry of the selection list"));
       return null;
-    }
-    return { kind: "list", name, alternatives: raw.map((m) => readFieldMap(path, m, out)) };
+    });
+    if (alternatives.some((a) => a === null)) return null;
+    return { kind: "list", name, alternatives: alternatives as SigmaFieldMatch[][] };
   }
   if (raw.every(isScalar)) return { kind: "keywords", name, values: raw };
   out.add(path, "a selection list must not mix field maps with bare values");

--- a/companion/src/analysis/sigmaRule.ts
+++ b/companion/src/analysis/sigmaRule.ts
@@ -73,7 +73,19 @@ function readDocument(text: string, out: Refusals): Plain | null {
     out.add("yaml", `the YAML does not parse: ${doc.errors[0].message.split("\n")[0]}`);
     return null;
   }
-  const value = doc.toJS() as unknown;
+  let value: unknown;
+  try {
+    value = doc.toJS();
+  } catch (error) {
+    // The yaml package guards itself against anchor/alias expansion bombs by THROWING from toJS()
+    // (doc.errors stays empty for that payload — #805). Adversary-authored input is a refusal.
+    const reason = error instanceof Error ? error.message.split("\n")[0] : String(error);
+    out.add(
+      "yaml",
+      `the YAML is too complex to read (the parser stopped it: ${reason}); paste a plain Sigma rule without anchors or aliases`,
+    );
+    return null;
+  }
   if (!isPlain(value)) {
     out.add("yaml", "the rule must be a YAML map with title, logsource and detection keys");
     return null;
@@ -242,19 +254,35 @@ function countValues(raw: unknown): number {
   return 1;
 }
 
+// An empty map `{}` matches nothing in Sigma and would compile to `WHERE ()` (#806): refused here,
+// before the compiler, so the analyst reads the reason at the selection that carries it.
+const NO_FIELDS = "this selection has no fields, so it matches nothing; give it at least one field";
+
 function readSelection(name: string, raw: unknown, out: Refusals): SigmaSelection | null {
   const path = `detection.${name}`;
   if (countValues(raw) > SIGMA_MAX_VALUES_PER_SELECTION) {
     out.add(path, `a selection is limited to ${SIGMA_MAX_VALUES_PER_SELECTION} values`);
     return null;
   }
-  if (isPlain(raw)) return { kind: "map", name, fields: readFieldMap(path, raw, out) };
+  if (isPlain(raw)) {
+    if (Object.keys(raw).length === 0) {
+      out.add(path, NO_FIELDS);
+      return null;
+    }
+    return { kind: "map", name, fields: readFieldMap(path, raw, out) };
+  }
   if (!Array.isArray(raw) || raw.length === 0) {
     out.add(path, "a selection must be a map of fields, a list of such maps, or a list of keywords");
     return null;
   }
-  if (raw.every(isPlain))
+  if (raw.every(isPlain)) {
+    const empty = raw.findIndex((m) => Object.keys(m).length === 0);
+    if (empty >= 0) {
+      out.add(`${path}[${empty}]`, NO_FIELDS.replace("this selection", "this entry of the selection list"));
+      return null;
+    }
     return { kind: "list", name, alternatives: raw.map((m) => readFieldMap(path, m, out)) };
+  }
   if (raw.every(isScalar)) return { kind: "keywords", name, values: raw };
   out.add(path, "a selection list must not mix field maps with bare values");
   return null;

--- a/companion/src/analysis/sigmaToVql.ts
+++ b/companion/src/analysis/sigmaToVql.ts
@@ -253,6 +253,11 @@ function collectGlobs(
       continue;
     }
     const globs = mode === "re" ? [WHOLE_DISK_GLOB] : fileGlob(value, mode as SigmaMatchMode);
+    if (!globs)
+      throw new CompileRefusal(
+        path,
+        `'${value}' is rooted on a drive or a host, and ${mode} searches every folder of C: for it, where a rooted path can never appear; match it with startswith or exactly, or drop the root to hunt the fragment`,
+      );
     for (const g of globs) if (!needs.globs.includes(g)) needs.globs.push(g);
   }
 }
@@ -278,6 +283,15 @@ function compileFieldMap(
   needs: Needs,
   out: SigmaRefusal[],
 ): string | null {
+  if (fields.length === 0) {
+    // The parser refuses this first (#806); here for a SigmaRule built without it, so `WHERE ()`
+    // is never assembled.
+    out.push({
+      path: selPath,
+      message: "this selection has no fields, so it matches nothing; give it at least one field",
+    });
+    return null;
+  }
   const parts: string[] = [];
   for (const m of fields) {
     try {

--- a/companion/src/analysis/sigmaVqlValues.ts
+++ b/companion/src/analysis/sigmaVqlValues.ts
@@ -62,13 +62,24 @@ export function re2Objection(pattern: string): string | null {
 
 // ── Paths and globs ───────────────────────────────────────────────────────────────────────────
 
+/** The glob that walks the whole disk, so the header can admit it. */
+export const WHOLE_DISK_GLOB = "C:/**";
+
+/** A drive root (`C:`) or a UNC root (`//host`) at the start of a slash-normalised path. */
+const ROOTED_PATH_RE = /^(?:[A-Za-z]:|\/\/)/;
+
 /**
  * A Sigma path value as Velociraptor globs: forward slashes, Sigma wildcards kept as glob wildcards.
  * Velociraptor's recursive `**` only works as a path component of its own, so a prefix that does not
  * end on a separator needs TWO globs: the same-component prefix (`C:/Temp*`) and everything under it
  * (`C:/Temp*` + `/**`). A prefix ending on a separator is a directory and gets one recursive glob.
+ *
+ * A `contains` / `endswith` value is a name or a fragment searched under every folder of C:. A value
+ * rooted on a drive or a UNC host can never appear there (a Windows filename holds no `:`), so it
+ * returns null and the caller refuses it (#807). A fragment that opens on a separator names a
+ * component boundary, which `C:/**` + `/` already is, so no `*` is put in front of it.
  */
-export function fileGlob(value: string, mode: SigmaMatchMode): string[] {
+export function fileGlob(value: string, mode: SigmaMatchMode): string[] | null {
   const p = value.replace(/\\/g, "/");
   switch (mode) {
     case "exact":
@@ -76,9 +87,11 @@ export function fileGlob(value: string, mode: SigmaMatchMode): string[] {
     case "startswith":
       return prefixGlobs(p);
     case "contains":
-      return ["C:/**/*" + p + "*"];
-    case "endswith":
-      return ["C:/**/*" + p];
+    case "endswith": {
+      if (ROOTED_PATH_RE.test(p)) return null;
+      const tail = p.startsWith("/") ? p.slice(1) : "*" + p;
+      return [`${WHOLE_DISK_GLOB}/${tail}${mode === "contains" ? "*" : ""}`];
+    }
   }
 }
 
@@ -87,9 +100,6 @@ export function prefixGlobs(p: string): string[] {
   if (p.endsWith("/")) return [p + "**"];
   return [p + "*", p + "*/**"];
 }
-
-/** The glob that walks the whole disk, so the header can admit it. */
-export const WHOLE_DISK_GLOB = "C:/**";
 
 const HIVES: ReadonlyArray<{ names: string[]; glob: string; regex: string }> = [
   { names: ["hklm", "hkey_local_machine"], glob: "HKEY_LOCAL_MACHINE", regex: "HKEY_LOCAL_MACHINE" },

--- a/companion/tests/analysis/sigmaRule.test.ts
+++ b/companion/tests/analysis/sigmaRule.test.ts
@@ -142,6 +142,20 @@ describe("parseSigmaRule — YAML boundary", () => {
     expect(refusals("- just\n- a list\n")[0].path).toBe("yaml");
   });
 
+  it("refuses an anchor/alias expansion bomb as a YAML refusal instead of throwing (#805)", () => {
+    // 432 bytes: nine aliases per level, eight levels deep. The yaml package stops it inside
+    // toJS() with a ReferenceError and leaves doc.errors empty, so only a catch turns it into a
+    // refusal — and the route above would otherwise answer 500.
+    let bomb = 'k1: &a1 ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]\n';
+    for (let i = 2; i <= 9; i++)
+      bomb += `k${i}: &a${i} [${Array(9)
+        .fill(`*a${i - 1}`)
+        .join(",")}]\n`;
+    expect(Buffer.byteLength(bomb)).toBeLessThan(SIGMA_MAX_RULE_BYTES);
+    const r = refusals(bomb);
+    expect(r).toEqual([{ path: "yaml", message: expect.stringMatching(/too complex.*anchors or aliases/) }]);
+  });
+
   it(`refuses text over ${SIGMA_MAX_RULE_BYTES} bytes before parsing it`, () => {
     const big = MINIMAL + "description: " + "x".repeat(SIGMA_MAX_RULE_BYTES) + "\n";
     const r = refusals(big);
@@ -280,6 +294,38 @@ detection:
         `title: T\nlogsource:\n  category: c\ndetection:\n  sel:\n    Image:\n${values}\n  condition: sel\n`,
       ),
     ).toEqual(["detection.sel"]);
+  });
+});
+
+describe("parseSigmaRule — a selection that matches nothing is refused (#806)", () => {
+  const withDetection = (detection: string) =>
+    `title: T\nlogsource:\n  category: process_creation\ndetection:\n${detection}`;
+
+  it("refuses an empty selection map at the selection's path", () => {
+    expect(refusals(withDetection("  sel: {}\n  condition: sel\n"))).toEqual([
+      { path: "detection.sel", message: expect.stringMatching(/no fields.*matches nothing/) },
+    ]);
+  });
+
+  it("refuses an empty map inside a selection list, naming the entry", () => {
+    const r = refusals(withDetection("  sel:\n    - {}\n    - Image: x\n  condition: sel\n"));
+    expect(r).toEqual([
+      { path: "detection.sel[0]", message: expect.stringMatching(/no fields.*matches nothing/) },
+    ]);
+    // A list whose maps all carry fields still parses as alternatives.
+    const rule = parsed(withDetection("  sel:\n    - Image: x\n    - Image: y\n  condition: sel\n"));
+    expect(rule.detection.selections[0].kind).toBe("list");
+  });
+
+  it("refuses '1 of them' and 'all of them' when the rule defines no selection", () => {
+    for (const condition of ["1 of them", "all of them", "not 1 of them"]) {
+      expect(refusals(withDetection(`  condition: ${condition}\n`))).toEqual([
+        { path: "detection.condition", message: expect.stringMatching(/'them'.*defines none/) },
+      ]);
+    }
+    // With one selection defined, `them` resolves to it as before.
+    const rule = parsed(withDetection("  sel:\n    Image: x\n  condition: 1 of them\n"));
+    expect(rule.detection.condition).toEqual({ kind: "oneOf", names: ["sel"] });
   });
 });
 

--- a/companion/tests/analysis/sigmaRule.test.ts
+++ b/companion/tests/analysis/sigmaRule.test.ts
@@ -156,6 +156,21 @@ describe("parseSigmaRule — YAML boundary", () => {
     expect(r).toEqual([{ path: "yaml", message: expect.stringMatching(/too complex.*anchors or aliases/) }]);
   });
 
+  it("refuses a cyclic alias, which converts without error and would overflow every later walk", () => {
+    const head = "title: T\nlogsource:\n  category: process_creation\ndetection:\n";
+    for (const detection of [
+      "  sel: &a [*a]\n  condition: sel\n",
+      "  sel: &a\n    Image: *a\n  condition: sel\n",
+    ]) {
+      expect(refusals(head + detection)).toEqual([
+        { path: "yaml", message: expect.stringMatching(/refers to itself.*anchors or aliases/) },
+      ]);
+    }
+    // A shared (acyclic) alias is ordinary YAML and still parses.
+    const shared = head + "  sel:\n    Image: &v x\n    CommandLine: *v\n  condition: sel\n";
+    expect(parsed(shared).detection.selections[0]).toMatchObject({ kind: "map" });
+  });
+
   it(`refuses text over ${SIGMA_MAX_RULE_BYTES} bytes before parsing it`, () => {
     const big = MINIMAL + "description: " + "x".repeat(SIGMA_MAX_RULE_BYTES) + "\n";
     const r = refusals(big);
@@ -311,6 +326,11 @@ describe("parseSigmaRule — a selection that matches nothing is refused (#806)"
     const r = refusals(withDetection("  sel:\n    - {}\n    - Image: x\n  condition: sel\n"));
     expect(r).toEqual([
       { path: "detection.sel[0]", message: expect.stringMatching(/no fields.*matches nothing/) },
+    ]);
+    // The entries after an empty one are still read, so the list of refusals stays complete.
+    expect(paths(withDetection("  sel:\n    - {}\n    - Image|base64: x\n  condition: sel\n"))).toEqual([
+      "detection.sel[0]",
+      "detection.sel.Image|base64",
     ]);
     // A list whose maps all carry fields still parses as alternatives.
     const rule = parsed(withDetection("  sel:\n    - Image: x\n    - Image: y\n  condition: sel\n"));

--- a/companion/tests/analysis/sigmaToVql.test.ts
+++ b/companion/tests/analysis/sigmaToVql.test.ts
@@ -658,3 +658,74 @@ describe("compileSigmaToVql — review fixes (#803)", () => {
     }
   });
 });
+
+describe("compileSigmaToVql — review fixes (#806, #807)", () => {
+  it("never assembles `WHERE ()`: an empty selection and a condition over no selection are refusals", () => {
+    const head = "title: T\nlogsource:\n  category: process_creation\n  product: windows\ndetection:\n";
+    for (const detection of [
+      "  sel: {}\n  condition: sel\n",
+      "  sel:\n    - {}\n  condition: sel\n",
+      "  condition: 1 of them\n",
+      "  condition: all of them\n",
+    ]) {
+      const r = compileSigmaText(head + detection);
+      expect(r.ok, detection).toBe(false);
+      if (!r.ok) expect(r.refusals.length, detection).toBeGreaterThan(0);
+    }
+  });
+
+  it("refuses an empty field list handed to the compiler directly, at the selection's path", () => {
+    const parsedRule = parseSigmaRule(proc("    Image: x"));
+    if (!parsedRule.ok) throw new Error("fixture must parse");
+    const rule = {
+      ...parsedRule.rule,
+      detection: {
+        ...parsedRule.rule.detection,
+        selections: [{ kind: "map" as const, name: "sel", fields: [] }],
+      },
+    };
+    const r = compileSigmaToVql(rule);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.refusals).toEqual([{ path: "detection.sel", message: expect.stringMatching(/no fields/) }]);
+    }
+  });
+
+  it("refuses a drive-rooted or UNC-rooted contains/endswith path, which a C:/** glob could never match (#807)", () => {
+    for (const [key, value] of [
+      ["TargetFilename|contains", "D:\\tools\\evil.log"],
+      ["TargetFilename|endswith", "D:\\tools\\evil.log"],
+      ["TargetFilename|contains", "C:\\tools\\evil.log"],
+      ["TargetFilename|endswith", "\\\\fileserver\\share\\evil.log"],
+    ]) {
+      const r = refusals(file(`    ${key}: '${value}'`));
+      expect(r, `${key}: ${value}`).toEqual([
+        { path: `detection.sel.${key}`, message: expect.stringMatching(/rooted.*never appear.*startswith/) },
+      ]);
+    }
+  });
+
+  it("keeps the rooted forms that do work: startswith and an exact match on another drive", () => {
+    expect(vql(file("    TargetFilename|startswith: 'D:\\tools'"))).toContain(
+      String.raw`glob(globs=["D:/tools*", "D:/tools*/**"])`,
+    );
+    expect(vql(file("    TargetFilename: 'D:\\tools\\evil.log'"))).toContain(
+      String.raw`glob(globs=["D:/tools/evil.log"])`,
+    );
+  });
+
+  it("treats a fragment that opens on a separator as a component boundary, so C:\\Temp\\x.exe itself is found", () => {
+    // Before: C:/**/*/Temp/x.exe, which needs one component between C: and Temp and so skips
+    // C:/Temp/x.exe. `**` already matches zero or more components.
+    expect(vql(file("    TargetFilename|endswith: '\\Temp\\x.exe'"))).toContain(
+      String.raw`glob(globs=["C:/**/Temp/x.exe"])`,
+    );
+    expect(vql(file("    TargetFilename|contains: '\\Temp\\'"))).toContain(
+      String.raw`glob(globs=["C:/**/Temp/*"])`,
+    );
+    // A bare name is unchanged: any folder, any prefix.
+    expect(vql(file("    TargetFilename|endswith: '.hta'"))).toContain(
+      String.raw`glob(globs=["C:/**/*.hta"])`,
+    );
+  });
+});

--- a/companion/tests/server/sigmaCompile.test.ts
+++ b/companion/tests/server/sigmaCompile.test.ts
@@ -69,6 +69,18 @@ describe("POST /cases/:id/sigma/compile", () => {
     expect(res.body.refusals[0].path).toBe("yaml");
   });
 
+  it("answers an anchor/alias expansion bomb with 400 and the YAML refusal, never 500 (#805)", async () => {
+    let bomb = 'k1: &a1 ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]\n';
+    for (let i = 2; i <= 9; i++)
+      bomb += `k${i}: &a${i} [${Array(9)
+        .fill(`*a${i - 1}`)
+        .join(",")}]\n`;
+    const res = await compile(bomb);
+    expect(res.status, res.text).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.refusals).toEqual([{ path: "yaml", message: expect.stringContaining("too complex") }]);
+  });
+
   it("answers a missing or non-string yaml with 400", async () => {
     expect((await request(app).post("/cases/c1/sigma/compile").send({})).status).toBe(400);
     expect((await compile(42)).status).toBe(400);

--- a/companion/tests/server/sigmaCompile.test.ts
+++ b/companion/tests/server/sigmaCompile.test.ts
@@ -81,6 +81,16 @@ describe("POST /cases/:id/sigma/compile", () => {
     expect(res.body.refusals).toEqual([{ path: "yaml", message: expect.stringContaining("too complex") }]);
   });
 
+  it("answers a cyclic alias with 400 and the YAML refusal, never 500", async () => {
+    const res = await compile(
+      "title: T\nlogsource:\n  category: process_creation\ndetection:\n  sel: &a [*a]\n  condition: sel\n",
+    );
+    expect(res.status, res.text).toBe(400);
+    expect(res.body.refusals).toEqual([
+      { path: "yaml", message: expect.stringContaining("refers to itself") },
+    ]);
+  });
+
   it("answers a missing or non-string yaml with 400", async () => {
     expect((await request(app).post("/cases/c1/sigma/compile").send({})).status).toBe(400);
     expect((await compile(42)).status).toBe(400);

--- a/mkdocs-docs/reference/threat-hunting.md
+++ b/mkdocs-docs/reference/threat-hunting.md
@@ -45,7 +45,10 @@ header that says which one it is:
 **What is refused.** Any other category, any field the template has no column for (for example
 `DestinationHostname` — `netstat()` has no hostname column), the modifiers `base64`, `windash`,
 `fieldref` and the like, aggregations, `near` and `timeframe`. A refusal lists every problem in
-the rule, one line each, with the YAML path. Nothing half-translated is ever offered to run.
+the rule, one line each, with the YAML path. A selection with no fields, a `1 of them` over no
+selection, and a `contains` / `endswith` path rooted on a drive or a host (`D:\tools\x.log`,
+which a search under `C:` could never find) are refused too. Nothing half-translated is ever
+offered to run.
 
 **A rule that spans categories becomes one hunt with several sources.** A finding's **Export as
 Sigma draft** writes a `process_creation` rule that also carries a network block and a file block


### PR DESCRIPTION
Closes #805, closes #806, closes #807. All three reproduced as filed, with the real functions, before any edit.

## #805 — anchor bomb threw instead of refusing
`parseSigmaRule` promised "never throws on input", but the `yaml` package's alias-expansion guard throws a `ReferenceError` from `toJS()` while `doc.errors` stays empty. `readDocument` now catches it and answers a refusal at path `yaml`, so `POST /cases/:id/sigma/compile` returns 400 with the sentence instead of 500.

## #806 — `WHERE ()`
An empty selection map, an empty map inside a selection list, and `1 of them` / `all of them` over a rule with no selection all compiled to `WHERE ()`. Each is now a parse refusal at its own path (`detection.sel`, `detection.sel[0]`, `detection.condition`). The compiler also refuses an empty field list, so a `SigmaRule` built by hand cannot assemble `WHERE ()` either.

## #807 — rooted `contains` / `endswith` could never match
`fileGlob` returns null for a value rooted on a drive or a UNC host, and `collectGlobs` refuses it, naming `startswith` and exact match as the forms that work on another drive.

**One deliberate departure from the issue's suggestion.** The issue also proposed refusing a fragment that opens on a separator. That would reject `TargetFilename|endswith: '\Temp\x.exe'`, the commonest shape in real Sigma file rules. Instead the glob for that shape is now correct: `C:/**/Temp/x.exe` rather than `C:/**/*/Temp/x.exe`, which required one component between `C:` and `Temp` and so skipped `C:\Temp\x.exe` itself. Bare names (`.hta`, `payload.ps1`) are unchanged, and the goldens prove it.

## Verification
- New tests at the parser, the compiler and the route for every shape above.
- Full companion suite: 727 files, 11854 tests, green. `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`, `check:us-map` all green.
- Docs: the "What is refused" paragraph in `mkdocs-docs/reference/threat-hunting.md` names the three new refusals.

## Codex review follow-up (second commit)
- A cyclic alias such as `sel: &a [*a]` converted without error and overflowed the stack in the parser's own walk, still a 500. The converted value is now checked once for a cycle; a shared acyclic alias still parses.
- In a selection list, an empty map returned before later entries were read, so a later unsupported modifier went unreported. Every entry is read first, so the refusal list stays complete.
