### PR TITLE
fix(kape): grade Prefetch rows through prefetchExecution

### DIFF
--- a/companion/src/analysis/kapeImport.ts
+++ b/companion/src/analysis/kapeImport.ts
@@ -30,6 +30,7 @@ import {
   maxEventsDefault,
 } from "./siemImport.js";
 import { detectTimestomp } from "./timestompDetect.js";
+import { prefetchSignal } from "./prefetchExecution.js";
 
 type Row = Record<string, unknown>;
 
@@ -107,11 +108,15 @@ const PROFILES: Profile[] = [
       const runCount = firstStr(row, ["RunCount"]);
       const proc = addProc(sink, exe);
       const time = ezTime(getCI(row, "LastRun")) || ezTime(getCI(row, "SourceModified"));
+      // Prefetch carries no command line, so the binary's NAME is all there is to grade — and ungraded it
+      // stays Info, below the forensic floor, where synthesis never reads it. PECmd exports no executable
+      // path column, so the location-dependent rules stay silent. See prefetchExecution.ts.
+      const signal = prefetchSignal(exe);
       return {
         timestamp: time,
         description: `Prefetch: ${exe} executed${runCount ? ` (run ${runCount}×)` : ""}`.slice(0, 600),
-        severity: "Info",
-        mitre: [],
+        severity: signal?.severity ?? "Info",
+        mitre: signal ? signal.mitre : [],
         aggKey: `pf|${exe.toLowerCase()}`,
         sources: ["Prefetch"],
         ...(proc ? { processName: proc } : {}),

--- a/companion/tests/analysis/kapeImport.test.ts
+++ b/companion/tests/analysis/kapeImport.test.ts
@@ -35,6 +35,30 @@ describe("parseKapeCsv — artifact detection & mapping", () => {
     expect(r.iocs.some((i) => i.type === "process" && i.value === "EVIL.EXE")).toBe(true);
   });
 
+  // prefetchExecution.ts exists because Info sits below the forensic floor, so an ungraded execution is
+  // never read by synthesis. The Velociraptor prefetch mapper called it; the KAPE one never did, so the
+  // same execution graded High from one collection tool and Info from the other.
+  it("Prefetch (PECmd): grades named offensive tooling above Info", () => {
+    const text = csv(
+      ["SourceFilename", "ExecutableName", "Hash", "Size", "RunCount", "LastRun", "PreviousRun0"],
+      [
+        [
+          "C:\\Windows\\Prefetch\\MIMIKATZ.EXE-1234.pf",
+          "MIMIKATZ.EXE",
+          "ABCD",
+          "10000",
+          "2",
+          "2023-04-01 10:00:00",
+          "2023-03-31 09:00:00",
+        ],
+      ],
+    );
+    const r = parseKapeCsv(text);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0].severity).toBe("High");
+    expect(r.events[0].mitreTechniques).toContain("T1003.001");
+  });
+
   it("Amcache: file + SHA1 hash IOC, FullPath as path", () => {
     const text = csv(
       ["ApplicationName", "FullPath", "FileKeyLastWriteTimestamp", "SHA1", "Size"],


### PR DESCRIPTION
Fixes #912.

## The bug

The KAPE Prefetch mapper hardcoded `severity: "Info"` and `mitre: []`, and `analysis/kapeImport.ts` never imported `prefetchSignal`.

The Velociraptor prefetch mapper has called it since `prefetchExecution.ts` was added. So the same execution on the same host graded High from a Velociraptor collection and Info from a KAPE collection.

## Why it matters

Info sits below the forensic floor, so an ungraded Prefetch row is never read by synthesis. That is the exact failure `prefetchExecution.ts` was written to fix — its header describes it on a real three-hour ransomware intrusion where the whole execution chain arrived at Info. The KAPE path still had it.

## The fix

Call `prefetchSignal(exe)` and apply the returned severity and techniques, matching the Velociraptor mapper.

PECmd exports no executable-path column, so only the executable name is passed. `prefetchSignal` already treats an absent path as "location unknown" and returns null for its browser-helper rules rather than guessing, so the missing column cannot produce a false positive.

Grading is unchanged for everything else: named offensive tooling grades High, dual-use LOLBins Medium, every other binary stays Info. The existing test asserting `Info` for a routine executable still passes untouched.

## Test

New: `Prefetch (PECmd): grades named offensive tooling above Info`.

Watched fail before the fix: `expected 'Info' to be 'High'`.

## Verification

- Full suite: 743 files, 12101 tests, all pass
- `typecheck`, `lint`, `format:check`, `check:size`, `check:imports`, `check:boundaries`: all pass

## Follow-on

Worth fixing before #909 item 10, which builds on the prefetch path.
