### PR TITLE
Fix the three open review findings in one pass: deploy-hunt VQL size limit, login burst limiter, stale import comments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,973 of the 2,012 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,974 of the 2,013 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -16,5 +16,5 @@
   "routes/import.ts": 3203,
   "routes/mcp.ts": 913,
   "routes/threatIntel.ts": 892,
-  "routes/velociraptor.ts": 1071
+  "routes/velociraptor.ts": 1070
 }

--- a/companion/src/auth/authRoutes.ts
+++ b/companion/src/auth/authRoutes.ts
@@ -311,14 +311,21 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
     }
     const loginLimiter = getLoginLimiter();
     const key = `${ip}:${username.toLowerCase()}`;
-    const remaining = loginLimiter.remainingLockout(key);
-    if (remaining > 0) {
-      res.setHeader("Retry-After", String(Math.ceil(remaining / 1_000)));
+    // The lockout check, the verification and the failure count are ONE serialized step per key
+    // (AttemptLimiter.attemptFor). The derivation runs on the threadpool (#863), which broke the
+    // old check → verify → record order this route still used: a burst of guesses against one
+    // account all passed the lockout check before any of them was counted, each buying a full
+    // scrypt derivation, so the five-attempt budget bounded nothing during the burst and a lucky
+    // success cleared failures that were counted after it started (#872). The client-wide IP
+    // budget above bounds the burst per CLIENT; this is what bounds it per ACCOUNT.
+    const outcome = await loginLimiter.attemptFor(key, () =>
+      auth.store.verifyLocalCredentials(username, bodyString(body, "password")),
+    );
+    if (outcome.kind === "locked") {
+      res.setHeader("Retry-After", String(Math.ceil(outcome.retryAfterMs / 1_000)));
       return res.status(429).json({ error: "too many attempts, try again later" });
     }
-    const identity = await auth.store.verifyLocalCredentials(username, bodyString(body, "password"));
-    if (!identity) {
-      loginLimiter.recordFailure(key);
+    if (outcome.kind === "failed") {
       // Bounded even though isValidUsername already caps it at 64 — the audit table is permanent,
       // and the detail column should never be the place a length assumption is first tested.
       auth.store.addAudit(
@@ -330,7 +337,7 @@ export function registerTeamAuthRoutes(app: Express, auth: TeamAuth, cases: Case
       );
       return res.status(401).json({ error: "invalid username or password" });
     }
-    loginLimiter.clear(key);
+    const identity = outcome.value;
     const created = auth.store.createSession(identity, auth.sessionTtlMs, {
       ip: req.ip,
       userAgent: req.get("user-agent"),

--- a/companion/src/http/rateLimiter.ts
+++ b/companion/src/http/rateLimiter.ts
@@ -6,6 +6,10 @@
 
 import type { Request, Response, NextFunction } from "express";
 
+/** What one serialized {@link AttemptLimiter.attemptFor} decided; `value` is what the check proved. */
+export type AttemptResult<T> =
+  { kind: "locked"; retryAfterMs: number } | { kind: "ok"; value: T } | { kind: "failed"; lockoutMs: number };
+
 /** What one serialized {@link AttemptLimiter.attempt} decided. */
 export type AttemptOutcome =
   /** The key was locked out before the check ran; nothing was tried. */
@@ -89,13 +93,28 @@ export class AttemptLimiter {
    * has to come through here, or the budget is shared in name only.
    */
   async attempt(key: string, check: () => Promise<boolean>): Promise<AttemptOutcome> {
+    const result = await this.attemptFor(key, async () => ((await check()) ? true : null));
+    return result.kind === "ok" ? { kind: "ok" } : result;
+  }
+
+  /**
+   * {@link attempt} for a check whose success carries something the caller needs — the identity a
+   * login just verified, say (#872). A non-null result IS the success; `null` is a failed attempt.
+   *
+   * This is where both forms are actually serialized. Returning the value through the limiter is
+   * what lets a caller that needs it still come through here: the alternative is assigning it to a
+   * variable from inside the check, which reads as the same code and quietly reopens the ordering
+   * hole the moment someone moves the lockout test back out of the chain.
+   */
+  async attemptFor<T>(key: string, check: () => Promise<T | null>): Promise<AttemptResult<T>> {
     const previous = this.inflight.get(key) ?? Promise.resolve();
-    const run = previous.then(async (): Promise<AttemptOutcome> => {
+    const run = previous.then(async (): Promise<AttemptResult<T>> => {
       const retryAfterMs = this.remainingLockout(key);
       if (retryAfterMs > 0) return { kind: "locked", retryAfterMs };
-      if (await check()) {
+      const value = await check();
+      if (value !== null) {
         this.clear(key);
-        return { kind: "ok" };
+        return { kind: "ok", value };
       }
       return { kind: "failed", lockoutMs: this.recordFailure(key) };
     });

--- a/companion/src/routes/encryptedImport.ts
+++ b/companion/src/routes/encryptedImport.ts
@@ -22,15 +22,18 @@ export function registerEncryptedImportRoutes(app: Express, ctx: RouteContext): 
   // corrupt archive, or malformed payload.
   //
   // Rate-limited like /unlock, and for a sharper reason: opening an archive costs a deliberate
-  // ~1s scrypt derivation (caseEncryption.ts) on the SYNCHRONOUS path, so an unauthenticated
-  // caller looping wrong-password imports holds the event loop — the whole server, not just this
-  // route — for as long as it cares to. The origin guard doesn't stop it (a caller with no Origin
-  // header is allowed by design, see http/originGuard.ts) and in container mode the port is on the
-  // network. Keyed by client IP because an import names no case until it has been decrypted; the
-  // key is coarse behind a reverse proxy that doesn't strip its own address, where every caller
-  // shares one bucket. That's the deliberate trade: a shared 30s import lockout is a far smaller
-  // failure than a wedged event loop, and refusing to trust a spoofable X-Forwarded-For is worth
-  // more than a per-caller bucket.
+  // ~1s scrypt derivation (caseEncryption.ts). Since #862 that derivation runs on libuv's
+  // threadpool rather than on the event loop, so a caller looping wrong-password imports no longer
+  // wedges the whole server outright — but the pool is four threads by default and is shared with
+  // every other user of it (file I/O, zlib, every OTHER derivation), so filling it still stalls
+  // unrelated work server-wide for as long as the caller cares to. That pool is the resource these
+  // limits protect. The origin guard doesn't stop it (a caller with no Origin header is allowed by
+  // design, see http/originGuard.ts) and in container mode the port is on the network. Keyed by
+  // client IP because an import names no case until it has been decrypted; the key is coarse
+  // behind a reverse proxy that doesn't strip its own address, where every caller shares one
+  // bucket. That's the deliberate trade: a shared 30s import lockout is a far smaller failure than
+  // a threadpool no other request can get onto, and refusing to trust a spoofable X-Forwarded-For
+  // is worth more than a per-caller bucket.
   app.post("/cases/import/encrypted", async (req: Request, res: Response) => {
     const limiter = getImportLimiter();
     const limiterKey = req.ip ?? "unknown";
@@ -50,11 +53,20 @@ export function registerEncryptedImportRoutes(app: Express, ctx: RouteContext): 
       if (typeof password !== "string" || !password) {
         return res.status(400).json({ error: "password is required" });
       }
-      // Everything past here reaches decryptBuffer, whose scrypt derivation blocks the event loop
-      // for about a second. The failure limiter above cannot bound that on its own: it counts only
-      // outcomes the catch classifies as failures, and deliberately never counts a conflict. This
-      // budget is charged per REQUEST, so no outcome — conflict, malformed archive, or success —
-      // is an unmetered way to buy another derivation (#424).
+      // Everything past here reaches decryptBuffer, whose scrypt derivation holds a threadpool
+      // thread for about a second. The failure limiter above cannot bound that on its own: it
+      // counts only outcomes the catch classifies as failures, and deliberately never counts a
+      // conflict. This budget is charged per REQUEST, so no outcome — conflict, malformed archive,
+      // or success — is an unmetered way to buy another derivation (#424).
+      //
+      // It is also why the failure limiter above may keep its three-step shape (check the lockout,
+      // decrypt, count in the catch) now that the derivation is async. /unlock and
+      // /auth/local/login had to move to AttemptLimiter.attemptFor when theirs did (#866, #872),
+      // because there the per-key failure budget was the ONLY bound and a burst slipped past the
+      // check before anything was counted. Here it is not: this per-request window is charged
+      // BEFORE the derivation rather than after it, so a burst is capped at 10/min per IP whatever
+      // order the failures land in. The serialized form would not fit anyway — it counts every
+      // non-success, and a conflict must stay uncounted (#424).
       if (!getImportIpLimiter().tryAcquire(limiterKey)) {
         res.setHeader("Retry-After", "60");
         return res.status(429).json({ error: "too many import attempts, try again later" });

--- a/companion/src/routes/huntDeployBody.ts
+++ b/companion/src/routes/huntDeployBody.ts
@@ -2,6 +2,7 @@
 // routes/velociraptor.ts, which sits at its file-size cap. Pure: no I/O, no request object.
 
 import type { HuntCoverage, HuntOutcomeSource } from "../analysis/huntOutcomes.js";
+import { vqlSizeProblem } from "../analysis/vqlInput.js";
 
 export interface DeployHuntBody {
   vql: string;
@@ -60,4 +61,22 @@ export function parseDeployHuntBody(raw: unknown): DeployHuntBody {
     ...(relatedHypothesisId ? { relatedHypothesisId } : {}),
     ...(coverage ? { coverage } : {}),
   };
+}
+
+/**
+ * The 400 this body earns, or null when it is usable.
+ *
+ * Lives here rather than in the route because routes/velociraptor.ts is at its file-size cap, and
+ * because the size check belongs with the parse: deploy-hunt was the one VQL-carrying route that
+ * never got `vqlSizeProblem` (#871), so an oversized program was packaged into a generated
+ * artifact — embedded into the outer program, so duplicated several times over — and only failed
+ * at the spawn, as an E2BIG the analyst could do nothing with.
+ */
+export function deployHuntBodyProblem(
+  body: Pick<DeployHuntBody, "vql" | "title" | "mode" | "hostname">,
+): string | null {
+  if (!body.vql) return "vql is required";
+  if (!body.title) return "title is required";
+  if (body.mode === "collection" && !body.hostname) return "hostname is required for a collection";
+  return vqlSizeProblem(body.vql);
 }

--- a/companion/src/routes/velociraptor.ts
+++ b/companion/src/routes/velociraptor.ts
@@ -13,7 +13,7 @@ import {
   type VeloArtifactInfo,
 } from "../integrations/velociraptor/velociraptorApi.js";
 import type { VeloHuntJob } from "../analysis/veloHuntStore.js";
-import { parseDeployHuntBody } from "./huntDeployBody.js";
+import { parseDeployHuntBody, deployHuntBodyProblem } from "./huntDeployBody.js";
 import { resolveCollectVql } from "../analysis/collectDirectiveResolve.js";
 import { resolveTimeScope, buildTimeScopePlan, type TimeScope } from "../analysis/veloTimeScope.js";
 import type { ArtifactBundle } from "../analysis/artifactBundleStore.js";
@@ -896,11 +896,10 @@ export function registerVelociraptorRoutes(app: Express, ctx: RouteContext): voi
       relatedHypothesisId,
       coverage,
     } = parseDeployHuntBody(req.body);
-    if (!vql) return res.status(400).json({ error: "vql is required" });
-    if (!title) return res.status(400).json({ error: "title is required" });
+    const bodyProblem = deployHuntBodyProblem({ vql, title, mode, hostname });
+    if (bodyProblem) return res.status(400).json({ error: bodyProblem });
     try {
       if (mode === "collection") {
-        if (!hostname) return res.status(400).json({ error: "hostname is required for a collection" });
         logLine(`[velociraptor] deploy-hunt collection "${title}" on ${hostname}`);
         const result = await collectHostResolved(hostname, vql, description);
         // A collection is a per-host FLOW (no huntId), so its outcome isn't auto-collected — but recording

--- a/companion/tests/http/loginBurst.test.ts
+++ b/companion/tests/http/loginBurst.test.ts
@@ -1,0 +1,139 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthStore } from "../../src/auth/authStore.js";
+import { TeamAuth } from "../../src/auth/teamAuth.js";
+import { createApp } from "../../src/server.js";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { verifyLocalPassword } from "../../src/auth/password.js";
+import { resetLimiters } from "../../src/http/rateLimiter.js";
+
+/**
+ * POST /auth/local/login under a CONCURRENT burst (#872).
+ *
+ * The password derivation runs on the threadpool, so the route's old three steps — check the
+ * lockout, verify, record the failure — were separable: twenty simultaneous guesses against one
+ * account all passed the lockout check before any of them was counted, every one of them paying
+ * for a scrypt derivation, and a correct guess could clear failures that had not been counted yet.
+ * The five-attempt budget only ever held because the derivation used to hold the event loop.
+ *
+ * The route now goes through AttemptLimiter.attemptFor, which serializes the three steps per key.
+ * These tests count the DERIVATIONS, which the status codes alone cannot distinguish from the old
+ * order: on master the statuses came out the same and the CPU cost did not.
+ */
+vi.mock("../../src/auth/password.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/auth/password.js")>();
+  return { ...actual, verifyLocalPassword: vi.fn(actual.verifyLocalPassword) };
+});
+
+const verifySpy = vi.mocked(verifyLocalPassword);
+
+const BOOTSTRAP_TOKEN = "test-bootstrap-token-with-enough-entropy";
+const GOOD = "correct horse battery staple";
+const WRONG = "not the password";
+
+let app: ReturnType<typeof createApp>;
+
+beforeEach(async () => {
+  resetLimiters();
+  const root = await mkdtemp(join(tmpdir(), "dfir-loginburst-"));
+  const cases = new CaseStore(join(root, "cases"));
+  const authStore = new AuthStore(join(root, "auth.sqlite"));
+  app = createApp(cases, {
+    teamAuth: new TeamAuth({
+      store: authStore,
+      bootstrapToken: BOOTSTRAP_TOKEN,
+      cookieSecure: false,
+      sessionTtlMs: 60 * 60_000,
+    }),
+  });
+  await request(app).post("/auth/bootstrap").send({
+    bootstrapToken: BOOTSTRAP_TOKEN,
+    username: "admin",
+    password: GOOD,
+    displayName: "Primary Admin",
+  });
+  verifySpy.mockClear(); // the bootstrap itself hashes, but never verifies
+});
+
+afterEach(() => resetLimiters());
+
+const login = (password: string) =>
+  request(app).post("/auth/local/login").send({ username: "admin", password });
+
+const derivedPasswords = () => verifySpy.mock.calls.map((c) => c[0]);
+
+describe("login limiter under a concurrent burst", () => {
+  it("a burst of 20 wrong guesses for one account derives at most 5 times before the lockout", async () => {
+    const results = await Promise.all(Array.from({ length: 20 }, () => login(WRONG)));
+    expect(verifySpy).toHaveBeenCalledTimes(5);
+    // The fifth failure locks the account but still answers 401 (a wrong password is a wrong
+    // password); every guess refused by the lockout answers 429.
+    expect(results.filter((r) => r.status === 401)).toHaveLength(5);
+    expect(results.filter((r) => r.status === 429)).toHaveLength(15);
+    expect(results.every((r) => r.status === 401 || r.status === 429)).toBe(true);
+  });
+
+  it("the account stays locked afterwards, and the correct password costs no derivation", async () => {
+    await Promise.all(Array.from({ length: 20 }, () => login(WRONG)));
+    expect(verifySpy).toHaveBeenCalledTimes(5);
+    const res = await login(GOOD);
+    expect(res.status).toBe(429);
+    expect(res.headers["retry-after"]).toBeTruthy();
+    expect(verifySpy).toHaveBeenCalledTimes(5); // refused before the threadpool was touched
+  });
+
+  // Requests reach the limiter in whatever order the HTTP layer delivers them, so the ORDER is not
+  // asserted — the OUTCOME of that order is. The derivations are serialized, so the sequence of
+  // passwords the mock saw IS the order the limiter processed them in; a short model of the
+  // limiter over that sequence gives the status each request must have received, and any attempt
+  // the model never derived must have been refused as locked. A success that cleared failures
+  // still in flight, or a derivation past the lockout, breaks the match.
+  function statusesForOrder(derived: string[], total: number): number[] {
+    let failures = 0;
+    let locked = false;
+    const out: number[] = [];
+    for (const pw of derived) {
+      expect(locked, "derived after the lockout").toBe(false);
+      if (pw === GOOD) {
+        failures = 0;
+        out.push(200);
+      } else {
+        if (++failures >= 5) locked = true;
+        out.push(401);
+      }
+    }
+    while (out.length < total) out.push(429);
+    return out.sort();
+  }
+
+  it("a correct password racing wrong ones clears only the failures counted before it", async () => {
+    const results = await Promise.all([
+      ...Array.from({ length: 3 }, () => login(WRONG)),
+      login(GOOD),
+      ...Array.from({ length: 4 }, () => login(WRONG)),
+    ]);
+    const derived = derivedPasswords();
+    expect(derived.length).toBeLessThanOrEqual(8);
+    expect(results.map((r) => r.status).sort()).toEqual(statusesForOrder(derived, 8));
+    // Whatever the order, a success can only have cleared failures counted BEFORE it: once five
+    // wrong guesses follow the last success (or no success derived at all), the account is locked.
+    const lastSuccess = derived.lastIndexOf(GOOD);
+    if (derived.length - (lastSuccess + 1) >= 5) {
+      expect((await login(GOOD)).status).toBe(429);
+      expect(derivedPasswords()).toHaveLength(derived.length); // refused without a derivation
+    }
+  });
+
+  it("a fresh account is unaffected by another account's lockout", async () => {
+    await Promise.all(Array.from({ length: 20 }, () => login(WRONG)));
+    // Keys never wait on each other, and a locked key never spends another account's budget.
+    const other = await request(app)
+      .post("/auth/local/login")
+      .send({ username: "someone-else", password: WRONG });
+    expect(other.status).toBe(401); // verified against the dummy hash, not refused as locked
+    expect(verifySpy).toHaveBeenCalledTimes(6);
+  });
+});

--- a/companion/tests/server/veloBundle.test.ts
+++ b/companion/tests/server/veloBundle.test.ts
@@ -196,7 +196,7 @@ describe("Velociraptor triage bundles — routes", () => {
   // oversized body could never run and used to surface only as an E2BIG spawn failure (#825,
   // #828); the routes now refuse it with a 400 before the client is touched, and they measure
   // UTF-8 bytes, because a character count under-reads a multibyte query by up to three times.
-  describe("VQL size limit on /velociraptor/run, /hunt and /collect-host", () => {
+  describe("VQL size limit on /velociraptor/run, /hunt, /collect-host and deploy-hunt", () => {
     const ROUTES = (vql: string) =>
       [
         ["/velociraptor/run", { vql }],
@@ -244,6 +244,42 @@ describe("Velociraptor triage bundles — routes", () => {
       const res = await request(spyApp).post("/velociraptor/run").send({ vql });
       expect(res.status).toBe(200);
       expect(calls).toHaveLength(1);
+    });
+
+    // The case-scoped deploy path was the one VQL-carrying route the limit missed (#871). It takes
+    // its VQL from the same body and — in hunt mode — splits it into statements and embeds each
+    // into a generated artifact before the spawn, so an oversized program is duplicated several
+    // times over on its way to an E2BIG nobody can act on.
+    it("refuses an oversized deploy-hunt body in BOTH modes and never invokes the client", async () => {
+      const calls: string[][] = [];
+      const { app: spyApp } = await makeApp(async (statements) => {
+        calls.push(statements);
+        return { rows: [], raw: "" };
+      });
+      const vql = "SELECT 1 FROM scope() -- " + "x".repeat(100_001);
+      for (const body of [
+        { vql, title: "oversized", mode: "hunt" },
+        { vql, title: "oversized", mode: "collection", hostname: "WS-1" },
+      ]) {
+        const res = await request(spyApp).post("/cases/c1/velociraptor/deploy-hunt").send(body);
+        expect(res.status, body.mode).toBe(400);
+        expect(res.body.error, body.mode).toMatch(/vql is too long/);
+      }
+      expect(calls).toHaveLength(0);
+    });
+
+    it("accepts a deploy-hunt body under the byte limit", async () => {
+      // This suite's default runner answers the bundle-launch shape (`artifacts=[`); a deploy-hunt
+      // launches a generated single artifact, so it needs a runner that answers that one.
+      const { app: spyApp } = await makeApp(async (statements) =>
+        statements[0].includes("hunt(") && statements[0].includes("artifacts=")
+          ? { rows: [{ Hunt: { HuntId: "H.SIZE1", state: "RUNNING" } }], raw: "" }
+          : { rows: [], raw: "" },
+      );
+      const res = await request(spyApp)
+        .post("/cases/c1/velociraptor/deploy-hunt")
+        .send({ vql: "SELECT 1 FROM scope() -- " + "x".repeat(90_000), title: "large", mode: "hunt" });
+      expect(res.status).toBe(200);
     });
   });
 


### PR DESCRIPTION
Closes #871, closes #872, closes #873.

All three open issues in one branch, so the gates run once. Each is a real finding; none was closed as invalid.

## #871 — `deploy-hunt` missed the VQL size limit *(bug)*

`vqlSizeProblem()` caps a request-borne VQL program at 100,000 UTF-8 bytes — the Linux per-argv ceiling below which the spawned CLI can never run. It reached `/velociraptor/collect`, `/run` and `/hunt` but not `POST /cases/:id/velociraptor/deploy-hunt`, which takes VQL from the same body and hands it to `launchHunt()` / `collectOnClient()`. An oversized program was packaged into a generated artifact — embedded into the outer program, so duplicated several times over — and died at the spawn with an `E2BIG` the analyst could do nothing with.

The three scattered body checks (`vql`, `title`, collection-mode `hostname`) plus the missing size check move into `huntDeployBody.deployHuntBodyProblem()`, beside the parse they validate. `routes/velociraptor.ts` is at its file-size cap and this nets a line back off it, so the ledger records the smaller number.

## #872 — `/auth/local/login` shared the 5-guess budget under a burst *(bug)*

#863 moved the scrypt derivation to the threadpool; #866 fixed what that broke for `/unlock` and `/captures`. The login route still used the old `remainingLockout → verify → recordFailure` order with an async `verifyLocalCredentials`, so a burst of guesses for one account all passed the lockout check before any was counted — each buying a full derivation — and a lucky success cleared failures counted after it started.

Login needs the identity the verification produces, which `attempt()` cannot return, so the serialized implementation graduates to `attemptFor<T>()` (a non-null result is the success) and `attempt()` delegates to it. Returning the value *through* the limiter is what keeps a caller that needs it inside the chain.

Behaviour that does **not** change: the per-IP pre-gate (60/min), and the status codes — a wrong password is still 401 including the one that trips the lockout; only a guess refused by an engaged lockout is 429.

## #873 — stale rationale on `/cases/import/encrypted` *(suggestion)*

Both comment blocks still described `decryptBuffer`'s derivation as synchronous and the rate limits as protection against a held event loop. #862 moved it to libuv's threadpool. The limits are still right — the pool is four threads by default and shared with every other user of it — so only the "why" changes.

The issue's second finding (the three-step limiter here) is **deliberately not** converted. Its per-request IP window is the real bound and is charged *before* the derivation, and `attemptFor` would not fit anyway: it counts every non-success, while a `CaseImportConflictError` must stay uncounted (#424). That reasoning is now recorded in the file rather than left for the next reader to re-derive.

## Test plan

- [x] `tests/http/loginBurst.test.ts` (new) — counts the *derivations* under a 20-guess burst, not just the status codes: exactly 5 before the lockout, the account stays locked without further threadpool cost, a correct password racing wrong ones clears only failures counted before it, and another account is unaffected. On `master` the statuses came out the same and the CPU cost did not.
- [x] `tests/server/veloBundle.test.ts` — deploy-hunt refused at 400 in **both** modes with the client never invoked, and a 90 KB body still accepted.
- [x] Full suite: `11,958 tests / 734 files` pass.
- [x] `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries` all clean. `ARCHITECTURE.md`'s cross-domain comply/total pair moves with the new `routes → analysis` edge, as `moduleMap.test.ts` requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mXaxwsRxd7tffg7PDuzu3
