### PR TITLE
feat(scripts): check:boundaries --update rewrites the ARCHITECTURE.md figures (#907)

### DIFF
--- a/companion/scripts/architectureCounts.d.mts
+++ b/companion/scripts/architectureCounts.d.mts
@@ -1,0 +1,23 @@
+// Types for architectureCounts.mjs. It has to be .mjs — check-boundaries.mjs imports it and runs
+// under plain `node` in CI, with no TypeScript loader — and tsconfig has no allowJs, so a test that
+// imports it needs this bridge. Nothing generates the file, so it can drift from the module; the
+// test asserts the runtime result's exact key set against what is declared here, which turns that
+// drift into a failure rather than a lie that type-checks.
+export interface BoundaryCounts {
+  complying: number;
+  crossDomain: number;
+  violations: number;
+}
+
+export interface ArchitectureRewrite {
+  /** The document with every derived figure replaced. Unchanged if it states none of them. */
+  text: string;
+  /** Whether anything actually moved — the caller skips the write when nothing did. */
+  changed: boolean;
+  /** Whether the comply/total sentence was found at all. */
+  pair: boolean;
+  /** How many "N violations" claims were rewritten. */
+  violationClaims: number;
+}
+
+export function architectureWithCounts(doc: string, counts: BoundaryCounts): ArchitectureRewrite;

--- a/companion/scripts/architectureCounts.mjs
+++ b/companion/scripts/architectureCounts.mjs
@@ -1,0 +1,52 @@
+/**
+ * The ARCHITECTURE.md numbers that check-boundaries.mjs derives (issue #907).
+ *
+ * WHY THIS EXISTS. Three figures in that document are outputs of the boundary scan: the comply/total
+ * pair, and the ledger's length wherever the prose quotes it. tests/architecture/moduleMap.test.ts
+ * asserts all three against the gate, so they cannot rot — but until now nothing WROTE them, so
+ * every PR that added a cross-domain import hand-edited a number it could not know without running
+ * the script, and two branches touching the same sentence conflicted on it. The gate already
+ * rewrites the ledger it derives; this is the same idea applied to the prose that quotes it.
+ *
+ * WHY IT IS A SEPARATE MODULE. check-boundaries.mjs executes its whole scan at import time and calls
+ * process.exit in most branches, so a test cannot import a function out of it. Pure string in,
+ * string out, here, and the writeFileSync stays with the caller.
+ *
+ * WHY IT ONLY EVER REWRITES. If a sentence is missing the function leaves the document untouched and
+ * says so, rather than inserting prose. A doc that lost the sentence has drifted structurally, which
+ * is a question for a person; silently writing a new one would hide the drift and let the guard test
+ * pass on text nobody wrote.
+ */
+
+// Deliberately the same two patterns tests/architecture/moduleMap.test.ts reads the claims with, so
+// the writer and the checker cannot disagree about what counts as a claim.
+const PAIR = /([\d,]+) of the ([\d,]+) cross-domain file dependencies already comply/;
+const VIOLATIONS = /(\d+)(\s+(?:recorded\s+)?(?:file-pair\s+)?violations?)/gi;
+
+// The two claims are formatted DIFFERENTLY, and the difference is load-bearing. The guard test reads
+// the pair with `[\d,]+` and the violation count with a bare `\d+`, so a thousands separator is
+// required on one and would break the other — `1,039 violations` matches that pattern as "039".
+// Group separators here, none below.
+const grouped = (n) => n.toLocaleString("en-US");
+
+/**
+ * `doc` with every derived figure replaced by this scan's own counts.
+ *
+ * Returns the new text plus what was found, so the caller can report a document that no longer
+ * carries a claim it is supposed to carry.
+ */
+export function architectureWithCounts(doc, { complying, crossDomain, violations }) {
+  const pair = PAIR.test(doc);
+  let text = doc.replace(
+    PAIR,
+    `${grouped(complying)} of the ${grouped(crossDomain)} cross-domain file dependencies already comply`,
+  );
+
+  let violationClaims = 0;
+  text = text.replace(VIOLATIONS, (_match, _count, tail) => {
+    violationClaims += 1;
+    return `${violations}${tail}`;
+  });
+
+  return { text, changed: text !== doc, pair, violationClaims };
+}

--- a/companion/scripts/check-boundaries.mjs
+++ b/companion/scripts/check-boundaries.mjs
@@ -38,17 +38,26 @@
  *   node scripts/check-boundaries.mjs --init     # re-baseline; additions are printed, justify them
  *   node scripts/check-boundaries.mjs --json     # the counts ARCHITECTURE.md quotes; read-only
  *
+ * --update AND --init ALSO REWRITE ARCHITECTURE.md (issue #907). Three figures in that document are
+ * outputs of this scan, and moduleMap.test.ts asserts all three, so they could not rot — but nothing
+ * wrote them either, which made every PR that changed the ledger hand-edit numbers it could not know
+ * without running this script, and made two branches touching the same sentence conflict on it. The
+ * gate already rewrites the ledger it derives; the prose quoting that ledger is the same kind of
+ * output. --json stays read-only, because reading the counts must never move anything.
+ *
  * No dependency: like check-imports.mjs, the graph is a regex over the import statements, because
  * the companion imports its own modules exclusively as relative specifiers ending in `.js`.
  */
 import { readdirSync, readFileSync, statSync, writeFileSync, existsSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { architectureWithCounts } from "./architectureCounts.mjs";
 
 const COMPANION = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const SRC = join(COMPANION, "src");
 const MAP = join(COMPANION, "scripts", "module-map.json");
 const LEDGER = join(COMPANION, "scripts", "boundary-violations.json");
+const ARCHITECTURE = join(COMPANION, "..", "ARCHITECTURE.md");
 
 const map = JSON.parse(readFileSync(MAP, "utf8"));
 
@@ -260,10 +269,36 @@ if (process.argv.includes("--json")) {
   process.exit(0);
 }
 
+// Rewrite the figures ARCHITECTURE.md quotes from this pass. Called after the ledger is written, by
+// both flags that write it — the comply figure moves whenever the ledger does, so updating one and
+// not the other just relocates the drift.
+//
+// A missing claim is REPORTED, not repaired: the sentence is the document's, and a script that
+// invents prose to satisfy its own guard test has removed the only signal that the doc changed shape.
+function syncArchitecture(violations) {
+  if (!existsSync(ARCHITECTURE)) return;
+  const before = readFileSync(ARCHITECTURE, "utf8");
+  const doc = architectureWithCounts(before, {
+    complying: crossDomain.size - violations,
+    crossDomain: crossDomain.size,
+    violations,
+  });
+  const where = relative(join(COMPANION, ".."), ARCHITECTURE);
+  if (!doc.pair || doc.violationClaims === 0) {
+    console.warn(
+      `[boundaries] ${where} no longer states ${!doc.pair ? "the comply/total pair" : "a violation count"} — left it alone; check the prose.`,
+    );
+  }
+  if (!doc.changed) return;
+  writeFileSync(ARCHITECTURE, doc.text);
+  console.log(`[boundaries] updated the derived figures in ${where}`);
+}
+
 if (process.argv.includes("--init")) {
   const previous = existsSync(LEDGER) ? JSON.parse(readFileSync(LEDGER, "utf8")) : [];
   const added = found.filter((v) => !previous.includes(v));
   writeFileSync(LEDGER, `${JSON.stringify(found, null, 2)}\n`);
+  syncArchitecture(found.length);
   console.log(`[boundaries] recorded ${found.length} violation(s) in ${relative(COMPANION, LEDGER)}`);
   if (added.length > 0) {
     console.log(`[boundaries] ${added.length} of them are NEW — justify each in the PR:`);
@@ -287,6 +322,7 @@ if (process.argv.includes("--update")) {
     process.exit(1);
   }
   writeFileSync(LEDGER, `${JSON.stringify(found, null, 2)}\n`);
+  syncArchitecture(found.length);
   console.log(`[boundaries] recorded ${found.length} violation(s) — ${removed.length} fewer`);
   process.exit(0);
 }
@@ -294,7 +330,9 @@ if (process.argv.includes("--update")) {
 if (removed.length > 0) {
   console.log(`[boundaries] ${removed.length} recorded violation(s) are gone — nice:`);
   for (const v of removed) console.log(`  - ${v}`);
-  console.log("[boundaries] run `npm run check:boundaries -- --update` to shrink the ledger.");
+  console.log(
+    "[boundaries] run `npm run check:boundaries -- --update` to shrink the ledger and update ARCHITECTURE.md.",
+  );
 }
 
 if (added.length > 0) {

--- a/companion/tests/architecture/architectureCounts.test.ts
+++ b/companion/tests/architecture/architectureCounts.test.ts
@@ -1,0 +1,119 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { architectureWithCounts } from "../../scripts/architectureCounts.mjs";
+import { runScript } from "../helpers/runScript.js";
+
+// #907. moduleMap.test.ts asserts that ARCHITECTURE.md's derived figures match the boundary scan.
+// This asserts the other half — that the writer which produces those figures agrees with the reader
+// that checks them. Two regexes over one document, and nothing but these tests keeps them in step.
+
+const ROOT = new URL("../../../", import.meta.url);
+const readDoc = (): Promise<string> => readFile(new URL("ARCHITECTURE.md", ROOT), "utf8");
+
+const boundaryCounts = (): { crossDomain: number; complying: number; violations: number } =>
+  // fileURLToPath, not `.pathname` — see the note in moduleMap.test.ts about Windows drives.
+  JSON.parse(
+    runScript(fileURLToPath(new URL("companion/scripts/check-boundaries.mjs", ROOT)), ["--json"]),
+  ) as { crossDomain: number; complying: number; violations: number };
+
+describe("architectureWithCounts (#907)", () => {
+  it("rewrites the comply/total pair, grouped the way the guard test reads it", () => {
+    const out = architectureWithCounts(
+      "For context: **1 of the 2 cross-domain file dependencies already comply.**",
+      {
+        complying: 1983,
+        crossDomain: 2022,
+        violations: 39,
+      },
+    );
+
+    expect(out.text).toBe(
+      "For context: **1,983 of the 2,022 cross-domain file dependencies already comply.**",
+    );
+    expect(out.pair).toBe(true);
+    expect(out.changed).toBe(true);
+  });
+
+  it("writes the violation count WITHOUT a separator, because the guard test matches it with a bare \\d+", () => {
+    // The load-bearing asymmetry. "1,039 violations" would satisfy this writer and then be read as
+    // "039" by moduleMap.test.ts — a disagreement that only appears once the ledger passes 999.
+    const out = architectureWithCounts("records the **39 violations** that break the map", {
+      complying: 0,
+      crossDomain: 1039,
+      violations: 1039,
+    });
+
+    expect(out.text).toContain("**1039 violations**");
+    expect(/(\d+)\s+violations/.exec(out.text)?.[1]).toBe("1039");
+  });
+
+  it("moves only the ledger number in 'N of the M recorded violations', not the type-only count", () => {
+    const out = architectureWithCounts("**15 of the 39 recorded violations are type-only**", {
+      complying: 0,
+      crossDomain: 0,
+      violations: 41,
+    });
+
+    expect(out.text).toBe("**15 of the 41 recorded violations are type-only**");
+    expect(out.violationClaims).toBe(1);
+  });
+
+  it("rewrites every violation claim in the document, not just the first", () => {
+    const out = architectureWithCounts("the 39 violations here, and the 39 recorded violations there", {
+      complying: 0,
+      crossDomain: 0,
+      violations: 7,
+    });
+
+    expect(out.text).toBe("the 7 violations here, and the 7 recorded violations there");
+    expect(out.violationClaims).toBe(2);
+  });
+
+  it("reports a missing sentence and leaves the text alone rather than inventing prose", () => {
+    const out = architectureWithCounts("A document that no longer says any of it.", {
+      complying: 1,
+      crossDomain: 2,
+      violations: 3,
+    });
+
+    expect(out.pair).toBe(false);
+    expect(out.violationClaims).toBe(0);
+    expect(out.changed).toBe(false);
+    expect(out.text).toBe("A document that no longer says any of it.");
+  });
+
+  it("is a no-op on the real ARCHITECTURE.md, so the writer and the committed doc already agree", async () => {
+    // The join to reality. Every case above is synthetic; this one fails if the writer would rewrite
+    // the live document differently from what is committed — which is exactly the drift #907 is about.
+    const doc = await readDoc();
+    const out = architectureWithCounts(doc, boundaryCounts());
+
+    expect(out.pair, "ARCHITECTURE.md should still state the comply/total pair").toBe(true);
+    expect(out.violationClaims, "ARCHITECTURE.md should still state a violation count").toBeGreaterThan(0);
+    expect(out.changed, "check:boundaries --update would rewrite ARCHITECTURE.md right now").toBe(false);
+  });
+
+  it("returns exactly the keys architectureCounts.d.mts declares", () => {
+    // The .d.mts is hand-written, so nothing stops it drifting from the module it describes. This is
+    // what stops it: a declaration that has gone stale fails here rather than type-checking a lie.
+    const out = architectureWithCounts("nothing derived here", {
+      complying: 1,
+      crossDomain: 2,
+      violations: 3,
+    });
+
+    expect(Object.keys(out).sort()).toEqual(["changed", "pair", "text", "violationClaims"]);
+    expect(typeof out.text).toBe("string");
+    expect(typeof out.changed).toBe("boolean");
+    expect(typeof out.pair).toBe("boolean");
+    expect(typeof out.violationClaims).toBe("number");
+  });
+
+  it("is idempotent — re-running it over its own output changes nothing", async () => {
+    const counts = boundaryCounts();
+    const once = architectureWithCounts(await readDoc(), counts);
+
+    expect(architectureWithCounts(once.text, counts).text).toBe(once.text);
+  });
+});


### PR DESCRIPTION
Closes #907.

## The problem

Three figures in `ARCHITECTURE.md` are outputs of the boundary scan:

| where | claim |
|---|---|
| `:222` | `**1,983 of the 2,022 cross-domain file dependencies already comply.**` |
| `:40` | `**15 of the 39 recorded violations are type-only**` |
| `:202` | `records the **39 violations** that break the map today` |

`tests/architecture/moduleMap.test.ts` asserts all three against the gate, so they cannot rot. But nothing **wrote** them, so every PR that changed the ledger hand-edited a number it could not know without running the script — a CI failure whose fix is mechanical and whose diff is two digits. Parallel branches then conflicted on the same line, which is what #897 was originally about.

## The change

`--update` and `--init` now rewrite all three from the pass they already make. `--json` stays read-only, because reading the counts must never move anything.

The rewrite is a separate module: `check-boundaries.mjs` runs its whole scan at import time and calls `process.exit` in most branches, so a test cannot import a function out of it. `architectureCounts.mjs` is pure string-in/string-out; the `writeFileSync` stays with the caller.

## Two load-bearing details

**The two claims are formatted differently, and must be.** The guard test reads the pair with `[\d,]+` and the violation count with a bare `\d+`. A thousands separator is required on one and would break the other — `1,039 violations` would satisfy this writer and be read back as `039`. A test pins the asymmetry.

**A missing sentence is reported, not repaired.** If the prose no longer states a claim, the function leaves the document alone and warns. A script that invents prose to satisfy its own guard test removes the only signal that the doc changed shape.

## Verification

End to end, against the real document:

| case | result |
|---|---|
| `--update` on the committed doc | writes nothing; `git diff` empty |
| mangle all three figures, then `--update` | restored **byte-for-byte identical** to the committed version |

Plus 8 unit tests, including one that asserts the writer is a no-op on the live `ARCHITECTURE.md` — so the writer and the guard test cannot drift apart — and one that pins the runtime shape against the hand-written `.d.mts`.

Gates: full suite **12,099 passed (743 files)**, `typecheck` clean, `lint` clean, `format:check` clean, `check:size`/`check:imports`/`check:boundaries`/`check:us-map` clean. (`check:a11y` needs `a11y-results.json` from the e2e run and is unrelated to this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
