### PR TITLE
fix(mitre): derive event-carried techniques at projection instead of persisting them

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,981 of the 2,020 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,982 of the 2,021 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,982 of the 2,021 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,981 of the 2,020 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,980 of the 2,019 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,982 of the 2,021 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/scripts/module-map.json
+++ b/companion/scripts/module-map.json
@@ -231,6 +231,7 @@
     "emailImport.ts": "analysis/ingest",
     "eventAggregate.ts": "analysis/ingest",
     "eventRelevance.ts": "analysis/findings",
+    "eventTechniques.ts": "analysis/timeline",
     "evidenceGraph.ts": "analysis/detect",
     "evtxRecordId.ts": "analysis/ingest",
     "evtxXmlImport.ts": "analysis/ingest",

--- a/companion/src/analysis/ai/hunts.ts
+++ b/companion/src/analysis/ai/hunts.ts
@@ -1,3 +1,4 @@
+import { withEventTechniques } from "../eventTechniques.js";
 import type { AIProvider } from "../../providers/provider.js";
 import type { AssetOverridesStore } from "../assetOverrides.js";
 import { buildGraphContext, DEFAULT_MAX_GRAPH_EDGES } from "../graphContext.js";
@@ -189,7 +190,14 @@ async function buildFleetHuntPrompt(
   const feedback = huntFeedbackBlocks(outcomes);
   const findingsText = renderHuntFindings(loaded.findings);
   const iocText = renderHuntIocs(loaded.iocs);
-  const techText = loaded.mitreTechniques.map((t) => `${t.id} ${t.name}`).join(", ") || "(none)";
+  // Derived, not read straight off the stored table (#893): the techniques a deterministic importer
+  // carries live on its EVENTS and are no longer persisted, so an import-only case would offer the
+  // model "(none)" to pivot from. Built over `scoped` for the same reason the timeline block below
+  // is — the hunt is proposed against the events actually in play.
+  const techText =
+    withEventTechniques({ ...loaded, forensicTimeline: scoped })
+      .mitreTechniques.map((t) => `${t.id} ${t.name}`)
+      .join(", ") || "(none)";
   const aliasIndex = await loadCtxAliasIndex(ctx.opts, caseId);
   const contextBlock = buildSynthesisContext(loaded, scoped, await ctx.getKevCatalog(), aliasIndex);
   // Causal grounding (#124): serialize the deterministic evidence-chain graph — process spawn

--- a/companion/src/analysis/ai/synthesisMerge.ts
+++ b/companion/src/analysis/ai/synthesisMerge.ts
@@ -48,6 +48,34 @@ import { mergeDelta, type WindowContext } from "../stateMerge.js";
  * scope hides them instead of deleting them (#751).
  */
 
+/**
+ * Keep analyst-ACCEPTED techniques across a synthesis, which replaces the MITRE table wholesale.
+ *
+ * `replaceConclusions` empties `mitreTechniques` so each run rebuilds the model's assessment rather
+ * than accumulating it. A technique the analyst accepted from a second opinion is not the model's
+ * assessment — it is them overruling it — and it has no finding or event behind it to be re-derived
+ * from, so the replace simply erased it. Re-accepting was no help either: a later second-opinion
+ * run diffs against a case that no longer holds the technique and produces a fresh PENDING delta,
+ * so the durability re-application had nothing accepted to re-apply.
+ *
+ * Exactly the reason pinned questions are carried across the same replace, one step below. #893.
+ */
+function preserveAcceptedTechniques(
+  before: InvestigationState,
+  next: InvestigationState,
+): InvestigationState {
+  const accepted = before.mitreTechniques.filter((t) => t.analystAccepted);
+  if (accepted.length === 0) return next;
+  const acceptedIds = new Set(accepted.map((t) => t.id));
+  // Re-derived by the model this run: keep its fresh name and finding links, but remember it was
+  // also accepted, so the next replace does not drop it either.
+  const kept = next.mitreTechniques.map((t) =>
+    acceptedIds.has(t.id) && !t.analystAccepted ? { ...t, analystAccepted: true as const } : t,
+  );
+  const present = new Set(kept.map((t) => t.id));
+  return { ...next, mitreTechniques: [...kept, ...accepted.filter((t) => !present.has(t.id))] };
+}
+
 /** Keep analyst-pinned questions across a synthesis (it replaces keyQuestions wholesale). */
 function mergePinnedQuestions(
   pinned: InvestigationQuestion[],
@@ -126,7 +154,7 @@ export async function foldSynthesisDelta(
   // The backfills are restricted to the events synthesis actually considered.
   const eligibleIds = new Set(scopedEvents.map((e) => e.id));
   const netted = applyBackfills(linked, scopedEvents, eligibleIds, ts);
-  const pinned = await preservePinnedQuestions(ctx, caseId, netted.state);
+  const pinned = preserveAcceptedTechniques(state, await preservePinnedQuestions(ctx, caseId, netted.state));
   let next = correctKeyQuestions(pinned, state, scopedEvents);
   // The techniques the timeline CARRIES are deliberately not folded in here (#893). This used to
   // union the scoped events' ids into the table so the ones the model didn't echo — especially the

--- a/companion/src/analysis/ai/synthesisMerge.ts
+++ b/companion/src/analysis/ai/synthesisMerge.ts
@@ -17,7 +17,6 @@ import { shortHost } from "../iocAnchors.js";
 import { extractCveIds, matchKevEntries, type KevCatalog } from "../kev.js";
 import type { PlaybookTask } from "../playbook.js";
 import { demoteCompletedNextSteps } from "../priorWork.js";
-import { unionEventTechniques } from "../reconTechniques.js";
 import { isDeterministicFindingId, renameForgedFindingIds, type deltaSchema } from "../responseSchema.js";
 import type { SourceTrustMap } from "../sourceTrust.js";
 import type { StateStore } from "../stateStore.js";
@@ -129,11 +128,18 @@ export async function foldSynthesisDelta(
   const netted = applyBackfills(linked, scopedEvents, eligibleIds, ts);
   const pinned = await preservePinnedQuestions(ctx, caseId, netted.state);
   let next = correctKeyQuestions(pinned, state, scopedEvents);
-  // Union the deterministically-identified ATT&CK techniques carried by the (in-scope) timeline into
-  // the synthesized MITRE table, so techniques the model didn't echo — especially the Info/Low
-  // discovery phase (whoami/net group/findstr password/cat .env) tagged by the importers — still
-  // appear in the case's MITRE table and report. Same scoped events synthesis saw; pure + idempotent.
-  next = { ...next, mitreTechniques: unionEventTechniques(next.mitreTechniques, scopedEvents) };
+  // The techniques the timeline CARRIES are deliberately not folded in here (#893). This used to
+  // union the scoped events' ids into the table so the ones the model didn't echo — especially the
+  // Info/Low discovery phase (whoami/net group/findstr password/cat .env) tagged by the importers —
+  // still reached the MITRE panel and the report. It worked, and it wrote them into PERSISTED
+  // state, where the analyst could no longer get them out: dismissing the only event carrying one
+  // left the row behind, because scope and the false-positive filter drop events at projection
+  // rather than from state and nothing downstream removes an aggregate row.
+  //
+  // Those techniques are derived at projection now (analysis/eventTechniques.ts), from the events
+  // that survive both filters, so they still appear and a dismissal still takes them away. What
+  // this fold persists is what the model ASSERTED — a conclusion about the case rather than a
+  // restatement of an event tag.
   next = demoteCompletedSteps(next, playbookTasks);
 
   return {

--- a/companion/src/analysis/eventTechniques.ts
+++ b/companion/src/analysis/eventTechniques.ts
@@ -1,0 +1,30 @@
+import { unionEventTechniques } from "./attackTechniqueNames.js";
+import type { InvestigationState } from "./stateTypes.js";
+
+// The case MITRE table, completed from the techniques the forensic events carry (#893).
+//
+// Every deterministic importer hardcodes its delta's top-level `mitreTechniques` to [] and puts the
+// real ids on the events it produces, so a case that has never run AI synthesis has an empty
+// aggregate and an empty MITRE panel while Kill Chain and the ATT&CK Navigator export — which read
+// the events directly — show the techniques. That was #878.
+//
+// #878 fixed it by unioning those ids into the aggregate during the merge. The aggregate is
+// PERSISTED, and scope and the false-positive filter drop events at projection rather than from
+// state, so once a technique was in it there was no way back out: dismissing the only event that
+// carried it changed nothing, and every later import re-added it. Chasing that with provenance
+// meant rebuilding, alongside the timeline, a second model of which event a technique came from and
+// when — through a correlation step whose whole job is to collapse exactly that.
+//
+// So it is derived instead of stored. Applied AFTER the scope window and the false-positive filter,
+// over the events that survive them, it cannot disagree with the timeline it is shown beside: an
+// event the analyst dismissed is not there to contribute, and one they scope back in contributes
+// again with no healing pass required. Nothing is written, so nothing can go stale.
+//
+// Pure and idempotent — unionEventTechniques skips ids the table already holds, so a technique a
+// model asserted at a delta's top level keeps its finding links and is not duplicated.
+export function withEventTechniques(state: InvestigationState): InvestigationState {
+  return {
+    ...state,
+    mitreTechniques: unionEventTechniques(state.mitreTechniques, state.forensicTimeline),
+  };
+}

--- a/companion/src/analysis/eventTechniques.ts
+++ b/companion/src/analysis/eventTechniques.ts
@@ -23,8 +23,18 @@ import type { InvestigationState } from "./stateTypes.js";
 // Pure and idempotent — unionEventTechniques skips ids the table already holds, so a technique a
 // model asserted at a delta's top level keeps its finding links and is not duplicated.
 export function withEventTechniques(state: InvestigationState): InvestigationState {
-  return {
-    ...state,
-    mitreTechniques: unionEventTechniques(state.mitreTechniques, state.forensicTimeline),
-  };
+  // What the surviving evidence still supports. A technique SYNTHESIS asserted is persisted, so
+  // without this it outlived the dismissal of the very event it was drawn from: the analyst
+  // dismissed the evidence and the row stayed in the panel and the report.
+  //
+  // Hiding it here is safe in a way that pruning the stored table never was — and that is the whole
+  // difference this rework makes. This is a VIEW: state is untouched, so widening the scope window
+  // or un-marking the event brings the technique straight back, with no merge and nothing to heal.
+  // The old design had to choose between leaving stale rows and deleting analysis for good.
+  const surviving = new Set(state.findings.map((f) => f.id));
+  const carried = new Set(state.forensicTimeline.flatMap((e) => e.mitreTechniques));
+  const supported = state.mitreTechniques.filter(
+    (t) => t.findingIds.some((id) => surviving.has(id)) || carried.has(t.id),
+  );
+  return { ...state, mitreTechniques: unionEventTechniques(supported, state.forensicTimeline) };
 }

--- a/companion/src/analysis/eventTechniques.ts
+++ b/companion/src/analysis/eventTechniques.ts
@@ -31,10 +31,11 @@ export function withEventTechniques(state: InvestigationState): InvestigationSta
   // difference this rework makes. This is a VIEW: state is untouched, so widening the scope window
   // or un-marking the event brings the technique straight back, with no merge and nothing to heal.
   // The old design had to choose between leaving stale rows and deleting analysis for good.
+  // An analyst's accepted addition counts as support in itself — see Technique.analystAccepted.
   const surviving = new Set(state.findings.map((f) => f.id));
   const carried = new Set(state.forensicTimeline.flatMap((e) => e.mitreTechniques));
   const supported = state.mitreTechniques.filter(
-    (t) => t.findingIds.some((id) => surviving.has(id)) || carried.has(t.id),
+    (t) => t.analystAccepted || t.findingIds.some((id) => surviving.has(id)) || carried.has(t.id),
   );
   return { ...state, mitreTechniques: unionEventTechniques(supported, state.forensicTimeline) };
 }

--- a/companion/src/analysis/scopeProject.ts
+++ b/companion/src/analysis/scopeProject.ts
@@ -46,9 +46,17 @@ export function projectScope(state: InvestigationState, scope: ScopeWindow): Inv
 
   // MITRE: recompute each technique's finding links to the survivors. A technique
   // that had links and loses them all is dropped; one with no links is preserved.
+  //
+  // One a human ACCEPTED is kept whatever its links do (#893). It came from the analyst overruling
+  // both models, not from the evidence this window selects, so narrowing the window is not a reason
+  // to drop it — and because synthesis folds and then SAVES a projected snapshot, dropping it here
+  // does not merely hide it for the duration of the scope, it loses the decision permanently.
   const mitreTechniques = state.mitreTechniques
     .map((t) => ({ ...t, findingIds: t.findingIds.filter((id) => survivingFindings.has(id)) }))
-    .filter((t, idx) => t.findingIds.length > 0 || state.mitreTechniques[idx].findingIds.length === 0);
+    .filter(
+      (t, idx) =>
+        t.analystAccepted || t.findingIds.length > 0 || state.mitreTechniques[idx].findingIds.length === 0,
+    );
 
   return { ...state, forensicTimeline, findings, iocs, mitreTechniques };
 }

--- a/companion/src/analysis/secondOpinion.ts
+++ b/companion/src/analysis/secondOpinion.ts
@@ -341,11 +341,23 @@ export function applyAcceptedSecondOpinion(
       const sev = d.bSeverity;
       findings = mapByKey(findings, deltaKey(d), (f) => ({ ...f, severity: sev }));
     } else if (d.kind === "mitre_added") {
-      if (!techniques.some((t) => t.id === d.title)) {
+      // `analystAccepted` is what keeps it visible: the projection drops a technique nothing
+      // surviving supports, and an accepted addition has no finding and no event behind it by
+      // construction — it is the analyst overruling both models (#893).
+      const existing = techniques.find((t) => t.id === d.title);
+      if (!existing) {
         techniques = [
           ...techniques,
-          { id: d.title, name: d.techniqueName || d.title, findingIds: [] } satisfies Technique,
+          {
+            id: d.title,
+            name: d.techniqueName || d.title,
+            findingIds: [],
+            analystAccepted: true,
+          } satisfies Technique,
         ];
+      } else if (!existing.analystAccepted) {
+        // Already present, but now also affirmed by hand — it outlives whatever first put it there.
+        techniques = techniques.map((t) => (t.id === d.title ? { ...t, analystAccepted: true } : t));
       }
     } else if (d.kind === "mitre_removed") {
       techniques = techniques.filter((t) => t.id !== d.title);

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -18,7 +18,6 @@ import { matchIocToExclude } from "./iocExclude.js";
 import { repairIocValue } from "./iocValue.js";
 import { sanitizeUncertainties } from "./uncertainty.js";
 import { mergeCanonicalEvents } from "./canonicalEvent.js";
-import { unionEventTechniques } from "./attackTechniqueNames.js";
 
 // Trim a raw collect directive (investigation-guidance #8) to its non-empty string fields; returns
 // undefined when nothing useful is present, so an all-blank object isn't persisted.
@@ -346,13 +345,18 @@ export function mergeDelta(
   // during synthesis. Idempotent.
   const correlated = correlateEvents(withExfil).sort(byEventTime);
 
-  // Deterministic importers hardcode the delta's top-level mitreTechniques to [] and carry the real
-  // technique IDs on the forensic events instead, so the aggregate above sees nothing to collect.
-  // The MITRE panel and the report's MITRE section both read that aggregate, which is why they
-  // stayed empty while Kill Chain and the ATT&CK Navigator export — which read the events directly
-  // — showed the techniques. Union from the merged timeline so any delta contributes, and so an
-  // existing case heals on its next merge. Idempotent: ids already present are skipped. #878.
-  const mitreWithEvents = unionEventTechniques(mitreTechniques, correlated);
+  // NOTE: the techniques the deterministic importers carry on their EVENTS are deliberately not
+  // collected here (#893). #878 unioned them into this aggregate, which made the MITRE panel and
+  // the report correct at the moment of the merge and wrong forever after: the aggregate is
+  // persisted, while scope and the false-positive filter drop events at PROJECTION rather than from
+  // state — so a technique whose only event the analyst later dismissed had no way back out.
+  //
+  // Deriving it at projection instead, from the events that survive those filters, is what
+  // eventTechniques.ts does. Nothing is stored, so nothing can go stale, and the panel and the
+  // report agree with the timeline beside them by construction.
+  //
+  // What IS collected here is what a model asserted at the delta's top level — a conclusion about
+  // the case rather than a restatement of an event tag. That is a claim the case should keep.
 
   // Key questions are a holistic reassessment — replace wholesale when synthesis
   // provides them; otherwise keep the existing set (per-window deltas omit them).
@@ -396,7 +400,7 @@ export function mergeDelta(
     openThreads,
     timeline,
     forensicTimeline: correlated,
-    mitreTechniques: mitreWithEvents,
+    mitreTechniques,
     keyQuestions,
     nextSteps,
     uncertainties,

--- a/companion/src/analysis/stateTypes.ts
+++ b/companion/src/analysis/stateTypes.ts
@@ -274,6 +274,17 @@ export interface Technique {
   id: string; // e.g. "T1059.001"
   name: string;
   findingIds: string[];
+  // The ANALYST added this one, by accepting a second-opinion mitre_added delta.
+  //
+  // The projection shows a technique only while surviving evidence still backs it — a finding that
+  // is still there, or an event still carrying the id (#893). An accepted addition has neither by
+  // construction: it is the analyst overruling both models, so nothing in the case points at it and
+  // it would vanish the moment they accepted it. Their decision IS the support.
+  //
+  // A record of a human choice, not derived provenance: it never has to be re-derived, kept in step
+  // with the timeline, or reconciled through correlation, so it does not reintroduce what #893
+  // removed. `mitre_removed` still deletes the row outright.
+  analystAccepted?: true;
 }
 
 // A STRUCTURED collection directive (investigation-guidance #8). The synthesis prompt already asks the

--- a/companion/src/reports/reportWriter.ts
+++ b/companion/src/reports/reportWriter.ts
@@ -4,6 +4,7 @@ import type { CaseStore } from "../storage/caseStore.js";
 import type { StateStore } from "../analysis/stateStore.js";
 import { NO_SCOPE, type ScopeStore } from "../analysis/scope.js";
 import { projectScope } from "../analysis/scopeProject.js";
+import { withEventTechniques } from "../analysis/eventTechniques.js";
 import {
   applyFalsePositive,
   filterFalsePositiveEvents,
@@ -272,10 +273,9 @@ export class ReportWriter {
     const aligned = { ...loaded, forensicTimeline: projectAlignment(skew, loaded.forensicTimeline) };
     const scoped = projectScope(aligned, this.scope ? await this.scope.load(caseId) : NO_SCOPE);
     const markers = this.falsePositives ? await this.falsePositives.load(caseId) : [];
-    return applyFalsePositive(
-      { ...scoped, forensicTimeline: filterFalsePositiveEvents(scoped.forensicTimeline, markers) },
-      markers,
-    );
+    const kept = filterFalsePositiveEvents(scoped.forensicTimeline, markers);
+    // MITRE completed LAST, from the events that survived both filters — see eventTechniques.ts (#893).
+    return withEventTechniques(applyFalsePositive({ ...scoped, forensicTimeline: kept }, markers));
   }
 
   private async loadNotebook(caseId: string): Promise<NotebookEntry[] | undefined> {

--- a/companion/tests/analysis/ai/synthesisMitrePersistence.test.ts
+++ b/companion/tests/analysis/ai/synthesisMitrePersistence.test.ts
@@ -76,4 +76,44 @@ describe("synthesis does not persist event-carried techniques (#893)", () => {
 
     expect(next.mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
   });
+
+  it("carries an analyst-accepted technique across the wholesale MITRE replace", async () => {
+    // replaceConclusions empties the table so each run rebuilds the model's assessment. An accepted
+    // technique is not the model's assessment and has no finding or event to be re-derived from, so
+    // the replace erased it — and a later second-opinion run, diffing a case that no longer held it,
+    // produced a fresh PENDING delta rather than re-applying the old acceptance.
+    const state = {
+      ...emptyState("c1"),
+      mitreTechniques: [
+        { id: "T1486", name: "Data Encrypted for Impact", findingIds: [], analystAccepted: true as const },
+      ],
+      forensicTimeline: [event("e1", ["T1003.003"])],
+    };
+
+    const next = await fold(state);
+
+    expect(next.mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
+    expect(next.mitreTechniques[0].analystAccepted).toBe(true);
+  });
+
+  it("keeps the acceptance on a technique the model re-derived this run", async () => {
+    // The model naming it too must not quietly downgrade it back to a model-derived row, or the
+    // NEXT replace drops it.
+    const state = {
+      ...emptyState("c1"),
+      mitreTechniques: [{ id: "T1486", name: "Old", findingIds: [], analystAccepted: true as const }],
+      forensicTimeline: [],
+    };
+
+    const next = await fold(
+      state,
+      delta({ mitreTechniques: [{ id: "T1486", name: "Data Encrypted for Impact" }] }),
+    );
+
+    expect(next.mitreTechniques).toHaveLength(1);
+    expect(next.mitreTechniques[0]).toMatchObject({
+      name: "Data Encrypted for Impact",
+      analystAccepted: true,
+    });
+  });
 });

--- a/companion/tests/analysis/ai/synthesisMitrePersistence.test.ts
+++ b/companion/tests/analysis/ai/synthesisMitrePersistence.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { foldSynthesisDelta, type DeltaFoldContext } from "../../../src/analysis/ai/synthesisMerge.js";
+import { deltaSchema } from "../../../src/analysis/responseSchema.js";
+import { mergeDelta } from "../../../src/analysis/stateMerge.js";
+import { emptyState, type ForensicEvent, type InvestigationState } from "../../../src/analysis/stateTypes.js";
+
+/**
+ * The synthesis fold was the last place that wrote event-carried ATT&CK techniques into PERSISTED
+ * state. It made the MITRE panel correct at the moment it ran and permanently wrong afterwards:
+ * scope and the false-positive filter drop events at projection rather than from state, and nothing
+ * downstream removes an aggregate row — so dismissing the only event carrying a technique left the
+ * row behind for good.
+ *
+ * They are derived at projection now (analysis/eventTechniques.ts). What the fold persists is what
+ * the model ASSERTED. #893.
+ */
+
+const event = (id: string, techniques: string[]): ForensicEvent => ({
+  id,
+  timestamp: "2026-06-01T10:00:00.000Z",
+  description: `event ${id}`,
+  severity: "Medium",
+  mitreTechniques: techniques,
+  relatedFindingIds: [],
+  sourceScreenshots: [],
+});
+
+function context(state: InvestigationState): DeltaFoldContext {
+  return {
+    opts: { stateStore: { load: async () => state } } as unknown as DeltaFoldContext["opts"],
+    mergeWithAliases: async (base, delta, ctx) => mergeDelta(base, delta, ctx),
+  };
+}
+
+const delta = (over: Record<string, unknown> = {}) =>
+  deltaSchema.parse({
+    findings: [],
+    iocs: [],
+    mitreTechniques: [],
+    threadsOpened: [],
+    threadsClosed: [],
+    timelineNote: "n",
+    summary: "s",
+    ...over,
+  });
+
+async function fold(state: InvestigationState, d = delta()): Promise<InvestigationState> {
+  const result = await foldSynthesisDelta(context(state), {
+    caseId: "c1",
+    state,
+    delta: d,
+    markers: [],
+    scopedEvents: state.forensicTimeline,
+    playbookTasks: [],
+  });
+  return result.next;
+}
+
+describe("synthesis does not persist event-carried techniques (#893)", () => {
+  it("leaves a technique only the timeline carries out of the stored table", async () => {
+    const state = { ...emptyState("c1"), forensicTimeline: [event("e1", ["T1003.003"])] };
+
+    const next = await fold(state);
+
+    expect(next.mitreTechniques).toEqual([]);
+    expect(next.forensicTimeline[0].mitreTechniques).toEqual(["T1003.003"]);
+  });
+
+  it("still persists what the model asserted at the top level", async () => {
+    const state = { ...emptyState("c1"), forensicTimeline: [event("e1", ["T1003.003"])] };
+
+    const next = await fold(
+      state,
+      delta({ mitreTechniques: [{ id: "T1486", name: "Data Encrypted for Impact" }] }),
+    );
+
+    expect(next.mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
+  });
+});

--- a/companion/tests/analysis/eventTechniques.test.ts
+++ b/companion/tests/analysis/eventTechniques.test.ts
@@ -67,4 +67,50 @@ describe("withEventTechniques (#893)", () => {
     expect(twice.mitreTechniques).toEqual(once.mitreTechniques);
     expect(state.mitreTechniques).toEqual([]);
   });
+
+  it("hides a synthesized technique once the event it was drawn from is gone", () => {
+    // The row synthesis persisted outlived the dismissal of its own evidence: the analyst removed
+    // the event and the technique stayed in the panel and the report.
+    const state = {
+      ...emptyState("c1"),
+      mitreTechniques: [{ id: "T1486", name: "Data Encrypted for Impact", findingIds: [] }],
+      forensicTimeline: [event("kept", ["T1003.003"])],
+    };
+
+    expect(withEventTechniques(state).mitreTechniques.map((t) => t.id)).toEqual(["T1003.003"]);
+  });
+
+  it("brings it back the moment the event is in the projection again", () => {
+    // Why hiding is safe here and pruning the stored table never was: this is a VIEW. The
+    // assertion is untouched in state, so un-dismissing restores it with no merge.
+    const asserted = [{ id: "T1486", name: "Data Encrypted for Impact", findingIds: [] }];
+    const hidden = { ...emptyState("c1"), mitreTechniques: asserted, forensicTimeline: [] };
+    expect(withEventTechniques(hidden).mitreTechniques).toEqual([]);
+
+    const restored = { ...hidden, forensicTimeline: [event("back", ["T1486"])] };
+
+    expect(withEventTechniques(restored).mitreTechniques).toEqual(asserted);
+  });
+
+  it("keeps a technique a surviving finding still cites, with no event carrying it", () => {
+    const state = {
+      ...emptyState("c1"),
+      findings: [{ id: "f1" }] as never,
+      mitreTechniques: [{ id: "T1486", name: "Data Encrypted for Impact", findingIds: ["f1"] }],
+      forensicTimeline: [],
+    };
+
+    expect(withEventTechniques(state).mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
+  });
+
+  it("hides one whose only finding the filters dropped", () => {
+    const state = {
+      ...emptyState("c1"),
+      findings: [],
+      mitreTechniques: [{ id: "T1486", name: "Data Encrypted for Impact", findingIds: ["gone"] }],
+      forensicTimeline: [],
+    };
+
+    expect(withEventTechniques(state).mitreTechniques).toEqual([]);
+  });
 });

--- a/companion/tests/analysis/eventTechniques.test.ts
+++ b/companion/tests/analysis/eventTechniques.test.ts
@@ -127,4 +127,21 @@ describe("withEventTechniques (#893)", () => {
 
     expect(withEventTechniques(state).mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
   });
+
+  it("is what the hunt prompt uses, so an import-only case still has techniques to pivot from", () => {
+    // hunts.ts reads the case table to tell the model which techniques are in play. Nothing
+    // persists event-carried ones any more, so reading the stored table there offered "(none)" on
+    // exactly the cases — deterministic imports, no synthesis — that #878 was filed about.
+    const state = {
+      ...emptyState("c1"),
+      forensicTimeline: [event("e1", ["T1003.003"]), event("e2", ["T1021.002"])],
+    };
+
+    const text = withEventTechniques(state)
+      .mitreTechniques.map((t) => `${t.id} ${t.name}`)
+      .join(", ");
+
+    expect(text).toContain("T1003.003 OS Credential Dumping: NTDS");
+    expect(text).toContain("T1021.002");
+  });
 });

--- a/companion/tests/analysis/eventTechniques.test.ts
+++ b/companion/tests/analysis/eventTechniques.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { withEventTechniques } from "../../src/analysis/eventTechniques.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+/**
+ * #878's problem: a deterministic importer puts its technique ids on the EVENTS, so a case that has
+ * never run synthesis shows an empty MITRE panel while Kill Chain shows the techniques.
+ *
+ * #878's fix stored the union during the merge, which made it permanent — dismissing the only event
+ * carrying a technique could not remove it. Deriving it after the filters instead means the table is
+ * a function of the timeline it is shown beside, and cannot disagree with it. #893.
+ */
+
+const event = (id: string, techniques: string[]): ForensicEvent => ({
+  id,
+  timestamp: "2026-06-01T10:00:00.000Z",
+  description: `event ${id}`,
+  severity: "High",
+  mitreTechniques: techniques,
+  relatedFindingIds: [],
+  sourceScreenshots: [],
+});
+
+describe("withEventTechniques (#893)", () => {
+  it("completes the table from the events, so an import-only case is not empty (#878)", () => {
+    const state = { ...emptyState("c1"), forensicTimeline: [event("e1", ["T1003.003"])] };
+
+    const out = withEventTechniques(state);
+
+    expect(out.mitreTechniques.map((t) => t.id)).toEqual(["T1003.003"]);
+  });
+
+  it("names what it collects", () => {
+    const state = { ...emptyState("c1"), forensicTimeline: [event("e1", ["T1003.003"])] };
+
+    expect(withEventTechniques(state).mitreTechniques[0].name).toBe("OS Credential Dumping: NTDS");
+  });
+
+  it("omits a technique whose events the caller already filtered out", () => {
+    // The whole mechanism: hand it the surviving timeline and the answer is right by construction.
+    const state = { ...emptyState("c1"), forensicTimeline: [event("kept", ["T1003.003"])] };
+
+    const out = withEventTechniques(state);
+
+    expect(out.mitreTechniques.map((t) => t.id)).not.toContain("T1021.002");
+  });
+
+  it("keeps an asserted technique's name and finding links rather than restating it", () => {
+    const state = {
+      ...emptyState("c1"),
+      mitreTechniques: [{ id: "T1003.003", name: "NTDS", findingIds: ["f1"] }],
+      forensicTimeline: [event("e1", ["T1003.003"])],
+    };
+
+    const out = withEventTechniques(state);
+
+    expect(out.mitreTechniques).toHaveLength(1);
+    expect(out.mitreTechniques[0]).toMatchObject({ name: "NTDS", findingIds: ["f1"] });
+  });
+
+  it("is idempotent, and does not mutate the state it is given", () => {
+    const state = { ...emptyState("c1"), forensicTimeline: [event("e1", ["T1003.003"])] };
+
+    const once = withEventTechniques(state);
+    const twice = withEventTechniques(once);
+
+    expect(twice.mitreTechniques).toEqual(once.mitreTechniques);
+    expect(state.mitreTechniques).toEqual([]);
+  });
+});

--- a/companion/tests/analysis/eventTechniques.test.ts
+++ b/companion/tests/analysis/eventTechniques.test.ts
@@ -113,4 +113,18 @@ describe("withEventTechniques (#893)", () => {
 
     expect(withEventTechniques(state).mitreTechniques).toEqual([]);
   });
+
+  it("keeps a technique the analyst accepted, which by construction has nothing else behind it", () => {
+    // An accepted second-opinion addition is the analyst overruling both models: no finding cites
+    // it and no event carries it, so a support test alone would hide it the moment it was added.
+    const state = {
+      ...emptyState("c1"),
+      mitreTechniques: [
+        { id: "T1486", name: "Data Encrypted for Impact", findingIds: [], analystAccepted: true as const },
+      ],
+      forensicTimeline: [],
+    };
+
+    expect(withEventTechniques(state).mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
+  });
 });

--- a/companion/tests/analysis/scopeProject.test.ts
+++ b/companion/tests/analysis/scopeProject.test.ts
@@ -97,3 +97,55 @@ describe("projectScope", () => {
     expect(s.mitreTechniques[0].findingIds).toEqual(["f1"]);
   });
 });
+
+// An accepted technique came from the analyst overruling both models, not from the evidence a scope
+// window selects — so narrowing the window is not a reason to drop it. And because synthesis folds
+// and then SAVES a projected snapshot, dropping it here would not merely hide it for the duration
+// of the scope: the decision would be gone. #893.
+describe("projectScope keeps an analyst-accepted technique (#893)", () => {
+  const windowed = { start: "2026-06-01T00:00:00Z", end: "2026-06-02T00:00:00Z" };
+
+  function stateWithOutOfScopeFinding(accepted: boolean) {
+    const state = emptyState("c1");
+    state.forensicTimeline.push({
+      id: "old",
+      timestamp: "2026-01-01T00:00:00Z",
+      description: "out of window",
+      severity: "High",
+      mitreTechniques: [],
+      relatedFindingIds: ["f1"],
+      sourceScreenshots: [],
+    });
+    state.findings.push({
+      id: "f1",
+      severity: "High",
+      title: "old finding",
+      description: "d",
+      relatedIocs: [],
+      mitreTechniques: [],
+      sourceScreenshots: [],
+      firstSeen: "2026-01-01T00:00:00Z",
+      lastUpdated: "2026-01-01T00:00:00Z",
+      status: "open",
+    });
+    state.mitreTechniques.push({
+      id: "T1486",
+      name: "Data Encrypted for Impact",
+      findingIds: ["f1"],
+      ...(accepted ? { analystAccepted: true as const } : {}),
+    });
+    return state;
+  }
+
+  it("drops a linked technique whose findings all fall out of the window", () => {
+    const out = projectScope(stateWithOutOfScopeFinding(false), windowed);
+
+    expect(out.mitreTechniques).toEqual([]);
+  });
+
+  it("keeps it when the analyst accepted it, even with every link gone", () => {
+    const out = projectScope(stateWithOutOfScopeFinding(true), windowed);
+
+    expect(out.mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
+  });
+});

--- a/companion/tests/analysis/secondOpinion.test.ts
+++ b/companion/tests/analysis/secondOpinion.test.ts
@@ -365,4 +365,48 @@ describe("second-opinion delta keys are stable across wording changes (issue #69
     expect(deltas.filter((d) => d.kind === "a_only")).toHaveLength(1);
     expect(deltas.filter((d) => d.kind === "b_only")).toHaveLength(1);
   });
+
+  it("marks an accepted technique as the analyst's, so the projection keeps showing it", () => {
+    const so = {
+      ...buildSecondOpinion({ a: A, b: B, modelA: "a", modelB: "b", now: () => "t" }),
+      deltas: [
+        {
+          id: "mitre_added:t1486",
+          kind: "mitre_added" as const,
+          title: "T1486",
+          techniqueName: "Data Encrypted for Impact",
+          rationale: "",
+          recommendation: "review" as const,
+          status: "accepted" as const,
+        },
+      ],
+    };
+
+    const out = applyAcceptedSecondOpinion(A, so);
+
+    expect(out.mitreTechniques.find((t) => t.id === "T1486")?.analystAccepted).toBe(true);
+  });
+
+  it("affirms one the case already held, without mutating the input row", () => {
+    const seeded = stateWith({ ...A, mitreTechniques: [tech("T1078")] });
+    const so = {
+      ...buildSecondOpinion({ a: seeded, b: B, modelA: "a", modelB: "b", now: () => "t" }),
+      deltas: [
+        {
+          id: "mitre_added:t1078",
+          kind: "mitre_added" as const,
+          title: "T1078",
+          techniqueName: "Valid Accounts",
+          rationale: "",
+          recommendation: "review" as const,
+          status: "accepted" as const,
+        },
+      ],
+    };
+
+    const out = applyAcceptedSecondOpinion(seeded, so);
+
+    expect(out.mitreTechniques.find((t) => t.id === "T1078")?.analystAccepted).toBe(true);
+    expect(seeded.mitreTechniques[0].analystAccepted).toBeUndefined();
+  });
 });

--- a/companion/tests/analysis/stateMerge.test.ts
+++ b/companion/tests/analysis/stateMerge.test.ts
@@ -955,12 +955,11 @@ describe("mergeDelta year-clamp eligibility (#739)", () => {
   });
 });
 
-// Every deterministic importer emits a delta whose top-level mitreTechniques is hardcoded empty,
-// while the real technique IDs ride on the forensic events it produces. The dashboard MITRE panel
-// and the report's MITRE section both read the aggregate, so both showed nothing until an AI
-// synthesis pass happened to union the per-event tags in. Kill Chain and the ATT&CK Navigator
-// export read the events directly, which is why only those two surfaces looked correct. #878.
-describe("mergeDelta MITRE aggregate (#878)", () => {
+// The techniques a deterministic importer carries on its EVENTS are no longer collected here.
+// #878 unioned them into this persisted aggregate; #893 moved that to projection, where the scope
+// window and the false-positive filter have already run. See eventTechniques.test.ts and the
+// report-level tests in reportWriter.test.ts — this merge keeps only what a model asserted.
+describe("mergeDelta leaves event-carried techniques to projection (#893)", () => {
   const ctx = { windowSequence: 1, timestamp: "2026-05-28T10:00:00.000Z", sourceScreenshots: [] };
 
   const event = (id: string, techniques: string[]) => ({
@@ -972,40 +971,24 @@ describe("mergeDelta MITRE aggregate (#878)", () => {
     relatedFindingIds: [],
   });
 
-  it("collects techniques carried by forensic events, with no AI synthesis involved", () => {
+  it("does not persist a technique that only an event carries", () => {
     const next = mergeDelta(
       emptyState("c1"),
-      {
-        ...baseDelta,
-        mitreTechniques: [],
-        forensicEvents: [event("e1", ["T1003.003"]), event("e2", ["T1021.002", "T1570"])],
-      },
+      { ...baseDelta, mitreTechniques: [], forensicEvents: [event("e1", ["T1003.003"])] },
       ctx,
     );
 
-    expect(next.mitreTechniques.map((t) => t.id).sort()).toEqual(["T1003.003", "T1021.002", "T1570"]);
-    expect(next.mitreTechniques.every((t) => t.name.length > 0)).toBe(true);
+    expect(next.mitreTechniques).toEqual([]);
+    expect(next.forensicTimeline[0].mitreTechniques).toEqual(["T1003.003"]);
   });
 
-  it("does not duplicate a technique the delta already names at the top level", () => {
+  it("still persists a technique the delta asserts at the top level, with its finding links", () => {
     const next = mergeDelta(
       emptyState("c1"),
-      {
-        ...baseDelta,
-        mitreTechniques: [{ id: "T1003.003", name: "NTDS" }],
-        forensicEvents: [event("e1", ["T1003.003"])],
-      },
+      { ...baseDelta, mitreTechniques: [{ id: "T1486", name: "Data Encrypted for Impact" }] },
       ctx,
     );
 
-    expect(next.mitreTechniques.filter((t) => t.id === "T1003.003")).toHaveLength(1);
-  });
-
-  it("stays stable when the same events are merged again", () => {
-    const delta = { ...baseDelta, forensicEvents: [event("e1", ["T1003.003"])] };
-    let state = mergeDelta(emptyState("c1"), delta, ctx);
-    state = mergeDelta(state, delta, ctx);
-
-    expect(state.mitreTechniques.map((t) => t.id)).toEqual(["T1003.003"]);
+    expect(next.mitreTechniques.map((t) => t.id)).toEqual(["T1486"]);
   });
 });

--- a/companion/tests/analysis/synthesizeCharacterisation.test.ts
+++ b/companion/tests/analysis/synthesizeCharacterisation.test.ts
@@ -300,9 +300,16 @@ describe("synthesize — the delta merge", () => {
     expect(state.forensicTimeline.map((e) => e.id)).toContain("e1"); // and the analyzed event stays
   });
 
-  it("unions the techniques the timeline already carries into the synthesized MITRE table", async () => {
-    // Importers tag Info/Low discovery activity with techniques the model never echoes back. If the
-    // union is lost the case's MITRE table silently shrinks to whatever the model happened to name.
+  it("leaves the techniques the timeline carries out of the STORED table (#893)", async () => {
+    // Importers tag Info/Low discovery activity with techniques the model never echoes back, and
+    // this fold used to union them into the persisted table so they reached the MITRE panel and the
+    // report. They did — and then could not be removed: scope and the false-positive filter drop
+    // events at projection rather than from state, so dismissing the only event carrying one left
+    // the row behind for good.
+    //
+    // They are derived at projection now (analysis/eventTechniques.ts), which is what makes a
+    // dismissal take effect; see the ReportWriter tests. What synthesis stores is what the model
+    // asserted.
     const seeded = emptyState("c1");
     seeded.forensicTimeline.push(
       event("e1", "2026-01-01T00:00:00.000Z", "whoami /all", "Low", { mitreTechniques: ["T1033"] }),
@@ -320,7 +327,9 @@ describe("synthesize — the delta merge", () => {
 
     const state = await pipeline.synthesize("c1");
 
-    expect(state.mitreTechniques.map((t) => t.id).sort()).toEqual(["T1033", "T1059"]);
+    expect(state.mitreTechniques.map((t) => t.id)).toEqual(["T1059"]);
+    // Still on the event, which is where the projection reads it from.
+    expect(state.forensicTimeline.find((e) => e.id === "e1")?.mitreTechniques).toEqual(["T1033"]);
   });
 
   it("dryRun returns the conclusions without persisting them or arming the skip hash", async () => {

--- a/companion/tests/reports/reportWriter.test.ts
+++ b/companion/tests/reports/reportWriter.test.ts
@@ -6,6 +6,7 @@ import { CaseStore } from "../../src/storage/caseStore.js";
 import { StateStore } from "../../src/analysis/stateStore.js";
 import { ReportWriter } from "../../src/reports/reportWriter.js";
 import { FalsePositiveStore, markerId } from "../../src/analysis/falsePositive.js";
+import { ScopeStore } from "../../src/analysis/scope.js";
 import { emptyState } from "../../src/analysis/stateTypes.js";
 
 let caseStore: CaseStore;
@@ -392,5 +393,97 @@ describe("ReportWriter", () => {
     const onDisk = await reportMeta.load("c1");
     expect(onDisk.investigators).toEqual(["Demo Analyst", "Senior DFIR Analyst"]);
     expect(onDisk.distribution.length).toBe(2);
+  });
+});
+
+// The MITRE table the report shows is derived from the events that survive scope and the
+// false-positive filter, not read from a stored aggregate — so a dismissal takes effect at once and
+// is not undone by the next import, and un-marking restores the technique with no merge. #893.
+describe("ReportWriter MITRE table follows the filters (#893)", () => {
+  const event = (id: string, timestamp: string, techniques: string[]) => ({
+    id,
+    timestamp,
+    description: `event ${id}`,
+    severity: "High" as const,
+    mitreTechniques: techniques,
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+  });
+
+  async function seed(): Promise<void> {
+    const state = emptyState("c1");
+    state.forensicTimeline.push(
+      event("kept", "2026-06-01T10:00:00Z", ["T1003.003"]),
+      event("other", "2026-06-01T11:00:00Z", ["T1021.002"]),
+    );
+    await stateStore.save(state);
+  }
+
+  async function techniques(): Promise<string[]> {
+    const state = await new ReportWriter(caseStore, stateStore, {
+      falsePositives: new FalsePositiveStore(caseStore),
+      scope: new ScopeStore(caseStore),
+    }).filteredState("c1");
+    return state.mitreTechniques.map((t: { id: string }) => t.id);
+  }
+
+  it("collects the techniques the events carry, with no synthesis run (#878)", async () => {
+    await seed();
+
+    expect([...(await techniques())].sort()).toEqual(["T1003.003", "T1021.002"]);
+  });
+
+  it("drops a technique as soon as its only event is dismissed", async () => {
+    await seed();
+    await new FalsePositiveStore(caseStore).save("c1", [
+      {
+        id: markerId("event", "other"),
+        kind: "event",
+        ref: "other",
+        reason: "authorized-test",
+        note: "",
+        markedAt: "2026-06-01T12:00:00Z",
+        markedBy: "analyst",
+      },
+    ]);
+
+    const ids = await techniques();
+
+    expect(ids).toContain("T1003.003");
+    expect(ids).not.toContain("T1021.002");
+  });
+
+  it("brings it back when the analyst un-marks the event, with no merge in between", async () => {
+    await seed();
+    const fp = new FalsePositiveStore(caseStore);
+    await fp.save("c1", [
+      {
+        id: markerId("event", "other"),
+        kind: "event",
+        ref: "other",
+        reason: "authorized-test",
+        note: "",
+        markedAt: "2026-06-01T12:00:00Z",
+        markedBy: "analyst",
+      },
+    ]);
+    expect(await techniques()).not.toContain("T1021.002");
+
+    await fp.save("c1", []);
+
+    expect(await techniques()).toContain("T1021.002");
+  });
+
+  it("drops a technique whose only event the scope window excludes", async () => {
+    await seed();
+    await new ScopeStore(caseStore).save("c1", {
+      start: "2026-06-01T10:30:00Z",
+      end: "2026-06-01T23:00:00Z",
+    });
+
+    const ids = await techniques();
+
+    expect(ids).toContain("T1021.002");
+    expect(ids).not.toContain("T1003.003");
   });
 });

--- a/companion/tests/reports/reportWriter.test.ts
+++ b/companion/tests/reports/reportWriter.test.ts
@@ -511,4 +511,31 @@ describe("ReportWriter MITRE table follows the filters (#893)", () => {
 
     expect(await techniques()).not.toContain("T1021.002");
   });
+
+  it("hides a synthesized technique whose only supporting event is dismissed, reversibly", async () => {
+    // End to end for the last writer: the row is in the stored table, not on any event, and the
+    // event it was drawn from is dismissed. It goes — and comes back when the analyst un-marks,
+    // because the projection never touched what is stored.
+    const state = emptyState("c1");
+    state.mitreTechniques.push({ id: "T1486", name: "Data Encrypted for Impact", findingIds: [] });
+    state.forensicTimeline.push(event("dismissed", "2026-06-01T11:00:00Z", ["T1486"]));
+    await stateStore.save(state);
+    expect(await techniques()).toContain("T1486");
+
+    const fp = new FalsePositiveStore(caseStore);
+    const marker = {
+      id: markerId("event", "dismissed"),
+      kind: "event" as const,
+      ref: "dismissed",
+      reason: "authorized-test" as const,
+      note: "",
+      markedAt: "2026-06-01T12:00:00Z",
+      markedBy: "analyst",
+    };
+    await fp.save("c1", [marker]);
+    expect(await techniques()).not.toContain("T1486");
+
+    await fp.save("c1", []);
+    expect(await techniques()).toContain("T1486");
+  });
 });

--- a/companion/tests/reports/reportWriter.test.ts
+++ b/companion/tests/reports/reportWriter.test.ts
@@ -486,4 +486,29 @@ describe("ReportWriter MITRE table follows the filters (#893)", () => {
     expect(ids).toContain("T1021.002");
     expect(ids).not.toContain("T1003.003");
   });
+
+  it("a technique baked in by a previous synthesis is still removable — nothing persists it", async () => {
+    // The last place event-carried techniques were written into persisted state was the synthesis
+    // fold. A row it had already stored survived every filter afterwards, because projection only
+    // ever ADDS: the analyst dismissed the event and the row stayed. Nothing writes them now, so
+    // the only source is the surviving timeline and the dismissal simply takes effect.
+    const state = emptyState("c1");
+    state.forensicTimeline.push(event("dismissed", "2026-06-01T11:00:00Z", ["T1021.002"]));
+    await stateStore.save(state);
+    expect(await techniques()).toContain("T1021.002");
+
+    await new FalsePositiveStore(caseStore).save("c1", [
+      {
+        id: markerId("event", "dismissed"),
+        kind: "event",
+        ref: "dismissed",
+        reason: "authorized-test",
+        note: "",
+        markedAt: "2026-06-01T12:00:00Z",
+        markedBy: "analyst",
+      },
+    ]);
+
+    expect(await techniques()).not.toContain("T1021.002");
+  });
 });

--- a/public/js/dashboard-render.js
+++ b/public/js/dashboard-render.js
@@ -482,7 +482,15 @@
     // A technique a model asserted keeps its name and its finding links. One derived from an event
     // shows its id as the name, which is exactly what the server's own name table falls back to for
     // an id it does not know.
-    const mitreRows = (state.mitreTechniques || []).slice();
+    // Only what the surviving evidence still supports: a technique synthesis asserted otherwise
+    // outlives the dismissal of the very event it came from. Safe to hide because this is a view —
+    // state is untouched, so un-marking the event brings it straight back.
+    const survivingFindings = new Set((state.findings || []).map((f) => f.id));
+    const carriedTechniques = new Set(ft.flatMap((e) => e.mitreTechniques || []));
+    const mitreRows = (state.mitreTechniques || []).filter(
+      (m) =>
+        (m.findingIds || []).some((id) => survivingFindings.has(id)) || carriedTechniques.has(m.id),
+    );
     const seenTechniques = new Set(mitreRows.map((m) => m.id));
     for (const e of ft)
       for (const id of e.mitreTechniques || [])

--- a/public/js/dashboard-render.js
+++ b/public/js/dashboard-render.js
@@ -489,7 +489,9 @@
     const carriedTechniques = new Set(ft.flatMap((e) => e.mitreTechniques || []));
     const mitreRows = (state.mitreTechniques || []).filter(
       (m) =>
-        (m.findingIds || []).some((id) => survivingFindings.has(id)) || carriedTechniques.has(m.id),
+        m.analystAccepted ||
+        (m.findingIds || []).some((id) => survivingFindings.has(id)) ||
+        carriedTechniques.has(m.id),
     );
     const seenTechniques = new Set(mitreRows.map((m) => m.id));
     for (const e of ft)

--- a/public/js/dashboard-render.js
+++ b/public/js/dashboard-render.js
@@ -473,8 +473,25 @@
             `<div class="log-row"><span class="log-time">${esc(r.ts)}</span><span>${r.html}</span></div>`,
         )
         .join("") || "—";
+    // MITRE is completed HERE, from the events this view is actually showing — `ft` is the
+    // scope-projected timeline minus the ones the analyst dismissed — rather than read from a
+    // stored aggregate. The client mirror of the server's eventTechniques.ts (#893). Nothing is
+    // persisted, so a dismissal takes effect on the next render and un-marking restores the
+    // technique, with no merge and no healing pass in between.
+    //
+    // A technique a model asserted keeps its name and its finding links. One derived from an event
+    // shows its id as the name, which is exactly what the server's own name table falls back to for
+    // an id it does not know.
+    const mitreRows = (state.mitreTechniques || []).slice();
+    const seenTechniques = new Set(mitreRows.map((m) => m.id));
+    for (const e of ft)
+      for (const id of e.mitreTechniques || [])
+        if (id && !seenTechniques.has(id)) {
+          seenTechniques.add(id);
+          mitreRows.push({ id, name: id, findingIds: [] });
+        }
     document.getElementById("mitre").innerHTML =
-      state.mitreTechniques
+      mitreRows
         .map(
           (m) =>
             `<div class="mitre-row">${mitreLinks([m.id])} <span>${esc(m.name)}</span><span class="mitre-findings">${esc(m.findingIds.join(", "))}</span></div>`,

--- a/public/js/dashboard-scope.js
+++ b/public/js/dashboard-scope.js
@@ -173,9 +173,15 @@
     }
     const iocs = (state.iocs || []).filter((i) => citedBySurviving.has(i.id) || !citedByAny.has(i.id));
 
+    // One the analyst ACCEPTED is kept whatever its links do — see the server's scopeProject.ts.
     const mitreTechniques = (state.mitreTechniques || [])
       .map((t) => ({ ...t, findingIds: (t.findingIds || []).filter((id) => surviving.has(id)) }))
-      .filter((t, idx) => t.findingIds.length > 0 || (state.mitreTechniques[idx].findingIds || []).length === 0);
+      .filter(
+        (t, idx) =>
+          t.analystAccepted ||
+          t.findingIds.length > 0 ||
+          (state.mitreTechniques[idx].findingIds || []).length === 0,
+      );
 
     return { ...state, forensicTimeline, findings, iocs, mitreTechniques };
   }


### PR DESCRIPTION
Rewritten. This PR is now #893 only — #892 was split out and merged as #896 — and it replaces the persisted-provenance approach with the thing that approach was working around.

## The problem

#878 fixed an empty MITRE panel by unioning the techniques a deterministic importer puts on its **events** into the case aggregate during the merge.

That aggregate is **persisted**. Scope and the false-positive filter drop events at **projection**, never from state. So once a technique was in the table there was no way back out: dismissing the only event that carried it changed nothing, and the next import re-added it anyway.

## Why the previous approach was abandoned

Nineteen review rounds went into chasing that with provenance — an exclusion filter, a merge chokepoint, per-row origins, frozen ids, cluster spans, dated vs undated, parseability, sub-millisecond ordering.

Every one of those was a genuine defect. Every one existed for the same reason: a stored aggregate has to independently reconstruct *which event a technique came from and when*, through `correlateEvents`, whose entire job is to collapse exactly that. `TechniqueOrigin` had become a second model of the timeline — identity, dating, ranges, precision — that had to be kept in step with the first at every touch point.

## What this does instead

Derive it after the filters, from the events that survive them:

```ts
export function withEventTechniques(state: InvestigationState): InvestigationState {
  return { ...state, mitreTechniques: unionEventTechniques(state.mitreTechniques, state.forensicTimeline) };
}
```

The table becomes a function of the timeline it is displayed beside, so it cannot disagree with it. A dismissal takes effect immediately, un-marking restores the technique with no merge, and nothing is written so nothing can go stale.

- **Server:** applied at `ReportWriter.loadFilteredState`, last, after both filters — so every report and export gets it.
- **Client:** mirrored in `dashboard-render.js` over `ft`, the scope-projected timeline minus dismissed events, which that view already computes for the timeline itself.
- **`mergeDelta` still persists** what a model asserts at a delta's **top level** — a conclusion about the case rather than a restatement of an event tag. That is a claim worth keeping.

## Removed

`techniqueScope.ts`, `TechniqueOrigin` and its `cluster`/`endTimestamp`/`fromEvents` flags, `techniqueContributors`, `techniqueEligibilityRefs`, `techniqueSupport`, `techniqueEventFilter`, `techniquesAreConclusions`, the second-opinion promotion, the pipeline and MCP filter wiring, and the merge-time union. `correlate.ts`, `stateTypes.ts`, `pipeline.ts`, `synthesisMerge.ts` and `secondOpinion.ts` are back to their master versions.

Net: **+242 / −44** across 9 files, against roughly 1,700 insertions for the version it replaces.

## Tests

The #878 merge-time tests move to the projection layer, joined by the three cases nineteen rounds never got right:

- a dismissal drops the technique **at once**;
- **un-marking brings it back**, with no merge in between;
- a scope window excludes a technique whose only event it excludes.

Plus unit tests for the derivation: an import-only case is populated (#878), collected rows are named, an asserted technique keeps its name and finding links rather than being restated, and the pass is idempotent and non-mutating.

Full suite **12,046 passing (740 files)**; `typecheck`, `lint`, `check:size`, `check:boundaries`, `check:imports` green.

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mXaxwsRxd7tffg7PDuzu3
