### PR TITLE
test(reports): pin which deck fields survive defangDeck (#901)

### DIFF
--- a/companion/tests/reports/defangDeck.test.ts
+++ b/companion/tests/reports/defangDeck.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { defangDeck } from "../../src/reports/defangDeck.js";
-import type { PresentationDeck } from "../../src/analysis/presentation.js";
+import type { PresentationDeck, PresentationSlide } from "../../src/analysis/presentation.js";
 
 // The standalone presentation export is a deliverable in the same sense the report is: it is served
 // as an attachment so it can be handed to a stakeholder, and the saved file opens from file:// with
@@ -17,6 +17,18 @@ const deck = (over: Partial<PresentationDeck> = {}): PresentationDeck => ({
   slideCount: 0,
   ...over,
 });
+
+// Every string left in the deck carrying a live `http://` after the pass, as dotted paths. The pass
+// is deliberately partial — defangSlide rewrites prose and IOC values and knowingly leaves the rest
+// — so the tripwire is the SET of survivors, not the absence of one.
+function liveUrlPaths(value: unknown, path = ""): string[] {
+  if (typeof value === "string") return value.includes("http://") ? [path] : [];
+  if (Array.isArray(value)) return value.flatMap((v, i) => liveUrlPaths(v, `${path}.${i}`));
+  if (value && typeof value === "object") {
+    return Object.entries(value).flatMap(([k, v]) => liveUrlPaths(v, path ? `${path}.${k}` : k));
+  }
+  return [];
+}
 
 describe("defangDeck (#892)", () => {
   it("defangs IOC values, which are the deck's only raw indicator field", () => {
@@ -126,5 +138,75 @@ describe("defangDeck (#892)", () => {
     );
 
     expect(defangDeck(once)).toEqual(once);
+  });
+
+  // #901. defangSlide rewrites title, body, description and IOC values, and knowingly leaves the rest
+  // alone: asset and sources are host/source names, screenshot is a filename the builder resolves,
+  // and branding/caseName are case metadata an analyst controls. Nothing reaching those can carry a
+  // live indicator today — but that is a claim about the BUILDER, re-derived by hand every time a
+  // slide field is added. This pins it instead, in both directions. The fixture is typed
+  // Required<PresentationSlide>, so a new field on the interface fails typecheck until it is poisoned
+  // here; the path assertion then fails until it is classified as rewritten or knowingly exempt.
+  it("pins which fields survive the pass, so a new slide field cannot smuggle a live URL into the export", () => {
+    const poisoned: Required<PresentationSlide> = {
+      kind: "event",
+      title: "C2 at http://evil.example/title",
+      branding: {
+        title: "http://evil.example/slide-brand-title",
+        subtitle: "http://evil.example/slide-brand-subtitle",
+        accentColor: "#000000", // hex-validated, never free text
+        companyName: "http://evil.example/slide-brand-company",
+      },
+      counts: { findings: 1, events: 1, iocs: 1 },
+      severityCounts: { Critical: 1, High: 0, Medium: 0, Low: 0, Info: 0 },
+      body: "beaconed to http://evil.example/body",
+      severity: "High",
+      // ISO stamps, enums and technique ids are format-constrained, so they are not poisoned.
+      timestamp: "2026-06-01T00:00:00.000Z",
+      endTimestamp: "2026-06-01T01:00:00.000Z",
+      description: "wget http://evil.example/description",
+      asset: "http://evil.example/asset",
+      sources: ["http://evil.example/source"],
+      mitreTechniques: ["T1071"],
+      iocs: [{ value: "http://evil.example/ioc", type: "url", verdict: "malicious" }],
+      screenshot: "http://evil.example/shot.png",
+      confidence: 0.9,
+      count: 2,
+    };
+
+    const out = defangDeck(
+      deck({
+        caseName: "http://evil.example/case-name",
+        branding: {
+          title: "http://evil.example/deck-brand-title",
+          subtitle: "http://evil.example/deck-brand-subtitle",
+          accentColor: "#000000",
+          companyName: "http://evil.example/deck-brand-company",
+        },
+        slides: [poisoned],
+        slideCount: 1,
+      }),
+    );
+
+    // Everything the pass claims to rewrite loses the clickable scheme.
+    expect(out.slides[0].title).toBe("C2 at hxxp://evil[.]example/title");
+    expect(out.slides[0].body).toBe("beaconed to hxxp://evil[.]example/body");
+    expect(out.slides[0].description).toBe("wget hxxp://evil[.]example/description");
+    expect(out.slides[0].iocs?.[0].value).toBe("hxxp://evil[.]example/ioc");
+
+    // ...and exactly these survive, every one of them inert at render (safe-dom text nodes, no
+    // autolinker). A field added later shows up here as an unclassified path.
+    expect(liveUrlPaths(out).sort()).toEqual([
+      "branding.companyName",
+      "branding.subtitle",
+      "branding.title",
+      "caseName",
+      "slides.0.asset",
+      "slides.0.branding.companyName",
+      "slides.0.branding.subtitle",
+      "slides.0.branding.title",
+      "slides.0.screenshot",
+      "slides.0.sources.0",
+    ]);
   });
 });


### PR DESCRIPTION
Closes #901.

## What

`defangDeck` makes the standalone presentation export's indicators inert. `defangSlide` rewrites `title`, `body`, `description` and IOC `value`, and knowingly leaves `asset`, `sources`, `screenshot`, `branding` and `caseName` alone.

Each exemption is safe today, but for a reason that lives in the **builder**, not in `defangDeck`: `asset`/`sources` are host names rendered as safe-dom text, `screenshot` is a filename the builder resolves, `branding`/`caseName` are analyst-controlled case metadata. Nothing that reaches those can carry a live indicator — a claim that has to be re-derived by hand every time a slide field is added.

This pins it instead, in both directions.

## How it trips

- The fixture is typed `Required<PresentationSlide>`, so a new field on the interface **fails typecheck** until it is poisoned in the test.
- The test then asserts the exact set of dotted paths that still carry a live scheme, so the new field **fails again** until it is classified as rewritten or knowingly exempt.

## Deviation from the issue's suggested fix

#901 asked for an assertion that the serialized deck contains no `http://`. That is false by design against the exemptions the same issue documents, so the test pins the **survivor set** rather than emptiness. Format-constrained fields (ISO stamps, enums, hex, technique IDs) are not poisoned, with a comment saying why.

## Verification

Mutation-tested — the tripwire was made to fire before being trusted:

| mutation | result |
|---|---|
| stop defanging `description` | 4 tests fail |
| add `referenceUrl?: string` and poison it | path assertion fails with `+ "slides.0.referenceUrl"` |
| add that field, omit it from the fixture | `npm run typecheck` fails: `Property 'referenceUrl' is missing ... but required in type 'Required<PresentationSlide>'` |

Gates: `vitest tests/reports/defangDeck.test.ts` 9/9, `npm run typecheck` clean, `eslint` clean, `prettier --check` clean. Test-only change; no source file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
