### PR TITLE
fix(analysis-runs): bind manifests to the requested case, stop rescanning the ledger on append

### DIFF
--- a/companion/src/analysis/analysisRunStore.ts
+++ b/companion/src/analysis/analysisRunStore.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, readdir, readFile } from "node:fs/promises";
+import { mkdir, open, readdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { CaseStore } from "../storage/caseStore.js";
@@ -9,9 +9,11 @@ import {
   ANALYSIS_RUN_SCHEMA_VERSION,
   analysisRunHeadSchema,
   analysisRunManifestSchema,
+  analysisRunPendingAppendSchema,
   type AnalysisRunHead,
   type AnalysisRunIntegrity,
   type AnalysisRunManifest,
+  type AnalysisRunPendingAppend,
   type AnalysisRunRecordInput,
   type ManifestValue,
 } from "./analysisRunTypes.js";
@@ -111,6 +113,10 @@ export class AnalysisRunStore {
     return join(this.dir(caseId), "head.json");
   }
 
+  private pendingPath(caseId: string): string {
+    return join(this.dir(caseId), "pending.json");
+  }
+
   private async readHead(caseId: string): Promise<AnalysisRunHead | null> {
     try {
       return analysisRunHeadSchema.parse(
@@ -122,10 +128,22 @@ export class AnalysisRunStore {
     }
   }
 
+  private async readPending(caseId: string): Promise<AnalysisRunPendingAppend | null> {
+    try {
+      return analysisRunPendingAppendSchema.parse(
+        JSON.parse(await readFile(this.pendingPath(caseId), "utf8")) as unknown,
+      );
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      // An unreadable marker still means an append was interrupted here.
+      return { id: "" };
+    }
+  }
+
   private async manifestNames(caseId: string): Promise<string[]> {
     try {
       return (await readdir(this.dir(caseId))).filter(
-        (name) => name.endsWith(".json") && name !== "head.json",
+        (name) => name.endsWith(".json") && name !== "head.json" && name !== "pending.json",
       );
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
@@ -150,28 +168,30 @@ export class AnalysisRunStore {
   /**
    * Resolve the sequence and hash to chain the next append onto.
    *
-   * `head.json` already pins both, so the healthy path costs one `readdir` plus one
-   * small read instead of parsing the whole ledger. The manifest count is the cheap
-   * cross-check: it equals the head sequence in an intact ledger, so any mismatch
-   * (missing, corrupt, or stale head after a crash between the two writes) falls
-   * back to rebuilding from the manifests themselves.
+   * `head.json` pins both and names its owner, so a healthy append reads two small
+   * files and never lists the directory — appending stays flat as a ledger grows.
+   *
+   * The head is trusted only when it names this case and no append marker is
+   * outstanding. A renamed archive import copies the source case's manifests and
+   * head in verbatim, so an owner mismatch means this case has no ledger of its own
+   * yet and must start a fresh chain rather than graft onto the source's. A marker
+   * means an append was interrupted, so the head may sit one behind the manifests.
+   * Either way the tip is rebuilt from the manifests this case actually owns.
    */
   private async ledgerTip(caseId: string): Promise<{ sequence: number; manifestHash: string | null }> {
-    const names = await this.manifestNames(caseId);
-    if (names.length === 0) return { sequence: 0, manifestHash: null };
-    let head: AnalysisRunHead | null = null;
-    try {
-      head = await this.readHead(caseId);
-    } catch {
-      head = null;
-    }
-    if (head && head.sequence === names.length) {
+    const [head, pending] = await Promise.all([
+      this.readHead(caseId).catch(() => null),
+      this.readPending(caseId),
+    ]);
+    if (!pending && head?.caseId === caseId) {
       return { sequence: head.sequence, manifestHash: head.manifestHash };
     }
-    const latest = (await this.readAll(caseId)).reduce<AnalysisRunManifest | undefined>(
-      (current, run) => (!current || run.sequence > current.sequence ? run : current),
-      undefined,
-    );
+    const latest = (await this.readAll(caseId))
+      .filter((run) => run.caseId === caseId)
+      .reduce<AnalysisRunManifest | undefined>(
+        (current, run) => (!current || run.sequence > current.sequence ? run : current),
+        undefined,
+      );
     return { sequence: latest?.sequence ?? 0, manifestHash: latest?.manifestHash ?? null };
   }
 
@@ -205,6 +225,13 @@ export class AnalysisRunStore {
         tip.manifestHash,
       );
       await mkdir(this.dir(caseId), { recursive: true });
+      // Ordering matters: the marker goes down first, so any crash that leaves the
+      // head behind the manifests also leaves the marker, and the next append knows
+      // to reconcile instead of trusting a stale tip.
+      await atomicWrite(
+        this.pendingPath(caseId),
+        JSON.stringify({ id: manifest.id } satisfies AnalysisRunPendingAppend),
+      );
       let handle;
       try {
         handle = await open(this.path(caseId, manifest.id), "wx");
@@ -212,8 +239,10 @@ export class AnalysisRunStore {
         await handle.sync();
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+          await rm(this.pendingPath(caseId), { force: true });
           throw new Error(`analysis run ${manifest.id} already exists`);
         }
+        await rm(this.pendingPath(caseId), { force: true });
         throw err;
       } finally {
         await handle?.close();
@@ -222,21 +251,33 @@ export class AnalysisRunStore {
         this.headPath(caseId),
         JSON.stringify({
           schemaVersion: ANALYSIS_RUN_SCHEMA_VERSION,
+          caseId,
           sequence: manifest.sequence,
           manifestHash: manifest.manifestHash,
         } satisfies AnalysisRunHead),
       );
+      await rm(this.pendingPath(caseId), { force: true });
       return manifest;
     });
   }
 
   async verify(caseId: string): Promise<AnalysisRunIntegrity> {
-    let runs: AnalysisRunManifest[];
+    let stored: AnalysisRunManifest[];
     try {
-      runs = [...(await this.readAll(caseId))].sort((a, b) => a.sequence - b.sequence);
+      stored = await this.readAll(caseId);
     } catch (err) {
-      return { ok: false, manifests: 0, problems: [`ledger unreadable: ${(err as Error).message}`] };
+      return {
+        ok: false,
+        manifests: 0,
+        problems: [`ledger unreadable: ${(err as Error).message}`],
+        foreignManifests: 0,
+      };
     }
+    // Only the runs this case owns form its chain. Manifests left behind by a renamed
+    // import belong to the source case's chain, so verifying them here would report
+    // failures against a ledger this case never wrote.
+    const runs = stored.filter((run) => run.caseId === caseId).sort((a, b) => a.sequence - b.sequence);
+    const foreignManifests = stored.length - runs.length;
     const problems: string[] = [];
     let head: AnalysisRunHead | null;
     try {
@@ -246,8 +287,12 @@ export class AnalysisRunStore {
         ok: false,
         manifests: runs.length,
         problems: [`ledger head unreadable: ${(err as Error).message}`],
+        foreignManifests,
       };
     }
+    // A head naming another case came in with that import too. A head with no owner
+    // predates the field, so it is read as this case's.
+    if (head && head.caseId !== undefined && head.caseId !== caseId) head = null;
     let previous: string | null = null;
     for (const [index, run] of runs.entries()) {
       if (run.sequence !== index + 1) problems.push(`${run.id}: ledger sequence mismatch`);
@@ -262,6 +307,6 @@ export class AnalysisRunStore {
     if (latest && head && (head.sequence !== latest.sequence || head.manifestHash !== latest.manifestHash)) {
       problems.push("ledger head mismatch");
     }
-    return { ok: problems.length === 0, manifests: runs.length, problems };
+    return { ok: problems.length === 0, manifests: runs.length, problems, foreignManifests };
   }
 }

--- a/companion/src/analysis/analysisRunStore.ts
+++ b/companion/src/analysis/analysisRunStore.ts
@@ -18,6 +18,9 @@ import {
 
 const VALID_RUN_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,119}$/;
 
+/** Cap on manifests opened at once so a large ledger cannot exhaust file descriptors. */
+const LEDGER_READ_CONCURRENCY = 32;
+
 export interface AnalysisRunStoreOptions {
   appVersion: string;
 }
@@ -119,30 +122,72 @@ export class AnalysisRunStore {
     }
   }
 
-  private async readAll(caseId: string): Promise<AnalysisRunManifest[]> {
-    let names: string[];
+  private async manifestNames(caseId: string): Promise<string[]> {
     try {
-      names = (await readdir(this.dir(caseId))).filter(
+      return (await readdir(this.dir(caseId))).filter(
         (name) => name.endsWith(".json") && name !== "head.json",
       );
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
       throw err;
     }
-    return Promise.all(
-      names.map(async (name) => parseManifest(await readFile(join(this.dir(caseId), name), "utf8"))),
+  }
+
+  private async readAll(caseId: string): Promise<AnalysisRunManifest[]> {
+    const names = await this.manifestNames(caseId);
+    const manifests: AnalysisRunManifest[] = [];
+    for (let start = 0; start < names.length; start += LEDGER_READ_CONCURRENCY) {
+      const batch = names.slice(start, start + LEDGER_READ_CONCURRENCY);
+      manifests.push(
+        ...(await Promise.all(
+          batch.map(async (name) => parseManifest(await readFile(join(this.dir(caseId), name), "utf8"))),
+        )),
+      );
+    }
+    return manifests;
+  }
+
+  /**
+   * Resolve the sequence and hash to chain the next append onto.
+   *
+   * `head.json` already pins both, so the healthy path costs one `readdir` plus one
+   * small read instead of parsing the whole ledger. The manifest count is the cheap
+   * cross-check: it equals the head sequence in an intact ledger, so any mismatch
+   * (missing, corrupt, or stale head after a crash between the two writes) falls
+   * back to rebuilding from the manifests themselves.
+   */
+  private async ledgerTip(caseId: string): Promise<{ sequence: number; manifestHash: string | null }> {
+    const names = await this.manifestNames(caseId);
+    if (names.length === 0) return { sequence: 0, manifestHash: null };
+    let head: AnalysisRunHead | null = null;
+    try {
+      head = await this.readHead(caseId);
+    } catch {
+      head = null;
+    }
+    if (head && head.sequence === names.length) {
+      return { sequence: head.sequence, manifestHash: head.manifestHash };
+    }
+    const latest = (await this.readAll(caseId)).reduce<AnalysisRunManifest | undefined>(
+      (current, run) => (!current || run.sequence > current.sequence ? run : current),
+      undefined,
     );
+    return { sequence: latest?.sequence ?? 0, manifestHash: latest?.manifestHash ?? null };
   }
 
   async list(caseId: string): Promise<AnalysisRunManifest[]> {
-    const runs = await this.readAll(caseId);
+    const runs = (await this.readAll(caseId)).filter((run) => run.caseId === caseId);
     return runs.sort((a, b) => b.startedAt.localeCompare(a.startedAt) || b.id.localeCompare(a.id));
   }
 
   async get(caseId: string, id: string): Promise<AnalysisRunManifest | null> {
     if (!VALID_RUN_ID.test(id)) return null;
     try {
-      return parseManifest(await readFile(this.path(caseId, id), "utf8"));
+      const manifest = parseManifest(await readFile(this.path(caseId, id), "utf8"));
+      // The requested case is authoritative. A renamed archive import copies the
+      // source case's manifests in verbatim, so a manifest naming another case is
+      // not this case's run and must never become a replay target here.
+      return manifest.caseId === caseId ? manifest : null;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw err;
@@ -151,18 +196,13 @@ export class AnalysisRunStore {
 
   async record(caseId: string, input: AnalysisRunRecordInput): Promise<AnalysisRunManifest> {
     return this.lock.runExclusive(caseId, async () => {
-      const existing = await this.readAll(caseId);
-      const latest = existing.reduce<AnalysisRunManifest | undefined>(
-        (current, run) => (!current || run.sequence > current.sequence ? run : current),
-        undefined,
-      );
-      const sequence = (latest?.sequence ?? 0) + 1;
+      const tip = await this.ledgerTip(caseId);
       const manifest = buildManifest(
         caseId,
         input,
         this.options.appVersion,
-        sequence,
-        latest?.manifestHash ?? null,
+        tip.sequence + 1,
+        tip.manifestHash,
       );
       await mkdir(this.dir(caseId), { recursive: true });
       let handle;

--- a/companion/src/analysis/analysisRunTypes.ts
+++ b/companion/src/analysis/analysisRunTypes.ts
@@ -167,14 +167,30 @@ export const analysisRunManifestSchema: z.ZodType<AnalysisRunManifest> = z.objec
 
 export interface AnalysisRunHead {
   schemaVersion: typeof ANALYSIS_RUN_SCHEMA_VERSION;
+  /**
+   * Case the pinned tip belongs to. Optional only to read ledgers written before the
+   * field existed; a head without it is not trusted and forces a rebuild, which then
+   * writes one carrying the owner.
+   */
+  caseId?: string;
   sequence: number;
   manifestHash: string;
 }
 
 export const analysisRunHeadSchema: z.ZodType<AnalysisRunHead> = z.object({
   schemaVersion: z.literal(ANALYSIS_RUN_SCHEMA_VERSION),
+  caseId: z.string().min(1).optional(),
   sequence: z.number().int().positive(),
   manifestHash: sha256Schema,
+});
+
+/** Marker written before a manifest and removed after the head is pinned. */
+export interface AnalysisRunPendingAppend {
+  id: string;
+}
+
+export const analysisRunPendingAppendSchema: z.ZodType<AnalysisRunPendingAppend> = z.object({
+  id: z.string().min(1),
 });
 
 export interface AnalysisRunRecordInput {
@@ -196,4 +212,10 @@ export interface AnalysisRunIntegrity {
   ok: boolean;
   manifests: number;
   problems: string[];
+  /**
+   * Manifests in the case directory that name a different case, as a renamed archive
+   * import leaves behind. They are retained for provenance but form no part of this
+   * case's chain, so they are counted rather than verified or hidden.
+   */
+  foreignManifests: number;
 }

--- a/companion/tests/analysis/analysisRunAppendCost.test.ts
+++ b/companion/tests/analysis/analysisRunAppendCost.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Counts directory listings while delegating to the real filesystem, so the cost of
+// an append is measured rather than inferred. Isolated in its own file because the
+// module mock is hoisted over every import in it.
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, readdir: vi.fn(actual.readdir) };
+});
+
+import { mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { AnalysisRunStore } from "../../src/analysis/analysisRunStore.js";
+import type { AnalysisRunRecordInput } from "../../src/analysis/analysisRunTypes.js";
+
+const BASE_RUN: Omit<AnalysisRunRecordInput, "id"> = {
+  kind: "deterministic",
+  startedAt: "2026-07-31T10:00:00.000Z",
+  finishedAt: "2026-07-31T10:00:01.000Z",
+  versions: {},
+  input: { artifacts: [], eventIds: [], entityIds: [] },
+  output: { entityIds: [], hashes: [], claims: [] },
+};
+
+function ledgerListings(): string[] {
+  return vi
+    .mocked(readdir)
+    .mock.calls.map(([target]) => String(target))
+    .filter((target) => target.includes("analysis-runs"));
+}
+
+describe("AnalysisRunStore append cost", () => {
+  let cases: CaseStore;
+  let store: AnalysisRunStore;
+
+  beforeEach(async () => {
+    const root = await mkdtemp(join(tmpdir(), "dfir-append-cost-"));
+    cases = new CaseStore(root);
+    await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+    store = new AnalysisRunStore(cases, { appVersion: "0.33.0" });
+    vi.mocked(readdir).mockClear();
+  });
+
+  it("never lists the ledger directory on a healthy append", async () => {
+    await store.record("c1", { ...BASE_RUN, id: "run-1" });
+    vi.mocked(readdir).mockClear();
+
+    for (const id of ["run-2", "run-3", "run-4", "run-5"]) {
+      await store.record("c1", { ...BASE_RUN, id });
+    }
+
+    expect(ledgerListings()).toEqual([]);
+  });
+
+  it("keeps append cost flat as the ledger grows", async () => {
+    for (const id of ["run-1", "run-2", "run-3", "run-4", "run-5", "run-6"]) {
+      await store.record("c1", { ...BASE_RUN, id });
+    }
+    vi.mocked(readdir).mockClear();
+
+    const late = await store.record("c1", { ...BASE_RUN, id: "run-7" });
+
+    expect(late.sequence).toBe(7);
+    expect(ledgerListings()).toEqual([]);
+  });
+
+  it("lists the directory only when the pinned head cannot be trusted", async () => {
+    await store.record("c1", { ...BASE_RUN, id: "run-1" });
+    await cases.createCase({ caseId: "c2", name: "n2", investigator: "i", aiProvider: null });
+    vi.mocked(readdir).mockClear();
+
+    // c2 has no head at all, so the tip has to be rebuilt from the directory.
+    await store.record("c2", { ...BASE_RUN, id: "own-1" });
+
+    expect(ledgerListings().length).toBeGreaterThan(0);
+  });
+});

--- a/companion/tests/analysis/analysisRunStore.test.ts
+++ b/companion/tests/analysis/analysisRunStore.test.ts
@@ -1,13 +1,25 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, readFile, unlink, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CaseStore } from "../../src/storage/caseStore.js";
 import { AnalysisRunStore } from "../../src/analysis/analysisRunStore.js";
+import type { AnalysisRunRecordInput } from "../../src/analysis/analysisRunTypes.js";
+
+const BASE_RUN: Omit<AnalysisRunRecordInput, "id"> = {
+  kind: "deterministic",
+  startedAt: "2026-07-31T10:00:00.000Z",
+  finishedAt: "2026-07-31T10:00:01.000Z",
+  versions: {},
+  input: { artifacts: [], eventIds: [], entityIds: [] },
+  output: { entityIds: [], hashes: [], claims: [] },
+};
 
 describe("AnalysisRunStore", () => {
   let cases: CaseStore;
   let store: AnalysisRunStore;
+
+  const ledgerDir = (caseId: string) => join(cases.stateDir(caseId), "analysis-runs");
 
   beforeEach(async () => {
     const root = await mkdtemp(join(tmpdir(), "dfir-analysis-runs-"));
@@ -163,5 +175,70 @@ describe("AnalysisRunStore", () => {
     const result = await store.verify("c1");
     expect(result.ok).toBe(false);
     expect(result.problems).toContain("ledger head mismatch");
+  });
+
+  describe("case binding", () => {
+    // A renamed archive import copies state/analysis-runs/*.json verbatim, so the
+    // manifests still name the source case. The requested case is authoritative.
+    async function copyLedgerToC2(runId: string): Promise<void> {
+      await cases.createCase({ caseId: "c2", name: "n2", investigator: "i", aiProvider: null });
+      await mkdir(ledgerDir("c2"), { recursive: true });
+      await cp(join(ledgerDir("c1"), `${runId}.json`), join(ledgerDir("c2"), `${runId}.json`));
+    }
+
+    it("refuses a run whose manifest names a different case", async () => {
+      const run = await store.record("c1", { ...BASE_RUN, id: "foreign-run" });
+      await copyLedgerToC2("foreign-run");
+
+      expect(run.caseId).toBe("c1");
+      expect(await store.get("c2", "foreign-run")).toBeNull();
+      expect(await store.get("c1", "foreign-run")).not.toBeNull();
+    });
+
+    it("omits a manifest that names a different case from the listing", async () => {
+      await store.record("c1", { ...BASE_RUN, id: "foreign-run" });
+      await copyLedgerToC2("foreign-run");
+
+      expect(await store.list("c2")).toEqual([]);
+    });
+  });
+
+  describe("append cost", () => {
+    it("appends without rereading historical manifests", async () => {
+      await store.record("c1", { ...BASE_RUN, id: "run-1" });
+      const second = await store.record("c1", { ...BASE_RUN, id: "run-2" });
+      // An unreadable historical manifest must not block an append: reaching it at
+      // all means the append is still scanning the whole ledger.
+      await writeFile(join(ledgerDir("c1"), "run-1.json"), "{ not valid json", "utf8");
+
+      const third = await store.record("c1", { ...BASE_RUN, id: "run-3" });
+
+      expect(third.sequence).toBe(3);
+      expect(third.previousManifestHash).toBe(second.manifestHash);
+    });
+
+    it("rebuilds the next sequence when the pinned head is missing", async () => {
+      await store.record("c1", { ...BASE_RUN, id: "run-1" });
+      const second = await store.record("c1", { ...BASE_RUN, id: "run-2" });
+      await unlink(join(ledgerDir("c1"), "head.json"));
+
+      const third = await store.record("c1", { ...BASE_RUN, id: "run-3" });
+
+      expect(third.sequence).toBe(3);
+      expect(third.previousManifestHash).toBe(second.manifestHash);
+      expect((await store.verify("c1")).ok).toBe(true);
+    });
+
+    it("does not reuse a sequence when the pinned head is ahead of the manifests", async () => {
+      const first = await store.record("c1", { ...BASE_RUN, id: "run-1" });
+      await store.record("c1", { ...BASE_RUN, id: "run-2" });
+      await unlink(join(ledgerDir("c1"), "run-2.json"));
+
+      const next = await store.record("c1", { ...BASE_RUN, id: "run-3" });
+
+      expect(next.sequence).toBe(2);
+      expect(next.previousManifestHash).toBe(first.manifestHash);
+      expect((await store.verify("c1")).ok).toBe(true);
+    });
   });
 });

--- a/companion/tests/analysis/analysisRunStore.test.ts
+++ b/companion/tests/analysis/analysisRunStore.test.ts
@@ -201,6 +201,35 @@ describe("AnalysisRunStore", () => {
 
       expect(await store.list("c2")).toEqual([]);
     });
+
+    it("starts a fresh chain when the directory holds another case's ledger", async () => {
+      await store.record("c1", { ...BASE_RUN, id: "src-1" });
+      await store.record("c1", { ...BASE_RUN, id: "src-2" });
+      // A renamed import copies head.json in too, so the head names the source case
+      // and its sequence still matches the manifest count.
+      await copyLedgerToC2("src-1");
+      await cp(join(ledgerDir("c1"), "src-2.json"), join(ledgerDir("c2"), "src-2.json"));
+      await cp(join(ledgerDir("c1"), "head.json"), join(ledgerDir("c2"), "head.json"));
+
+      const own = await store.record("c2", { ...BASE_RUN, id: "own-1" });
+
+      expect(own.sequence).toBe(1);
+      expect(own.previousManifestHash).toBeNull();
+      expect((await store.list("c2")).map((run) => run.id)).toEqual(["own-1"]);
+    });
+
+    it("scopes integrity reporting to the runs the case owns", async () => {
+      await store.record("c1", { ...BASE_RUN, id: "src-1" });
+      await copyLedgerToC2("src-1");
+      await cp(join(ledgerDir("c1"), "head.json"), join(ledgerDir("c2"), "head.json"));
+      await store.record("c2", { ...BASE_RUN, id: "own-1" });
+
+      const result = await store.verify("c2");
+
+      expect(result.ok).toBe(true);
+      expect(result.manifests).toBe(1);
+      expect(result.foreignManifests).toBe(1);
+    });
   });
 
   describe("append cost", () => {
@@ -229,16 +258,46 @@ describe("AnalysisRunStore", () => {
       expect((await store.verify("c1")).ok).toBe(true);
     });
 
-    it("does not reuse a sequence when the pinned head is ahead of the manifests", async () => {
+    it("recovers the tip when a crash left the head one behind the manifests", async () => {
       const first = await store.record("c1", { ...BASE_RUN, id: "run-1" });
-      await store.record("c1", { ...BASE_RUN, id: "run-2" });
+      const second = await store.record("c1", { ...BASE_RUN, id: "run-2" });
+      // Rewind to the state a crash between the manifest write and the head write
+      // leaves behind: run-2 on disk, head still pinned to run-1, marker outstanding.
+      await writeFile(
+        join(ledgerDir("c1"), "head.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          caseId: "c1",
+          sequence: first.sequence,
+          manifestHash: first.manifestHash,
+        }),
+        "utf8",
+      );
+      await writeFile(join(ledgerDir("c1"), "pending.json"), JSON.stringify({ id: "run-2" }), "utf8");
+
+      const third = await store.record("c1", { ...BASE_RUN, id: "run-3" });
+
+      expect(third.sequence).toBe(3);
+      expect(third.previousManifestHash).toBe(second.manifestHash);
+      expect((await store.verify("c1")).ok).toBe(true);
+    });
+
+    it("leaves a deleted manifest visible instead of backfilling its sequence", async () => {
+      await store.record("c1", { ...BASE_RUN, id: "run-1" });
+      const second = await store.record("c1", { ...BASE_RUN, id: "run-2" });
       await unlink(join(ledgerDir("c1"), "run-2.json"));
 
       const next = await store.record("c1", { ...BASE_RUN, id: "run-3" });
 
-      expect(next.sequence).toBe(2);
-      expect(next.previousManifestHash).toBe(first.manifestHash);
-      expect((await store.verify("c1")).ok).toBe(true);
+      // Reusing the vacated sequence would erase the evidence that run-2 ever
+      // existed. The new run keeps its own place and still names the missing
+      // manifest as its predecessor, so verify() reports the gap permanently.
+      expect(next.sequence).toBe(3);
+      expect(next.previousManifestHash).toBe(second.manifestHash);
+      const result = await store.verify("c1");
+      expect(result.ok).toBe(false);
+      expect(result.problems).toContain("run-3: ledger sequence mismatch");
+      expect(result.problems).toContain("run-3: previous manifest hash mismatch");
     });
   });
 });

--- a/companion/tests/reports/reportReleaseStore.test.ts
+++ b/companion/tests/reports/reportReleaseStore.test.ts
@@ -119,7 +119,7 @@ describe("ReportReleaseStore", () => {
       workflow: workflow(),
       actor,
       analysisRuns: [analysisRun()],
-      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      analysisIntegrity: { ok: true, manifests: 1, problems: [], foreignManifests: 0 },
       custody: {
         head: { records: 0, headSeq: null, headHash: "" },
         chainBreaks: [],
@@ -146,7 +146,7 @@ describe("ReportReleaseStore", () => {
         workflow: workflow(),
         actor,
         analysisRuns: [analysisRun()],
-        analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+        analysisIntegrity: { ok: true, manifests: 1, problems: [], foreignManifests: 0 },
         custody: {
           head: { records: 0, headSeq: null, headHash: "" },
           chainBreaks: [],
@@ -162,7 +162,7 @@ describe("ReportReleaseStore", () => {
       workflow: workflow(),
       actor,
       analysisRuns: [analysisRun()],
-      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      analysisIntegrity: { ok: true, manifests: 1, problems: [], foreignManifests: 0 },
       custody: {
         head: { records: 1, headSeq: 1, headHash: HASH },
         chainBreaks: [{ line: 1, seq: 1, reason: "prev-hash-mismatch" as const }],
@@ -190,7 +190,7 @@ describe("ReportReleaseStore", () => {
     await expect(
       releases.create("c1", {
         ...base,
-        analysisIntegrity: { ok: false, manifests: 1, problems: ["head mismatch"] },
+        analysisIntegrity: { ok: false, manifests: 1, problems: ["head mismatch"], foreignManifests: 0 },
         custody: { ...base.custody, chainBreaks: [] },
       }),
     ).rejects.toThrow("analysis run ledger");
@@ -200,7 +200,7 @@ describe("ReportReleaseStore", () => {
     const common = {
       actor,
       analysisRuns: [analysisRun()],
-      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      analysisIntegrity: { ok: true, manifests: 1, problems: [], foreignManifests: 0 },
       custody: {
         head: { records: 0, headSeq: null, headHash: "" },
         chainBreaks: [],
@@ -238,7 +238,7 @@ describe("ReportReleaseStore", () => {
       workflow: workflow(),
       actor,
       analysisRuns: [analysisRun()],
-      analysisIntegrity: { ok: true, manifests: 1, problems: [] },
+      analysisIntegrity: { ok: true, manifests: 1, problems: [], foreignManifests: 0 },
       custody: {
         head: { records: 0, headSeq: null, headHash: "" },
         chainBreaks: [],

--- a/companion/tests/server/analysisRunRoutes.test.ts
+++ b/companion/tests/server/analysisRunRoutes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import request from "supertest";
@@ -141,5 +141,37 @@ describe("analysis-run routes", () => {
     expect(replay.status).toBe(409);
     expect(replay.body.blockers).toContain("provider/model unavailable: missing-provider/missing-model");
     expect(await analysisRunStore.list("c1")).toHaveLength(1);
+  });
+
+  it("refuses to read or replay a run whose manifest names another case", async () => {
+    const { app, analysisRunStore, cases } = await harness();
+    await analysisRunStore.record("c1", {
+      id: "foreign-run",
+      kind: "synthesis",
+      startedAt: "2026-07-31T10:00:00.000Z",
+      finishedAt: "2026-07-31T10:00:01.000Z",
+      versions: { schema: "synthesis/v1" },
+      input: { artifacts: [], eventIds: [], entityIds: [] },
+      configuration: { promptHash: hashManifestValue(getSynthesisPrompt()) },
+      output: { entityIds: [], hashes: [], claims: [] },
+    });
+    await request(app).post("/cases").send({
+      caseId: "c2",
+      name: "n2",
+      investigator: "i",
+      aiProvider: null,
+    });
+    // A renamed archive import copies the source ledger in verbatim, so c2 holds a
+    // manifest still naming c1. Authorization is checked against the route's case,
+    // so replay must not accept it as a c2 run and act on c1.
+    await mkdir(join(cases.stateDir("c2"), "analysis-runs"), { recursive: true });
+    await cp(
+      join(cases.stateDir("c1"), "analysis-runs", "foreign-run.json"),
+      join(cases.stateDir("c2"), "analysis-runs", "foreign-run.json"),
+    );
+
+    expect((await request(app).get("/cases/c2/analysis-runs/foreign-run")).status).toBe(404);
+    expect((await request(app).post("/cases/c2/analysis-runs/foreign-run/replay")).status).toBe(404);
+    expect((await request(app).get("/cases/c1/analysis-runs/foreign-run")).status).toBe(200);
   });
 });


### PR DESCRIPTION
Fixes #885. Fixes #886.

Both defects live in `AnalysisRunStore` and are reachable through the ordinary export-then-rename-import flow, so they were fixed together. A second commit addresses two findings from an adversarial review of the first.

## #885 — cross-case replay authorization bypass (Critical)

A renamed archive import copies `state/analysis-runs/*.json` in verbatim, so those manifests still name the **source** case. `get()` used the requested case only to build the file path and never checked the manifest it read back. Meanwhile the replay route authorizes on `req.params.id` but executes on `run.caseId`.

Net effect: a caller with write access to only the importing case could drive import, tagger, enrichment, synthesis, deep-pass and report actions against the source case — crossing the RBAC boundary in team mode.

**Fix:** `get()` returns `null` when the manifest names a different case, closing it at the single choke point the replay, detail and compare routes already funnel through (`routes/analysisRuns.ts:313,314,322,328`). All three already treat `null` as 404.

## Ownership is now one rule (adversarial review finding)

The first commit filtered by owner in `get()`/`list()` but not in `record()`/`verify()`, which left a split-brain ledger. `head.json` carried no owner, so after an import the copied head still matched the copied manifest count and was trusted — the destination case's first run chained onto the **source** case's tip, while `get()`/`list()` rejected those same manifests and `verify()` walked the raw mixed directory and could still report `ok`.

`head.json` now carries a `caseId`. A head belonging to another case is not trusted, so the importing case starts a fresh chain instead of grafting onto one it cannot read. `verify()` scopes the chain walk to owned manifests and reports the rest as `foreignManifests` — they stay on disk unaltered, counted rather than verified or hidden.

This keeps the deliberate decision **not** to rewrite and re-chain manifests at import: recomputing those hashes would destroy the tamper evidence the chain exists to provide.

## #886 — append cost

`record()` called `readAll()` purely to find the latest sequence and hash, making every append O(N) and a case lifetime O(N²), and `readAll()` opened every manifest with an unbounded `Promise.all`.

The first commit removed the N reads and parses but **kept a `readdir` on every append** — so appends were still O(N) in directory entries. The original description of that as O(1) was wrong; the adversarial review was right to call it.

The `readdir` existed to catch a head left stale by a crash between the manifest and head writes. A `pending.json` marker — written before the manifest, removed after the head is pinned — detects that window directly. A healthy append now reads two small files and never lists the directory. `readAll()`, still used for reconciliation and `verify()`, reads in bounded batches of 32.

## Behaviour change worth calling out

Deleting a manifest no longer causes the next append to backfill the vacated sequence. Reusing it erased the evidence that the deleted run existed and left `verify()` reporting a clean ledger after a single append. The new run now keeps its own sequence and still names the missing manifest as its predecessor, so `verify()` reports the gap permanently (`ledger sequence mismatch` + `previous manifest hash mismatch`).

## Tests

Written first, each watched fail for the right reason:

- `get()` and `list()` refuse a manifest naming another case; replay and detail routes return 404 for one (RED: returned 200)
- a renamed-import ledger yields a fresh chain — sequence 1, null predecessor (RED: `expected 3 to be 1`, the split-brain)
- `verify()` reports owned vs foreign manifest counts separately
- appends issue **no directory listing**, asserted by instrumenting `readdir` (RED: 4 listings for 4 appends), and still list when the head cannot be trusted
- an interrupted append recovers the correct tip from the marker
- a deleted manifest stays visible instead of being renumbered away

## Verification

- Full companion suite: **735 files, 11,970 tests, all passing**
- Gates green: `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check`

Note `typecheck` caught two `AnalysisRunIntegrity` fixtures in `reportReleaseStore.test.ts` that vitest alone did not — the new field is required, so release records now carry it.

## Deferred

Pagination on the HTTP list endpoint (also requested in #886) changes the API contract and the dashboard consumer, so it belongs in its own PR.
