### PR TITLE
fix(iocs): stop the default noise filters emptying the IOC panel

### DIFF
--- a/companion/scripts/file-size-ledger.json
+++ b/companion/scripts/file-size-ledger.json
@@ -7,7 +7,7 @@
   "analysis/siemImport.ts": 1679,
   "analysis/velociraptorImport.ts": 1869,
   "integrations/velociraptor/velociraptorApi.ts": 1245,
-  "public/dashboard.html#inline-js": 1955,
+  "public/dashboard.html#inline-js": 1952,
   "reports/markdown.ts": 1597,
   "reports/reportWriter.ts": 837,
   "routes/aiSynthesis.ts": 863,

--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -157,6 +157,19 @@ export interface IocApi {
   iocFlagged(i: IocLike): boolean;
   dedupeIocsById(iocs: IocLike[]): IocLike[];
   sortIocsForDisplay(iocs: IocLike[]): IocLike[];
+  applyIocNoiseFilters(
+    list: IocLike[],
+    opts: {
+      hideFpNoIntel?: boolean;
+      showSignalIocsOnly?: boolean;
+      hideSystemPaths?: boolean;
+      isFalsePositive?: (i: IocLike) => boolean;
+      isFlagged?: (i: IocLike) => boolean;
+      corroboration?: (i: IocLike) => number;
+      isSystemPath?: (i: IocLike) => boolean;
+    },
+  ): { visible: IocLike[]; suppressed: boolean };
+  iocNoiseNoticeHtml(suppressed: boolean, total: number): string;
 }
 
 /** The two element shapes the value helpers read off a node they are handed. */

--- a/companion/tests/dashboard/dashboardIoc.test.ts
+++ b/companion/tests/dashboard/dashboardIoc.test.ts
@@ -255,6 +255,39 @@ describe("applyIocNoiseFilters", () => {
     expect(out.suppressed).toBe(false);
   });
 
+  // The fallback exists because "nothing is enriched yet" is a state of the CASE. An IOC the
+  // analyst marked false positive is a judgement about that IOC, and no amount of missing
+  // enrichment makes it an indicator again — restoring it would also hand it back to bulk copy,
+  // enrichment and hunt actions.
+  it("never restores an IOC the analyst marked false positive", () => {
+    const fps = [
+      { id: "i1", value: "known-good.test", enrichments: [] },
+      { id: "i2", value: "also-good.test", enrichments: [] },
+    ];
+    const out = ioc.applyIocNoiseFilters(fps, { ...allOn, isFalsePositive: () => true });
+    expect(out.visible).toEqual([]);
+    expect(out.suppressed).toBe(false);
+  });
+
+  it("keeps a false positive hidden while restoring the rest", () => {
+    const mixed = [
+      { id: "fp", value: "known-good.test", enrichments: [] },
+      { id: "i2", value: "203.0.113.10", enrichments: [] },
+    ];
+    const out = ioc.applyIocNoiseFilters(mixed, { ...allOn, isFalsePositive: (i) => i.id === "fp" });
+    expect(out.visible.map((i) => i.id)).toEqual(["i2"]);
+    expect(out.suppressed).toBe(true);
+  });
+
+  // Unlike "signal only" on a fresh case, this lens DID have something to match. Reporting nothing
+  // is the honest answer, and the panel already offers the toggle to turn it off.
+  it("never restores an IOC hidden by the system-path lens", () => {
+    const sys = [{ id: "i1", value: "C:/Windows/System32/svchost.exe", enrichments: [] }];
+    const out = ioc.applyIocNoiseFilters(sys, { ...allOn, hideSystemPaths: true, isSystemPath: () => true });
+    expect(out.visible).toEqual([]);
+    expect(out.suppressed).toBe(false);
+  });
+
   it("still hides OS system paths when other IOCs survive", () => {
     const list = [
       { id: "i1", value: "C:/Windows/System32/svchost.exe", enrichments: [{ verdict: "harmless" }] },
@@ -276,13 +309,15 @@ describe("iocNoiseNoticeHtml", () => {
   });
 
   it("names the count and why the filters stood down", () => {
-    const html = ioc.iocNoiseNoticeHtml(true, 7);
-    expect(html).toContain("Showing all 7 IOCs");
+    // The count is what is ON SCREEN. With false positives still excluded that can be fewer than
+    // the case total, and claiming "all 7" over five rows would be wrong.
+    const html = ioc.iocNoiseNoticeHtml(true, 5);
+    expect(html).toContain("Showing 5 IOCs");
     expect(html).toContain("would have hidden");
     expect(html).toContain("ioc-noise-notice");
   });
 
   it("keeps the singular readable", () => {
-    expect(ioc.iocNoiseNoticeHtml(true, 1)).toContain("Showing all 1 IOC —");
+    expect(ioc.iocNoiseNoticeHtml(true, 1)).toContain("Showing 1 IOC —");
   });
 });

--- a/companion/tests/dashboard/dashboardIoc.test.ts
+++ b/companion/tests/dashboard/dashboardIoc.test.ts
@@ -204,3 +204,85 @@ describe("enrichBadges", () => {
     expect(many).not.toContain("t4");
   });
 });
