### PR TITLE
fix(dashboard): derive MITRE from the false-positive-filtered findings (#917, #918)

### DIFF
--- a/companion/tests/dashboard/dashboardApi.ts
+++ b/companion/tests/dashboard/dashboardApi.ts
@@ -144,6 +144,15 @@ export interface FiltersApi {
   originFacets(ft: EventLike[] | null): string[];
   isLowSignalEvent(e: EventLike): boolean;
   lowSignalChip(e: EventLike): string;
+  /**
+   * `findings` is the FALSE-POSITIVE-FILTERED list, never raw state.findings — the server's own
+   * order is withEventTechniques(applyFalsePositive(...)), and passing the raw list here is #917.
+   */
+  deriveMitreRows(
+    findings: Array<{ id: string }> | null,
+    forensicTimeline: Array<{ mitreTechniques?: string[] }> | null,
+    table: Array<{ id: string; name: string; findingIds?: string[]; analystAccepted?: boolean }> | null,
+  ): Array<{ id: string; name: string; findingIds: string[] }>;
 }
 
 export interface IocApi {

--- a/companion/tests/dashboard/dashboardMitreParity.test.ts
+++ b/companion/tests/dashboard/dashboardMitreParity.test.ts
@@ -1,0 +1,281 @@
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { withEventTechniques } from "../../src/analysis/eventTechniques.js";
+import { applyFalsePositive, type FalsePositiveMarker } from "../../src/analysis/falsePositive.js";
+import { emptyState, type InvestigationState } from "../../src/analysis/stateTypes.js";
+import type { FiltersApi } from "./dashboardApi.js";
+import { callsWithin, functionsOf, scriptFromSource, type DashboardScript } from "../helpers/dashboardAst.js";
+import { DASHBOARD_HELPER_FILES, loadDashboardModule } from "../helpers/dashboardModule.js";
+
+// The MITRE derivation is the same rule written twice — src/analysis/eventTechniques.ts on the
+// server, deriveMitreRows() in public/js/dashboard-filters.js on the client — and until now nothing
+// checked that the mirror still matched (#918).
+//
+// tests/dashboard/dashboardScope.test.ts documents this exact failure mode for projectScope: "the
+// same rule written twice... nothing checked that the mirror still matched". That suite is the
+// template here, and it is followed in the part that matters most: the server's REAL function is
+// imported and run, never re-implemented in the test. A re-implementation pins the test author's
+// reading of the rule, which is the divergence it was written to catch.
+//
+// TWO HALVES, BECAUSE THE BUG THIS SUITE EXISTS FOR WAS IN NEITHER FUNCTION.
+//
+//   1. The rule — deriveMitreRows vs withEventTechniques over the same inputs. Pure, so it is
+//      compared directly.
+//   2. The COMPOSITION — which findings list render() feeds it. #917 was exactly this: both
+//      functions were right, and render() handed the derivation the raw state.findings while the
+//      findings panel three hundred lines above used the false-positive-filtered `notFp`. A
+//      technique whose only support was a finding the analyst had just confirmed benign stayed in
+//      the dashboard panel while the report and every server-side export had already dropped it.
+//      Half 1 cannot see that; render() is a 700-line DOM function with no behavioural harness, so
+//      half 2 answers it at the call site, the way dashboardRenderOriginLens.test.ts does.
+
+const RENDER_SOURCE = readFileSync(
+  new URL("../../../public/js/dashboard-render.js", import.meta.url),
+  "utf8",
+);
+
+function filters(): FiltersApi {
+  const globals = loadDashboardModule<{ DfirFilters: FiltersApi }>(
+    "dashboard-filters.js",
+    DASHBOARD_HELPER_FILES.filter((f) => f !== "dashboard-filters.js"),
+  );
+  return globals.DfirFilters;
+}
+
+/**
+ * A state exercising every branch of the rule at once.
+ *
+ * f-benign is the #917 case: "beaconing" is the only support T1071 has, and a marker confirms it
+ * benign. f-open backs T1059, which an event also carries. T1486 is in the table with no support at
+ * all. T1583 is analyst-accepted, so it survives with no support by construction. T1490 is carried
+ * only by an event and is not in the table, so it has to be appended — and it is one of the ids the
+ * SERVER's name table knows, which is what makes the name carve-out below observable at all.
+ */
+function fixture(): InvestigationState {
+  const finding = (id: string, title: string) => ({
+    id,
+    severity: "High" as const,
+    title,
+    description: "",
+    relatedIocs: [],
+    mitreTechniques: [],
+    sourceScreenshots: [],
+    firstSeen: "",
+    lastUpdated: "",
+    status: "open" as const,
+  });
+  const event = (id: string, techniques: string[]) => ({
+    id,
+    timestamp: "2026-05-20T09:00:00Z",
+    description: id,
+    severity: "High" as const,
+    mitreTechniques: techniques,
+    relatedFindingIds: [],
+    sourceScreenshots: [],
+  });
+  return {
+    ...emptyState("c1"),
+    findings: [finding("f-open", "Encoded PowerShell"), finding("f-benign", "beaconing")],
+    forensicTimeline: [event("e1", ["T1059"]), event("e2", ["T1490"]), event("e3", [])],
+    mitreTechniques: [
+      { id: "T1059", name: "Command and Scripting Interpreter", findingIds: ["f-open"] },
+      { id: "T1071", name: "Application Layer Protocol", findingIds: ["f-benign"] },
+      { id: "T1486", name: "Data Encrypted for Impact", findingIds: [] },
+      { id: "T1583", name: "Acquire Infrastructure", findingIds: [], analystAccepted: true },
+    ],
+  };
+}
+
+/**
+ * Ids and finding links only.
+ *
+ * THE `name` FIELD IS A KNOWN, DELIBERATE DIVERGENCE, not an oversight this normalisation hides.
+ * A row appended from an event id gets its real name on the server, from the id -> name table in
+ * analysis/attackTechniqueNames.ts, and the bare id on the client, which is never sent that table.
+ * It is pinned as its own test below rather than left to fail here, so the day someone ships the
+ * table to the browser this suite says which assertion to delete.
+ */
+function shape(rows: ReadonlyArray<{ id: string; findingIds: string[] }>) {
+  return rows.map((r) => ({ id: r.id, findingIds: r.findingIds }));
+}
+
+// ── HALF 1: THE RULE ─────────────────────────────────────────────────────────────────────────────
+describe("the client MITRE derivation matches the server's", () => {
+  const CASES: Array<[string, (s: InvestigationState) => InvestigationState]> = [
+    ["the full fixture", (s) => s],
+    ["no findings at all", (s) => ({ ...s, findings: [] })],
+    ["no events at all", (s) => ({ ...s, forensicTimeline: [] })],
+    ["an empty stored table", (s) => ({ ...s, mitreTechniques: [] })],
+    ["nothing anywhere", (s) => ({ ...s, findings: [], forensicTimeline: [], mitreTechniques: [] })],
+    [
+      "an event carrying an empty id, which neither side may append",
+      (s) => ({
+        ...s,
+        forensicTimeline: [
+          ...s.forensicTimeline,
+          { ...s.forensicTimeline[0], id: "e9", mitreTechniques: [""] },
+        ],
+      }),
+    ],
+    [
+      "the same id on two events, which must appear once",
+      (s) => ({
+        ...s,
+        forensicTimeline: [...s.forensicTimeline, { ...s.forensicTimeline[1], id: "e8" }],
+      }),
+    ],
+  ];
+
+  it.each(CASES)("agrees with the server: %s", (_label, shapeIt) => {
+    const state = shapeIt(fixture());
+    const client = filters().deriveMitreRows(state.findings, state.forensicTimeline, state.mitreTechniques);
+    const server = withEventTechniques(state).mitreTechniques;
+    expect(shape(client)).toEqual(shape(server));
+  });
+
+  // The one field that does not match, stated out loud. Both sides keep the stored name for a row
+  // that was already in the table; only an APPENDED row differs.
+  it("keeps the stored name on both sides, and differs only on an appended row", () => {
+    const state = fixture();
+    const client = filters().deriveMitreRows(state.findings, state.forensicTimeline, state.mitreTechniques);
+    const server = withEventTechniques(state).mitreTechniques;
+    const nameOf = (rows: ReadonlyArray<{ id: string; name: string }>, id: string) =>
+      rows.find((r) => r.id === id)?.name;
+    expect(nameOf(client, "T1059")).toBe("Command and Scripting Interpreter");
+    expect(nameOf(server, "T1059")).toBe("Command and Scripting Interpreter");
+    // T1490 is appended from e2, and the server's table knows it. The client has no table, so it
+    // shows the bare id — the one field where the two disagree, and the reason shape() drops name.
+    expect(nameOf(client, "T1490")).toBe("T1490");
+    expect(nameOf(server, "T1490")).toBe("Inhibit System Recovery");
+  });
+
+  // SHALLOW ON BOTH SIDES, and pinned as such rather than asserted away. The server's
+  // unionEventTechniques() spreads each row ({ ...t }), so the row objects are fresh but their
+  // findingIds arrays are the state's own. The client copies the same way. Claiming a deep copy
+  // here would be the mirror drifting in the test rather than in the code — so the check is that
+  // the two ALIAS ALIKE, which is the property a mirror actually owes.
+  it("copies rows but shares findingIds — the same shallowness as the server", () => {
+    const state = fixture();
+    const client = filters().deriveMitreRows(state.findings, state.forensicTimeline, state.mitreTechniques);
+    const server = withEventTechniques(state).mitreTechniques;
+    expect(client[0]).not.toBe(state.mitreTechniques[0]);
+    expect(server[0]).not.toBe(state.mitreTechniques[0]);
+    expect(client[0].findingIds).toBe(state.mitreTechniques[0].findingIds);
+    expect(server[0].findingIds).toBe(state.mitreTechniques[0].findingIds);
+  });
+
+  // The list itself is fresh, which is the half render() depends on: it appends event-carried rows.
+  it("appends to its own array, leaving the stored table's length alone", () => {
+    const state = fixture();
+    const rows = filters().deriveMitreRows(state.findings, state.forensicTimeline, state.mitreTechniques);
+    rows.push({ id: "T9999", name: "injected", findingIds: [] });
+    expect(state.mitreTechniques).toHaveLength(4);
+    expect(state.mitreTechniques.map((t) => t.id)).not.toContain("T9999");
+  });
+
+  it("tolerates the null and missing shapes the dashboard can hand it mid-load", () => {
+    expect(filters().deriveMitreRows(null, null, null)).toEqual([]);
+    expect(filters().deriveMitreRows([], [{}], [])).toEqual([]);
+  });
+});
+
+// ── HALF 2: THE COMPOSITION — #917 ───────────────────────────────────────────────────────────────
+//
+// The server states the order in one expression, so the test can state it the same way: dismissing
+// f-benign must take T1071 out of the table. Whether render() honours that order is the AST test
+// below; this one pins what the order MEANS, so the AST check has something to point at.
+describe("a finding confirmed false-positive withdraws the support it was giving", () => {
+  const markers: FalsePositiveMarker[] = [
+    {
+      id: "finding:beaconing",
+      kind: "finding",
+      ref: "beaconing",
+      reason: "authorized-test",
+      markedAt: "2026-05-21T00:00:00Z",
+      markedBy: "analyst",
+      note: "",
+    },
+  ];
+
+  it("drops the technique on the server", () => {
+    const rows = withEventTechniques(applyFalsePositive(fixture(), markers)).mitreTechniques;
+    expect(rows.map((r) => r.id)).not.toContain("T1071");
+  });
+
+  it("drops it on the client too, when the FILTERED findings are passed", () => {
+    const state = fixture();
+    const notFp = state.findings.filter((f) => !filters().isFindingFalsePositive(f.title, ["beaconing"]));
+    const rows = filters().deriveMitreRows(notFp, state.forensicTimeline, state.mitreTechniques);
+    expect(rows.map((r) => r.id)).not.toContain("T1071");
+    expect(shape(rows)).toEqual(
+      shape(withEventTechniques(applyFalsePositive(state, markers)).mitreTechniques),
+    );
+  });
+
+  // The bug itself, pinned as a fact about the inputs rather than as a claim about render(): the
+  // two lists give DIFFERENT answers, so which one render() passes is a real decision and not a
+  // stylistic one. If this ever stops being true the AST test below is worth nothing.
+  it("and keeps it when the RAW findings are passed — why the call site matters", () => {
+    const state = fixture();
+    const rows = filters().deriveMitreRows(state.findings, state.forensicTimeline, state.mitreTechniques);
+    expect(rows.map((r) => r.id)).toContain("T1071");
+  });
+});
+
+describe("render() feeds the derivation the false-positive-filtered findings", () => {
+  function renderBody(script: DashboardScript): ts.Node {
+    const fn = functionsOf(script).find((f) => f.name === "render" && f.declaration);
+    if (!fn) throw new Error("render() function declaration not found in dashboard-render.js");
+    return fn.node;
+  }
+
+  // Scoped to render's own body, not the whole file: parsed alone, dashboard-render.js never
+  // invokes render() — it publishes it as window.render and its 17 call sites are in other scripts
+  // — so callsByName would call the entire body dead code. dashboardRenderOriginLens.test.ts hit
+  // the same wall and settled it the same way.
+  function deriveMitreRowsArgs(node: ts.Node): string[] {
+    let call: ts.CallExpression | undefined;
+    const visit = (n: ts.Node): void => {
+      if (call) return;
+      if (
+        ts.isCallExpression(n) &&
+        ts.isIdentifier(n.expression) &&
+        n.expression.text === "deriveMitreRows"
+      ) {
+        call = n;
+        return;
+      }
+      ts.forEachChild(n, visit);
+    };
+    visit(node);
+    if (!call) throw new Error("deriveMitreRows call not found in render()");
+    return call.arguments.map((a) => (ts.isIdentifier(a) ? a.text : `<non-identifier: ${a.getText()}>`));
+  }
+
+  it("calls deriveMitreRows rather than deriving inline", () => {
+    const script = scriptFromSource("dashboard-render.js", RENDER_SOURCE);
+    expect(callsWithin(renderBody(script)).has("deriveMitreRows")).toBe(true);
+  });
+
+  it("goes red when the call is removed — the gate's own mutation check", () => {
+    const stripped = RENDER_SOURCE.replace(/deriveMitreRows/g, "derivationRemovedByTest");
+    const script = scriptFromSource("dashboard-render.js", stripped);
+    expect(callsWithin(renderBody(script)).has("deriveMitreRows")).toBe(false);
+  });
+
+  // THE ARGUMENT, WHICH IS THE WHOLE OF #917. "is called" is true whether the first argument is
+  // notFp or state.findings, and the two give different answers — the test three blocks up proves
+  // that. `notFp` is the list the findings panel itself renders, so this also pins that the panel
+  // and the MITRE table are reading the same findings.
+  it("passes notFp — the filtered list — as the findings argument", () => {
+    const script = scriptFromSource("dashboard-render.js", RENDER_SOURCE);
+    expect(deriveMitreRowsArgs(renderBody(script))[0]).toBe("notFp");
+  });
+
+  it("goes red when the raw state.findings is passed instead", () => {
+    const swapped = RENDER_SOURCE.replace("deriveMitreRows(notFp,", "deriveMitreRows(state.findings,");
+    const script = scriptFromSource("dashboard-render.js", swapped);
+    expect(deriveMitreRowsArgs(renderBody(script))[0]).not.toBe("notFp");
+  });
+});

--- a/companion/tests/dashboard/dashboardModules.test.ts
+++ b/companion/tests/dashboard/dashboardModules.test.ts
@@ -157,9 +157,11 @@ describe("every moved function still resolves at its call sites", () => {
   // shared reading of a filename's extension (#673); 104 with yearClampChip, the timeline row's
   // year-clamp note (#739); 106 with applyIocNoiseFilters and iocNoiseNoticeHtml, which took the
   // IOC panel's three noise lenses out of the inline script so their "never empty a non-empty list"
-  // rule could be tested directly (#876). The number is a vacuity guard, not a budget.
-  it("moved 106 functions, so the check below is not vacuous", () => {
-    expect(MOVED.length).toBe(106);
+  // rule could be tested directly (#876); 107 with deriveMitreRows, the client mirror of the
+  // server's eventTechniques.ts, lifted out of render() so it could be run against the real server
+  // function (#918). The number is a vacuity guard, not a budget.
+  it("moved 107 functions, so the check below is not vacuous", () => {
+    expect(MOVED.length).toBe(107);
   });
 
   it("provides every one of them as a global once the tagged scripts have run", async () => {

--- a/public/js/dashboard-filters.js
+++ b/public/js/dashboard-filters.js
@@ -191,6 +191,52 @@ function findingPassesOriginLens(f, hideAuto, hideGap) {
   return true;
 }
 
+// The case MITRE table, completed from the techniques the surviving events carry (#893).
+//
+// THE CLIENT MIRROR OF src/analysis/eventTechniques.ts. It is a separate function rather than two
+// dozen inline lines in render() for the same reason findingPassesOriginLens above is: render() is
+// a 700-line DOM function with no behavioural harness, so a rule written inside it can only be
+// checked by reading it. As a pure function it is run directly against the REAL server function in
+// tests/dashboard/dashboardMitreParity.test.ts, which is what #918 asked for.
+//
+// `findings` MUST ALREADY HAVE THE FALSE-POSITIVE FILTER APPLIED. That is not a detail of the
+// caller's convenience — it is half the rule. On the server the order is fixed and visible in one
+// expression, withEventTechniques(applyFalsePositive(state, markers)) at reports/reportWriter.ts,
+// so a technique whose only support was a finding the analyst just confirmed benign is gone from
+// the table. Passing the raw state.findings here instead reproduces #917: the panel keeps a row
+// the report has already dropped, until a background re-synthesis happens to land.
+//
+// Nothing is persisted. This is a VIEW over state, so dismissing an event takes effect on the next
+// render and un-marking it brings the technique straight back, with no merge and nothing to heal.
+//
+// One knowing divergence from the server, and it is in the NAME only: a row derived from an event
+// id shows the bare id, because the id -> name table is server-side reference data
+// (analysis/attackTechniqueNames.ts) that the dashboard is never sent. Ids and finding links match
+// the server exactly; the parity suite pins that and documents the carve-out.
+function deriveMitreRows(findings, forensicTimeline, table) {
+  const ft = forensicTimeline || [];
+  const surviving = new Set((findings || []).map((f) => f.id));
+  const carried = new Set(ft.flatMap((e) => e.mitreTechniques || []));
+  // Copied, not aliased — the server's unionEventTechniques() hands back copies, and a caller that
+  // edited a row in place would otherwise be editing the persisted state object.
+  const rows = (table || [])
+    .filter(
+      (m) =>
+        m.analystAccepted ||
+        (m.findingIds || []).some((id) => surviving.has(id)) ||
+        carried.has(m.id),
+    )
+    .map((m) => ({ ...m }));
+  const seen = new Set(rows.map((m) => m.id));
+  for (const e of ft)
+    for (const id of e.mitreTechniques || [])
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        rows.push({ id, name: id, findingIds: [] });
+      }
+  return rows;
+}
+
 // Published for the inline script and the other helper modules. EVERY function this file
 // defines is listed: a helper that stays private here but is still called by name from
 // dashboard.html is a ReferenceError, which is the mistake #414 shipped and then fixed.
@@ -212,6 +258,7 @@ window.DfirFilters = {
   isAutoBackfillFinding,
   isGapFinding,
   findingPassesOriginLens,
+  deriveMitreRows,
   ftOriginOf,
   originFacets,
 };

--- a/public/js/dashboard-render.js
+++ b/public/js/dashboard-render.js
@@ -479,27 +479,14 @@
     // persisted, so a dismissal takes effect on the next render and un-marking restores the
     // technique, with no merge and no healing pass in between.
     //
-    // A technique a model asserted keeps its name and its finding links. One derived from an event
-    // shows its id as the name, which is exactly what the server's own name table falls back to for
-    // an id it does not know.
-    // Only what the surviving evidence still supports: a technique synthesis asserted otherwise
-    // outlives the dismissal of the very event it came from. Safe to hide because this is a view —
-    // state is untouched, so un-marking the event brings it straight back.
-    const survivingFindings = new Set((state.findings || []).map((f) => f.id));
-    const carriedTechniques = new Set(ft.flatMap((e) => e.mitreTechniques || []));
-    const mitreRows = (state.mitreTechniques || []).filter(
-      (m) =>
-        m.analystAccepted ||
-        (m.findingIds || []).some((id) => survivingFindings.has(id)) ||
-        carriedTechniques.has(m.id),
-    );
-    const seenTechniques = new Set(mitreRows.map((m) => m.id));
-    for (const e of ft)
-      for (const id of e.mitreTechniques || [])
-        if (id && !seenTechniques.has(id)) {
-          seenTechniques.add(id);
-          mitreRows.push({ id, name: id, findingIds: [] });
-        }
+    // THE FINDINGS ARGUMENT IS `notFp`, NOT `state.findings`, and that is the whole of #917. The
+    // findings panel a few hundred lines up already renders `notFp` — the list with the
+    // just-confirmed false positives dropped — and the server derives MITRE in that same order,
+    // withEventTechniques(applyFalsePositive(...)) in reports/reportWriter.ts. Passing the raw list
+    // here left a technique whose only support was a finding the analyst had confirmed benign
+    // sitting in this panel while the report and every server-side export had already dropped it,
+    // until a background re-synthesis happened to land. Pinned by dashboardMitreParity.test.ts.
+    const mitreRows = deriveMitreRows(notFp, ft, state.mitreTechniques);
     document.getElementById("mitre").innerHTML =
       mitreRows
         .map(


### PR DESCRIPTION
Closes #917. Closes #918.

## #917 — the MITRE panel counted false-positive findings

`render()` built `survivingFindings` from the raw `state.findings`, while the findings panel a few hundred lines above rendered `notFp` — the list with the just-confirmed false positives dropped. So a technique whose only support was a finding the analyst had confirmed benign stayed in the dashboard MITRE panel while the report and every server-side export had already dropped it, until a background re-synthesis happened to land.

The server has no such gap. `reports/reportWriter.ts` derives MITRE as `withEventTechniques(applyFalsePositive(...))`, in that order.

## #918 — nothing pinned the mirror

#893 wrote the derivation rule twice — `analysis/eventTechniques.ts` on the server, inline in `render()` on the client — with no suite holding them together. That is the same failure `tests/dashboard/dashboardScope.test.ts` documents for `projectScope`, and the mirror drifted the same way.

## What changed

The rule moves out of `render()` into `deriveMitreRows()` in `public/js/dashboard-filters.js`, beside the false-positive predicate it composes with. `render()` is a 700-line DOM function with no behavioural harness, so a rule written inside it can only be checked by reading it; as a pure function it can be run directly against the imported server function instead. This follows the precedent `dashboardRenderOriginLens.test.ts` set for `findingPassesOriginLens`.

`tests/dashboard/dashboardMitreParity.test.ts` covers both halves, because the defect was in neither function:

- **The rule.** Seven fixture shapes run the client function against the REAL `withEventTechniques`, imported rather than re-implemented. Branches: analyst-accepted, finding-backed, event-carried, unsupported, empty id, duplicate id, and the three empty inputs.
- **The composition.** Three tests prove the two findings lists give *different* answers, so the call site is a real decision and not a stylistic one. Four AST tests then pin that `render()` calls the function and passes `notFp`, each with a mutation check confirming the gate goes red.

Written test-first. The red run caught the three expected failures plus two wrong assumptions in the test itself.

## One divergence pinned, not hidden

A row appended from an event id shows the bare id on the client and its real ATT&CK name on the server — `T1490` versus "Inhibit System Recovery" — because the id-to-name table is server-side reference data the browser is never sent. Ids and finding links match exactly. It is an explicit test with the deletion instructions written into it, so the day the table reaches the browser the suite says which assertions to remove.

## Verification

| Gate | Result |
|---|---|
| `npm run typecheck` | pass |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run check:size` | pass — 18 ledgered files, none grew |
| `npm run check:boundaries` | pass — 39 known, none new |
| `npm run check:imports` | pass — no new cycles |
| `npm run test` | 12923 passed, 1 failed (see below) |
| `npm run check:a11y` | not run locally — needs a full e2e run first |

The one failure is unrelated: `caseExportArchive.test.ts > rejects a reserved Windows device name` timed out at 15s during the full run. Re-run alone it passes 52/52 in 47.3s — that file's own tests need 45.6s, so a 15s per-test timeout blows under load. The run showed `tests 1326s` against a 433s wall clock, which is the contention.

New suite: `dashboardMitreParity.test.ts` 18/18. `dashboardModules.test.ts` 48/48 after bumping its moved-function vacuity guard from 106 to 107, as its own comment instructs.

E2E was not run locally: the port is a machine-wide singleton and `check:a11y` depends on its output. This change touches no markup or CSS, and no e2e spec asserts the MITRE panel's rendered rows.
