### PR TITLE
feat(sandbox): promotion carries an intent; lab rows never close a second-look request (#932 item 5, part B)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ established, and it works the same way.
 The graph is built the same way `check-imports.mjs` builds it: a regex over relative `.js`
 specifiers, because the companion imports its own modules exclusively that way. No resolver needed.
 
-For context: **2,051 of the 2,090 cross-domain file dependencies already comply.** The map is mostly
+For context: **2,056 of the 2,095 cross-domain file dependencies already comply.** The map is mostly
 a description of how this codebase is already written, which is the only kind of rule people follow.
 Both figures come from `npm run check:boundaries -- --json`, which counts them in the same pass that
 finds the violations, and a test asserts this sentence against it. The pair read 1,275 of 1,323 long

--- a/companion/src/analysis/ai/analystQueries.ts
+++ b/companion/src/analysis/ai/analystQueries.ts
@@ -12,6 +12,7 @@ import type { SuperTimelineStore } from "../superTimelineStore.js";
 import { buildSynthesisContext } from "../synthSelect.js";
 import type { VelociraptorClientStore } from "../velociraptorClientStore.js";
 import { getAskPrompt, getExplainEventPrompt, getFpSimilarityPrompt } from "./prompts/index.js";
+import type { PromotionIntent } from "../ingest/timelineImports.js";
 import {
   callAiJson,
   fitTimelineText,
@@ -45,7 +46,7 @@ export interface AnalystQueryContext extends AiCallContext {
   promoteSuperTimeline(
     caseId: string,
     events: ForensicEvent[],
-    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+    opts: { importedAt: string; intent: PromotionIntent; tagById?: Record<string, string[]>; note?: string },
   ): Promise<InvestigationState>;
 }
 
@@ -125,6 +126,7 @@ async function resolveFocalEvent(
     if (raw) {
       state = await ctx.promoteSuperTimeline(caseId, [raw], {
         importedAt: new Date().toISOString(),
+        intent: "explain",
         note: `Promoted 1 raw event for "explain this event"`,
       });
       event = state.forensicTimeline.find((e) => e.id === eventId);

--- a/companion/src/analysis/ai/synthesis.ts
+++ b/companion/src/analysis/ai/synthesis.ts
@@ -55,6 +55,8 @@ import {
 } from "./synthesisInputs.js";
 import { carryOutOfWindowFindings, foldSynthesisDelta, gradeFindings } from "./synthesisMerge.js";
 import { persistSynthesis } from "./synthesisPersist.js";
+import { isPendingLabRow } from "../labIntel.js";
+import type { PromotionIntent } from "../ingest/timelineImports.js";
 
 /**
  * Synthesis: the AI call that turns the case's timeline into its conclusions (#418).
@@ -112,7 +114,7 @@ export interface SynthesisContext
   promoteSuperTimeline(
     caseId: string,
     events: ForensicEvent[],
-    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+    opts: { importedAt: string; intent: PromotionIntent; tagById?: Record<string, string[]>; note?: string },
   ): Promise<InvestigationState>;
   /** Once per process: warn that a configured prompt override is missing shipped capabilities. */
   warnOnPromptDrift(): void;
@@ -721,7 +723,11 @@ async function collectSecondLookCandidates(
   const omitted = input.scopedEvents.filter((e) => !shownIds.has(e.id));
   const superRows = (await superStore.query(caseId, { from: window.from, to: window.to })).events;
   const byId = new Map<string, ForensicEvent>();
-  for (const e of [...omitted, ...superRows]) if (!byId.has(e.id)) byId.set(e.id, e);
+  // A pending lab row (sandbox behaviour nobody promoted) is out of the pool ENTIRELY — not just
+  // out of the promotable subset. It may not be promoted, and it may not satisfy a request either:
+  // a request whose only match is hidden lab evidence still needs a collection lead. A lab row the
+  // analyst promoted is in the forensic timeline by their choice and may match (#932 item 5 part B).
+  for (const e of [...omitted, ...superRows]) if (!byId.has(e.id) && !isPendingLabRow(e)) byId.set(e.id, e);
   return [...byId.values()];
 }
 
@@ -768,6 +774,7 @@ async function runSecondLook(
 
   if (plan.promotions.length) {
     await ctx.promoteSuperTimeline(caseId, plan.promotions, {
+      intent: "second-look",
       importedAt: new Date().toISOString(),
       tagById: plan.tagById,
       note: `Second look: promoted ${plan.promotions.length} raw event(s) matching open questions`,

--- a/companion/src/analysis/ai/viewReports.ts
+++ b/companion/src/analysis/ai/viewReports.ts
@@ -1,3 +1,4 @@
+import type { PromotionIntent } from "../ingest/timelineImports.js";
 import type { AIProvider } from "../../providers/provider.js";
 import { z } from "zod";
 import { sortByEventTime } from "../forensicSort.js";
@@ -55,7 +56,7 @@ export interface ViewReportContext extends AiCallContext {
   promoteSuperTimeline(
     caseId: string,
     events: ForensicEvent[],
-    opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+    opts: { importedAt: string; intent: PromotionIntent; tagById?: Record<string, string[]>; note?: string },
   ): Promise<InvestigationState>;
 }
 
@@ -137,6 +138,7 @@ async function resolveStarredEvents(
     }
     if (promotable.length) {
       state = await ctx.promoteSuperTimeline(caseId, promotable, {
+        intent: "starred-report",
         importedAt: new Date().toISOString(),
         note: `Promoted ${promotable.length} starred raw event(s) for the starred report`,
       });

--- a/companion/src/analysis/correlate.ts
+++ b/companion/src/analysis/correlate.ts
@@ -249,6 +249,13 @@ function mergeGroup(events: ForensicEvent[], trustMap?: SourceTrustMap): Forensi
     relatedFindingIds: uniq(events.flatMap((e) => e.relatedFindingIds)),
     sourceScreenshots: uniq(events.flatMap((e) => e.sourceScreenshots)),
     sources: sources.length ? sources : undefined,
+    // Provenance markers are a UNION, not the primary's: an analyst's "[promoted]" on a lab row must
+    // survive a merge with an incidental (explain / starred-report) copy of the same sample whose
+    // longer description wins primary, or second-look would treat their choice as pending again
+    // (#932 item 5 part B). Same shape as sources and mitreTechniques above.
+    ...(events.some((e) => e.provenance?.length)
+      ? { provenance: uniq(events.flatMap((e) => e.provenance ?? [])) }
+      : {}),
     // artifactName, unlike the fields below, is an ATTRIBUTION of the shown description (which artifact
     // produced this text) — not a neutral shared fact about the underlying process/host/connection — so
     // it must come from the SAME event as `description` (primary), never borrowed from a different

--- a/companion/src/analysis/ingest/timelineImports.ts
+++ b/companion/src/analysis/ingest/timelineImports.ts
@@ -11,6 +11,7 @@ import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
 import { persistPlasoParsed } from "./importState.js";
 import type { ImportContext } from "./importContext.js";
+import { isLabProduced, PROMOTED_MARKER } from "../labIntel.js";
 
 /**
  * Whole-timeline sources. Plaso arrives already normalised into timeline rows, and
@@ -78,12 +79,32 @@ export async function importPlasoFile(
 // routed there exclusively) that is never synthesized; this is how the analyst pulls the events that
 // matter into the analyzed timeline. Reuses mergeDelta (dedups forensic events by id) — a stored super
 // event keeps its id, so a double-promote is a no-op. No AI here; the caller re-synthesizes.
+// Who is promoting, and therefore what a lab row is allowed to become (#932 item 5 part B). Four
+// callers share this function; "manually promoted" had no executable meaning until this enum.
+//   manual      — the analyst chose these rows in the super-timeline. A lab row is normalised
+//                 (origin lab, Info) and stamped PROMOTED_MARKER: their decision is respected and
+//                 remembered.
+//   explain     — "explain this event" on a raw row promotes it so it can be explained. Incidental:
+//                 normalised, NOT marked. It stays a pending lab row.
+//   starred-report — a report over the rows the analyst starred promotes them first (§7: the model
+//                 reads the forensic timeline, never the raw record). Same as explain: the analyst
+//                 asked for a report, not for a lab row to become incident evidence.
+//   second-look — the automated loop. A lab row is REFUSED here outright, marker or not: the loop
+//                 must never move sandbox behaviour into the incident chronology on its own.
+export type PromotionIntent = "manual" | "explain" | "starred-report" | "second-look";
+
 export async function promoteSuperTimeline(
   ctx: ImportContext,
   caseId: string,
-  events: ForensicEvent[],
-  opts: { importedAt: string; tagById?: Record<string, string[]>; note?: string },
+  requested: ForensicEvent[],
+  opts: { importedAt: string; intent: PromotionIntent; tagById?: Record<string, string[]>; note?: string },
 ): Promise<InvestigationState> {
+  const events = requested
+    .filter((e) => !(opts.intent === "second-look" && isLabProduced(e)))
+    .map((e) => (isLabProduced(e) ? { ...e, origin: "lab" as const, severity: "Info" as const } : e));
+  const marked: Record<string, string[]> = { ...(opts.tagById ?? {}) };
+  if (opts.intent === "manual")
+    for (const e of events) marked[e.id] = [...new Set([...(marked[e.id] ?? []), PROMOTED_MARKER])];
   return ctx.withStateLock(caseId, async () => {
     let state = await ctx.opts.stateStore.load(caseId);
     if (!events.length) return state;
@@ -105,13 +126,13 @@ export async function promoteSuperTimeline(
     // Stamp provenance markers on the promoted rows (second-look #11) — mergeDelta carries no
     // provenance through the delta schema, so apply them here by id (union with any existing). Lets the
     // forensic timeline show WHY a raw row was pulled up ("[second-look: h2]").
-    if (opts.tagById) {
-      const tagged = new Set(Object.keys(opts.tagById));
+    if (Object.keys(marked).length) {
+      const tagged = new Set(Object.keys(marked));
       state = {
         ...state,
         forensicTimeline: state.forensicTimeline.map((e) =>
           tagged.has(e.id)
-            ? { ...e, provenance: [...new Set([...(e.provenance ?? []), ...opts.tagById![e.id]])] }
+            ? { ...e, provenance: [...new Set([...(e.provenance ?? []), ...marked[e.id]])] }
             : e,
         ),
       };

--- a/companion/src/analysis/labIntel.ts
+++ b/companion/src/analysis/labIntel.ts
@@ -169,3 +169,22 @@ export function isLabProduced(e: Pick<ForensicEvent, "origin" | "sources" | "des
   if (sources.length === 0 || !sources.every((s) => SANDBOX_SOURCES.has(s))) return false;
   return SANDBOX_DESCRIPTION_PREFIXES.some((p) => e.description.startsWith(p));
 }
+
+// The one provenance marker that says "an analyst deliberately put this row in the forensic
+// timeline". Stamped by promoteSuperTimeline for the manual intent only — explain-on-demand
+// promotes incidentally and second-look promotes automatically, and neither is a human deciding
+// that a lab row is incident evidence. Distinct from "[second-look: hN]" on purpose.
+export const PROMOTED_MARKER = "[promoted]";
+
+export function hasPromotedMarker(e: Pick<ForensicEvent, "provenance">): boolean {
+  return (e.provenance ?? []).includes(PROMOTED_MARKER);
+}
+
+// A lab-produced row in the forensic timeline that no analyst chose to put there. Excluded from
+// second-look matching and promotion (a hidden lab row must never close a collection request), and
+// the population #950's legacy remedy is about.
+export function isPendingLabRow(
+  e: Pick<ForensicEvent, "origin" | "sources" | "description" | "provenance">,
+): boolean {
+  return isLabProduced(e) && !hasPromotedMarker(e);
+}

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -122,6 +122,9 @@ export const deltaSchema = z.object({
     .array(
       z.object({
         id: z.string().min(1),
+        // Evidence origin (#932 item 5). Promotion parses through this schema; without the field
+        // a promoted lab row would arrive in the forensic timeline as a host observation.
+        origin: z.enum(["lab"]).optional().catch(undefined),
         // Event's real time as shown in the artifact. A model that returns a NAIVE stamp (no "Z", no
         // offset) is tagged UTC here, at the one boundary every AI event crosses (#757) — otherwise
         // each downstream Date.parse reads it in the server's own zone, and the same delta yields a

--- a/companion/src/analysis/responseSchema.ts
+++ b/companion/src/analysis/responseSchema.ts
@@ -426,7 +426,16 @@ export function renameForgedFindingIds(delta: AnalysisDelta, known: ReadonlySet<
 // extraction/synthesis call site (never at the deterministic-importer call sites, which build
 // their delta objects field-by-field and set extractedFrom themselves via resolveExtractedFrom).
 export function stripAiExtractedFrom(delta: AnalysisDelta): AnalysisDelta {
-  return { ...delta, iocs: delta.iocs.map(({ extractedFrom, ...rest }) => rest) };
+  return {
+    ...delta,
+    iocs: delta.iocs.map(({ extractedFrom, ...rest }) => rest),
+    // `origin` is trusted: it keeps a row out of host correlation and off the second-look pool
+    // (#932 item 5). The schema carries it so deterministic promotion can transport a lab row, but
+    // a model must never be able to assert it on a host observation — a prompt-injected or merely
+    // weak response saying origin:"lab" would silently misclassify real evidence. Same reason
+    // extractedFrom is stripped above: provenance is not the model's to claim.
+    forensicEvents: (delta.forensicEvents ?? []).map(({ origin, ...rest }) => rest),
+  };
 }
 
 // Answer to an analyst's free-form question about the case ("was data exfiltrated?").

--- a/companion/src/analysis/stateMerge.ts
+++ b/companion/src/analysis/stateMerge.ts
@@ -335,6 +335,7 @@ export function mergeDelta(
         ...(incoming.srcIp ? { srcIp: incoming.srcIp } : {}),
         ...(incoming.dstIp ? { dstIp: incoming.dstIp } : {}),
         ...(incoming.port !== undefined ? { port: incoming.port } : {}),
+        ...(incoming.origin ? { origin: incoming.origin } : {}),
       };
       forensicTimeline.push(created);
       byId.set(incoming.id, created);

--- a/companion/src/routes/timeline.ts
+++ b/companion/src/routes/timeline.ts
@@ -259,6 +259,7 @@ export function registerTimelineRoutes(app: Express, ctx: RouteContext): void {
       if (!events.length) return res.status(404).json({ error: "no matching super-timeline events" });
       await options.pipeline.promoteSuperTimeline(req.params.id, events, {
         importedAt: new Date().toISOString(),
+        intent: "manual",
       });
       resynthesizeInBackground(req.params.id);
       return res.status(200).json({ promoted: events.length });

--- a/companion/tests/analysis/labPromotion.test.ts
+++ b/companion/tests/analysis/labPromotion.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CaseStore } from "../../src/storage/caseStore.js";
+import { StateStore } from "../../src/analysis/stateStore.js";
+import { SuperTimelineStore } from "../../src/analysis/superTimelineStore.js";
+import { StateLock } from "../../src/analysis/stateLock.js";
+import { AnalysisPipeline } from "../../src/analysis/pipeline.js";
+import { PROMOTED_MARKER, isPendingLabRow } from "../../src/analysis/labIntel.js";
+import { emptyState, type ForensicEvent } from "../../src/analysis/stateTypes.js";
+
+// #932 item 5 part B: what happens when a lab row is promoted into the forensic timeline, and how
+// the second-look loop treats lab rows. Promotion carries an INTENT because four callers share it
+// and only an analyst's deliberate choice earns the exemption marker.
+
+const SHA = "a".repeat(64);
+const labRow = (over: Partial<ForensicEvent> = {}): ForensicEvent => ({
+  id: "sb1e1",
+  timestamp: "2023-09-01T10:00:00Z",
+  description: "CAPE sandbox: [run 42] Emotet — invoice.exe score 9/10",
+  severity: "High", // a legacy copy: written before part A forced Info
+  mitreTechniques: [],
+  relatedFindingIds: [],
+  sourceScreenshots: [],
+  sources: ["CAPEv2"],
+  sha256: SHA,
+  ...over,
+});
+
+let cases: CaseStore;
+let stateStore: StateStore;
+let superTimelineStore: SuperTimelineStore;
+let pipeline: AnalysisPipeline;
+
+beforeEach(async () => {
+  cases = new CaseStore(await mkdtemp(join(tmpdir(), "dfir-labpromo-")));
+  await cases.createCase({ caseId: "c1", name: "n", investigator: "i", aiProvider: null });
+  stateStore = new StateStore(cases);
+  await stateStore.save(emptyState("c1"));
+  superTimelineStore = new SuperTimelineStore(cases);
+  pipeline = new AnalysisPipeline({
+    stateStore,
+    superTimelineStore,
+    stateLock: new StateLock(),
+    imageLoader: async () => ({ base64: "", mimeType: "image/webp" }),
+  });
+});
+
+describe("promoting a lab row", () => {
+  it("manual promotion normalises the row (origin lab, Info) and stamps the exemption marker", async () => {
+    await superTimelineStore.append("c1", [labRow()]);
+    const state = await pipeline.promoteSuperTimeline("c1", [labRow()], {
+      importedAt: "2026-09-11T12:00:00Z",
+      intent: "manual",
+    });
+    const e = state.forensicTimeline.find((x) => x.id === "sb1e1");
+    expect(e?.origin).toBe("lab");
+    expect(e?.severity).toBe("Info"); // the sandbox's High is capability, not incident severity
+    expect(e?.provenance).toContain(PROMOTED_MARKER);
+    expect(isPendingLabRow(e!)).toBe(false);
+  });
+
+  it("explain-on-demand promotion normalises but does NOT stamp the exemption — it was incidental", async () => {
+    const state = await pipeline.promoteSuperTimeline("c1", [labRow()], {
+      importedAt: "2026-09-11T12:00:00Z",
+      intent: "explain",
+    });
+    const e = state.forensicTimeline.find((x) => x.id === "sb1e1");
+    expect(e?.origin).toBe("lab");
+    expect(e?.severity).toBe("Info");
+    expect(e?.provenance ?? []).not.toContain(PROMOTED_MARKER);
+    expect(isPendingLabRow(e!)).toBe(true);
+  });
+
+  it("second-look promotion of a lab row is refused at the promotion boundary, marker or not", async () => {
+    const state = await pipeline.promoteSuperTimeline("c1", [labRow()], {
+      importedAt: "2026-09-11T12:00:00Z",
+      intent: "second-look",
+      tagById: { sb1e1: ["[second-look: h1]"] },
+    });
+    expect(state.forensicTimeline.find((x) => x.id === "sb1e1")).toBeUndefined();
+  });
+
+  it("a host row promoted manually is untouched apart from the marker", async () => {
+    const host = labRow({
+      id: "h1",
+      sources: ["KAPE"],
+      description: "prefetch: EVIL.EXE executed",
+      severity: "Low",
+    });
+    const state = await pipeline.promoteSuperTimeline("c1", [host], {
+      importedAt: "2026-09-11T12:00:00Z",
+      intent: "manual",
+    });
+    const e = state.forensicTimeline.find((x) => x.id === "h1");
+    expect(e?.origin).toBeUndefined();
+    expect(e?.severity).toBe("Low");
+    expect(e?.provenance).toContain(PROMOTED_MARKER);
+  });
+});
+
+describe("isPendingLabRow", () => {
+  it("is a lab-produced row without the exemption marker; a second-look marker does not exempt", () => {
+    expect(isPendingLabRow(labRow())).toBe(true);
+    expect(isPendingLabRow(labRow({ provenance: ["[second-look: h1]"] }))).toBe(true);
+    expect(isPendingLabRow(labRow({ provenance: [PROMOTED_MARKER] }))).toBe(false);
+    expect(isPendingLabRow(labRow({ sources: ["CAPEv2", "KAPE"] }))).toBe(false); // merged: not lab-produced
+  });
+});

--- a/companion/tests/analysis/labPromotion.test.ts
+++ b/companion/tests/analysis/labPromotion.test.ts
@@ -108,3 +108,49 @@ describe("isPendingLabRow", () => {
     expect(isPendingLabRow(labRow({ sources: ["CAPEv2", "KAPE"] }))).toBe(false); // merged: not lab-produced
   });
 });
+
+describe("origin is not the model's to assert", () => {
+  it("stripAiExtractedFrom removes origin from every model-produced forensic event", async () => {
+    const { deltaSchema, stripAiExtractedFrom } = await import("../../src/analysis/responseSchema.js");
+    const delta = deltaSchema.parse({
+      findings: [],
+      iocs: [],
+      mitreTechniques: [],
+      threadsOpened: [],
+      threadsClosed: [],
+      timelineNote: "",
+      summary: "",
+      forensicEvents: [
+        {
+          id: "e1",
+          timestamp: "2023-03-15T08:00:00Z",
+          description: "process create invoice.exe on WS-01",
+          severity: "High",
+          mitreTechniques: [],
+          relatedFindingIds: [],
+          origin: "lab", // a prompt-injected or weak model claiming a host event is lab evidence
+        },
+      ],
+    });
+    expect(delta.forensicEvents?.[0]?.origin).toBe("lab"); // the schema transports it …
+    expect(stripAiExtractedFrom(delta).forensicEvents?.[0]?.origin).toBeUndefined(); // … the AI guard drops it
+  });
+});
+
+describe("the promotion marker survives correlation", () => {
+  it("a lab/lab merge keeps [promoted] even when the other member's longer description wins primary", async () => {
+    const { correlateEvents } = await import("../../src/analysis/correlate.js");
+    const manual = labRow({ id: "man", severity: "Info", origin: "lab", provenance: [PROMOTED_MARKER] });
+    const incidental = labRow({
+      id: "exp",
+      severity: "Info",
+      origin: "lab",
+      description:
+        "CAPE sandbox: [run 42] Emotet — invoice.exe score 9/10 — promoted so it could be explained",
+    });
+    const out = correlateEvents([manual, incidental]);
+    expect(out).toHaveLength(1);
+    expect(out[0].provenance).toContain(PROMOTED_MARKER);
+    expect(isPendingLabRow(out[0])).toBe(false);
+  });
+});

--- a/companion/tests/analysis/secondLookLoop.test.ts
+++ b/companion/tests/analysis/secondLookLoop.test.ts
@@ -142,6 +142,57 @@ describe("second-look loop end-to-end (#11)", () => {
     expect(meta.secondLook?.leads.length).toBeGreaterThan(0);
   });
 
+  // #932 item 5 part B: a pending lab row (sandbox behaviour nobody promoted) is out of the
+  // candidate pool ENTIRELY. It must not be promoted — and it must not satisfy the request either,
+  // or hidden lab evidence would silently close a collection request.
+  it("never promotes a lab row, and a request matching only a lab row still becomes a collection lead", async () => {
+    await superStore.append("c1", [
+      {
+        ...event(
+          "sblab",
+          "2026-05-20T10:00:00.000Z",
+          "CAPE signature: [run 42] rsync_exfil — rsync archive.zip to remote",
+        ),
+        origin: "lab",
+        sources: ["CAPEv2"],
+      },
+    ]);
+
+    const { pipeline, analyze } = makePipeline(deltaWithRequest("rsync"));
+    await pipeline.synthesize("c1");
+
+    const state = await stateStore.load("c1");
+    expect(state.forensicTimeline.some((e) => e.id === "sblab")).toBe(false);
+    expect(analyze).toHaveBeenCalledTimes(1);
+    const meta = await synthMetaStore.load("c1");
+    expect(meta.secondLook?.promoted).toBe(0);
+    expect(meta.secondLook?.leads.length).toBeGreaterThan(0);
+  });
+
+  it("lets a lab row the analyst promoted satisfy a request (it is forensic evidence by their choice)", async () => {
+    const seeded = await stateStore.load("c1");
+    seeded.forensicTimeline.push({
+      ...event(
+        "sbprom",
+        "2026-05-20T10:00:00.000Z",
+        "CAPE signature: [run 42] rsync_exfil — rsync archive.zip to remote",
+      ),
+      origin: "lab",
+      sources: ["CAPEv2"],
+      severity: "Info",
+      provenance: ["[promoted]"],
+    });
+    await stateStore.save(seeded);
+
+    const { pipeline, analyze } = makePipeline(deltaWithRequest("rsync"));
+    await pipeline.synthesize("c1");
+
+    const meta = await synthMetaStore.load("c1");
+    expect(meta.secondLook?.promoted).toBe(0); // already forensic — nothing to promote
+    expect(meta.secondLook?.leads).toHaveLength(0); // the request was satisfied by the promoted row
+    expect(analyze).toHaveBeenCalledTimes(1);
+  });
+
   it("does not sweep when superTimelineStore is not wired", async () => {
     const provider = new MockProvider("mock", deltaWithRequest("rsync"));
     const analyze = vi.spyOn(provider, "analyze");


### PR DESCRIPTION
Item 5 of #932, **part B**: what a lab row becomes when it is promoted, and how the second-look loop treats lab rows. Part A (#948) stopped new sandbox rows entering the forensic timeline; this settles the two doors they could still come back through.

## Promotion carries an intent

`promoteSuperTimeline` is shared by four callers, and "manually promoted" had no executable meaning — only the second-look loop supplied a provenance marker; the analyst's own promote button supplied none. It now takes a required intent:

| Intent | Caller | Lab row becomes |
|---|---|---|
| `manual` | the super-timeline promote button | origin lab, Info, **`[promoted]`** — their decision, remembered |
| `explain` | "explain this event" on a raw row | origin lab, Info, no marker — the promotion was the mechanism |
| `starred-report` | report over starred rows | same as explain |
| `second-look` | the automated loop | **refused** |

`[promoted]` is distinct from `[second-look: hN]` on purpose: only a human's deliberate choice earns the exemption a future legacy remedy (#950) will honour. A lab row is normalised to Info whoever promotes it — the sandbox's score is capability, not incident severity, and a promoted High lab row would have tripped the high-severity backfill into minting a finding.

## A hidden lab row never closes a collection request

A pending lab row — lab-produced, no `[promoted]` — is out of the second-look candidate pool *entirely*, not merely out of the promotable subset. Excluding it only from promotion would have let it silently satisfy a request and suppress the collection lead. A lab row the analyst promoted may match: it is forensic evidence by their choice.

## What the code review then found

- **The model could forge `origin`.** The delta schema is shared with extraction responses; a weak or prompt-injected model saying `origin: "lab"` on a host event would have kept real evidence out of correlation. The guard that strips model-asserted `extractedFrom` now strips `origin` too.
- **Correlation could drop `[promoted]`.** A merge spreads the primary; provenance markers are now a union across members.

## Deferred — your decision

Rows imported **before** part A still sit in the forensic timeline of older cases. Four design rounds did not converge on a bounded remedy: candidate review (legacy promotions carry no marker), a cross-store cascade, a retraction state and a closed export boundary each proved to be a project. It is written up as #950 with those findings as acceptance criteria, for you to size against your case population. #951 records the pre-existing export gap it uncovered (MISP/IRIS pushes ignore false-positive markers).

## Verification

- Promotion: manual normalises and marks; explain normalises and does not; second-look refuses a lab row; a host row is untouched apart from the marker.
- `isPendingLabRow`: second-look marker does not exempt; a merged row is not lab-produced.
- Through the real loop with a mock provider: a lab-only match becomes a collection lead and promotes nothing; a promoted lab row satisfies the request with no lead.
- Adversarial: a model-produced event carrying `origin: "lab"` loses it at the AI guard; a lab/lab merge keeps `[promoted]` when the other member wins primary.
- Gates: typecheck, explicit eslint on every changed file, format:check, check:size, check:imports, check:boundaries, eval:change-gate (not required — no prompt changed), full unit suite: **783 files, 13,113 tests, exit 0**.

Part of #932.
