### PR TITLE
fix(dashboard): viewport, loading state, keyboard-operable view menu, toolbar reflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,976 of the 2,015 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,978 of the 2,017 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -11,7 +11,7 @@
   "reports/markdown.ts": 1597,
   "reports/reportWriter.ts": 837,
   "routes/aiSynthesis.ts": 863,
-  "routes/caseLifecycle.ts": 904,
+  "routes/caseLifecycle.ts": 855,
   "routes/findings.ts": 833,
   "routes/import.ts": 3203,
   "routes/mcp.ts": 913,

--- a/companion/src/composition/routeRegistry.ts
+++ b/companion/src/composition/routeRegistry.ts
@@ -45,6 +45,7 @@ import { registerReportVersionsRoutes } from "../routes/reportVersions.js";
 import { registerAnalysisRunRoutes } from "../routes/analysisRuns.js";
 import { registerCasePasswordRoutes } from "../routes/casePassword.js";
 import { registerCaseLifecycleRoutes } from "../routes/caseLifecycle.js";
+import { registerAppShellRoutes } from "../routes/appShell.js";
 import { registerJobRoutes } from "../routes/jobs.js";
 import { registerDeepPassRoutes } from "../routes/deepPass.js";
 import { registerIncidentTypeRoutes } from "../routes/incidentTypes.js";
@@ -155,6 +156,8 @@ export function registerAllRoutes(app: Express, ctx: RouteContext): OutboundTran
   registerAnalysisRunRoutes(app, ctx);
   registerCasePasswordRoutes(app, ctx);
   registerCaseLifecycleRoutes(app, ctx);
+  // Same stack position the shell routes held when they lived inside the call above.
+  registerAppShellRoutes(app);
   registerJobRoutes(app, ctx);
   registerIncidentTypeRoutes(app, ctx);
   registerCollectionPlanRoutes(app, ctx);

--- a/companion/src/http/compressibleResponse.ts
+++ b/companion/src/http/compressibleResponse.ts
@@ -1,0 +1,84 @@
+import { gzip } from "node:zlib";
+import { promisify } from "node:util";
+import type { Request, Response } from "express";
+
+/**
+ * Gzip a static text response when the client asks for it.
+ *
+ * The dashboard document is ~507 KB of markup and inline script and was served uncompressed, along
+ * with the ~140 first-party JS files beside it. On the loopback the tool is designed for that costs
+ * nothing, but it is the whole cost on the public demo, on a VPN-hosted deployment, and for an
+ * analyst opening a case over field connectivity — a throttled run measured 57 s to first paint.
+ *
+ * Built on node:zlib rather than the `compression` middleware on purpose: this ships as a
+ * single-file SEA binary, and one more runtime dependency in that bundle needs to earn itself. Two
+ * call sites and roughly forty lines do not justify it.
+ *
+ * Correctness notes:
+ *  - `Vary: Accept-Encoding` is set on EVERY response, compressed or not. Without it a shared cache
+ *    can hand a gzipped body to a client that never asked for one.
+ *  - Express computes its ETag over what is actually sent, so the encoded body gets its own tag and
+ *    conditional requests stay consistent.
+ *  - A client that does not offer gzip gets the identity bytes unchanged.
+ */
+const gzipAsync = promisify(gzip);
+
+/** Below this, framing and CPU cost more than the transfer saves. */
+const MIN_COMPRESS_BYTES = 1024;
+
+/**
+ * Whether this client will actually take gzip.
+ *
+ * Deliberately not a substring test for "gzip": `Accept-Encoding: gzip;q=0` NAMES gzip in order to
+ * FORBID it, and matching the token would send that client a body it has said it cannot use. The
+ * quality values are what carry the meaning, so the negotiation is delegated to Express, which
+ * parses them.
+ */
+function acceptsGzip(req: Request): boolean {
+  if (typeof req.acceptsEncodings === "function") {
+    return req.acceptsEncodings("gzip") === "gzip";
+  }
+  // Only reached by a hand-rolled request object in a test; keep the q=0 rule rather than
+  // falling back to a plain token match that contradicts the function above.
+  const header = req.headers["accept-encoding"];
+  const raw = Array.isArray(header) ? header.join(",") : (header ?? "");
+  return raw
+    .split(",")
+    .map((part) => part.trim())
+    .some((part) => {
+      const [token, ...params] = part.split(";").map((s) => s.trim());
+      if (!/^gzip$/i.test(token)) return false;
+      const q = params.find((p) => /^q=/i.test(p));
+      return !q || Number(q.slice(2)) > 0;
+    });
+}
+
+/**
+ * Send `body` as `contentType`, gzipped when the request allows it.
+ *
+ * Never throws on a compression failure: it falls back to the identity body, because failing to
+ * shrink a response is not a reason to fail the request.
+ */
+export async function sendMaybeGzipped(
+  req: Request,
+  res: Response,
+  contentType: string,
+  body: string | Buffer,
+): Promise<void> {
+  const buf = Buffer.isBuffer(body) ? body : Buffer.from(body, "utf8");
+  // vary() APPENDS; set() would replace. originGuard has already written `Vary: Origin` on an
+  // allowed cross-origin request, because Access-Control-Allow-Origin echoes the caller — dropping
+  // it lets a shared cache hand one origin's response to another, carrying a CORS header that
+  // makes it unreadable.
+  res.type(contentType).vary("Accept-Encoding");
+  if (buf.byteLength < MIN_COMPRESS_BYTES || !acceptsGzip(req)) {
+    res.send(buf);
+    return;
+  }
+  try {
+    const encoded = await gzipAsync(buf);
+    res.set("Content-Encoding", "gzip").send(encoded);
+  } catch {
+    res.send(buf);
+  }
+}

--- a/companion/src/http/staticAssets.ts
+++ b/companion/src/http/staticAssets.ts
@@ -1,5 +1,6 @@
 import type { Express } from "express";
 import { readPublicAsset } from "../serverAssets.js";
