### PR TITLE
Fix the Windows CI failure left by #866 (identity path in the delivery-merge test)

### DIFF
--- a/companion/tests/integrations/mcpServerStore.test.ts
+++ b/companion/tests/integrations/mcpServerStore.test.ts
@@ -268,14 +268,17 @@ describe("McpServerStore delivery config", () => {
   });
 
   it("merges a delivery update field-wise instead of resetting the rest", async () => {
-    await store.add({ id: "sift-mcp", delivery: { ...SCP, identityFile: "/home/dfir/.ssh/lab" } });
+    // An absolute path for the platform the suite runs on: the identity file is validated against
+    // process.platform, so a POSIX path is refused by a Windows runner (see #850).
+    const identityFile = process.platform === "win32" ? "C:\\Users\\dfir\\.ssh\\lab" : "/home/dfir/.ssh/lab";
+    await store.add({ id: "sift-mcp", delivery: { ...SCP, identityFile } });
 
     const updated = await store.update("sift-mcp", { delivery: { remoteDir: "/cases/staging" } });
 
     expect(updated?.delivery).toMatchObject({
       mode: "scp",
       host: "sift.lab",
-      identityFile: "/home/dfir/.ssh/lab",
+      identityFile,
       remoteDir: "/cases/staging",
     });
   });


### PR DESCRIPTION
Master's **Companion test (Windows)** job is red since #866 merged (run 33865475247). One pre-existing test, `McpServerStore delivery config › merges a delivery update field-wise instead of resetting the rest`, saves `identityFile: "/home/dfir/.ssh/lab"` through `store.add()`. #866 made the identity-file check judge "absolute" for the platform scp runs on, and to a Windows scp that POSIX path is a relative filename, so the runner refused it with `must be an absolute Windows path`.

The test now picks the path by `process.platform`, the same way the tests #866 added do. One test file, no production code.

Verified locally: `tests/integrations/mcpServerStore.test.ts`, `mcpDelivery.test.ts` and `tests/server/mcpRoutes.test.ts` pass (89 tests), plus typecheck, lint and format:check. The Linux job was already green on this test; the Windows job on this PR is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126aNypiSSUF9ZZxBhPezkD

---
_Generated by [Claude Code](https://claude.ai/code/session_0126aNypiSSUF9ZZxBhPezkD)_