### PR TITLE
fix(kape): an MFT record names a file, not a process (#913)

### DIFF
--- a/companion/src/analysis/kapeImport.ts
+++ b/companion/src/analysis/kapeImport.ts
@@ -353,8 +353,10 @@ const PROFILES: Profile[] = [
       const fileName = firstStr(row, ["FileName"]);
       if (!fileName) return null;
       const path = (parent ? `${parent.replace(/[\\/]+$/, "")}\\` : "") + fileName;
+      // A record names a FILE, not a process — same rule as the journal mapper above (#913). The
+      // path is the indicator; running every filename on the volume through addProc made documents
+      // into process names that prevalence and the evidence graph then keyed on.
       addFile(sink, path);
-      const proc = addProc(sink, fileName);
       const size = firstStr(row, ["FileSize"]);
       // Timestomp check: MFTECmd emits $SI (Created0x10) and $FN (Created0x30) creation on the same
       // row. Pass the RAW strings (not ezTime, which drops the sub-second the truncation signal needs).
@@ -374,7 +376,6 @@ const PROFILES: Profile[] = [
         ...(ezTime(getCI(row, "LastModified0x10"))
           ? { fileModified: ezTime(getCI(row, "LastModified0x10")) }
           : {}),
-        ...(proc ? { processName: proc } : {}),
       };
     },
   },

--- a/companion/tests/analysis/kapeImport.test.ts
+++ b/companion/tests/analysis/kapeImport.test.ts
@@ -155,6 +155,46 @@ describe("parseKapeCsv — artifact detection & mapping", () => {
     expect(r.events[0].path).toBe(".\\Users\\bob\\Desktop\\evil.exe");
   });
 
+  // An MFT record names a FILE, not a process — the same rule the journal mapper follows. The MFT
+  // lists every file on the volume, so running its names through addProc turned `report.docx` into
+  // a process indicator AND a processName, which prevalence, chain signatures and the evidence graph
+  // key on (#913). The path stays a file indicator; nothing becomes a process.
+  it("MFT: never turns a filename into a process indicator", () => {
+    const text = csv(
+      [
+        "EntryNumber",
+        "InUse",
+        "ParentPath",
+        "FileName",
+        "Extension",
+        "FileSize",
+        "IsDirectory",
+        "Created0x10",
+        "LastModified0x10",
+      ],
+      [
+        [
+          "100",
+          "True",
+          ".\\Users\\bob\\Documents",
+          "report.docx",
+          ".docx",
+          "12345",
+          "False",
+          "2023-04-01 07:00:00",
+          "2023-04-01 07:00:00",
+        ],
+      ],
+    );
+    const r = parseKapeCsv(text);
+    expect(r.artifact).toBe("MFT");
+    expect(r.iocs.some((i) => i.type === "process")).toBe(false);
+    expect(r.events[0].processName).toBeUndefined();
+    expect(r.iocs.some((i) => i.type === "file" && i.value === ".\\Users\\bob\\Documents\\report.docx")).toBe(
+      true,
+    );
+  });
+
   it("MFT: flags timestomping when $SI (Created0x10) is backdated before $FN (Created0x30)", () => {
     const text = csv(
       [


### PR DESCRIPTION
Closes #913.

## What changes for the analyst

A KAPE `$MFT` import no longer turns every filename on the disk into a process indicator. `report.docx`, `notes.txt` and `invoice.pdf` stay file indicators; nothing from the MFT is shown as a process name, so prevalence counts, chain signatures and the evidence graph stop treating documents as programs.

## Triage of #913

| Claim | Verdict |
|---|---|
| The journal (`$J`) mapper registers every filename as a process | **Already fixed in 792feaff (#934)**, which also added the pinning test the issue asked for (`usnLifecycle.test.ts` "never turns a journal filename into a process indicator"). #934 did not cite #913. |
| `processName` is a grouping key in `correlate.ts` | Not as stated — it is a merged output field there. The sink is real elsewhere: `prevalence.ts`, `chainSignature.ts`, `assetGraph.ts`, `evidenceGraph.ts` key on it. |
| ShimCache is the other caller of the helper | Incomplete — five callers. Prefetch, Amcache, ShimCache and SRUM each name a program by artifact definition. **The MFT mapper had the same defect as the journal**, measured: an MFT row for `report.docx` produced `process = report.docx` at master. |

## Fix

The MFT mapper drops the `addProc` call and the `processName` it set — the same shape #934 chose for the journal. Timestomp corroboration matches MFT observations on `path`, never on `processName`, so it is unaffected.

The issue's other option — an executable-extension allowlist inside the helper — was declined: it rejects `.hta .cpl .msi .ocx .jar .wsf .pif .msc .drv .vbe .jse`, which Amcache and ShimCache record as program files.

## Test

`kapeImport.test.ts` "MFT: never turns a filename into a process indicator" — red before the change (`expected true to be false` on the process-IOC check), green after.

## Gates

companion: lint, format:check, check:size, check:imports, check:boundaries, eval:change-gate, check:us-map, build, typecheck, vitest 793 files / 13274 tests — all green. extension: typecheck, test (329), build, build:firefox — all green.

Unchecked: Velociraptor's own `usn`/`mft` row shapes in `velociraptorImport.ts` (lines 385–386, 491) — whether they register process IOCs from filenames.