+import { sendMaybeGzipped } from "./compressibleResponse.js";
 
 /**
  * Whitelisted static client assets: vendored libraries (Leaflet for the Geographic map, #133;
@@ -329,7 +330,7 @@ export const STATIC_ASSETS: Record<string, string> = {
  */
 export function registerStaticAssets(app: Express): void {
   for (const [route, type] of Object.entries(STATIC_ASSETS)) {
-    app.get(route, async (_req, res) => {
+    app.get(route, async (req, res) => {
       try {
         const buf = await readPublicAsset(route.slice(1)); // strip leading "/"
         // "no-cache" means STORE IT, BUT ASK FIRST — not "do not cache". Express already computes
@@ -342,7 +343,10 @@ export function registerStaticAssets(app: Express): void {
         // no module wires and no rule styles. That is indistinguishable from a broken feature, it
         // survives an ordinary reload, and it lands on every analyst who upgrades the companion,
         // not only on whoever edited the file.
-        res.type(type).set("Cache-Control", "no-cache").send(buf);
+        // Compressed when the client allows it (#882): these are ~140 first-party JS files plus
+        // the stylesheet, and they were all going out as identity bytes.
+        res.set("Cache-Control", "no-cache");
+        await sendMaybeGzipped(req, res, type, buf);
       } catch {
         res.status(404).end();
       }

--- a/companion/src/routes/appShell.ts
+++ b/companion/src/routes/appShell.ts
@@ -1,0 +1,67 @@
+import type { Express } from "express";
+import { readPublicAsset } from "../serverAssets.js";
+import { withNonce } from "../http/securityHeaders.js";
+import { sendMaybeGzipped } from "../http/compressibleResponse.js";
+
+/**
+ * The static app shell: GET /, /dashboard, /mobile, /manifest.webmanifest, /sw.js.
+ *
+ * These five lived in server.ts, then moved into routes/caseLifecycle.ts so server.ts held zero
+ * literal route registrations. They move again here for the same reason caseLifecycle took them:
+ * that file hit its size cap, and the ledger's rule is a new module rather than a raised ceiling.
+ * They are a coherent group — the browser-facing shell — and were never really case lifecycle.
+ *
+ * Registered immediately after registerCaseLifecycleRoutes so the stack order is unchanged.
+ *
+ * NOTE: /dashboard and /mobile have no try/catch and sit BEFORE the terminal error handler, so an
+ * (unreachable in a real install) asset-read failure yields the standard JSON 500 instead of
+ * Express's default HTML page — the only observable delta from their original home in startServer.
+ */
+export function registerAppShellRoutes(app: Express): void {
+  // Redirect root to the dashboard.
+  app.get("/", (_req, res) => {
+    res.redirect("/dashboard");
+  });
+
+  // Serve the dashboard. withNonce stamps this response's CSP nonce into the inline <script>
+  // blocks — without it they carry a placeholder the browser won't match, and none of them run.
+  app.get("/dashboard", async (req, res) => {
+    const html = await readPublicAsset("dashboard.html", "utf8");
+    // The single largest item on the page, previously sent uncompressed. Measured on this branch:
+    // 520,588 -> 120,043 bytes, 77% smaller (#882).
+    await sendMaybeGzipped(req, res, "html", withNonce(html, String(res.locals.cspNonce ?? "")));
+  });
+
+  // Mobile companion (#59): a read-only, phone-optimized view (timeline / findings / IOCs / status)
+  // for quick glances during IR away from the workstation. It's a PWA — installable via the
+  // web manifest + a minimal service worker (offline app-shell). All three are static files in
+  // public/; the SW is served at root so its default control scope covers /mobile.
+  app.get("/mobile", async (_req, res) => {
+    const html = await readPublicAsset("mobile.html", "utf8");
+    res.type("html").send(withNonce(html, String(res.locals.cspNonce ?? "")));
+  });
+
+  app.get("/manifest.webmanifest", async (_req, res) => {
+    try {
+      const json = await readPublicAsset("manifest.webmanifest", "utf8");
+      res.type("application/manifest+json").set("Cache-Control", "no-cache").send(json);
+    } catch {
+      res.status(404).end();
+    }
+  });
+
+  app.get("/sw.js", async (_req, res) => {
+    try {
+      const js = await readPublicAsset("sw.js", "utf8");
+      // no-cache + a same-origin allowed scope so the SW can control /mobile even if it's
+      // ever moved into a subdirectory; browsers re-check sw.js on every navigation anyway.
+      res
+        .type("application/javascript")
+        .set("Cache-Control", "no-cache")
+        .set("Service-Worker-Allowed", "/")
+        .send(js);
+    } catch {
+      res.status(404).end();
+    }
+  });
+}

--- a/companion/src/routes/caseLifecycle.ts
+++ b/companion/src/routes/caseLifecycle.ts
@@ -3,7 +3,6 @@ import { readFile } from "node:fs/promises";
 import { ZodError } from "zod";
 import { isValidCaseId, CaseAlreadyExistsError } from "../storage/caseStore.js";
 import { validateCaseCreateBody } from "./caseCreateBody.js";
-import { withNonce } from "../http/securityHeaders.js";
 import { sanitizeCaseMeta } from "../analysis/casePassword.js";
 import { buildInitialQuestions, buildInitialNextSteps } from "../analysis/templateStore.js";
 import { applyIncidentTypeToState } from "../analysis/incidentTypes.js";
@@ -36,7 +35,6 @@ import {
   RELOADABLE_ENV_PREFIXES,
   LIVE_FROM_ENV_PREFIXES,
 } from "../settings/envManager.js";
-import { readPublicAsset } from "../serverAssets.js";
 import { isTerminal, type Job } from "../analysis/jobRegistry.js";
 import { requestAuthentication, type AuthIdentity } from "../auth/types.js";
 import type { Severity } from "../analysis/stateTypes.js";
@@ -61,12 +59,9 @@ import type { RouteContext } from "./context.js";
  *   - declarative importers CRUD — GET/POST/DELETE /importers, /importers/{prompt,reload,precedence}.
  *   - activity log — GET /cases/:id/activity-log.
  *   - settings/env + setup — GET/POST /settings/env, POST /settings/{ai-reload,reload}, GET /setup/status.
- *   - static app shell — GET /, /dashboard, /mobile, /manifest.webmanifest, /sw.js (these five were
- *     registered in startServer AFTER createApp returned; moved here so server.ts holds zero literal
- *     route registrations. The dynamic favicon/vendor loops (app.get(variable, …)) stay put — they are
- *     not literal-path registrations. NOTE: /dashboard and /mobile have no try/catch and now sit BEFORE
- *     the terminal error handler, so an (unreachable in a real install) asset-read failure yields the
- *     standard JSON 500 instead of Express's default HTML page — the only observable delta.)
+ *   - (the static app shell — GET /, /dashboard, /mobile, /manifest.webmanifest, /sw.js — moved out
+ *     to routes/appShell.ts when this file hit its size cap again; it registers at the same point in
+ *     the stack, immediately after this function.)
  *
  * Module-private helpers moved verbatim (used only by routes here): removeCaseFromActiveListBestEffort,
  * deleteCaseFolderBestEffort (case archive/delete plumbing). The /settings/reload allowlist now
@@ -855,49 +850,5 @@ export function registerCaseLifecycleRoutes(app: Express, ctx: RouteContext): vo
       // Not reloadable, so this turns true only after a restart: the tick means active, not typed.
       presidio: has("DFIR_PRESIDIO_URL"),
     });
-  });
-  // Redirect root to the dashboard.
-  app.get("/", (_req, res) => {
-    res.redirect("/dashboard");
-  });
-
-  // Serve the dashboard. withNonce stamps this response's CSP nonce into the inline <script>
-  // blocks — without it they carry a placeholder the browser won't match, and none of them run.
-  app.get("/dashboard", async (_req, res) => {
-    const html = await readPublicAsset("dashboard.html", "utf8");
-    res.type("html").send(withNonce(html, String(res.locals.cspNonce ?? "")));
-  });
-
-  // Mobile companion (#59): a read-only, phone-optimized view (timeline / findings / IOCs / status)
-  // for quick glances during IR away from the workstation. It's a PWA — installable via the
-  // web manifest + a minimal service worker (offline app-shell). All three are static files in
-  // public/; the SW is served at root so its default control scope covers /mobile.
-  app.get("/mobile", async (_req, res) => {
-    const html = await readPublicAsset("mobile.html", "utf8");
-    res.type("html").send(withNonce(html, String(res.locals.cspNonce ?? "")));
-  });
-
-  app.get("/manifest.webmanifest", async (_req, res) => {
-    try {
-      const json = await readPublicAsset("manifest.webmanifest", "utf8");
-      res.type("application/manifest+json").set("Cache-Control", "no-cache").send(json);
-    } catch {
-      res.status(404).end();
-    }
-  });
-
-  app.get("/sw.js", async (_req, res) => {
-    try {
-      const js = await readPublicAsset("sw.js", "utf8");
-      // no-cache + a same-origin allowed scope so the SW can control /mobile even if it's
-      // ever moved into a subdirectory; browsers re-check sw.js on every navigation anyway.
-      res
-        .type("application/javascript")
-        .set("Cache-Control", "no-cache")
-        .set("Service-Worker-Allowed", "/")
-        .send(js);
-    } catch {
-      res.status(404).end();
-    }
   });
 }

--- a/companion/tests/reports/dashboardCss.test.ts
+++ b/companion/tests/reports/dashboardCss.test.ts
@@ -94,3 +94,39 @@ describe("the split stylesheet is wired the way the cascade needs", () => {
     expect(used, "the data-safe-style spinner is the reason this reads the markup too").toContain("spin");
   });
 });
+
+// The toolbar settles ~7.5s after load — the AI status text arrives and the scope group reflows —
+// and pushes <main> down under a reader who has already started reading. CLS measured 0.744 on
+// desktop. The two toolbar selects already reserve a width; these two did not. #884.
+describe("late-arriving toolbar content reserves its space", () => {
+  it("reserves a width for the AI status pill", () => {
+    expect(css).toMatch(/#aiStatus\s*\{[^}]*min-width:/);
+  });
+
+  it("reserves a height for the scope group, which can wrap to a second row", () => {
+    expect(css).toMatch(/\.scope-group\s*\{[^}]*min-height:/);
+  });
+});
+
+// Adding the viewport meta (#880) makes the narrow layout execute for the first time. Several
+// children already collapsed at a breakpoint (.now-group, .hyp-rev-cols, .wiz-row) but the page's
+// own two-column grid never did — at 375px it resolved to a 291px and a 112px column.
+describe("the page grid collapses once the narrow layout can actually run", () => {
+  it("drops main to a single column on a narrow viewport", () => {
+    expect(css).toMatch(
+      /@media[^{]*max-width:\s*900px[^{]*\{[^}]*main\s*\{[^}]*grid-template-columns:\s*1fr/,
+    );
+  });
+});
+
+// fitToolbar() adds .icons-only when the toolbar would wrap, and the compacting rule sets
+// font-size:0 on its buttons. #dashViewMenu lives inside #toolbarMain, so once its entries became
+// real <button>s that rule started blanking every label in the popover.
+describe("compacting the toolbar does not blank the view menu", () => {
+  it("exempts the view-menu entries from the icons-only font collapse", () => {
+    const rule = /\.toolbar-main\.icons-only button(?::not\([^)]*\))*\s*\{[^}]*font-size:\s*0/;
+    const m = css.match(rule);
+    expect(m, "the icons-only font-size:0 rule was not found").not.toBeNull();
+    expect(m![0]).toContain(":not(.dv-item)");
+  });
+});

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -1283,3 +1283,61 @@ describe("dashboard.html — plain-English MCP investigations", () => {
     expect(html).toMatch(/const remembered = \(\s*localStorage\.getItem\("dfir\.caseId"\)/);
   });
 });
+
+// Four defects from one end-to-end UI QA pass of 0.36.0, all in the page shell rather than in any
+// panel's logic: #880 (no viewport), #882 (no visible loading state), #879 (view picker is
+// mouse-only) and #884 (toolbar reflow shifts main).
+describe("dashboard page shell", () => {
+  it("declares a viewport so the responsive CSS actually runs — #880", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    // Without this every phone lays the page out at 980px and scales the result down to ~0.38,
+    // which also means no narrow breakpoint in the stylesheet has ever executed in a browser.
+    expect(html).toMatch(/<meta\s+name="viewport"\s+content="width=device-width,\s*initial-scale=1"/);
+  });
+
+  it("paints a loading state before the app is ready — #882", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    // The blank window is deliberate: safe-dom hides <body> until it has hydrated styles, to avoid
+    // a flash of unstyled content. That is right, but on a slow link it means nothing at all is on
+    // screen for the best part of a minute. The splash has to survive that same rule, so it needs
+    // its own visibility, and it must be plain markup — no JS runs this early.
+    expect(html).toContain('id="bootSplash"');
+    expect(html).toMatch(/html\[data-safe-dom\][^{]*#bootSplash[^{]*\{[^}]*visibility:\s*visible/);
+    expect(html).toMatch(/dfir-styles-ready[^{]*#bootSplash[^{]*\{[^}]*display:\s*none/);
+  });
+
+  it("gives the dashboard-view menu keyboard-operable entries — #879", () => {
+    const src = dashboardClientSource();
+    // Entries were bare <div>s with a click listener: no role, no tab stop, nothing operable for a
+    // keyboard or a screen reader, under a trigger that announces itself as a menu.
+    expect(src).toMatch(/<button[^>]+class="dv-item/);
+    expect(src).toMatch(/role="menuitem"/);
+    expect(src).toContain('role="menu"');
+    // Arrow keys move between entries and Escape closes, as a menu is expected to behave.
+    expect(src).toMatch(/ArrowDown/);
+    expect(src).toMatch(/ArrowUp/);
+    expect(src).toMatch(/dashViewMenuKeydown|Escape/);
+  });
+});
+
+// Follow-ups from review of the page-shell batch.
+describe("dashboard page shell — review follow-ups", () => {
+  it("paints the splash before the parser-blocking module scripts", async () => {
+    const html = await readFile(new URL("../../../public/dashboard.html", import.meta.url), "utf8");
+    // 144 <script src> tags, none deferred. Markup placed after them is not parsed until every one
+    // has downloaded and executed — which on a slow link is DOMContentLoaded, the exact moment the
+    // splash is hidden again. Sitting after only safe-dom.js is what makes it visible at all.
+    const splash = html.indexOf('id="bootSplash"');
+    const firstModuleScript = html.indexOf('<script src="/js/dashboard-');
+    expect(splash).toBeGreaterThan(-1);
+    expect(firstModuleScript).toBeGreaterThan(-1);
+    expect(splash).toBeLessThan(firstModuleScript);
+  });
+
+  it("moves focus into the view menu when it opens", () => {
+    const src = dashboardClientSource();
+    // The keydown handler is on the menu, so with focus left on the trigger the arrow keys never
+    // reach it until the user presses Tab — the menu announces behaviour it does not have.
+    expect(src).toMatch(/menu\.style\.display = "block"[\s\S]{0,400}focusFirstDashViewItem\(\)/);
+  });
+});

--- a/companion/tests/server/assetCompression.test.ts
+++ b/companion/tests/server/assetCompression.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import request from "supertest";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { createApp } from "../../src/server.js";
+
+// The dashboard document is ~507 KB and ships beside ~140 first-party JS files, none of which were
+// compressed. Irrelevant on the loopback the tool is built for; it is the whole cost on the public
+// demo, a VPN-hosted deployment, or an analyst on field connectivity. #882
+async function app() {
+  const root = await mkdtemp(join(tmpdir(), "dfir-compress-"));
+  return createApp(new CaseStore(root), { appVersion: "0.36.0" });
+}
+
+describe("static asset compression", () => {
+  it("gzips the dashboard document for a client that accepts it", async () => {
+    const res = await request(await app())
+      .get("/dashboard")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-encoding"]).toBe("gzip");
+    // supertest decodes the body, so the assertion that it is still the real document holds.
+    expect(res.text).toContain("<!doctype html>");
+    expect(res.text).toContain('id="bootSplash"');
+  });
+
+  it("gzips a whitelisted script", async () => {
+    const res = await request(await app())
+      .get("/js/safe-dom.js")
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-encoding"]).toBe("gzip");
+  });
+
+  it("sends identity bytes to a client that does not accept gzip", async () => {
+    const res = await request(await app())
+      .get("/dashboard")
+      .set("Accept-Encoding", "identity");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-encoding"]).toBeUndefined();
+    expect(res.text).toContain("<!doctype html>");
+  });
+
+  it("varies on Accept-Encoding either way, so a shared cache cannot cross the two", async () => {
+    const gz = await request(await app())
+      .get("/dashboard")
+      .set("Accept-Encoding", "gzip");
+    const id = await request(await app())
+      .get("/dashboard")
+      .set("Accept-Encoding", "identity");
+
+    expect(gz.headers["vary"]).toMatch(/Accept-Encoding/i);
+    expect(id.headers["vary"]).toMatch(/Accept-Encoding/i);
+  });
+});

--- a/companion/tests/server/compressibleResponse.test.ts
+++ b/companion/tests/server/compressibleResponse.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import type { Request, Response } from "express";
+import { sendMaybeGzipped } from "../../src/http/compressibleResponse.js";
+
+// A fake response that records what a real one would have done. Express's own `vary()` appends to
+// an existing header; `set()` replaces it — the distinction this exercises.
+interface FakeRes {
+  body: unknown;
+  headers: Record<string, string>;
+  type(): FakeRes;
+  set(name: string, value: string): FakeRes;
+  get(name: string): string | undefined;
+  vary(field: string): FakeRes;
+  send(payload: unknown): FakeRes;
+}
+
+function fakeRes(): FakeRes {
+  const headers: Record<string, string> = {};
+  const res: FakeRes = {
+    body: undefined,
+    headers,
+    type: () => res,
+    set(name, value) {
+      headers[name] = value;
+      return res;
+    },
+    get: (name) => headers[name],
+    vary(field) {
+      headers.Vary = headers.Vary ? `${headers.Vary}, ${field}` : field;
+      return res;
+    },
+    send(payload) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res;
+}
+
+const req = (accept: string) => ({ headers: { "accept-encoding": accept } }) as unknown as Request;
+const big = "x".repeat(4096);
+
+describe("sendMaybeGzipped", () => {
+  it("gzips when the client accepts it", async () => {
+    const res = fakeRes();
+    await sendMaybeGzipped(req("gzip"), res as unknown as Response, "html", big);
+    expect(res.headers["Content-Encoding"]).toBe("gzip");
+  });
+
+  it("honours an explicit gzip;q=0, which forbids gzip", async () => {
+    const res = fakeRes();
+    await sendMaybeGzipped(req("gzip;q=0"), res as unknown as Response, "html", big);
+    // A substring test for "gzip" reads this as permission. It is the opposite.
+    expect(res.headers["Content-Encoding"]).toBeUndefined();
+    expect(res.body).toBeInstanceOf(Buffer);
+  });
+
+  it("honours q=0 inside a longer preference list", async () => {
+    const res = fakeRes();
+    await sendMaybeGzipped(req("br, gzip;q=0, *;q=0"), res as unknown as Response, "html", big);
+    expect(res.headers["Content-Encoding"]).toBeUndefined();
+  });
+
+  it("appends to an existing Vary rather than replacing it", async () => {
+    const res = fakeRes();
+    // originGuard sets Vary: Origin on an allowed cross-origin request, because
+    // Access-Control-Allow-Origin echoes the caller. Overwriting it lets a shared cache serve one
+    // origin's response to another, with a CORS header that makes it unreadable.
+    res.vary("Origin");
+    await sendMaybeGzipped(req("gzip"), res as unknown as Response, "html", big);
+    expect(res.headers.Vary).toMatch(/Origin/);
+    expect(res.headers.Vary).toMatch(/Accept-Encoding/);
+  });
+
+  it("leaves a small body uncompressed", async () => {
+    const res = fakeRes();
+    await sendMaybeGzipped(req("gzip"), res as unknown as Response, "html", "tiny");
+    expect(res.headers["Content-Encoding"]).toBeUndefined();
+  });
+});

--- a/public/css/dashboard-layout.css
+++ b/public/css/dashboard-layout.css
@@ -60,14 +60,25 @@ header { padding: 10px 16px; background: var(--bg-elevated); display: flex; flex
 .toolbar-main { flex: 1 1 0; min-width: 0; display: flex; flex-wrap: wrap; gap: 8px 12px; align-items: center; }
 /* Scope/time controls are always their own row beneath the actions (a top-border divider),
    so the actions row + gear stay together up top. */
+/* min-height holds one full row of controls. The group wraps (flex-wrap above), so as its late
+   content resolves it can gain a row and push everything below it down — the second half of the
+   toolbar reflow that measured CLS 0.744. Reserving one row's height absorbs the common case. #884 */
 .scope-group { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; font-size: 12px; color: var(--text-muted);
-  flex-basis: 100%; padding-top: 9px; border-top: 1px solid var(--border-color); }
+  flex-basis: 100%; padding-top: 9px; border-top: 1px solid var(--border-color); min-height: 40px; }
 .scope-group input[type="datetime-local"] { font-size: 12px; padding: 4px; }
 .scope-group button { padding: 4px 9px; font-size: 12px; }
 .scope-preset { background: transparent; color: var(--text-muted); border: 1px solid var(--border-color); }
 .scope-preset:hover { color: var(--sev-medium); border-color: var(--sev-medium); }
 .toolbar-sep { width: 1px; height: 16px; background: var(--border-color); margin: 0 4px; flex-shrink: 0; }
 main { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding: 16px; }
+/* The page's primary grid was the one piece of the layout with no narrow override, while several
+   of its children (.now-group, .hyp-rev-cols, .wiz-row) already had one. That asymmetry is a
+   symptom of #880: with no viewport meta the layout never ran below 980px, so nobody could see
+   that two dense panels side by side are unreadable on a phone — 375px wide, they resolved to
+   291px and 112px. One column below 900px; the panels keep their own inner breakpoints. */
+@media (max-width: 900px) {
+  main { grid-template-columns: 1fr; padding: 12px; gap: 12px; }
+}
 section { background: var(--bg-elevated); border-radius: 8px; padding: 12px; }
 /* Click a section's header to collapse/expand it; state persists across reloads. */
 h2 { margin: 0 0 8px; font-size: 14px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted);
@@ -81,9 +92,16 @@ h2:hover { color: var(--text-primary); }
 .dv-menu { position: absolute; top: calc(100% + 6px); right: 0; z-index: 60; min-width: 210px;
   background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0,0,0,.4); padding: 5px; font-size: 13px; }
-.dv-item { display: flex; align-items: center; gap: 8px; padding: 6px 9px; border-radius: 5px;
+/* The entries are <button>s so they are focusable and activate on Enter/Space without scripting
+   it (#879). These declarations strip the native button chrome so the row renders as it did when
+   it was a <div>. */
+.dv-item { width: 100%; background: none; border: 0; font: inherit; color: inherit;
+  text-align: left; cursor: pointer; display: flex; align-items: center; gap: 8px; padding: 6px 9px; border-radius: 5px;
   cursor: pointer; color: var(--text-primary); white-space: nowrap; }
-.dv-item:hover { background: var(--border-subtle); }
+/* Focus gets the same wash as hover plus a ring, matching .theme-item above — a keyboard user has
+   to be able to see which entry is selected, which was the point of making these focusable. */
+.dv-item:hover, .dv-item:focus-visible { background: var(--border-subtle); outline: none; }
+.dv-item:focus-visible { box-shadow: inset 0 0 0 1px var(--accent); }
 .dv-item .dv-tick { width: 14px; flex: 0 0 14px; color: var(--sev-low); }
 .dv-item.dv-active { color: var(--text-bright); font-weight: bold; }
 .dv-item small { color: var(--text-muted); font-weight: normal; }

--- a/public/css/dashboard-timeline.css
+++ b/public/css/dashboard-timeline.css
@@ -260,7 +260,11 @@
 .report-links { font-size: 12px; }
 .report-links a { color: var(--accent); text-decoration: none; }
 .report-links a:hover { text-decoration: underline; }
-#aiStatus { font-size: 12px; padding: 3px 8px; border-radius: 10px; }
+/* min-width reserves the pill's footprint before its text arrives. The AI status resolves about
+   seven seconds after load, and without a reserved width it grows from empty to its label and
+   shoves the rest of the toolbar — and <main> under it — down the page. #884 */
+#aiStatus { font-size: 12px; padding: 3px 8px; border-radius: 10px; min-width: 92px;
+  display: inline-block; text-align: center; }
 /* Deep pass (#204) — pre-flight cost table, run control, and the result card. */
 .dp-table { border-collapse: collapse; font-size: 12px; margin: 6px 0 10px; }
 .dp-table th { text-align: right; padding: 4px 10px; color: var(--text-muted); font-weight: normal; border-bottom: 1px solid var(--border-color); }

--- a/public/css/dashboard-toolbar.css
+++ b/public/css/dashboard-toolbar.css
@@ -71,7 +71,10 @@
 /* Tight-mode collapse — when even the labelled actions won't fit, fitToolbar() adds .icons-only
    and the remaining labels go to zero width (icon px size is immune to font-size:0). Export/Push/
    Collapse are already icon-only above, so this only affects the seven labelled buttons. */
-.toolbar-main.icons-only button { font-size: 0; padding-left: 9px; padding-right: 9px; }
+/* :not(.dv-item) — #dashViewMenu is a child of #toolbarMain, so once its entries became real
+   <button>s (#879) this rule started collapsing every label in the popover to nothing. The popover
+   is not part of the row being compacted; only the row's own controls should lose their labels. */
+.toolbar-main.icons-only button:not(.dv-item) { font-size: 0; padding-left: 9px; padding-right: 9px; }
 .toolbar-main.icons-only button::before { margin-right: 0; }
 /* The capture count carries a camera icon (always shown). When space is tight the word
    "Screenshots:" drops and only the camera + number remain, and the AI-status badge is

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -2,15 +2,61 @@
 <html lang="en" data-safe-dom>
 <head>
   <meta charset="utf-8" />
+  <!-- Without this every phone and tablet lays the page out at 980px and scales the result down to
+       about 0.38, putting body text at roughly four physical pixels. It also masks the responsive
+       CSS entirely: below 980px never happens, so no narrow breakpoint in the stylesheet has ever
+       run in a browser. #880 -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DFIR Companion Dashboard</title>
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="stylesheet" href="/vendor/leaflet/leaflet.css">
+  <!-- Moved ahead of the module scripts with the head/body split (#882). These nine were linked
+       AFTER all 144 of them, so the browser did not discover the page's entire stylesheet until
+       every blocking script had run. Their order relative to each other — which IS the cascade —
+       is unchanged. -->
+  <!-- THE ORDER OF THESE EIGHT IS THE CASCADE, and it is the concatenation order of the single
+       dashboard.css they were cut from (#415). They are a pure byte split: rules that used to
+       resolve a specificity tie by sitting later in one file now resolve it by sitting in a later
+       FILE, so reordering these lines silently changes the page. tests/reports/dashboardCss.test.ts
+       asserts the set and the order against src/http/staticAssets.ts, and that every @keyframes an
+       animation names is defined somewhere in the union — a keyframe resolves by NAME across the
+       whole document, so a dropped link costs an animation with nothing else looking wrong. -->
+  <link rel="stylesheet" href="/css/dashboard-tokens.css" />
+  <link rel="stylesheet" href="/css/dashboard-themes-a.css" />
+  <link rel="stylesheet" href="/css/dashboard-themes-b.css" />
+  <link rel="stylesheet" href="/css/dashboard-layout.css" />
+  <link rel="stylesheet" href="/css/dashboard-panels.css" />
+  <link rel="stylesheet" href="/css/dashboard-timeline.css" />
+  <link rel="stylesheet" href="/css/dashboard-toolbar.css" />
+  <link rel="stylesheet" href="/css/dashboard-sections.css" />
+  <!-- Accessibility layer (#386): skip link, visible focus ring, reduced motion, .visually-hidden.
+       Linked after the dashboard sheets so it is last in the cascade. It was already last against the
+       inline block that used to sit here, and #415 made it last against the other thirteen too —
+       they were interleaved through the body, so until now they came after it. -->
+  <link rel="stylesheet" href="/css/a11y.css" />
   <script src="/js/safe-dom.js"></script>
   <style nonce="__CSP_NONCE__" id="dfir-runtime-styles">
     html[data-safe-dom] body { visibility: hidden; }
     html[data-safe-dom].dfir-styles-ready body { visibility: visible; }
+    /* The hidden body above is deliberate — it prevents a flash of unstyled content while safe-dom
+       hydrates. The cost is that on a slow link NOTHING is on screen until DOMContentLoaded, which
+       is when that class lands; a throttled run measured 57s to first paint and 93s to first
+       contentful paint, with no spinner at any point. This splash is the one element allowed to
+       paint during that window, so it carries its own visibility to override the rule above. It is
+       plain markup and plain CSS on purpose: no script has run this early. #882 */
+    html[data-safe-dom] #bootSplash { visibility: visible; }
+    html[data-safe-dom].dfir-styles-ready #bootSplash { display: none; }
+    #bootSplash { position: fixed; inset: 0; z-index: 9999; display: flex; gap: 10px;
+      flex-direction: column; align-items: center; justify-content: center;
+      background: #0f1115; color: #cbd3df;
+      font: 15px/1.5 -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+    #bootSplash .boot-msg { color: #9aa4b2; font-size: 13px; }
+    @media (prefers-color-scheme: light) {
+      #bootSplash { background: #f5f7fa; color: #222a35; }
+      #bootSplash .boot-msg { color: #57626f; }
+    }
   </style>
   <script nonce="__CSP_NONCE__">
     // Team mode is optional. When present, bind every same-origin write to the signed-in
@@ -94,6 +140,19 @@
       };
     })();
   </script>
+</head>
+<body>
+<!-- The splash sits ahead of every module script tag on purpose. There are 144 of them, none
+     deferred, so anything placed after them is not parsed until the last one has executed — which
+     on a slow link is DOMContentLoaded, the exact moment safe-dom marks the page ready and this
+     element is hidden again. Ahead of them it costs one small blocking request (safe-dom.js) and
+     is on screen for the whole download. The scripts below are still parser-blocking and still run
+     in document order; only the head/body boundary moved. #882 -->
+<div id="bootSplash" role="status" aria-live="polite">
+  <div class="boot-mark">DFIR Companion</div>
+  <div class="boot-msg">Loading case…</div>
+</div>
+
   <!-- Who owns dashboard state (#415). The store the remaining top-level bindings are meant to
        migrate onto, and the written argument for which of them should and which should not.
        It now owns the case snapshot — the three cells 84 reader functions go through — plus the
@@ -391,28 +450,7 @@
        No angle-bracketed tag names in this comment, on purpose: tests/reports/safeDomPolicy
        finds inline blocks by regex over the raw file, so a literal one written here reads to it
        as a real, un-nonced block. -->
-  <!-- THE ORDER OF THESE EIGHT IS THE CASCADE, and it is the concatenation order of the single
-       dashboard.css they were cut from (#415). They are a pure byte split: rules that used to
-       resolve a specificity tie by sitting later in one file now resolve it by sitting in a later
-       FILE, so reordering these lines silently changes the page. tests/reports/dashboardCss.test.ts
-       asserts the set and the order against src/http/staticAssets.ts, and that every @keyframes an
-       animation names is defined somewhere in the union — a keyframe resolves by NAME across the
-       whole document, so a dropped link costs an animation with nothing else looking wrong. -->
-  <link rel="stylesheet" href="/css/dashboard-tokens.css" />
-  <link rel="stylesheet" href="/css/dashboard-themes-a.css" />
-  <link rel="stylesheet" href="/css/dashboard-themes-b.css" />
-  <link rel="stylesheet" href="/css/dashboard-layout.css" />
-  <link rel="stylesheet" href="/css/dashboard-panels.css" />
-  <link rel="stylesheet" href="/css/dashboard-timeline.css" />
-  <link rel="stylesheet" href="/css/dashboard-toolbar.css" />
-  <link rel="stylesheet" href="/css/dashboard-sections.css" />
-  <!-- Accessibility layer (#386): skip link, visible focus ring, reduced motion, .visually-hidden.
-       Linked after the dashboard sheets so it is last in the cascade. It was already last against the
-       inline block that used to sit here, and #415 made it last against the other thirteen too —
-       they were interleaved through the body, so until now they came after it. -->
-  <link rel="stylesheet" href="/css/a11y.css" />
-</head>
-<body>
+
 <!-- First thing in the tab order (#386). Without it a keyboard user walks the entire toolbar —
      dozens of controls — on every page load before reaching any case content. -->
 <a class="skip-link" href="#main">Skip to main content</a>
@@ -476,10 +514,10 @@
     <button id="presentBtn" type="button" data-tip="Presentation mode — a read-only, step-through slide deck of the case (cover, summary, key findings, then the timeline one event at a time) for handoff briefings and executive walkthroughs. Respects the current severity filter. Opens in a new tab; export a self-contained offline deck via Export → Presentation deck.">Present</button>
     <span id="reportLinks" class="report-links"></span>
     <span id="dashViewWrap" data-safe-style="position:relative;display:inline-flex;align-items:center">
-      <button id="dashViewBtn" type="button" aria-haspopup="true" aria-expanded="false" data-tip="Dashboard view — switch the panel layout + severity filter for a role (Analyst / Lead / Executive) or phase (Triage / Report / Deep-Dive / Hunt-Prep), or edit your own. Remembered per-case.">
+      <button id="dashViewBtn" type="button" aria-haspopup="menu" aria-expanded="false" data-tip="Dashboard view — switch the panel layout + severity filter for a role (Analyst / Lead / Executive) or phase (Triage / Report / Deep-Dive / Hunt-Prep), or edit your own. Remembered per-case.">
         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
       </button>
-      <div id="dashViewMenu" class="dv-menu" data-safe-style="display:none"></div>
+      <div id="dashViewMenu" class="dv-menu" role="menu" aria-labelledby="dashViewBtn" data-safe-style="display:none"></div>
     </span>
     <button id="toggleAll" data-tip="Collapse or expand all sections">Collapse all</button>
     <button id="toggleSearchBar" type="button" aria-label="Filter" aria-expanded="false" aria-controls="searchFilterBar" data-tip="Filter events, findings and IOCs by text and time range (press /)">Filter</button>

--- a/public/js/dashboard-view-presets.js
+++ b/public/js/dashboard-view-presets.js
@@ -64,6 +64,43 @@
     const b = document.getElementById("dashViewBtn");
     if (b) b.setAttribute("aria-expanded", "false");
   }
+  // Opening with the keyboard has to land focus INSIDE the menu: the key handler below is attached
+  // to the menu, so while focus sits on the trigger the arrow keys never reach it. Prefers the
+  // active view so the menu opens on the entry that is currently in effect. #879
+  function focusFirstDashViewItem() {
+    const m = document.getElementById("dashViewMenu");
+    if (!m) return;
+    const items = [...m.querySelectorAll(".dv-item")];
+    if (!items.length) return;
+    (items.find((el) => el.classList.contains("dv-active")) || items[0]).focus();
+  }
+
+  // Arrow keys move between entries, Home/End jump to the ends, Escape closes and hands focus back
+  // to the trigger. Enter and Space need no handling — the entries are real <button>s, so the
+  // browser activates them and the existing click listener runs. #879
+  function dashViewMenuKeydown(ev) {
+    const menu = document.getElementById("dashViewMenu");
+    if (!menu) return;
+    const items = [...menu.querySelectorAll(".dv-item")];
+    if (!items.length) return;
+    const at = items.indexOf(document.activeElement);
+    if (ev.key === "Escape") {
+      ev.preventDefault();
+      closeDashViewMenu();
+      const b = document.getElementById("dashViewBtn");
+      if (b) b.focus();
+      return;
+    }
+    let next = -1;
+    if (ev.key === "ArrowDown") next = at < 0 ? 0 : (at + 1) % items.length;
+    else if (ev.key === "ArrowUp") next = at <= 0 ? items.length - 1 : at - 1;
+    else if (ev.key === "Home") next = 0;
+    else if (ev.key === "End") next = items.length - 1;
+    if (next < 0) return;
+    ev.preventDefault();
+    items[next].focus();
+  }
+
   // Build the popover: Custom + every view (active ticked), then a divider, the matching-report
   // action (only when the active view has one), and "Edit views…".
   function renderDashViewMenu() {
@@ -73,7 +110,7 @@
     const rows = [];
     const view = DfirState.activeView();
     rows.push(
-      `<div class="dv-item ${!view ? "dv-active" : ""}" data-view="">${tick(!view)}Custom <small>(your layout)</small></div>`,
+      `<button type="button" role="menuitem" class="dv-item ${!view ? "dv-active" : ""}" data-view="">${tick(!view)}Custom <small>(your layout)</small></button>`,
     );
     for (const v of DASHBOARD_VIEWS) {
       const active = !!view && view.id === v.id;
@@ -83,19 +120,21 @@
           ? ""
           : " <small>(custom)</small>";
       rows.push(
-        `<div class="dv-item ${active ? "dv-active" : ""}" data-view="${escAttr(v.id)}" title="${escAttr(v.description || "")}">${tick(active)}${esc(v.name)}${tag}</div>`,
+        `<button type="button" role="menuitem" class="dv-item ${active ? "dv-active" : ""}" data-view="${escAttr(v.id)}" title="${escAttr(v.description || "")}">${tick(active)}${esc(v.name)}${tag}</button>`,
       );
     }
-    rows.push(`<div class="dv-sep"></div>`);
+    rows.push(`<div class="dv-sep" role="separator"></div>`);
     const repLabel = dashViewReportLabel();
     if (repLabel)
       rows.push(
-        `<div class="dv-item dv-item-action" data-action="report">↳ Generate ${esc(repLabel)}</div>`,
+        `<button type="button" role="menuitem" class="dv-item dv-item-action" data-action="report">↳ Generate ${esc(repLabel)}</button>`,
       );
     rows.push(
-      `<div class="dv-item dv-item-action" data-action="edit">✎ Edit views…</div>`,
+      `<button type="button" role="menuitem" class="dv-item dv-item-action" data-action="edit">✎ Edit views…</button>`,
     );
     m.innerHTML = rows.join("");
+    // Same function reference every render, so repeated calls do not stack listeners.
+    m.addEventListener("keydown", dashViewMenuKeydown);
     m.querySelectorAll(".dv-item").forEach((el) =>
       el.addEventListener("click", () => {
         const action = el.dataset.action;
@@ -251,6 +290,7 @@
           renderDashViewMenu();
           menu.style.display = "block";
           btn.setAttribute("aria-expanded", "true");
+          focusFirstDashViewItem();
         });
         document.addEventListener("click", (e) => {
           if (


### PR DESCRIPTION
Fixes #880. Fixes #882. Fixes #879. Fixes #884.

Four page-shell defects from one end-to-end UI QA pass of 0.36.0. All verified in a real browser, not just by test.

## #880 — no viewport meta

Every phone laid the page out at 980px and scaled it to ~0.38. Adding the meta then **exposed what it had been hiding**: the page's own grid was the one part of the layout with no narrow override, while several children (`.now-group`, `.hyp-rev-cols`, `.wiz-row`) already had one. At 375px it resolved to a 291px column beside a 112px one. It now collapses to a single column below 900px.

Verified: `body.clientWidth` 375 at mobile (was 980); `main` one column narrow, two columns at 1440.

## #882 — no loading state, nothing compressed

The blank window is deliberate — safe-dom hides `<body>` until styles hydrate, to avoid a FOUC. On a throttled link that meant 57s to first paint with no indicator.

**Placement was the whole fix.** All 144 script tags were in `<head>`, none deferred, so markup after them isn't parsed until the last has executed — which is DOMContentLoaded, the exact moment the splash gets hidden. A splash placed in the old `<body>` position would have been a no-op on precisely the connection it was written for. The head/body boundary moved ahead of them: **158 head scripts → 2**.

The nine stylesheet links moved into the head with it. They had been linked *after* all 144 blocking scripts, so the page's entire stylesheet was discovered last. Their order relative to each other — which is the cascade — is unchanged, and `dashboardCss.test.ts` still passes.

Compression uses `node:zlib`, not the `compression` middleware: this ships as a single-file SEA binary and another runtime dependency in that bundle needs to earn itself. Measured on the dashboard document: **520,588 → 120,043 bytes, 77% smaller**.

Negotiation is delegated to Express, so `gzip;q=0` — which names gzip in order to *forbid* it — is honoured. `Vary` is appended via `res.vary()`, so the `Vary: Origin` that `originGuard` writes for an allowed cross-origin request survives; overwriting it would let a shared cache serve one origin's response to another with an unusable CORS header.

## #879 — view picker was mouse-only

Entries were bare `<div>`s with click listeners under a trigger announcing itself as a menu. They are now real `<button role="menuitem">`, so Enter/Space need no scripting. Arrows move, Home/End jump, Escape closes and returns focus to the trigger, and **opening lands focus on the active entry** — without that the handler on the menu never sees a key, because focus is still on the trigger. `aria-haspopup` was `"true"`, now `"menu"`.

That conversion had one consequence worth naming: `#dashViewMenu` is a child of `#toolbarMain`, so `.toolbar-main.icons-only button { font-size: 0 }` — the rule `fitToolbar()` uses to compact the row — began blanking every label in the popover. The rule now excludes the menu entries. Verified: in compact mode entries stay 13px while the toolbar's own button collapses to 0px.

## #884 — toolbar reflow

`#aiStatus` and `.scope-group` both sized to content and resolved ~7s after load, pushing `main` down under a reader. Both now reserve their footprint. The two selects the report also named already had a fixed width — that part of the report was wrong.

## Structural change

`routes/caseLifecycle.ts` hit its size cap, so the static app shell (`/`, `/dashboard`, `/mobile`, `/manifest.webmanifest`, `/sw.js`) moved to `routes/appShell.ts`, registering at the same stack position. It was never really case lifecycle. That file drops **904 → 855** lines and the size ledger is ratcheted down to match.

## Verification

- Full suite: **738 files, 12,012 tests, all passing**
- Gates green: `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check`
- `check:a11y` green after a real `playwright` run — 24 a11y specs pass including the axe scan, ledger reports 0 violations, none new
- ARCHITECTURE.md comply/total → 1,978 / 2,017 for the two new imports

## Follow-up worth tracking

The narrow layout now executes for the first time. `main` collapsing is the load-bearing fix, but the panels below it have never been laid out at phone width, so more narrow-layout polish likely remains. Note the product also ships a dedicated `/mobile` view, so the dashboard being desktop-first is partly by design.