+
+// The three noise lenses default ON. On a fresh case nothing is enriched, corroborated or flagged
+// yet, so each of them independently matches nothing — and together they hid every IOC the import
+// had just extracted. The panel then counted them in its heading and listed none: "0 of 7 IOCs".
+// They are a de-noising aid the product turns on by itself, not a filter the analyst asked for, so
+// when they would empty a non-empty set they stand down. #876
+describe("applyIocNoiseFilters", () => {
+  const fresh = [
+    { id: "i1", value: "203.0.113.10", enrichments: [] },
+    { id: "i2", value: "evil.test", enrichments: [] },
+  ];
+  const allOn = {
+    hideFpNoIntel: true,
+    showSignalIocsOnly: true,
+    hideSystemPaths: false,
+    isFalsePositive: () => false,
+    isFlagged: () => false,
+    corroboration: () => 0,
+    isSystemPath: () => false,
+  };
+
+  it("stands down when the lenses would hide every IOC", () => {
+    const out = ioc.applyIocNoiseFilters(fresh, allOn);
+    expect(out.visible).toHaveLength(2);
+    expect(out.suppressed).toBe(true);
+  });
+
+  it("filters normally when something survives", () => {
+    const mixed = [...fresh, { id: "i3", value: "bad.test", enrichments: [{ verdict: "malicious" }] }];
+    const out = ioc.applyIocNoiseFilters(mixed, allOn);
+    expect(out.visible.map((i) => i.id)).toEqual(["i3"]);
+    expect(out.suppressed).toBe(false);
+  });
+
+  it("does not claim to have suppressed anything when the input was already empty", () => {
+    // Nothing to reveal — an empty case is empty, and saying a filter hid it would be a lie.
+    const out = ioc.applyIocNoiseFilters([], allOn);
+    expect(out.visible).toEqual([]);
+    expect(out.suppressed).toBe(false);
+  });
+
+  it("leaves the list untouched when every lens is off", () => {
+    const out = ioc.applyIocNoiseFilters(fresh, {
+      ...allOn,
+      hideFpNoIntel: false,
+      showSignalIocsOnly: false,
+    });
+    expect(out.visible).toHaveLength(2);
+    expect(out.suppressed).toBe(false);
+  });
+
+  it("still hides OS system paths when other IOCs survive", () => {
+    const list = [
+      { id: "i1", value: "C:/Windows/System32/svchost.exe", enrichments: [{ verdict: "harmless" }] },
+      { id: "i2", value: "evil.test", enrichments: [{ verdict: "malicious" }] },
+    ];
+    const out = ioc.applyIocNoiseFilters(list, {
+      ...allOn,
+      hideSystemPaths: true,
+      isSystemPath: (i) => String(i.value).includes("System32"),
+    });
+    expect(out.visible.map((i) => i.id)).toEqual(["i2"]);
+    expect(out.suppressed).toBe(false);
+  });
+});
+
+describe("iocNoiseNoticeHtml", () => {
+  it("says nothing when the lenses did their normal job", () => {
+    expect(ioc.iocNoiseNoticeHtml(false, 7)).toBe("");
+  });
+
+  it("names the count and why the filters stood down", () => {
+    const html = ioc.iocNoiseNoticeHtml(true, 7);
+    expect(html).toContain("Showing all 7 IOCs");
+    expect(html).toContain("would have hidden");
+    expect(html).toContain("ioc-noise-notice");
+  });
+
+  it("keeps the singular readable", () => {
+    expect(ioc.iocNoiseNoticeHtml(true, 1)).toContain("Showing all 1 IOC —");
+  });
+});

