### PR TITLE
fix(memory): classify ldrmodules as a DLL list, not a kernel module

### DIFF
--- a/companion/src/analysis/memoryImport.ts
+++ b/companion/src/analysis/memoryImport.ts
@@ -148,13 +148,13 @@ function classify(plugin: string, cols: Set<string>): Category {
   if (/svcscan|services/.test(p)) return "service";
   if (any("binary", "servicedll", "binary path") && any("state", "start", "display")) return "service";
 
+  if (/dlllist|ldrmodules|dlldump/.test(p)) return "dll"; // before /modules/ — it matches ldrmodules
+  if (has("pid") && any("base", "dllbase") && any("path", "loadtime", "mappedpath") && has("size"))
+    return "dll";
+
   if (/driver|modscan|modules|modlist|lsmod|kernel_module/.test(p)) return "module";
   if (any("base", "dllbase") && has("size") && any("name", "path", "driver name") && !has("pid"))
     return "module";
-
-  if (/dlllist|ldrmodules|dlldump/.test(p)) return "dll";
-  if (has("pid") && any("base", "dllbase") && any("path", "loadtime", "mappedpath") && has("size"))
-    return "dll";
 
   if (/handles?/.test(p)) return "handle";
 

--- a/companion/tests/analysis/memoryImport.test.ts
+++ b/companion/tests/analysis/memoryImport.test.ts
@@ -452,6 +452,35 @@ describe("parseMemory — options & edges", () => {
     expect(tel.events.length).toBe(1);
   });
 
+  // `ldrmodules` enumerates a PROCESS's loaded modules and its loader-list membership flags — it is a
+  // DLL listing, not the kernel driver table. classify() tested /modules/ before /ldrmodules/, and
+  // "modules" is a substring of "ldrmodules", so every row reached the kernel-module mapper and lost
+  // both its process attribution and the flags the plugin exists to expose.
+  it("classifies ldrmodules as a DLL list, not a kernel module", () => {
+    const ldr = [
+      {
+        __children: [],
+        Pid: 3120,
+        Process: "evil.exe",
+        Base: "0x7ffb10000000",
+        InLoad: true,
+        InInit: false,
+        InMem: true,
+        MappedPath: "C:\\Temp\\evil.dll",
+      },
+    ];
+    const json = JSON.stringify({ "windows.ldrmodules.LdrModules": ldr });
+    // The DLL mapper harvests the path and stays silent unless telemetry is opted in; the kernel-module
+    // mapper emits an Info event per row regardless.
+    const r = parseMemory(json);
+    expect(r.events.length).toBe(0);
+    expect(r.iocs.some((i) => i.type === "file" && /evil\.dll/i.test(i.value))).toBe(true);
+    // Opted in, the row carries the process it was loaded into — which the kernel-module mapper cannot say.
+    const tel = parseMemory(json, { dllTelemetry: true });
+    expect(tel.events).toHaveLength(1);
+    expect(tel.events[0].description).toContain("evil.exe (PID 3120)");
+  });
+
   it("reports empty for non-memory JSON", () => {
     const r = parseMemory(JSON.stringify({ foo: "bar" }));
     expect(r.events.length).toBe(0);


### PR DESCRIPTION
Fixes #911.

## The bug

`classify()` in `analysis/memoryImport.ts` tested the plugin name against `/driver|modscan|modules|modlist|lsmod|kernel_module/` before `/dlllist|ldrmodules|dlldump/`.

`modules` is a substring of `ldrmodules`, so the first test always won. Every `ldrmodules` table was classified `"module"` and mapped by `mapModule`, which reads the kernel driver table.

## What that cost

`mapModule` reads no PID and no process name. So an ldrmodules row lost the process the module was loaded into, and it lost the loader-list membership flags (`InLoad` / `InInit` / `InMem`) whose disagreement is the cross-view discrepancy the plugin is collected for. The row was presented as driver enumeration.

## The fix

The two DLL tests move above the two module tests. Nothing else changes.

The move is safe in both directions: the two column fingerprints are mutually exclusive on `has("pid")`, so no driver row can reach the DLL column test and no DLL row can reach the module column test. Only the plugin-name tests overlapped, and only on this one token.

It is a reorder, not an addition. `analysis/memoryImport.ts` sits exactly at its file-size ledger ceiling and cannot take another line, so the ordering rationale is a trailing comment on the moved line and the full explanation lives in the test.

## Test

New: `classifies ldrmodules as a DLL list, not a kernel module`, using real Volatility 3 `windows.ldrmodules.LdrModules` columns.

It pins both halves of the routing. By default the DLL mapper harvests the path and emits nothing, where the kernel-module mapper emitted one Info event per row. With `dllTelemetry: true` the event names the process the module was loaded into, which the kernel-module mapper cannot say.

Watched fail before the fix: `expected 1 to be +0`.

## Verification

- Full suite: 743 files, 12101 tests, all pass
- `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`: all pass
- `check:size` passing confirms the reorder cost no lines

## Follow-on

This is a prerequisite for #909 item 3, which asks for the loader-list flags to be retained. That item describes the rows as flattened into generic DLL records. They were not — they were filed as kernel modules, and no amount of work on the DLL mapper would have reached them.