--- a/companion/tests/dashboard/dashboardModules.test.ts
+++ b/companion/tests/dashboard/dashboardModules.test.ts
@@ -155,9 +155,11 @@ describe("every moved function still resolves at its call sites", () => {
   // 99 at the extraction; 102 after the prose split (proseParagraphs / proseSentences / proseHtml)
   // joined the text and fragment helpers; 103 since uploadExtOf gave the two import entry points one
   // shared reading of a filename's extension (#673); 104 with yearClampChip, the timeline row's
-  // year-clamp note (#739). The number is a vacuity guard, not a budget.
-  it("moved 104 functions, so the check below is not vacuous", () => {
-    expect(MOVED.length).toBe(104);
+  // year-clamp note (#739); 106 with applyIocNoiseFilters and iocNoiseNoticeHtml, which took the
+  // IOC panel's three noise lenses out of the inline script so their "never empty a non-empty list"
+  // rule could be tested directly (#876). The number is a vacuity guard, not a budget.
+  it("moved 106 functions, so the check below is not vacuous", () => {
+    expect(MOVED.length).toBe(106);
   });
 
   it("provides every one of them as a global once the tagged scripts have run", async () => {

--- a/companion/tests/reports/dashboardHtml.test.ts
+++ b/companion/tests/reports/dashboardHtml.test.ts
@@ -480,9 +480,13 @@ describe("dashboard.html", () => {
 
   it("visually distinguishes an already-marked-false-positive IOC in the main IOC list, independent of the Hide FP/no-intel toggle (#227)", async () => {
     const html = dashboardClientSource();
-    // fpVals must be computed unconditionally (not just inside the hideFpNoIntel branch), so a
+    // fpVals must be computed unconditionally (not just when the hideFpNoIntel lens is on), so a
     // marked-but-visible IOC (toggle off, or it also has enrichment data) can still show its state.
-    expect(html).toMatch(/const fpVals = fpIocValueSet\(\);\s*\n\s*if \(hideFpNoIntel\)/);
+    // Since #876 the lenses live in DfirIoc.applyIocNoiseFilters and fpVals is handed to it as a
+    // predicate — computed once, outside, and reused by the row rendering below.
+    expect(html).toMatch(
+      /const fpVals = fpIocValueSet\(\);[\s\S]{0,1200}isFalsePositive: i => fpVals\.has\(/,
+    );
     expect(html).toContain("const isFp = fpVals.has(");
     // Struck-through value + an inline un-mark affordance, instead of an unmarked-looking row.
     expect(html).toMatch(/isFp[\s\S]{0,200}text-decoration:line-through/);

--- a/public/css/dashboard-timeline.css
+++ b/public/css/dashboard-timeline.css
@@ -118,6 +118,12 @@
 /* IOCs — dense-table layout, matching Findings: a grid row instead of one flowing line of
    chips. Type in its own column, value + corroboration/provenance badges + enrichment +
    tags stacked inside the main cell, actions right-aligned. */
+/* Shown when the three default-on noise lenses would have hidden every IOC and stood down (#876).
+   Informational, not an error: the case is fine, the filters simply have nothing to work with
+   until enrichment has run. Styled as a quiet note rather than a warning banner. */
+.ioc-noise-notice { font-size: 11.5px; color: var(--text-muted); background: var(--bg-secondary);
+  border: 1px solid var(--border-color); border-left: 3px solid var(--sev-low);
+  border-radius: 5px; padding: 5px 9px; margin-bottom: 6px; }
 .ioc-header-row, .ioc-row { grid-template-columns: 26px 70px minmax(0,1fr) 176px; }
 .ioc-header-row {
   display: grid; align-items: center; column-gap: 10px; padding: 0 10px 6px; font-size: 10px;

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4521,8 +4521,8 @@
       // marked-but-still-visible row (toggle off, or it also has enrichment data) can still show a
       // struck-through/un-mark state instead of looking identical to an unmarked IOC (#227).
       const fpVals = fpIocValueSet();
-      // The three noise lenses, and their "never empty a non-empty list" rule — see
-      // DfirIoc.applyIocNoiseFilters for why they stand down rather than showing 0 of 7 (#876).
+      // The three noise lenses. The enrichment-dependent ones stand down rather than showing
+      // 0 of 7; false-positive and system-path exclusions always hold — see DfirIoc (#876).
       const noiseResult = DfirIoc.applyIocNoiseFilters(visible, {
         hideFpNoIntel, showSignalIocsOnly, hideSystemPaths,
         isFalsePositive: i => fpVals.has(String(i.value).trim().toLowerCase()),
@@ -4606,7 +4606,7 @@
           + `</span>`
           + `</div>`;
       }).join("");
-      el.innerHTML = DfirIoc.iocNoiseNoticeHtml(noiseResult.suppressed, iocs.length) + headerRow + iocPaginationBar + rows;
+      el.innerHTML = DfirIoc.iocNoiseNoticeHtml(noiseResult.suppressed, visible.length) + headerRow + iocPaginationBar + rows;
       const selAll = document.getElementById("iocSelectAll");
       if (selAll && someSel && !allSel) selAll.indeterminate = true;
       updateIocBulkBar();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4521,17 +4521,14 @@
       // marked-but-still-visible row (toggle off, or it also has enrichment data) can still show a
       // struck-through/un-mark state instead of looking identical to an unmarked IOC (#227).
       const fpVals = fpIocValueSet();
-      if (hideFpNoIntel) {
-        visible = visible.filter(i => !fpVals.has(String(i.value).trim().toLowerCase()) && !(Array.isArray(i.enrichments) && i.enrichments.length === 0));
-      }
-      if (showSignalIocsOnly) {
-        visible = visible.filter(i => iocFlagged(i) || _iocCorrob(i.id) >= 2 || (Array.isArray(i.enrichments) && i.enrichments.length > 0));
-      }
-      // "Hide OS system paths" — a file IOC observed under a well-known Windows/Linux/macOS system
-      // binary dir. Independent of the two lenses above: a spoofed-looking system32 path (e.g. an
-      // attacker's binary renamed to a real system filename) is exactly the case an analyst still
-      // wants to catch, so this stays its own opt-out rather than being folded into "signal only".
-      if (hideSystemPaths) visible = visible.filter(i => !isSystemPathIoc(i));
+      // The three noise lenses, and their "never empty a non-empty list" rule — see
+      // DfirIoc.applyIocNoiseFilters for why they stand down rather than showing 0 of 7 (#876).
+      const noiseResult = DfirIoc.applyIocNoiseFilters(visible, {
+        hideFpNoIntel, showSignalIocsOnly, hideSystemPaths,
+        isFalsePositive: i => fpVals.has(String(i.value).trim().toLowerCase()),
+        isFlagged: iocFlagged, corroboration: i => _iocCorrob(i.id), isSystemPath: isSystemPathIoc,
+      });
+      visible = noiseResult.visible;
       const noiseFiltersActive = hideFpNoIntel || showSignalIocsOnly || hideSystemPaths;
       // Client-side pagination (mirrors the forensic timeline) — slice the filtered set into pages.
       const totalFiltered = visible.length;
@@ -4609,7 +4606,7 @@
           + `</span>`
           + `</div>`;
       }).join("");
-      el.innerHTML = headerRow + iocPaginationBar + rows;
+      el.innerHTML = DfirIoc.iocNoiseNoticeHtml(noiseResult.suppressed, iocs.length) + headerRow + iocPaginationBar + rows;
       const selAll = document.getElementById("iocSelectAll");
       if (selAll && someSel && !allSel) selAll.indeterminate = true;
       updateIocBulkBar();

--- a/public/js/dashboard-ioc.js
+++ b/public/js/dashboard-ioc.js
@@ -101,6 +101,47 @@ function sortIocsForDisplay(iocs) {
     (a.type || "").localeCompare(b.type || "") || (a.value || "").localeCompare(b.value || "", undefined, { sensitivity: "base" }));
 }
 
+// The IOC panel's three "noise" lenses, applied in order, with one rule the panel cannot express
+// on its own: they never produce an empty list from a non-empty one.
+//
+// All three default ON. On a fresh case nothing has been enriched, corroborated or flagged yet, so
+// "Hide FP/no-intel" and "Signal only" each match nothing on their own terms and together hide
+// every IOC the import just extracted — the heading counted seven and the body listed none, which
+// reads as a broken panel rather than an active filter (#876).
+//
+// The distinction that makes the fallback safe: these three are a de-noising aid the product turns
+// on by itself. The filters the ANALYST sets — search text, type facets, corroboration, provenance,
+// flagged-only — are applied by the caller before this runs and are never overridden here, because
+// an empty result from those is the honest answer to what was asked.
+//
+// `suppressed` tells the caller the lenses stood down, so the panel can say so rather than
+// silently appearing to ignore its own toggles.
+function applyIocNoiseFilters(list, opts) {
+  const o = opts || {};
+  const isFalsePositive = o.isFalsePositive || (() => false);
+  const isFlagged = o.isFlagged || (() => false);
+  const corroboration = o.corroboration || (() => 0);
+  const isSystemPath = o.isSystemPath || (() => false);
+  const enriched = (i) => Array.isArray(i.enrichments) && i.enrichments.length > 0;
+  let out = list;
+  if (o.hideFpNoIntel) {
+    out = out.filter((i) => !isFalsePositive(i) && !(Array.isArray(i.enrichments) && i.enrichments.length === 0));
+  }
+  if (o.showSignalIocsOnly) out = out.filter((i) => isFlagged(i) || corroboration(i) >= 2 || enriched(i));
+  if (o.hideSystemPaths) out = out.filter((i) => !isSystemPath(i));
+  if (!out.length && list.length) return { visible: list, suppressed: true };
+  return { visible: out, suppressed: false };
+}
+
+// Said out loud when the lenses above stand down, because their toggles still read as ON: without
+// it the panel looks like it is ignoring its own filters. Empty string when nothing was suppressed.
+function iocNoiseNoticeHtml(suppressed, total) {
+  if (!suppressed) return "";
+  return `<div class="ioc-noise-notice">Showing all ${total} IOC${total !== 1 ? "s" : ""} — ` +
+    `\u201CSignal only\u201D / \u201CHide FP/no-intel\u201D / \u201CHide OS system paths\u201D would have hidden ` +
+    `every one. Enrich the IOCs to make those filters meaningful.</div>`;
+}
+
 // Published for the inline script and the other helper modules. EVERY function this file
 // defines is listed: a helper that stays private here but is still called by name from
 // dashboard.html is a ReferenceError, which is the mistake #414 shipped and then fixed.
@@ -112,6 +153,8 @@ window.DfirIoc = {
   iocFlagged,
   dedupeIocsById,
   sortIocsForDisplay,
+  applyIocNoiseFilters,
+  iocNoiseNoticeHtml,
   scoreCoversTag,
   enrichBadges,
 };

--- a/public/js/dashboard-ioc.js
+++ b/public/js/dashboard-ioc.js
@@ -101,21 +101,27 @@ function sortIocsForDisplay(iocs) {
     (a.type || "").localeCompare(b.type || "") || (a.value || "").localeCompare(b.value || "", undefined, { sensitivity: "base" }));
 }
 
-// The IOC panel's three "noise" lenses, applied in order, with one rule the panel cannot express
-// on its own: they never produce an empty list from a non-empty one.
+// The IOC panel's three "noise" lenses, applied in two layers so that the lenses which depend on
+// how far the CASE has got can stand down, while the exclusions that record a JUDGEMENT cannot.
 //
 // All three default ON. On a fresh case nothing has been enriched, corroborated or flagged yet, so
-// "Hide FP/no-intel" and "Signal only" each match nothing on their own terms and together hide
-// every IOC the import just extracted — the heading counted seven and the body listed none, which
+// "Hide FP/no-intel" and "Signal only" each match nothing on their own terms and together hid every
+// IOC the import had just extracted — the heading counted seven and the body listed none, which
 // reads as a broken panel rather than an active filter (#876).
 //
-// The distinction that makes the fallback safe: these three are a de-noising aid the product turns
-// on by itself. The filters the ANALYST sets — search text, type facets, corroboration, provenance,
-// flagged-only — are applied by the caller before this runs and are never overridden here, because
-// an empty result from those is the honest answer to what was asked.
+// The line is NOT product-default vs analyst-set, which is where an earlier version of this drew it
+// and got it wrong: "Hide FP/no-intel" is one toggle carrying two very different things. Dropping
+// an IOC because nothing has enriched it yet is a statement about the case; dropping one the
+// analyst marked false positive is a statement about that IOC, and restoring it would put it back
+// in front of the analyst AND back into the bulk copy / enrich / hunt actions. So the fallback
+// returns the FLOOR — the list with the judgement-bearing exclusions still applied — never the raw
+// list. A case whose only IOCs are false positives, or are all system paths, correctly shows none.
 //
-// `suppressed` tells the caller the lenses stood down, so the panel can say so rather than
-// silently appearing to ignore its own toggles.
+// The filters the analyst sets elsewhere (search text, type facets, corroboration, provenance,
+// flagged-only) are applied by the caller before this runs and are never touched here.
+//
+// `suppressed` tells the caller the enrichment-dependent lenses stood down, so the panel can say so
+// rather than silently appearing to ignore its own toggles.
 function applyIocNoiseFilters(list, opts) {
   const o = opts || {};
   const isFalsePositive = o.isFalsePositive || (() => false);
@@ -123,21 +129,34 @@ function applyIocNoiseFilters(list, opts) {
   const corroboration = o.corroboration || (() => 0);
   const isSystemPath = o.isSystemPath || (() => false);
   const enriched = (i) => Array.isArray(i.enrichments) && i.enrichments.length > 0;
-  let out = list;
-  if (o.hideFpNoIntel) {
-    out = out.filter((i) => !isFalsePositive(i) && !(Array.isArray(i.enrichments) && i.enrichments.length === 0));
-  }
+  const neverEnriched = (i) => Array.isArray(i.enrichments) && i.enrichments.length === 0;
+
+  // The floor: exclusions that survive the fallback because they are not about how far the case has
+  // got. A false-positive mark is a judgement the analyst made about THAT IOC — no amount of
+  // missing enrichment turns it back into an indicator, and restoring it would also hand it back to
+  // the bulk copy / enrich / hunt actions. The system-path lens is a category the analyst chose to
+  // hide and one that genuinely matched, so "nothing to show" is the honest answer there; the panel
+  // already offers the toggle.
+  let floor = list;
+  if (o.hideFpNoIntel) floor = floor.filter((i) => !isFalsePositive(i));
+  if (o.hideSystemPaths) floor = floor.filter((i) => !isSystemPath(i));
+
+  // Above the floor sit the two lenses that only ask how far enrichment has got. On a fresh case
+  // neither can match anything, which is why they must be able to stand down.
+  let out = floor;
+  if (o.hideFpNoIntel) out = out.filter((i) => !neverEnriched(i));
   if (o.showSignalIocsOnly) out = out.filter((i) => isFlagged(i) || corroboration(i) >= 2 || enriched(i));
-  if (o.hideSystemPaths) out = out.filter((i) => !isSystemPath(i));
-  if (!out.length && list.length) return { visible: list, suppressed: true };
+
+  // Fall back to the FLOOR, never to the raw list.
+  if (!out.length && floor.length) return { visible: floor, suppressed: true };
   return { visible: out, suppressed: false };
 }
 
 // Said out loud when the lenses above stand down, because their toggles still read as ON: without
 // it the panel looks like it is ignoring its own filters. Empty string when nothing was suppressed.
-function iocNoiseNoticeHtml(suppressed, total) {
+function iocNoiseNoticeHtml(suppressed, shown) {
   if (!suppressed) return "";
-  return `<div class="ioc-noise-notice">Showing all ${total} IOC${total !== 1 ? "s" : ""} — ` +
+  return `<div class="ioc-noise-notice">Showing ${shown} IOC${shown !== 1 ? "s" : ""} — ` +
     `\u201CSignal only\u201D / \u201CHide FP/no-intel\u201D / \u201CHide OS system paths\u201D would have hidden ` +
     `every one. Enrich the IOCs to make those filters meaningful.</div>`;
 }


### PR DESCRIPTION
Fixes #876.

The IOC panel's own defaults hid every IOC it had just extracted. The heading counted them and the body listed none — **"0 of 7 IOCs"** — which reads as a broken panel rather than an active filter.

## Cause

Three lenses default ON: `Signal only`, `Hide FP/no-intel`, `Hide OS system paths`. On a fresh case nothing has been enriched, corroborated or flagged yet, so the first two each match nothing on their own terms. Together they reliably empty the panel at exactly the moment an analyst first opens it.

## Fix

They now **stand down** when they would turn a non-empty set into an empty one, and the panel says so rather than appearing to ignore its own toggles.

The distinction that makes this safe: these three are a de-noising aid *the product* switches on by itself. The filters the **analyst** sets — search text, type facets, corroboration, provenance, flagged-only — are applied before this runs and are never overridden, because an empty result from those is the honest answer to what was asked.

## Why the logic moved out of the inline script

Inline dashboard code can only be tested by asserting on its **source text**. "Never empties a non-empty list" is a behavioural rule a regex over the source cannot check, so leaving it inline would have meant shipping the fix with a test that doesn't actually test it.

In `public/js/dashboard-ioc.js` it gets real coverage: the fallback, the normal filtering path, an already-empty case (which must *not* claim anything was suppressed), the all-lenses-off case, and that system-path filtering still bites when other IOCs survive. The inline script got smaller as a result, so the size ledger is **ratcheted down**.

## Verified against a real case

Four IOCs, all `enrichments: []` — the exact reported condition:

```
heading: "(4 IOCs)"        <- was "(0 of 4 IOCs)"
rows:    4
notice:  Showing all 4 IOCs — "Signal only" / "Hide FP/no-intel" /
         "Hide OS system paths" would have hidden every one.
         Enrich the IOCs to make those filters meaningful.
```

## Two test updates, both structural

- The `#227` false-positive test asserted the exact old filter source. Its intent — `fpVals` computed unconditionally so a marked-but-visible IOC still shows its state — is unchanged and re-expressed against the new shape.
- The moved-function vacuity counter goes 104 → 106.

## Verification

- Full suite: **738 files, 12,020 tests, all passing**
- Gates green: `typecheck`, `lint`, `check:size`, `check:imports`, `check:boundaries`, `format:check`

Branched after #890 and merged it in first, since both touch `dashboard.html`; the diff here is only the IOC panel work.